### PR TITLE
[24.2] Fix empty default Optionals for tool_shed_repositories API.

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11807,12 +11807,12 @@ export interface components {
              * Latest installed revision
              * @description Most recent version available on the tool shed
              */
-            latest_installable_revision: string | null;
+            latest_installable_revision?: string | null;
             /**
              * Repository deprecated
              * @description Repository has been depreciated on the tool shed
              */
-            repository_deprecated: string | null;
+            repository_deprecated?: string | null;
             /** Revision Update */
             revision_update: string;
             /** Revision Upgrade */
@@ -11875,7 +11875,7 @@ export interface components {
              */
             tool_shed: string;
             /** Latest updated status from the tool shed */
-            tool_shed_status: components["schemas"]["InstalledRepositoryToolShedStatus"] | null;
+            tool_shed_status?: components["schemas"]["InstalledRepositoryToolShedStatus"] | null;
             /** Uninstalled */
             uninstalled: boolean;
         };

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2755,12 +2755,12 @@ class InstalledRepositoryToolShedStatus(Model):
     # See https://github.com/galaxyproject/galaxy/issues/10453 , bad booleans
     # See https://github.com/galaxyproject/galaxy/issues/16135 , optional fields
     latest_installable_revision: Optional[str] = Field(
-        title="Latest installed revision", description="Most recent version available on the tool shed"
+        None, title="Latest installed revision", description="Most recent version available on the tool shed"
     )
     revision_update: str
     revision_upgrade: Optional[str] = None
     repository_deprecated: Optional[str] = Field(
-        title="Repository deprecated", description="Repository has been depreciated on the tool shed"
+        None, title="Repository deprecated", description="Repository has been depreciated on the tool shed"
     )
 
 
@@ -2792,7 +2792,7 @@ class InstalledToolShedRepository(Model, WithModelClass):
         title="Changeset revision", description="Changeset revision of the repository - a mercurial commit hash"
     )
     tool_shed_status: Optional[InstalledRepositoryToolShedStatus] = Field(
-        title="Latest updated status from the tool shed"
+        None, title="Latest updated status from the tool shed"
     )
 
 


### PR DESCRIPTION
It looks like it should fix https://github.com/galaxyproject/galaxy/issues/20641.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. ???

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
