### PR TITLE
[25.0] Prevent importing workflows with invalid step UUID

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1798,6 +1798,8 @@ class WorkflowContentsManager(UsesAnnotations):
             step_dict = supplied_steps[step_index]
             uuid = step_dict.get("uuid", None)
             if uuid and uuid != "None":
+                if not util.is_valid_uuid_v4(uuid):
+                    raise exceptions.ObjectAttributeInvalidException(f"Invalid step UUID '{uuid}' in request.")
                 if uuid in discovered_uuids:
                     raise exceptions.DuplicatedIdentifierException(f"Duplicate step UUID '{uuid}' in request.")
                 discovered_uuids.add(uuid)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1799,7 +1799,7 @@ class WorkflowContentsManager(UsesAnnotations):
             uuid = step_dict.get("uuid", None)
             if uuid and uuid != "None":
                 if not util.is_valid_uuid_v4(uuid):
-                    raise exceptions.ObjectAttributeInvalidException(f"Invalid step UUID '{uuid}' in request.")
+                    raise exceptions.ObjectAttributeInvalidException(f"Invalid step UUID4 '{uuid}' in request.")
                 if uuid in discovered_uuids:
                     raise exceptions.DuplicatedIdentifierException(f"Duplicate step UUID '{uuid}' in request.")
                 discovered_uuids.add(uuid)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -24,6 +24,7 @@ import textwrap
 import threading
 import time
 import unicodedata
+import uuid
 import xml.dom.minidom
 from datetime import (
     datetime,
@@ -241,6 +242,15 @@ def is_uuid(value):
     if re.match(uuid_re, str(value)):
         return True
     else:
+        return False
+
+
+def is_valid_uuid_v4(uuid_str: str) -> bool:
+    """Check if a string is a valid UUID v4."""
+    try:
+        u = uuid.UUID(uuid_str)
+        return u.version == 4
+    except ValueError:
         return False
 
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1134,6 +1134,16 @@ steps:
         response = self.workflow_populator.create_workflow_response(workflow_dup_uuids)
         self._assert_status_code_is(response, 400)
 
+    def test_require_step_valid_v4_uuids(self):
+        workflow_invalid_uuid = self.workflow_populator.load_workflow(name="test_import")
+        first_step = next(iter(workflow_invalid_uuid["steps"].values()), None)
+        if first_step is None:
+            raise AssertionError("No steps found in the workflow, cannot test invalid UUIDs.")
+        # Set the first step's uuid to a v1 uuid, which is not valid.
+        first_step["uuid"] = "00000000-0000-1000-8000-000000000000"
+        response = self.workflow_populator.create_workflow_response(workflow_invalid_uuid)
+        self._assert_status_code_is(response, 400)
+
     def test_require_unique_step_labels(self):
         workflow_dup_label = self.workflow_populator.load_workflow(name="test_import")
         for step_dict in workflow_dup_label["steps"].values():

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1136,9 +1136,7 @@ steps:
 
     def test_require_step_valid_v4_uuids(self):
         workflow_invalid_uuid = self.workflow_populator.load_workflow(name="test_import")
-        first_step = next(iter(workflow_invalid_uuid["steps"].values()), None)
-        if first_step is None:
-            raise AssertionError("No steps found in the workflow, cannot test invalid UUIDs.")
+        first_step = next(iter(workflow_invalid_uuid["steps"].values()))
         # Set the first step's uuid to a v1 uuid, which is not valid.
         first_step["uuid"] = "00000000-0000-1000-8000-000000000000"
         response = self.workflow_populator.create_workflow_response(workflow_invalid_uuid)


### PR DESCRIPTION
Prevents and closes #20506

This checks that the workflow step UUID is not only a valid UUID but also uses the correct version (v4).

Before you could import workflows with steps using UUIDv1, which later could not be serialized because the schema expects UUIDv4 for the steps.

![image](https://github.com/user-attachments/assets/c7c9a9ee-410b-427d-be43-0cc5ac637e21)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
