### PR TITLE
Add Hugging Face 🤗 file source and user-defined template

### DIFF
--- a/client/src/api/fileSources.ts
+++ b/client/src/api/fileSources.ts
@@ -1,4 +1,4 @@
-import { faAws, faDropbox, faGoogleDrive } from "@fortawesome/free-brands-svg-icons";
+import { faAws, faDropbox, faGoogleDrive, faHubspot } from "@fortawesome/free-brands-svg-icons";
 import { faCloud, faFolderTree, faNetworkWired, type IconDefinition } from "font-awesome-6";
 
 import type { components } from "@/api/schema";
@@ -65,6 +65,10 @@ export const templateTypes: FileSourceTypesDetail = {
     dataverse: {
         icon: faNetworkWired,
         message: "This is a repository plugin that connects with a Dataverse.org instance.",
+    },
+    huggingface: {
+        icon: faHubspot,
+        message: "This is a file repository plugin that connects with the Hugging Face Hub.",
     },
 };
 

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11184,7 +11184,8 @@ export interface components {
                 | "inveniordm"
                 | "zenodo"
                 | "rspace"
-                | "dataverse";
+                | "dataverse"
+                | "huggingface";
             /** Variables */
             variables?:
                 | (
@@ -21585,7 +21586,8 @@ export interface components {
                 | "inveniordm"
                 | "zenodo"
                 | "rspace"
-                | "dataverse";
+                | "dataverse"
+                | "huggingface";
             /** Uri Root */
             uri_root: string;
             /**

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -333,6 +333,9 @@ class ConditionalDependencies:
 
         return celery_enabled and is_redis_url(celery_result_backend) or is_redis_url(celery_broker_url)
 
+    def check_huggingface_hub(self):
+        return "huggingface" in self.file_sources
+
 
 def optional(config_file=None):
     if not config_file:

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -33,6 +33,7 @@ fs.onedatarestfs==21.2.5.2 # type: onedata, depends on onedatafilerestclient
 fs-basespace # type: basespace
 fs-azureblob # type: azure
 rspace-client>=2.6.1,<3  # type: rspace
+huggingface_hub
 
 # Vault backend
 hvac

--- a/lib/galaxy/files/sources/_fsspec.py
+++ b/lib/galaxy/files/sources/_fsspec.py
@@ -141,6 +141,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         try:
             cache_options = self._get_cache_options(context.config)
             fs = self._open_fs(context, cache_options)
+            path = self._to_filesystem_path(path)
 
             if recursive:
                 return self._list_recursive(fs, path)
@@ -182,6 +183,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         """Download a file from the fsspec filesystem to a local path."""
         cache_options = self._get_cache_options(context.config)
         fs = self._open_fs(context, cache_options)
+        source_path = self._to_filesystem_path(source_path)
         fs.get_file(source_path, native_path)
 
     def _write_from(
@@ -193,6 +195,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         """Upload a file from a local path to the fsspec filesystem."""
         cache_options = self._get_cache_options(context.config)
         fs = self._open_fs(context, cache_options)
+        target_path = self._to_filesystem_path(target_path)
         fs.put_file(native_path, target_path)
 
     def _adapt_entry_path(self, filesystem_path: str) -> str:
@@ -202,6 +205,14 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         By default, returns the filesystem path unchanged.
         """
         return filesystem_path
+
+    def _to_filesystem_path(self, path: str) -> str:
+        """Convert an entry path to the filesystem path format.
+
+        Subclasses can override this to transform paths (e.g., virtual to filesystem paths).
+        By default, returns the path unchanged.
+        """
+        return path
 
     def _extract_timestamp(self, info: dict) -> Optional[str]:
         """Extract and format timestamp from fsspec file info."""

--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -140,7 +140,7 @@ class HuggingFaceFilesSource(
             repos_iter = api.list_models(search=query, sort="downloads", direction=-1, limit=MAX_REPO_LIMIT)
 
             # Convert repositories to directory entries
-            entries_list = []
+            entries_list: list[AnyRemoteEntry] = []
             for repo in repos_iter:
                 repo_id = repo.id if hasattr(repo, "id") else str(repo)
                 entry = RemoteDirectory(

--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -101,6 +101,11 @@ class HuggingFaceFilesSource(
         # Remove leading slash for HF compatibility
         return path.lstrip("/")
 
+    def _extract_timestamp(self, info: dict) -> Optional[str]:
+        """Extract timestamp from Hugging Face file info to use it in the RemoteFile entry."""
+        last_commit: dict = info.get("last_commit", {})
+        return last_commit.get("date")
+
     def _list(
         self,
         context: FilesSourceRuntimeContext[HuggingFaceFileSourceConfiguration],

--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -5,6 +5,7 @@ Hugging Face Hub file source plugin using fsspec.
 import logging
 from typing import (
     Annotated,
+    Literal,
     Optional,
     Union,
 )
@@ -37,6 +38,10 @@ from galaxy.files.sources._fsspec import (
 from galaxy.util.config_templates import TemplateExpansion
 
 log = logging.getLogger(__name__)
+
+SortByOptions = Literal["last_modified", "trending_score", "created_at", "downloads", "likes"]
+
+DEFAULT_SORT_BY: SortByOptions = "downloads"
 
 MAX_REPO_LIMIT = 1000
 
@@ -137,7 +142,7 @@ class HuggingFaceFilesSource(
             endpoint=config.endpoint,
         )
         try:
-            repos_iter = api.list_models(search=query, sort="downloads", direction=-1, limit=MAX_REPO_LIMIT)
+            repos_iter = api.list_models(search=query, sort=DEFAULT_SORT_BY, direction=-1, limit=MAX_REPO_LIMIT)
 
             # Convert repositories to directory entries
             entries_list: list[AnyRemoteEntry] = []

--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -1,0 +1,168 @@
+"""
+Hugging Face Hub file source plugin using fsspec.
+"""
+
+import logging
+from typing import (
+    Annotated,
+    Optional,
+    Union,
+)
+
+from fsspec import AbstractFileSystem
+from pydantic import Field
+
+from galaxy.files.models import (
+    AnyRemoteEntry,
+    FilesSourceRuntimeContext,
+    RemoteDirectory,
+)
+
+try:
+    from huggingface_hub import (
+        HfApi,
+        HfFileSystem,
+    )
+except ImportError:
+    HfApi = None
+    HfFileSystem = None
+
+from galaxy.exceptions import MessageException
+from galaxy.files.sources._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+from galaxy.util.config_templates import TemplateExpansion
+
+log = logging.getLogger(__name__)
+
+MAX_REPO_LIMIT = 1000
+
+
+class HuggingFaceFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
+    token: Annotated[
+        Union[str, TemplateExpansion, None],
+        Field(
+            description="Hugging Face API token for accessing private model repositories. "
+            "If not provided, only public repositories will be accessible.",
+        ),
+    ] = None
+    endpoint: Annotated[
+        Union[str, TemplateExpansion, None],
+        Field(
+            description="Custom endpoint for Hugging Face Hub. "
+            "If not provided, the default Hugging Face Hub will be used (https://huggingface.co).",
+        ),
+    ] = None
+
+
+class HuggingFaceFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
+    token: Optional[str] = None
+    endpoint: Optional[str] = None
+
+
+class HuggingFaceFilesSource(
+    FsspecFilesSource[HuggingFaceFileSourceTemplateConfiguration, HuggingFaceFileSourceConfiguration]
+):
+    plugin_type = "huggingface"
+    required_module = HfFileSystem
+    required_package = "huggingface_hub"
+
+    template_config_class = HuggingFaceFileSourceTemplateConfiguration
+    resolved_config_class = HuggingFaceFileSourceConfiguration
+
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[HuggingFaceFileSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ) -> AbstractFileSystem:
+        if HfFileSystem is None:
+            raise self.required_package_exception
+
+        config = context.config
+        return HfFileSystem(
+            token=config.token or False,  # Use False to disable authentication
+            endpoint=config.endpoint,
+            **cache_options,
+        )
+
+    def _adapt_path(self, path: str) -> str:
+        """Transform Galaxy path to Hugging Face filesystem path."""
+        if path == "/":
+            # Hugging Face does not implement access to the repositories root
+            return ""
+        # Remove leading slash for HF compatibility
+        return path.lstrip("/")
+
+    def _list(
+        self,
+        context: FilesSourceRuntimeContext[HuggingFaceFileSourceConfiguration],
+        path="/",
+        recursive=False,
+        write_intent: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query: Optional[str] = None,
+        sort_by: Optional[str] = None,
+    ) -> tuple[list[AnyRemoteEntry], int]:
+        # If we're at the root, list repositories using HfApi
+        if path == "/":
+            return self._list_repositories(config=context.config, limit=limit, offset=offset, query=query)
+
+        # For non-root paths, use the parent implementation
+        path = self._adapt_path(path)
+        return super()._list(
+            context=context,
+            path=path,
+            recursive=recursive,
+            limit=limit,
+            offset=offset,
+            query=query,
+            sort_by=sort_by,
+        )
+
+    def _list_repositories(
+        self,
+        config: HuggingFaceFileSourceConfiguration,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query: Optional[str] = None,
+    ) -> tuple[list[AnyRemoteEntry], int]:
+        if HfApi is None:
+            raise self.required_package_exception
+
+        api = HfApi(
+            token=config.token or False,  # Use False to disable authentication
+            endpoint=config.endpoint,
+        )
+        try:
+            repos_iter = api.list_models(search=query, sort="downloads", direction=-1, limit=MAX_REPO_LIMIT)
+
+            # Convert repositories to directory entries
+            entries_list = []
+            for repo in repos_iter:
+                repo_id = repo.id if hasattr(repo, "id") else str(repo)
+                entry = RemoteDirectory(
+                    name=repo_id,
+                    uri=self.uri_from_path(repo_id),
+                    path=repo_id,
+                )
+                entries_list.append(entry)
+
+            total_count = len(entries_list)
+
+            # Apply pagination
+            if offset is not None and limit is not None:
+                entries_list = entries_list[offset : offset + limit]
+            elif limit is not None:
+                entries_list = entries_list[:limit]
+
+            return entries_list, total_count
+
+        except Exception as e:
+            raise MessageException(f"Failed to list repositories from Hugging Face Hub: {e}") from e
+
+
+__all__ = ["HuggingFaceFilesSource"]

--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -88,8 +88,8 @@ class HuggingFaceFilesSource(
             **cache_options,
         )
 
-    def _adapt_path(self, path: str) -> str:
-        """Transform Galaxy path to Hugging Face filesystem path."""
+    def _to_filesystem_path(self, path: str) -> str:
+        """Transform entry path to Hugging Face filesystem path."""
         if path == "/":
             # Hugging Face does not implement access to the repositories root
             return ""
@@ -112,7 +112,6 @@ class HuggingFaceFilesSource(
             return self._list_repositories(config=context.config, limit=limit, offset=offset, query=query)
 
         # For non-root paths, use the parent implementation
-        path = self._adapt_path(path)
         return super()._list(
             context=context,
             path=path,

--- a/lib/galaxy/files/templates/examples/production_huggingface.yml
+++ b/lib/galaxy/files/templates/examples/production_huggingface.yml
@@ -1,0 +1,24 @@
+- id: huggingface
+  version: 0
+  name: Hugging Face Hub 🤗
+  description: |
+      [Hugging Face Hub](https://huggingface.co) is a platform for sharing machine learning models and datasets.
+      Using this plugin you can connect to the Hugging Face Hub to access public or private machine learning models repositories.
+  variables:
+      endpoint:
+          label: Hugging Face Hub Endpoint
+          type: string
+          help: |
+              Custom endpoint of the Hugging Face Hub you are connecting to. This should be the full URL including the protocol (http or https) and the domain name.
+              You can leave this blank to use the default Hugging Face Hub endpoint (https://huggingface.co).
+          default: https://huggingface.co
+  secrets:
+      token:
+          label: Hugging Face Access Token
+          help: |
+              The personal access token to use to connect to the Hugging Face Hub. You can generate a new token in your Hugging Face account settings.
+              This will allow Galaxy to access private models if you have the necessary permissions.
+  configuration:
+      type: huggingface
+      endpoint: "{{ variables.endpoint }}"
+      token: "{{ secrets.token }}"

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -45,6 +45,7 @@ FileSourceTemplateType = Literal[
     "zenodo",
     "rspace",
     "dataverse",
+    "huggingface",
 ]
 
 
@@ -296,6 +297,20 @@ class DataverseFileSourceConfiguration(StrictModel):
     writable: bool = True
 
 
+class HuggingFaceFileSourceTemplateConfiguration(StrictModel):
+    type: Literal["huggingface"]
+    token: Union[str, TemplateExpansion, None] = None
+    endpoint: Union[str, TemplateExpansion, None] = None
+    template_start: Optional[str] = None
+    template_end: Optional[str] = None
+
+
+class HuggingFaceFileSourceConfiguration(StrictModel):
+    type: Literal["huggingface"]
+    token: Optional[str] = None
+    endpoint: Optional[str] = None
+
+
 FileSourceTemplateConfiguration = Annotated[
     Union[
         PosixFileSourceTemplateConfiguration,
@@ -311,6 +326,7 @@ FileSourceTemplateConfiguration = Annotated[
         ZenodoFileSourceTemplateConfiguration,
         RSpaceFileSourceTemplateConfiguration,
         DataverseFileSourceTemplateConfiguration,
+        HuggingFaceFileSourceTemplateConfiguration,
     ],
     Field(discriminator="type"),
 ]
@@ -330,6 +346,7 @@ FileSourceConfiguration = Annotated[
         ZenodoFileSourceConfiguration,
         RSpaceFileSourceConfiguration,
         DataverseFileSourceConfiguration,
+        HuggingFaceFileSourceConfiguration,
     ],
     Field(discriminator="type"),
 ]
@@ -407,6 +424,7 @@ TypesToConfigurationClasses: dict[FileSourceTemplateType, type[FileSourceConfigu
     "zenodo": ZenodoFileSourceConfiguration,
     "rspace": RSpaceFileSourceConfiguration,
     "dataverse": DataverseFileSourceConfiguration,
+    "huggingface": HuggingFaceFileSourceConfiguration,
 }
 
 


### PR DESCRIPTION
Requires #20799 and #20806

This PR adds a new file source to access Hugging Face models based on the fsspec plugin.
Includes a user template.

<img width="889" height="589" alt="Screenshot from 2025-08-21 15-00-08" src="https://github.com/user-attachments/assets/253dcc97-667e-4dd4-9fb2-e06ab81d1369" />

<img width="889" height="589" alt="Screenshot from 2025-08-21 15-03-34" src="https://github.com/user-attachments/assets/4ced4702-a398-497b-915c-7148989085f0" />


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Ensure you add the following line to your `config/file_source_templates.yml` and then start your Galaxy server:
    ```
    - include: ./lib/galaxy/files/templates/examples/production_huggingface.yml
    ```
  1. Go to `{your_galaxy}/file_source_instances/index`
  2. Select the `Hugging Face Hub` file source
  3. Give it a name and fill in what you want in the template, and hit "create".
  4. Go to `Upload`, then `Choose from repository`, and then select your Hugging Face instance.
  5. Browse at your will.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
