### PR TITLE
Improve docs for `invalidjobexception_state` and `_retry` of DRMAA runners

### DIFF
--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -4,17 +4,20 @@ runners:
     workers: 4
   drmaa:
     load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
-    # Different DRMs (SLURM, condor, SGE, univa, ...) handle successfully completed jobs differently.
-    # That is they may raise an InternalException or InvalidJobException when querying a finished job.
+    # Configuration of a Distributed Resource Manager (DRM) compatible with the
+    # Distributed Resource Management Application API (DRMAA), e.g. Slurm,
+    # HTCondor, Oracle Grid Engine (a.k.a. SGE), Altair Grid Engine (a.k.a. Univa).
+    # Different DRMs handle successfully completed jobs differently.
+    # For example they may raise an InternalException or InvalidJobException when querying a finished job.
     # The following options allow to configure if Galaxy should consider the jobs as OK or in error in such a case.
     #
-    # For setting up a DRMAA runner it may be advisable to test with the state set to error and use ok
+    # For setting up a DRMAA runner it may be advisable to test with the state set to "error" and use "ok"
     # only if all (including successfull jobs) fail with one of the two exceptions.
     # 
     # In case these exceptions may occur transiently a number of retries can be configured.
     # 
     # Defaults are shown below. 
-    # Possible values for the states are ok and error.
+    # Possible values for the states are "ok" and "error".
     invalidjobexception_state: ok
     invalidjobexception_retries: 0
     internalexception_state: ok

--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -4,10 +4,17 @@ runners:
     workers: 4
   drmaa:
     load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
-
-    # Different DRMs handle successfully completed jobs differently,
-    # these options can be changed to handle such differences.
-    # Defaults are shown:
+    # Different DRMs (SLURM, condor, SGE, univa, ...) handle successfully completed jobs differently.
+    # That is they may raise an InternalException or InvalidJobException when querying a finished job.
+    # The following options allow to configure if Galaxy should consider the jobs as OK or in error in such a case.
+    #
+    # For setting up a DRMAA runner it may be advisable to test with the state set to error and use ok
+    # only if all (including successfull jobs) fail with one of the two exceptions.
+    # 
+    # In case these exceptions may occur transiently a number of retries can be configured.
+    # 
+    # Defaults are shown below. 
+    # Possible values for the states are ok and error.
     invalidjobexception_state: ok
     invalidjobexception_retries: 0
     internalexception_state: ok


### PR DESCRIPTION
IMO error would be a much better default, but I'm fine with just adding docs. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
