### PR TITLE
[25.0] Don't fail volume mount construction for tools without tool directory

### DIFF
--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -298,7 +298,8 @@ def preprocess_volumes(volumes_raw_str: str, container_type: str) -> List[str]:
     if not volumes_raw_str:
         return []
 
-    volumes = [Volume(v, container_type) for v in volumes_raw_str.split(",")]
+    # filter out empty strings, this happens for tools without tool directories.
+    volumes = [Volume(v, container_type) for v in volumes_raw_str.split(",") if v]
     rw_paths = [v.target for v in volumes if v.mode == "rw"]
     for volume in volumes:
         mode = volume.mode


### PR DESCRIPTION
Dev's hate this one simple trick: https://github.com/galaxyproject/usegalaxy-playbook/blob/4963808ac295ef49b786f619b5b659d158e0be0b/env/main/group_vars/galaxyservers/vars.yml#L133

In a default setup we dynamically add `$tool_directory` but that doesn't work if it's hardcoded like that.
Fixes https://github.com/galaxyproject/galaxy/issues/20489

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
