### PR TITLE
[25.0] Add `num_unique_values` tiff metadata element, fixed

### DIFF
--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -5,6 +5,7 @@ Image classes
 import base64
 import json
 import logging
+import math
 import struct
 from typing import (
     Any,
@@ -368,7 +369,8 @@ class Tiff(Image):
             if mmap_chunk_size > len(arr_flat):
                 yield arr_flat
             else:
-                yield from np.array_split(arr_flat, mmap_chunk_size)
+                chunks_count = math.ceil(len(arr_flat) / mmap_chunk_size)
+                yield from np.array_split(arr_flat, chunks_count)
 
     @staticmethod
     def _read_segments(page: Union[tifffile.TiffPage, tifffile.TiffFrame]) -> Iterator["np.typing.NDArray"]:

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -85,6 +85,14 @@ class Image(data.Data):
     )
 
     MetadataElement(
+        name="num_unique_values",
+        desc="Number of unique values in the image data (e.g., should be 2 for binary images)",
+        readonly=True,
+        visible=True,
+        optional=True,
+    )
+
+    MetadataElement(
         name="width",
         desc="Width of the image (in pixels)",
         readonly=True,
@@ -263,6 +271,7 @@ class Tiff(Image):
                         "channels",
                         "depth",
                         "frames",
+                        "num_unique_values",
                     ]
                 }
 
@@ -279,6 +288,9 @@ class Tiff(Image):
                     metadata["channels"].append(Tiff._get_axis_size(series.shape, axes, "C"))
                     metadata["depth"].append(Tiff._get_axis_size(series.shape, axes, "Z"))
                     metadata["frames"].append(Tiff._get_axis_size(series.shape, axes, "T"))
+
+                    # Determine the metadata values that require reading the image data
+                    metadata["num_unique_values"].append(Tiff._get_num_unique_values(series))
 
                 # Populate the metadata fields based on the values determined above
                 for key, values in metadata.items():

--- a/test/unit/data/datatypes/test_images.py
+++ b/test/unit/data/datatypes/test_images.py
@@ -52,6 +52,7 @@ def __assert_empty_metadata(metadata):
     for key in (
         "axes",
         "dtype",
+        "num_unique_values",
         "width",
         "height",
         "channels",
@@ -68,6 +69,8 @@ test_tiff_axes_zcyx = __create_test(Tiff, "im6_uint8.tif", "axes", "ZCYX")
 test_tiff_dtype_uint8 = __create_test(Tiff, "im6_uint8.tif", "dtype", "uint8")
 test_tiff_dtype_uint16 = __create_test(Tiff, "im8_uint16.tif", "dtype", "uint16")
 test_tiff_dtype_float64 = __create_test(Tiff, "im4_float.tif", "dtype", "float64")
+test_tiff_num_unique_values_2 = __create_test(Tiff, "im3_b.tif", "num_unique_values", 2)
+test_tiff_num_unique_values_618 = __create_test(Tiff, "im4_float.tif", "num_unique_values", 618)
 test_tiff_width_16 = __create_test(Tiff, "im7_uint8.tif", "width", 16)  # axes: ZYX
 test_tiff_width_32 = __create_test(Tiff, "im3_b.tif", "width", 32)  # axes: YXS
 test_tiff_height_8 = __create_test(Tiff, "im7_uint8.tif", "height", 8)  # axes: ZYX
@@ -97,11 +100,15 @@ def test_tiff_unsupported_compression(metadata):
     assert metadata.depth == 0
     assert metadata.frames == 0
 
+    # The other fields should be missing
+    assert getattr(metadata, "num_unique_values", None) is None
+
 
 @__test(Tiff, "im9_multiseries.tif")
 def test_tiff_multiseries(metadata):
     assert metadata.axes == ["YXS", "YX"]
     assert metadata.dtype == ["uint8", "uint16"]
+    assert metadata.num_unique_values == [2, 255]
     assert metadata.width == [32, 256]
     assert metadata.height == [32, 256]
     assert metadata.channels == [3, 0]
@@ -114,6 +121,8 @@ def test_tiff_multiseries(metadata):
 test_png_axes_yx = __create_test(Image, "im1_uint8.png", "axes", "YX")
 test_png_axes_yxc = __create_test(Image, "im3_a.png", "axes", "YXC")
 test_png_dtype_uint8 = __create_test(Image, "im1_uint8.png", "dtype", "uint8")
+test_png_num_unique_values_1 = __create_test(Image, "im2_a.png", "num_unique_values", None)
+test_png_num_unique_values_2 = __create_test(Image, "im2_b.png", "num_unique_values", None)
 test_png_width_32 = __create_test(Image, "im2_b.png", "width", 32)
 test_png_height_32 = __create_test(Image, "im2_b.png", "height", 32)
 test_png_channels_0 = __create_test(Image, "im1_uint8.png", "channels", 0)


### PR DESCRIPTION
This was originally added in https://github.com/galaxyproject/galaxy/pull/18951 and refactored in https://github.com/galaxyproject/galaxy/pull/19830 but an issue with the implementation was found in https://github.com/galaxyproject/galaxy/pull/19830#pullrequestreview-2929061314 that lead to very slow run times, and it was thus removed later in https://github.com/galaxyproject/galaxy/pull/20464.

This PR brings it back with a fixed implementation. There was a bug in the [refactored implementation (#19830)](https://github.com/galaxyproject/galaxy/pull/19830):
https://github.com/galaxyproject/galaxy/blob/77a8f6e030896557c9dc4c7869b3efb4081ac7f8/lib/galaxy/datatypes/images.py#L368
The bug was that `np.array_split` expects not the *chunk size* as an argument (16384 bytes), but the maximum *number of chunks*. Since this number was set to 16384, this branch of code lead to very long run times. The fix is provided in 87bbd62042eacd242a9db4b44f51a20634376a65.

I have tested 87bbd62042eacd242a9db4b44f51a20634376a65 with the 600KB tiff file provided by @mvdbeek in https://github.com/galaxyproject/galaxy/pull/19830#pullrequestreview-2929061314 and found that it now finishes in less than a second, as opposed to the "more than 20 minutes" that were reported earlier.

## Alternatives

Finally, I'd like to point out that there sure _are_ alternatives how we can handle this, as @mvdbeek suggested in https://github.com/galaxyproject/galaxy/pull/20464#issue-3147307064:

> Besides improving the efficiency, Perhaps there is a more gentle way to approach
> 
> > Many tools assume that images are binary, or label maps, for example, and it makes no sense to run those tools on other images.
> 
> ?
> 
> Could those tools just error out, and/or consume a different datatype ? Do we need the full unique values, or is it ok to just check if it's more than n unique values ?

The problem with erroring out is that it is not so nice that the user interface accepts "wrong" images as inputs in the first place. For a good UX, the user should be *prevented* from making faulty inputs, I think. Using designated datatypes is something we can think about. For most use cases, I *assume* that it also would be sufficient to check if it's more than n unique values. However, improving efficiency by fixing the bug in the previous implementation was the quickest and most minimally invasive solution, from my point of view.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
