### PR TITLE
Increase wait time (retry) in UCSC data source test

### DIFF
--- a/lib/galaxy_test/selenium/test_data_source_tools.py
+++ b/lib/galaxy_test/selenium/test_data_source_tools.py
@@ -31,6 +31,8 @@ class TestDataSource(SeleniumTestCase, UsesHistoryItemAssertions):
         # It doesn't seem to me this should be needed but we're getting occasional failures about inaccessible
         # history I cannot explain otherwise. -John
         self.wait_for_masthead()
-        self.history_panel_wait_for_hid_ok(1)
+        # Data source tools like UCSC can take longer to process external requests,
+        # so we allow force refreshes to give the test more time to complete
+        self.history_panel_wait_for_hid_ok(1, allowed_force_refreshes=2)
         # Make sure we're still logged in (xref https://github.com/galaxyproject/galaxy/issues/11374)
         self.components.masthead.logged_in_only.wait_for_visible()


### PR DESCRIPTION
To reduce the chance of failure, just because we didn't wait enough.

Fixes https://github.com/galaxyproject/galaxy/actions/runs/16912824782/job/47919303092?pr=20728#step:11:2910

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
