### PR TITLE
[24.2] Upgrade requests-unixsocket for requests compatibility

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -166,7 +166,7 @@ repoze-lru==0.7
 requests==2.32.3
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
-requests-unixsocket==0.3.0
+requests-unixsocket==0.4.1
 rich==13.9.4
 rocrate==0.11.0
 routes==2.5.1

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -166,7 +166,8 @@ repoze-lru==0.7
 requests==2.32.3
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
-requests-unixsocket==0.4.1
+requests-unixsocket==0.3.0 ; python_full_version < '3.9'
+requests-unixsocket==0.4.1 ; python_full_version >= '3.9'
 rich==13.9.4
 rocrate==0.11.0
 routes==2.5.1


### PR DESCRIPTION
Currently it does not work with the pinned version of requests, see https://github.com/msabramo/requests-unixsocket/pull/72

This is used by Gravity, `galaxyctl graceful` when gunicorn is configured to use unix domain sockets.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1.  ```
      gravity:
        gunicorn:
          - bind: unix:/tmp/gx0.sock
          - bind: unix:/tmp/gx1.sock
      ```
  2. `galaxyctl start`
  3. `galaxyctl graceful`
  4. fail
  5. `pip install requests-unixsocket==0.4.1`
  6. `galaxyctl graceful`
  7. success

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
