### PR TITLE
Only show breadcrumb when on history permissions route (not in sharing view)

### DIFF
--- a/client/src/components/History/HistoryDatasetPermissions.vue
+++ b/client/src/components/History/HistoryDatasetPermissions.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { computed, ref } from "vue";
+import { useRoute } from "vue-router/composables";
 
 import { initRefs, updateRefs, useCallbacks } from "@/composables/datasetPermissions";
 import { useHistoryBreadCrumbsToForProps } from "@/composables/historyBreadcrumbs";
@@ -14,6 +15,8 @@ interface HistoryDatasetPermissionsProps {
     noRedirect?: boolean;
 }
 const props = defineProps<HistoryDatasetPermissionsProps>();
+
+const route = useRoute();
 
 const loading = ref(true);
 
@@ -67,7 +70,7 @@ const { onSuccess, onError } = useCallbacks(init);
 
 <template>
     <div>
-        <BreadcrumbHeading :items="breadcrumbItems" />
+        <BreadcrumbHeading v-if="route.path === '/histories/permissions'" :items="breadcrumbItems" />
 
         <DatasetPermissionsForm
             :loading="loading"


### PR DESCRIPTION
Without this, we had two breadcrumbs in the permissions tab in the history sharing view (`histories/sharing`):

| Before | After |
| ---- | ---- |
| <img width="1137" height="488" alt="firefox_fQtTd9JPsG" src="https://github.com/user-attachments/assets/91c7d428-d283-46cf-92ed-37f99d7cc563" /> | <img width="1137" height="488" alt="SeX3nbVYdm" src="https://github.com/user-attachments/assets/1cf452a1-2c10-46ca-8fe0-c5b08369369c" /> |

The `histories/permissions` route view remains as is:

<img width="1137" height="488" alt="1CvS8argm8" src="https://github.com/user-attachments/assets/48437880-2e88-46c9-a4cb-b600afcb4c43" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to the sharing view `histories/sharing?id=` for any history (Share & Manage Access)
  2. Go to the 2nd tab: Set Permissions
  3. There should be only 1 breadcrumb at the top, not inside the tab too (like there was before these changes)
  4. Go to `histories/permissions?id=` view for any history
  5. There is a breadcrumb there as well (remains unchanged after these changes)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
