### PR TITLE
Add MobilIon and mzMLb datatypes

### DIFF
--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -16,11 +16,11 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-22.04  # Python 3.7 is not available via setup-python on ubuntu >=24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']  # don't upgrade, see https://github.com/galaxyproject/galaxy/pull/16649
+        python-version: ['3.8']  # don't upgrade, see https://github.com/galaxyproject/galaxy/pull/16649
     steps:
       - uses: actions/checkout@v4
         with:

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -235,6 +235,8 @@
     <datatype extension="h5mu" type="galaxy.datatypes.binary:H5" mimetype="application/octet-stream" display_in_upload="true" subclass="true" description="MuData is a format analogous to Anndata for multimodal datasets and is based on HDF5" description_url="https://github.com/scverse/mudata"/>
     <datatype extension="visium.tar.gz" type="galaxy.datatypes.binary:Visium" subclass="true" display_in_upload="true" description="Visium is a tar.gz archive with at least a 'Spatial' subfolder, a filtered h5 file and a raw h5 file." />
     <datatype extension="mz5" type="galaxy.datatypes.binary:H5" subclass="true" mimetype="application/octet-stream" display_in_upload="true"/>
+    <datatype extension="mzmlb" type="galaxy.datatypes.binary:H5" subclass="true" mimetype="application/octet-stream" display_in_upload="true"/>
+    <datatype extension="mbi" type="galaxy.datatypes.binary:H5" subclass="true" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="hyphy_results.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="false"/>
     <datatype extension="hivtrace" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="false"/>
     <datatype extension="cool" type="galaxy.datatypes.binary:Cool" mimetype="application/octet-stream" display_in_upload="true"/>

--- a/packages/job_metrics/setup.cfg
+++ b/packages/job_metrics/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -37,7 +36,7 @@ install_requires =
     galaxy-util
     backports.zoneinfo;python_version<'3.9'
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 exclude =

--- a/packages/objectstore/setup.cfg
+++ b/packages/objectstore/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +37,7 @@ install_requires =
     pydantic>=2,!=2.6.0,!=2.6.1
     PyYAML
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 exclude =

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -46,7 +45,7 @@ install_requires =
     sortedcontainers
     typing-extensions
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =

--- a/packages/tool_util_models/setup.cfg
+++ b/packages/tool_util_models/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -37,7 +36,7 @@ install_requires =
     pydantic>=2,!=2.6.0,!=2.6.1
     typing-extensions
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -46,7 +45,7 @@ install_requires =
     typing-extensions
     zipstream-new
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 image-util =


### PR DESCRIPTION
mzMLb is an open format for MS data based on HDF5. It has better ion mobility support than mz5.

MBI is a "proprietary" HDF5 format from MobilIon for storing their ion mobility data. ProteoWizard added support for reading it last year.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. I need these datatypes to update and add automated tests for a toolshed tool in another repository's PR.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
