### PR TITLE
Add missing cleanup table

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -11820,6 +11820,15 @@ class CleanupEventImplicitlyConvertedDatasetAssociationAssociation(Base):
     )
 
 
+class CleanupEventUserAssociation(Base):
+    __tablename__ = "cleanup_event_user_association"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
+    cleanup_event_id: Mapped[int] = mapped_column(ForeignKey("cleanup_event.id"), index=True, nullable=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id"), index=True, nullable=True)
+
+
 class CeleryUserRateLimit(Base):
     """
     For each user stores the last time a task was scheduled for execution.

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/338d0e5deb03_add_cleanup_event_user_assoc_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/338d0e5deb03_add_cleanup_event_user_assoc_table.py
@@ -1,0 +1,44 @@
+"""Add cleanup_event_user_assoc table
+
+Revision ID: 338d0e5deb03
+Revises: c44ae5f3dcf1
+Create Date: 2025-07-02 13:59:34.849280
+
+"""
+
+import logging
+
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import (
+    create_table,
+    drop_table,
+    table_exists,
+)
+
+log = logging.getLogger(__name__)
+
+# revision identifiers, used by Alembic.
+revision = "338d0e5deb03"
+down_revision = "c44ae5f3dcf1"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "cleanup_event_user_association"
+
+
+def upgrade():
+    if not table_exists(TABLE_NAME, True):
+        create_table(
+            TABLE_NAME,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("create_time", sa.DateTime),
+            sa.Column("cleanup_event_id", sa.Integer, sa.ForeignKey("cleanup_event.id"), index=True),
+            sa.Column("user_id", sa.Integer, sa.ForeignKey("galaxy_user.id"), index=True),
+        )
+    else:
+        log.info(f"Skipping revision script: table {TABLE_NAME} already exists")
+
+
+def downgrade():
+    drop_table(TABLE_NAME)


### PR DESCRIPTION
The `cleanup_event_user_association` table was never added to the model. As a result, if anyone tried to run a cleanup action involving this table (e.g. `delete_inactive_users`) would get this error, obviously:

```
psycopg2.errors.UndefinedTable: relation "cleanup_event_user_association" does not exist
LINE 17:           AS (INSERT INTO cleanup_event_user_association
```

main is not affected since the table exists in the db.  How this went undetected for so long, I have no idea.

Bug discovered by @ccoulombe - thank you!

The script will log a message if the table already exists (which is the case with main and is likely to be with at least some other instances).

I'm adding this to dev because it's not critical and involves a migration - it's not worth the trouble of yet another merge commit to reconsile the dev and 25.0 (or pre-24.*) branches.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
