### PR TITLE
Fix optional numeric column definitions for sample sheets.

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormColumnDefinition.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormColumnDefinition.vue
@@ -176,8 +176,19 @@ const isOptional = ref(props.value.optional ?? false);
 const defaultBoolean = ref(props.value.default_value === null ? "null" : props.value.default_value ? "true" : "false");
 const defaultString = ref(props.value.default_value || "");
 // form framework doesn't yield typed values it seems
-const defaultIntAsStr = ref(props.value.default_value ? props.value.default_value.toString() : "0");
-const defaultFloatAsStr = ref(props.value.default_value ? props.value.default_value.toString() : "0.0");
+
+function defaultNumberAsString(defaultForType: string): string {
+    if (props.value.default_value !== null && props.value.default_value !== undefined) {
+        return props.value.default_value.toString();
+    } else if (props.value.optional) {
+        return "";
+    } else {
+        return defaultForType;
+    }
+}
+
+const defaultIntAsStr = ref(defaultNumberAsString("0"));
+const defaultFloatAsStr = ref(defaultNumberAsString("0.0"));
 
 watch(isOptional, setIsOptional);
 watch(defaultIntAsStr, setDefaultByType);


### PR DESCRIPTION
It would work properly the first time but then regress on reload and resave in the form because this initialization logic wasn't taking into account optional parameter types.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Open the workflow editor and add a sample sheet input to the workflow.
  2. Add a column by clicking the step and scrolling down the right panel.
  3. Make the column an optional integer. Swap the default of "0" to an empty input box.
  4. Save the workflow - notice the "null" default is saved properly over the wire.
  5. Reload the workflow - notice that without this change the empty input box for the default has become "0".

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
