### PR TITLE
Add support for hierarchical module systems in lmod + module dependency resolvers

### DIFF
--- a/doc/source/admin/dependency_resolvers.rst
+++ b/doc/source/admin/dependency_resolvers.rst
@@ -264,6 +264,7 @@ Lmod Dependency Resolver
       settargexec: <filesystem path>
       modulepath: <filesystem path[:filesystem path:...]>
       mapping_files: <filesystem path>
+      skip_availability_check: <true|false>
 
 
 The ``lmod`` dependency resolver interacts with the `Lmod environment modules system <https://lmod.readthedocs.io/>`__
@@ -291,6 +292,13 @@ mapping_files
     Path to a YAML configuration file that can be used to link tools requirements with existing Lmod modules. Default:
     ``config/lmod_modules_mapping.yml``
 
+skip_availability_check
+    Set to ``true`` to skip filtering module dependencies using ``module avail`` and attempt to load each
+    module listed in the depedencies (default: ``false``).
+    This setting should be used when during dependency resolution modules are not listed in ``module avail``,
+    but can be expected to be present when using ``module load`` in the job script,  such as child modules
+    in hierarchical module systems. Note: the order in which dependencies are listed could be important.
+
 Environment Modules Dependency Resolver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -303,6 +311,7 @@ Environment Modules Dependency Resolver
       find_by: <directory|avail>
       prefetch: <true|false>
       default_indicator: <string>
+      skip_availability_check: <true|false>
 
 
 The ``modules`` dependency resolver interacts with the `Environment Modules system <https://modules.sourceforge.net/>`__
@@ -330,6 +339,13 @@ default_indicator
     What indicates to the AvailModuleChecker that a module is the default version (default: ``(default)``). Note
     that the first module found is considered the default when no version is used by the resolver, so
     the sort order of modules matters.
+
+skip_availability_check
+    Set to ``true`` to skip filtering module dependencies using ``module avail`` and attempt to load each
+    module listed in the depedencies (default: ``false``).
+    This setting should be used when during dependency resolution modules are not listed in ``module avail``,
+    but can be expected to be present when using ``module load`` in the job script,  such as child modules
+    in hierarchical module systems. Note: the order in which dependencies are listed could be important.
 
 The Environment Modules dependency resolver can work in two modes. The ``AvailModuleChecker`` searches the results
 of the ``module avail`` command for the name of the dependency. If it is configured in versionless mode,

--- a/test/unit/tool_util/test_tool_deps.py
+++ b/test/unit/tool_util/test_tool_deps.py
@@ -331,9 +331,7 @@ Mothur/1.36.1
 """,
         )
         resolver = ModuleDependencyResolver(
-            _SimpleDependencyManager(),
-            modulecmd=module_script,
-            skip_availability_check="true"
+            _SimpleDependencyManager(), modulecmd=module_script, skip_availability_check="true"
         )
 
         module = resolver.resolve(ToolRequirement(name="Mothur", version="1.36.1", type="package"))
@@ -355,8 +353,6 @@ Mothur/1.36.1
         module = resolver.resolve(ToolRequirement(name="Bar", version=None, type="package"))
         assert module.module_name == "Bar"
         assert module.module_version is None
-
-        assert module.shell_commands() == ""
 
 
 def _setup_module_command(temp_directory, contents):
@@ -534,7 +530,7 @@ Mothur/1.36.1
             _SimpleDependencyManager(),
             lmodexec=lmod_script,
             skip_availability_check="true",
-            modulepath="/path/to/modulefiles"
+            modulepath="/path/to/modulefiles",
         )
 
         lmod = resolver.resolve(ToolRequirement(name="Mothur", version="1.36.1", type="package"))

--- a/test/unit/tool_util/test_tool_deps.py
+++ b/test/unit/tool_util/test_tool_deps.py
@@ -319,6 +319,46 @@ blast/2.24.0-mpi
         assert module.module_version == "2.22.0-mpi", module.module_version
 
 
+def test_module_dependency_resolver_skip_availability_check():
+    with __test_base_path() as temp_directory:
+        module_script = _setup_module_command(
+            temp_directory,
+            """
+-------------------------- /soft/modules/modulefiles ---------------------------
+BlastPlus/2.4.0+
+Infernal/1.1.2
+Mothur/1.36.1
+""",
+        )
+        resolver = ModuleDependencyResolver(
+            _SimpleDependencyManager(),
+            modulecmd=module_script,
+            skip_availability_check="true"
+        )
+
+        module = resolver.resolve(ToolRequirement(name="Mothur", version="1.36.1", type="package"))
+        assert module.module_name == "Mothur"
+        assert module.module_version == "1.36.1"
+
+        module = resolver.resolve(ToolRequirement(name="BlastPlus", version="2.3", type="package"))
+        assert module.module_name == "BlastPlus"
+        assert module.module_version == "2.3"
+
+        module = resolver.resolve(ToolRequirement(name="Infernal", version=None, type="package"))
+        assert module.module_name == "Infernal"
+        assert module.module_version is None
+
+        module = resolver.resolve(ToolRequirement(name="Foo", version="0.1", type="package"))
+        assert module.module_name == "Foo"
+        assert module.module_version == "0.1"
+
+        module = resolver.resolve(ToolRequirement(name="Bar", version=None, type="package"))
+        assert module.module_name == "Bar"
+        assert module.module_version is None
+
+        assert module.shell_commands() == ""
+
+
 def _setup_module_command(temp_directory, contents):
     module_script = os.path.join(temp_directory, "modulecmd")
     __write_script(
@@ -477,6 +517,47 @@ Mothur/1.38.1.1
         lmod = resolver.resolve(ToolRequirement(name="Mothur", version="1.38", type="package"))
         assert lmod.module_name == "Mothur"
         assert lmod.module_version == "1.38.1.1", lmod.module_version
+
+
+def test_lmod_dependency_resolver_skip_availability_check():
+    with __test_base_path() as temp_directory:
+        lmod_script = _setup_lmod_command(
+            temp_directory,
+            """
+/opt/apps/modulefiles:
+BlastPlus/2.4.0+
+Infernal/1.1.2
+Mothur/1.36.1
+""",
+        )
+        resolver = LmodDependencyResolver(
+            _SimpleDependencyManager(),
+            lmodexec=lmod_script,
+            skip_availability_check="true",
+            modulepath="/path/to/modulefiles"
+        )
+
+        lmod = resolver.resolve(ToolRequirement(name="Mothur", version="1.36.1", type="package"))
+        assert lmod.module_name == "Mothur"
+        assert lmod.module_version == "1.36.1"
+
+        lmod = resolver.resolve(ToolRequirement(name="BlastPlus", version="2.3", type="package"))
+        assert lmod.module_name == "BlastPlus"
+        assert lmod.module_version == "2.3"
+
+        lmod = resolver.resolve(ToolRequirement(name="Infernal", version=None, type="package"))
+        assert lmod.module_name == "Infernal"
+        assert lmod.module_version is None
+
+        lmod = resolver.resolve(ToolRequirement(name="Foo", version="0.1", type="package"))
+        assert lmod.module_name == "Foo"
+        assert lmod.module_version == "0.1"
+
+        lmod = resolver.resolve(ToolRequirement(name="Bar", version=None, type="package"))
+        assert lmod.module_name == "Bar"
+        assert lmod.module_version is None
+
+        assert lmod.shell_commands() == ""
 
 
 def _setup_lmod_command(temp_directory, contents):

--- a/test/unit/tool_util/test_tool_deps.py
+++ b/test/unit/tool_util/test_tool_deps.py
@@ -557,8 +557,6 @@ Mothur/1.36.1
         assert lmod.module_name == "Bar"
         assert lmod.module_version is None
 
-        assert lmod.shell_commands() == ""
-
 
 def _setup_lmod_command(temp_directory, contents):
     lmod_script = os.path.join(temp_directory, "lmod")


### PR DESCRIPTION
Added a `skip_availability_check` configuration option to the lmod and module dependency resolvers, so users can load dependencies from hierarchical module systems and/or modules that are only available at runtime and not during the module resolution process.

Issue: https://github.com/galaxyproject/galaxy/issues/20508

## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:

Note: these manual tests will only work on a system that has cwltool and the [EESSI] modules (https://www.eessi.io/) available.
  1. Create a cwl pipeline env.cwl with software requirements:
  ```{yaml}
  cwlVersion: v1.2
class: CommandLineTool
label: Run env command
doc: |
  Inspect environment

hints:
  SoftwareRequirement:
    packages:
      - package: EESSI
        version: ["2023.06"]
      - package: GROMACS
        version: ["2024.4-foss-2023b"]

baseCommand: [env]

inputs: []

outputs:
  - id: stderr
    type: stderr
  - id: stdout
    type: stdout

stderr: env.err
stdout: env.out
```
  2. Create a dependency resolver config dependency-resolvers-conf.yml:
  ```{yaml}
  - type: lmod
  modulepath: /cvmfs/software.eessi.io/versions/2023.06/init/modules
  lmodexec: /usr/share/lmod/lmod/libexec/lmod
# - type: modules
#   modulepath: /cvmfs/software.eessi.io/versions/2023.06/init/modules
#   modulecmd: /usr/share/lmod/lmod/libexec/lmod
#   prefetch: false
  ```
  3. Run the pipeline:
  ```{bash}
  cwltool --beta-dependency-resolvers-configuration dependency-resolvers-conf.yml env.cwl
```
  4. Observe that in the environment printed in `env.out` both the EESSI module and the GROMACS module are loaded.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
