### PR TITLE
Add FastAPI route for PUT /api/workflows/{workflow_id}

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -19200,6 +19200,11 @@ export interface components {
                 [key: string]: components["schemas"]["WorkflowInput"];
             };
             /**
+             * The ID of the latest workflow
+             * @description The encoded ID of the latest version of this workflow.
+             */
+            latest_workflow_id?: string | null;
+            /**
              * Latest workflow UUID
              * @description TODO
              */
@@ -19209,6 +19214,11 @@ export interface components {
              * @description SPDX Identifier of the license associated with this workflow.
              */
             license?: string | null;
+            /**
+             * Logo URL
+             * @description A URL to a logo for this workflow.
+             */
+            logo_url?: string | null;
             /**
              * Model class
              * @description The name of the database model class.
@@ -20448,6 +20458,11 @@ export interface components {
              * @description Additional information about the creator (or multiple creators) of this workflow.
              */
             creator?: (components["schemas"]["Person"] | components["schemas"]["Organization-Input"])[] | null;
+            /**
+             * Deleted
+             * @description Indicates if the workflow is marked as deleted or not.
+             */
+            deleted?: boolean | null;
             /**
              * DOI
              * @description A list of Digital Object Identifiers associated with this workflow.
@@ -39742,9 +39757,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["StoredWorkflowDetailed"];
                 };
             };
             /** @description Request Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -5513,7 +5513,8 @@ export interface paths {
         };
         /** Displays information needed to run a workflow. */
         get: operations["show_workflow_api_workflows__workflow_id__get"];
-        put?: never;
+        /** Updates the values for the workflow with the given ID. */
+        put: operations["update_api_workflows__workflow_id__put"];
         post?: never;
         /** Add the deleted flag to a workflow. */
         delete: operations["delete_workflow_api_workflows__workflow_id__delete"];
@@ -10934,6 +10935,97 @@ export interface components {
              */
             update_time: string;
         };
+        /** FrameComment */
+        FrameComment: {
+            /**
+             * Child Comments
+             * @description A list of ids (see `id`) of all Comments which are encompassed by this Frame
+             */
+            child_comments?: number[] | null;
+            /**
+             * Child Steps
+             * @description A list of ids of all Steps (see WorkflowStep.id) which are encompassed by this Frame
+             */
+            child_steps?: number[] | null;
+            /**
+             * Color
+             * @description Color this comment is displayed as. The exact color hex is determined by the client
+             * @enum {string}
+             */
+            color: "none" | "black" | "blue" | "turquoise" | "green" | "lime" | "orange" | "yellow" | "red" | "pink";
+            data: components["schemas"]["FrameCommentData"];
+            /**
+             * Id
+             * @description Unique identifier for this comment. Determined by the comments order
+             */
+            id: number;
+            /**
+             * Position
+             * @description [x, y] position of this comment in the Workflow
+             */
+            position: [number, number];
+            /**
+             * Size
+             * @description [width, height] size of this comment
+             */
+            size: [number, number];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "frame";
+        };
+        /** FrameCommentData */
+        FrameCommentData: {
+            /**
+             * Title
+             * @description The Frames title
+             */
+            title: string;
+        };
+        /** FreehandComment */
+        FreehandComment: {
+            /**
+             * Color
+             * @description Color this comment is displayed as. The exact color hex is determined by the client
+             * @enum {string}
+             */
+            color: "none" | "black" | "blue" | "turquoise" | "green" | "lime" | "orange" | "yellow" | "red" | "pink";
+            data: components["schemas"]["FreehandCommentData"];
+            /**
+             * Id
+             * @description Unique identifier for this comment. Determined by the comments order
+             */
+            id: number;
+            /**
+             * Position
+             * @description [x, y] position of this comment in the Workflow
+             */
+            position: [number, number];
+            /**
+             * Size
+             * @description [width, height] size of this comment
+             */
+            size: [number, number];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "freehand";
+        };
+        /** FreehandCommentData */
+        FreehandCommentData: {
+            /**
+             * Line
+             * @description List of [x, y] coordinates determining the unsmoothed line. Smoothing is done client-side using Catmull-Rom
+             */
+            line: [number, number][];
+            /**
+             * Thickness
+             * @description Width of the Line in pixels
+             */
+            thickness: number;
+        };
         /** FtpImportElement */
         FtpImportElement: {
             /** Md5 */
@@ -16146,6 +16238,44 @@ export interface components {
          * @enum {string}
          */
         MandatoryNotificationCategory: "broadcast";
+        /** MarkdownComment */
+        MarkdownComment: {
+            /**
+             * Color
+             * @description Color this comment is displayed as. The exact color hex is determined by the client
+             * @enum {string}
+             */
+            color: "none" | "black" | "blue" | "turquoise" | "green" | "lime" | "orange" | "yellow" | "red" | "pink";
+            data: components["schemas"]["MarkdownCommentData"];
+            /**
+             * Id
+             * @description Unique identifier for this comment. Determined by the comments order
+             */
+            id: number;
+            /**
+             * Position
+             * @description [x, y] position of this comment in the Workflow
+             */
+            position: [number, number];
+            /**
+             * Size
+             * @description [width, height] size of this comment
+             */
+            size: [number, number];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "markdown";
+        };
+        /** MarkdownCommentData */
+        MarkdownCommentData: {
+            /**
+             * Text
+             * @description The unrendered source Markdown for this Comment
+             */
+            text: string;
+        };
         /** MaterializeDatasetInstanceAPIRequest */
         MaterializeDatasetInstanceAPIRequest: {
             /**
@@ -16712,6 +16842,38 @@ export interface components {
              * @default 0
              */
             version: number;
+        };
+        /** Organization */
+        "Organization-Input": {
+            /** Address */
+            address?: string | null;
+            /** Alternate Name */
+            alternateName?: string | null;
+            /**
+             * Class
+             * @default Organization
+             */
+            class: string;
+            /** Email */
+            email?: string | null;
+            /** Fax Number */
+            faxNumber?: string | null;
+            /**
+             * Identifier
+             * @description Identifier (typically an orcid.org ID)
+             */
+            identifier?: string | null;
+            /** Image URL */
+            image?: string | null;
+            /**
+             * Name
+             * @description The name of the creator.
+             */
+            name?: string | null;
+            /** Telephone */
+            telephone?: string | null;
+            /** URL */
+            url?: string | null;
         };
         /** OutputReferenceByLabel */
         OutputReferenceByLabel: {
@@ -18996,7 +19158,7 @@ export interface components {
             creator_deleted: boolean;
             /**
              * Deleted
-             * @description Whether this item is marked as deleted.
+             * @description Whether this workflow is marked as deleted.
              */
             deleted: boolean;
             /**
@@ -19011,9 +19173,9 @@ export interface components {
             email_hash: string | null;
             /**
              * Help
-             * @description The detailed help text for how to use the workflow and debug problems with it.
+             * @description A help text for how to use the workflow and debug problems with it.
              */
-            help: string | null;
+            help?: string | null;
             /**
              * Hidden
              * @description TODO
@@ -19028,7 +19190,7 @@ export interface components {
              * Importable
              * @description Indicates if the workflow is importable by the current user.
              */
-            importable: boolean | null;
+            importable?: boolean | null;
             /**
              * Inputs
              * @description A dictionary containing information about all the inputs of the workflow.
@@ -19055,7 +19217,7 @@ export interface components {
             model_class: "StoredWorkflow";
             /**
              * Name
-             * @description The name of the history.
+             * @description The name of the workflow.
              */
             name: string;
             /**
@@ -19075,9 +19237,9 @@ export interface components {
             published: boolean;
             /**
              * Readme
-             * @description The detailed markdown readme of the workflow.
+             * @description A markdown formatted readme for this workflow.
              */
-            readme: string | null;
+            readme?: string | null;
             /**
              * Show in Tool Panel
              * @description Whether to display this workflow in the Tools Panel.
@@ -19356,6 +19518,59 @@ export interface components {
             variables: {
                 [key: string]: string | boolean | number;
             };
+        };
+        /** TextComment */
+        TextComment: {
+            /**
+             * Color
+             * @description Color this comment is displayed as. The exact color hex is determined by the client
+             * @enum {string}
+             */
+            color: "none" | "black" | "blue" | "turquoise" | "green" | "lime" | "orange" | "yellow" | "red" | "pink";
+            data: components["schemas"]["TextCommentData"];
+            /**
+             * Id
+             * @description Unique identifier for this comment. Determined by the comments order
+             */
+            id: number;
+            /**
+             * Position
+             * @description [x, y] position of this comment in the Workflow
+             */
+            position: [number, number];
+            /**
+             * Size
+             * @description [width, height] size of this comment
+             */
+            size: [number, number];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "text";
+        };
+        /** TextCommentData */
+        TextCommentData: {
+            /**
+             * Bold
+             * @description If the Comments text is bold. Absent is interpreted as false
+             */
+            bold?: boolean | null;
+            /**
+             * Italic
+             * @description If the Comments text is italic. Absent is interpreted as false
+             */
+            italic?: boolean | null;
+            /**
+             * Size
+             * @description Relative size (1 -> 100%) of the text compared to the default text sitz
+             */
+            size: number;
+            /**
+             * Text
+             * @description The plaintext text of this comment
+             */
+            text: string;
         };
         /** TextParameterModel */
         TextParameterModel: {
@@ -20213,6 +20428,108 @@ export interface components {
             preferences: {
                 [key: string]: components["schemas"]["NotificationCategorySettings"];
             };
+        };
+        /** UpdateWorkflowPayload */
+        UpdateWorkflowPayload: {
+            /**
+             * Allow Missing Tools
+             * @description Allow missing tools when updating workflow
+             */
+            allow_missing_tools?: boolean | null;
+            /** Annotation */
+            annotation?: string | null;
+            /**
+             * Comments
+             * @description A list of comments to modify in the workflow.
+             */
+            comments?: components["schemas"]["WorkflowCommentModel"][] | null;
+            /**
+             * Creator
+             * @description Additional information about the creator (or multiple creators) of this workflow.
+             */
+            creator?: (components["schemas"]["Person"] | components["schemas"]["Organization-Input"])[] | null;
+            /**
+             * DOI
+             * @description A list of Digital Object Identifiers associated with this workflow.
+             */
+            doi?: string[] | null;
+            /** Dry Run */
+            dry_run?: boolean | null;
+            /**
+             * Exact Tools
+             * @description If False, allow running with less exact tool versions.
+             * @default true
+             */
+            exact_tools: boolean | null;
+            /**
+             * Fill Defaults
+             * @description Fill in default tool state when updating, may change tool_state.
+             */
+            fill_defaults?: boolean | null;
+            /**
+             * From Tool Form
+             * @description True iff encoded state coming from generated form.
+             */
+            from_tool_form?: boolean | null;
+            /**
+             * Help
+             * @description A help text for how to use the workflow and debug problems with it.
+             */
+            help?: string | null;
+            /** Hidden */
+            hidden?: boolean | null;
+            /**
+             * Importable
+             * @description Indicates if the workflow is importable by the current user.
+             */
+            importable?: boolean | null;
+            /**
+             * License
+             * @description SPDX Identifier of the license associated with this workflow.
+             */
+            license?: string | null;
+            /**
+             * Logo URL
+             * @description A URL to a logo for this workflow.
+             */
+            logo_url?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Published */
+            published?: boolean | null;
+            /**
+             * Readme
+             * @description A markdown formatted readme for this workflow.
+             */
+            readme?: string | null;
+            /**
+             * Workflow Report
+             * @description The workflow report.
+             */
+            report?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Bookmark Workflow
+             * @description Whether to add the workflow to the list of bookmarked workflows.
+             */
+            show_in_tool_panel?: boolean | null;
+            /**
+             * Steps
+             * @description A dictionary with information about all the steps of the workflow.
+             */
+            steps?: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            } | null;
+            tags?: components["schemas"]["TagCollection"] | null;
+            /**
+             * Update Stored Workflow Attributes
+             * @description When updating the workflow's representation with name or annotation, updates the corresponding `StoredWorkflow`.
+             * @default true
+             */
+            update_stored_workflow_attributes: boolean | null;
         };
         /** UpgradeAllStepsAction */
         UpgradeAllStepsAction: {
@@ -21207,6 +21524,12 @@ export interface components {
              */
             revision: string;
         };
+        /** WorkflowCommentModel */
+        WorkflowCommentModel:
+            | components["schemas"]["TextComment"]
+            | components["schemas"]["MarkdownComment"]
+            | components["schemas"]["FrameComment"]
+            | components["schemas"]["FreehandComment"];
         /** WorkflowInput */
         WorkflowInput: {
             /**
@@ -39366,6 +39689,62 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["StoredWorkflowDetailed"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    update_api_workflows__workflow_id__put: {
+        parameters: {
+            query?: {
+                instance?: boolean | null;
+                /** @description View to be passed to the serializer */
+                view?: string | null;
+                /** @description Comma-separated list of keys to be passed to the serializer */
+                keys?: string | null;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The encoded database identifier of the Stored Workflow. */
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateWorkflowPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Request Error */

--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -119,7 +119,7 @@ export async function undeleteWorkflow(id: string): Promise<WorkflowSummary> {
     return data as WorkflowSummary;
 }
 
-export async function updateWorkflow(id: string, payload: UpdateWorkflowPayload): Promise<WorkflowSummary> {
+export async function updateWorkflow(id: string, payload: UpdateWorkflowPayload) {
     const { data, error } = await GalaxyApi().PUT("/api/workflows/{workflow_id}", {
         params: {
             path: {
@@ -133,7 +133,7 @@ export async function updateWorkflow(id: string, payload: UpdateWorkflowPayload)
         rethrowSimple(error);
     }
 
-    return data as WorkflowSummary;
+    return data;
 }
 
 export function hasCreator(entry?: AnyWorkflow): entry is StoredWorkflowDetailed {

--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -5,6 +5,7 @@ import { GalaxyApi } from "./client";
 
 export type Creator = components["schemas"]["Person"] | components["schemas"]["galaxy__schema__schema__Organization"];
 export type StoredWorkflowDetailed = components["schemas"]["StoredWorkflowDetailed"];
+export type UpdateWorkflowPayload = components["schemas"]["UpdateWorkflowPayload"];
 
 //TODO: replace with generated schema model when available
 export type WorkflowSummary = {
@@ -109,6 +110,23 @@ export async function undeleteWorkflow(id: string): Promise<WorkflowSummary> {
                 workflow_id: id,
             },
         },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data as WorkflowSummary;
+}
+
+export async function updateWorkflow(id: string, payload: UpdateWorkflowPayload): Promise<WorkflowSummary> {
+    const { data, error } = await GalaxyApi().PUT("/api/workflows/{workflow_id}", {
+        params: {
+            path: {
+                workflow_id: id,
+            },
+        },
+        body: payload,
     });
 
     if (error) {

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -1,3 +1,4 @@
+import type { UpdateWorkflowPayload } from "@/api/workflows";
 import reportDefault from "@/components/Workflow/Editor/reportDefault";
 import { useWorkflowCommentStore, type WorkflowComment } from "@/stores/workflowEditorCommentStore";
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
@@ -134,8 +135,9 @@ export async function fromSimple(
     toolbarStore.currentTool = "pointer";
 }
 
-export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "version"> {
-    const steps = workflow.steps;
+export function toSimple(id: string, workflow: Workflow): UpdateWorkflowPayload {
+    // TODO: This is a temporary workaround; we need to use the backend types for `Steps` in the stores.
+    const steps = workflow.steps as any;
     const report = workflow.report;
     const license = workflow.license;
     const creator = workflow.creator;
@@ -146,6 +148,8 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
     const readme = workflow.readme;
     const help = workflow.help;
     const doi = workflow.doi;
+    const update_stored_workflow_attributes = true;
+    const exact_tools = true;
 
     const commentStore = useWorkflowCommentStore(id);
     commentStore.resolveCommentsInFrames();
@@ -153,5 +157,20 @@ export function toSimple(id: string, workflow: Workflow): Omit<Workflow, "versio
 
     const comments = workflow.comments.filter((comment) => !(comment.type === "text" && comment.data.text === ""));
 
-    return { steps, report, license, creator, annotation, name, comments, tags, readme, help, logo_url, doi };
+    return {
+        steps,
+        report,
+        license,
+        creator,
+        annotation,
+        name,
+        comments,
+        tags,
+        readme,
+        help,
+        logo_url,
+        doi,
+        update_stored_workflow_attributes,
+        exact_tools,
+    };
 }

--- a/client/src/components/Workflow/Editor/modules/services.ts
+++ b/client/src/components/Workflow/Editor/modules/services.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { updateWorkflow, type WorkflowSummary } from "@/api/workflows";
+import { updateWorkflow } from "@/api/workflows";
 import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString, rethrowSimple } from "@/utils/simple-error";
 
@@ -57,16 +57,11 @@ export async function loadWorkflow({ id, version = null }: { id: string; version
     }
 }
 
-// TODO: The backend return will be typed as the update response
-type WorkflowSummaryExtended = WorkflowSummary & {
-    version: number;
-    annotation: string;
-};
 export async function saveWorkflow(workflow: Record<string, any>) {
     if (workflow.hasChanges) {
         try {
             const requestData = { ...toSimple(workflow.id, workflow as Workflow), from_tool_form: true };
-            const data = (await updateWorkflow(workflow.id, requestData)) as WorkflowSummaryExtended;
+            const data = await updateWorkflow(workflow.id, requestData);
             workflow.name = data.name;
             workflow.hasChanges = false;
             workflow.stored = true;

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -3,10 +3,10 @@ import { storeToRefs } from "pinia";
 import { computed } from "vue";
 
 import type { WorkflowSummary } from "@/api/workflows";
+import { updateWorkflow } from "@/api/workflows";
 import { useWorkflowCardActions } from "@/components/Workflow/List/useWorkflowCardActions";
 import { useWorkflowCardBadges } from "@/components/Workflow/List/useWorkflowCardBadges";
 import { useWorkflowCardIndicators } from "@/components/Workflow/List/useWorkflowCardIndicators";
-import { updateWorkflow } from "@/components/Workflow/workflows.services";
 import { useUserStore } from "@/stores/userStore";
 
 import GCard from "@/components/Common/GCard.vue";
@@ -65,7 +65,7 @@ const description = computed(() => {
 
 async function onTagsUpdate(tags: string[]) {
     workflow.value.tags = tags;
-    await updateWorkflow(workflow.value.id, { tags });
+    await updateWorkflow(workflow.value.id, { tags, update_stored_workflow_attributes: true, exact_tools: true });
     emit("refreshList", true, true);
 }
 

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -7,9 +7,9 @@ import { filter } from "underscore";
 import { computed, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { loadWorkflows, undeleteWorkflow, type WorkflowSummary } from "@/api/workflows";
+import { loadWorkflows, undeleteWorkflow, updateWorkflow, type WorkflowSummary } from "@/api/workflows";
 import { getWorkflowFilters, helpHtml } from "@/components/Workflow/List/workflowFilters";
-import { deleteWorkflow, updateWorkflow } from "@/components/Workflow/workflows.services";
+import { deleteWorkflow } from "@/components/Workflow/workflows.services";
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { Toast } from "@/composables/toast";
 import { useUserStore } from "@/stores/userStore";
@@ -306,7 +306,11 @@ async function onBulkTagsAdd(tags: string[]) {
         for (const w of selectedWorkflowIds.value) {
             const prevTags = workflowsLoaded.value.find((workflow) => workflow.id === w.id)?.tags || [];
 
-            await updateWorkflow(w.id, { tags: [...new Set([...prevTags, ...tags])] });
+            await updateWorkflow(w.id, {
+                tags: [...new Set([...prevTags, ...tags])],
+                update_stored_workflow_attributes: true,
+                exact_tools: true,
+            });
 
             tmpSelected.splice(
                 tmpSelected.findIndex((s) => s.id === w.id),

--- a/client/src/components/Workflow/List/WorkflowRename.vue
+++ b/client/src/components/Workflow/List/WorkflowRename.vue
@@ -2,7 +2,7 @@
 import { BForm, BFormInput, BModal } from "bootstrap-vue";
 import { ref } from "vue";
 
-import { updateWorkflow } from "@/components/Workflow/workflows.services";
+import { updateWorkflow } from "@/api/workflows";
 import { Toast } from "@/composables/toast";
 import localize from "@/utils/localization";
 
@@ -26,7 +26,7 @@ const workflowNameInput = ref<HTMLInputElement | null>(null);
 
 async function onRename(newName: string) {
     try {
-        await updateWorkflow(props.id, { name: newName });
+        await updateWorkflow(props.id, { name: newName, update_stored_workflow_attributes: true, exact_tools: true });
         Toast.success("Workflow renamed");
     } catch (e) {
         Toast.error("Failed to rename workflow");

--- a/client/src/components/Workflow/List/useWorkflowCardActions.ts
+++ b/client/src/components/Workflow/List/useWorkflowCardActions.ts
@@ -16,13 +16,12 @@ import { storeToRefs } from "pinia";
 import { computed, type Ref } from "vue";
 
 import type { WorkflowSummary } from "@/api/workflows";
-import { undeleteWorkflow } from "@/api/workflows";
+import { undeleteWorkflow, updateWorkflow as updateWorkflowService } from "@/api/workflows";
 import { getFullAppUrl } from "@/app/utils";
 import type { CardAttributes } from "@/components/Common/GCard.types";
 import {
     copyWorkflow as copyWorkflowService,
     deleteWorkflow as deleteWorkflowService,
-    updateWorkflow as updateWorkflowService,
 } from "@/components/Workflow/workflows.services";
 import { useConfirmDialog } from "@/composables/confirmDialog";
 import { useToast } from "@/composables/toast";
@@ -109,6 +108,8 @@ export function useWorkflowCardActions(
         try {
             await updateWorkflowService(workflow.value.id, {
                 show_in_tool_panel: checked,
+                update_stored_workflow_attributes: true,
+                exact_tools: true,
             });
 
             toast.info(`Workflow ${checked ? "added to" : "removed from"} bookmarks`);

--- a/client/src/components/Workflow/workflows.services.ts
+++ b/client/src/components/Workflow/workflows.services.ts
@@ -4,11 +4,6 @@ import type { WorkflowSummary } from "@/api/workflows";
 import { useUserStore } from "@/stores/userStore";
 import { withPrefix } from "@/utils/redirect";
 
-export async function updateWorkflow(id: string, changes: object): Promise<WorkflowSummary> {
-    const { data } = await axios.put(withPrefix(`/api/workflows/${id}`), changes);
-    return data;
-}
-
 export async function copyWorkflow(id: string, currentOwner?: string, version?: string): Promise<WorkflowSummary> {
     let path = `/api/workflows/${id}/download`;
     if (version) {

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -915,8 +915,6 @@ class ModelDeserializer(HasAModelManager[T]):
         Convert an incoming serialized dict into values that can be
         directly assigned to an item's attributes and assign them
         """
-        # TODO: constrain context to current_user/whos_asking when that's all we need (trans)
-        sa_session = self.app.model.context
         new_dict = {}
         for key, val in data.items():
             if key in self.deserializers:
@@ -925,6 +923,8 @@ class ModelDeserializer(HasAModelManager[T]):
 
         # TODO:?? add and flush here or in manager?
         if flush and len(new_dict):
+            # TODO: constrain context to current_user/whos_asking when that's all we need (trans)
+            sa_session = self.app.model.context
             sa_session.add(item)
             sa_session.commit()
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1858,6 +1858,10 @@ class WorkflowContentsManager(UsesAnnotations):
         item["help"] = workflow.help
         item["logo_url"] = workflow.logo_url
         item["doi"] = workflow.doi
+        item["number_of_steps"] = len(workflow.steps)
+        item["show_in_tool_panel"] = False
+        if trans.user is not None:
+            item["show_in_tool_panel"] = stored.show_in_tool_panel(user_id=trans.user.id)
 
         steps = {}
         steps_to_order_index = {}

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -610,6 +610,7 @@ class WorkflowDeserializer(sharable.SharableModelDeserializer, deletable.Deletab
 
     def add_deserializers(self):
         super().add_deserializers()
+        deletable.DeletableDeserializerMixin.add_deserializers(self)
 
         self.deserializers.update(
             {

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2333,6 +2333,11 @@ class StoredWorkflowSummary(Model, WithModelClass):
         title="Owner",
         description="The name of the user who owns this workflow.",
     )
+    latest_workflow_id: Optional[EncodedDatabaseIdField] = Field(
+        None,
+        title="The ID of the latest workflow",
+        description="The encoded ID of the latest version of this workflow.",
+    )
     latest_workflow_uuid: Optional[UUID4] = Field(
         None,
         title="Latest workflow UUID",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2302,7 +2302,7 @@ class StoredWorkflowSummary(Model, WithModelClass):
     name: str = Field(
         ...,
         title="Name",
-        description="The name of the history.",
+        description="The name of the workflow.",
     )
     url: RelativeUrlField
     published: bool = Field(
@@ -2321,7 +2321,7 @@ class StoredWorkflowSummary(Model, WithModelClass):
     deleted: bool = Field(
         ...,
         title="Deleted",
-        description="Whether this item is marked as deleted.",
+        description="Whether this workflow is marked as deleted.",
     )
     hidden: bool = Field(
         ...,

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -229,6 +229,11 @@ WorkflowLicenseField = Field(
     title="License",
     description="SPDX Identifier of the license associated with this workflow.",
 )
+WorklowLogoUrlField = Field(
+    default=None,
+    title="Logo URL",
+    description="A URL to a logo for this workflow.",
+)
 WorkflowReadmeField = Field(
     None,
     title="Readme",
@@ -259,11 +264,7 @@ class UpdateWorkflowPayload(Model):
     )
     importable: Optional[bool] = WorkflowImportableField
     license: Optional[str] = WorkflowLicenseField
-    logo_url: Optional[str] = Field(
-        default=None,
-        title="Logo URL",
-        description="A URL to a logo for this workflow.",
-    )
+    logo_url: Optional[str] = WorklowLogoUrlField
     name: Optional[str] = None
     published: Optional[bool] = None
     readme: Optional[str] = WorkflowReadmeField
@@ -355,6 +356,7 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
     )
     readme: Optional[str] = WorkflowReadmeField
     help: Optional[str] = WorkflowHelpField
+    logo_url: Optional[str] = WorklowLogoUrlField
     slug: Optional[str] = Field(
         ...,
         title="Slug",

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -252,6 +252,11 @@ class UpdateWorkflowPayload(Model):
     doi: Optional[List[str]] = WorkflowDOIField
     help: Optional[str] = WorkflowHelpField
     hidden: Optional[bool] = None
+    deleted: Optional[bool] = Field(
+        default=None,
+        title="Deleted",
+        description="Indicates if the workflow is marked as deleted or not.",
+    )
     importable: Optional[bool] = WorkflowImportableField
     license: Optional[str] = WorkflowLicenseField
     logo_url: Optional[str] = Field(

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -461,10 +461,14 @@ class WorkflowsAPIController(
 
             if "published" in workflow_dict and stored_workflow.published != workflow_dict["published"]:
                 stored_workflow.published = workflow_dict["published"]
+                if stored_workflow.importable is False and stored_workflow.published:
+                    stored_workflow.importable = True
                 require_flush = True
 
             if "importable" in workflow_dict and stored_workflow.importable != workflow_dict["importable"]:
                 stored_workflow.importable = workflow_dict["importable"]
+                if stored_workflow.importable is False and stored_workflow.published:
+                    stored_workflow.published = False
                 require_flush = True
 
             if "annotation" in workflow_dict and not steps_updated:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -845,7 +845,7 @@ class FastAPIWorkflows:
         ),
         instance: InstanceQueryParam = False,
         serialization_params: SerializationParams = Depends(query_serialization_params),
-    ) -> Dict[str, Any]:
+    ) -> StoredWorkflowDetailed:
         return self.service.update(trans, workflow_id, payload, serialization_params, instance or False)
 
     @router.put(

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -975,6 +975,29 @@ steps:
         workflow_dict = self.workflow_populator.download_workflow(workflow["id"])
         assert workflow_dict["name"] == original_name
 
+    def test_update_published_flag_makes_importable(self):
+        # Setting the "published" flag to True also sets the "importable" flag to True.
+
+        # Load a workflow to publish.
+        original_name = "test publish workflow"
+        workflow_object = self.workflow_populator.load_workflow(name=original_name)
+        upload_response = self.__test_upload(workflow=workflow_object, name=original_name)
+        workflow = upload_response.json()
+        assert workflow["published"] is False
+        assert workflow["importable"] is False
+
+        # Publish the workflow.
+        data = {"published": True}
+        update_response = self._update_workflow(workflow["id"], data).json()
+        assert update_response["published"] is True
+        assert update_response["importable"] is True
+
+        # Setting the "importable" flag to False makes a published workflow unpublished.
+        data = {"importable": False}
+        update_response = self._update_workflow(workflow["id"], data).json()
+        assert update_response["published"] is False
+        assert update_response["importable"] is False
+
     @skip_without_tool("select_from_dataset_in_conditional")
     def test_workflow_run_form_with_broken_dataset(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow(


### PR DESCRIPTION
Also Fixes https://github.com/galaxyproject/galaxy/issues/20093

Adds and uses a `WorkflowDeserializer`, except for `steps` and `comments` which are still set via services methods.

## TODO:
- [x] ~Backend doesn't have a serialized return yet.~ _Update: The return is nicely typed now, so maybe we don't need to use the_ `WorkflowSerializer`
- [ ] Improve the backend schema type for `steps` in `UpdateWorkflowPayload`.
- [ ] Improve typing for `Steps` in frontend. It would be great if we can use the backend types everywhere in the step store.
- [ ] Resolve most other TODOs I've added in these changes in general
- [ ] ADD and FIX API tests, good test coverage for this in general

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
