### PR TITLE
Improve cli and slurmcli runner traceability for job status and failure reasons

### DIFF
--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -174,7 +174,7 @@ class ShellJobRunner(AsynchronousJobRunner):
                 shell_params, job_params = self.parse_destination_params(ajs.job_destination.params)
                 shell, job_interface = self.get_cli_plugins(shell_params, job_params)
                 cmd_out = shell.execute(job_interface.get_single_status(external_job_id))
-                state = job_interface.parse_single_status(cmd_out.stdout, external_job_id)
+                state = job_interface.parse_single_status(cmd_out.stdout, external_job_id, shell)
                 if not state == model.Job.states.OK:
                     log.warning(
                         f"({id_tag}/{external_job_id}) job not found in batch state check, but found in individual state check"

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -217,18 +217,18 @@ class ShellJobRunner(AsynchronousJobRunner):
         cmd_out = shell.execute(job_interface.get_failure_reason(external_job_id))
         if cmd_out is not None:
             jobstate_map = {
-              JobState.runner_states.MEMORY_LIMIT_REACHED: (
-                "Tool failed due to insufficient memory. Try with more memory.",
-                f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit memory limit (SLURM state: OUT_OF_MEMORY)"
-              ),
-              JobState.runner_states.WALLTIME_REACHED: (
-                "This job was terminated because it ran longer than the maximum allowed job run time.",
-                f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit walltime"
-              ),
-              JobState.runner_states.UNKNOWN_ERROR: (
-                "This job ran into an unknown error.",
-                f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit unknown error"
-              )
+                JobState.runner_states.MEMORY_LIMIT_REACHED: (
+                    "Tool failed due to insufficient memory. Try with more memory.",
+                    f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit memory limit (SLURM state: OUT_OF_MEMORY)",
+                ),
+                JobState.runner_states.WALLTIME_REACHED: (
+                    "This job was terminated because it ran longer than the maximum allowed job run time.",
+                    f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit walltime",
+                ),
+                JobState.runner_states.UNKNOWN_ERROR: (
+                    "This job ran into an unknown error.",
+                    f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit unknown error",
+                ),
             }
             reported_jobstate = job_interface.parse_failure_reason(cmd_out.stdout, external_job_id)
             if reported_jobstate in jobstate_map:

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -219,15 +219,15 @@ class ShellJobRunner(AsynchronousJobRunner):
             jobstate_map = {
               JobState.runner_states.MEMORY_LIMIT_REACHED: (
                 "Tool failed due to insufficient memory. Try with more memory.",
-                "(%s/%s) Job hit memory limit (SLURM state: OUT_OF_MEMORY)" % (ajs.job_wrapper.get_id_tag(), ajs.job_id)
+                f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit memory limit (SLURM state: OUT_OF_MEMORY)"
               ),
               JobState.runner_states.WALLTIME_REACHED: (
                 "This job was terminated because it ran longer than the maximum allowed job run time.",
-                "(%s/%s) Job hit walltime" % (ajs.job_wrapper.get_id_tag(), ajs.job_id)
+                f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit walltime"
               ),
               JobState.runner_states.UNKNOWN_ERROR: (
                 "This job ran into an unknown error.",
-                "(%s/%s) Job hit unknown error" % (ajs.job_wrapper.get_id_tag(), ajs.job_id)
+                f"({ajs.job_wrapper.get_id_tag()}/{ajs.job_id}) Job hit unknown error"
               )
             }
             reported_jobstate = job_interface.parse_failure_reason(cmd_out.stdout, external_job_id)

--- a/lib/galaxy/jobs/runners/util/cli/job/__init__.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/__init__.py
@@ -69,7 +69,7 @@ class BaseJobExec(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def parse_single_status(self, status: str, job_id: str) -> job_states:
+    def parse_single_status(self, status: str, job_id: str, shell) -> job_states:
         """
         Parse the status of output from get_single_status command.
         """

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -73,7 +73,7 @@ class LSF(BaseJobExec):
                 rval[job_id] = self._get_job_state(state)
         return rval
 
-    def parse_single_status(self, status, job_id):
+    def parse_single_status(self, status, job_id, shell_interfance):
         if not status:
             # Job not found in LSF, most probably finished and forgotten.
             # lsf outputs: Job <num> is not found -- but that is on the stderr

--- a/lib/galaxy/jobs/runners/util/cli/job/slurm.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/slurm.py
@@ -6,6 +6,7 @@ from . import (
     BaseJobExec,
     job_states,
 )
+from ... import runner_states
 
 log = getLogger(__name__)
 
@@ -13,6 +14,30 @@ argmap = {"time": "-t", "ncpus": "-c", "partition": "-p"}
 
 
 class Slurm(BaseJobExec):
+    slurm_longjobstate_to_shortjobstate = {
+        'BOOT_FAIL': 'BF',
+        'CANCELLED': 'CA',
+        'COMPLETED': 'CD',
+        'DEADLINE': 'DL',
+        'FAILED': 'F',
+        'NODE_FAIL': 'NF',
+        'OUT_OF_MEMORY': 'OOM',
+        'PENDING': 'PD',
+        'PREEMPTED': 'PR',
+        'RUNNING': 'R',
+        'REQUEUED': 'RQ',
+        'RESIZING': 'RS',
+        'REVOKED': 'RV',
+        'SUSPENDED': 'S',
+        'TIMEOUT': 'TO',
+        'UNKNOWN': 'UN' # Custom for code in case one isn't available here
+    }
+    slurmstate_runnerstate_map = {
+        "OOM": runner_states.MEMORY_LIMIT_REACHED,
+        "TO": runner_states.WALLTIME_REACHED,
+        "UN": runner_states.UNKNOWN_ERROR
+    }
+
     def job_script_kwargs(self, ofile, efile, job_name):
         scriptargs = {"-o": ofile, "-e": efile, "-J": job_name}
 
@@ -61,20 +86,77 @@ class Slurm(BaseJobExec):
             # Job still on cluster and has state.
             id, state = status[1].split()
             return self._get_job_state(state)
+        elif len(status) <= 1:
+            log.debug(f"For job '{job_id}', relying on 'sacct' method to determine job state")
+            # Job no longer on cluster, retrieve state
+            pdata = subprocess.run(['sacct', '-o', 'JobIDRaw,State', '-P', '-n', '-j', job_id], capture_output=True, encoding='utf-8')
+            job_data = pdata.stdout.splitlines()
+
+            if len(job_data) == 0:
+                log.debug(f"Job '{job_id}' cannot be found. Returning error for job.")
+                return self._get_job_state('F')
+
+            state = "CD"
+            for jobline in job_data:
+                # Ignore the '.batch' and '.extern' in the output
+                if ".batch" in jobline or ".extern" in jobline:
+                    continue
+
+                splitjobdata = jobline.split('|')
+                if len(splitjobdata) >= 2:
+                    (s_jobid, s_jobstate) = splitjobdata
+                    if ' ' in s_jobstate:
+                        s_jobstate, s_jobotherinfo = s_jobstate.split(' ', 1)
+                    state = self.slurm_longjobstate_to_shortjobstate.get(s_jobstate, 'UN')
         # else line like "slurm_load_jobs error: Invalid job id specified"
         return job_states.OK
 
     def _get_job_state(self, state: str) -> str:
         try:
             return {
-                "F": job_states.ERROR,
-                "R": job_states.RUNNING,
-                "CG": job_states.RUNNING,
-                "PD": job_states.QUEUED,
+                "BF": job_states.ERROR,
+                "CA": job_states.ERROR,
                 "CD": job_states.OK,
-            }[state]
+                "CG": job_states.RUNNING,
+                "DL": job_states.ERROR,
+                "F": job_states.ERROR,
+                "NF": job_states.ERROR,
+                "OOM": job_states.ERROR,
+                "PD": job_states.QUEUED,
+                "PR": job_states.RUNNING,
+                "R": job_states.RUNNING,
+                "RQ": job_states.RUNNING,
+                "RS": job_states.RUNNING,
+                "RV": job_states.ERROR,
+                "S": job_states.RUNNING,
+                "TO": job_states.ERROR,
+                "UN": job_states.ERROR # Custom code for unknown
+            }.get(state)
         except KeyError:
             raise KeyError(f"Failed to map slurm status code [{state}] to job state.")
+
+        def get_failure_reason(self, job_id):
+        return f"sacct -o JobIDRaw,State -P -n -j {job_id}"
+
+    def parse_failure_reason(self, reason, job_id):
+        state = "CD"
+        for line in reason.splitlines():
+            if ".batch" in line or ".extern" in line:
+                continue
+
+            splitjobdata = line.split('|')
+            log.debug(f"State split line: {len(splitjobdata)}")
+            if len(splitjobdata) >= 2:
+                (s_jobid, s_jobstate) = splitjobdata
+                if ' ' in s_jobstate:
+                    s_jobstate, s_jobotherinfo = s_jobstate.split(' ', 1)
+                    log.debug(f"Found space in jobstate, split into: {s_jobstate} - {s_jobotherinfo}")
+                log.debug(f"State job data: {s_jobid} - {s_jobstate}")
+                state = self.slurm_longjobstate_to_shortjobstate.get(s_jobstate, 'UN')
+
+        if state in self.slurmstate_runnerstate_map:
+            return self.slurmstate_runnerstate_map.get(state, runner_states.UNKNOWN_ERROR)
+        return None
 
 
 __all__ = ("Slurm",)

--- a/lib/galaxy/jobs/runners/util/cli/job/slurm.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/slurm.py
@@ -135,7 +135,7 @@ class Slurm(BaseJobExec):
         except KeyError:
             raise KeyError(f"Failed to map slurm status code [{state}] to job state.")
 
-        def get_failure_reason(self, job_id):
+    def get_failure_reason(self, job_id):
         return f"sacct -o JobIDRaw,State -P -n -j {job_id}"
 
     def parse_failure_reason(self, reason, job_id):

--- a/lib/galaxy/jobs/runners/util/cli/job/slurm.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/slurm.py
@@ -134,7 +134,7 @@ class Slurm(BaseJobExec):
                 "S": job_states.RUNNING,
                 "TO": job_states.ERROR,
                 "UN": job_states.ERROR,  # Custom code for unknown
-            }.get(state)
+            }[state]
         except KeyError:
             raise KeyError(f"Failed to map slurm status code [{state}] to job state.")
 

--- a/lib/galaxy/jobs/runners/util/cli/job/slurm.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/slurm.py
@@ -1,6 +1,7 @@
 # A simple CLI runner for slurm that can be used when running Galaxy from a
 # non-submit host and using a Slurm cluster.
 from logging import getLogger
+import subprocess
 
 from . import (
     BaseJobExec,

--- a/lib/galaxy/jobs/runners/util/cli/job/torque.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/torque.py
@@ -92,7 +92,7 @@ class Torque(BaseJobExec):
                     rval[id_] = self._get_job_state(state)
         return rval
 
-    def parse_single_status(self, status, job_id):
+    def parse_single_status(self, status, job_id, shell):
         for line in status.splitlines():
             line = line.split(" = ")
             if line[0].strip() == "job_state":


### PR DESCRIPTION
The current Slurm Cli and the Cli system do not support a variety of different failure reasons for jobs, this should improve the state handling of jobs on Slurm submitted through Cli as well as allowing failure messages based on OOM and walltime to be presented properly. The state will no longer assume the job finished well if it can no longer be found.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use Slurm cli cluster submission
  2. Reach OOM or walltime limit with a tool

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
