### PR TITLE
Use a streaming based parser (ijson) when setting metadata for biom1 files.

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -83,6 +83,7 @@ httpcore==1.0.9
 httpx==0.28.1
 humanfriendly==10.0
 idna==3.10
+ijson==3.4.0
 importlib-metadata==8.7.0 ; python_full_version < '3.10'
 importlib-resources==6.5.2 ; python_full_version < '3.12'
 invoke==2.2.0

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     galaxy-sequence-utils
     h5grove>=1.2.1
     h5py
+    ijson
     isa-rwval>=0.10.11
     isal>=1.7.0
     MarkupSafe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "h5grove>=1.2.1",
     "h5py>=3.12",  # Python 3.13 support
     "httpx",
+    "ijson",
     "importlib-resources ; python_version<'3.12'",  # for importlib.{abc.Traversable,resources.{files, Package}}
     "isa-rwval>=0.10.11",  # https://github.com/ISA-tools/isa-rwval/pull/17
     "isal>=1.7.0",  # Python 3.13 support


### PR DESCRIPTION
This PR supersedes #20802 

Loading an entire JSON file into memory with `json.load()` can cause the worker process to be OOM-killed.  This problem has only been reported when setting metadata for the `biom1` datatype so that is all that this PR addresses (if it ain't broke don't fix it).  It would be easy enough to use the same approach with other datatypes that read entire JSON files when setting metadata.

See #20750 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
