### PR TITLE
[24.2] Fix invocation header

### DIFF
--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -68,9 +68,7 @@ const workflowTags = computed(() => {
                     <FontAwesomeIcon :icon="faHdd" />History:
 
                     <span class="history-link-wrapper">
-                        <SwitchToHistoryLink
-                            :history-id="props.historyId"
-                        />
+                        <SwitchToHistoryLink :history-id="props.historyId" />
                     </span>
 
                     <BBadge

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -100,25 +100,24 @@ const workflowTags = computed(() => {
     </div>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
 .history-link-wrapper {
     max-width: 300px;
     display: inline-block;
     vertical-align: middle;
-}
 
-::v-deep(.history-link-wrapper .history-link button) {
-    display: inline-block !important;
-    overflow: hidden !important;
-    white-space: nowrap !important;
-    text-overflow: ellipsis !important;
-    max-width: 100% !important;
-    vertical-align: middle;
-}
+    &:deep(.history-link) {
+        max-width: 100%;
+        overflow: hidden;
 
-::v-deep(.history-link-wrapper .history-link) {
-    max-width: 100%;
-    overflow: hidden;
+        button {
+            display: inline-block !important;
+            overflow: hidden !important;
+            white-space: nowrap !important;
+            text-overflow: ellipsis !important;
+            max-width: 100% !important;
+            vertical-align: middle;
+        }
+    }
 }
-
 </style>

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -68,7 +68,9 @@ const workflowTags = computed(() => {
                     <FontAwesomeIcon :icon="faHdd" />History:
 
                     <span class="history-link-wrapper">
-                        <SwitchToHistoryLink :history-id="props.historyId" />
+                        <SwitchToHistoryLink
+                            :history-id="props.historyId"
+                        />
                     </span>
 
                     <BBadge
@@ -105,16 +107,18 @@ const workflowTags = computed(() => {
     vertical-align: middle;
 }
 
-::v-deep(.history-link-wrapper a),
-::v-deep(.history-link-wrapper div) {
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: normal;
-    word-break: break-word;
-    line-height: 1.2em;
-    max-height: 3.6em;
+::v-deep(.history-link-wrapper .history-link button) {
+    display: inline-block !important;
+    overflow: hidden !important;
+    white-space: nowrap !important;
+    text-overflow: ellipsis !important;
+    max-width: 100% !important;
+    vertical-align: middle;
 }
+
+::v-deep(.history-link-wrapper .history-link) {
+    max-width: 100%;
+    overflow: hidden;
+}
+
 </style>

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -101,20 +101,13 @@ const workflowTags = computed(() => {
 <style scoped lang="scss">
 .history-link-wrapper {
     max-width: 300px;
-    display: inline-block;
-    vertical-align: middle;
 
     &:deep(.history-link) {
-        max-width: 100%;
-        overflow: hidden;
-
-        button {
-            display: inline-block !important;
-            overflow: hidden !important;
-            white-space: nowrap !important;
-            text-overflow: ellipsis !important;
-            max-width: 100% !important;
-            vertical-align: middle;
+        a {
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            display: block;
         }
     }
 }

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -41,11 +41,7 @@ const owned = computed(() => {
 });
 
 const description = computed(() => {
-    if (workflow.value?.annotation) {
-        return workflow.value.annotation?.trim();
-    } else {
-        return null;
-    }
+    return workflow.value?.annotation?.trim() || null;
 });
 
 const timeElapsed = computed(() => {
@@ -70,7 +66,11 @@ const workflowTags = computed(() => {
                 </i>
                 <span v-if="invocationUpdateTime" class="d-flex flex-gapx-1 align-items-center">
                     <FontAwesomeIcon :icon="faHdd" />History:
-                    <SwitchToHistoryLink :history-id="props.historyId" />
+
+                    <span class="history-link-wrapper">
+                        <SwitchToHistoryLink :history-id="props.historyId" />
+                    </span>
+
                     <BBadge
                         v-if="useHistoryStore().currentHistoryId !== props.historyId"
                         v-b-tooltip.hover.noninteractive
@@ -97,3 +97,24 @@ const workflowTags = computed(() => {
         </div>
     </div>
 </template>
+
+<style scoped>
+.history-link-wrapper {
+    max-width: 300px;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+::v-deep(.history-link-wrapper a),
+::v-deep(.history-link-wrapper div) {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    word-break: break-word;
+    line-height: 1.2em;
+    max-height: 3.6em;
+}
+</style>


### PR DESCRIPTION
This PR addresses issue #20554 by constraining the workflow invocation header to a maximum of three lines and enforcing a fixed width. As shown in the screenshot, without this change the full history name is displayed and the progress bar is omitted.

<img width="1816" height="564" alt="f3ae6c3f-07a4-45d1-8bbf-e33ceb622284" src="https://github.com/user-attachments/assets/472b7199-fafe-44e7-8063-dd8f963fdafb" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a workflow invocation that uses a very long history name.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
