### PR TITLE
[25.0] Fix maximum workflow invocation duration test

### DIFF
--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -305,7 +305,12 @@ class WorkflowRequestMonitor(Monitors):
         )
         self.invocation_grabber = None
         self.update_time_tracking_dict: Dict[int, datetime] = {}
-        self.timedelta = timedelta(seconds=DEFAULT_SCHEDULER_BACKFILL_SECONDS)
+        backfill_seconds = (
+            min(app.config.maximum_workflow_invocation_duration, DEFAULT_SCHEDULER_BACKFILL_SECONDS)
+            if app.config.maximum_workflow_invocation_duration > 0
+            else DEFAULT_SCHEDULER_BACKFILL_SECONDS
+        )
+        self.timedelta = timedelta(seconds=backfill_seconds)
         self_handler_tags = set(self.app.job_config.self_handler_tags)
         self_handler_tags.add(self.workflow_scheduling_manager.default_handler_id)
         handler_assignment_method = InvocationGrabber.get_grabbable_handler_assignment_method(


### PR DESCRIPTION
Broke this in https://github.com/galaxyproject/galaxy/pull/20522 ... the functionality still works, it's just that we'd have to wait for the 5 minute backfill.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
