### PR TITLE
Drop old load_workflow controller method, use API

### DIFF
--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -86,7 +86,7 @@ export async function loadWorkflows({
     return { data, totalMatches };
 }
 
-export async function getWorkflowInfo(workflowId: string, version?: number) {
+export async function getWorkflowInfo(workflowId: string, version?: number, instance?: boolean) {
     const { data, error } = await GalaxyApi().GET("/api/workflows/{workflow_id}", {
         params: {
             path: {
@@ -94,6 +94,7 @@ export async function getWorkflowInfo(workflowId: string, version?: number) {
             },
             query: {
                 version: version,
+                instance: instance,
             },
         },
     });

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -3,7 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEye, faEyeSlash } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
-import { computed, type ComputedRef, type PropType, type Ref, ref } from "vue";
+import { computed, type ComputedRef, type Ref, ref } from "vue";
 
 import { useGlobalUploadModal } from "@/composables/globalUploadModal";
 import { useToolRouting } from "@/composables/route";
@@ -25,15 +25,12 @@ const emit = defineEmits<{
     (e: "update:show-advanced", showAdvanced: boolean): void;
     (e: "update:panel-query", query: string): void;
     (e: "onInsertTool", toolId: string, toolName: string): void;
-    (e: "onInsertModule", moduleName: string, moduleTitle: string | undefined): void;
 }>();
 
 const props = defineProps({
     workflow: { type: Boolean, default: false },
     showAdvanced: { type: Boolean, default: false, required: true },
     panelQuery: { type: String, required: true },
-    dataManagers: { type: Array, default: null },
-    moduleSections: { type: Array as PropType<Record<string, any>>, default: null },
     useSearchWorker: { type: Boolean, default: true },
 });
 
@@ -70,17 +67,6 @@ const { currentPanelView, currentToolSections } = storeToRefs(toolStore);
 const hasResults = computed(() => results.value.length > 0);
 const queryTooShort = computed(() => query.value && query.value.length < 3);
 const queryFinished = computed(() => query.value && queryPending.value != true);
-
-const hasDataManagerSection = computed(() => props.workflow && props.dataManagers && props.dataManagers.length > 0);
-const dataManagerSection = computed(() => {
-    const dynamicSection: ToolSectionType = {
-        model_class: "ToolSection",
-        id: "__data_managers",
-        name: localize("Data Managers"),
-        elems: props.dataManagers as Tool[],
-    };
-    return dynamicSection;
-});
 
 /** `toolsById` from `toolStore`, except it only has valid tools for `props.workflow` value */
 const localToolsById = computed(() => {
@@ -131,11 +117,6 @@ const localPanel: ComputedRef<Record<string, Tool | ToolSectionType> | null> = c
 
 const buttonIcon = computed(() => (showSections.value ? faEyeSlash : faEye));
 const buttonText = computed(() => (showSections.value ? localize("Hide Sections") : localize("Show Sections")));
-
-function onInsertModule(module: Record<string, any>, event: Event) {
-    event.preventDefault();
-    emit("onInsertModule", module.name, module.title);
-}
 
 function onToolClick(tool: Tool, evt: Event) {
     if (!props.workflow) {
@@ -231,24 +212,6 @@ function onToggle() {
         <div v-if="!propShowAdvanced" class="unified-panel-body">
             <div class="toolMenuContainer">
                 <div v-if="localPanel" class="toolMenu">
-                    <div v-if="props.workflow">
-                        <ToolSection
-                            v-for="category in moduleSections"
-                            :key="category.name"
-                            :hide-name="true"
-                            :category="category"
-                            tool-key="name"
-                            :section-name="category.name"
-                            :query-filter="queryFilter || undefined"
-                            :disable-filter="true"
-                            @onClick="onInsertModule" />
-                    </div>
-                    <ToolSection
-                        v-if="hasDataManagerSection"
-                        :category="dataManagerSection"
-                        :query-filter="queryFilter || undefined"
-                        :disable-filter="true"
-                        @onClick="onToolClick" />
                     <div v-for="(panel, key) in localPanel" :key="key">
                         <ToolSection
                             v-if="panel"

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -108,8 +108,6 @@ describe("ToolPanel", () => {
             propsData: {
                 workflow: false,
                 editorWorkflows: null,
-                dataManagers: null,
-                moduleSections: null,
                 useSearchWorker: false,
             },
             localVue,

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -21,14 +21,11 @@ const toolStore = useToolStore();
 
 const userStore = useUserStore();
 const props = defineProps({
-    dataManagers: { type: Array, default: null },
-    moduleSections: { type: Array, default: null },
     useSearchWorker: { type: Boolean, default: true },
     workflow: { type: Boolean, default: false },
 });
 
 const emit = defineEmits<{
-    (e: "onInsertModule", moduleName: string, moduleTitle: string | undefined): void;
     (e: "onInsertTool", toolId: string, toolName: string): void;
     (e: "onInsertWorkflow", workflowLatestId: string | undefined, workflowName: string): void;
     (e: "onInsertWorkflowSteps", workflowId: string, workflowStepCount: number | undefined): void;
@@ -106,10 +103,6 @@ async function updatePanelView(panelView: string) {
     panelName.value = panels.value[panelView]?.name || "";
     await toolStore.setPanel(panelView);
     panelName.value = "";
-}
-
-function onInsertModule(moduleName: string, moduleTitle: string | undefined) {
-    emit("onInsertModule", moduleName, moduleTitle);
 }
 
 function onInsertTool(toolId: string, toolName: string) {
@@ -191,11 +184,8 @@ initializePanel();
             :workflow="props.workflow"
             :panel-query.sync="query"
             :show-advanced.sync="showAdvanced"
-            :data-managers="dataManagers"
-            :module-sections="moduleSections"
             :use-search-worker="useSearchWorker"
             @onInsertTool="onInsertTool"
-            @onInsertModule="onInsertModule"
             @onInsertWorkflow="onInsertWorkflow"
             @onInsertWorkflowSteps="onInsertWorkflowSteps" />
         <div v-else-if="errorMessage" data-description="tool panel error message">

--- a/client/src/components/Workflow/Editor/Index.test.ts
+++ b/client/src/components/Workflow/Editor/Index.test.ts
@@ -6,10 +6,11 @@ import { getLocalVue } from "tests/jest/helpers";
 
 import { useServerMock } from "@/api/client/__mocks__";
 import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
+import { getWorkflowFull } from "@/components/Workflow/workflows.services";
 import { getAppRoot } from "@/onload/loadConfig";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 
-import { getVersions, loadWorkflow } from "./modules/services";
+import { getVersions } from "./modules/services";
 import { getStateUpgradeMessages } from "./modules/utilities";
 
 import Index from "./Index.vue";
@@ -22,6 +23,7 @@ jest.mock("./modules/services");
 jest.mock("layout/modal");
 jest.mock("onload/loadConfig");
 jest.mock("./modules/utilities");
+jest.mock("@/components/Workflow/workflows.services");
 
 jest.mock("app");
 
@@ -29,7 +31,7 @@ const { server, http } = useServerMock();
 
 const mockGetAppRoot = getAppRoot as jest.Mocked<typeof getAppRoot>;
 const mockGetStateUpgradeMessages = getStateUpgradeMessages as jest.Mock<typeof getStateUpgradeMessages>;
-const mockLoadWorkflow = loadWorkflow as jest.Mocked<typeof loadWorkflow>;
+const mockLoadWorkflow = getWorkflowFull as jest.Mocked<typeof getWorkflowFull>;
 const MockGetVersions = getVersions as jest.Mocked<typeof getVersions>;
 
 function mockUnprivilegedToolsRequest() {
@@ -62,8 +64,6 @@ describe("Index", () => {
                 workflowId: "workflow_id",
                 initialVersion: 1,
                 workflowTags: ["moo", "cow"],
-                moduleSections: [],
-                dataManagers: [],
                 workflows: [],
                 toolbox: [],
             },

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -40,17 +40,6 @@ export async function refactor(id, actions, dryRun = false) {
     }
 }
 
-export async function loadWorkflow({ id, version = null }) {
-    try {
-        const versionQuery = Number.isInteger(version) ? `version=${version}` : "";
-        const { data } = await axios.get(`${getAppRoot()}workflow/load_workflow?_=true&id=${id}&${versionQuery}`);
-        return data;
-    } catch (e) {
-        console.debug(e);
-        rethrowSimple(e);
-    }
-}
-
 export async function saveWorkflow(workflow) {
     if (workflow.hasChanges) {
         try {

--- a/client/src/components/Workflow/workflows.services.ts
+++ b/client/src/components/Workflow/workflows.services.ts
@@ -41,10 +41,10 @@ export async function createWorkflow(workflowName: string, workflowAnnotation: s
 }
 
 export async function getWorkflowFull(workflowId: string, version?: number) {
-    let url = `/workflow/load_workflow?_=true&id=${workflowId}`;
-    if (version !== undefined) {
-        url += `&version=${version}`;
+    const params: { style: string; version?: number } = { style: "editor" };
+    if (Number.isInteger(version)) {
+        params.version = version;
     }
-    const { data } = await axios.get(withPrefix(url));
+    const { data } = await axios.get(withPrefix(`/api/workflows/${workflowId}/download`), { params });
     return data;
 }

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -1,19 +1,17 @@
 <template>
     <Editor
-        v-if="editorConfig"
+        v-if="storedWorkflowId || newWorkflow"
         :key="editorReloadKey"
-        :workflow-id="editorConfig.id"
-        :data-managers="editorConfig.dataManagers"
-        :initial-version="editorConfig.initialVersion"
-        :module-sections="editorConfig.moduleSections"
-        :workflow-tags="editorConfig.tags"
+        :workflow-id="storedWorkflowId"
+        :initial-version="version"
         @update:confirmation="$emit('update:confirmation', $event)"
         @skipNextReload="() => (skipNextReload = true)" />
 </template>
 <script>
 import Editor from "components/Workflow/Editor/Index";
 import Query from "utils/query-string-parsing";
-import { urlData } from "utils/url";
+
+import { getWorkflowInfo } from "@/api/workflows";
 
 export default {
     components: {
@@ -24,9 +22,10 @@ export default {
             storedWorkflowId: null,
             workflowId: null,
             version: null,
-            editorConfig: null,
+            storedWorkflow: null,
             editorReloadKey: 0,
             skipNextReload: false,
+            newWorkflow: false,
         };
     },
     watch: {
@@ -40,32 +39,25 @@ export default {
     methods: {
         async getEditorConfig() {
             let reloadEditor = true;
-
             if (this.skipNextReload) {
                 reloadEditor = false;
                 this.skipNextReload = false;
             }
-
-            this.storedWorkflowId = Query.get("id");
-            this.workflowId = Query.get("workflow_id");
-            this.version = Query.get("version");
-            this.previousHistoryLength = window.history.length;
-
-            const params = {};
-
-            if (this.workflowId) {
-                params.workflow_id = this.workflowId;
-            } else if (this.storedWorkflowId) {
-                params.id = this.storedWorkflowId;
-            }
-            if (this.version) {
-                params.version = this.version;
-            }
-
-            this.editorConfig = await urlData({ url: "/workflow/editor", params });
-
             if (reloadEditor) {
                 this.editorReloadKey += 1;
+            }
+
+            this.version = Query.get("version");
+            this.storedWorkflowId = Query.get("id");
+            this.workflowId = Query.get("workflow_id");
+            const workflowId = this.workflowId || this.storedWorkflowId;
+            if (!workflowId) {
+                this.newWorkflow = true;
+                return;
+            }
+            if (this.workflowId) {
+                const { id: storedWorkflowId } = await getWorkflowInfo(workflowId, this.version, true);
+                this.storedWorkflowId = storedWorkflowId;
             }
         },
     },

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1261,6 +1261,7 @@ class WorkflowContentsManager(UsesAnnotations):
         data["source_metadata"] = workflow.source_metadata
         data["annotation"] = self.get_item_annotation_str(trans.sa_session, trans.user, stored) or ""
         data["comments"] = [comment.to_dict() for comment in workflow.comments]
+        data["tags"] = stored.make_tag_string_list()
 
         output_label_index = set()
         input_step_types = set(workflow.input_step_types)

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2647,24 +2647,6 @@ module_types = dict(
 module_factory = WorkflowModuleFactory(module_types)
 
 
-def load_module_sections(trans):
-    """Get abstract description of the workflow modules this Galaxy instance
-    is configured with.
-    """
-    module_sections = {}
-
-    if trans.app.config.enable_beta_workflow_modules:
-        module_sections["experimental"] = {
-            "name": "experimental",
-            "title": "Experimental",
-            "modules": [
-                {"name": "pause", "title": "Pause Workflow for Dataset Review", "description": "Pause for Review"}
-            ],
-        }
-
-    return module_sections
-
-
 class DelayedWorkflowEvaluation(Exception):
     def __init__(self, why=None):
         self.why = why


### PR DESCRIPTION
Also drops unused stuff, like data managers in workflows, and module insertion via tool panel (that happens via the inputs menu now). 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
