### PR TITLE
  Remove vue-tsc diff comparison from CI

### DIFF
--- a/.github/workflows/js_lint.yaml
+++ b/.github/workflows/js_lint.yaml
@@ -35,45 +35,6 @@ jobs:
       - name: Run prettier checks
         run: yarn run format-check
         working-directory: client
-      # Run vue-tsc, compare with base, only fail if errors increased.
-      - name: Run vue-tsc on PR
-        id: current
+      - name: Run vue-tsc
         working-directory: client
-        run: |
-          # Run vue-tsc in a simulated TTY to capture the summary output.
-          script -q -c 'npx vue-tsc --noEmit' current.log 
-          # Extract the error count from the summary line; default to 0 if not found.
-          CURRENT_ERRORS=$(grep -oE 'Found [0-9]+ errors' current.log | head -1 | grep -oE '[0-9]+' || echo 0)
-          echo "Current vue-tsc errors: $CURRENT_ERRORS"
-          echo "current_errors=$CURRENT_ERRORS" >> $GITHUB_OUTPUT
-      # Check out the target base branch into a separate directory called "base".
-      - name: Checkout target base branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-      - run: yarn install --frozen-lockfile
-        working-directory: client
-      # Run vue-tsc on the base branch and capture its error count.
-      - name: Run vue-tsc on base branch
-        id: baseline
-        working-directory: client
-        run: |
-          # Run vue-tsc in a simulated TTY and save the output to baseline.log.
-          script -q -c 'npx vue-tsc --noEmit' baseline.log 
-          # Extract the error count from the summary line; default to 0 if not found.
-          BASE_ERRORS=$(grep -oE 'Found [0-9]+ errors' baseline.log | head -1 | grep -oE '[0-9]+' || echo 0)
-          echo "Baseline vue-tsc errors: $BASE_ERRORS"
-          echo "baseline_errors=$BASE_ERRORS" >> $GITHUB_OUTPUT
-      # Compare the error counts between the PR branch and the base branch.
-      - name: Compare vue-tsc error counts
-        run: |
-          CURRENT=${{ steps.current.outputs.current_errors }}
-          BASE=${{ steps.baseline.outputs.baseline_errors }}
-          echo "Current errors: ${CURRENT}"
-          echo "Baseline errors: ${BASE}"
-          if [ "$CURRENT" -gt "$BASE" ]; then
-            echo "vue-tsc error count increased from ${BASE} to ${CURRENT}. Failing the build."
-            exit 1
-          else
-            echo "vue-tsc error count did not increase."
-          fi
+        run: npx vue-tsc --noEmit

--- a/client/src/components/Collections/common/CollectionNameInput.vue
+++ b/client/src/components/Collections/common/CollectionNameInput.vue
@@ -28,6 +28,10 @@ watch(
 watch(name, (newValue) => {
     emit("input", newValue);
 });
+
+function updateName(v: string) {
+    name.value = v;
+}
 </script>
 
 <template>
@@ -43,6 +47,6 @@ watch(name, (newValue) => {
             size="sm"
             required
             :state="!name ? false : null"
-            @update="(v) => (name = v)" />
+            @update="updateName" />
     </BFormGroup>
 </template>

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -40,7 +40,7 @@ const showError = computed(() => {
     return props.item.state === "error" || props.item.state === "failed_metadata";
 });
 const showInfo = computed(() => {
-    return props.item.state !== "noPermission";
+    return props.item.accessible;
 });
 const showVisualizations = computed(() => {
     return !props.item.purged && ["ok", "failed_metadata", "error"].includes(props.item.state);

--- a/client/src/components/Workflow/Editor/NodeInspector.vue
+++ b/client/src/components/Workflow/Editor/NodeInspector.vue
@@ -48,6 +48,10 @@ function close() {
     inspectorStore.generalMaximized = false;
     emit("close");
 }
+
+function updateStored(v: boolean) {
+    inspectorStore.setStored(props.step, v);
+}
 </script>
 
 <template>
@@ -92,7 +96,7 @@ function close() {
                     <BDropdownForm form-class="px-2" title="remember size for all steps using this tool">
                         <BFormCheckbox
                             :checked="inspectorStore.isStored(props.step)"
-                            @input="(v) => inspectorStore.setStored(props.step, v)">
+                            @input="updateStored">
                             remember size
                         </BFormCheckbox>
                     </BDropdownForm>

--- a/client/src/components/Workflow/Editor/NodeInspector.vue
+++ b/client/src/components/Workflow/Editor/NodeInspector.vue
@@ -94,9 +94,7 @@ function updateStored(v: boolean) {
                     </template>
 
                     <BDropdownForm form-class="px-2" title="remember size for all steps using this tool">
-                        <BFormCheckbox
-                            :checked="inspectorStore.isStored(props.step)"
-                            @input="updateStored">
+                        <BFormCheckbox :checked="inspectorStore.isStored(props.step)" @input="updateStored">
                             remember size
                         </BFormCheckbox>
                     </BDropdownForm>

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -272,6 +272,10 @@ function onStorageUpdate(objectStoreId: string, intermediate: boolean) {
     }
 }
 
+function updateActiveNodeId(nodeId: number | null) {
+    activeNodeId.value = nodeId;
+}
+
 async function onExecute() {
     waitingForRequest.value = true;
 
@@ -463,7 +467,7 @@ async function onExecute() {
                             @onChange="onChange"
                             @onValidation="onValidation"
                             @stop-flagging="checkInputMatching = false"
-                            @update:active-node-id="($event) => (activeNodeId = $event)" />
+                            @update:active-node-id="updateActiveNodeId" />
                     </BOverlay>
                 </div>
                 <div v-if="showRightPanel" class="h-100 w-50 d-flex flex-shrink-0">


### PR DESCRIPTION
(note: this will fail, but I'll address the issues in this branch)

  Now that we've fixed most TypeScript errors, switch to failing on any
  vue-tsc errors instead of comparing against baseline. This simplifies
  the workflow and ensures we maintain zero TypeScript errors going
  forward.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
