### PR TITLE
Stabilize client build after client-dev-server 

### DIFF
--- a/client-api/tsconfig.json
+++ b/client-api/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "target": "es2020",
-        "module": "es2020",
+        "target": "es2022",
+        "module": "es2022",
         "moduleResolution": "node",
         
         "verbatimModuleSyntax": true,

--- a/client-api/tsup.config.ts
+++ b/client-api/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   minify: false,
-  target: 'es2020',
+  target: 'es2022',
   esbuildOptions(options) {
     options.external = [
       ...options.external || [],

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "extends": "@vue/tsconfig/tsconfig.json",
     "compilerOptions": {
-        "target": "es2020",
-        "module": "es2020",
+        "target": "es2022",
+        "module": "es2022",
         "moduleResolution": "Bundler",
 
         "verbatimModuleSyntax": true,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -38,6 +38,8 @@ const buildDate = new Date();
 module.exports = (env = {}, argv = {}) => {
     // environment name based on -d, -p, webpack flag
     const targetEnv = process.env.NODE_ENV == "production" || argv.mode == "production" ? "production" : "development";
+    // Detect if running under webpack-dev-server
+    const isDevServer = argv.$0 && argv.$0.includes("webpack-dev-server");
 
     let minimizations = {};
     if (targetEnv == "production") {
@@ -323,6 +325,9 @@ module.exports = (env = {}, argv = {}) => {
             buildDependencies: {
                 config: [__filename],
             },
+            // Use different cache directories for dev server vs regular build
+            // to prevent conflicts when switching between modes
+            name: isDevServer ? "dev-server" : "build",
         },
         devServer: {
             client: {


### PR DESCRIPTION
## TL;DR

The client's build cache was corrupted when switching from `make client-dev-server` to `make client`. This PR uses 2 different cache folders for each build mode, so there is no interaction between them.

It also updates the typescript configuration to target ES2022 as we are relying in many places on features available only in this version, like `Array.prototype.at`.

## Original description

@mvdbeek, I think this could fix the issue with the client build failure after using `client-dev-server`:

```
TypeError: Cannot read properties of undefined (reading 'buildMeta')
    at HarmonyImportSpecifierDependency._getEffectiveExportPresenceLevel (/Users/mvandenb/src/galaxy/client/node_modules/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:220:41)
    at HarmonyImportSpecifierDependency.getWarnings (/Users/mvandenb/src/galaxy/client/node_modules/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:233:32)
    at Compilation.reportDependencyErrorsAndWarnings (/Users/mvandenb/src/galaxy/client/node_modules/webpack/lib/Compilation.js:3498:24)
    at /Users/mvandenb/src/galaxy/client/node_modules/webpack/lib/Compilation.js:3035:28
    at eval (eval at create (/Users/mvandenb/src/galaxy/client/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:29:1)
    at /Users/mvandenb/src/galaxy/client/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:404:10
    at /Users/mvandenb/src/galaxy/client/node_modules/neo-async/async.js:2830:7
    at Object.each (/Users/mvandenb/src/galaxy/client/node_modules/neo-async/async.js:2850:39)
    at /Users/mvandenb/src/galaxy/client/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:374:17
    at /Users/mvandenb/src/galaxy/client/node_modules/neo-async/async.js:2830:7
```

This is what I did:
```
cd client && rm -rf node_modules yarn.lock
```
```
yarn cache clean
```
```
yarn install
```
Then I tried adding an unmet peer dependency (postcss) for postcss-loader that was highlighted in one of the warnings, although I'm not sure if this was really fixing anything tbh...

After rebuilding everything from scratch, I started seeing the typescript issues you mentioned in the chat the other day about:

```
Property 'at' does not exist on type 'SelectionItem[]'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2022' or later.
```
So I downgraded the syntax to make it compatible with older compiler options.

Now I can alternate run `make client-dev-server` and `make client` without getting the "buildMeta" error :+1: 

## Update

I reverted the changes to avoid using `Array.prototype.at` since we are still using it more extensively in other parts of the codebase that are not TypeScript checked. So, instead, I've updated the typescript configuration to target `es2022`.

Also, it turned out that the initial changes described above didn't really get rid of the "buildMeta" issue; it was just temporarily working until the webpack cache got corrupted again between alternating between both build modes. However, the solution (thanks to Copilot) was to define 2 different cache directories for each build, which makes sense to me :tada: 

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
