### PR TITLE
Update location of latest tpv shared db

### DIFF
--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -817,7 +817,7 @@ execution:
       function: map_tool_to_destination
       rules_module: tpv.rules
       tpv_config_files:
-        - https://gxy.io/tpv/db.yml
+        - https://gxy.io/tpv/db-latest.yml
         # - config/tpv_rules_local.yml
 
     docker_dispatch:


### PR DESCRIPTION
Depends on: https://github.com/galaxyproject/gxy.io/pull/81

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
