### PR TITLE
Migrate icon defs in CollectionOperations.vue to best practices.

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { faDownload, faInfoCircle, faRedo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
@@ -36,7 +38,7 @@ function onDownload() {
                     variant="link"
                     :href="downloadUrl"
                     @click="onDownload">
-                    <Icon class="mr-1" icon="download" />
+                    <FontAwesomeIcon class="mr-1" :icon="faDownload" />
                     <span>Download</span>
                 </b-button>
                 <b-button
@@ -47,7 +49,7 @@ function onDownload() {
                     variant="link"
                     :href="showCollectionDetailsUrl"
                     @click.prevent.stop="router.push(showCollectionDetailsUrl)">
-                    <icon icon="info-circle" />
+                    <FontAwesomeIcon class="mr-1" :icon="faInfoCircle" />
                     <span>Show Details</span>
                 </b-button>
                 <b-button
@@ -58,7 +60,7 @@ function onDownload() {
                     variant="link"
                     :href="rerunUrl"
                     @click.prevent.stop="router.push(rerunUrl)">
-                    <Icon class="mr-1" icon="redo" />
+                    <FontAwesomeIcon class="mr-1" :icon="faRedo" />
                     <span>Run Job Again</span>
                 </b-button>
             </b-button-group>


### PR DESCRIPTION
<img width="859" height="266" alt="Screenshot 2025-08-28 at 10 33 53 AM" src="https://github.com/user-attachments/assets/faeda014-afbd-4cb0-b1e7-d3641db9e5be" />

It will clean up #20798 a bit.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Click a collection in the history panel and ensure the operation icons toward the top of the right bar are still there.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
