### PR TITLE
Adapt S3 file source to fsspec

### DIFF
--- a/lib/galaxy/files/sources/_fsspec.py
+++ b/lib/galaxy/files/sources/_fsspec.py
@@ -195,26 +195,39 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         fs = self._open_fs(context, cache_options)
         fs.put_file(native_path, target_path)
 
-    def _file_info_to_entry(self, dir_path: str, info: dict) -> AnyRemoteEntry:
+    def _adapt_entry_path(self, filesystem_path: str) -> str:
+        """Adapt the filesystem path to the desired entry path.
+
+        Subclasses can override this to transform paths (e.g., filesystem to virtual paths).
+        By default, returns the filesystem path unchanged.
+        """
+        return filesystem_path
+
+    def _extract_timestamp(self, info: dict) -> Optional[str]:
+        """Extract and format timestamp from fsspec file info."""
+        # Handle timestamp fields more robustly - check for None explicitly
+        mtime = info.get("mtime")
+        if mtime is None:
+            mtime = info.get("modified")
+        if mtime is None:
+            mtime = info.get("LastModified")
+
+        ctime_result = self.to_dict_time(mtime)
+        return ctime_result
+
+    def _info_to_entry(self, info: dict) -> AnyRemoteEntry:
         """Convert fsspec file info to Galaxy's remote entry format."""
-        name = os.path.basename(info["name"])
-        path = os.path.join(dir_path, name)
-        uri = self.uri_from_path(dir_path)
+        filesystem_path = info["name"]
+        entry_path = self._adapt_entry_path(filesystem_path)
+        name = os.path.basename(entry_path)
+        uri = self.uri_from_path(entry_path)
 
         if info.get("type") == "directory":
-            return RemoteDirectory(name=name, uri=uri, path=dir_path)
+            return RemoteDirectory(name=name, uri=uri, path=entry_path)
         else:
             size = int(info.get("size", 0))
-            # Handle timestamp fields more robustly - check for None explicitly
-            mtime = info.get("mtime")
-            if mtime is None:
-                mtime = info.get("modified")
-            if mtime is None:
-                mtime = info.get("LastModified")
-
-            ctime_result = self.to_dict_time(mtime) if mtime is not None else ""
-            ctime = ctime_result if ctime_result is not None else ""
-            return RemoteFile(name=name, size=size, ctime=ctime, uri=uri, path=path)
+            ctime = self._extract_timestamp(info)
+            return RemoteFile(name=name, size=size, ctime=ctime, uri=uri, path=entry_path)
 
     def _list_recursive(self, fs: AbstractFileSystem, path: str) -> tuple[list[AnyRemoteEntry], int]:
         """Handle recursive directory listing with item limit."""
@@ -223,12 +236,12 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         # Limiting the number of items returned for now.
         res: list[AnyRemoteEntry] = []
         count = 0
-        for p, dirs, files in fs.walk(path, detail=True):
+        for _, dirs, files in fs.walk(path, detail=True):
             # We are using detail=True to get file info as dicts,
             # so we can safely cast the result.
             dirs = cast(dict[str, dict], dirs)
             files = cast(dict[str, dict], files)
-            to_entry = functools.partial(self._file_info_to_entry, str(p))
+            to_entry = functools.partial(self._info_to_entry)
             res.extend(map(to_entry, dirs.values()))
             res.extend(map(to_entry, files.values()))
             count += len(dirs) + len(files)
@@ -252,8 +265,9 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         # Using detail=True returns a dict with file paths as keys and their info as
         # values so we can safely cast the result.
         matched_paths = cast(dict[str, dict], fs.glob(glob_pattern, detail=True))
-        for file_path, info in matched_paths.items():
-            entries_list.append(self._file_info_to_entry(str(file_path), info))
+        for entry_path, info in matched_paths.items():
+            if entry_path:  # Only process entries with valid paths
+                entries_list.append(self._info_to_entry(info))
         return entries_list
 
     def _list_directory(self, fs: AbstractFileSystem, path: str) -> list[AnyRemoteEntry]:
@@ -263,7 +277,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         for entry in entries:
             entry_path = entry.get("name", entry.get("path", ""))
             if entry_path:  # Only process entries with valid paths
-                entries_list.append(self._file_info_to_entry(entry_path, entry))
+                entries_list.append(self._info_to_entry(entry))
         return entries_list
 
     def _apply_pagination(

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -82,6 +82,13 @@ class S3FsFilesSource(FsspecFilesSource[S3FSFileSourceTemplateConfiguration, S3F
             raise exceptions.MessageException("Bucket name is required for S3FsFilesSource.")
         return self._bucket_path(bucket or "", path)
 
+    def _adapt_entry_path(self, filesystem_path: str) -> str:
+        """Remove the S3 bucket name from the filesystem path."""
+        if self.template_config.bucket:
+            bucket_prefix = f"{self.template_config.bucket}/"
+            return filesystem_path.replace(bucket_prefix, "", 1)
+        return filesystem_path
+
     def _list(
         self,
         context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration],

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -1,6 +1,4 @@
-import functools
 import logging
-import os
 from typing import (
     Optional,
     Union,
@@ -9,29 +7,30 @@ from typing import (
 from galaxy import exceptions
 from galaxy.files.models import (
     AnyRemoteEntry,
-    BaseFileSourceConfiguration,
-    BaseFileSourceTemplateConfiguration,
     FilesSourceRuntimeContext,
-    RemoteDirectory,
-    RemoteFile,
+)
+from galaxy.files.sources._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
 )
 from galaxy.util.config_templates import TemplateExpansion
 
 try:
-    import s3fs
+    from s3fs import S3FileSystem
 except ImportError:
-    s3fs = None
+    S3FileSystem = None
 
-from . import BaseFilesSource
 
 DEFAULT_ENFORCE_SYMLINK_SECURITY = True
 DEFAULT_DELETE_ON_REALIZE = False
-FS_PLUGIN_TYPE = "s3fs"
+REQUIRED_PACKAGE = FS_PLUGIN_TYPE = "s3fs"
 
 log = logging.getLogger(__name__)
 
 
-class S3FSFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
+class S3FSFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
     anon: Union[bool, TemplateExpansion] = False
     endpoint_url: Union[str, TemplateExpansion, None] = None
     bucket: Union[str, TemplateExpansion, None] = None
@@ -39,7 +38,7 @@ class S3FSFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
     key: Union[str, TemplateExpansion, None] = None
 
 
-class S3FSFileSourceConfiguration(BaseFileSourceConfiguration):
+class S3FSFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
     anon: bool = False
     endpoint_url: Optional[str] = None
     bucket: Optional[str] = None
@@ -47,26 +46,41 @@ class S3FSFileSourceConfiguration(BaseFileSourceConfiguration):
     key: Optional[str] = None
 
 
-class S3FsFilesSource(BaseFilesSource[S3FSFileSourceTemplateConfiguration, S3FSFileSourceConfiguration]):
+class S3FsFilesSource(FsspecFilesSource[S3FSFileSourceTemplateConfiguration, S3FSFileSourceConfiguration]):
     plugin_type = FS_PLUGIN_TYPE
+    required_module = S3FileSystem
+    required_package = REQUIRED_PACKAGE
 
     template_config_class = S3FSFileSourceTemplateConfiguration
     resolved_config_class = S3FSFileSourceConfiguration
 
-    def _open_fs(self, context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration]):
-        if s3fs is None:
-            raise Exception("Missing s3fs package, please install it to use S3 file sources.")
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ):
+        if S3FileSystem is None:
+            raise self.required_package_exception
 
         config = context.config
         client_kwargs = {"endpoint_url": config.endpoint_url} if config.endpoint_url else None
-        fs = s3fs.S3FileSystem(
+        fs = S3FileSystem(
             anon=config.anon,
             key=config.key,
             secret=config.secret,
             client_kwargs=client_kwargs,
-            listings_expiry_time=config.file_sources_config.listings_expiry_time,
+            **cache_options,
         )
         return fs
+
+    def _to_bucket_path(self, path: str, config: S3FSFileSourceConfiguration) -> str:
+        """Adapt the path to the S3 bucket format."""
+        if path.startswith("s3://"):
+            return path.replace("s3://", "")
+        bucket = config.bucket
+        if not bucket and not path.startswith("s3://"):
+            raise exceptions.MessageException("Bucket name is required for S3FsFilesSource.")
+        return self._bucket_path(bucket or "", path)
 
     def _list(
         self,
@@ -79,38 +93,28 @@ class S3FsFilesSource(BaseFilesSource[S3FSFileSourceTemplateConfiguration, S3FSF
         query: Optional[str] = None,
         sort_by: Optional[str] = None,
     ) -> tuple[list[AnyRemoteEntry], int]:
-        _bucket_name = context.config.bucket or ""
-        fs = self._open_fs(context)
-        if recursive:
-            res: list[AnyRemoteEntry] = []
-            bucket_path = self._bucket_path(_bucket_name, path)
-            for p, dirs, files in fs.walk(bucket_path, detail=True):
-                to_dict = functools.partial(self._resource_info_to_dict, p)
-                res.extend(map(to_dict, dirs.values()))
-                res.extend(map(to_dict, files.values()))
-            return res, len(res)
-        else:
-            bucket_path = self._bucket_path(_bucket_name, path)
-            try:
-                res = fs.ls(bucket_path, detail=True)
-            except Exception as e:
-                raise exceptions.MessageException(f"Error listing {bucket_path}: {e}")
-            to_dict = functools.partial(self._resource_info_to_dict, path)
-            return list(map(to_dict, res)), len(res)
+        bucket_path = self._to_bucket_path(path, context.config)
+        return super()._list(
+            context=context,
+            path=bucket_path,
+            recursive=recursive,
+            limit=limit,
+            offset=offset,
+            query=query,
+            sort_by=sort_by,
+        )
 
     def _realize_to(
         self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration]
     ):
-        _bucket_name = context.config.bucket or ""
-        fs = self._open_fs(context)
-        bucket_path = self._bucket_path(_bucket_name, source_path)
-        fs.download(bucket_path, native_path)
+        bucket_path = self._to_bucket_path(source_path, context.config)
+        super()._realize_to(source_path=bucket_path, native_path=native_path, context=context)
 
-    def _write_from(self, target_path, native_path, context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration]):
-        _bucket_name = context.config.bucket or ""
-        fs = self._open_fs(context)
-        bucket_path = self._bucket_path(_bucket_name, target_path)
-        fs.upload(native_path, bucket_path)
+    def _write_from(
+        self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration]
+    ):
+        bucket_path = self._to_bucket_path(target_path, context.config)
+        super()._write_from(target_path=bucket_path, native_path=native_path, context=context)
 
     def _bucket_path(self, bucket_name: str, path: str):
         if path.startswith("s3://"):
@@ -118,21 +122,6 @@ class S3FsFilesSource(BaseFilesSource[S3FSFileSourceTemplateConfiguration, S3FSF
         elif not path.startswith("/"):
             path = f"/{path}"
         return f"{bucket_name}{path}"
-
-    def _resource_info_to_dict(self, dir_path: str, resource_info) -> AnyRemoteEntry:
-        name = str(os.path.basename(resource_info["name"]))
-        path = os.path.join(dir_path, name)
-        uri = self.uri_from_path(path)
-        if resource_info["type"] == "directory":
-            return RemoteDirectory(name=name, uri=uri, path=path)
-        else:
-            return RemoteFile(
-                name=name,
-                size=resource_info["size"],
-                ctime=self.to_dict_time(resource_info["LastModified"]),
-                uri=uri,
-                path=path,
-            )
 
     def score_url_match(self, url: str):
         # We need to use template_config here because this is called before the template is expanded.

--- a/lib/galaxy/files/sources/temp.py
+++ b/lib/galaxy/files/sources/temp.py
@@ -74,7 +74,7 @@ class TempFilesSource(FsspecFilesSource[TempFileSourceTemplateConfiguration, Tem
 
         i.e. /a/b/c -> /{root_path}/a/b/c
         """
-        relative_path = path.lstrip(os.sep)
+        relative_path = path.lstrip("/")
         if not relative_path:
             return self._root_path
         return os.path.join(self._root_path, relative_path)
@@ -87,10 +87,10 @@ class TempFilesSource(FsspecFilesSource[TempFileSourceTemplateConfiguration, Tem
         # Remove the root path prefix
         if native_path.startswith(self._root_path):
             virtual_path = native_path[len(self._root_path) :]
-            # Ensure the path starts with a single slash
-            if not virtual_path.startswith(os.sep):
-                virtual_path = os.sep + virtual_path
-            elif virtual_path.startswith(os.sep + os.sep):
+            # Ensure the path starts with a single forward slash
+            if not virtual_path.startswith("/"):
+                virtual_path = f"/{virtual_path}"
+            elif virtual_path.startswith("//"):
                 # Remove extra leading slash if present
                 virtual_path = virtual_path[1:]
             return virtual_path


### PR DESCRIPTION
Requires #20698 and #20799
Fixes #20791

The underlying s3fs library is already compatible with fsspec, so "it should work out of the box" (famous last words).

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Use any existing S3 file source

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
