### PR TITLE
[24.2] Fix ``test_base_image_for_targets`` mulled test to use mzmine

### DIFF
--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -18,7 +18,7 @@ from ..util import external_dependency_management
 @pytest.mark.parametrize(
     "target,version,base_image",
     [
-        ("maker", None, DEFAULT_EXTENDED_BASE_IMAGE),
+        ("mzmine", None, DEFAULT_EXTENDED_BASE_IMAGE),
         ("qiime", "1.9.1", DEFAULT_EXTENDED_BASE_IMAGE),
         ("samtools", None, DEFAULT_BASE_IMAGE),
     ],


### PR DESCRIPTION
maker is not using the ``extended-base`` image since https://github.com/bioconda/bioconda-recipes/commit/ce27c583fdd8fcaa60166fa3b0173083e352fd6b

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
