### PR TITLE
Make invocations panel reactive using the invocation store

### DIFF
--- a/client/src/api/invocations.ts
+++ b/client/src/api/invocations.ts
@@ -18,3 +18,9 @@ export type StepJobSummary =
     | components["schemas"]["InvocationStepJobsResponseCollectionJobsModel"];
 
 export type WorkflowInvocation = components["schemas"]["WorkflowInvocationResponse"];
+
+export function isWorkflowInvocationElementView(
+    item: WorkflowInvocation | null
+): item is WorkflowInvocationElementView {
+    return item !== null && "steps" in item;
+}

--- a/client/src/components/ScrollList/ScrollList.test.ts
+++ b/client/src/components/ScrollList/ScrollList.test.ts
@@ -284,7 +284,8 @@ describe("ScrollList with prop items and a local state loader", () => {
 
         expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE * 2 + 1} out of ${TOTAL_ITEMS + 1} ${ITEM_NAME_PLURAL}`);
 
-        // We confirm that we don't need `adjustForTotalCountChanges` anymore, as the counts are now aligned
+        // We confirm that the adjustment based on `adjustForTotalCountChanges` in the `totalItemCount` computed was not calculated
+        // here, since localItems and propItems are in sync.
         await wrapper.setProps({ adjustForTotalCountChanges: false });
 
         expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE * 2 + 1} out of ${TOTAL_ITEMS + 1} ${ITEM_NAME_PLURAL}`);

--- a/client/src/components/ScrollList/ScrollList.test.ts
+++ b/client/src/components/ScrollList/ScrollList.test.ts
@@ -13,6 +13,7 @@ const TOTAL_ITEMS = 50;
 const BUFFER_SIZE = 5;
 const TEST_ITEM_DIV = "div[data-description='test item']";
 const LOAD_MORE_BUTTON = "[data-description='load more items button']";
+const TEST_ITEM_SLOT = '<div data-description="test item" slot-scope="{ item, index }">Test {{ item.name }}</div>';
 const ITEM_NAME = "test item";
 const ITEM_NAME_PLURAL = "test items";
 
@@ -24,7 +25,7 @@ function createTestItems(count: number): TestItem[] {
     return items;
 }
 
-/** The infinite scroll callback, given the same name as the callback in `ScrollList`. */
+/** The infinite scroll callback mock, given the same name as the callback in `ScrollList`. */
 let loadItems: (() => void) | null = null;
 
 // Mock useInfiniteScroll to store the component's callback in the callback here
@@ -48,13 +49,43 @@ async function scrollOnce() {
 
 const TEST_ITEMS = createTestItems(TOTAL_ITEMS);
 
-/** Returns `BUFFER_SIZE` items each time, given the current offset. */
-const testLoader = jest.fn((offset: number, limit: number): Promise<{ items: TestItem[]; total: number }> => {
-    return Promise.resolve({
-        items: TEST_ITEMS.slice(offset, offset + limit),
-        total: TOTAL_ITEMS,
-    });
-});
+/** For the specific case where `propItems` is passed and updated by the loader,
+ * we keep track of the expected total count to calculate changes that are unrelated
+ * to scrolling/loading (e.g., an item or more added/removed externally in some other component). */
+let expectedTotalItemCount = 0;
+
+/** Returns `BUFFER_SIZE` items each time, given the current offset.
+ *
+ * Note: _The_ `wrapper` _parameter is optional and we use it to update `props.propItems`.
+ * This serves to mock the behavior of the parent component updating the `propItems` (via a store for e.g.)._
+ * @param offset The current offset to load items from.
+ * @param limit The number of items to load.
+ * @param wrapper Optional component wrapper to update the `propItems` with new items.
+ */
+const testLoader = jest.fn(
+    (offset: number, limit: number, wrapper?: Wrapper<Vue>): Promise<{ items: TestItem[]; total: number }> => {
+        const newItems = TEST_ITEMS.slice(offset, offset + limit);
+
+        if (wrapper) {
+            const currentPropItems = wrapper.props().propItems || [];
+
+            // Calculate external changes: actual length vs what we expected before this load
+            const externalChanges = currentPropItems.length - expectedTotalItemCount;
+
+            // Update expected length for next call
+            expectedTotalItemCount = currentPropItems.length + newItems.length;
+
+            wrapper.setProps({
+                propItems: [...(wrapper.props().propItems || []), ...newItems],
+                propTotalCount: TOTAL_ITEMS + externalChanges,
+            });
+        }
+        return Promise.resolve({
+            items: newItems,
+            total: TOTAL_ITEMS,
+        });
+    }
+);
 
 describe("ScrollList with local loader and data", () => {
     let wrapper: Wrapper<Vue>;
@@ -70,7 +101,7 @@ describe("ScrollList with local loader and data", () => {
             },
             localVue: getLocalVue(),
             scopedSlots: {
-                item: '<div data-description="test item" slot-scope="{ item, index }">Test {{ item.name }}</div>',
+                item: TEST_ITEM_SLOT,
             },
             stubs: {
                 FontAwesomeIcon: true,
@@ -140,7 +171,7 @@ describe("ScrollList with prop items and no local state", () => {
             },
             localVue: getLocalVue(),
             scopedSlots: {
-                item: '<div data-description="test item" slot-scope="{ item, index }">Test {{ item.name }}</div>',
+                item: TEST_ITEM_SLOT,
             },
             stubs: {
                 FontAwesomeIcon: true,
@@ -149,6 +180,9 @@ describe("ScrollList with prop items and no local state", () => {
     });
 
     it("renders all items without scrolling/loading", async () => {
+        // Assert that `propItems` is already populated
+        expect(wrapper.props().propItems.length).toBe(TOTAL_ITEMS);
+
         expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(TOTAL_ITEMS);
         expect(wrapper.text()).toContain(`All ${ITEM_NAME_PLURAL} loaded`);
         expect(wrapper.find(LOAD_MORE_BUTTON).exists()).toBe(false);
@@ -156,5 +190,103 @@ describe("ScrollList with prop items and no local state", () => {
         // We try to scroll, but since there are no items to load, the loader should not be called
         await scrollOnce();
         expect(testLoader).toHaveBeenCalledTimes(0);
+    });
+});
+
+describe("ScrollList with prop items and a local state loader", () => {
+    let wrapper: Wrapper<Vue>;
+
+    beforeEach(() => {
+        expectedTotalItemCount = 0;
+
+        wrapper = mount(ScrollList as object, {
+            propsData: {
+                // We make sure the `loader` updates the `propItems` (mock the loader loading via a pinia store for e.g.)
+                loader: (offset: number, limit: number) => testLoader(offset, limit, wrapper),
+                limit: BUFFER_SIZE,
+                propItems: [],
+                propTotalCount: TOTAL_ITEMS,
+                itemKey: (item: TestItem) => item.id,
+                name: ITEM_NAME,
+                namePlural: ITEM_NAME_PLURAL,
+                adjustForTotalCountChanges: false, // Default; we will adjust this to test this later
+            },
+            localVue: getLocalVue(),
+            scopedSlots: {
+                item: TEST_ITEM_SLOT,
+            },
+            stubs: {
+                FontAwesomeIcon: true,
+            },
+        });
+    });
+
+    it("updates the propItems on scroll", async () => {
+        // Assert that `propItems` is initially empty
+        expect(wrapper.props().propItems.length).toBe(0);
+
+        await scrollOnce();
+
+        // First `BUFFER_SIZE` items should be loaded
+        expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(BUFFER_SIZE);
+
+        // And the `propItems` have been updated as well
+        expect(wrapper.props().propItems.length).toBe(BUFFER_SIZE);
+
+        // And this happened through the loader
+        expect(testLoader).toHaveBeenCalledTimes(1);
+
+        // Next, we scroll twice more to find a total of `BUFFER_SIZE * 3` items
+        await scrollOnce();
+        await scrollOnce();
+        expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(BUFFER_SIZE * 3);
+        expect(wrapper.props().propItems.length).toBe(BUFFER_SIZE * 3);
+        expect(testLoader).toHaveBeenCalledTimes(3);
+    });
+
+    it("handles the count change discrepancy between propItems and local state", async () => {
+        // Initially, propItems is empty, so the count should be 0
+        expect(wrapper.text()).toContain(`Loaded 0 out of ${TOTAL_ITEMS} ${ITEM_NAME_PLURAL}`);
+
+        await scrollOnce();
+
+        // After loading first BUFFER_SIZE items, the count should be updated via the loader
+        expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE} out of ${TOTAL_ITEMS} ${ITEM_NAME_PLURAL}`);
+        expect(testLoader).toHaveBeenCalledTimes(1);
+
+        // Mock a change in the propItems (e.g., a store update like added/removed item) which is unrelated to scroll fetching
+        // and DOESN'T UPDATE `propTotalCount`
+        await wrapper.setProps({
+            propItems: [...(wrapper.props().propItems || []), { id: "extra-item", name: "Extra Item" }],
+        });
+
+        // Confirm that this did not happen via the loader
+        expect(testLoader).toHaveBeenCalledTimes(1);
+
+        // The count is initially not handled correctly; current count updates but total count remains the same
+        expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE + 1} out of ${TOTAL_ITEMS} ${ITEM_NAME_PLURAL}`);
+
+        // Now we trigger the adjustment for total count changes
+        await wrapper.setProps({ adjustForTotalCountChanges: true });
+
+        // The count should now reflect the total items correctly
+        expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE + 1} out of ${TOTAL_ITEMS + 1} ${ITEM_NAME_PLURAL}`);
+
+        // Scroll again to load more items and check the count
+        await scrollOnce();
+        expect(testLoader).toHaveBeenCalledTimes(2);
+
+        // This is a very important assertion:
+        // It confirms that after the external change, the loader loads the correct number of items
+        // from the correct offset, and that the loader's total count is adjusted correctly
+        // meaning there is no discrepancy between the propItems and the local state's counts.
+        // (So the `adjustForTotalCountChanges` did not come into play here).
+
+        expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE * 2 + 1} out of ${TOTAL_ITEMS + 1} ${ITEM_NAME_PLURAL}`);
+
+        // We confirm that we don't need `adjustForTotalCountChanges` anymore, as the counts are now aligned
+        await wrapper.setProps({ adjustForTotalCountChanges: false });
+
+        expect(wrapper.text()).toContain(`Loaded ${BUFFER_SIZE * 2 + 1} out of ${TOTAL_ITEMS + 1} ${ITEM_NAME_PLURAL}`);
     });
 });

--- a/client/src/components/ScrollList/ScrollList.test.ts
+++ b/client/src/components/ScrollList/ScrollList.test.ts
@@ -1,0 +1,104 @@
+import { getLocalVue } from "@tests/jest/helpers";
+import { mount, type Wrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
+
+import ScrollList from "./ScrollList.vue";
+
+interface TestItem {
+    id: string;
+    name: string;
+}
+
+const TOTAL_ITEMS = 50;
+const BUFFER_SIZE = 5;
+const TEST_ITEM_DIV = "div[data-description='test item']";
+
+function createTestItems(count: number): TestItem[] {
+    const items = Array.from({ length: count }, (_, index) => ({
+        id: `item-${index}`,
+        name: `Item ${index + 1}`,
+    }));
+    return items;
+}
+
+/** The infinite scroll callback, given the same name as the callback in `ScrollList`. */
+let loadItems: (() => void) | null = null;
+
+// Mock useInfiniteScroll to store the component's callback in the callback here
+jest.mock("@vueuse/core", () => ({
+    ...jest.requireActual("@vueuse/core"),
+    useInfiniteScroll: jest.fn((element, callback) => {
+        // On component mount, `useInfiniteScroll` is called and here, we store the callback
+        loadItems = callback;
+        return {};
+    }),
+}));
+
+/** Mocks a single scroll event to trigger the infinite scroll callback. */
+async function scrollOnce() {
+    if (loadItems) {
+        loadItems();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        await nextTick();
+    }
+}
+
+describe("ScrollList with local loader and data", () => {
+    let wrapper: Wrapper<Vue>;
+    const items = createTestItems(TOTAL_ITEMS);
+
+    /** Returns `BUFFER_SIZE` items each time, given the current offset. */
+    const testLoader = jest.fn((offset: number, limit: number): Promise<{ items: TestItem[]; total: number }> => {
+        return Promise.resolve({
+            items: items.slice(offset, offset + limit),
+            total: items.length,
+        });
+    });
+
+    beforeEach(async () => {
+        wrapper = mount(ScrollList as object, {
+            propsData: {
+                loader: (offset: number, limit: number) => testLoader(offset, limit),
+                itemKey: (item: TestItem) => item.id,
+                limit: BUFFER_SIZE,
+            },
+            localVue: getLocalVue(),
+            scopedSlots: {
+                item: '<div data-description="test item" slot-scope="{ item, index }">Test {{ item.name }}</div>',
+            },
+            stubs: {
+                FontAwesomeIcon: true,
+            },
+        });
+    });
+
+    it("loads items on scroll", async () => {
+        await scrollOnce();
+
+        // First `BUFFER_SIZE` items should be loaded
+        const items = wrapper.findAll(TEST_ITEM_DIV);
+        expect(items.length).toBe(BUFFER_SIZE);
+
+        // Next, we scroll twice more to find a total of `BUFFER_SIZE * 3` items
+        await scrollOnce();
+        await scrollOnce();
+        expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(BUFFER_SIZE * 3);
+
+        // Confirm that that the loader (testLoader) was called thrice (since we call `scrollOnce` 3 times)
+        expect(testLoader).toHaveBeenCalledTimes(3);
+
+        // Then we scroll until all items are loaded
+        while (wrapper.findAll(TEST_ITEM_DIV).length < TOTAL_ITEMS) {
+            await scrollOnce();
+        }
+        expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(TOTAL_ITEMS);
+
+        // Confirm that the loader was called enough times to load all items
+        expect(testLoader).toHaveBeenCalledTimes(Math.ceil(TOTAL_ITEMS / BUFFER_SIZE));
+
+        // Check that even if we scroll again, no new items are loaded
+        await scrollOnce();
+        expect(wrapper.findAll(TEST_ITEM_DIV).length).toBe(TOTAL_ITEMS);
+        expect(testLoader).toHaveBeenCalledTimes(Math.ceil(TOTAL_ITEMS / BUFFER_SIZE));
+    });
+});

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -28,6 +28,11 @@ interface Props<T> {
     propItems?: T[];
     propTotalCount?: number;
     propBusy?: boolean;
+    /**
+     * If true, the component will adjust the total item count based on changes in propItems.
+     * This is useful when propItems can change independently of the loader.
+     */
+    adjustForTotalCountChanges?: boolean;
 }
 
 // TODO: In Vue 3, we'll be able to use generic types directly in the template, so we can remove this type assertion
@@ -42,6 +47,7 @@ const props = withDefaults(defineProps<Props<T>>(), {
     propItems: undefined,
     propTotalCount: undefined,
     propBusy: undefined,
+    adjustForTotalCountChanges: false,
 });
 
 const emit = defineEmits(["load-more"]);
@@ -53,15 +59,33 @@ const scrollableDiv = ref<HTMLElement | null>(null);
 const localItems = ref<T[]>([]);
 
 const localTotalItemCount = ref<number | undefined>(undefined);
-const currentPage = ref(0);
 const localBusy = ref(false);
 const errorMessage = ref("");
 
 // Computed properties, which check whether the props are provided or local state is to be used
 const items = computed(() => (props.propItems !== undefined ? props.propItems : localItems.value));
-const totalItemCount = computed(() =>
-    props.propTotalCount !== undefined ? props.propTotalCount : localTotalItemCount.value
-);
+const totalItemCount = computed(() => {
+    // We are using local state entirely
+    if (props.propTotalCount === undefined && props.propItems === undefined) {
+        return localTotalItemCount.value;
+    }
+
+    const givenTotalCount: number | undefined =
+        props.propTotalCount !== undefined ? props.propTotalCount : localTotalItemCount.value;
+
+    // We are using a loader which means that the local state updates.
+    // We also have prop items which might be more or less than local items (e.g.: store updates like new invocation/deleted history).
+    // Note: We treat the prop items as the source of truth for the items to display.
+    if (props.adjustForTotalCountChanges && props.propItems !== undefined && props.loader !== undefined) {
+        // Here, we consider the case that prop items are updated via some external mechanism, and hence the total count might change
+        // and then the given total count will not reflect that difference.
+        return givenTotalCount !== undefined && props.propItems.length !== localItems.value.length
+            ? Math.max(0, givenTotalCount + (props.propItems.length - localItems.value.length))
+            : givenTotalCount;
+    }
+
+    return givenTotalCount;
+});
 const busy = computed(() => (props.propBusy !== undefined ? props.propBusy : localBusy.value));
 
 // check if we have scrolled to the top or bottom of the scrollable div
@@ -88,12 +112,11 @@ async function loadItems() {
             }
 
             localBusy.value = true;
-            const offset = props.limit * currentPage.value;
+            const offset = items.value.length;
             const { items: newItems, total } = await props.loader(offset, props.limit);
             // @ts-ignore - Vue 2.7 generic type compatibility issue, fix in Vue 3
-            localItems.value = localItems.value.concat(newItems);
+            localItems.value = props.propItems ? props.propItems : localItems.value.concat(newItems);
             localTotalItemCount.value = total;
-            currentPage.value += 1;
             errorMessage.value = "";
         } catch (e) {
             errorMessage.value = `Failed to load items: ${e}`;

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -62,9 +62,9 @@ const scrollableDiv = ref<HTMLElement | null>(null);
 
 // TODO: In Vue 3, we'll be able to use generic types directly in the template, so we can remove this type assertion
 // eslint-disable-next-line no-undef
-const localItems = ref<T[]>([]);
+const localItems = ref<T[]>(props.propItems || []);
 
-const localTotalItemCount = ref<number | undefined>(undefined);
+const localTotalItemCount = ref<number | undefined>(props.propTotalCount);
 const localBusy = ref(false);
 const errorMessage = ref("");
 

--- a/client/src/components/Workflow/Invocation/InvocationScrollList.vue
+++ b/client/src/components/Workflow/Invocation/InvocationScrollList.vue
@@ -19,7 +19,7 @@ import ScrollList from "@/components/ScrollList/ScrollList.vue";
 const currentUser = computed(() => useUserStore().currentUser);
 
 const invocationStore = useInvocationStore();
-const { storedInvocations } = storeToRefs(invocationStore);
+const { storedInvocations, scrollListScrollTop } = storeToRefs(invocationStore);
 
 interface Props {
     inPanel?: boolean;
@@ -120,7 +120,8 @@ function getInvocationBadges(invocation: WorkflowInvocation) {
         adjust-for-total-count-changes
         name="invocation"
         name-plural="invocations"
-        :load-disabled="!currentUser || currentUser.isAnonymous">
+        :load-disabled="!currentUser || currentUser.isAnonymous"
+        :prop-scroll-top.sync="scrollListScrollTop">
         <template v-slot:item="{ item: invocation }">
             <GCard
                 :id="`invocation-${invocation.id}`"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BBadge, BTab, BTabs } from "bootstrap-vue";
 import { computed, onUnmounted, ref, watch } from "vue";
 
-import type { InvocationStep, WorkflowInvocationElementView } from "@/api/invocations";
+import { type InvocationStep, isWorkflowInvocationElementView } from "@/api/invocations";
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
 import { useInvocationStore } from "@/stores/invocationStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
@@ -94,11 +94,14 @@ useAnimationFrameResizeObserver(scrollableDiv, ({ clientSize, scrollSize }) => {
     isScrollable.value = scrollSize.height >= clientSize.height + 1;
 });
 
-const invocation = computed(() =>
-    invocationLoaded.value
-        ? (invocationStore.getInvocationById(props.invocationId) as WorkflowInvocationElementView)
-        : null
-);
+const invocation = computed(() => {
+    const storedInvocation = invocationStore.getInvocationById(props.invocationId);
+    if (invocationLoaded.value && isWorkflowInvocationElementView(storedInvocation)) {
+        return storedInvocation;
+    } else {
+        return null;
+    }
+});
 const invocationState = computed(() => invocation.value?.state || "new");
 const invocationAndJobTerminal = computed(() => invocationSchedulingTerminal.value && jobStatesTerminal.value);
 const invocationSchedulingTerminal = computed(() => {

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -17,6 +17,7 @@ type GraphSteps = { [index: string]: GraphStep };
 
 export const useInvocationStore = defineStore("invocationStore", () => {
     const graphStepsByStoreId = ref<{ [index: string]: GraphSteps }>({});
+    const scrollListScrollTop = ref(0);
 
     async function fetchInvocationDetails(params: FetchParams): Promise<WorkflowInvocation> {
         const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}", {
@@ -131,5 +132,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         isLoadingInvocation,
         storedInvocations,
         updateInvocation,
+        /** The current scroll position of the list (used to track where the user has scrolled to). */
+        scrollListScrollTop,
     };
 });

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -82,7 +82,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         if (error) {
             rethrowSimple(error);
         }
-        storedInvocations.value[invocationId] = data;
+        updateInvocation(invocationId, data);
         return data;
     }
 

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, set } from "vue";
 
 import { GalaxyApi } from "@/api";
 import type {
@@ -85,6 +85,17 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         return data;
     }
 
+    function updateInvocation(id: string, updatedData: Partial<WorkflowInvocation>) {
+        if (storedInvocations.value[id]) {
+            set(storedInvocations.value, id, {
+                ...storedInvocations.value[id],
+                ...updatedData,
+            });
+        } else {
+            set(storedInvocations.value, id, updatedData);
+        }
+    }
+
     const {
         fetchItemById: fetchInvocationById,
         getItemById: getInvocationById,
@@ -118,5 +129,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         getInvocationRequestById,
         graphStepsByStoreId,
         isLoadingInvocation,
+        storedInvocations,
+        updateInvocation,
     };
 });

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref, set } from "vue";
+import { computed, ref, set } from "vue";
 
 import { GalaxyApi } from "@/api";
 import type {
@@ -116,6 +116,14 @@ export const useInvocationStore = defineStore("invocationStore", () => {
 
     const { getItemById: getInvocationRequestById } = useKeyedCache<WorkflowInvocationRequest>(fetchInvocationRequest);
 
+    const sortedStoredInvocations = computed(() => {
+        return Object.values(storedInvocations.value)
+            .sort((a, b) => new Date(b.update_time).getTime() - new Date(a.update_time).getTime())
+            .filter((invocation) => invocation !== undefined);
+    });
+
+    const totalInvocationCount = ref<number | undefined>(undefined);
+
     return {
         cancelWorkflowScheduling,
         fetchInvocationById,
@@ -130,7 +138,8 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         getInvocationRequestById,
         graphStepsByStoreId,
         isLoadingInvocation,
-        storedInvocations,
+        sortedStoredInvocations,
+        totalInvocationCount,
         updateInvocation,
         /** The current scroll position of the list (used to track where the user has scrolled to). */
         scrollListScrollTop,


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20543

https://github.com/user-attachments/assets/3bb29414-6fd5-4762-8848-7d2f751e71f6

The invocations are stored in the `invocationStore`, therefore, any new invocation is also detected in the scroll list. Note that the scroll list also remembers the scroll offset even after collapsing the panel.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open the invocations panel
  2. Run a workflow, notice that the count in the panel is updated and the invocation also shows up at the top
  3. Scroll down to find and click to view an older run
  4. Collapse and open the panel again to find that we have retained the scroll offset in the panel

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
