### PR TITLE
Fix Switch to history link click actions and add extensive jests

### DIFF
--- a/client/src/components/History/SwitchToHistoryLink.test.ts
+++ b/client/src/components/History/SwitchToHistoryLink.test.ts
@@ -52,6 +52,15 @@ jest.mock("@/stores/historyStore", () => {
     };
 });
 
+// Mock the event store to track ctrlKey presses
+jest.mock("@/stores/eventStore", () => {
+    return {
+        useEventStore: () => ({
+            isCtrlKey: jest.fn((event: MouseEvent) => event.ctrlKey),
+        }),
+    };
+});
+
 /** Clear up and initialize all mocks for the jest. */
 function initializeMocks() {
     mockSetCurrentHistory.mockClear();
@@ -137,6 +146,14 @@ async function expectActionForHistory(
     expect(mockSetCurrentHistory).toHaveBeenCalledTimes(setsCurrentHistory ? 1 : 0);
     expect(mockApplyFilters).toHaveBeenCalledTimes(setsFilters ? 1 : 0);
     expect(mockWindowOpen).toHaveBeenCalledTimes(opensInNewTab ? 1 : 0);
+
+    // Click with ctrl key pressed down this time
+    await wrapper.find(selectors.historyLinkButton).trigger("click", { ctrlKey: true });
+
+    // None of the other click operations are called (counts remain as is), but we always open the history in a new tab
+    expect(mockSetCurrentHistory).toHaveBeenCalledTimes(setsCurrentHistory ? 1 : 0);
+    expect(mockApplyFilters).toHaveBeenCalledTimes(setsFilters ? 1 : 0);
+    expect(mockWindowOpen).toHaveBeenCalledTimes(opensInNewTab ? 2 : 1); // Ctrl+Click opens in new tab
 }
 
 describe("SwitchToHistoryLink", () => {

--- a/client/src/components/History/SwitchToHistoryLink.test.ts
+++ b/client/src/components/History/SwitchToHistoryLink.test.ts
@@ -15,9 +15,24 @@ const { server, http } = useServerMock();
 
 const selectors = {
     historyLink: ".history-link",
+    historyLinkButton: ".history-link-click",
+    tooltip: ".g-tooltip",
 } as const;
 
-// Mock the history store to always return the same current history id
+// Click action mocks
+const mockSetCurrentHistory = jest.fn();
+const mockApplyFilters = jest.fn();
+const mockWindowOpen = jest.fn(() => null);
+
+jest.mock("vue-router/composables", () => ({
+    useRouter: () => ({
+        resolve: (route: string) => ({
+            href: `resolved-${route}`,
+        }),
+    }),
+}));
+
+// Mock the history store
 jest.mock("@/stores/historyStore", () => {
     const originalModule = jest.requireActual("@/stores/historyStore");
     return {
@@ -25,11 +40,34 @@ jest.mock("@/stores/historyStore", () => {
         useHistoryStore: () => ({
             ...originalModule.useHistoryStore(),
             currentHistoryId: "current-history-id",
+            setCurrentHistory: mockSetCurrentHistory,
+            applyFilters: jest.fn().mockImplementation((historyId: string) => {
+                // We mock what the actual method does: set the current history if not current
+                if (historyId !== "current-history-id") {
+                    mockSetCurrentHistory();
+                }
+                mockApplyFilters();
+            }),
         }),
     };
 });
 
-function mountSwitchToHistoryLinkForHistory(history: HistorySummaryExtended) {
+/** Clear up and initialize all mocks for the jest. */
+function initializeMocks() {
+    mockSetCurrentHistory.mockClear();
+    mockApplyFilters.mockClear();
+    mockWindowOpen.mockClear();
+    const windowSpy = jest.spyOn(window, "open");
+    windowSpy.mockImplementation(() => mockWindowOpen());
+}
+
+/** Mock `<SwitchToHistoryLink>` component for testing.
+ * @param history - The history to be mocked
+ * @param hasFilters - Whether the component has the `filters` prop (generates sample filters)
+ */
+function mountSwitchToHistoryLinkForHistory(history: HistorySummaryExtended, hasFilters = false) {
+    initializeMocks();
+
     const pinia = createTestingPinia();
 
     server.use(
@@ -38,9 +76,12 @@ function mountSwitchToHistoryLinkForHistory(history: HistorySummaryExtended) {
         })
     );
 
+    const filters = hasFilters ? { deleted: false, visible: true, hid: "1" } : undefined;
+
     const wrapper = mount(SwitchToHistoryLink as object, {
         propsData: {
             historyId: history.id,
+            filters,
         },
         localVue,
         pinia,
@@ -66,14 +107,36 @@ function mountSwitchToHistoryLinkForHistory(history: HistorySummaryExtended) {
     return wrapper;
 }
 
-async function expectOptionForHistory(option: string, history: HistorySummaryExtended) {
-    const wrapper = mountSwitchToHistoryLinkForHistory(history);
+/**
+ * This function expects a specific action to be taken based on the provided history's properties.
+ * @param tooltip What tooltip text to expect
+ * @param history The history object to test (with variations like `deleted`, `archived`, etc.)
+ * @param opensInNewTab Whether the history should open in a new tab on click
+ * @param hasFilters Whether the `SwitchToHistoryLink` has a `filters` prop
+ * @param setsCurrentHistory Whether we set the current history on click
+ * @param setsFilters Whether filters are applied to the current history on click
+ */
+async function expectActionForHistory(
+    tooltip: "Switch to this history" | "This is your current history" | "View in new tab" | "Show in history",
+    history: HistorySummaryExtended,
+    opensInNewTab = false,
+    hasFilters = false,
+    setsCurrentHistory = false,
+    setsFilters = false
+) {
+    const wrapper = mountSwitchToHistoryLinkForHistory(history, hasFilters);
 
     // Wait for the history to be loaded
     await flushPromises();
 
-    expect(wrapper.html()).toContain(option);
+    expect(wrapper.find(selectors.tooltip).text()).toEqual(tooltip);
     expect(wrapper.text()).toContain(history.name);
+
+    await wrapper.find(selectors.historyLinkButton).trigger("click");
+
+    expect(mockSetCurrentHistory).toHaveBeenCalledTimes(setsCurrentHistory ? 1 : 0);
+    expect(mockApplyFilters).toHaveBeenCalledTimes(setsFilters ? 1 : 0);
+    expect(mockWindowOpen).toHaveBeenCalledTimes(opensInNewTab ? 1 : 0);
 }
 
 describe("SwitchToHistoryLink", () => {
@@ -97,7 +160,7 @@ describe("SwitchToHistoryLink", () => {
         expect(wrapper.text()).toContain(history.name);
     });
 
-    it("should display the Switch option when the history can be switched to", async () => {
+    it("sets current history or applies filters if the history can be switched to", async () => {
         const history = {
             id: "active-history-id",
             name: "History Active",
@@ -106,10 +169,15 @@ describe("SwitchToHistoryLink", () => {
             archived: false,
             user_id: "user_id",
         } as HistorySummaryExtended;
-        await expectOptionForHistory("Switch", history);
+
+        // We switch to this history
+        await expectActionForHistory("Switch to this history", history, false, false, true, false);
+
+        // Since history was not current, we switch to it AND apply filters
+        await expectActionForHistory("Show in history", history, false, true, true, true);
     });
 
-    it("should display the appropriate text when the history is the Current history", async () => {
+    it("only applies filters when the history is the Current history", async () => {
         const history = {
             id: "current-history-id",
             name: "History Current",
@@ -118,10 +186,15 @@ describe("SwitchToHistoryLink", () => {
             archived: false,
             user_id: "user_id",
         } as HistorySummaryExtended;
-        await expectOptionForHistory("This is your current history", history);
+
+        // We do nothing since the history is already current
+        await expectActionForHistory("This is your current history", history);
+
+        // Since history is already current, we only apply filters
+        await expectActionForHistory("Show in history", history, false, true, false, true);
     });
 
-    it("should display the View option when the history is purged", async () => {
+    it("opens purged history in new tab or applies filters", async () => {
         const history = {
             id: "purged-history-id",
             name: "History Purged",
@@ -130,10 +203,15 @@ describe("SwitchToHistoryLink", () => {
             archived: false,
             user_id: "user_id",
         } as HistorySummaryExtended;
-        await expectOptionForHistory("View", history);
+
+        // We view the purged history in a new tab
+        await expectActionForHistory("View in new tab", history, true);
+
+        // We switch to the purged history and apply filters
+        await expectActionForHistory("Show in history", history, false, true, true, true);
     });
 
-    it("should display the View option when the history is archived", async () => {
+    it("opens archived history in new tab or applies filters", async () => {
         const history = {
             id: "archived-history-id",
             name: "History Archived",
@@ -142,10 +220,15 @@ describe("SwitchToHistoryLink", () => {
             archived: true,
             user_id: "user_id",
         } as HistorySummaryExtended;
-        await expectOptionForHistory("View", history);
+
+        // We view the archived history in a new tab
+        await expectActionForHistory("View in new tab", history, true);
+
+        // We switch to the archived history and apply filters
+        await expectActionForHistory("Show in history", history, false, true, true, true);
     });
 
-    it("should view in new tab when the history is accessible", async () => {
+    it("only opens an accessible unowned history in new tab", async () => {
         const history = {
             id: "public-history-id",
             name: "History Published",
@@ -155,7 +238,12 @@ describe("SwitchToHistoryLink", () => {
             published: true,
             user_id: "other_user_id",
         } as HistorySummaryExtended;
-        await expectOptionForHistory("View", history);
+
+        // We view the accessible (but other user's) history in a new tab
+        await expectActionForHistory("View in new tab", history, true);
+
+        // Since the history isn't owned, we can't switch to it and apply filters; so we just view it in a new tab
+        await expectActionForHistory("View in new tab", history, true);
     });
 
     // if the history is inaccessible, the HistorySummary would never be fetched in the first place


### PR DESCRIPTION
Refactored and enhanced the logic and test coverage for the `SwitchToHistoryLink` component. 

- There was a bug wherein if a history is purged or archived, we wouldn't be able to apply filters upon clicking `SwitchToHistoryLink`. (e.g.: in Datasets list)
- Same applies to if a history is current; we wouldn't be able to apply filters, which is now fixed.
- The logic for tooltips and click actions is streamlined: users receive clearer feedback whether they're switching histories, applying filters, or viewing histories in new tabs, all given different history states (current, archived, purged, published, filtered etc.)
- The **test file** now includes more comprehensive mocking and new helper functions to better simulate each scenario for clicking the component: such as when to switch to current, apply filters, and open in new tab, including Ctrl+Click scenarios.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
