### PR TITLE
Sort collection dialog by HID descending.

### DIFF
--- a/client/src/components/SelectionDialog/DatasetCollectionDialog.test.js
+++ b/client/src/components/SelectionDialog/DatasetCollectionDialog.test.js
@@ -31,7 +31,7 @@ describe("DatasetCollectionDialog.vue", () => {
 
     it("loads correctly in loading state, shows options when optionsShow becomes true", async () => {
         // Initially in loading state.
-        const collectionsResponse = [{ id: "f2db41e1fa331b3e", name: "Awesome Collection" }];
+        const collectionsResponse = [{ id: "f2db41e1fa331b3e", name: "Awesome Collection", hid: 1 }];
         axiosMock
             .onGet(`/api/histories/${mockOptions.history}/contents?type=dataset_collection`)
             .reply(200, collectionsResponse);

--- a/client/src/components/SelectionDialog/DatasetCollectionDialog.vue
+++ b/client/src/components/SelectionDialog/DatasetCollectionDialog.vue
@@ -12,6 +12,7 @@ interface HistoryItem {
     id: string;
     name: string;
     created_time: string;
+    hid: number;
 }
 
 interface Props {
@@ -55,7 +56,8 @@ function load() {
     axios
         .get(url)
         .then((response) => {
-            items.value = response.data.map((item: HistoryItem) => {
+            const collection_instances = response.data.sort((a: HistoryItem, b: HistoryItem) => b.hid - a.hid);
+            items.value = collection_instances.map((item: HistoryItem) => {
                 return {
                     id: item.id,
                     label: item.name,


### PR DESCRIPTION
Requested by @mvdbeek in #19305.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Create a couple collections in your history.
  2. Create a new page - add a collection component - notice the collections are now sorted by descending HID.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
