### PR TITLE
[25.0] Directory converters: fix for flat zip files

### DIFF
--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -6,7 +6,8 @@
     <command><![CDATA[
         mkdir '$output1.files_path' &&
         cd '$output1.files_path' &&
-        python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.')"
+        python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.')" &&
+        if [ -d \$(basename "$input1" .dat) ]; then mv "\$(basename "$input1" .dat)"/* . && rmdir "\$(basename "$input1" .dat)"; fi
     ]]></command>
     <configfiles>
         <configfile filename="metadata_json"><![CDATA[{

--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_archive_to_directory" name="Unpack archive to directory" version="1.0.0" profile="21.09">
     <!-- Use compression_utils instead of shell commands (tar/unzip) so we can verify safety of results -->
     <requirements>
-        <requirement type="package" version="25.0">galaxy-util</requirement>
+        <requirement type="package" version="25.0.2">galaxy-util</requirement>
     </requirements>
     <command><![CDATA[
         mkdir '$output1.files_path' &&

--- a/lib/galaxy/datatypes/converters/archive_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/archive_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_archive_to_directory" name="Unpack archive to directory" version="1.0.0" profile="21.09">
     <!-- Use compression_utils instead of shell commands (tar/unzip) so we can verify safety of results -->
     <requirements>
-        <requirement type="package" version="23.2.1">galaxy-util</requirement>
+        <requirement type="package" version="25.0">galaxy-util</requirement>
     </requirements>
     <command><![CDATA[
         mkdir '$output1.files_path' &&

--- a/lib/galaxy/datatypes/converters/tar_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/tar_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_tar_to_directory" name="Convert tar to directory" version="1.0.1" profile="21.09">
     <!-- Don't use tar directly so we can verify safety of results - tar -xzf '$input1'; -->
     <requirements>
-        <requirement type="package" version="25.0">galaxy-util</requirement>
+        <requirement type="package" version="25.0.2">galaxy-util</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 cp '$provided_metadata' 'galaxy.json' &&

--- a/lib/galaxy/datatypes/converters/tar_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/tar_to_directory.xml
@@ -1,7 +1,7 @@
 <tool id="CONVERTER_tar_to_directory" name="Convert tar to directory" version="1.0.1" profile="21.09">
     <!-- Don't use tar directly so we can verify safety of results - tar -xzf '$input1'; -->
     <requirements>
-        <requirement type="package" version="23.2.1">galaxy-util</requirement>
+        <requirement type="package" version="25.0">galaxy-util</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 cp '$provided_metadata' 'galaxy.json' &&

--- a/lib/galaxy/datatypes/converters/tar_to_directory.xml
+++ b/lib/galaxy/datatypes/converters/tar_to_directory.xml
@@ -7,7 +7,8 @@
 cp '$provided_metadata' 'galaxy.json' &&
 mkdir '$output1.files_path' &&
 cd '$output1.files_path' &&
-python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.');"
+python -c "from galaxy.util.compression_utils import CompressedFile; CompressedFile('$input1').extract('.');" &&
+if [ -d \$(basename "$input1" .dat) ]; then mv "\$(basename "$input1" .dat)"/* . && rmdir "\$(basename "$input1" .dat)"; fi
     ]]></command>
     <configfiles>
         <configfile name="provided_metadata">{"output1": {"created_from_basename": "${input1.created_from_basename}"}}


### PR DESCRIPTION
Was wondering converters should be added automatically for subclassed datatypes?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
