### PR TITLE
Drop unnecessary getattr(config, "key") calls

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -288,7 +288,7 @@ class LibraryActions:
         uploaded_dataset.space_to_tab = params.get("space_to_tab", None)
         uploaded_dataset.tag_using_filenames = params.get("tag_using_filenames", False)
         uploaded_dataset.tags = params.get("tags", None)
-        uploaded_dataset.purge_source = getattr(trans.app.config, "ftp_upload_purge", True)
+        uploaded_dataset.purge_source = trans.app.config.ftp_upload_purge
         if in_folder:
             uploaded_dataset.in_folder = in_folder
         uploaded_dataset.data = upload_common.new_upload(trans, "api", uploaded_dataset, library_bunch)

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -386,7 +386,7 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
             )
         self.container_finder = containers.ContainerFinder(app_info, mulled_resolution_cache=mulled_resolution_cache)
         self._set_enabled_container_types()
-        index_help = getattr(self.config, "index_tool_help", True)
+        index_help = self.config.index_tool_help
         self.toolbox_search = self._register_singleton(
             ToolBoxSearch,
             ToolBoxSearch(self.toolbox, index_dir=self.config.tool_search_index_dir, index_help=index_help),
@@ -494,7 +494,7 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
     def _configure_models(self, check_migrate_databases=False, config_file=None):
         """Preconditions: object_store must be set on self."""
         # TODO this block doesn't seem to belong in this method
-        if getattr(self.config, "max_metadata_value_size", None):
+        if self.config.max_metadata_value_size:
             custom_types.MAX_METADATA_VALUE_SIZE = self.config.max_metadata_value_size
 
         db_url = self.config.database_connection
@@ -526,8 +526,8 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
     def _verify_databases(self, engine, install_engine, combined_install_database):
         install_template, install_encoding = None, None
         if not combined_install_database:  # Otherwise these options are not used.
-            install_template = getattr(self.config, "install_database_template", None)
-            install_encoding = getattr(self.config, "install_database_encoding", None)
+            install_template = self.config.install_database_template
+            install_encoding = self.config.install_database_encoding
 
         verify_databases(
             engine,

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1024,7 +1024,7 @@ class Data(metaclass=DataMeta):
 
     def _clean_and_set_mime_type(self, trans, mime: str, headers: Headers) -> None:
         if mime.lower() in XSS_VULNERABLE_MIME_TYPES:
-            if not getattr(trans.app.config, "serve_xss_vulnerable_mimetypes", True):
+            if not trans.app.config.serve_xss_vulnerable_mimetypes:
                 mime = DEFAULT_MIME_TYPE
         headers["content-type"] = mime
 

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -187,7 +187,7 @@ class Registry:
                 auto_compressed_types = galaxy.util.listify(elem.get("auto_compressed_types", ""))
                 sniff_compressed_types = galaxy.util.string_as_bool_or_none(elem.get("sniff_compressed_types", "None"))
                 if sniff_compressed_types is None:
-                    sniff_compressed_types = getattr(self.config, "sniff_compressed_dynamic_datatypes_default", True)
+                    sniff_compressed_types = self.config.sniff_compressed_dynamic_datatypes_default
                     # Make sure this is set in the elems we write out so the config option is passed to the upload
                     # tool which does not have a config object.
                     elem.set("sniff_compressed_types", str(sniff_compressed_types))
@@ -498,7 +498,7 @@ class Registry:
             for elem in root.find("build_sites").findall("site"):
                 load_build_site(elem)
         else:
-            build_sites_config_file = getattr(self.config, "build_sites_config_file", None)
+            build_sites_config_file = self.config.build_sites_config_file
             if build_sites_config_file and os.path.exists(build_sites_config_file):
                 with open(build_sites_config_file) as f:
                     build_sites_config = yaml.safe_load(f)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1183,7 +1183,7 @@ class MinimalJobWrapper(HasResourceParameters):
 
     @property
     def shell(self):
-        return self.job_destination.shell or getattr(self.app.config, "default_job_shell", DEFAULT_JOB_SHELL)
+        return self.job_destination.shell or self.app.config.default_job_shell
 
     def disable_commands_in_new_shell(self):
         """Provide an extension point to disable this isolation,

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -97,7 +97,7 @@ class DynamicToolManager(ModelManager[model.DynamicTool]):
         return self.session().scalars(stmt).one_or_none()
 
     def create_tool(self, tool_payload: DynamicToolPayload):
-        if not getattr(self.app.config, "enable_beta_tool_formats", False):
+        if not self.app.config.enable_beta_tool_formats:
             raise exceptions.ConfigDoesNotAllowException(
                 "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
             )
@@ -156,7 +156,7 @@ class DynamicToolManager(ModelManager[model.DynamicTool]):
     def create_unprivileged_tool(
         self, user: model.User, tool_payload: DynamicUnprivilegedToolCreatePayload
     ) -> DynamicTool:
-        if not getattr(self.app.config, "enable_beta_tool_formats", False):
+        if not self.app.config.enable_beta_tool_formats:
             raise exceptions.ConfigDoesNotAllowException(
                 "Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools."
             )

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -320,7 +320,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             return None
 
     def check_bootstrap_admin_api_key(self, api_key):
-        bootstrap_admin_api_key = getattr(self.app.config, "bootstrap_admin_api_key", None)
+        bootstrap_admin_api_key = self.app.config.bootstrap_admin_api_key
         if not bootstrap_admin_api_key:
             return False
         # Hash keys to make them the same size, so we can do safe comparison.
@@ -615,7 +615,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         """
         if not self.app.config.use_remote_user:
             return None
-        if getattr(self.app.config, "normalize_remote_user_email", False):
+        if self.app.config.normalize_remote_user_email:
             remote_user_email = remote_user_email.lower()
         user = get_user_by_email(self.session(), remote_user_email, self.app.model.User)
         if user:

--- a/lib/galaxy/tool_shed/tools/tool_validator.py
+++ b/lib/galaxy/tool_shed/tools/tool_validator.py
@@ -80,7 +80,7 @@ class ToolValidator:
     def load_tool_from_config(self, repository_id, full_path):
         tool_source = get_tool_source(
             full_path,
-            enable_beta_formats=getattr(self.app.config, "enable_beta_tool_formats", False),
+            enable_beta_formats=self.app.config.enable_beta_tool_formats,
             tool_location_fetcher=ToolLocationFetcher(),
         )
         try:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -613,7 +613,7 @@ class ToolBox(AbstractToolBox):
         try:
             return get_tool_source(
                 config_file,
-                enable_beta_formats=getattr(self.app.config, "enable_beta_tool_formats", False),
+                enable_beta_formats=self.app.config.enable_beta_tool_formats,
                 tool_location_fetcher=self.tool_location_fetcher,
                 **kwargs,
             )
@@ -723,7 +723,7 @@ class ToolBox(AbstractToolBox):
         )
 
     def _looks_like_a_tool(self, path):
-        return looks_like_a_tool(path, enable_beta_formats=getattr(self.app.config, "enable_beta_tool_formats", False))
+        return looks_like_a_tool(path, enable_beta_formats=self.app.config.enable_beta_tool_formats)
 
     def _init_dependency_manager(self):
         use_tool_dependency_resolution = getattr(self.app, "use_tool_dependency_resolution", True)

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -518,7 +518,7 @@ class UploadDataset(Group):
                                         "local_filename": os.path.abspath(os.path.join(user_ftp_dir, path)),
                                         "filename": os.path.basename(path),
                                     }
-                                    purge = getattr(trans.app.config, "ftp_upload_purge", True)
+                                    purge = trans.app.config.ftp_upload_purge
                                     file_bunch = get_data_file_filename(
                                         ftp_data_file,
                                         override_name=name,
@@ -617,7 +617,7 @@ class UploadDataset(Group):
                     "local_filename": os.path.abspath(os.path.join(user_ftp_dir, ftp_file)),
                     "filename": os.path.basename(ftp_file),
                 }
-                purge = getattr(trans.app.config, "ftp_upload_purge", True)
+                purge = trans.app.config.ftp_upload_purge
                 file_bunch = get_data_file_filename(ftp_data_file, override_name=name, override_info=info, purge=purge)
                 if file_bunch.path:
                     file_bunch.to_posix_lines = to_posix_lines

--- a/lib/galaxy/web_stack/__init__.py
+++ b/lib/galaxy/web_stack/__init__.py
@@ -54,7 +54,7 @@ class ApplicationStack:
         self._supports_returning = None
         self._supports_skip_locked = None
         self._preferred_handler_assignment_method = None
-        multiprocessing.current_process().name = getattr(self.config, "server_name", "main")
+        multiprocessing.current_process().name = self.config.server_name
         if app:
             log.debug("%s initialized", self.__class__.__name__)
 

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -770,7 +770,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         self.set_cookie(self.security.encode_guid(self.galaxy_session.session_key), name=name, path=self.cookie_path)
 
     def check_user_library_import_dir(self, user):
-        if getattr(self.app.config, "user_library_import_dir_auto_creation", False):
+        if self.app.config.user_library_import_dir_auto_creation:
             # try to create a user library import directory
             try:
                 safe_makedirs(os.path.join(self.app.config.user_library_import_dir, user.email))

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -193,7 +193,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
                 message, status = self.resend_activation_email(trans, user.email, user.username)
                 return self.message_exception(trans, message, sanitize=False)
         else:  # activation is OFF
-            pw_expires = getattr(trans.app.config, "password_expiration_period", None)
+            pw_expires = trans.app.config.password_expiration_period
             if pw_expires and user.last_password_change < datetime.today() - pw_expires:
                 # Password is expired, we don't log them in.
                 return {

--- a/lib/galaxy/webapps/galaxy/services/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/services/_fetch_util.py
@@ -54,7 +54,7 @@ def validate_and_normalize_targets(trans, payload):
     # in_place and purge_source are set on the individual upload fetch sources as needed based
     # on this.
     run_as_real_user = trans.app.config.external_chown_script is not None  # See comment in upload.py
-    purge_ftp_source = getattr(trans.app.config, "ftp_upload_purge", True) and not run_as_real_user
+    purge_ftp_source = trans.app.config.ftp_upload_purge and not run_as_real_user
 
     payload["check_content"] = trans.app.config.check_upload_content
 


### PR DESCRIPTION
They're always set, no point in doing this.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
