### PR TITLE
[25.0] Render Tool Descriptions in Markdown in TRS imports

### DIFF
--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -9,6 +9,7 @@ import { useRouter } from "vue-router/composables";
 
 import { getRedirectOnImportPath } from "@/components/Workflow/redirectPath";
 import { Services } from "@/components/Workflow/services";
+import { useMarkdown } from "@/composables/markdown";
 import { withPrefix } from "@/utils/redirect";
 
 import type { TrsSelection } from "./types";
@@ -25,6 +26,8 @@ type TrsSearchData = {
     description: string;
     [key: string]: unknown;
 };
+
+const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 
 const fields = [
     { key: "name", label: "Name" },
@@ -195,7 +198,22 @@ async function importVersion(trsId?: string, toolIdToImport?: string, version?: 
                             @onImport="(versionId) => importVersion(trsSelection?.id, row.item.data.id, versionId)" />
                     </BCard>
                 </template>
+
+                <template v-slot:cell(description)="row">
+                    <span class="trs-description" v-html="renderMarkdown(row.item.data.description)" />
+                </template>
             </BTable>
         </div>
     </BCard>
 </template>
+
+<style>
+.trs-description {
+    position: relative;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+}
+</style>

--- a/client/src/components/Workflow/Import/TrsTool.vue
+++ b/client/src/components/Workflow/Import/TrsTool.vue
@@ -4,6 +4,8 @@ import { faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton } from "bootstrap-vue";
 
+import { useMarkdown } from "@/composables/markdown";
+
 import type { TrsTool, TrsToolVersion } from "./types";
 
 library.add(faUpload);
@@ -17,6 +19,8 @@ const props = defineProps<Props>();
 const emit = defineEmits<{
     (e: "onImport", versionId: string): void;
 }>();
+
+const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 
 function importVersion(version: TrsToolVersion) {
     const version_id = version.id.includes(`:${version.name}`) ? version.name : version.id;
@@ -34,7 +38,7 @@ function importVersion(version: TrsToolVersion) {
         <div>
             <b>Description:</b>
 
-            <span>{{ props.trsTool.description }}</span>
+            <span v-html="renderMarkdown(props.trsTool.description)" />
         </div>
         <div>
             <b>Organization</b>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -680,7 +680,7 @@ trs_search:
     search: "#trs-search-query"
     search_result:
       type: xpath
-      selector: "//td[contains(text(), '${workflow_name}')]"
+      selector: "//td[contains(., '${workflow_name}')]"
     import_button: ".workflow-import"
     select_server_button: "#dropdownTrsServer"
     import_version: '[data-version-name*="${version}"]'


### PR DESCRIPTION
This PR fixes the tool descriptions in raw Markdown text in the TRS import workflow by rendering them, with additional styling to limit description length in the table for better readability.

|Before|After|
|---|---|
|<img width="1525" height="1060" alt="image" src="https://github.com/user-attachments/assets/6fdba032-9003-456e-aaaa-e59a14e97ffd" />|<img width="1525" height="1060" alt="image" src="https://github.com/user-attachments/assets/7d0e878e-9389-42ab-9578-74fdf8e5f666" />|
|<img width="1525" height="1060" alt="image" src="https://github.com/user-attachments/assets/290093a7-6b84-4c0f-8611-bf584bf347c9" />|<img width="1525" height="1060" alt="image" src="https://github.com/user-attachments/assets/7c1c1c6b-e50b-4e53-82e9-ad2e1b796502" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to `Workflows` from the activity bar
  2. Click on the `Import` button at the top
  3. Select `GA4GH servers`
  4. Search for a tool which uses markdown for its description

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
