### PR TITLE
[25.0] DatasetView Header - fixes text wrapping issues on small screens

### DIFF
--- a/client/src/components/Dataset/DatasetState.vue
+++ b/client/src/components/Dataset/DatasetState.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 import { STATES } from "@/components/History/Content/model/states";
 import { useDatasetStore } from "@/stores/datasetStore";
+
+import GTooltip from "@/components/BaseComponents/GTooltip.vue";
 
 const datasetStore = useDatasetStore();
 
@@ -24,13 +26,37 @@ const contentCls = computed(() => {
         return `alert-${status}`;
     }
 });
+
+// Compute short display text - capitalize the state name
+const displayText = computed(() => {
+    if (!dataset.value) {
+        return "n/a";
+    }
+    const state = dataset.value.state;
+    if (!state) {
+        return "n/a";
+    }
+
+    // Capitalize first letter and replace underscores with spaces
+    return state.charAt(0).toUpperCase() + state.slice(1).replace(/_/g, " ");
+});
+
+// Get the full descriptive text for tooltip
+const tooltipText = computed(() => {
+    return contentState.value?.text || null;
+});
+
+// Ref for the state badge element
+const stateBadgeRef = ref<HTMLElement | null>(null);
 </script>
 
 <template>
-    <span v-if="dataset && contentState" class="rounded px-2 py-1 ml-2" :class="contentCls">
+    <span v-if="dataset && contentState" ref="stateBadgeRef" class="rounded px-2 py-1 ml-2" :class="contentCls">
         <span v-if="contentState.icon" class="mr-1">
             <FontAwesomeIcon fixed-width :icon="contentState.icon" :spin="contentState.spin" />
         </span>
-        {{ contentState.text || dataset.state || "n/a" }}
+        {{ displayText }}
+
+        <GTooltip v-if="tooltipText" :reference="stateBadgeRef" :text="tooltipText" />
     </span>
 </template>

--- a/client/src/components/Dataset/DatasetState.vue
+++ b/client/src/components/Dataset/DatasetState.vue
@@ -27,26 +27,17 @@ const contentCls = computed(() => {
     }
 });
 
-// Compute short display text - capitalize the state name
 const displayText = computed(() => {
-    if (!dataset.value) {
-        return "n/a";
-    }
-    const state = dataset.value.state;
-    if (!state) {
-        return "n/a";
+    if (contentState.value?.displayName) {
+        return contentState.value.displayName;
     }
 
-    // Capitalize first letter and replace underscores with spaces
-    return state.charAt(0).toUpperCase() + state.slice(1).replace(/_/g, " ");
+    const state = dataset.value?.state;
+    return state ? state.replace(/_/g, " ") : "n/a";
 });
 
-// Get the full descriptive text for tooltip
-const tooltipText = computed(() => {
-    return contentState.value?.text || null;
-});
+const tooltipText = computed(() => contentState.value?.text || null);
 
-// Ref for the state badge element
 const stateBadgeRef = ref<HTMLElement | null>(null);
 </script>
 

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -97,14 +97,18 @@ watch(
                     separator
                     inline
                     size="lg"
-                    class="flex-grow-1 d-flex flex-wrap align-items-center"
+                    class="flex-grow-1"
                     :collapse="headerState"
                     @click="toggleHeaderCollapse">
-                    <span class="dataset-hid">{{ dataset?.hid }}:</span>
-                    <span class="dataset-name font-weight-bold">{{ dataset?.name }}</span>
-                    <span class="dataset-state-header">
-                        <DatasetState :dataset-id="datasetId" />
-                    </span>
+                    <div class="dataset-header-content">
+                        <div class="dataset-title-row">
+                            <span class="dataset-hid">{{ dataset?.hid }}:</span>
+                            <span class="dataset-name font-weight-bold">{{ dataset?.name }}</span>
+                        </div>
+                        <span class="dataset-state-header">
+                            <DatasetState :dataset-id="datasetId" />
+                        </span>
+                    </div>
                 </Heading>
             </div>
             <transition v-if="dataset" name="header">
@@ -277,6 +281,20 @@ watch(
     opacity: 0;
 }
 
+.dataset-header-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.dataset-title-row {
+    display: flex;
+    align-items: baseline;
+    min-width: 0; // Allow to shrink below content
+    flex: 1 1 auto; // Allow to grow and shrink
+}
+
 .dataset-hid {
     white-space: nowrap;
     margin-right: 0.25rem;
@@ -284,14 +302,13 @@ watch(
 
 .dataset-name {
     word-break: break-word;
-    min-width: 0; // Allow flex item to shrink below content size
+    min-width: 0; // Allow text to wrap
 }
 
 .dataset-state-header {
     font-size: $h5-font-size;
-    vertical-align: middle;
-    margin-left: 0.5rem;
-    flex-shrink: 0; // Prevent state badge from shrinking
+    flex: 0 0 auto; // Don't grow or shrink
+    white-space: nowrap; // Prevent state badge from wrapping internally
 }
 
 .tab-content-panel {

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -291,8 +291,8 @@ watch(
 .dataset-title-row {
     display: flex;
     align-items: baseline;
-    min-width: 0; // Allow to shrink below content
-    flex: 1 1 auto; // Allow to grow and shrink
+    min-width: 0;
+    flex: 1 1 auto;
 }
 
 .dataset-hid {
@@ -302,13 +302,13 @@ watch(
 
 .dataset-name {
     word-break: break-word;
-    min-width: 0; // Allow text to wrap
+    min-width: 0;
 }
 
 .dataset-state-header {
     font-size: $h5-font-size;
-    flex: 0 0 auto; // Don't grow or shrink
-    white-space: nowrap; // Prevent state badge from wrapping internally
+    flex: 0 0 auto;
+    white-space: nowrap;
 }
 
 .tab-content-panel {

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -97,7 +97,7 @@ watch(
                     separator
                     inline
                     size="lg"
-                    class="flex-grow-1"
+                    class="flex-grow-1 d-flex flex-wrap align-items-center"
                     :collapse="headerState"
                     @click="toggleHeaderCollapse">
                     <span class="dataset-hid">{{ dataset?.hid }}:</span>
@@ -277,23 +277,21 @@ watch(
     opacity: 0;
 }
 
-.dataset-hid,
-.dataset-state-header {
-    white-space: nowrap;
-}
-
 .dataset-hid {
+    white-space: nowrap;
     margin-right: 0.25rem;
 }
 
 .dataset-name {
     word-break: break-word;
+    min-width: 0; // Allow flex item to shrink below content size
 }
 
 .dataset-state-header {
     font-size: $h5-font-size;
     vertical-align: middle;
     margin-left: 0.5rem;
+    flex-shrink: 0; // Prevent state badge from shrinking
 }
 
 .tab-content-panel {

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -14,6 +14,7 @@ type State =
 interface StateRepresentation {
     status: "success" | "warning" | "info" | "danger" | "secondary";
     text?: string;
+    displayName?: string;
     icon?: string;
     spin?: boolean;
     nonDb?: boolean;
@@ -31,28 +32,33 @@ export const STATES: StateMap = {
     /** has successfully completed running */
     ok: {
         status: "success",
+        displayName: "ok",
     },
     /** has no data */
     empty: {
         status: "success",
         text: "No data.",
+        displayName: "empty",
     },
     /** was created without a tool */
     new: {
         status: "warning",
         text: "This is a new dataset and not all of its data are available yet.",
+        displayName: "new",
         icon: "clock",
     },
     /** the job that will produce the dataset queued in the runner */
     queued: {
         status: "warning",
         text: "This job is waiting to run.",
+        displayName: "queued",
         icon: "clock",
     },
     /** the job that will produce the dataset is running */
     running: {
         status: "warning",
         text: "This job is currently running.",
+        displayName: "running",
         icon: "spinner",
         spin: true,
     },
@@ -60,6 +66,7 @@ export const STATES: StateMap = {
     setting_metadata: {
         status: "warning",
         text: "Metadata is being auto-detected.",
+        displayName: "setting metadata",
         icon: "spinner",
         spin: true,
     },
@@ -67,6 +74,7 @@ export const STATES: StateMap = {
     upload: {
         status: "warning",
         text: "This dataset is currently uploading.",
+        displayName: "uploading",
         icon: "spinner",
         spin: true,
     },
@@ -74,41 +82,48 @@ export const STATES: StateMap = {
     deferred: {
         status: "info",
         text: "This dataset is remote, has not been ingested by Galaxy, and full metadata may not be available.",
+        displayName: "deferred",
         icon: "cloud",
     },
     /** the job that will produce the dataset paused */
     paused: {
         status: "info",
         text: "This job is paused. Use the 'Resume Paused Jobs' in the history menu to resume.",
+        displayName: "paused",
         icon: "pause",
     },
     /** deleted while uploading */
     discarded: {
         status: "danger",
         text: "This dataset is discarded - the job creating it may have been cancelled or it may have been imported without file data.",
+        displayName: "discarded",
         icon: "exclamation-triangle",
     },
     /** the tool producing this dataset has errored */
     error: {
         status: "danger",
         text: "An error occurred with this dataset.",
+        displayName: "error",
         icon: "exclamation-triangle",
     },
     /** metadata discovery/setting failed or errored (but otherwise ok) */
     failed_metadata: {
         status: "danger",
         text: "Metadata generation failed. Please retry.",
+        displayName: "failed metadata",
         icon: "exclamation-triangle",
     },
     /** the job has failed, this is not a dataset but a job state used in the collection job state summary. */
     failed: {
         status: "danger",
+        displayName: "failed",
         icon: "exclamation-triangle",
     },
     /** the dataset is not yet loaded in the UI. This state is only visual and transitional, it does not exist in the database. */
     placeholder: {
         status: "secondary",
         text: "This dataset is being fetched.",
+        displayName: "loading",
         icon: "spinner",
         spin: true,
         nonDb: true,
@@ -117,6 +132,7 @@ export const STATES: StateMap = {
     failed_populated_state: {
         status: "danger",
         text: "Failed to populate the collection.",
+        displayName: "failed",
         icon: "exclamation-triangle",
         nonDb: true,
     },
@@ -124,12 +140,14 @@ export const STATES: StateMap = {
     new_populated_state: {
         status: "warning",
         text: "This is a new collection and not all of its data are available yet.",
+        displayName: "new",
         icon: "clock",
         nonDb: true,
     },
     inaccessible: {
         status: "warning",
         text: "User not allowed to access this dataset.",
+        displayName: "inaccessible",
         icon: "lock",
         nonDb: true,
     },


### PR DESCRIPTION
Dataset states now show concise labels (e.g., "running" instead of "This job is currently running") with tooltips for the full description.  This saves a lot of space in the state badge.  The state badge wraps to a new line when needed, instead of squashing the dataset name.

Originally had a computed turning the state id/text (snake_case in some cases) into a short displayName but having it as an explicit part of the model makes more sense.

fixes half of #20706


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
