### PR TITLE
Refactor/cleanup admin_cleanup_datasets.py script

### DIFF
--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -22,6 +22,7 @@ Optional Arguments:
     -i --info_only - Print results, but don't email or delete anything
     -e --email_only - Email notifications, but don't delete anything
         Useful for notifying users of pending deletion
+    --no-send - Do no send email (Default: false)
 
     --smtp - Specify smtp server
         If not specified, use smtp settings specified in config file
@@ -121,6 +122,7 @@ def main():
         help="Send emails only, don't delete",
         default=False,
     )
+    parser.add_argument("--no-send", action="store_true", help="Do not send email", default=False)
     parser.add_argument(
         "--smtp", default=None, help="SMTP Server to use to send email. Default: [read from galaxy config file]"
     )
@@ -188,13 +190,14 @@ def main():
         config=config,
         email_only=args.email_only,
         info_only=args.info_only,
+        no_send=args.no_send,
     )
     app.shutdown()
     sys.exit(0)
 
 
 def administrative_delete_datasets(
-    app, cutoff_time, cutoff_days, tool_id, template_file, config, email_only=False, info_only=False
+    app, cutoff_time, cutoff_days, tool_id, template_file, config, email_only=False, info_only=False, no_send=False
 ):
     # Marks dataset history association deleted and email users
     start = time.time()
@@ -269,7 +272,7 @@ def administrative_delete_datasets(
         print(f"Subject: {subject}")
         print("----------")
         print(msgtext)
-        if not info_only:
+        if not no_send and not info_only:
             galaxy.util.send_mail(fromaddr, email, subject, msgtext, config)
 
     stop = time.time()

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -260,7 +260,8 @@ def administrative_delete_datasets(
     emailtemplate = Template(filename=template_file)
     for email, dataset_list in user_notifications.items():
         msgtext = emailtemplate.render(email=email, datasets=dataset_list, cutoff=cutoff_days)
-        subject = f"Galaxy Server Cleanup - {len(dataset_list)} datasets DELETED"
+        state = "" if info_only or email_only else " DELETED"
+        subject = f"Galaxy Server Cleanup - {len(dataset_list)} datasets{state}"
         fromaddr = config.email_from
         print()
         print(f"From: {fromaddr}")

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -273,7 +273,7 @@ def administrative_delete_datasets(
     stop = time.time()
     print()
     print(f"Marked {deleted_instance_count} dataset instances as deleted")
-    print("Total elapsed time: ", stop - start)
+    print(f"Total elapsed time: {stop - start:.3f} seconds")
     print("##########################################")
 
 

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -235,14 +235,14 @@ def administrative_delete_datasets(
             .select_from(
                 sa.join(model.User.__table__, model.History.__table__).join(model.HistoryDatasetAssociation.__table__)
             )
-            .set_label_style()
+            .set_label_style(sa.LABEL_STYLE_DEFAULT)
         )
 
         for result in app.sa_session.execute(user_query):
-            user_notifications[result[model.User.__table__.c.email]].append(
+            user_notifications[result._mapping[model.User.__table__.c.email]].append(
                 (
-                    result[model.HistoryDatasetAssociation.__table__.c.name],
-                    result[model.History.__table__.c.name],
+                    result._mapping[model.HistoryDatasetAssociation.__table__.c.name],
+                    result._mapping[model.History.__table__.c.name],
                 )
             )
             deleted_instance_count += 1

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -51,11 +51,9 @@ from datetime import (
 )
 from time import strftime
 
-import sqlalchemy as sa
 from mako.template import Template
 from sqlalchemy import (
     and_,
-    false,
     select,
 )
 from sqlalchemy.orm import aliased
@@ -66,7 +64,6 @@ from cleanup_datasets import CleanupDatasetsApplication
 
 import galaxy.config
 import galaxy.util
-from galaxy import model
 from galaxy.util.script import (
     app_properties_from_args,
     populate_config_args,
@@ -289,7 +286,6 @@ def _get_tool_id_for_hda(app, hda_id):
     # Aliases for ORM‑mapped classes
     Job = aliased(app.model.Job)
     JTODA = aliased(app.model.JobToOutputDatasetAssociation)
-    HDA = aliased(app.model.HistoryDatasetAssociation)
 
     session = app.sa_session
 

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -209,7 +209,7 @@ def administrative_delete_datasets(
     # Get HDAs older than cutoff time (ignore tool_id at this point)
     hda_ids_query = (
         select(HistoryDatasetAssociation.id)
-        .join(Dataset, Dataset.id == HistoryDatasetAssociation.dataset_id, isouter=True)
+        .join(Dataset, isouter=True)
         .where(and_(
             Dataset.deleted == false(),
             HistoryDatasetAssociation.update_time < cutoff_time,
@@ -236,8 +236,8 @@ def administrative_delete_datasets(
         # Bind hda_id for current iteration
         rows = session.execute(
             select(User.email, HistoryDatasetAssociation.name, History.name)
-            .join(History, History.user_id == User.id)
-            .join(HistoryDatasetAssociation, HistoryDatasetAssociation.history_id == History.id)
+            .join(History)
+            .join(HistoryDatasetAssociation)
             .where(HistoryDatasetAssociation.id == hda_id)
         ).all()
 
@@ -292,7 +292,7 @@ def _get_tool_id_for_hda(app, hda_id):
 
     job_query = (
         select(Job.tool_id)
-        .join(JTODA, JTODA.job_id == Job.id)
+        .join(JTODA)
         .where(JTODA.dataset_id == hda_id)
     )
 

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -210,10 +210,13 @@ def administrative_delete_datasets(
     hda_ids_query = (
         select(HistoryDatasetAssociation.id)
         .join(Dataset, isouter=True)
-        .where(and_(
-            Dataset.deleted == false(),
-            HistoryDatasetAssociation.update_time < cutoff_time,
-            HistoryDatasetAssociation.deleted == false()))
+        .where(
+            and_(
+                Dataset.deleted == false(),
+                HistoryDatasetAssociation.update_time < cutoff_time,
+                HistoryDatasetAssociation.deleted == false(),
+            )
+        )
     )
 
     # Add all datasets associated with Histories to our list
@@ -290,11 +293,7 @@ def _get_tool_id_for_hda(app, hda_id):
 
     session = app.sa_session
 
-    job_query = (
-        select(Job.tool_id)
-        .join(JTODA)
-        .where(JTODA.dataset_id == hda_id)
-    )
+    job_query = select(Job.tool_id).join(JTODA).where(JTODA.dataset_id == hda_id)
 
     tool_id = session.execute(job_query).scalars().first()
     if tool_id is not None:

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -211,9 +211,9 @@ def administrative_delete_datasets(
         select(HDA.id)
         .join(Dataset, Dataset.id == HDA.dataset_id, isouter=True)
         .where(and_(
-            Dataset.deleted.is_(False),
+            Dataset.deleted == false(),
             HDA.update_time < cutoff_time,
-            HDA.deleted.is_(False)))
+            HDA.deleted == false()))
     )
 
     # Add all datasets associated with Histories to our list

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -301,9 +301,6 @@ def _get_tool_id_for_hda(app, hda_id):
         return tool_id
 
     hda = session.get(HistoryDatasetAssociation, hda_id)
-    if hda is None:
-        return None
-
     return _get_tool_id_for_hda(app, hda.copied_from_history_dataset_association_id)
 
 

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -280,6 +280,7 @@ def administrative_delete_datasets(
 
 
 def _get_tool_id_for_hda(app, hda_id):
+    # TODO Some datasets don't seem to have an entry in jtod or a copied_from
     if hda_id is None:
         return None
 

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -54,6 +54,7 @@ from time import strftime
 from mako.template import Template
 from sqlalchemy import (
     and_,
+    false,
     select,
 )
 from sqlalchemy.orm import aliased


### PR DESCRIPTION
Update the `admin_cleanup_datasets.py` script to work with SQLAlchemy 2.x. Plus a few little updates.

Changes:
- Nicer time format [b6f5553615397655639ea4ed60d429293b634825]
- Update to work with SA 2.x [39047212083e4c6508bcbd842fd43828ff0183af]
- Refactored and updated the `administrative_delete_datasets` function to be compatible with SA 2.x, and easier to the eye [860e2cda72aba8bb008a309625bbbed0414157cc]
- Refactored and updated the `_get_tool_id` function to be compatible with SA 2.x and easier to the eye [651426ae39ba305e927cc8649eda7b2812a7f797]
- Add state of deletion to email subject [f0e63ff652e7dd75386381b3dcbc577a19be3b3a]
- Add option to not send the email upon deletion [85d8e6a78f2e2ccff71db761bde4a18274fcce34]

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. On the galaxy server, export `$GALAXY_CONFIG_FILE` to the galaxy config, activate the virtual environment, move to the `<root>/server/scripts/cleanup_datasets` directory
  2. Create dummy datasets, and create one with a specific tool
  3. Run `python admin_cleanup_datasets.py --days 0 --info_only --config $GALAXY_CONFIG_FILE --template admin_cleanup_warning_template.txt.sample`
  4. Run `python admin_cleanup_datasets.py --days 0 --info_only --config $GALAXY_CONFIG_FILE --template admin_cleanup_warning_template.txt.sample --tool_id <id>`
  5. Run `python admin_cleanup_datasets.py --days 0 --email_only --config $GALAXY_CONFIG_FILE --template admin_cleanup_warning_template.txt.sample --tool_id <id>` and check for the email containing the datasets from the tool that generated them
  6. Run `python admin_cleanup_datasets.py --days 0 --config $GALAXY_CONFIG_FILE --template admin_cleanup_warning_template.txt.sample --tool_id <id>` and check for deleted datasets
  7. Run both versions of the scripts and compare their output
