### PR TITLE
Refactor MESSAGES constant in FileSourceTypeSpan.vue

### DIFF
--- a/client/src/components/FileSources/FileSourceTypeSpan.vue
+++ b/client/src/components/FileSources/FileSourceTypeSpan.vue
@@ -2,22 +2,11 @@
 import { computed } from "vue";
 
 import type { FileSourceTypes } from "@/api/fileSources";
+import { templateTypes } from "@/api/fileSources";
 
-const MESSAGES = {
-    posix: "This is a simple path based repository plugin that assumes the all the relevant paths are already mounted on the Galaxy server and target worker nodes.",
-    s3fs: "This is a repository plugin based on the Amazon Simple Storage Service (S3) interface. The AWS interface has become an industry standard and many storage vendors support it and use it to expose 'object' based storage.",
-    azure: "This is a repository plugin based on the Azure service.",
-    onedata: "This is a repository plugin based on the Onedata service.",
-    ftp: "This is a repository plugin based on the FTP protocol.",
-    webdav: "This is a repository plugin based on the WebDAV protocol.",
-    dropbox: "This is a repository plugin that connects with the commercial Dropbox service.",
-    googledrive: "This is a repository plugin that connects with the commercial Google Drive service.",
-    elabftw: "This is a repository plugin that connects with an eLabFTW instance.",
-    inveniordm: "This is a repository plugin that connects with an InvenioRDM instance.",
-    zenodo: "This is a repository plugin that connects with https://zenodo.org/.",
-    rspace: "This is a repository plugin that connects with an RSpace instance.",
-    dataverse: "This is a repository plugin that connects with a Dataverse.org instance.",
-};
+const MESSAGES = Object.fromEntries(
+    Object.entries(templateTypes).map(([type, { message }]) => [type, message])
+) as Record<FileSourceTypes, string>;
 
 interface Props {
     type: FileSourceTypes;


### PR DESCRIPTION
Small refactoring extracted from #20805 to dynamically generate messages from `templateTypes` to enhance maintainability and reduce redundancy.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
