### PR TITLE
Fix fsspec fs path handling

### DIFF
--- a/lib/galaxy/files/sources/_fsspec.py
+++ b/lib/galaxy/files/sources/_fsspec.py
@@ -195,26 +195,39 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         fs = self._open_fs(context, cache_options)
         fs.put_file(native_path, target_path)
 
-    def _file_info_to_entry(self, dir_path: str, info: dict) -> AnyRemoteEntry:
+    def _adapt_entry_path(self, filesystem_path: str) -> str:
+        """Adapt the filesystem path to the desired entry path.
+
+        Subclasses can override this to transform paths (e.g., filesystem to virtual paths).
+        By default, returns the filesystem path unchanged.
+        """
+        return filesystem_path
+
+    def _extract_timestamp(self, info: dict) -> Optional[str]:
+        """Extract and format timestamp from fsspec file info."""
+        # Handle timestamp fields more robustly - check for None explicitly
+        mtime = info.get("mtime")
+        if mtime is None:
+            mtime = info.get("modified")
+        if mtime is None:
+            mtime = info.get("LastModified")
+
+        ctime_result = self.to_dict_time(mtime)
+        return ctime_result
+
+    def _info_to_entry(self, info: dict) -> AnyRemoteEntry:
         """Convert fsspec file info to Galaxy's remote entry format."""
-        name = os.path.basename(info["name"])
-        path = os.path.join(dir_path, name)
-        uri = self.uri_from_path(dir_path)
+        filesystem_path = info["name"]
+        entry_path = self._adapt_entry_path(filesystem_path)
+        name = os.path.basename(entry_path)
+        uri = self.uri_from_path(entry_path)
 
         if info.get("type") == "directory":
-            return RemoteDirectory(name=name, uri=uri, path=dir_path)
+            return RemoteDirectory(name=name, uri=uri, path=entry_path)
         else:
             size = int(info.get("size", 0))
-            # Handle timestamp fields more robustly - check for None explicitly
-            mtime = info.get("mtime")
-            if mtime is None:
-                mtime = info.get("modified")
-            if mtime is None:
-                mtime = info.get("LastModified")
-
-            ctime_result = self.to_dict_time(mtime) if mtime is not None else ""
-            ctime = ctime_result if ctime_result is not None else ""
-            return RemoteFile(name=name, size=size, ctime=ctime, uri=uri, path=path)
+            ctime = self._extract_timestamp(info)
+            return RemoteFile(name=name, size=size, ctime=ctime, uri=uri, path=entry_path)
 
     def _list_recursive(self, fs: AbstractFileSystem, path: str) -> tuple[list[AnyRemoteEntry], int]:
         """Handle recursive directory listing with item limit."""
@@ -223,12 +236,12 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         # Limiting the number of items returned for now.
         res: list[AnyRemoteEntry] = []
         count = 0
-        for p, dirs, files in fs.walk(path, detail=True):
+        for _, dirs, files in fs.walk(path, detail=True):
             # We are using detail=True to get file info as dicts,
             # so we can safely cast the result.
             dirs = cast(dict[str, dict], dirs)
             files = cast(dict[str, dict], files)
-            to_entry = functools.partial(self._file_info_to_entry, str(p))
+            to_entry = functools.partial(self._info_to_entry)
             res.extend(map(to_entry, dirs.values()))
             res.extend(map(to_entry, files.values()))
             count += len(dirs) + len(files)
@@ -252,8 +265,9 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         # Using detail=True returns a dict with file paths as keys and their info as
         # values so we can safely cast the result.
         matched_paths = cast(dict[str, dict], fs.glob(glob_pattern, detail=True))
-        for file_path, info in matched_paths.items():
-            entries_list.append(self._file_info_to_entry(str(file_path), info))
+        for entry_path, info in matched_paths.items():
+            if entry_path:  # Only process entries with valid paths
+                entries_list.append(self._info_to_entry(info))
         return entries_list
 
     def _list_directory(self, fs: AbstractFileSystem, path: str) -> list[AnyRemoteEntry]:
@@ -263,7 +277,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         for entry in entries:
             entry_path = entry.get("name", entry.get("path", ""))
             if entry_path:  # Only process entries with valid paths
-                entries_list.append(self._file_info_to_entry(entry_path, entry))
+                entries_list.append(self._info_to_entry(entry))
         return entries_list
 
     def _apply_pagination(

--- a/lib/galaxy/files/sources/temp.py
+++ b/lib/galaxy/files/sources/temp.py
@@ -74,7 +74,7 @@ class TempFilesSource(FsspecFilesSource[TempFileSourceTemplateConfiguration, Tem
 
         i.e. /a/b/c -> /{root_path}/a/b/c
         """
-        relative_path = path.lstrip(os.sep)
+        relative_path = path.lstrip("/")
         if not relative_path:
             return self._root_path
         return os.path.join(self._root_path, relative_path)
@@ -87,10 +87,10 @@ class TempFilesSource(FsspecFilesSource[TempFileSourceTemplateConfiguration, Tem
         # Remove the root path prefix
         if native_path.startswith(self._root_path):
             virtual_path = native_path[len(self._root_path) :]
-            # Ensure the path starts with a single slash
-            if not virtual_path.startswith(os.sep):
-                virtual_path = os.sep + virtual_path
-            elif virtual_path.startswith(os.sep + os.sep):
+            # Ensure the path starts with a single forward slash
+            if not virtual_path.startswith("/"):
+                virtual_path = f"/{virtual_path}"
+            elif virtual_path.startswith("//"):
                 # Remove extra leading slash if present
                 virtual_path = virtual_path[1:]
             return virtual_path


### PR DESCRIPTION
Extracted from #20794 for easier review.

I noticed in #20794 that the bucket name was showing as part of the path and URI in the elements in one of the selenium tests, while in the previous implementation, it wasn't. So, checking the results from the other `fssspec` file sources, I noticed the paths and URIs were also not correct (missing '/', etc.).

I added a lot of tests to verify the expected values for each entry as expected by the test scenario, and then fixed the issue by providing a way to "adapt the paths" when necessary in each file source implementation.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
