### PR TITLE
[24.1] Do not set attribute on a namedtuple

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1350,7 +1350,11 @@ class DistributedObjectStore(NestedObjectStore):
                     log.warning(
                         f"{obj.__class__.__name__} object with ID {obj.id} found in backend object store with ID {id}"
                     )
-                    obj.object_store_id = id
+                    try:
+                        obj.object_store_id = id
+                    except AttributeError:
+                        # obj is likely a namedtuple (/scripts/cleanup_datasets/pgcleanup.py::RemovesDatasets)
+                        log.info("Unable to set object_store_id on a readonly dataset object: %s", obj)
                     return id
         return None
 


### PR DESCRIPTION
This line can be reached when executing the `pgcleanup.py` script, in which case `obj` is an instance of `namedtuple`, which is immutable, so an error is raised:

```
2025-07-03 16:04:01,885 WARNING __get_store_id_for(): Dataset object with ID 1 found in backend object store with ID legacy
2025-07-03 16:04:01,885 ERROR <module>(): Caught exception in run sequence:
Traceback (most recent call last):
  File "/home/john/0dev/galaxy/_galaxy/t/dev/./scripts/cleanup_datasets/pgcleanup.py", line 1392, in <module>
    app.run()
 ...
  File "/home/john/0dev/galaxy/_galaxy/t/dev/lib/galaxy/objectstore/__init__.py", line 1614, in __get_store_id_for
    obj.object_store_id = id
    ^^^^^^^^^^^^^^^^^^^
AttributeError: can't set attribute
```

There is no clean way that I know of to check if an object is an instance of a namedtuple, so we just log a message on error.

The initial modification was made in #13764.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
