### PR TITLE
Fix assertion on python version

### DIFF
--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -73,7 +73,7 @@ log = logging.getLogger()
 log.setLevel(logging.INFO)
 log.addHandler(logging.StreamHandler(sys.stdout))
 
-assert sys.version_info[:2] >= (2, 6)
+assert sys.version_info[:2] >= (3, 6)
 
 
 def main():


### PR DESCRIPTION
Likely a typo, f-strings were introduced in 3.6

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
