### PR TITLE
Support remote file source hashes

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -18632,6 +18632,11 @@ export interface components {
              */
             ctime: string;
             /**
+             * Hashes
+             * @description List of precomputed hashes for the file, if available.
+             */
+            hashes?: components["schemas"]["RemoteFileHash"][] | null;
+            /**
              * Name
              * @description The name of the entry.
              */
@@ -18651,6 +18656,16 @@ export interface components {
              * @description The URI of the entry.
              */
             uri: string;
+        };
+        /** RemoteFileHash */
+        RemoteFileHash: {
+            /**
+             * Hash Function
+             * @enum {string}
+             */
+            hash_function: "MD5" | "SHA-1" | "SHA-256" | "SHA-512";
+            /** Hash Value */
+            hash_value: string;
         };
         /**
          * RemoteFilesDisableMode

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -35,7 +35,7 @@ const filesSources = useFileSources();
 
 interface FilesDialogProps {
     /** Callback function to be called passing the results when selection is complete */
-    callback?: (files: SelectionItem[]) => void;
+    callback?: (files: SelectionItem | SelectionItem[]) => void;
     /** Options to filter the file sources */
     filterOptions?: FilterFileSourcesOptions;
     /** Decide wether to keep the underlying modal static or dynamic */
@@ -424,7 +424,7 @@ function onSelectAll() {
 function finalize() {
     const results = selectionModel.value.finalize();
     modalShow.value = false;
-    props.callback(Array.isArray(results) ? results : [results]);
+    props.callback(results);
 }
 
 function onOk() {

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -388,6 +388,7 @@ function entryToRecord(entry: RemoteEntry): SelectionItem {
         isLeaf: entry.class === "File",
         url: entry.uri,
         size: entry.class === "File" ? entry.size : 0,
+        entry: entry,
     };
     return result;
 }

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -35,7 +35,7 @@ const filesSources = useFileSources();
 
 interface FilesDialogProps {
     /** Callback function to be called passing the results when selection is complete */
-    callback?: (files: any) => void;
+    callback?: (files: SelectionItem[]) => void;
     /** Options to filter the file sources */
     filterOptions?: FilterFileSourcesOptions;
     /** Decide wether to keep the underlying modal static or dynamic */
@@ -423,7 +423,7 @@ function onSelectAll() {
 function finalize() {
     const results = selectionModel.value.finalize();
     modalShow.value = false;
-    props.callback(results);
+    props.callback(Array.isArray(results) ? results : [results]);
 }
 
 function onOk() {

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -15,10 +15,6 @@ interface Props {
     selectedItem?: SelectionItem;
 }
 
-interface SelectableFile {
-    url: string;
-}
-
 const props = withDefaults(defineProps<Props>(), {
     mode: "file",
     requireWritable: false,
@@ -46,8 +42,8 @@ const selectFile = () => {
         filterOptions: props.filterOptions,
         selectedItem: props.selectedItem,
     };
-    filesDialog((selected: SelectableFile) => {
-        currentValue.value = selected?.url;
+    filesDialog((selected: SelectionItem) => {
+        currentValue.value = selected.url;
     }, dialogProps);
 };
 

--- a/client/src/components/FilesDialog/utilities.ts
+++ b/client/src/components/FilesDialog/utilities.ts
@@ -21,6 +21,7 @@ export function fileSourcePluginToItem(plugin: BrowsableFilesSourcePlugin): Sele
         details: plugin.doc || "",
         isLeaf: false,
         url: plugin.uri_root,
+        entry: plugin,
     };
     return result;
 }

--- a/client/src/components/SelectionDialog/BasicSelectionDialog.vue
+++ b/client/src/components/SelectionDialog/BasicSelectionDialog.vue
@@ -6,6 +6,10 @@ import { errorMessageAsString } from "@/utils/simple-error";
 
 import SelectionDialog from "@/components/SelectionDialog/SelectionDialog.vue";
 
+interface BasicItem extends SelectionItem {
+    time: string | null;
+}
+
 interface Props {
     detailsKey?: string;
     getData: () => Promise<Array<object> | undefined>;
@@ -54,17 +58,19 @@ async function load() {
         // this could potentially load quite a lot of items
         const incoming = await props.getData();
         if (incoming) {
-            items.value = incoming.map((item: any) => {
-                const timeStamp = item[props.timeKey];
+            items.value = incoming.map((entry: any) => {
+                const timeStamp = entry[props.timeKey];
                 showTime.value = !!timeStamp;
-                return {
-                    id: item.id,
-                    label: item[props.labelKey] || null,
-                    details: item[props.detailsKey] || null,
+                const item: BasicItem = {
+                    id: entry.id,
+                    label: entry[props.labelKey] || null,
+                    details: entry[props.detailsKey] || null,
                     time: timeStamp || null,
+                    entry: entry,
                     isLeaf: true,
                     url: "",
                 };
+                return item;
             });
         }
         optionsShow.value = true;

--- a/client/src/components/SelectionDialog/HistoryDatasetPicker.vue
+++ b/client/src/components/SelectionDialog/HistoryDatasetPicker.vue
@@ -16,6 +16,11 @@ import SelectionDialog from "@/components/SelectionDialog/SelectionDialog.vue";
 
 interface HistoryRecord extends SelectionItem {
     size: number;
+    update_time: string;
+}
+
+interface DatasetRecord extends SelectionItem {
+    update_time: string | null;
 }
 
 interface Props {
@@ -89,7 +94,7 @@ const selectAllIcon = computed(() => {
 });
 
 function historyEntryToRecord(entry: HistorySummary): HistoryRecord {
-    const result = {
+    const result: HistoryRecord = {
         id: entry.id,
         label: entry.name,
         details: entry.annotation || "",
@@ -97,19 +102,21 @@ function historyEntryToRecord(entry: HistorySummary): HistoryRecord {
         url: entry.url,
         size: entry.count,
         update_time: entry.update_time,
+        entry: entry,
     };
 
     return result;
 }
 
-function datasetEntryToRecord(entry: HDASummary): SelectionItem {
-    const result = {
+function datasetEntryToRecord(entry: HDASummary): DatasetRecord {
+    const result: DatasetRecord = {
         id: entry.id,
         label: entry.name || "",
         details: "",
         isLeaf: true,
         url: entry.url,
         update_time: entry.update_time,
+        entry: entry,
     };
 
     return result;

--- a/client/src/components/SelectionDialog/selectionTypes.ts
+++ b/client/src/components/SelectionDialog/selectionTypes.ts
@@ -18,6 +18,7 @@ export interface SelectionItem {
     details: string;
     isLeaf: boolean;
     url: string;
+    entry: Record<string, unknown>;
     _rowVariant?: SelectionState;
 }
 

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -6,6 +6,7 @@ import { useRouter } from "vue-router/composables";
 
 import type { HDASummary } from "@/api";
 import type { CollectionBuilderType } from "@/components/History/adapters/buildCollectionModal";
+import type { SelectionItem } from "@/components/SelectionDialog/selectionTypes";
 import { monitorUploadedHistoryItems } from "@/composables/monitorUploadedHistoryItems";
 import type { DbKey, ExtensionDetails } from "@/composables/uploadConfigurations";
 import { archiveExplorerEventBus, type ArchiveSource } from "@/composables/zipExplorer";
@@ -13,7 +14,8 @@ import { filesDialog } from "@/utils/dataModals";
 import { UploadQueue } from "@/utils/upload-queue.js";
 
 import type { ComponentSize } from "../BaseComponents/componentVariants";
-import { defaultModel, isLocalFile, type UploadFile, type UploadItem } from "./model";
+import type { UploadFile, UploadItem } from "./model";
+import { defaultModel, isLocalFile } from "./model";
 import { COLLECTION_TYPES, DEFAULT_FILE_NAME, hasBrowserSupport } from "./utils";
 
 import GButton from "../BaseComponents/GButton.vue";
@@ -253,7 +255,7 @@ async function eventExplore(archiveSource: ArchiveSource) {
 /** Show remote files dialog or FTP files */
 function eventRemoteFiles() {
     filesDialog(
-        (items: UploadFile[]) => {
+        (items: SelectionItem[]) => {
             queue.value.add(
                 items.map((item) => {
                     const rval = {

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -261,7 +261,7 @@ function eventRemoteFiles() {
                     const rval = {
                         mode: "url",
                         name: item.label,
-                        size: item.size,
+                        size: item.entry.size,
                         path: item.url,
                     };
                     return rval;

--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -263,6 +263,7 @@ function eventRemoteFiles() {
                         name: item.label,
                         size: item.entry.size,
                         path: item.url,
+                        hashes: item.entry.hashes,
                     };
                     return rval;
                 }),

--- a/client/src/utils/upload-payload.js
+++ b/client/src/utils/upload-payload.js
@@ -79,6 +79,10 @@ export function uploadPayload(items, historyId, composite = false) {
                         }
                     case "url":
                         if (isUrl(urlContent)) {
+                            const hashes = item.fileData?.hashes;
+                            if (hashes) {
+                                elem["hashes"] = hashes;
+                            }
                             return {
                                 src: "url",
                                 url: urlContent,

--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -29,6 +29,7 @@ from galaxy.util.config_templates import (
     EnvironmentDict,
     partial_model,
 )
+from galaxy.util.hash_util import HashFunctionNames
 from galaxy.util.template import fill_template
 
 if TYPE_CHECKING:
@@ -326,12 +327,25 @@ class RemoteDirectory(RemoteEntry):
     class_: Annotated[Literal["Directory"], Field(..., serialization_alias="class")] = "Directory"
 
 
+class RemoteFileHash(StrictModel):
+    hash_function: HashFunctionNames
+    hash_value: str
+
+
 class RemoteFile(RemoteEntry):
     class_: Annotated[Literal["File"], Field(..., serialization_alias="class")] = "File"
     size: Annotated[int, Field(..., title="Size", description="The size of the file in bytes.")] = 0
     ctime: Annotated[
-        Optional[str], Field(default="Unknown", title="Creation time", description="The creation time of the file.")
+        Optional[str], Field(default=None, title="Creation time", description="The creation time of the file.")
     ]
+    hashes: Annotated[
+        Optional[list[RemoteFileHash]],
+        Field(
+            default=None,
+            title="Hashes",
+            description="List of precomputed hashes for the file, if available.",
+        ),
+    ] = None
 
 
 AnyRemoteEntry = Union[RemoteDirectory, RemoteFile]

--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -17,6 +17,7 @@ from galaxy.files.models import (
     AnyRemoteEntry,
     FilesSourceRuntimeContext,
     RemoteDirectory,
+    RemoteFileHash,
 )
 
 try:
@@ -105,6 +106,13 @@ class HuggingFaceFilesSource(
         """Extract timestamp from Hugging Face file info to use it in the RemoteFile entry."""
         last_commit: dict = info.get("last_commit", {})
         return last_commit.get("date")
+
+    def _get_file_hashes(self, info: dict) -> Optional[list[RemoteFileHash]]:
+        """Get optional file hashes provided by Hugging Face for the RemoteFile entry."""
+        # Files stored in Hugging Face repositories using Git LFS may have SHA-256 hashes.
+        lfs = info.get("lfs") or {}
+        sha256 = lfs.get("sha256")
+        return [RemoteFileHash(hash_function="SHA-256", hash_value=sha256)] if sha256 else None
 
     def _list(
         self,

--- a/lib/galaxy/schema/fetch_data.py
+++ b/lib/galaxy/schema/fetch_data.py
@@ -15,9 +15,7 @@ from pydantic import (
     Json,
     TypeAdapter,
 )
-from typing_extensions import (
-    Literal,
-)
+from typing_extensions import Literal
 
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -27,6 +25,7 @@ from galaxy.schema.schema import (
 )
 from galaxy.schema.terms import HelpTerms
 from galaxy.schema.types import CoercedStringType
+from galaxy.util.hash_util import HashFunctionNames
 
 HELP_TERMS = HelpTerms()
 
@@ -112,7 +111,7 @@ class ExtraFiles(FetchBaseModel):
 
 
 class FetchDatasetHash(Model):
-    hash_function: Literal["MD5", "SHA-1", "SHA-256", "SHA-512"]
+    hash_function: HashFunctionNames
     hash_value: str
 
     model_config = ConfigDict(extra="forbid")

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import (
     Annotated,
     Any,
+    Literal,
     Optional,
     Union,
 )
@@ -10,11 +11,9 @@ from pydantic import (
     Field,
     RootModel,
 )
-from typing_extensions import (
-    Literal,
-)
 
 from galaxy.schema.schema import Model
+from galaxy.util.hash_util import HashFunctionNames
 
 
 class RemoteFilesTarget(str, Enum):
@@ -135,10 +134,18 @@ class RemoteDirectory(RemoteEntry):
     class_: Literal["Directory"] = Field(..., alias="class")
 
 
+class RemoteFileHash(Model):
+    hash_function: HashFunctionNames
+    hash_value: str
+
+
 class RemoteFile(RemoteEntry):
     class_: Literal["File"] = Field(..., alias="class")
     size: int = Field(..., title="Size", description="The size of the file in bytes.")
     ctime: str = Field(..., title="Creation time", description="The creation time of the file.")
+    hashes: Optional[list[RemoteFileHash]] = Field(
+        None, title="Hashes", description="List of precomputed hashes for the file, if available."
+    )
 
 
 class ListJstreeResponse(RootModel):

--- a/lib/galaxy/util/hash_util.py
+++ b/lib/galaxy/util/hash_util.py
@@ -12,6 +12,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -40,6 +41,11 @@ class HashFunctionNameEnum(str, Enum):
     sha1 = "SHA-1"
     sha256 = "SHA-256"
     sha512 = "SHA-512"
+
+
+# IMPORTANT: Keep this literal type in sync with HashFunctionNameEnum values above
+# as well as with HASH_NAME_ALIAS and HASH_NAME_MAP below.
+HashFunctionNames = Literal["MD5", "SHA-1", "SHA-256", "SHA-512"]
 
 
 HASH_NAME_ALIAS: Dict[str, str] = {


### PR DESCRIPTION
Closes #20832

This allows passing a pre-computed set of hashes provided by the remote file system for a particular remote file to the fetch request, so it can be taken into account for integrity verification or file deduplication.

Note: only implemented for the Hugging Face file source plugin, but it is easy to implement for other file sources, just override the `_get_file_hashes` function in the plugin implementation.

This is how the fetch payload will look for one of the models:

```json
{
  "history_id": "e85a3be143d5905b",
  "targets": [
    {
      "destination": { "type": "hdas" },
      "elements": [
        {
          "src": "url",
          "url": "gxuserfiles://c3de0646-aeb9-411b-874d-8418bd982f18/prajjwal1/bert-tiny/pytorch_model.bin",
          "deferred": false,
          "dbkey": "?",
          "ext": "auto",
          "name": "pytorch_model.bin",
          "space_to_tab": false,
          "to_posix_lines": true,
          "hashes": [
            {
              "hash_function": "SHA-256",
              "hash_value": "dab2c2bddcfb48ea430ef63fd76d46d67d704487844d967256a50dd7d7fd0a66"
            }
          ]
        }
      ]
    }
  ],
  "auto_decompress": true,
  "files": []
}
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Set up the Hugging Face plugin in your local Galaxy instance like in #20805
  - Browse and try to download a model
  - Check the fetch request for the model in your browser dev tools
  - **Note**: only model files are stored in Git LFS, so only model files will have computed hashes in Hugging Face repositories.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
