### PR TITLE
Rework and expand client job state handling constants.

### DIFF
--- a/client/src/api/jobs.ts
+++ b/client/src/api/jobs.ts
@@ -8,9 +8,9 @@ export type JobInputSummary = components["schemas"]["JobInputSummary"];
 export type JobDisplayParametersSummary = components["schemas"]["JobDisplayParametersSummary"];
 export type JobMetric = components["schemas"]["JobMetric"];
 
-export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting"];
-export const ERROR_STATES = ["error", "deleted"];
-export const TERMINAL_STATES = ["ok", "skipped"].concat(ERROR_STATES);
+export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting", "paused", "resubmitted", "stop"];
+export const ERROR_STATES = ["error", "deleted", "deleting"];
+export const TERMINAL_STATES = ["ok", "skipped", "stop", "stopping", "skipped"].concat(ERROR_STATES);
 
 interface JobDef {
     tool_id: string;

--- a/client/src/api/jobs.ts
+++ b/client/src/api/jobs.ts
@@ -8,6 +8,10 @@ export type JobInputSummary = components["schemas"]["JobInputSummary"];
 export type JobDisplayParametersSummary = components["schemas"]["JobDisplayParametersSummary"];
 export type JobMetric = components["schemas"]["JobMetric"];
 
+export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting"];
+export const ERROR_STATES = ["error", "deleted"];
+export const TERMINAL_STATES = ["ok", "skipped"].concat(ERROR_STATES);
+
 interface JobDef {
     tool_id: string;
 }

--- a/client/src/api/tools.ts
+++ b/client/src/api/tools.ts
@@ -6,36 +6,6 @@ export type FetchDataPayload = components["schemas"]["FetchDataPayload"];
 export type UrlDataElement = components["schemas"]["UrlDataElement"];
 export type NestedElement = components["schemas"]["NestedElement"];
 
-export function urlDataElement(identifier: string, uri: string): UrlDataElement {
-    const element: UrlDataElement = {
-        src: "url",
-        url: uri,
-        name: identifier,
-        // these shouldn't be required but the way our model -> ts stuff works it is...
-        auto_decompress: false,
-        dbkey: "?",
-        ext: "auto",
-        to_posix_lines: false,
-        deferred: false,
-        space_to_tab: false,
-    };
-    return element;
-}
-
-export function nestedElement(identifier: string, elements: NestedElement["elements"]) {
-    const nestedElement: NestedElement = {
-        name: identifier,
-        elements: elements,
-        auto_decompress: false,
-        dbkey: "?",
-        ext: "auto",
-        to_posix_lines: false,
-        deferred: false,
-        space_to_tab: false,
-    };
-    return nestedElement;
-}
-
 export async function fetch(payload: FetchDataPayload) {
     const { data } = await GalaxyApi().POST("/api/tools/fetch", {
         body: payload,

--- a/client/src/api/tools.ts
+++ b/client/src/api/tools.ts
@@ -1,0 +1,69 @@
+import { type components, GalaxyApi } from "@/api";
+import { ERROR_STATES, type ShowFullJobResponse } from "@/api/jobs";
+
+export type HdcaUploadTarget = components["schemas"]["HdcaDataItemsTarget"];
+export type FetchDataPayload = components["schemas"]["FetchDataPayload"];
+export type UrlDataElement = components["schemas"]["UrlDataElement"];
+export type NestedElement = components["schemas"]["NestedElement"];
+
+export function urlDataElement(identifier: string, uri: string): UrlDataElement {
+    const element: UrlDataElement = {
+        src: "url",
+        url: uri,
+        name: identifier,
+        // these shouldn't be required but the way our model -> ts stuff works it is...
+        auto_decompress: false,
+        dbkey: "?",
+        ext: "auto",
+        to_posix_lines: false,
+        deferred: false,
+        space_to_tab: false,
+    };
+    return element;
+}
+
+export function nestedElement(identifier: string, elements: NestedElement["elements"]) {
+    const nestedElement: NestedElement = {
+        name: identifier,
+        elements: elements,
+        auto_decompress: false,
+        dbkey: "?",
+        ext: "auto",
+        to_posix_lines: false,
+        deferred: false,
+        space_to_tab: false,
+    };
+    return nestedElement;
+}
+
+export async function fetch(payload: FetchDataPayload) {
+    const { data } = await GalaxyApi().POST("/api/tools/fetch", {
+        body: payload,
+    });
+    return fetchResponseToJobId(data as FetchResponseInterface);
+}
+
+interface FetchResponseInterface {
+    jobs: { id: string }[];
+}
+
+function fetchResponseToJobId(response: FetchResponseInterface) {
+    return response.jobs[0]!.id;
+}
+
+export function fetchJobErrorMessage(jobDetails: ShowFullJobResponse): string | undefined {
+    const stderr = jobDetails.stderr;
+    let errorMessage: string | undefined = undefined;
+    if (stderr) {
+        errorMessage = "An error was encountered while running your upload job. ";
+        if (stderr.indexOf("binary file contains inappropriate content") > -1) {
+            errorMessage +=
+                "The problem may be that the batch uploader will not automatically decompress your files the way the normal uploader does, please specify a correct extension or upload decompressed data.";
+        }
+        errorMessage += "Upload job completed with standard error: " + stderr;
+    } else if (ERROR_STATES.indexOf(jobDetails.state) !== -1) {
+        errorMessage =
+            "Unknown error encountered while running your data import job, this could be a server issue or a problem with the upload definition.";
+    }
+    return errorMessage;
+}

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -1,9 +1,9 @@
 <script setup>
+import { NON_TERMINAL_STATES } from "api/jobs";
 import CopyToClipboard from "components/CopyToClipboard";
 import HelpText from "components/Help/HelpText";
 import { JobConsoleOutputProvider, JobDetailsProvider } from "components/providers/JobProvider";
 import UtcDate from "components/UtcDate";
-import { NON_TERMINAL_STATES } from "components/WorkflowInvocationState/util";
 import { computed, ref, watch } from "vue";
 
 import { GalaxyApi } from "@/api";

--- a/client/src/components/JobStates/wait.js
+++ b/client/src/components/JobStates/wait.js
@@ -1,5 +1,5 @@
+import { ERROR_STATES, NON_TERMINAL_STATES } from "api/jobs";
 import axios from "axios";
-import { ERROR_STATES, NON_TERMINAL_STATES } from "components/WorkflowInvocationState/util";
 import { getAppRoot } from "onload/loadConfig";
 
 export function waitOnJob(jobId, onStateUpdate = null, interval = 1000) {

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -595,6 +595,7 @@
 
 <script>
 import HotTable from "@handsontable/vue";
+import { ERROR_STATES, NON_TERMINAL_STATES } from "api/jobs";
 import { fetch, fetchJobErrorMessage } from "api/tools";
 import { getGalaxyInstance } from "app";
 import axios from "axios";
@@ -615,7 +616,6 @@ import SaveRules from "components/RuleBuilder/SaveRules";
 import StateDiv from "components/RuleBuilder/StateDiv";
 import Select2 from "components/Select2";
 import UploadUtils from "components/Upload/utils";
-import { ERROR_STATES, NON_TERMINAL_STATES } from "components/WorkflowInvocationState/util";
 import $ from "jquery";
 import { getAppRoot } from "onload/loadConfig";
 import _ from "underscore";

--- a/client/src/components/WorkflowInvocationState/util.ts
+++ b/client/src/components/WorkflowInvocationState/util.ts
@@ -1,8 +1,8 @@
 import type { InvocationJobsSummary } from "@/api/invocations";
+import { ERROR_STATES, NON_TERMINAL_STATES, TERMINAL_STATES } from "@/api/jobs";
 
-export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting"];
-export const ERROR_STATES = ["error", "deleted"];
-export const TERMINAL_STATES = ["ok", "skipped"].concat(ERROR_STATES);
+export { ERROR_STATES, NON_TERMINAL_STATES, TERMINAL_STATES } from "@/api/jobs";
+
 export const POPULATED_STATE_FAILED = "failed";
 
 function countStates(jobSummary: InvocationJobsSummary | null, queryStates: string[]): number {

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -105,12 +105,12 @@
 </template>
 
 <script>
+import { NON_TERMINAL_STATES } from "api/jobs";
 import axios from "axios";
 import JobsTable from "components/admin/JobsTable";
 import Heading from "components/Common/Heading";
 import filtersMixin from "components/Indices/filtersMixin";
 import { jobsProvider } from "components/providers/JobProvider";
-import { NON_TERMINAL_STATES } from "components/WorkflowInvocationState/util";
 import { getAppRoot } from "onload/loadConfig";
 import { errorMessageAsString } from "utils/simple-error";
 

--- a/client/src/components/providers/utils.js
+++ b/client/src/components/providers/utils.js
@@ -1,4 +1,4 @@
-import { NON_TERMINAL_STATES } from "components/WorkflowInvocationState/util";
+import { NON_TERMINAL_STATES } from "api/jobs";
 import { snakeCase } from "lodash";
 
 export function stateIsTerminal(result) {

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -5,7 +5,7 @@
 
 import axios, { type AxiosError, type AxiosResponse } from "axios";
 
-import { NON_TERMINAL_STATES } from "@/components/WorkflowInvocationState/util";
+import { NON_TERMINAL_STATES } from "@/api/jobs";
 import _l from "@/utils/localization";
 
 export function stateIsTerminal(result: Record<string, any>) {


### PR DESCRIPTION
This is a refactoring I have used in both #19305  and #20592 - @mvdbeek wanted me to expand the states covered - https://github.com/galaxyproject/galaxy/pull/19305#discussion_r2213493313. So I've extracted that commit out, polished it a bit, and expanded the list of used states.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
