### PR TITLE
Display the Galaxy Citation within the Export Tool References List

### DIFF
--- a/client/src/components/Citation/CitationsList.test.ts
+++ b/client/src/components/Citation/CitationsList.test.ts
@@ -1,0 +1,65 @@
+import { getLocalVue } from "@tests/jest/helpers";
+import { mount, type Wrapper } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+
+import CitationItem from "./CitationItem.vue";
+import MountTarget from "./CitationsList.vue";
+
+const localVue = getLocalVue(true);
+
+jest.mock("@/composables/config", () => ({
+    useConfig: jest.fn(() => ({
+        config: {
+            value: {
+                citation_bibtex:
+                    "@article{Galaxy2024, title={The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update}, author={{The Galaxy Community}}, journal={Nucleic Acids Research}, year={2024}, doi={10.1093/nar/gkae410}, url={https://doi.org/10.1093/nar/gkae410}}",
+            },
+        },
+    })),
+}));
+
+jest.mock("@/components/Citation/services", () => ({
+    getCitations: jest.fn(() =>
+        Promise.resolve([
+            {
+                raw: "@article{Hourahine_2020,\n\tdoi = {10.1063/1.5143190},\n\turl = {https://doi.org/10.1063%2F1.5143190},\n\tyear = 2020,\n\tmonth = {mar},\n\tpublisher = {{AIP} Publishing},\n\tvolume = {152},\n\tnumber = {12},\n\tpages = {124101},\n\tauthor = {B. Hourahine and B. Aradi and V. Blum and F. Bonaf{\\'{e}} and A. Buccheri and C. Camacho and C. Cevallos and M. Y. Deshaye and T. Dumitric{\\u{a}} and A. Dominguez and S. Ehlert and M. Elstner and T. van der Heide and J. Hermann and S. Irle and J. J. Kranz and C. K\u00f6hler and T. Kowalczyk and T. Kuba{\\v{r}} and I. S. Lee and V. Lutsker and R. J. Maurer and S. K. Min and I. Mitchell and C. Negre and T. A. Niehaus and A. M. N. Niklasson and A. J. Page and A. Pecchia and G. Penazzi and M. P. Persson and J. {\\v{R}}ez{\\'{a}}{\\v{c}} and C. G. S{\\'{a}}nchez and M. Sternberg and M. St\u00f6hr and F. Stuckenberg and A. Tkatchenko and V. W.-z. Yu and T. Frauenheim},\n\ttitle = {{DFTB}$\\mathplus$, a software package for efficient approximate density functional theory based atomistic simulations},\n\tjournal = {The Journal of Chemical Physics}\n}",
+                cite: {
+                    format: jest.fn(
+                        () =>
+                            '<div class="csl-bib-body"><div data-csl-entry-id="Hourahine_2020" class="csl-entry">Hourahine, B. (2020). DFTB$\\mathplus$, a software package for efficient approximate density functional theory based atomistic simulations. The Journal of Chemical Physics, 152(12), 124101. https://doi.org/10.1063/1.5143190</div></div>'
+                    ),
+                },
+            },
+        ])
+    ),
+}));
+
+describe("CitationsList", () => {
+    let wrapper: Wrapper<Vue>;
+
+    beforeEach(async () => {
+        wrapper = mount(MountTarget as object, {
+            propsData: {
+                id: "test-id",
+                source: "histories",
+            },
+            localVue,
+        });
+
+        await flushPromises();
+    });
+
+    it("renders the config Galaxy citation and any fetched citations", () => {
+        const citationItems = wrapper.findAllComponents(CitationItem);
+
+        // It finds the Galaxy citation from the config, and the mocked citation for the history tools.
+        expect(citationItems.length).toBe(2);
+
+        expect(citationItems.at(0).text()).toContain(
+            "The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update"
+        );
+        expect(citationItems.at(1).text()).toContain(
+            "DFTB$\\mathplus$, a software package for efficient approximate density functional theory based atomistic simulations"
+        );
+    });
+});

--- a/client/src/components/Citation/services.ts
+++ b/client/src/components/Citation/services.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+import { useConfig } from "@/composables/config";
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
@@ -19,7 +20,19 @@ export async function getCitations(source: string, id: string): Promise<Citation
                 console.warn(`Error parsing bibtex: ${err}`);
             }
         }
-        return citations;
+        // Inject Galaxy citation from config, using Cite for formatting
+        const { config } = useConfig();
+        let galaxyCitation = null;
+        const galaxy_bibtex = config.value?.citation_bibtex;
+        if (galaxy_bibtex) {
+            try {
+                const cite = new Cite(galaxy_bibtex);
+                galaxyCitation = { raw: galaxy_bibtex, cite };
+            } catch (err) {
+                console.warn("Error parsing Galaxy BibTeX:", err);
+            }
+        }
+        return galaxyCitation ? [galaxyCitation, ...citations] : citations;
     } catch (e) {
         rethrowSimple(e);
     }

--- a/client/src/components/Citation/services.ts
+++ b/client/src/components/Citation/services.ts
@@ -1,6 +1,5 @@
 import axios from "axios";
 
-import { useConfig } from "@/composables/config";
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
@@ -20,19 +19,7 @@ export async function getCitations(source: string, id: string): Promise<Citation
                 console.warn(`Error parsing bibtex: ${err}`);
             }
         }
-        // Inject Galaxy citation from config, using Cite for formatting
-        const { config } = useConfig();
-        let galaxyCitation = null;
-        const galaxy_bibtex = config.value?.citation_bibtex;
-        if (galaxy_bibtex) {
-            try {
-                const cite = new Cite(galaxy_bibtex);
-                galaxyCitation = { raw: galaxy_bibtex, cite };
-            } catch (err) {
-                console.warn("Error parsing Galaxy BibTeX:", err);
-            }
-        }
-        return galaxyCitation ? [galaxyCitation, ...citations] : citations;
+        return citations;
     } catch (e) {
         rethrowSimple(e);
     }

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2464,6 +2464,17 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~
+``citation_bibtex``
+~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The BibTeX citation for Galaxy, to be displayed in the History
+    Tool Reference List
+:Default: ``@article{Galaxy2024, title={The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update}, author={{The Galaxy Community}}, journal={Nucleic Acids Research}, year={2024}, doi={10.1093/nar/gkae410}, url={https://doi.org/10.1093/nar/gkae410}}``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~
 ``release_doc_base_url``
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1521,6 +1521,10 @@ galaxy:
   # The URL linked by the "How to Cite Galaxy" link in the "Help" menu.
   #citation_url: https://galaxyproject.org/citing-galaxy
 
+  # The BibTeX citation for Galaxy, to be displayed in the History Tool
+  # Reference List
+  #citation_bibtex: '@article{Galaxy2024, title={The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update}, author={{The Galaxy Community}}, journal={Nucleic Acids Research}, year={2024}, doi={10.1093/nar/gkae410}, url={https://doi.org/10.1093/nar/gkae410}}'
+
   # The URL linked by the "Galaxy Version" link in the "Help" menu.
   #release_doc_base_url: https://docs.galaxyproject.org/en/release_
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1837,6 +1837,14 @@ mapping:
         desc: |
           The URL linked by the "How to Cite Galaxy" link in the "Help" menu.
 
+      citation_bibtex:
+        type: str
+        default: "@article{Galaxy2024, title={The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update}, author={{The Galaxy Community}}, journal={Nucleic Acids Research}, year={2024}, doi={10.1093/nar/gkae410}, url={https://doi.org/10.1093/nar/gkae410}}"
+        required: false
+        per_host: true
+        desc: |
+          The BibTeX citation for Galaxy, to be displayed in the History Tool Reference List
+
       release_doc_base_url:
         type: str
         default: https://docs.galaxyproject.org/en/release_

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -131,6 +131,7 @@ class ConfigSerializer(base.ModelSerializer):
             "wiki_url": _use_config,
             "screencasts_url": _use_config,
             "citation_url": _use_config,
+            "citation_bibtex": _use_config,
             "citations_export_message_html": _use_config,
             "support_url": _use_config,
             "quota_url": _use_config,

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -236,6 +236,9 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
             elif container == "instance_citation_link":
                 url = trans.app.config.citation_url
                 rval = self.handle_instance_citation_link(line, url)
+            elif container == "instance_citation_bibtex":
+                url = trans.app.config.citation_bibtex
+                rval = self.handle_instance_citation_bibtex(line, url)
             elif container == "instance_terms_link":
                 url = trans.app.config.terms_url
                 rval = self.handle_instance_terms_link(line, url)

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -391,6 +391,10 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
+    def handle_instance_citation_bibtex(self, line, url):
+        pass
+
+    @abc.abstractmethod
     def handle_instance_terms_link(self, line, url):
         pass
 
@@ -510,6 +514,9 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         pass
 
     def handle_instance_citation_link(self, line, url):
+        pass
+
+    def handle_instance_citation_bibtex(self, line, url):
         pass
 
     def handle_instance_terms_link(self, line, url):
@@ -775,6 +782,9 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
         return self._handle_link(url)
 
     def handle_instance_citation_link(self, line, url):
+        return self._handle_link(url)
+
+    def handle_instance_citation_bibtex(self, line, url):
         return self._handle_link(url)
 
     def handle_instance_terms_link(self, line, url):


### PR DESCRIPTION
This commit implements a new feature to display a user-defined Galaxy Citation within the "Export Tool References List". By default, this includes a reference to the NAR paper, but this can be changed at runtime via a galaxy.yml edit or by rebuilding the client with an updated config_schma.yml. This feature was proposed and discussed here: https://github.com/galaxyproject/galaxy/issues/19362

Summary of changes:
- Define a new configuration property for citation_bibtex with a reference to the current main galaxy paper.
- Inject that as a citation within the Export Tool Refernences to diplay alongside other tools used in the current history.
- Uses the Cite() package to format in bibtex or APA as needed (as done for all other tools too)
- Updates the docs, and schema as needed to provide the default value and description

Example showing Galaxy citation along with several others
<img width="1789" alt="image" src="https://github.com/user-attachments/assets/db595d6f-1996-4745-a7ca-db8e45003fb7" />

Example with a blank history just showing Galaxy
<img width="1789" alt="image" src="https://github.com/user-attachments/assets/97f93f49-9eff-41b5-94c2-45b94bf02f34" />


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Load/create a history
  2. Select "Export Tool References" from the History options hamburger menu

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
