### PR TITLE
[25.0] Disable Run Tool button when there are errors

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -225,16 +225,16 @@ export default {
             return this.uuid || this.formConfig.uuid;
         },
         tooltip() {
-            switch (true) {
-                case !this.canMutateHistory:
-                    return this.immutableHistoryMessage;
-                case this.hasConfigOrValErrors:
-                    return "Please correct errors before running the tool.";
-                case this.showExecuting:
-                    return "Tool is being executed...";
-                default:
-                    return `Run tool: ${this.formConfig.name} (${this.formConfig.version})`;
+            if (!this.canMutateHistory) {
+                return this.immutableHistoryMessage;
             }
+            if (this.hasConfigOrValErrors) {
+                return "Please resolve highlighted issues before running the tool.";
+            }
+            if (this.showExecuting) {
+                return "Tool is being executed...";
+            }
+            return `Run tool: ${this.formConfig.name} (${this.formConfig.version})`;
         },
         errorContentPretty() {
             return JSON.stringify(this.errorContent, null, 4);

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -87,7 +87,7 @@
                     id="execute"
                     class="text-nowrap"
                     title="Run Tool"
-                    :disabled="!canMutateHistory"
+                    :disabled="runButtonDisabled"
                     size="small"
                     :wait="showExecuting"
                     :tooltip="tooltip"
@@ -97,7 +97,7 @@
                 <ButtonSpinner
                     title="Run Tool"
                     class="mt-3 mb-3"
-                    :disabled="!canMutateHistory"
+                    :disabled="runButtonDisabled"
                     :wait="showExecuting"
                     :tooltip="tooltip"
                     @onClick="onExecute(config, currentHistoryId)" />
@@ -224,10 +224,16 @@ export default {
             return this.uuid || this.formConfig.uuid;
         },
         tooltip() {
-            if (!this.canMutateHistory) {
-                return this.immutableHistoryMessage;
+            switch (true) {
+                case !this.canMutateHistory:
+                    return this.immutableHistoryMessage;
+                case this.formConfig.errors && Object.values(this.formConfig.errors).length > 0:
+                    return "Please correct errors before running the tool.";
+                case this.showExecuting:
+                    return "Tool is being executed...";
+                default:
+                    return `Run tool: ${this.formConfig.name} (${this.formConfig.version})`;
             }
-            return `Run tool: ${this.formConfig.name} (${this.formConfig.version})`;
         },
         errorContentPretty() {
             return JSON.stringify(this.errorContent, null, 4);
@@ -252,8 +258,10 @@ export default {
         canMutateHistory() {
             return this.currentHistory && canMutateHistory(this.currentHistory);
         },
-        runButtonTitle() {
-            return "Run Tool";
+        runButtonDisabled() {
+            return (
+                this.disabled || !this.canMutateHistory || (this.formConfig.errors && Object.values(this.formConfig.errors).length > 0)
+            );
         },
     },
     watch: {


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20816 Fixes https://github.com/galaxyproject/galaxy/issues/20085 ?

I reckon this should prevent a lot of confusion since there is an obvious tooltip that indicates there are errors and therefore, the tool cannot be run.

| 🔴 Before |
| ---- |
| <img width="1718" height="404" alt="firefox_KD1fSLRsxN" src="https://github.com/user-attachments/assets/020fe3c0-c00a-42dc-bfe9-eabb65c9e9c5" /> |

| 🟢 After |
| ---- |
| <img width="1718" height="404" alt="wg7EE26VzC" src="https://github.com/user-attachments/assets/d2366987-e721-40fe-93a6-0744715ce334" /> |


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
