### PR TITLE
[25.0] Cascade newly created windows in window manager

### DIFF
--- a/client/src/layout/window-manager.js
+++ b/client/src/layout/window-manager.js
@@ -26,14 +26,17 @@ export class WindowManager {
     }
 
     /** Add and display a new window based on options. */
-    add(options) {
-        const url = withPrefix(options.url);
+    add(options, layout = 10, margin = 20, index = 850) {
+        const url = this._build_url(withPrefix(options.url), { hide_panels: true, hide_masthead: true });
+        const x = this.counter * margin;
+        const y = (this.counter % layout) * margin;
         this.counter++;
-        const boxUrl = this._build_url(url, { hide_panels: true, hide_masthead: true });
         WinBox.new({
+            index: index,
             title: options.title || "Window",
-            url: boxUrl,
-            index: 850,
+            url: url,
+            x: x,
+            y: y,
             onclose: () => {
                 this.counter--;
             },


### PR DESCRIPTION
This pull request fixes the window manager so that newly created windows no longer stack directly on top of each other. Instead, each new window is slightly offset in both the x and y directions, creating a cascading effect. This makes it easier to distinguish and access multiple windows at once without having to move them manually.

![chira](https://github.com/user-attachments/assets/11ab8b36-3ad0-4896-be44-ccf43951b238)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
