### PR TITLE
Sample Sheet Bug Fixes around Preserving Collection Metadata

### DIFF
--- a/client/src/components/Collections/sheet/SampleSheetGrid.vue
+++ b/client/src/components/Collections/sheet/SampleSheetGrid.vue
@@ -178,8 +178,19 @@ function validate(value: string, columnDefinition: SampleSheetColumnDefinition):
 }
 
 function valueSetter(params: ValueSetterParams, columnDefinition: SampleSheetColumnDefinition): boolean {
-    const value = params.newValue;
+    let value = params.newValue;
+    const columnType = columnDefinition.type;
     if (validate(value, columnDefinition)) {
+        if (columnType !== "string" && value === "" && columnDefinition.optional) {
+            value = null;
+        } else if (columnType === "boolean") {
+            value = value.toLowerCase() === "true";
+        } else if (columnType === "int") {
+            value = parseInt(value, 10);
+        } else if (columnType === "float") {
+            value = parseFloat(value);
+        }
+
         params.data[params.colDef.field!] = value;
         return true;
     } else {

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -108,6 +108,11 @@ class MetadataSourceProvider(AbstractMetadataSourceProvider):
         return self._inp_data[input_name]
 
 
+def copy_collection_metadata_from_target_dict(hdca, target: dict):
+    if "column_definitions" in target:
+        hdca.collection.column_definitions = target["column_definitions"]
+
+
 def collect_dynamic_outputs(
     job_context: "BaseJobContext",
     output_collections: dict[str, Any],
@@ -144,8 +149,7 @@ def collect_dynamic_outputs(
                 collection_type_description = COLLECTION_TYPE_DESCRIPTION_FACTORY.for_collection_type(collection_type)
                 structure = UninitializedTree(collection_type_description)
                 hdca = job_context.create_hdca(name, structure)
-                if "column_definitions" in unnamed_output_dict:
-                    hdca.collection.column_definitions = unnamed_output_dict["column_definitions"]
+                copy_collection_metadata_from_target_dict(hdca, unnamed_output_dict)
                 output_collections[name] = hdca
                 job_context.add_dataset_collection(hdca)
             error_message = unnamed_output_dict.get("error_message")

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7341,6 +7341,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             type=self.collection_type,
             populated_state=self.populated_state,
             populated_state_message=self.populated_state_message,
+            column_definitions=self.column_definitions,
             elements=[e.serialize(id_encoder, serialization_options) for e in self.elements],
         )
         serialization_options.attach_identifier(id_encoder, self, rval)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -880,6 +880,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                     "collection_type",
                     "populated_state",
                     "populated_state_message",
+                    "column_definitions",
                     "element_count",
                 ]
                 for attribute in attributes:
@@ -891,6 +892,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 dc = model.DatasetCollection(collection_type=collection_attrs["type"])
                 dc.populated_state = collection_attrs["populated_state"]
                 dc.populated_state_message = collection_attrs.get("populated_state_message")
+                dc.column_definitions = collection_attrs.get("column_definitions")
                 self._attach_raw_id_if_editing(dc, collection_attrs)
                 materialize_elements(dc)
 

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -4,6 +4,7 @@ import os
 from typing import Optional
 
 from galaxy.exceptions import RequestParameterMissingException
+from galaxy.job_execution.output_collect import copy_collection_metadata_from_target_dict
 from galaxy.model import (
     History,
     Job,
@@ -185,6 +186,7 @@ def _precreate_fetched_collection_instance(trans, history, target, outputs):
     hdca = collections_manager.precreate_dataset_collection_instance(
         trans, history, name, structure=structure, tags=tags
     )
+    copy_collection_metadata_from_target_dict(hdca, target)
     outputs.append(hdca)
     # Following flushed needed for an ID.
     trans.sa_session.commit()

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -344,6 +344,13 @@ class TestDatasetCollectionsApi(ApiTestCase):
         assert len(columns) == 1
         assert columns[0] == 42
 
+        hdca_id = dataset_collection["id"]
+        dataset_collection_url = f"/api/dataset_collections/{hdca_id}"
+        dataset_collection = self._get(dataset_collection_url).json()
+        assert dataset_collection["id"] == hdca_id
+        assert dataset_collection["collection_type"] == "sample_sheet:paired"
+        assert dataset_collection["column_definitions"] is not None
+
     def test_sample_sheet_validating_against_column_definition(self, history_id):
         contents = [
             ("sample1", "1\t2\t3"),
@@ -815,6 +822,14 @@ class TestDatasetCollectionsApi(ApiTestCase):
             assert element0["columns"][0] == 42
             object0 = element0["object"]
             assert object0["state"] == "ok"
+            assert hdca["column_definitions"] is not None
+
+            hdca_id = hdca["id"]
+            dataset_collection_response = self._get(f"dataset_collections/{hdca_id}")
+            self._assert_status_code_is(dataset_collection_response, 200)
+            collection = dataset_collection_response.json()
+            assert collection["collection_type"] == "sample_sheet"
+            assert collection["column_definitions"] is not None
 
     def test_upload_sample_sheet_paired(self):
         column_definitions = [{"type": "int", "name": "replicate", "optional": False, "default_value": 0}]

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -147,6 +147,8 @@ SKIP_FLAKEY_TESTS_ON_ERROR = os.environ.get("GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ER
 
 PRIVATE_ROLE_TYPE = "private"
 
+HistoryContentsType = Literal["dataset_collections", "datasets"]
+
 
 def flakey(method):
     @wraps(method)
@@ -1356,6 +1358,11 @@ class BaseDatasetPopulator(BasePopulator):
     def get_history_contents(self, history_id: str, data=None) -> list[dict[str, Any]]:
         contents_response = self._get_contents_request(history_id, data=data)
         contents_response.raise_for_status()
+        return contents_response.json()
+
+    def get_history_contents_of_type(self, history_id: str, content_type: str) -> list[dict[str, Any]]:
+        contents_response = self._get_contents_request(history_id, f"/{content_type}")
+        api_asserts.assert_status_code_is_ok(contents_response)
         return contents_response.json()
 
     def _get_contents_request(self, history_id: str, suffix: str = "", data=None) -> Response:

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -31,6 +31,9 @@ from requests import Response
 
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy.util.unittest import TestCase
+from galaxy_test.api.test_dataset_collections import (
+    upload_flat_sample_sheet,
+)
 from galaxy_test.base.api_util import TEST_USER
 from galaxy_test.base.constants import (
     ONE_TO_SIX_ON_WINDOWS,
@@ -983,3 +986,28 @@ class TestLinkDataUploadExtendedMetadata(BaseUploadContentConfigurationTestCase)
 
     def test_link_data_only(self) -> None:
         link_data_only(self.server_dir(), self.library_populator)
+
+
+# With the API tests all using celery metadata - I think subtle differences in older
+# but perfectly valid configurations for running metadata are not being tested by API
+# tests anymore.
+class TestUploadWithDirectoryMetadata(BaseUploadContentConfigurationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config) -> None:
+        super().handle_galaxy_config_kwds(config)
+        config["metadata_strategy"] = "directory"
+
+    def test_upload_flat_sample_sheet(self):
+        upload_flat_sample_sheet(self.dataset_populator)
+
+
+class TestUploadWithExtendedMetadata(BaseUploadContentConfigurationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config) -> None:
+        super().handle_galaxy_config_kwds(config)
+        config["metadata_strategy"] = "extended"
+
+    def test_upload_flat_sample_sheet(self):
+        upload_flat_sample_sheet(self.dataset_populator)


### PR DESCRIPTION
We have a few different ways of collecting metadata after jobs and they seem to create collections in scarily different ways - as a result only the celery setup used by the API tests would actually preserve column definitions in the database after the data fetch tool creates those collections. This ports one of the sample sheet collection tests over to the integration test framework so we can test different metadata strategies - it would probably be nice to run a lot more of our data fetch tests in these new test cases but this PR only address the two specific bugs I've found so far.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
