### PR TITLE
[25.0] Fix Invenio file downloads for published records with draft

### DIFF
--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -419,13 +419,13 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
     def _is_draft_record(self, record_id: str, user_context: OptionalUserContext = None):
         request_url = self._get_draft_record_url(record_id)
         headers = self._get_request_headers(user_context)
-        response = requests.get(request_url, headers=headers)
+        response = requests.head(request_url, headers=headers)
         return response.status_code == 200
 
     def _is_published_record(self, record_id: str, user_context: OptionalUserContext = None):
         request_url = self._get_record_url(record_id)
         headers = self._get_request_headers(user_context)
-        response = requests.get(request_url, headers=headers)
+        response = requests.head(request_url, headers=headers)
         return response.status_code == 200
 
     def _get_record_url(self, record_id: str):


### PR DESCRIPTION
It seems you can edit an already published record, which will create an associated "draft" record for the same record ID. Before this change, we relied on the existence of the "draft" record to determine if the file had been published or not, but this no longer works if you edit the published record.

So this makes sure the records exist, first as published, and if not, as a draft and not the other way around.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Create a draft record with a file in Zenodo Sandbox
  - Publish the record
  - Then "edit" the record, creating a new draft
  - Try to import the file into Galaxy
  - It should work now

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
