### PR TITLE
Render Markdown in Dataset Preview

### DIFF
--- a/client/src/components/Dataset/DatasetMarkdown/DatasetInMarkdown.vue
+++ b/client/src/components/Dataset/DatasetMarkdown/DatasetInMarkdown.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import axios from "axios";
+import { onMounted, ref } from "vue";
+
+import { useMarkdown } from "@/composables/markdown";
+import { Toast } from "@/composables/toast";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+interface Props {
+    historyContentId: string;
+}
+
+const props = defineProps<Props>();
+
+const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true, removeNewlinesAfterList: true });
+
+const content = ref("");
+
+async function getMarkdownData() {
+    try {
+        const { data } = await axios.get(`/api/datasets/${props.historyContentId}/display?preview=true`);
+        content.value = data;
+    } catch (error) {
+        console.error("Error fetching dataset content", props.historyContentId, error);
+        Toast.error(errorMessageAsString(error));
+    }
+}
+
+onMounted(async () => {
+    await getMarkdownData();
+});
+</script>
+
+<template>
+    <div class="dataset-in-markdown">
+        <div v-if="content" v-html="renderMarkdown(content)" />
+    </div>
+</template>

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -15,6 +15,7 @@ import LoadingSpan from "../LoadingSpan.vue";
 import DatasetAsImage from "./DatasetAsImage/DatasetAsImage.vue";
 import DatasetState from "./DatasetState.vue";
 import Heading from "@/components/Common/Heading.vue";
+import DatasetInMarkdown from "@/components/Dataset/DatasetMarkdown/DatasetInMarkdown.vue";
 import DatasetAttributes from "@/components/DatasetInformation/DatasetAttributes.vue";
 import DatasetDetails from "@/components/DatasetInformation/DatasetDetails.vue";
 import VisualizationsList from "@/components/Visualizations/Index.vue";
@@ -66,6 +67,9 @@ const isImageDataset = computed(() => {
     return datatypesMapperStore.datatypesMapper.isSubTypeOfAny(dataset.value.file_ext, [
         "galaxy.datatypes.images.Image",
     ]);
+});
+const isMarkdownDataset = computed(() => {
+    return dataset.value?.file_ext === "markdown";
 });
 
 const isPdfDataset = computed(() => {
@@ -205,6 +209,7 @@ watch(
                 :history-dataset-id="datasetId"
                 :allow-size-toggle="true"
                 class="p-3" />
+            <DatasetInMarkdown v-else-if="isMarkdownDataset" :history-content-id="datasetId" />
             <CenterFrame
                 v-else
                 :src="`/datasets/${datasetId}/display/?preview=True`"


### PR DESCRIPTION
This pull request adds support for rendering datasets with the `markdown` file extension directly in the dataset view. 

|Before|After|
|---|---|
|<img width="1517" height="947" alt="image" src="https://github.com/user-attachments/assets/dd2b57bc-15dd-4a5b-9c99-ae151c1037ea" />|<img width="1517" height="947" alt="image" src="https://github.com/user-attachments/assets/4fc96c09-5854-4304-9f50-d347dabb4aae" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Preview a dataset in markdown

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
