### PR TITLE
Update pytest to v8

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -11,6 +11,7 @@ async-timeout==5.0.1 ; python_full_version < '3.11'
 attrs==25.3.0
 axe-selenium-python==2.1.6
 babel==2.17.0
+backports-asyncio-runner==1.2.0 ; python_full_version < '3.11'
 backports-tarfile==1.2.0 ; python_full_version < '3.12' and platform_machine != 'ppc64le' and platform_machine != 's390x'
 black==25.1.0
 boto3==1.40.18
@@ -126,8 +127,8 @@ pyproject-hooks==1.2.0
 pyshacl==0.26.0 ; python_full_version < '3.10'
 pyshacl==0.30.1 ; python_full_version >= '3.10'
 pysocks==1.7.1
-pytest==7.4.4
-pytest-asyncio==0.23.8
+pytest==8.4.2
+pytest-asyncio==1.2.0
 pytest-base-url==2.1.0
 pytest-cov==7.0.0
 pytest-html==4.1.1

--- a/lib/galaxy/dependencies/pinned-test-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-test-requirements.txt
@@ -8,6 +8,7 @@ ase==3.26.0
 async-timeout==5.0.1 ; python_full_version < '3.11'
 attrs==25.3.0
 axe-selenium-python==2.1.6
+backports-asyncio-runner==1.2.0 ; python_full_version < '3.11'
 boto3==1.40.18
 botocore==1.40.18
 cachecontrol==0.14.3
@@ -94,8 +95,8 @@ pyparsing==3.2.3
 pyshacl==0.26.0 ; python_full_version < '3.10'
 pyshacl==0.30.1 ; python_full_version >= '3.10'
 pysocks==1.7.1
-pytest==7.4.4
-pytest-asyncio==0.23.8
+pytest==8.4.2
+pytest-asyncio==1.2.0
 pytest-base-url==2.1.0
 pytest-cov==7.0.0
 pytest-html==4.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ test = [
     "onedatafilerestclient==21.2.5.2",
     "pkce",
     "playwright>=1.48.0",  # Python 3.13 support
-    "pytest<8",  # https://github.com/galaxyproject/galaxy/issues/17561
+    "pytest",
     "pytest-asyncio",
     "pytest-cov",
     "pytest-html",

--- a/test/integration/objectstore/test_onedata_objectstore.py
+++ b/test/integration/objectstore/test_onedata_objectstore.py
@@ -28,7 +28,10 @@ TEST_TOOL_IDS = [
 
 
 class TestOnedataObjectStoreIntegration(BaseOnedataObjectStoreIntegrationTestCase):
-    pass
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["enable_celery_tasks"] = False
 
 
 instance = integration_util.integration_module_instance(TestOnedataObjectStoreIntegration)


### PR DESCRIPTION
Close https://github.com/galaxyproject/galaxy/issues/17561 .

The issue with "An existing process seems bound to specified test server port" seems solved now, but (in my initial CI testing on my fork) several integration tests now fails with:

```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1147)
```

when trying to download from GitHub or quay.io .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
