### PR TITLE
Fix new linting errors in unit test mounts

### DIFF
--- a/client/src/components/Masthead/QuotaMeter.test.ts
+++ b/client/src/components/Masthead/QuotaMeter.test.ts
@@ -19,7 +19,7 @@ async function createQuotaMeterWrapper(config: any, user: RegisteredUser) {
     const pinia = createTestingPinia();
     const userStore = useUserStore();
     userStore.currentUser = user;
-    const wrapper = mount(QuotaMeter, {
+    const wrapper = mount(QuotaMeter as object, {
         localVue,
         pinia,
     });

--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
@@ -58,7 +58,7 @@ async function mountBroadcastsOverlayWith(broadcasts: BroadcastNotification[] = 
         broadcastsStore.broadcasts = broadcastsStore.broadcasts.filter((b) => b.id !== broadcast.id);
     });
 
-    const wrapper = mount(BroadcastsOverlay, {
+    const wrapper = mount(BroadcastsOverlay as object, {
         localVue,
         pinia,
         stubs: {

--- a/client/src/components/User/DiskUsage/DiskUsageSummary.test.ts
+++ b/client/src/components/User/DiskUsage/DiskUsageSummary.test.ts
@@ -48,7 +48,7 @@ async function mountDiskUsageSummaryWrapper(enableQuotas: boolean) {
     );
 
     const pinia = createPinia();
-    const wrapper = mount(DiskUsageSummary, {
+    const wrapper = mount(DiskUsageSummary as object, {
         localVue,
         pinia,
     });

--- a/client/src/components/Workflow/Import/FromFileOrUrl.test.ts
+++ b/client/src/components/Workflow/Import/FromFileOrUrl.test.ts
@@ -21,7 +21,7 @@ const invalidUrl = "http://127.0.0.1:8081/u/admin/w/unnamed-workflow/additional-
 
 describe("FromFileOrUrl", () => {
     it("converts shared urls to json urls", async () => {
-        const wrapper = mount(FromFileOrUrl, { localVue });
+        const wrapper = mount(FromFileOrUrl as object, { localVue });
 
         {
             const input = wrapper.find("#workflow-import-url-input");

--- a/client/src/entry/analysis/modules/Login.test.ts
+++ b/client/src/entry/analysis/modules/Login.test.ts
@@ -42,7 +42,7 @@ function shallowMountLogin(routerQuery: object = {}) {
     const pinia = createTestingPinia();
     setActivePinia(pinia);
 
-    return shallowMount(Login, {
+    return shallowMount(Login as object, {
         localVue,
         pinia,
         mocks: {


### PR DESCRIPTION
This is a known issue with TypeScript inference in vue-test-utils for vue 2.7
What I don't understand is why they are popping out now, rather than long ago... maybe a dependency update :thinking: 

Fixes:
```
npm warn exec The following package was not found and will be installed: vue-tsc@3.0.6
Error: src/components/Masthead/QuotaMeter.test.ts(22,27): error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'DefineComponent<{}, unknown, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, Readonly<ExtractPropTypes<{}>>, {}>' is not assignable to parameter of type 'ExtendedVue<Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>>, {}, {}, {}, DefaultProps>'.
      Type 'ComponentPublicInstanceConstructor<Vue3Instance<{}, Readonly<ExtractPropTypes<{}>>, Readonly<ExtractPropTypes<{}>>, {}, {}, true, ComponentOptionsBase<any, any, any, ... 6 more ..., any>> & ... 4 more ... & Readonly<...>> & ComponentOptionsBase<...> & { ...; }' is missing the following properties from type 'VueConstructor<ExtractComputedReturns<{}> & DefaultProps & Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<...>> & ShallowUnwrapRef<...> & Vue<...>>': extend, nextTick, set, delete, and 10 more.
Error: src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts(61,27): error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'DefineComponent<{}, unknown, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, Readonly<ExtractPropTypes<{}>>, {}>' is not assignable to parameter of type 'ExtendedVue<Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>>, {}, {}, {}, DefaultProps>'.
      Type 'ComponentPublicInstanceConstructor<Vue3Instance<{}, Readonly<ExtractPropTypes<{}>>, Readonly<ExtractPropTypes<{}>>, {}, {}, true, ComponentOptionsBase<any, any, any, ... 6 more ..., any>> & ... 4 more ... & Readonly<...>> & ComponentOptionsBase<...> & { ...; }' is missing the following properties from type 'VueConstructor<ExtractComputedReturns<{}> & DefaultProps & Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<...>> & ShallowUnwrapRef<...> & Vue<...>>': extend, nextTick, set, delete, and 10 more.
Error: src/components/User/DiskUsage/DiskUsageSummary.test.ts(51,27): error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'DefineComponent<{}, unknown, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, Readonly<ExtractPropTypes<{}>>, {}>' is not assignable to parameter of type 'ExtendedVue<Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>>, {}, {}, {}, DefaultProps>'.
      Type 'ComponentPublicInstanceConstructor<Vue3Instance<{}, Readonly<ExtractPropTypes<{}>>, Readonly<ExtractPropTypes<{}>>, {}, {}, true, ComponentOptionsBase<any, any, any, ... 6 more ..., any>> & ... 4 more ... & Readonly<...>> & ComponentOptionsBase<...> & { ...; }' is missing the following properties from type 'VueConstructor<ExtractComputedReturns<{}> & DefaultProps & Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<...>> & ShallowUnwrapRef<...> & Vue<...>>': extend, nextTick, set, delete, and 10 more.
Error: src/components/Workflow/Import/FromFileOrUrl.test.ts(24,31): error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'DefineComponent<{}, unknown, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, Readonly<ExtractPropTypes<{}>>, {}>' is not assignable to parameter of type 'ExtendedVue<Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>>, {}, {}, {}, DefaultProps>'.
      Type 'ComponentPublicInstanceConstructor<Vue3Instance<{}, Readonly<ExtractPropTypes<{}>>, Readonly<ExtractPropTypes<{}>>, {}, {}, true, ComponentOptionsBase<any, any, any, ... 6 more ..., any>> & ... 4 more ... & Readonly<...>> & ComponentOptionsBase<...> & { ...; }' is missing the following properties from type 'VueConstructor<ExtractComputedReturns<{}> & DefaultProps & Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<...>> & ShallowUnwrapRef<...> & Vue<...>>': extend, nextTick, set, delete, and 10 more.
Error: src/entry/analysis/modules/Login.test.ts(45,25): error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'DefineComponent<{}, unknown, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, Readonly<ExtractPropTypes<{}>>, {}>' is not assignable to parameter of type 'ExtendedVue<Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<Record<string, any>, Record<string, any>, never, never, ...>>, {}, {}, {}, DefaultProps>'.
      Type 'ComponentPublicInstanceConstructor<Vue3Instance<{}, Readonly<ExtractPropTypes<{}>>, Readonly<ExtractPropTypes<{}>>, {}, {}, true, ComponentOptionsBase<any, any, any, ... 6 more ..., any>> & ... 4 more ... & Readonly<...>> & ComponentOptionsBase<...> & { ...; }' is missing the following properties from type 'VueConstructor<ExtractComputedReturns<{}> & DefaultProps & Vue<Record<string, any>, Record<string, any>, never, never, (event: string, ...args: any[]) => Vue<...>> & ShallowUnwrapRef<...> & Vue<...>>': extend, nextTick, set, delete, and 10 more.
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
