### PR TITLE
Removes `entries` from purged filter label in history grid

### DIFF
--- a/client/src/components/Grid/configs/histories.ts
+++ b/client/src/components/Grid/configs/histories.ts
@@ -333,7 +333,7 @@ const validFilters: Record<string, ValidFilter<string | boolean | undefined>> = 
         menuItem: true,
     },
     purged: {
-        placeholder: "Purged entries",
+        placeholder: "Purged",
         type: Boolean,
         boolType: "is",
         handler: equals("purged", "purged", toBool),


### PR DESCRIPTION
This PR remove the `entries` term from the purged history list filter checkbox label for consistency.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
