### PR TITLE
Enable data label column selection in basic Plotly plots and add heatmap

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -71,7 +71,7 @@ phylocanvas:
     version: 0.0.11
 plotly:
     package: "@galaxyproject/plotly"
-    version: 0.0.17
+    version: 0.0.18
 plotly_box:
     package: "@galaxyproject/plotly_box"
     version: 0.0.0

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -71,10 +71,13 @@ phylocanvas:
     version: 0.0.11
 plotly:
     package: "@galaxyproject/plotly"
-    version: 0.0.18
+    version: 0.0.22
 plotly_box:
     package: "@galaxyproject/plotly_box"
     version: 0.0.0
+plotly_heatmap:
+    package: "@galaxyproject/plotly_heatmap"
+    version: 0.0.1
 plotly_histogram:
     package: "@galaxyproject/plotly_histogram"
     version: 0.0.0


### PR DESCRIPTION
Improvements for #20808.

1) Allow selection of data point labels for basic plotly charts.

![chira](https://github.com/user-attachments/assets/79ef4757-8fc7-4aad-8625-6ad9a0537c53)

2) Add plotly 2d Heatmap plot, using the first row and column as category labels.

![chira](https://github.com/user-attachments/assets/4cea5620-8049-4dc7-ae95-5f8109aa87e3)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
