### PR TITLE
[25.0] Add datatype for LexicMap index

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -342,6 +342,7 @@
     </datatype>
     <datatype extension="directory" type="galaxy.datatypes.data:Directory"/>
     <datatype extension="bwa_mem2_index" display_in_upload="true" type="galaxy.datatypes.data:Directory" subclass="true"/>
+    <datatype extension="lexicmap_index" display_in_upload="true" type="galaxy.datatypes.data:Directory" subclass="true"/>
     <datatype extension="zarr" type="galaxy.datatypes.data:ZarrDirectory">
         <infer_from suffix="zarr" />
     </datatype>

--- a/test/functional/tools/sample_datatypes_conf.xml
+++ b/test/functional/tools/sample_datatypes_conf.xml
@@ -62,6 +62,7 @@
     <datatype extension="directory" type="galaxy.datatypes.data:Directory">
     </datatype>
     <datatype extension="bwa_mem2_index" display_in_upload="true" type="galaxy.datatypes.data:Directory" subclass="true"/>
+    <datatype extension="lexicmap_index" display_in_upload="true" type="galaxy.datatypes.data:Directory" subclass="true"/>
     <datatype extension="h5" type="galaxy.datatypes.binary:H5" mimetype="application/octet-stream" display_in_upload="true"/>
   </registration>
 </datatypes>


### PR DESCRIPTION
### [LexicMap](https://github.com/shenwei356/LexicMap)

**LexicMap** is a nucleotide sequence alignment tool for efficiently querying gene, plasmid, viral, or long-read sequences (>100 bp) against up to millions of prokaryotic genomes.

To perform queries, an index must first be created. The index is stored as a folder structure containing metadata and binary data files.

#### Example Index Directory Structure

lexicmap_index/
├── genomes.chunks.bin
├── genomes.map.bin
├── info.xml
├── masks.bin
├── genomes/
│ ├── batch_0000/
│ │ ├── genomes.bin
│ │ └── genomes.bin.idx
│ └── batch_NNNN/
│ ├── genomes.bin
│ └── genomes.bin.idx
└── seeds/
├── chunk_000.bin
├── chunk_000.bin.idx
...
├── chunk_NNN.bin
└── chunk_NNN.bin.idx

  


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
