### PR TITLE
History Components Navigation/Heading Improvements

### DIFF
--- a/client/src/components/Citation/CitationsList.test.ts
+++ b/client/src/components/Citation/CitationsList.test.ts
@@ -1,11 +1,14 @@
+import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/jest/helpers";
 import { mount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
+import VueRouter from "vue-router";
 
 import CitationItem from "./CitationItem.vue";
 import MountTarget from "./CitationsList.vue";
 
 const localVue = getLocalVue(true);
+localVue.use(VueRouter);
 
 jest.mock("@/composables/config", () => ({
     useConfig: jest.fn(() => ({
@@ -38,12 +41,19 @@ describe("CitationsList", () => {
     let wrapper: Wrapper<Vue>;
 
     beforeEach(async () => {
+        const pinia = createTestingPinia();
+
+        const router = new VueRouter();
+        router.push("/histories/citations?id=test-id");
+
         wrapper = mount(MountTarget as object, {
             propsData: {
                 id: "test-id",
                 source: "histories",
             },
             localVue,
+            pinia,
+            router,
         });
 
         await flushPromises();

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -6,13 +6,14 @@ import { computed, onMounted, onUpdated, ref } from "vue";
 
 import { getCitations } from "@/components/Citation/services";
 import { useConfig } from "@/composables/config";
+import { useHistoryStore } from "@/stores/historyStore";
 import { copy } from "@/utils/clipboard";
 
 import type { Citation } from ".";
 import { Cite } from "./cite";
 
 import CitationItem from "@/components/Citation/CitationItem.vue";
-import Heading from "@/components/Common/Heading.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 
 const outputFormats = Object.freeze({
     CITATION: "bibliography",
@@ -31,6 +32,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const { config } = useConfig(true);
+const historyStore = useHistoryStore();
 
 const emit = defineEmits(["rendered", "show", "shown", "hide", "hidden"]);
 
@@ -52,6 +54,16 @@ onMounted(async () => {
         isLoading.value = false;
     }
 });
+
+const breadcrumbItems = computed(() => [
+    { title: "Histories", to: "/histories/list" },
+    {
+        title: historyStore.getHistoryNameById(props.id),
+        to: `/histories/view?id=${props.id}`,
+        superText: historyStore.currentHistoryId === props.id ? "current" : undefined,
+    },
+    { title: "Tool References" },
+]);
 
 /** The fetched Citations in addition to the Galaxy citation from config */
 const citations = computed<Citation[]>(() => {
@@ -120,7 +132,8 @@ function citationsToBibtexAsText() {
 
 <template>
     <div>
-        <Heading h1 separator inline size="lg">History Tool References</Heading>
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
         <div v-if="isLoading" class="text-center">
             <BSpinner />
             <p class="ml-2">Loading references...</p>

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BLink } from "bootstrap-vue";
 import type { RawLocation } from "vue-router";
 import { useRouter } from "vue-router/composables";
@@ -33,9 +34,11 @@ function isPathActive(path: RawLocation): boolean {
                     :title="`Go back to ${localize(item.title)}`"
                     :to="item.to"
                     class="breadcrumb-heading-header-active">
+                    <FontAwesomeIcon v-if="item.icon" :icon="item.icon" />
                     {{ localize(item.title) }}
                 </BLink>
                 <span v-else :key="'else-' + index" class="breadcrumb-heading-header-inactive">
+                    <FontAwesomeIcon v-if="item.icon" :icon="item.icon" />
                     {{ localize(item.title) }}
                 </span>
 

--- a/client/src/components/Common/index.ts
+++ b/client/src/components/Common/index.ts
@@ -1,3 +1,4 @@
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import type { RawLocation } from "vue-router";
 
 // TODO: Not sure if this is the best place for this type
@@ -9,14 +10,24 @@ export type ColorVariant = "primary" | "secondary" | "success" | "danger" | "war
  * displayed alongside the item.
  */
 export interface BreadcrumbItem {
-    /** The display text for the breadcrumb item */
+    /**
+     * The label of the breadcrumb item.
+     */
     title: string;
-    /** Optional The URL or route to navigate to when the breadcrumb item is clicked.
+
+    /**
+     * Optional The URL or route to navigate to when the breadcrumb item is clicked.
      * the item will not be clickable if this is not provided or the current route matches this location.
      */
     to?: RawLocation;
+
     /**
      * Optional additional text displayed above the item.
      */
     superText?: string;
+
+    /**
+     * Optional icon to display alongside the breadcrumb item.
+     */
+    icon?: IconDefinition;
 }

--- a/client/src/components/Grid/GridInvocation.vue
+++ b/client/src/components/Grid/GridInvocation.vue
@@ -22,6 +22,7 @@ interface Props {
     ownerGrid?: boolean;
     filteredFor?: { type: "History" | "StoredWorkflow"; id: string; name: string };
     invocationsList?: WorkflowInvocation[];
+    hideHeading?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -30,6 +31,7 @@ const props = withDefaults(defineProps<Props>(), {
     ownerGrid: true,
     filteredFor: undefined,
     invocationsList: undefined,
+    hideHeading: false,
 });
 
 const { currentUser } = storeToRefs(useUserStore());
@@ -100,7 +102,7 @@ function refreshTable() {
 
 <template>
     <div class="d-flex flex-column">
-        <div v-if="forStoredWorkflow || forHistory" class="d-flex">
+        <div v-if="!hideHeading && (forStoredWorkflow || forHistory)" class="d-flex">
             <Heading h1 separator inline truncate size="lg" class="flex-grow-1 mb-2">{{ effectiveTitle }}</Heading>
         </div>
         <GridList

--- a/client/src/components/History/Archiving/HistoryArchiveWizard.test.ts
+++ b/client/src/components/History/Archiving/HistoryArchiveWizard.test.ts
@@ -27,7 +27,6 @@ const { server, http } = useServerMock();
 const TEST_HISTORY_ID = "test-history-id";
 const TEST_HISTORY = {
     id: TEST_HISTORY_ID,
-    name: "fake-history-name",
     archived: false,
 };
 
@@ -61,13 +60,6 @@ describe("HistoryArchiveWizard.vue", () => {
                 return response(200).json([]);
             })
         );
-    });
-
-    it("should render the history name in the header", async () => {
-        const wrapper = await mountComponentWithHistory(TEST_HISTORY as HistorySummary);
-
-        const header = wrapper.find("h1");
-        expect(header.text()).toContain(TEST_HISTORY.name);
     });
 
     it("should render only the simple archival mode when no writeable file sources are available", async () => {

--- a/client/src/components/History/Archiving/HistoryArchiveWizard.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveWizard.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
 import { faArchive } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BCard, BTab, BTabs } from "bootstrap-vue";
 import { computed, ref } from "vue";
 import { RouterLink } from "vue-router";
@@ -12,11 +10,10 @@ import { useFileSources } from "@/composables/fileSources";
 import { useToast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
 
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import HistoryArchiveExportSelector from "@/components/History/Archiving/HistoryArchiveExportSelector.vue";
 import HistoryArchiveSimple from "@/components/History/Archiving/HistoryArchiveSimple.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
-
-library.add(faArchive);
 
 const historyStore = useHistoryStore();
 const { config } = useConfig(true);
@@ -65,16 +62,25 @@ async function onArchiveHistory(exportRecordId?: string) {
         isArchiving.value = false;
     }
 }
+
+const breadcrumbItems = computed(() => [
+    { title: "Histories", to: "/histories/list" },
+    {
+        title: history.value?.name || "Archive History",
+        to: `/histories/view?id=${props.historyId}`,
+        superText: historyStore.currentHistoryId === props.historyId ? "current" : undefined,
+    },
+    { title: "Archive", icon: faArchive },
+]);
 </script>
 
 <template>
     <div class="history-archive-wizard">
-        <FontAwesomeIcon icon="archive" size="2x" class="text-primary float-left mr-2" />
-        <h1 class="h-lg">
-            Archive
-            <LoadingSpan v-if="!history" spinner-only />
-            <b v-else>{{ history.name }}</b>
-        </h1>
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
+        <BAlert v-if="!history" show>
+            <LoadingSpan spinner-only />
+        </BAlert>
 
         <BAlert v-if="isHistoryAlreadyArchived" id="history-archived-alert" show variant="success">
             This history has been archived. You can access it from the

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -1,119 +1,41 @@
 <script setup lang="ts">
-import {
-    faArchive,
-    faBars,
-    faBurn,
-    faColumns,
-    faCopy,
-    faExchangeAlt,
-    faFileArchive,
-    faFileExport,
-    faList,
-    faPlay,
-    faPlus,
-    faSpinner,
-    faStream,
-    faTrash,
-    faUsersCog,
-} from "@fortawesome/free-solid-svg-icons";
+import { faExchangeAlt, faPlus, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import axios from "axios";
-import {
-    BButton,
-    BButtonGroup,
-    BDropdown,
-    BDropdownDivider,
-    BDropdownItem,
-    BDropdownText,
-    BFormCheckbox,
-    BModal,
-    BSpinner,
-} from "bootstrap-vue";
+import { BButton, BButtonGroup } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { ref } from "vue";
 
-import { canMutateHistory, type HistorySummary } from "@/api";
-import { iframeRedirect } from "@/components/plugins/legacyNavigation";
-import { useToast } from "@/composables/toast";
-import { getAppRoot } from "@/onload/loadConfig";
+import type { HistorySummary } from "@/api";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
-import { rethrowSimple } from "@/utils/simple-error";
 
-import CopyModal from "@/components/History/Modals/CopyModal.vue";
+import HistoryOptions from "@/components/History/HistoryOptions.vue";
 import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
 
 interface Props {
-    histories: HistorySummary[];
     history: HistorySummary;
-    historiesLoading?: boolean;
     minimal?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    historiesLoading: false,
     minimal: false,
 });
 
-// modal refs
+const historyStore = useHistoryStore();
+const { histories, changingCurrentHistory } = storeToRefs(historyStore);
+
 const showSwitchModal = ref(false);
-const showDeleteModal = ref(false);
-const showCopyModal = ref(false);
-
-const purgeHistory = ref(false);
-
-const toast = useToast();
 
 const userStore = useUserStore();
-const historyStore = useHistoryStore();
 
 const { isAnonymous } = storeToRefs(userStore);
-const { totalHistoryCount, changingCurrentHistory } = storeToRefs(historyStore);
-
-const canEditHistory = computed(() => {
-    return canMutateHistory(props.history);
-});
-
-const isDeletedNotPurged = computed(() => {
-    return props.history.deleted && !props.history.purged;
-});
-
-const historyState = computed(() => {
-    if (props.history.purged) {
-        return "purged";
-    } else if (props.history.deleted) {
-        return "deleted";
-    } else if (props.history.archived) {
-        return "archived";
-    } else {
-        return "active";
-    }
-});
-
-function onDelete() {
-    if (purgeHistory.value) {
-        historyStore.deleteHistory(props.history.id, true);
-    } else {
-        historyStore.deleteHistory(props.history.id, false);
-    }
-}
 
 function userTitle(title: string) {
     if (isAnonymous.value) {
         return localize("Log in to") + " " + localize(title);
     } else {
         return localize(title);
-    }
-}
-
-async function resumePausedJobs() {
-    const url = `${getAppRoot()}history/resume_paused_jobs?current=True`;
-    try {
-        const response = await axios.get(url);
-        toast.success(response.data.message);
-    } catch (e) {
-        rethrowSimple(e);
     }
 }
 </script>
@@ -154,130 +76,7 @@ async function resumePausedJobs() {
                         :spin="changingCurrentHistory" />
                 </BButton>
 
-                <BDropdown
-                    v-b-tooltip.top.hover.noninteractive
-                    no-caret
-                    size="sm"
-                    :variant="props.minimal ? 'outline-info' : 'link'"
-                    toggle-class="text-decoration-none"
-                    menu-class="history-options-button-menu"
-                    title="History options"
-                    right
-                    data-description="history options">
-                    <template v-slot:button-content>
-                        <FontAwesomeIcon fixed-width :icon="faBars" />
-                        <span class="sr-only">History Options</span>
-                    </template>
-
-                    <BDropdownText>
-                        <div v-if="historiesLoading">
-                            <BSpinner v-if="historiesLoading" small />
-                            <span>Fetching histories from server</span>
-                        </div>
-
-                        <span v-else-if="!props.minimal">You have {{ totalHistoryCount }} histories.</span>
-                        <span v-else>Manage History</span>
-                    </BDropdownText>
-
-                    <BDropdownItem
-                        v-if="!props.minimal"
-                        data-description="switch to multi history view"
-                        :disabled="isAnonymous"
-                        :title="userTitle('Open History Multiview')"
-                        @click="$router.push('/histories/view_multiple')">
-                        <FontAwesomeIcon fixed-width class="mr-1" :icon="faColumns" />
-                        <span v-localize>Show Histories Side-by-Side</span>
-                    </BDropdownItem>
-
-                    <BDropdownDivider v-if="!props.minimal" />
-
-                    <BDropdownText v-if="!canEditHistory">
-                        This history has been <span class="font-weight-bold">{{ historyState }}</span
-                        >.
-                        <span v-localize>Some actions might not be available.</span>
-                    </BDropdownText>
-
-                    <BDropdownDivider v-if="!canEditHistory" />
-
-                    <BDropdownItem
-                        :disabled="!canEditHistory"
-                        :title="localize('Resume all Paused Jobs in this History')"
-                        @click="resumePausedJobs()">
-                        <FontAwesomeIcon fixed-width :icon="faPlay" class="mr-1" />
-                        <span v-localize>Resume Paused Jobs</span>
-                    </BDropdownItem>
-
-                    <BDropdownDivider />
-
-                    <BDropdownItem
-                        :disabled="isAnonymous"
-                        :title="userTitle('Copy History to a New History')"
-                        @click="showCopyModal = !showCopyModal">
-                        <FontAwesomeIcon fixed-width :icon="faCopy" class="mr-1" />
-                        <span v-localize>Copy this History</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        :disabled="!canEditHistory"
-                        :title="localize(isDeletedNotPurged ? 'Permanently Delete History' : 'Delete History')"
-                        @click="showDeleteModal = !showDeleteModal">
-                        <FontAwesomeIcon fixed-width :icon="isDeletedNotPurged ? faBurn : faTrash" class="mr-1" />
-                        <span v-if="isDeletedNotPurged" v-localize>Permanently Delete History</span>
-                        <span v-else v-localize>Delete this History</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        :title="localize('Export references for all Tools used in this History')"
-                        @click="$router.push(`/histories/citations?id=${history.id}`)">
-                        <FontAwesomeIcon fixed-width :icon="faStream" class="mr-1" />
-                        <span v-localize>Export Tool References</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        data-description="export to file"
-                        :disabled="history.purged"
-                        :title="localize('Export and Download History as a File')"
-                        @click="$router.push(`/histories/${history.id}/export`)">
-                        <FontAwesomeIcon fixed-width :icon="faFileArchive" class="mr-1" />
-                        <span v-localize>Export History to File</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        :disabled="isAnonymous || history.archived || history.purged"
-                        data-description="archive history"
-                        :title="userTitle('Archive this History')"
-                        @click="$router.push(`/histories/${history.id}/archive`)">
-                        <FontAwesomeIcon fixed-width :icon="faArchive" class="mr-1" />
-                        <span v-localize>Archive History</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        :disabled="isAnonymous"
-                        :title="userTitle('Convert History to Workflow')"
-                        @click="iframeRedirect(`/workflow/build_from_current_history?history_id=${history.id}`)">
-                        <FontAwesomeIcon fixed-width :icon="faFileExport" class="mr-1" />
-                        <span v-localize>Extract Workflow</span>
-                    </BDropdownItem>
-
-                    <BDropdownItem
-                        :disabled="isAnonymous"
-                        :title="userTitle('Display Workflow Invocations')"
-                        @click="$router.push(`/histories/${history.id}/invocations`)">
-                        <FontAwesomeIcon fixed-width :icon="faList" class="mr-1" />
-                        <span v-localize>Show Invocations</span>
-                    </BDropdownItem>
-
-                    <BDropdownDivider />
-
-                    <BDropdownItem
-                        :disabled="isAnonymous || !canEditHistory"
-                        data-description="share and manage access"
-                        :title="userTitle('Share, Publish, or Set Permissions for this History')"
-                        @click="$router.push(`/histories/sharing?id=${history.id}`)">
-                        <FontAwesomeIcon fixed-width :icon="faUsersCog" class="mr-1" />
-                        <span v-localize>Share & Manage Access</span>
-                    </BDropdownItem>
-                </BDropdown>
+                <HistoryOptions :history="history" :minimal="props.minimal" />
             </BButtonGroup>
         </nav>
 
@@ -288,21 +87,5 @@ async function resumePausedJobs() {
             :additional-options="['center', 'multi']"
             :show-modal.sync="showSwitchModal"
             @selectHistory="historyStore.setCurrentHistory($event.id)" />
-
-        <CopyModal :history="history" :show-modal.sync="showCopyModal" />
-
-        <BModal
-            v-model="showDeleteModal"
-            :title="isDeletedNotPurged ? 'Permanently Delete History?' : 'Delete History?'"
-            title-tag="h2"
-            @ok="onDelete"
-            @show="purgeHistory = isDeletedNotPurged">
-            <p v-localize>
-                Do you also want to permanently delete the history <i class="ml-1">{{ history.name }}</i>
-            </p>
-            <BFormCheckbox id="purge-history" v-model="purgeHistory" :disabled="isDeletedNotPurged">
-                <span v-localize>Yes, permanently delete this history.</span>
-            </BFormCheckbox>
-        </BModal>
     </div>
 </template>

--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -39,7 +39,6 @@ const FAKE_HISTORY: HistorySummary = {
 };
 
 const selectors = {
-    historyName: "#history-name",
     latestExportRecord: "#latest-export-record",
     showPreviousExportRecordsButton: "#show-old-records-button",
     fatalErrorAlert: "#fatal-error-alert",
@@ -72,12 +71,6 @@ describe("HistoryExport.vue", () => {
         );
     });
 
-    it("should render the history name", async () => {
-        const wrapper = await mountHistoryExport();
-
-        expect(wrapper.find(selectors.historyName).text()).toBe(FAKE_HISTORY.name);
-    });
-
     it("should not display the latest export record if there is no export record", async () => {
         const wrapper = await mountHistoryExport();
 
@@ -108,7 +101,6 @@ describe("HistoryExport.vue", () => {
         const wrapper = await mountHistoryExport();
 
         expect(wrapper.find(selectors.fatalErrorAlert).exists()).toBe(false);
-        expect(wrapper.find(selectors.historyName).exists()).toBe(true);
     });
 
     it("should not render the UI and display a fatal error message if the history cannot be found or loaded", async () => {
@@ -127,6 +119,5 @@ describe("HistoryExport.vue", () => {
         const wrapper = await mountHistoryExport();
 
         expect(wrapper.find(selectors.fatalErrorAlert).exists()).toBe(true);
-        expect(wrapper.find(selectors.historyName).exists()).toBe(false);
     });
 });

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -30,7 +30,6 @@ import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import ExportRecordDetails from "@/components/Common/ExportRecordDetails.vue";
 import ExportRecordTable from "@/components/Common/ExportRecordTable.vue";
 import Heading from "@/components/Common/Heading.vue";
-import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const {
     isRunning: isExportTaskRunning,

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -26,6 +26,7 @@ import type { HistoryExportData } from "./types";
 import HistoryExportWizard from "./HistoryExportWizard.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GModal from "@/components/BaseComponents/GModal.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import ExportRecordDetails from "@/components/Common/ExportRecordDetails.vue";
 import ExportRecordTable from "@/components/Common/ExportRecordTable.vue";
 import Heading from "@/components/Common/Heading.vue";
@@ -221,16 +222,31 @@ onUnmounted(() => {
     stopWaitingForTask();
     stopMonitoringShortTermStorage();
 });
+
+const breadcrumbItems = computed(() => [
+    { title: "Histories", to: "/histories/list" },
+    {
+        title: historyName.value,
+        to: `/histories/view?id=${props.historyId}`,
+        superText: historyStore.currentHistoryId === props.historyId ? "current" : undefined,
+    },
+    { title: "Export", icon: faFileExport },
+]);
 </script>
+
 <template>
     <div class="history-export-component">
-        <Heading h1 separator inline>
-            <FontAwesomeIcon :icon="faFileExport" class="text-primary float-left mr-2" />
-            Export
-            <b v-if="isFatalError" class="text-danger">Error</b>
-            <LoadingSpan v-else-if="!history" spinner-only />
-            <b v-else id="history-name">{{ historyName }}</b>
-        </Heading>
+        <BreadcrumbHeading :items="breadcrumbItems">
+            <GButton
+                v-if="hasPreviousExports"
+                id="show-old-records-button"
+                outline
+                color="blue"
+                @click="onShowOldRecords">
+                <FontAwesomeIcon :icon="faList" class="mr-1" />
+                Show old export records
+            </GButton>
+        </BreadcrumbHeading>
 
         <BAlert v-if="isFatalError" id="fatal-error-alert" variant="danger" class="mt-3" show>
             {{ errorMessage }}
@@ -238,7 +254,6 @@ onUnmounted(() => {
 
         <div v-if="history">
             <div v-if="latestExportRecord">
-                <Heading h2 size="md">Latest Export Record</Heading>
                 <ExportRecordDetails
                     v-if="latestExportRecord"
                     :record="latestExportRecord"
@@ -249,16 +264,6 @@ onUnmounted(() => {
                     @onCopyDownloadLink="copyDownloadLinkFromRecord"
                     @onReimport="reimportFromRecord"
                     @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
-
-                <GButton
-                    v-if="hasPreviousExports"
-                    id="show-old-records-button"
-                    outline
-                    color="blue"
-                    @click="onShowOldRecords">
-                    <FontAwesomeIcon :icon="faList" class="mr-1" />
-                    Show old export records
-                </GButton>
 
                 <Heading h2 size="md" class="mt-3">Export your history again</Heading>
             </div>

--- a/client/src/components/History/HistoryAccessibility.vue
+++ b/client/src/components/History/HistoryAccessibility.vue
@@ -2,16 +2,16 @@
 import { faExclamation, faLock, faShareAlt, faUserLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BBadge, BTab, BTabs } from "bootstrap-vue";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
 
-import Heading from "../Common/Heading.vue";
 import PortletSection from "../Common/PortletSection.vue";
 import SharingPage from "../Sharing/SharingPage.vue";
 import HistoryDatasetPermissions from "./HistoryDatasetPermissions.vue";
 import HistoryMakePrivate from "./HistoryMakePrivate.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 
 const props = defineProps<{
     historyId: string;
@@ -24,6 +24,16 @@ const historyPrivacyChanged = ref(false);
 
 /** Once the history is made private, this boolean is used to notify the user if sharing status has also changed or not. */
 const sharingStatusChanged = ref(false);
+
+const breadcrumbItems = computed(() => [
+    { title: "Histories", to: "/histories/list" },
+    {
+        title: historyStore.getHistoryNameById(props.historyId),
+        to: `/histories/view?id=${props.historyId}`,
+        superText: historyStore.currentHistoryId === props.historyId ? "current" : undefined,
+    },
+    { title: "Share & Manage Access" },
+]);
 
 function historyMadePrivate(hasSharingStatusChanged: boolean) {
     sharingStatusChanged.value = hasSharingStatusChanged;
@@ -38,10 +48,7 @@ function openSharingTab() {
 
 <template>
     <div aria-labelledby="history-sharing-heading">
-        <Heading id="history-sharing-heading" h1 separator inline truncate size="lg">
-            {{ localize("Manage History") }}
-            "{{ historyStore.getHistoryNameById(props.historyId) }}"
-        </Heading>
+        <BreadcrumbHeading :items="breadcrumbItems" />
 
         <BTabs class="mt-3">
             <BTab :lazy="historyPrivacyChanged" @click="openSharingTab">

--- a/client/src/components/History/HistoryDatasetPermissions.vue
+++ b/client/src/components/History/HistoryDatasetPermissions.vue
@@ -2,9 +2,11 @@
 import { computed, ref } from "vue";
 
 import { initRefs, updateRefs, useCallbacks } from "@/composables/datasetPermissions";
+import { useHistoryStore } from "@/stores/historyStore";
 
 import { getPermissions, getPermissionsUrl, setPermissions } from "./services";
 
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import DatasetPermissionsForm from "@/components/Dataset/DatasetPermissionsForm.vue";
 
 interface HistoryDatasetPermissionsProps {
@@ -12,6 +14,8 @@ interface HistoryDatasetPermissionsProps {
     noRedirect?: boolean;
 }
 const props = defineProps<HistoryDatasetPermissionsProps>();
+
+const historyStore = useHistoryStore();
 
 const loading = ref(true);
 
@@ -39,6 +43,18 @@ const formConfig = computed(() => {
     };
 });
 
+const breadcrumbItems = computed(() => {
+    return [
+        { title: "Histories", to: "/histories/list" },
+        {
+            title: historyStore.getHistoryNameById(props.historyId),
+            to: `/histories/view?id=${props.historyId}`,
+            superText: historyStore.currentHistoryId === props.historyId ? "current" : undefined,
+        },
+        { title: "Dataset Permissions" },
+    ];
+});
+
 async function change(value: unknown) {
     const managePermissionValue: number = managePermissions.value[0] as number;
     let access: number[] = [] as number[];
@@ -62,11 +78,15 @@ const { onSuccess, onError } = useCallbacks(init);
 </script>
 
 <template>
-    <DatasetPermissionsForm
-        :loading="loading"
-        :simple-permissions="simplePermissions"
-        :title="title"
-        :form-config="formConfig"
-        :checked="checked"
-        @change="change" />
+    <div>
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
+        <DatasetPermissionsForm
+            :loading="loading"
+            :simple-permissions="simplePermissions"
+            :title="title"
+            :form-config="formConfig"
+            :checked="checked"
+            @change="change" />
+    </div>
 </template>

--- a/client/src/components/History/HistoryOptions.test.ts
+++ b/client/src/components/History/HistoryOptions.test.ts
@@ -1,0 +1,104 @@
+import { getLocalVue } from "@tests/jest/helpers";
+import { shallowMount } from "@vue/test-utils";
+import { createPinia } from "pinia";
+
+import { useHistoryStore } from "@/stores/historyStore";
+import { useUserStore } from "@/stores/userStore";
+
+import HistoryOptions from "./HistoryOptions.vue";
+
+const localVue = getLocalVue();
+
+// all options
+const expectedOptions = [
+    "Show Histories Side-by-Side",
+    "Resume Paused Jobs",
+    "Copy this History",
+    "Delete this History",
+    "Export Tool References",
+    "Export History to File",
+    "Archive History",
+    "Extract Workflow",
+    "Show Invocations",
+    "Share & Manage Access",
+];
+
+// options enabled for logged-out users
+const anonymousOptions = [
+    "Resume Paused Jobs",
+    "Delete this History",
+    "Export Tool References",
+    "Export History to File",
+];
+
+// options disabled for logged-out users
+const anonymousDisabledOptions = expectedOptions.filter((option) => !anonymousOptions.includes(option));
+
+async function createWrapper(propsData: object, userData?: any) {
+    const pinia = createPinia();
+
+    const wrapper = shallowMount(HistoryOptions as object, {
+        propsData,
+        localVue,
+        pinia,
+    });
+
+    const userStore = useUserStore();
+    userStore.currentUser = { ...userStore.currentUser, ...userData };
+
+    const historyStore = useHistoryStore();
+    jest.spyOn(historyStore, "currentHistoryId", "get").mockReturnValue("current_history_id");
+
+    return wrapper;
+}
+
+describe("History Navigation", () => {
+    it("presents all options to logged-in users", async () => {
+        const wrapper = await createWrapper(
+            {
+                history: { id: "current_history_id" },
+                histories: [],
+            },
+            {
+                id: "user.id",
+                email: "user.email",
+            }
+        );
+
+        const dropDown = wrapper.find("*[data-description='history options']");
+        const optionElements = dropDown.findAll("bdropdownitem-stub");
+        const optionTexts = optionElements.wrappers.map((el) => el.text());
+
+        expect(optionTexts).toStrictEqual(expectedOptions);
+    });
+
+    it("disables options for anonymous users", async () => {
+        const wrapper = await createWrapper({
+            history: { id: "current_history_id" },
+            histories: [],
+        });
+
+        const dropDown = wrapper.find("*[data-description='history options']");
+        const enabledOptionElements = dropDown.findAll("bdropdownitem-stub:not([disabled])");
+        const enabledOptionTexts = enabledOptionElements.wrappers.map((el) => el.text());
+        expect(enabledOptionTexts).toStrictEqual(anonymousOptions);
+
+        const disabledOptionElements = dropDown.findAll("bdropdownitem-stub[disabled]");
+        const disabledOptionTexts = disabledOptionElements.wrappers.map((el) => el.text());
+        expect(disabledOptionTexts).toStrictEqual(anonymousDisabledOptions);
+    });
+
+    it("prompts anonymous users to log in", async () => {
+        const wrapper = await createWrapper({
+            history: { id: "current_history_id" },
+            histories: [],
+        });
+
+        const dropDown = wrapper.find("*[data-description='history options']");
+        const disabledOptionElements = dropDown.findAll("bdropdownitem-stub[disabled]");
+
+        disabledOptionElements.wrappers.forEach((option) => {
+            expect((option.attributes("title") as string).toLowerCase()).toContain("log in");
+        });
+    });
+});

--- a/client/src/components/History/HistoryOptions.vue
+++ b/client/src/components/History/HistoryOptions.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import {
+    faArchive,
+    faBars,
+    faBurn,
+    faColumns,
+    faCopy,
+    faFileArchive,
+    faFileExport,
+    faList,
+    faPlay,
+    faStream,
+    faTrash,
+    faUsersCog,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import axios from "axios";
+import { BDropdown, BDropdownDivider, BDropdownItem, BDropdownText, BFormCheckbox, BModal } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
+import { computed, ref } from "vue";
+
+import { canMutateHistory, type HistorySummary } from "@/api";
+import { iframeRedirect } from "@/components/plugins/legacyNavigation";
+import { useToast } from "@/composables/toast";
+import { getAppRoot } from "@/onload/loadConfig";
+import { useHistoryStore } from "@/stores/historyStore";
+import { useUserStore } from "@/stores/userStore";
+import localize from "@/utils/localization";
+import { rethrowSimple } from "@/utils/simple-error";
+
+import CopyModal from "@/components/History/Modals/CopyModal.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
+
+interface Props {
+    history: HistorySummary;
+    minimal?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    minimal: false,
+});
+
+const toast = useToast();
+
+const userStore = useUserStore();
+const { isAnonymous } = storeToRefs(userStore);
+
+const historyStore = useHistoryStore();
+const { totalHistoryCount, historiesLoading } = storeToRefs(historyStore);
+
+const purgeHistory = ref(false);
+const showCopyModal = ref(false);
+const showDeleteModal = ref(false);
+
+const canEditHistory = computed(() => {
+    return canMutateHistory(props.history);
+});
+
+const isDeletedNotPurged = computed(() => {
+    return props.history.deleted && !props.history.purged;
+});
+
+const historyState = computed(() => {
+    if (props.history.purged) {
+        return "purged";
+    } else if (props.history.deleted) {
+        return "deleted";
+    } else if (props.history.archived) {
+        return "archived";
+    } else {
+        return "active";
+    }
+});
+
+function userTitle(title: string) {
+    if (isAnonymous.value) {
+        return localize("Log in to") + " " + localize(title);
+    } else {
+        return localize(title);
+    }
+}
+
+async function resumePausedJobs() {
+    const url = `${getAppRoot()}history/resume_paused_jobs?current=True`;
+    try {
+        const response = await axios.get(url);
+        toast.success(response.data.message);
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+function onDelete() {
+    if (purgeHistory.value) {
+        historyStore.deleteHistory(props.history.id, true);
+    } else {
+        historyStore.deleteHistory(props.history.id, false);
+    }
+}
+</script>
+
+<template>
+    <div>
+        <BDropdown
+            v-b-tooltip.top.hover.noninteractive
+            no-caret
+            size="sm"
+            :variant="props.minimal ? 'outline-info' : 'link'"
+            toggle-class="text-decoration-none"
+            menu-class="history-options-button-menu"
+            title="History options"
+            right
+            data-description="history options">
+            <template v-slot:button-content>
+                <FontAwesomeIcon fixed-width :icon="faBars" />
+                <span class="sr-only">History Options</span>
+            </template>
+
+            <BDropdownText>
+                <LoadingSpan v-if="historiesLoading" message="Fetching histories from server" />
+                <span v-else-if="!props.minimal">You have {{ totalHistoryCount }} histories.</span>
+                <span v-else>Manage History</span>
+            </BDropdownText>
+
+            <BDropdownItem
+                v-if="!props.minimal"
+                data-description="switch to multi history view"
+                :disabled="isAnonymous"
+                :title="userTitle('Open History Multiview')"
+                to="/histories/view_multiple">
+                <FontAwesomeIcon fixed-width :icon="faColumns" />
+                <span v-localize>Show Histories Side-by-Side</span>
+            </BDropdownItem>
+
+            <BDropdownDivider v-if="!props.minimal" />
+
+            <BDropdownText v-if="!canEditHistory">
+                This history has been <span class="font-weight-bold">{{ historyState }}</span
+                >.
+                <span v-localize>Some actions might not be available.</span>
+            </BDropdownText>
+
+            <BDropdownDivider v-if="!canEditHistory" />
+
+            <BDropdownItem
+                :disabled="!canEditHistory"
+                :title="localize('Resume all Paused Jobs in this History')"
+                @click="resumePausedJobs()">
+                <FontAwesomeIcon fixed-width :icon="faPlay" />
+                <span v-localize>Resume Paused Jobs</span>
+            </BDropdownItem>
+
+            <BDropdownDivider />
+
+            <BDropdownItem
+                :disabled="isAnonymous"
+                :title="userTitle('Copy History to a New History')"
+                @click="showCopyModal = !showCopyModal">
+                <FontAwesomeIcon fixed-width :icon="faCopy" />
+                <span v-localize>Copy this History</span>
+            </BDropdownItem>
+
+            <BDropdownItem
+                :disabled="!canEditHistory"
+                :title="localize(isDeletedNotPurged ? 'Permanently Delete History' : 'Delete History')"
+                @click="showDeleteModal = !showDeleteModal">
+                <FontAwesomeIcon fixed-width :icon="isDeletedNotPurged ? faBurn : faTrash" />
+                <span v-if="isDeletedNotPurged" v-localize>Permanently Delete History</span>
+                <span v-else v-localize>Delete this History</span>
+            </BDropdownItem>
+
+            <BDropdownItem
+                :title="localize('Export references for all Tools used in this History')"
+                :to="`/histories/citations?id=${history.id}`">
+                <FontAwesomeIcon fixed-width :icon="faStream" />
+                <span v-localize>Export Tool References</span>
+            </BDropdownItem>
+
+            <BDropdownItem
+                data-description="export to file"
+                :disabled="history.purged"
+                :title="localize('Export and Download History as a File')"
+                :to="`/histories/${history.id}/export`">
+                <FontAwesomeIcon fixed-width :icon="faFileArchive" />
+                <span v-localize>Export History to File</span>
+            </BDropdownItem>
+
+            <BDropdownItem
+                :disabled="isAnonymous || history.archived || history.purged"
+                data-description="archive history"
+                :title="userTitle('Archive this History')"
+                :to="`/histories/${history.id}/archive`">
+                <FontAwesomeIcon fixed-width :icon="faArchive" />
+                <span v-localize>Archive History</span>
+            </BDropdownItem>
+
+            <BDropdownItem
+                v-if="historyStore.currentHistoryId === history.id"
+                :disabled="isAnonymous"
+                :title="userTitle('Convert History to Workflow')"
+                @click="iframeRedirect(`/workflow/build_from_current_history?history_id=${history.id}`)">
+                <FontAwesomeIcon fixed-width :icon="faFileExport" />
+                <span v-localize>Extract Workflow</span>
+            </BDropdownItem>
+
+            <BDropdownItem
+                :disabled="isAnonymous"
+                :title="userTitle('Display Workflow Invocations')"
+                :to="`/histories/${history.id}/invocations`">
+                <FontAwesomeIcon fixed-width :icon="faList" />
+                <span v-localize>Show Invocations</span>
+            </BDropdownItem>
+
+            <BDropdownDivider />
+
+            <BDropdownItem
+                :disabled="isAnonymous || !canEditHistory"
+                data-description="share and manage access"
+                :title="userTitle('Share, Publish, or Set Permissions for this History')"
+                :to="`/histories/sharing?id=${history.id}`">
+                <FontAwesomeIcon fixed-width :icon="faUsersCog" />
+                <span v-localize>Share & Manage Access</span>
+            </BDropdownItem>
+        </BDropdown>
+
+        <CopyModal :history="history" :show-modal.sync="showCopyModal" />
+
+        <BModal
+            v-model="showDeleteModal"
+            centered
+            :title="isDeletedNotPurged ? 'Permanently Delete History?' : 'Delete History?'"
+            title-tag="h2"
+            :ok-title="isDeletedNotPurged ? 'Permanently Delete' : 'Delete'"
+            ok-variant="danger"
+            cancel-variant="outline-primary"
+            @ok="onDelete"
+            @show="purgeHistory = isDeletedNotPurged">
+            <p v-localize>
+                Do you also want to permanently delete the history <i class="ml-1">{{ history.name }}</i>
+            </p>
+
+            <BFormCheckbox id="purge-history" v-model="purgeHistory" :disabled="isDeletedNotPurged">
+                <span v-localize>Yes, permanently delete this history.</span>
+            </BFormCheckbox>
+        </BModal>
+    </div>
+</template>

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -44,7 +44,7 @@
 
 <script>
 import { faFileImport } from "@fortawesome/free-solid-svg-icons";
-import FontAwesomeIcon from "@fortawesome/vue-fontawesome";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { mapActions, mapState } from "pinia";
 
 import { isAnonymousUser } from "@/api";

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -1,25 +1,30 @@
 <template>
     <div v-if="currentUser && history" class="d-flex flex-column h-100">
-        <div class="flex-row flex-grow-0 pb-3">
-            <b-button
-                v-if="userOwnsHistory"
-                size="sm"
-                :title="setAsCurrentTitle"
-                :disabled="isSetAsCurrentDisabled"
-                data-description="switch to history button"
-                @click="setCurrentHistory(history.id)">
-                Switch to this history
-            </b-button>
+        <BreadcrumbHeading :items="breadcrumbItems">
+            <div class="d-flex flex-gapx-1">
+                <GButton
+                    v-if="userOwnsHistory"
+                    color="blue"
+                    :title="setAsCurrentTitle"
+                    :disabled="isSetAsCurrentDisabled"
+                    data-description="switch to history button"
+                    @click="setCurrentHistory(history.id)">
+                    Switch to this history
+                </GButton>
 
-            <b-button
-                v-if="canImportHistory"
-                v-b-modal:copy-history-modal
-                size="sm"
-                title="Import this history"
-                data-description="import history button">
-                Import this history
-            </b-button>
-        </div>
+                <GButton
+                    v-if="canImportHistory"
+                    v-b-modal:copy-history-modal
+                    color="blue"
+                    title="Import this history"
+                    data-description="import history button">
+                    <FontAwesomeIcon :icon="faFileImport" />
+                    Import this history
+                </GButton>
+
+                <HistoryOptions :history="history" minimal />
+            </div>
+        </BreadcrumbHeading>
 
         <b-alert :show="copySuccess">
             History imported and is now your active history. <b-link :to="importedHistoryLink">View here</b-link>.
@@ -38,6 +43,7 @@
 </template>
 
 <script>
+import FontAwesomeIcon from "@fortawesome/vue-fontawesome";
 import { mapActions, mapState } from "pinia";
 
 import { isAnonymousUser } from "@/api";
@@ -48,11 +54,19 @@ import CollectionPanel from "./CurrentCollection/CollectionPanel";
 import HistoryPanel from "./CurrentHistory/HistoryPanel";
 import CopyModal from "./Modals/CopyModal";
 
+import GButton from "@/components/BaseComponents/GButton.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
+import HistoryOptions from "@/components/History/HistoryOptions.vue";
+
 export default {
     components: {
         HistoryPanel,
         CollectionPanel,
         CopyModal,
+        FontAwesomeIcon,
+        GButton,
+        BreadcrumbHeading,
+        HistoryOptions,
     },
     props: {
         id: {
@@ -69,6 +83,16 @@ export default {
     computed: {
         ...mapState(useUserStore, ["currentUser"]),
         ...mapState(useHistoryStore, ["getHistoryById", "currentHistory"]),
+        breadcrumbItems() {
+            return [
+                { title: "Histories", to: "/histories/list" },
+                {
+                    title: this.history.name,
+                    to: `/histories/view?id=${this.history.id}`,
+                    superText: this.isCurrentHistory ? "current" : undefined,
+                },
+            ];
+        },
         history() {
             return this.getHistoryById(this.id);
         },

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -43,6 +43,7 @@
 </template>
 
 <script>
+import { faFileImport } from "@fortawesome/free-solid-svg-icons";
 import FontAwesomeIcon from "@fortawesome/vue-fontawesome";
 import { mapActions, mapState } from "pinia";
 
@@ -76,6 +77,7 @@ export default {
     },
     data() {
         return {
+            faFileImport,
             selectedCollections: [],
             copySuccess: false,
         };

--- a/client/src/components/History/Index.vue
+++ b/client/src/components/History/Index.vue
@@ -14,7 +14,7 @@ const userStore = useUserStore();
 const historyStore = useHistoryStore();
 
 const { currentUser } = storeToRefs(userStore);
-const { currentHistory, histories, historiesLoading } = storeToRefs(historyStore);
+const { currentHistory } = storeToRefs(historyStore);
 
 const listOffset = ref<number | undefined>(0);
 const breadcrumbs = ref<CollectionEntry[]>([]);
@@ -37,10 +37,7 @@ function onViewCollection(collection: CollectionEntry, currentOffset?: number) {
             :filterable="true"
             @view-collection="onViewCollection">
             <template v-slot:navigation>
-                <HistoryNavigation
-                    :history="currentHistory"
-                    :histories="histories"
-                    :histories-loading="historiesLoading" />
+                <HistoryNavigation :history="currentHistory" />
             </template>
         </HistoryPanel>
 

--- a/client/src/components/History/Multiple/MultipleViewItem.vue
+++ b/client/src/components/History/Multiple/MultipleViewItem.vue
@@ -9,8 +9,8 @@ import { computed, ref } from "vue";
 import { useExtendedHistory } from "@/composables/detailedHistory";
 import { useHistoryStore } from "@/stores/historyStore";
 
-import HistoryNavigation from "../CurrentHistory/HistoryNavigation.vue";
 import CollectionPanel from "@/components/History/CurrentCollection/CollectionPanel.vue";
+import HistoryNavigation from "@/components/History/CurrentHistory/HistoryNavigation.vue";
 import HistoryPanel from "@/components/History/CurrentHistory/HistoryPanel.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -26,7 +26,7 @@ interface Props {
 const props = defineProps<Props>();
 
 const historyStore = useHistoryStore();
-const { currentHistoryId, histories, historiesLoading, pinnedHistories } = storeToRefs(historyStore);
+const { currentHistoryId, pinnedHistories } = storeToRefs(historyStore);
 
 const { history } = useExtendedHistory(props.source.id);
 
@@ -71,11 +71,8 @@ function onViewCollection(collection: object) {
                     Hide
                 </BButton>
             </div>
-            <HistoryNavigation
-                :history="history"
-                :histories="histories"
-                :histories-loading="historiesLoading"
-                minimal />
+
+            <HistoryNavigation :history="history" minimal />
         </div>
 
         <hr class="w-100 m-1" />

--- a/client/src/components/Workflow/HistoryInvocations.vue
+++ b/client/src/components/Workflow/HistoryInvocations.vue
@@ -3,7 +3,8 @@ import { computed } from "vue";
 
 import { useHistoryStore } from "@/stores/historyStore";
 
-import GridInvocation from "../Grid/GridInvocation.vue";
+import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
+import GridInvocation from "@/components/Grid/GridInvocation.vue";
 
 interface HistoryInvocationProps {
     historyId: string;
@@ -11,14 +12,24 @@ interface HistoryInvocationProps {
 
 const props = defineProps<HistoryInvocationProps>();
 
-const { getHistoryNameById } = useHistoryStore();
-const historyName = computed(() => getHistoryNameById(props.historyId));
+const historyStore = useHistoryStore();
+const historyName = computed(() => historyStore.getHistoryNameById(props.historyId));
+
+const breadcrumbItems = computed(() => [
+    { title: "Histories", to: "/histories/list" },
+    {
+        title: historyName.value,
+        to: `/histories/view?id=${props.historyId}`,
+        superText: historyStore.currentHistoryId === props.historyId ? "current" : undefined,
+    },
+    { title: "Workflow Invocations" },
+]);
 </script>
+
 <template>
-    <GridInvocation
-        :filtered-for="{
-            type: 'History',
-            id: props.historyId,
-            name: historyName,
-        }" />
+    <div>
+        <BreadcrumbHeading :items="breadcrumbItems" />
+
+        <GridInvocation hide-heading :filtered-for="{ type: 'History', id: props.historyId, name: historyName }" />
+    </div>
 </template>


### PR DESCRIPTION
This PR updates most of the history-related pages' navigation and header to enhance user experience and a modernised interface.

|Before|After|
|---|---|
|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/b55a7eb3-868a-4377-8971-56e42c4224ed" />|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/5cc7fbe5-2531-4ecc-9fc1-d50690b162ee" />|
||<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/634c2414-6624-4630-b828-ca3e57f73655" />|
|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/8300bd45-e446-4185-839e-732f7653c0d9" />|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/2200cc89-853d-4b21-be9c-143547feb747" />|
|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/9409aa9c-d54a-4905-9cf5-b335b789d7c3" />|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/3bbc5985-b991-44ef-bfd5-fcdc182dfa1e" />|
|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/6d367efd-2f7f-45f1-a97e-9d5bddf47dd3" />|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/2ec117ff-52cd-4cea-b669-ee35a6932d08" />|
|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/216b412f-ae52-48b3-993a-6abb7f75ee8d" />|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/fdc84b50-0f55-4143-8103-3cc44c404b15" />|
|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/8a32cbb4-3463-4a62-bc87-bd226d62ae38" />|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/4b512c4b-e6b9-421a-9571-b1f0e11cfcf3" />|
|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/e173c6c6-c74d-41e2-9dd3-774cac797189" />|<img width="1918" height="991" alt="image" src="https://github.com/user-attachments/assets/ef9ed6c0-a689-4084-9421-7c6225cbe543" />|

## Key changes:
- Breadcrumbs component now supports an icon for each item
- Common history actions from HistoryNavigation moved into a new, reusable HistoryOptions component
- Most of the history-related components now have consistent headings

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. From the current history panel OR in the histories list click on `view` from a history menu, select an action from the history options menu.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
