### PR TITLE
[25.0] Fix password reset functionality for lowercase emails

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -580,7 +580,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     def get_reset_token(self, trans, email):
         reset_user = get_user_by_email(trans.sa_session, email, self.app.model.User)
-        if not reset_user and email != email.lower():
+        if not reset_user:
             reset_user = self._get_user_by_email_case_insensitive(trans.sa_session, email)
         if reset_user and not reset_user.deleted:
             prt = self.app.model.PasswordResetToken(reset_user)

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -85,6 +85,7 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
     Validates the email format.
     Checks whether the domain is blocklisted in the disposable domains configuration.
     Checks whether the email address is banned.
+    Optionally checks if email exists.
     """
     if (user and user.email == email) or (email == "" and allow_empty):
         return ""

--- a/test/unit/webapps/test_login.py
+++ b/test/unit/webapps/test_login.py
@@ -11,11 +11,11 @@ from galaxy.security.passwords import check_password
 from galaxy.util.unittest import TestCase
 from galaxy.webapps.galaxy.controllers.user import User
 
-admin_email = "admin@admin.admin"
+admin_email = "admin@example.org"
 admin_users = admin_email
 default_password = "123456"
 changed_password = "654321"
-user2_data = dict(email="user2@user2.user2", username="user2", password=default_password)
+user2_data = dict(email="User2@example.org", username="user2", password=default_password)
 
 
 class TestLoginController(TestCase):
@@ -84,3 +84,14 @@ class TestLoginController(TestCase):
             controller.login(self.trans, payload={"login": user2.username, "password": default_password})
         )
         assert response["message"] == "Success."
+
+    def test_get_reset_token(self):
+        def _check_reset_token(email):
+            reset_user, prt = self.user_manager.get_reset_token(self.trans, email)
+            assert user2 == reset_user
+            assert prt.user == user2
+
+        user2 = self.user_manager.create(**user2_data)
+        _check_reset_token(user2_data["email"])
+        _check_reset_token(user2_data["email"].lower())
+        _check_reset_token(user2_data["email"].upper())


### PR DESCRIPTION
Fixes #20687 

The previous version did not work correctly in the case when the user provided a lowercase email address, but the value stored in the database was non-lowercase. So, if I registered my account as "John@Foo.com", but submitted "john@foo.com", password reset would not work. But if it were the other way round ("john@foo.com" stored in the database), it would have worked. This fixes it.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
