### PR TITLE
[24.2] Fix token refresh bug (cilogon)

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -133,6 +133,8 @@ class OIDCAuthnzBase(IdentityProvider):
                 return False
         except jwt.exceptions.DecodeError:
             log.error("Refresh token is non-decodable")
+            # If the refresh token is non-decodable, we do not use it. See discussion in https://github.com/galaxyproject/galaxy/pull/20821
+            return False
 
         oauth2_session = self._create_oauth2_session()
         token_endpoint = self.config.token_endpoint

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -123,11 +123,17 @@ class OIDCAuthnzBase(IdentityProvider):
             return False
         if not custos_authnz_token.refresh_token:
             return False
-        refresh_token_decoded = self._decode_token_no_signature(custos_authnz_token.refresh_token)
-        # do not attempt to use refresh token that is already expired
-        if int(refresh_token_decoded["exp"]) <= int(time.time()):
-            # in the future we might want to log out the user here
-            return False
+
+        # Try to extract expiration date from the refresh token. If expired, do not refresh token.
+        try: 
+            refresh_token_decoded = self._decode_token_no_signature(custos_authnz_token.refresh_token)
+            # do not attempt to use refresh token that is already expired
+            if int(refresh_token_decoded["exp"]) <= int(time.time()):
+                # in the future we might want to log out the user here
+                return False
+        except jwt.exceptions.DecodeError:
+            log.error("Refresh token is non-decodable")
+
         oauth2_session = self._create_oauth2_session()
         token_endpoint = self.config.token_endpoint
         if self.config.iam_client_secret:

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -132,8 +132,8 @@ class OIDCAuthnzBase(IdentityProvider):
                 # in the future we might want to log out the user here
                 return False
         except jwt.exceptions.DecodeError:
-            log.error("Refresh token is non-decodable")
-            # If the refresh token is non-decodable, we do not use it. See discussion in https://github.com/galaxyproject/galaxy/pull/20821
+            log.warning("Refresh token cannot be decoded. Galaxy does not support non-decodable refresh tokens.")
+            # If the refresh token is non-decodable, we do not use it because we cannot reliably determine its expiration date. See discussion in https://github.com/galaxyproject/galaxy/pull/20821
             return False
 
         oauth2_session = self._create_oauth2_session()

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -125,7 +125,7 @@ class OIDCAuthnzBase(IdentityProvider):
             return False
 
         # Try to extract expiration date from the refresh token. If expired, do not refresh token.
-        try: 
+        try:
             refresh_token_decoded = self._decode_token_no_signature(custos_authnz_token.refresh_token)
             # do not attempt to use refresh token that is already expired
             if int(refresh_token_decoded["exp"]) <= int(time.time()):


### PR DESCRIPTION
Fixes bug introduced in #19411

This line: `refresh_token_decoded = self._decode_token_no_signature(custos_authnz_token.refresh_token)` raises the following error on usegalaxy.ca: 

```
galaxy.authnz.managers ERROR 2025-08-27 00:56:47,996 [pN:main.2,p:338273,tN:WSGI_1] An error occurred when refreshing user token
Traceback (most recent call last):
  File "/mnt/nfs/galaxy/venv/lib/python3.10/site-packages/jwt/api_jws.py", line 258, in _load
    signing_input, crypto_segment = jwt.rsplit(b".", 1)
ValueError: not enough values to unpack (expected 2, got 1)
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/mnt/nfs/galaxy/server/lib/galaxy/authnz/managers.py", line 291, in refresh_expiring_oidc_tokens_for_provider
    refreshed = backend.refresh(trans, auth)
  File "/mnt/nfs/galaxy/server/lib/galaxy/authnz/custos_authnz.py", line 126, in refresh
    refresh_token_decoded = self._decode_token_no_signature(custos_authnz_token.refresh_token)
  File "/mnt/nfs/galaxy/server/lib/galaxy/authnz/custos_authnz.py", line 115, in _decode_token_no_signature
    return jwt.decode(token, audience=self.config.client_id, options={"verify_signature": False})
  File "/mnt/nfs/galaxy/venv/lib/python3.10/site-packages/jwt/api_jwt.py", line 211, in decode
    decoded = self.decode_complete(
  File "/mnt/nfs/galaxy/venv/lib/python3.10/site-packages/jwt/api_jwt.py", line 152, in decode_complete
    decoded = api_jws.decode_complete(
  File "/mnt/nfs/galaxy/venv/lib/python3.10/site-packages/jwt/api_jws.py", line 199, in decode_complete
    payload, signing_input, header, signature = self._load(jwt)
  File "/mnt/nfs/galaxy/venv/lib/python3.10/site-packages/jwt/api_jws.py", line 261, in _load
    raise DecodeError("Not enough segments") from err
jwt.exceptions.DecodeError: Not enough segments
```
The value at `custos_authnz_token.refresh_token` is not meant to be decoded: it's not JWT format (unlike `id_token`). This value is used to refresh a token - it is submitted to cilogon to obtain a token response containing a new token. (see this example: https://www.cilogon.org/oidc#h.p_ABWOaEJR9iv2)

The expiration time should be accessed via `id_token_decoded["exp"]`, like in line 122.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
