### PR TITLE
Fix lint error in `WorkflowRunSuccess`

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -23,7 +23,7 @@ const targetHistories = computed(() =>
             histories.push(invocation.history_id);
         }
         return histories;
-    }, [] as string[])
+    }, [] as string[]),
 );
 </script>
 


### PR DESCRIPTION
This was caused in https://github.com/galaxyproject/galaxy/pull/20797

> This broke client linting tests on `src/components/Workflow/Run/WorkflowRunSuccess.vue` , can you please fix it? Thanks!

_Originally posted by @nsoranzo in https://github.com/galaxyproject/galaxy/issues/20797#issuecomment-3237586999_
            

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
