### PR TITLE
[25.0] Prevent negative offset in historyStore handleTotalCountChange

### DIFF
--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -305,7 +305,8 @@ export const useHistoryStore = defineStore("historyStore", () => {
      * @param reduction Whether it is a reduction or addition (default)
      */
     async function handleTotalCountChange(count = 0, reduction = false) {
-        historiesOffset.value += !reduction ? count : -count;
+        const adjustment = !reduction ? count : -count;
+        historiesOffset.value = Math.max(0, historiesOffset.value + adjustment);
         await loadTotalHistoryCount();
     }
 


### PR DESCRIPTION
Fixes #20648

I tried to find a way to reproduce this error by deleting and messing with histories in a different browser session, etc., but couldn't manage to reproduce. In any case, this change should prevent wrong requests.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
