### PR TITLE
Fix `multiple="true"` data collection map over for shell_command tools

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1948,7 +1948,10 @@ class BaseDataToolParameter(ToolParameter):
 
         if isinstance(value, MutableMapping) and "values" in value:
             if hasattr(self, "multiple") and self.multiple is True:
-                return [history_item_dict_to_python(v, app, self.name) for v in value["values"]]
+                history_items = [history_item_dict_to_python(v, app, self.name) for v in value["values"]]
+                if len(history_items) == 1 and isinstance(history_items[0], HistoryDatasetCollectionAssociation):
+                    return history_items[0]
+                return history_items
             elif len(value["values"]) > 0:
                 return history_item_dict_to_python(value["values"][0], app, self.name)
 

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1827,6 +1827,27 @@ class TestToolsApi(ApiTestCase, TestsTools):
         output_content = self.dataset_populator.get_history_dataset_content(history_id)
         assert output_content == "abc\n"
 
+    @skip_without_tool("cat_multiple_user_defined")
+    def test_collection_into_multiple_true(self):
+        with (
+            self.dataset_populator.test_history() as history_id,
+            self.dataset_populator.user_tool_execute_permissions(),
+        ):
+            hdca = self.dataset_collection_populator.create_list_in_history(history_id, wait=True).json()[
+                "output_collections"
+            ][0]
+            response = self._run(
+                "cat_multiple_user_defined",
+                history_id,
+                {"datasets": {"values": [{"src": "hdca", "id": hdca["id"]}]}},
+                assert_ok=True,
+                wait_for_job=True,
+            )
+            output_content = self.dataset_populator.get_history_dataset_content(
+                history_id, response["outputs"][0]["id"]
+            )
+            assert output_content == "TestData123\n" * 3
+
     def test_show_dynamic_tools(self):
         # Create tool.
         original_list = self.dataset_populator.list_dynamic_tools()

--- a/test/functional/tools/cat_multiple_user_defined.yml
+++ b/test/functional/tools/cat_multiple_user_defined.yml
@@ -1,0 +1,29 @@
+class: GalaxyUserTool
+id: cat_multiple_user_defined
+version: "0.1"
+name: Concatenate Multiple Files
+description: tail-to-head
+container: busybox
+shell_command: |
+  cat $(inputs.datasets.map((input) => `'${input.path}'`).join(' ')) > output.txt
+inputs:
+  - name: datasets
+    type: data
+    multiple: true
+outputs:
+  - name: output1
+    type: data
+    format_source: datasets
+    from_work_dir: output.txt
+tests:
+  - inputs:
+      datasets:
+        - simple_line.txt
+        - simple_line_alternative.txt
+    outputs:
+      output1:
+        asserts:
+          - has_line:
+              line: This is a different line of text.
+          - has_line:
+              line: This is a line of text.

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -306,6 +306,7 @@
   <tool file="explicit_singularity_container.xml"/>
   <tool file="simple_constructs.yml" />
   <tool file="cat_user_defined.yml" />
+  <tool file="cat_multiple_user_defined.yml" />
   <tool file="configfile_user_defined.yml" />
   <tool file="from_work_dir_glob.xml" />
 


### PR DESCRIPTION
For regular tools `DatasetListWrapper` handles this. Something analogous would be another option, but I like this a little more ? Otherwise we'd have to go back and ask "is this multiple="true" and are we getting a collection" which seems awkward elsewhere ?


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
