### PR TITLE
Replace json.load() with json_stream.load()

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -13,8 +13,8 @@ from typing import (
     Optional,
 )
 
-import yaml
 import json_stream
+import yaml
 
 from galaxy.datatypes.data import (
     get_file_peek,

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import yaml
+import json_stream
 
 from galaxy.datatypes.data import (
     get_file_peek,
@@ -438,7 +439,7 @@ class Biom1(Json):
         if dataset.has_data():
             with open(dataset.get_file_name()) as fh:
                 try:
-                    json_dict = json.load(fh)
+                    json_dict = json_stream.load(fh)
                 except Exception:
                     return
 

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -142,7 +142,7 @@ class DataManagerJson(Json):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd):
         super().set_meta(dataset=dataset, overwrite=overwrite, **kwd)
         with open(dataset.get_file_name()) as fh:
-            data_tables = json.load(fh)["data_tables"]
+            data_tables = json_stream.load(fh)["data_tables"]
         dataset.metadata.data_tables = data_tables
 
 
@@ -161,7 +161,7 @@ class ExpressionJson(Json):
             file_path = dataset.get_file_name()
             try:
                 with open(file_path) as f:
-                    obj = json.load(f)
+                    obj = json_stream.load(f)
                     if isinstance(obj, int):
                         json_type = "int"
                     elif isinstance(obj, float):
@@ -196,7 +196,7 @@ class Ipynb(Json):
         if self._looks_like_json(file_prefix):
             try:
                 with open(file_prefix.filename) as f:
-                    ipynb = json.load(f)
+                    ipynb = json_stream.load(f)
                 if ipynb.get("nbformat", False) is not False and ipynb.get("metadata", False):
                     return True
                 else:
@@ -540,7 +540,7 @@ class ImgtJson(Json):
         if dataset.has_data():
             with open(dataset.get_file_name()) as fh:
                 try:
-                    json_dict = json.load(fh)
+                    json_dict = json_stream.load(fh)
                     tax_names = []
                     for entry in json_dict:
                         if "taxonId" in entry:
@@ -1245,7 +1245,7 @@ class BCSLts(Json):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             lines = "States: {}\nTransitions: {}\nUnique agents: {}\nInitial state: {}"
-            ts = json.load(open(dataset.get_file_name()))
+            ts = json_stream.load(open(dataset.get_file_name()))
             dataset.peek = lines.format(len(ts["nodes"]), len(ts["edges"]), len(ts["ordering"]), ts["initial"])
             dataset.blurb = nice_size(dataset.get_size())
         else:

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -93,6 +93,8 @@ jinja2==3.1.6
 jmespath==1.0.1
 jsonref==1.1.0
 jsonschema==4.25.0
+json-stream==2.3.3
+json-stream-rs-tokenizer==0.4.29
 jsonschema-specifications==2025.4.1
 kombu==5.5.4
 lagom==2.7.7

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -94,7 +94,6 @@ jmespath==1.0.1
 jsonref==1.1.0
 jsonschema==4.25.0
 json-stream==2.3.3
-json-stream-rs-tokenizer==0.4.29
 jsonschema-specifications==2025.4.1
 kombu==5.5.4
 lagom==2.7.7


### PR DESCRIPTION
Attempting to load an entire JSON file into memory can cause OOM errors on large files.

This does not address the question raised by @mvdbeek regarding why even bother when the metadata is optional and is not guaranteed to be present. However, until that question is addressed this prevents OOM errors we are seeing in Kubernetes deployments.

See #20750 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

