### PR TITLE
Add more info to inheritance chain

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9319,10 +9319,11 @@ export interface components {
              */
             name: string;
             /**
-             * Same User
-             * @description Whether the referenced dataset belongs to the same user.
+             * User Id
+             * @description ID of the user who owns the referenced dataset.
+             * @example 0123456789ABCDEF
              */
-            same_user: boolean;
+            user_id: string;
         };
         /**
          * DatasetPermissionAction

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9308,10 +9308,21 @@ export interface components {
              */
             dep: string;
             /**
+             * Id
+             * @description ID of the referenced dataset
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
              * Name
              * @description Name of the referenced dataset
              */
             name: string;
+            /**
+             * Same User
+             * @description Whether the referenced dataset belongs to the same user.
+             */
+            same_user: boolean;
         };
         /**
          * DatasetPermissionAction

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -174,7 +174,9 @@ class DatasetInheritanceChainEntry(Model):
     dep: str = Field(
         description="Name of the source of the referenced dataset at this point of the inheritance chain.",
     )
-    same_user: bool = Field(description="Whether the referenced dataset belongs to the same user.")
+    user_id: EncodedDatabaseIdField = Field(
+        description="ID of the user who owns the referenced dataset.",
+    )
 
 
 class DatasetInheritanceChain(RootModel):
@@ -503,7 +505,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                     id=dep[0].id,
                     name=dep[0].name,
                     dep=dep[1],
-                    same_user=dep[0].user.id == dataset_instance.user.id,
+                    user_id=dep[0].user.id,
                 )
             )
 

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -162,6 +162,9 @@ class DatasetStorageDetails(Model):
 
 
 class DatasetInheritanceChainEntry(Model):
+    id: DecodedDatabaseIdField = Field(
+        description="ID of the referenced dataset",
+    )
     name: str = Field(
         description="Name of the referenced dataset",
     )
@@ -491,7 +494,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         inherit_chain = dataset_instance.source_dataset_chain
         result = []
         for dep in inherit_chain:
-            result.append(DatasetInheritanceChainEntry(name=f"{dep[0].name}", dep=dep[1]))
+            result.append(DatasetInheritanceChainEntry(id=self.encode_id(dep[0].id), name=dep[0].name, dep=dep[1]))
 
         return DatasetInheritanceChain(root=result)
 


### PR DESCRIPTION
This PR adds a `same_user` flag to dataset inheritance metadata to help detect whether copied datasets come from the same user. The goal is to improve plagiarism detection while avoiding false positives and without exposing user IDs. I’m open to feedback on whether this approach is acceptable or if exposing `user_id` would be preferred for flexibility.
This is needed because existing endpoints don’t reliably provide user info for inherited datasets, and accessing user IDs via history is only possible if the history is public or shared, which is often not the case.
This way, if the user copied a dataset, we should see somewhere from this endpoint that it is not from the user, for example:
```json
[
  {
    "id": "3f5830403180d620",
    "name": "test",
    "dep": "Copy of 'test'",
    "same_user": true
  },
  {
    "id": "ebfb8f50c6abde6d",
    "name": "test",
    "dep": "test",
    "same_user": false
  }
]
```

Edit:
instead of `same_user` it will show `user_id`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
