### PR TITLE
Fix various collection descriptions in history panel.

### DIFF
--- a/client/src/components/History/Content/Collection/CollectionDescription.test.ts
+++ b/client/src/components/History/Content/Collection/CollectionDescription.test.ts
@@ -97,7 +97,7 @@ describe("CollectionDescription", () => {
                 collection_type: "other",
             },
         });
-        expect(wrapper.text()).toBe("a nested list with 10 dataset collections");
+        expect(wrapper.text()).toBe("a collection with 10 dataset collections");
     });
 
     it("should display expected homogeneous descriptions", async () => {
@@ -155,10 +155,20 @@ describe("CollectionDescription", () => {
             hdca: {
                 ...defaultTestHDCA,
                 element_count: 10,
+                collection_type: "paired:paired",
+                elements_datatypes: [EXPECTED_HOMOGENEOUS_DATATYPE],
+            },
+        });
+        expect(wrapper.text()).toBe(`a nested collection with 10 ${EXPECTED_HOMOGENEOUS_DATATYPE} dataset collections`);
+
+        await wrapper.setProps({
+            hdca: {
+                ...defaultTestHDCA,
+                element_count: 10,
                 collection_type: "other",
                 elements_datatypes: [EXPECTED_HOMOGENEOUS_DATATYPE],
             },
         });
-        expect(wrapper.text()).toBe(`a nested list with 10 ${EXPECTED_HOMOGENEOUS_DATATYPE} dataset collections`);
+        expect(wrapper.text()).toBe(`a collection with 10 ${EXPECTED_HOMOGENEOUS_DATATYPE} dataset collections`);
     });
 });

--- a/client/src/components/History/Content/Collection/CollectionDescription.vue
+++ b/client/src/components/History/Content/Collection/CollectionDescription.vue
@@ -20,6 +20,8 @@ const labels = new Map([
     ["list:list", "list"],
     ["paired", "pair"],
     ["sample_sheet", "sample sheet"],
+    ["sample_sheet:paired", "sample sheet"],
+    ["sample_sheet:paired_or_unpaired", "sample sheet"],
 ]);
 
 const jobStateSummary = computed(() => {
@@ -28,7 +30,18 @@ const jobStateSummary = computed(() => {
 
 const collectionLabel = computed(() => {
     const collectionType = props.hdca.collection_type;
-    return labels.get(collectionType) ?? "nested list";
+    const isList = collectionType.startsWith("list");
+    if (labels.get(collectionType)) {
+        return labels.get(collectionType);
+    } else if (isList) {
+        // call everything like list:list:paired or list:list:list a nested list
+        return "nested list";
+    } else if (collectionType.indexOf(":") > -1) {
+        // e.g. paired:paired or paired:list:list
+        return "nested collection";
+    } else {
+        return "collection";
+    }
 });
 const hasSingleElement = computed(() => {
     return props.hdca.element_count === 1;


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20730 - I had fixed it but only for flat sample sheets. I think Marius' screenshots were for paired sample sheets. Those should now be fixed and I've picked a better fallback than nested list - so things like say paired:paired are called collections and not nested lists.

Paired and unpaired sample sheets:

<img width="436" height="225" alt="Screenshot 2025-08-04 at 10 58 12 AM" src="https://github.com/user-attachments/assets/57a48f91-0be0-42f4-bc31-eb4a20ae7895" />

paired:paired collections left over from testing data landing requests:

<img width="446" height="82" alt="Screenshot 2025-08-04 at 10 58 21 AM" src="https://github.com/user-attachments/assets/bcb11949-e496-42e1-be02-3dd945618de3" />

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Create a paired sample sheet collection and look at history description of this dataset.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
