### PR TITLE
Ignore yaml and json in prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml.sample
+++ b/.pre-commit-config.yaml.sample
@@ -13,6 +13,9 @@ repos:
     - id: prettier
       additional_dependencies:
         - prettier@3.6.2 # SEE: https://github.com/pre-commit/pre-commit/issues/3133
+      exclude_types:  # .prettierignore ignored apparently ...
+        - yaml
+        - json
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0  # Use the ref you want to point at
     hooks:


### PR DESCRIPTION
The .prettierignore file appears to not be respected, but I think this is the only relevant discrepancy with .prettierignore, as we either won't change the remaining files or they're already in .gitignore.

Noticed this while editing client/src/utils/navigation/navigation.yml

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
