### PR TITLE
[25.0] Improve dataset collection fetch performance in the invocation view

### DIFF
--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -1,5 +1,11 @@
 <template>
-    <component :is="providerComponent" :id="itemId" v-slot="{ result: item, loading }" auto-refresh>
+    <component
+        :is="providerComponent"
+        :id="itemId"
+        :key="view"
+        v-slot="{ result: item, loading }"
+        :view="view"
+        auto-refresh>
         <LoadingSpan v-if="loading" message="Loading dataset" />
         <div v-else>
             <ContentItem
@@ -11,7 +17,7 @@
                 :expand-dataset="expandDataset"
                 :is-dataset="item.history_content_type == 'dataset' || item.element_type == 'hda'"
                 @update:expand-dataset="expandDataset = $event"
-                @view-collection="viewCollection = !viewCollection"
+                @view-collection="onViewCollection"
                 @delete="onDelete"
                 @toggleHighlights="onHighlight(item)"
                 @undelete="onUndelete(item)"
@@ -60,6 +66,7 @@ export default {
         return {
             viewCollection: false,
             expandDataset: false,
+            view: this.itemSrc === "hdca" ? "collection" : "element",
         };
     },
     computed: {
@@ -123,6 +130,12 @@ export default {
             } catch (error) {
                 this.onError(error, "Failed to highlight related items");
             }
+        },
+        onViewCollection(collection) {
+            if (this.view === "collection" && collection.model_class === "HistoryDatasetCollectionAssociation") {
+                this.view = "element";
+            }
+            this.viewCollection = !this.viewCollection;
         },
     },
 };

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.test.ts
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.test.ts
@@ -95,6 +95,7 @@ async function mountWorkflowInvocationInputOutputTabs(invocation: WorkflowInvoca
         propsData: {
             invocation,
             terminal,
+            tabsNotLazy: true,
         },
         stubs: {
             ContentItem: true,

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
@@ -19,6 +19,7 @@ const OUTPUTS_NOT_AVAILABLE_YET_MSG =
 const props = defineProps<{
     invocation: WorkflowInvocationElementView;
     terminal?: boolean;
+    tabsNotLazy?: boolean;
 }>();
 
 // Fetching full workflow to get the workflow output labels (for when invocation is not terminal)
@@ -64,13 +65,13 @@ const parameters = computed(() => Object.values(props.invocation.input_step_para
 </script>
 <template>
     <span>
-        <BTab title="Inputs" lazy>
+        <BTab title="Inputs" :lazy="!props.tabsNotLazy">
             <div v-if="parameters.length || inputData.length">
                 <WorkflowInvocationInputs :invocation="props.invocation" />
             </div>
             <BAlert v-else show variant="info"> No input data was provided for this workflow invocation. </BAlert>
         </BTab>
-        <BTab title="Outputs" lazy>
+        <BTab title="Outputs" :lazy="!props.tabsNotLazy">
             <div v-if="outputs.length">
                 <div
                     v-for="([key, output], index) in outputs"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
@@ -64,13 +64,13 @@ const parameters = computed(() => Object.values(props.invocation.input_step_para
 </script>
 <template>
     <span>
-        <BTab title="Inputs">
+        <BTab title="Inputs" lazy>
             <div v-if="parameters.length || inputData.length">
                 <WorkflowInvocationInputs :invocation="props.invocation" />
             </div>
             <BAlert v-else show variant="info"> No input data was provided for this workflow invocation. </BAlert>
         </BTab>
-        <BTab title="Outputs">
+        <BTab title="Outputs" lazy>
             <div v-if="outputs.length">
                 <div
                     v-for="([key, output], index) in outputs"

--- a/client/src/components/providers/DatasetCollectionProvider.js
+++ b/client/src/components/providers/DatasetCollectionProvider.js
@@ -1,10 +1,15 @@
 import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 
-import { fetchCollectionDetails } from "@/api/datasetCollections";
+import { fetchCollectionDetails, fetchCollectionSummary } from "@/api/datasetCollections";
 
 // There isn't really a good way to know when to stop polling for HDCA updates,
 // but we know the populated_state should at least be ok.
 export default SingleQueryProvider(
-    (params) => fetchCollectionDetails({ hdca_id: params.id }),
+    (params) => {
+        if (params.view && params.view === "collection") {
+            return fetchCollectionSummary({ hdca_id: params.id });
+        }
+        return fetchCollectionDetails({ hdca_id: params.id });
+    },
     (result) => result.populated_state === "ok"
 );

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -12,7 +12,7 @@ import { storeToRefs } from "pinia";
 import { computed, type Ref, ref, set } from "vue";
 
 import { GalaxyApi } from "@/api";
-import { fetchCollectionDetails } from "@/api/datasetCollections";
+import { fetchCollectionSummary } from "@/api/datasetCollections";
 import { fetchDatasetDetails } from "@/api/datasets";
 import type { InvocationStep, StepJobSummary, WorkflowInvocationElementView } from "@/api/invocations";
 import type { StoredWorkflowDetailed } from "@/api/workflows";
@@ -334,7 +334,7 @@ export function useInvocationGraph(
                 set(graphStep, "state", getContentItemState(hda));
                 set(graphStep, "nodeText", `${hda.hid}: <b>${hda.name}</b>`);
             } else {
-                const hdca = await fetchCollectionDetails({ hdca_id: inputItem.id });
+                const hdca = await fetchCollectionSummary({ hdca_id: inputItem.id });
                 // TODO: Same type mismatch as above
                 set(graphStep, "state", getContentItemState(hdca));
                 set(graphStep, "nodeText", `${hdca.hid}: <b>${hdca.name}</b>`);


### PR DESCRIPTION
Fixes the 25.0 part of https://github.com/galaxyproject/galaxy/issues/20864. 

- We lazy load the input/output tabs as well
- We fetch "collection" view for HDCAs in `GenericItem` and `useInvocationGraph` by default
  - For the generic content items (used outside of the history panel), there is no need to fetch the entire "element" view when displaying the content item unexpanded. Therefore, I have made the default view "collection", until you click to expand an HDCA which is when the `DatasetCollectionProvider` is remounted to fetch the "element" (detailed) view for the HDCA.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
