### PR TITLE
[25.0] Ensure that workflow invocations are persisted with state

### DIFF
--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -523,6 +523,7 @@ def workflow_run_config_to_request(
     workflow_invocation = WorkflowInvocation()
     workflow_invocation.uuid = uuid.uuid1()
     workflow_invocation.history = run_config.target_history
+    workflow_invocation.state = WorkflowInvocation.states.NEW
     ensure_object_added_to_session(workflow_invocation, object_in_session=run_config.target_history)
 
     def add_parameter(name: str, value: str, type: WorkflowRequestInputParameter.types) -> None:
@@ -579,8 +580,6 @@ def workflow_run_config_to_request(
                 subworkflow_run_config,
                 subworkflow,
             )
-            if subworkflow_invocation.state is None:
-                subworkflow_invocation.state = WorkflowInvocation.states.NEW
             workflow_invocation.attach_subworkflow_invocation_for_step(
                 step,
                 subworkflow_invocation,

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -579,6 +579,8 @@ def workflow_run_config_to_request(
                 subworkflow_run_config,
                 subworkflow,
             )
+            if subworkflow_invocation.state is None:
+                subworkflow_invocation.state = WorkflowInvocation.states.NEW
             workflow_invocation.attach_subworkflow_invocation_for_step(
                 step,
                 subworkflow_invocation,

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -173,7 +173,13 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         if exception:
             raise exception
 
-    def queue(self, workflow_invocation, request_params, flush=True, initial_state: Optional[InvocationState] = None):
+    def queue(
+        self,
+        workflow_invocation: model.WorkflowInvocation,
+        request_params,
+        flush=True,
+        initial_state: Optional[InvocationState] = None,
+    ):
         initial_state = initial_state or model.WorkflowInvocation.states.NEW
         workflow_invocation.set_state(initial_state)
         workflow_invocation.scheduler = request_params.get("scheduler", None) or self.default_scheduler_id

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -177,7 +177,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         self,
         workflow_invocation: model.WorkflowInvocation,
         request_params,
-        flush=True,
+        flush: bool = True,
         initial_state: Optional[InvocationState] = None,
     ):
         initial_state = initial_state or model.WorkflowInvocation.states.NEW


### PR DESCRIPTION
Subworkflow invocations didn't get a state and that's causing the new workflow tracking logic in planemo to quit.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
