### PR TITLE
Attempt to reuse previously materialized datasets

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5472,6 +5472,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
 
     history_id: Mapped[Optional[int]]
     dataset_id: Mapped[Optional[int]]
+    extension: Mapped[str]
     hidden_beneath_collection_instance: Mapped[Optional["HistoryDatasetCollectionAssociation"]]
     tags: Mapped[list["HistoryDatasetAssociationTagAssociation"]]
     copied_to_history_dataset_associations: Mapped[list["HistoryDatasetAssociation"]]

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -29,12 +29,14 @@ from galaxy.model import (
     LibraryDatasetDatasetAssociation,
     required_object_session,
     TRANSFORM_ACTIONS,
+    User,
 )
 from galaxy.objectstore import (
     ObjectStore,
     ObjectStorePopulator,
 )
 from galaxy.util.hash_util import verify_hash
+from .dereference import get_replacement_dataset
 
 log = logging.getLogger(__name__)
 
@@ -141,27 +143,48 @@ class DatasetInstanceMaterializer:
             materialized_dataset.hashes = materialized_dataset_hashes
         target_source = self._find_closest_dataset_source(dataset)
         transient_paths = None
+        replacement_dataset: Optional[HistoryDatasetAssociation] = None
 
         exception_materializing: Optional[Exception] = None
+        history = target_history
+        if history is None and isinstance(dataset_instance, HistoryDatasetAssociation):
+            try:
+                history = dataset_instance.history
+            except DetachedInstanceError:
+                history = None
+
         if attached:
             object_store_populator = self._object_store_populator
             assert object_store_populator
             object_store = object_store_populator.object_store
             store_by = object_store.get_store_by(dataset)
+            sa_session = self._sa_session
+            if sa_session is None:
+                sa_session = required_object_session(dataset_instance)
             if store_by == "id":
                 # we need a flush...
-                sa_session = self._sa_session
-                if sa_session is None:
-                    sa_session = required_object_session(dataset_instance)
                 sa_session.add(materialized_dataset)
                 sa_session.commit()
             object_store_populator.set_dataset_object_store_id(materialized_dataset)
-            try:
-                path = self._stream_source(target_source, dataset_instance.datatype, materialized_dataset)
-                object_store.update_from_file(materialized_dataset, file_name=path)
-                materialized_dataset.set_size()
-            except Exception as e:
-                exception_materializing = e
+            user: Optional[User] = None
+            if history:
+                user = history.user
+            replacement_dataset = get_replacement_dataset(
+                session=sa_session,
+                user=user,
+                dataset_sources=materialized_dataset.sources,
+                dataset_hashes=materialized_dataset.hashes,
+                extension=dataset_instance.extension,
+                object_store_id=materialized_dataset.object_store_id,
+                created_from_basename=materialized_dataset.created_from_basename,
+            )
+            if not replacement_dataset:
+                try:
+                    path = self._stream_source(target_source, dataset_instance.datatype, materialized_dataset)
+                    object_store.update_from_file(materialized_dataset, file_name=path)
+                    materialized_dataset.set_size()
+                except Exception as e:
+                    exception_materializing = e
         else:
             transient_path_mapper = self._transient_path_mapper
             assert transient_path_mapper
@@ -174,13 +197,6 @@ class DatasetInstanceMaterializer:
                 materialized_dataset.external_filename = transient_paths.external_filename
             except Exception as e:
                 exception_materializing = e
-
-        history = target_history
-        if history is None and isinstance(dataset_instance, HistoryDatasetAssociation):
-            try:
-                history = dataset_instance.history
-            except DetachedInstanceError:
-                history = None
 
         materialized_dataset_instance: HistoryDatasetAssociation
         if not in_place:
@@ -203,8 +219,19 @@ class DatasetInstanceMaterializer:
             sa_session.add(materialized_dataset_instance)
         if not in_place:
             materialized_dataset_instance.copy_from(
-                dataset_instance, new_dataset=materialized_dataset, include_tags=attached, include_metadata=True
+                replacement_dataset or dataset_instance,
+                new_dataset=replacement_dataset and replacement_dataset.dataset or materialized_dataset,
+                include_tags=attached,
+                include_metadata=True,
             )
+        elif replacement_dataset:
+            materialized_dataset_instance.dataset = replacement_dataset.dataset
+            materialized_dataset_instance.dataset_id = replacement_dataset.dataset_id
+            materialized_dataset_instance._metadata = replacement_dataset._metadata
+        if replacement_dataset:
+            # we have checked that we don't need to regenerate metadata in the get_replacement_dataset call
+            materialized_dataset_instance.metadata_deferred = False
+            return materialized_dataset_instance
         require_metadata_regeneration = (
             materialized_dataset_instance.has_metadata_files or materialized_dataset_instance.metadata_deferred
         )

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -40,6 +40,7 @@ is then added to populators to be shared across tests or across testing framewor
 
 import base64
 import contextlib
+import hashlib
 import json
 import os
 import tarfile
@@ -574,6 +575,20 @@ class BaseDatasetPopulator(BasePopulator):
         }
         if ext:
             item["ext"] = ext
+        output = self.fetch_hda(history_id, item)
+        details = self.get_history_dataset_details(history_id, dataset=output)
+        return details
+
+    def create_deferred_hda_with_hash(self, history_id: str, content: str) -> dict[str, Any]:
+        url = f"base64://{base64.b64encode(content.encode()).decode()}"
+        hashes = [{"hash_function": "SHA-1", "hash_value": hashlib.sha1(content.encode()).hexdigest()}]
+        item = {
+            "ext": "txt",
+            "src": "url",
+            "url": url,
+            "hashes": hashes,
+            "deferred": True,
+        }
         output = self.fetch_hda(history_id, item)
         details = self.get_history_dataset_details(history_id, dataset=output)
         return details


### PR DESCRIPTION
The conditions are:
- the replacement dataset exists in the same object store
- the replacement dataset exists in a history that the user owns
- the replacement dataset has a HDA of the same datatype
- the dataset hash or dataset source hash matches
- the replacement dataset is not purged or deleted and in OK state
- the same transform is applied

Providing hashes is currently a bit of a niche thing, but we do use this in BRC analytics (in particular all fastq files contain hashes).
This should help a lot with demo'ing things.

We should also be able to make use of this in planemo, where this would be a realistic path to enable "invocation resume" functionality.

We might eventually allow this for public datasets as well, but perhaps this should be a little more explicit. We could for instance include cache hints in the dataset request syntax (maybe something like `cache_strategy: own`, `cache_strategy: public`, `cache_strategy: never`) and a top level setting for the workflow request.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
