### PR TITLE
[25.0] Fix parameter models for optional color params.

### DIFF
--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -921,14 +921,14 @@ class ColorParameterModel(BaseGalaxyToolParameterModelDefinition):
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         py_type = self.py_type
-        initialize: Any = ...
+        requires_value = self.request_requires_value
+        initialize = ... if requires_value else None
         if state_representation == "workflow_step_linked":
             py_type = allow_connected_value(py_type)
             validators = {
                 "color_format": field_validator(self.name)(ColorParameterModel.validate_color_str_or_connected_value)
             }
         elif state_representation == "workflow_step":
-            initialize = None
             validators = {"color_format": field_validator(self.name)(ColorParameterModel.validate_color_str_if_value)}
         else:
             validators = {"color_format": field_validator(self.name)(ColorParameterModel.validate_color_str)}

--- a/test/functional/tools/parameters/gx_color_optional.xml
+++ b/test/functional/tools/parameters/gx_color_optional.xml
@@ -1,0 +1,28 @@
+<tool id="gx_color_optional" name="gx_color_optional" version="1.0.0">
+    <command>
+        echo "$parameter"  > $out_file1;
+    </command>
+    <inputs>
+        <param name="parameter" type="color" value="#aabbcc" optional="true" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="parameter" value="#aaaaaa" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="#aaaaaa" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="#aabbcc" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>


### PR DESCRIPTION
Should fix https://github.com/galaxyproject/galaxy/issues/20697.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
