### PR TITLE
Bump requirement of directory converters

### DIFF
--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_archive_to_directory" name="Unpack archive to directory" version="1.0.0" profile="21.09">
     <!-- Use compression_utils instead of shell commands (tar/unzip) so we can verify safety of results -->
     <requirements>
-        <requirement type="package" version="23.2.1">galaxy-util</requirement>
+        <requirement type="package" version="25.0">galaxy-util</requirement>
     </requirements>
     <command><![CDATA[
         mkdir '$output1.files_path' &&

--- a/lib/galaxy/datatypes/converters/tar_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/tar_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_tar_to_directory" name="Convert tar to directory" version="1.0.1" profile="21.09">
     <!-- Don't use tar directly so we can verify safety of results - tar -xzf '$input1'; -->
     <requirements>
-        <requirement type="package" version="23.2.1">galaxy-util</requirement>
+        <requirement type="package" version="25.0">galaxy-util</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 cp '$provided_metadata' 'galaxy.json' &&


### PR DESCRIPTION
with conda I get (because it chooses a python without imghdr). We dropped the need for this module in 24.2 https://github.com/galaxyproject/galaxy/pull/18449

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from galaxy.util.compression_utils import CompressedFile; CompressedFile('/tmp/tmp3v2nuot4/files/a/9/7/dataset_a97aebb4-46f7-47a9-b418-11ff1deeed74.dat').extract('.')
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/berntm/miniforge3/envs/__galaxy-util@23.2.1/lib/python3.13/site-packages/galaxy/util/compression_utils.py", line 29, in <module>
    from .checkers import (
    ...<2 lines>...
    )
  File "/home/berntm/miniforge3/envs/__galaxy-util@23.2.1/lib/python3.13/site-packages/galaxy/util/checkers.py", line 20, in <module>
    from galaxy.util.image_util import image_type
  File "/home/berntm/miniforge3/envs/__galaxy-util@23.2.1/lib/python3.13/site-packages/galaxy/util/image_util.py", line 3, in <module>
    import imghdr
ModuleNotFoundError: No module named 'imghdr'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
