### PR TITLE
Update Integration tests

### DIFF
--- a/.ci/minikube-test-setup/deployment.yaml
+++ b/.ci/minikube-test-setup/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: test
     spec:
       containers:
-      - image: postgres:12
+      - image: postgres:17
         name: postgres
         ports:
         - containerPort: 5432

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -42,9 +42,8 @@ jobs:
       - name: Clean dotnet folder for space
         run: rm -Rf /usr/share/dotnet
       - name: Install packages
-        # conntrack: mandatory for later k8s versions
         # ffmpeg: ffprobe needed by media datatypes
-        run: sudo apt-get update && sudo apt-get -y install conntrack ffmpeg
+        run: sudo apt-get update && sudo apt-get -y install ffmpeg
       - name: Setup Minikube
         uses: medyagh/setup-minikube@latest
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,8 +16,6 @@ on:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
 env:
-  GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'
-  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
   GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
@@ -33,19 +31,6 @@ jobs:
       matrix:
         python-version: ['3.9']
         chunk: ['0', '1', '2', '3']
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-      rabbitmq:
-        image: rabbitmq
-        ports:
-          - 5672:5672
     steps:
       - if: github.event_name == 'schedule'
         run: |


### PR DESCRIPTION
- Drop conntrack from the list of packages to install. It will be installed as part of the medyagh/setup-minikube action.
- Drop unneeded postgres and rabbitmq services. We are always running them via minikube since commit 992edaa8b4b6cacc543b72baa275b508f1cc9529 .
- Update PostgreSQL image version to 17 in minikube test setup to sync it with the other CI workflows.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
