### PR TITLE
Put ajs instead of tuple into watch queue

### DIFF
--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -449,7 +449,7 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
                         # TODO: This is where any cleanup would occur
                         self.handle_stop()
                         return
-                    self.watched.append((async_job_state.job_id, async_job_state))
+                    self.watched.append(async_job_state)
             except Empty:
                 pass
             # Iterate over the list of watched jobs and check state
@@ -466,11 +466,12 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
         self.watched = [x for x in self.watched if x[0] not in done]
 
     def check_watched_items_by_batch(self, start: int, end: int, done: set[str]):
-        jobs = self.watched[start : start + self.MAX_JOBS_PER_QUERY]
-        if not jobs:
+        async_job_states = self.watched[start : start + self.MAX_JOBS_PER_QUERY]
+        if not async_job_states:
             return
 
-        jobs_dict = dict(jobs)
+        jobs_dict = {ajs.job_id: ajs for ajs in async_job_states}
+
         resp = self._batch_client.describe_jobs(jobs=list(jobs_dict.keys()))
 
         gotten = set()

--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -463,7 +463,7 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
     def check_watched_items(self):
         done: set[str] = set()
         self.check_watched_items_by_batch(0, len(self.watched), done)
-        self.watched = [x for x in self.watched if x[0] not in done]
+        self.watched = [ajs for ajs in self.watched if ajs.job_id not in done]
 
     def check_watched_items_by_batch(self, start: int, end: int, done: set[str]):
         async_job_states = self.watched[start : start + self.MAX_JOBS_PER_QUERY]


### PR DESCRIPTION
This is a quick fix (untested) for the following reported stack trace.

```
Exception in thread AWSBatchRunner.monitor_thread:
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/app/galaxy/lib/galaxy/jobs/runners/aws.py", line 453, in monitor
    self.watched.append((async_job_state.job_id, async_job_state))
                         ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'object' object has no attribute 'job_id'
```

The problem is that  monitor is enqueuing a tuple instead of an asynchronous job state, which works the first time, but fails on subsequent enqueuings.
ping @ksuderman 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
