### PR TITLE
[25.0] Bump up pulsar dependency to 0.15.9

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -129,7 +129,7 @@ prompt-toolkit==3.0.51
 propcache==0.3.1
 prov==1.5.1
 psutil==7.0.0
-pulsar-galaxy-lib==0.15.8
+pulsar-galaxy-lib==0.15.9
 pycparser==2.22
 pycryptodome==3.22.0
 pydantic==2.11.3


### PR DESCRIPTION
This fixes GALAXY_SLOTS for pulsar jobs on htcondor

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
