### PR TITLE
[25.0] Fix bug: tool output file may be overwritten by Runner's multi work t…

### DIFF
--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -288,9 +288,9 @@ class JobIO(UsesDictVisibleKeys):
         job_outputs = []
         for da in job.output_datasets + job.output_library_datasets:
             da_false_path = dataset_path_rewriter.rewrite_dataset_path(da.dataset, "output")
-            if da_false_path:
-                with open(da_false_path, "wb"):
-                    pass
+            #if da_false_path:
+            #    with open(da_false_path, "wb"):
+            #        pass
             mutable = da.dataset.dataset.external_filename is None
             dataset_path = DatasetPath(
                 da.dataset.dataset.id,

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -288,9 +288,9 @@ class JobIO(UsesDictVisibleKeys):
         job_outputs = []
         for da in job.output_datasets + job.output_library_datasets:
             da_false_path = dataset_path_rewriter.rewrite_dataset_path(da.dataset, "output")
-            #if da_false_path:
-            #    with open(da_false_path, "wb"):
-            #        pass
+            if da_false_path and not os.path.exists(da_false_path):
+                with open(da_false_path, "ab"):
+                    pass
             mutable = da.dataset.dataset.external_filename is None
             dataset_path = DatasetPath(
                 da.dataset.dataset.id,


### PR DESCRIPTION
## What is the bug?

After a tool successful execution, sometimes the result file contains content while other times it remains empty.

![image](https://github.com/user-attachments/assets/5654b529-33f1-407e-9015-16abe1602512)

When performing batch runs on a collection of items, some files in the result list may be empty while others contain data.

![image](https://github.com/user-attachments/assets/126d5067-3436-4a62-9fe8-a9e38fba1fe8)

**This scenario only occurs with the asynchronous runner, while the local runner does not exhibit this behavior.**


## Why does this happen?

lib/galaxy/job_execution/setup.py
```python
class JobOutputs(threading.local):
    def __init__(self) -> None:
        super().__init__()
        self.output_hdas_and_paths: Optional[OutputHdasAndType] = None
        self.output_paths: Optional[OutputPaths] = None

    @property
    def populated(self) -> bool:
        return self.output_hdas_and_paths is not None

    def set_job_outputs(self, job_outputs: List[JobOutput]) -> None:
        self.output_paths = [t[2] for t in job_outputs]
        self.output_hdas_and_paths = {t.output_name: (t.dataset, t.dataset_path) for t in job_outputs}
```

`The class JobOutputs inherits from threading.local, indicating that it is a thread-safe class.`

Internally, Galaxy accesses JobOutputs through the class JobIO, for example:

lib/galaxy/job_execution/setup.py
```python
class JobIO(UsesDictVisibleKeys):
    def __init__(
        ...

        self.job_outputs = JobOutputs()

    @property
    def output_paths(self) -> OutputPaths:
        if not self.job_outputs.populated:
            self.compute_outputs()
        return cast(OutputPaths, self.job_outputs.output_paths)

    @property
    def output_hdas_and_paths(self) -> OutputHdasAndType:
        if not self.job_outputs.populated:
            self.compute_outputs()
        return cast(OutputHdasAndType, self.job_outputs.output_hdas_and_paths)
```

The job_outputs member variable of JobIO, is a instance of JobOutputs。

During task execution, when different threads access self.job_outputs, it triggers a new instantiation of JobOutputs. This means each thread maintains its own independent self.job_outputs instance. Upon instantiation, the member variable populated in JobOutputs is initialized to False. In this state, any calls to JobIO.output_paths or JobIO.output_hdas_and_paths will invoke a new JobIO.compute_outputs() operation.

lib/galaxy/job_execution/setup.py
```python
class JobIO(UsesDictVisibleKeys):

    ...

    def compute_outputs(self) -> None:
        dataset_path_rewriter = self.dataset_path_rewriter

        job = self.job
        # Job output datasets are combination of history, library, and jeha datasets.
        special = self.sa_session.query(JobExportHistoryArchive).filter_by(job=job).first()
        false_path = None

        job_outputs = []
        for da in job.output_datasets + job.output_library_datasets:
            da_false_path = dataset_path_rewriter.rewrite_dataset_path(da.dataset, "output")
            if da_false_path:
                with open(da_false_path, "wb"):
                    pass
            mutable = da.dataset.dataset.external_filename is None
            dataset_path = DatasetPath(
                da.dataset.dataset.id,
                da.dataset.get_file_name(sync_cache=False),
                false_path=da_false_path,
                mutable=mutable,
            )
            job_outputs.append(JobOutput(da.name, da.dataset, dataset_path))

        if special:
            false_path = dataset_path_rewriter.rewrite_dataset_path(special, "output")
            dsp = DatasetPath(special.dataset.id, special.dataset.get_file_name(), false_path)
            job_outputs.append(JobOutput("output_file", special.fda, dsp))

        self.job_outputs.set_job_outputs(job_outputs)
```

We can see that:
```python
if da_false_path:
    with open(da_false_path, "wb"):
        pass
```

When the application sets `outputs_to_working_directory: true` in config file galaxy.yml，the da_false_path will not None。

So，the output content (in da_false_path, such as job_work_dir/outputs/dataset_633b3d48-9d5b-416d-91c3-f9dd66d30e52.dat)，will be overwritten。

## Solution

### solution 1: Remove these redundant code lines.
```python
if da_false_path:
    with open(da_false_path, "wb"):
        pass
```

### solution 2: Set outputs_to_working_directory: false in galaxy.yml

### solution 3:  Use 1 worker for AsynchronousJobRunner

Finally，we should remove the redundant code，and set outputs_to_working_directory: false in galaxy.yml.

One more thing，Do we really need a thread-local JobOutputs implementation?

### 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
