### PR TITLE
Fix visualization installs

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -63,25 +63,10 @@ function stagePlugins(callback) {
     // Flatten the glob patterns to actual directory paths
     const dirs = [...globSync(visualizationDirs)];
 
-    // Get list of installed visualization plugin names to filter out
-    const installedVisualizationNames = Object.keys(VISUALIZATION_PLUGINS);
-
     // Process each directory
     const copyPromises = dirs.map((sourceDir) => {
         // Get the relative path from the plugin base dir
         const relativeDir = path.relative(PATHS.pluginBaseDir, sourceDir);
-
-        // Extract the plugin name from the path (e.g., "visualizations/myvis/static" -> "myvis")
-        const pathParts = relativeDir.split(path.sep);
-        const pluginName = pathParts[1]; // visualizations/[pluginName]/static
-
-        // Skip if this is an installed visualization plugin
-        if (installedVisualizationNames.includes(pluginName)) {
-            console.log(`Skipping plugin staging for '${pluginName}' (already installed via npm package)`);
-            return Promise.resolve();
-        } else {
-            console.log(`Staging filesystem plugin '${pluginName}' from ${sourceDir}`);
-        }
 
         // The target should preserve the full path including 'static'
         const targetDir = path.join(staticPluginDir, relativeDir);
@@ -117,7 +102,7 @@ function stagePlugins(callback) {
  * Produce plugins from fully self-contained npm packages
  */
 async function installVisualizations(callback, forceReinstall = false) {
-    const visualizationsDir = path.join(staticPluginDir, "visualizations");
+    const visualizationsDir = path.join(PATHS.pluginBaseDir, "visualizations");
     fs.ensureDirSync(visualizationsDir);
     for (const pluginName of Object.keys(VISUALIZATION_PLUGINS)) {
         const { package: pluginPackage, version } = VISUALIZATION_PLUGINS[pluginName];

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -63,10 +63,26 @@ function stagePlugins(callback) {
     // Flatten the glob patterns to actual directory paths
     const dirs = [...globSync(visualizationDirs)];
 
+    // Get list of installed visualization plugin names to filter out
+    const installedVisualizationNames = Object.keys(VISUALIZATION_PLUGINS);
+
     // Process each directory
     const copyPromises = dirs.map((sourceDir) => {
         // Get the relative path from the plugin base dir
         const relativeDir = path.relative(PATHS.pluginBaseDir, sourceDir);
+
+        // Extract the plugin name from the path (e.g., "visualizations/myvis/static" -> "myvis")
+        const pathParts = relativeDir.split(path.sep);
+        const pluginName = pathParts[1]; // visualizations/[pluginName]/static
+
+        // Skip if this is an installed visualization plugin
+        if (installedVisualizationNames.includes(pluginName)) {
+            console.log(`Skipping plugin staging for '${pluginName}' (already installed via npm package)`);
+            return Promise.resolve();
+        } else {
+            console.log(`Staging filesystem plugin '${pluginName}' from ${sourceDir}`);
+        }
+
         // The target should preserve the full path including 'static'
         const targetDir = path.join(staticPluginDir, relativeDir);
 


### PR DESCRIPTION
Per conversation in ui/ux, this pulls our staging approach back to a single path (everything installed to config, then staged), which resolves the persistent rebuilding error described: https://matrix.to/#/!XciPHtOkuKNqKoVeKD:gitter.im/$Be8p_hKrvlkvmVo6IKemM69D6xC7-5yU7soCplcr2sM?via=gitter.im&via=matrix.org&via=matrix.midnightmechanism.xyz

Also adds a SKIP_VIZ env var that I've been using locally to just force skip anything viz.

I hope to revisit #20371 and fix this for good at some point.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
