### PR TITLE
[25.0] Add username filter to published pages grid

### DIFF
--- a/client/src/components/Grid/GridVisualization.vue
+++ b/client/src/components/Grid/GridVisualization.vue
@@ -18,10 +18,12 @@ library.add(faPlus);
 
 interface Props {
     activeList?: "my" | "shared" | "published";
+    username?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     activeList: "my",
+    username: undefined,
 });
 </script>
 
@@ -59,6 +61,6 @@ withDefaults(defineProps<Props>(), {
         </BNav>
         <GridList v-if="activeList === 'my'" :grid-config="visualizationsGridConfig" embedded />
         <GridList v-else-if="activeList === 'shared'" :grid-config="visualizationsSharedGridConfig" embedded />
-        <GridList v-else :grid-config="visualizationsPublishedGridConfig" embedded />
+        <GridList v-else :grid-config="visualizationsPublishedGridConfig" embedded :username-search="props.username" />
     </div>
 </template>

--- a/client/src/components/Grid/configs/historiesPublished.ts
+++ b/client/src/components/Grid/configs/historiesPublished.ts
@@ -88,7 +88,10 @@ const fields: FieldArray = [
     {
         key: "username",
         title: "Username",
-        type: "text",
+        type: "link",
+        handler: (data: HistoryEntry) => {
+            emit(`/histories/list_published?f-username=${data.username}`);
+        },
     },
 ];
 

--- a/client/src/components/Grid/configs/pagesPublished.ts
+++ b/client/src/components/Grid/configs/pagesPublished.ts
@@ -87,7 +87,10 @@ const fields: FieldArray = [
     {
         key: "username",
         title: "Owner",
-        type: "text",
+        type: "link",
+        handler: (data: PageEntry) => {
+            emit(`/pages/list_published?f-username=${data.username}`);
+        },
     },
 ];
 

--- a/client/src/components/Grid/configs/pagesPublished.ts
+++ b/client/src/components/Grid/configs/pagesPublished.ts
@@ -97,6 +97,7 @@ const fields: FieldArray = [
 const validFilters: Record<string, ValidFilter<string | boolean | undefined>> = {
     title: { placeholder: "title", type: String, handler: contains("title"), menuItem: true },
     slug: { handler: contains("slug"), menuItem: false },
+    user: { placeholder: "user", type: String, handler: contains("username"), menuItem: true },
 };
 
 /**

--- a/client/src/components/Grid/configs/visualizationsPublished.ts
+++ b/client/src/components/Grid/configs/visualizationsPublished.ts
@@ -76,7 +76,10 @@ const fields: FieldArray = [
     {
         key: "username",
         title: "Owner",
-        type: "text",
+        type: "link",
+        handler: (data: VisualizationEntry) => {
+            emit(`/visualizations/list_published?f-username=${data.username}`);
+        },
     },
     {
         key: "tags",

--- a/client/src/components/Grid/configs/visualizationsPublished.ts
+++ b/client/src/components/Grid/configs/visualizationsPublished.ts
@@ -103,6 +103,7 @@ const validFilters: Record<string, ValidFilter<string | boolean | undefined>> = 
         handler: contains("tag", "tag", expandNameTag),
         menuItem: true,
     },
+    user: { placeholder: "user", type: String, handler: contains("username"), menuItem: true },
 };
 
 /**

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -662,9 +662,10 @@ export function getRouter(Galaxy) {
                     {
                         path: "visualizations/list_published",
                         component: GridVisualization,
-                        props: {
+                        props: (route) => ({
                             activeList: "published",
-                        },
+                            username: route.query["f-username"],
+                        }),
                     },
                     {
                         path: "visualizations/list_shared",


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20481

## Also turns published grids' username fields to filter links
An additional improvement:

https://github.com/user-attachments/assets/42d24351-95f9-4e3b-b140-357ea4574ae7




## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
