### PR TITLE
Improve BreadcrumbHeading and add unit tests

### DIFF
--- a/client/src/components/Common/BreadcrumbHeading.test.ts
+++ b/client/src/components/Common/BreadcrumbHeading.test.ts
@@ -1,0 +1,116 @@
+import { getLocalVue } from "@tests/jest/helpers";
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { nextTick } from "vue";
+import VueRouter from "vue-router";
+
+import type { BreadcrumbItem } from "@/components/Common/index";
+
+import BreadcrumbHeading from "./BreadcrumbHeading.vue";
+
+const ACTIVE_CLASS = ".breadcrumb-heading-header-active";
+const INACTIVE_CLASS = ".breadcrumb-heading-header-inactive";
+const BETA_CLASS = ".breadcrumb-heading-header-beta";
+
+const localVue = getLocalVue();
+
+localVue.use(VueRouter);
+
+async function mountComponent(items: BreadcrumbItem[] = [], routePath: string = "/home", slotContent: string = "") {
+    const router = new VueRouter();
+
+    router.push(routePath);
+
+    const wrapper = mount(BreadcrumbHeading as object, {
+        localVue,
+        router,
+        propsData: {
+            items,
+        },
+        slots: {
+            default: slotContent,
+        },
+    });
+
+    await flushPromises();
+
+    return wrapper;
+}
+
+describe("BreadcrumbHeading.vue", () => {
+    it("renders a single breadcrumb item without link when no 'to' property", async () => {
+        const items = [{ title: "Home" }];
+
+        const wrapper = await mountComponent(items);
+
+        expect(wrapper.find(INACTIVE_CLASS).text()).toBe(items[0]?.title);
+        expect(wrapper.findAll("a")).toHaveLength(0);
+    });
+
+    it("renders a single breadcrumb item as inactive when current route matches and without separator", async () => {
+        const items = [{ title: "Home", to: "/home" }];
+
+        const wrapper = await mountComponent(items);
+
+        expect(wrapper.find(INACTIVE_CLASS).text()).toBe(items[0]?.title);
+        expect(wrapper.findAll("a")).toHaveLength(0);
+
+        const wrapperContent = wrapper.text();
+
+        expect(wrapperContent).not.toContain(" / ");
+    });
+
+    it("renders a single breadcrumb item as link when not on current route", async () => {
+        const items = [{ title: "Test Title", to: "/test" }];
+
+        const wrapper = await mountComponent(items, "/different-route");
+
+        await flushPromises();
+        await nextTick();
+
+        const link = wrapper.find("a");
+
+        expect(link.exists()).toBe(true);
+        expect(link.text()).toBe(items[0]?.title);
+        expect(link.classes()).toContain(ACTIVE_CLASS.replace(".", ""));
+    });
+
+    it("renders multiple breadcrumb items with separators", async () => {
+        const items = [
+            { title: "Home", to: "/" },
+            { title: "Test Title", to: "/test" },
+            { title: "Current Page", to: "/current" },
+        ];
+
+        const wrapper = await mountComponent(items, "/current");
+
+        const links = wrapper.findAll("a");
+        expect(links).toHaveLength(2);
+
+        expect(wrapper.find(INACTIVE_CLASS).text()).toBe(items[2]?.title);
+
+        const wrapperContent = wrapper.text();
+        const separatorCount = (wrapperContent.match(/ \/ /g) || []).length;
+
+        expect(separatorCount).toBe(2);
+    });
+
+    it("renders superText when provided", async () => {
+        const items = [{ title: "Beta Feature", superText: "BETA" }];
+        const wrapper = await mountComponent(items);
+
+        const superText = wrapper.find(BETA_CLASS);
+
+        expect(superText.exists()).toBe(true);
+        expect(superText.text()).toBe("BETA");
+    });
+
+    it("renders slot content", async () => {
+        const items = [{ title: "Home" }];
+        const slotContent = '<div class="test-slot">Additional content</div>';
+
+        const wrapper = await mountComponent(items, "/home", slotContent);
+
+        expect(wrapper.html()).toContain("Additional content");
+    });
+});

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import { BLink } from "bootstrap-vue";
 import type { RawLocation } from "vue-router";
-import { RouterLink } from "vue-router";
 import { useRouter } from "vue-router/composables";
 
 import type { BreadcrumbItem } from "@/components/Common/index";
@@ -26,7 +26,7 @@ function isPathActive(path: RawLocation): boolean {
     <div class="breadcrumb-heading mb-2">
         <Heading h1 separator inline size="lg" class="breadcrumb-heading-header mr-2 mb-0">
             <template v-for="(item, index) in props.items">
-                <RouterLink
+                <BLink
                     v-if="item.to && !isPathActive(item.to)"
                     :key="index"
                     v-b-tooltip.hover.bottom.noninteractive
@@ -34,7 +34,7 @@ function isPathActive(path: RawLocation): boolean {
                     :to="item.to"
                     class="breadcrumb-heading-header-active">
                     {{ localize(item.title) }}
-                </RouterLink>
+                </BLink>
                 <span v-else :key="'else-' + index" class="breadcrumb-heading-header-inactive">
                     {{ localize(item.title) }}
                 </span>

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import type { RawLocation } from "vue-router";
 import { RouterLink } from "vue-router";
+import { useRouter } from "vue-router/composables";
 
 import type { BreadcrumbItem } from "@/components/Common/index";
 import localize from "@/utils/localization";
@@ -7,10 +9,17 @@ import localize from "@/utils/localization";
 import Heading from "@/components/Common/Heading.vue";
 
 interface Props {
+    /** Array of items to display in the breadcrumb */
     items: BreadcrumbItem[];
 }
 
 const props = defineProps<Props>();
+
+const router = useRouter();
+
+function isPathActive(path: RawLocation): boolean {
+    return router.currentRoute.path === router.resolve(path).route.path;
+}
 </script>
 
 <template>
@@ -18,7 +27,7 @@ const props = defineProps<Props>();
         <Heading h1 separator inline size="lg" class="breadcrumb-heading-header mr-2 mb-0">
             <template v-for="(item, index) in props.items">
                 <RouterLink
-                    v-if="item.to"
+                    v-if="item.to && !isPathActive(item.to)"
                     :key="index"
                     v-b-tooltip.hover.bottom.noninteractive
                     :title="`Go back to ${localize(item.title)}`"

--- a/client/src/components/Common/index.ts
+++ b/client/src/components/Common/index.ts
@@ -3,8 +3,20 @@ import type { RawLocation } from "vue-router";
 // TODO: Not sure if this is the best place for this type
 export type ColorVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "light" | "dark";
 
+/**
+ * Represents a breadcrumb item in the BreadcrumbHeading component.
+ * Each item can have a title, an optional URL to navigate to, and optional additional text
+ * displayed alongside the item.
+ */
 export interface BreadcrumbItem {
+    /** The display text for the breadcrumb item */
     title: string;
+    /** Optional The URL or route to navigate to when the breadcrumb item is clicked.
+     * the item will not be clickable if this is not provided or the current route matches this location.
+     */
     to?: RawLocation;
+    /**
+     * Optional additional text displayed above the item.
+     */
     superText?: string;
 }


### PR DESCRIPTION
This PR enhances BreadcrumbHeading navigation by adding a check for the active path when the `to` property for an item is provided, preventing clicks on the current route, and updates the `BreadcrumbItem` type documentation for clarity on its properties. It also includes unit tests.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
