### PR TITLE
[25.0] Remove base_dir from zip in make_fast_zipfile

### DIFF
--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -440,10 +440,6 @@ def make_fast_zipfile(
             if root_dir is not None:
                 base_dir = os.path.join(root_dir, base_dir)
             base_dir = os.path.normpath(base_dir)
-            if arcname != os.curdir:
-                zf.write(base_dir, arcname)
-                if logger is not None:
-                    logger.info("adding '%s'", base_dir)
             for dirpath, dirnames, filenames in os.walk(base_dir):
                 arcdirpath = dirpath
                 if root_dir is not None:


### PR DESCRIPTION
Fixes #20686

Removing this entry gets rid of the empty temporary directory in ZIP files exported by Galaxy. Like in this case: `/corral4/main/celery-scratch/tmpwgae1vdm/`

<img width="716" height="414" alt="image" src="https://github.com/user-attachments/assets/ba34d358-5389-4967-84ad-a0b862f8df01" />


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
