### PR TITLE
[25.0] Input linter: add missing attribute to `sort_by`

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -588,6 +588,7 @@ FILTER_ALLOWED_ATTRIBUTES["attribute_value_splitter"].extend(["pair_separator", 
 FILTER_ALLOWED_ATTRIBUTES["add_value"].extend(["name", "index"])
 FILTER_ALLOWED_ATTRIBUTES["remove_value"].extend(["value", "ref", "meta_ref", "key"])
 FILTER_ALLOWED_ATTRIBUTES["data_table"].append("keep")
+FILTER_ALLOWED_ATTRIBUTES["sort_by"].append("reverse_sort_order")
 
 
 class InputsOptionsFiltersAllowedAttributes(Linter):


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/blob/63f0d25a40a08aeab183114258f117aca66157de/lib/galaxy/tools/parameters/dynamic_options.py#L553C49-L553C67

fixes https://github.com/galaxyproject/tools-iuc/pull/7141#issuecomment-3109315037

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
