### PR TITLE
Improve type annotation for job runners and ``InteractiveToolManager``

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -619,6 +619,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         self.role_manager = self._register_singleton(RoleManager)
         self.job_manager = self._register_singleton(JobManager)
         self.notification_manager = self._register_singleton(NotificationManager)
+        self.interactivetool_manager = InteractiveToolManager(self)
 
         self.task_manager = self._register_abstract_singleton(
             AsyncTasksManager, CeleryAsyncTasksManager  # type: ignore[type-abstract]  # https://github.com/python/mypy/issues/4717
@@ -839,8 +840,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication, InstallationT
         # Must be initialized after job_config.
         self.workflow_scheduling_manager = scheduling_manager.WorkflowSchedulingManager(self)
 
-        # We need InteractiveToolManager before the job handler starts
-        self.interactivetool_manager = InteractiveToolManager(self)
         # Start the job manager
         self.application_stack.register_postfork_function(self.job_manager.start)
         # Must be initialized after any component that might make use of stack messaging is configured. Alternatively if

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2582,8 +2582,8 @@ class MinimalJobWrapper(HasResourceParameters):
                     command = f"{dependency_shell_commands}; {command}"
         return command
 
-    def check_for_entry_points(self, check_already_configured=True):
-        if not self.tool.produces_entry_points:
+    def check_for_entry_points(self, check_already_configured: bool = True) -> bool:
+        if self.tool and not self.tool.produces_entry_points:
             return True
 
         job = self.get_job()
@@ -2611,6 +2611,7 @@ class MinimalJobWrapper(HasResourceParameters):
             self.fail(error_message)
             # local job runner uses return value to determine if we're done polling
             return True
+        return False
 
     def container_monitor_command(self, container, **kwds):
         if (

--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -449,7 +449,7 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
                         # TODO: This is where any cleanup would occur
                         self.handle_stop()
                         return
-                    self.watched.append((async_job_state.job_id, async_job_state))
+                    self.watched.append(async_job_state)
             except Empty:
                 pass
             # Iterate over the list of watched jobs and check state
@@ -466,11 +466,12 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
         self.watched = [x for x in self.watched if x[0] not in done]
 
     def check_watched_items_by_batch(self, start: int, end: int, done: set[str]):
-        jobs = self.watched[start : start + self.MAX_JOBS_PER_QUERY]
-        if not jobs:
+        async_job_states = self.watched[start : start + self.MAX_JOBS_PER_QUERY]
+        if not async_job_states:
             return
 
-        jobs_dict = dict(jobs)
+        jobs_dict = {ajs.job_id: ajs for ajs in async_job_states}
+
         resp = self._batch_client.describe_jobs(jobs=list(jobs_dict.keys()))
 
         gotten = set()

--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -463,7 +463,7 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
     def check_watched_items(self):
         done: set[str] = set()
         self.check_watched_items_by_batch(0, len(self.watched), done)
-        self.watched = [x for x in self.watched if x[0] not in done]
+        self.watched = [ajs for ajs in self.watched if ajs.job_id not in done]
 
     def check_watched_items_by_batch(self, start: int, end: int, done: set[str]):
         async_job_states = self.watched[start : start + self.MAX_JOBS_PER_QUERY]

--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -465,12 +465,12 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
         self.check_watched_items_by_batch(0, len(self.watched), done)
         self.watched = [ajs for ajs in self.watched if ajs.job_id not in done]
 
-    def check_watched_items_by_batch(self, start: int, end: int, done: set[str]):
+    def check_watched_items_by_batch(self, start: int, end: int, done: set[str]) -> None:
         async_job_states = self.watched[start : start + self.MAX_JOBS_PER_QUERY]
         if not async_job_states:
             return
 
-        jobs_dict = {ajs.job_id: ajs for ajs in async_job_states}
+        jobs_dict = {ajs.job_id: ajs for ajs in async_job_states if ajs.job_id is not None}
 
         resp = self._batch_client.describe_jobs(jobs=list(jobs_dict.keys()))
 
@@ -493,27 +493,26 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
             # remain queued for "SUBMITTED", "PENDING" and "RUNNABLE"
             # TODO else?
 
-        for job_id in jobs_dict:
+        for job_id, job_state in jobs_dict.items():
             if job_id in gotten:
                 continue
-            job_state = jobs_dict[job_id]
             reason = f"The track of Job {job_state} was lost for unknown reason!"
             self._mark_as_failed(job_state, reason)
             done.add(job_id)
 
         self.check_watched_items_by_batch(start + self.MAX_JOBS_PER_QUERY, end, done)
 
-    def _mark_as_successful(self, job_state):
+    def _mark_as_successful(self, job_state: AsynchronousJobState) -> None:
         _write_logfile(job_state.output_file, "")
         _write_logfile(job_state.error_file, "")
         job_state.running = False
         self.mark_as_finished(job_state)
 
-    def _mark_as_active(self, job_state):
+    def _mark_as_active(self, job_state: AsynchronousJobState) -> None:
         job_state.running = True
         job_state.job_wrapper.change_state(model.Job.states.RUNNING)
 
-    def _mark_as_failed(self, job_state, reason):
+    def _mark_as_failed(self, job_state: AsynchronousJobState, reason: str) -> None:
         _write_logfile(job_state.error_file, reason)
         job_state.running = False
         job_state.stop_job = False

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -2,6 +2,7 @@ import json
 import logging
 import time
 from datetime import datetime
+from typing import Union
 
 from galaxy import model
 from galaxy.jobs.runners import (
@@ -167,7 +168,7 @@ class GodockerJobRunner(AsynchronousJobRunner):
             )
             self.monitor_queue.put(ajs)
 
-    def check_watched_item(self, job_state):
+    def check_watched_item(self, job_state: AsynchronousJobState) -> Union[AsynchronousJobState, None]:
         """Get the job current status from GoDocker
                 using job_id and update the status in galaxy.
         If the job execution is successful, call

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -10,6 +10,7 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Union
 
 import yaml
 
@@ -242,7 +243,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         )
         return bool(job_wrapper.guest_ports) or bool(job_wrapper.get_job().interactivetool_entry_points)
 
-    def __configure_port_routing(self, ajs):
+    def __configure_port_routing(self, ajs: AsynchronousJobState) -> None:
         # Configure interactive tool entry points first
         guest_ports = ajs.job_wrapper.guest_ports
         ports_dict = {}
@@ -712,7 +713,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     def __get_k8s_job_name(self, prefix, job_wrapper):
         return f"{prefix}-{self.__force_label_conformity(job_wrapper.get_id_tag())}"
 
-    def check_watched_item(self, job_state):
+    def check_watched_item(self, job_state: AsynchronousJobState) -> Union[AsynchronousJobState, None]:
         """Checks the state of a job already submitted on k8s. Job state is an AsynchronousJobState"""
         jobs = find_job_object_by_name(self._pykube_api, job_state.job_id, self.runner_params["k8s_namespace"])
 
@@ -754,7 +755,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             job_persisted_state = job_state.job_wrapper.get_state()
 
             # This assumes jobs dependent on a single pod, single container
-            if succeeded > 0 or job_state == model.Job.states.STOPPED:
+            if succeeded > 0 or job_persisted_state == model.Job.states.STOPPED:
                 job_state.running = False
                 self.mark_as_finished(job_state)
                 log.debug(f"Job id: {job_state.job_id} with k8s id: {k8s_job.name} succeeded")

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -4,6 +4,7 @@ SLURM job control via the DRMAA API.
 
 import os
 import time
+from typing import TYPE_CHECKING
 
 from galaxy import model
 from galaxy.jobs.runners.drmaa import DRMAAJobRunner
@@ -12,6 +13,9 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.custom_logging import get_logger
+
+if TYPE_CHECKING:
+    from galaxy.jobs.runners import AsynchronousJobState
 
 log = get_logger(__name__)
 
@@ -40,7 +44,7 @@ class SlurmJobRunner(DRMAAJobRunner):
     runner_name = "SlurmRunner"
     restrict_job_name_length = False
 
-    def _complete_terminal_job(self, ajs, drmaa_state, **kwargs):
+    def _complete_terminal_job(self, ajs: "AsynchronousJobState", drmaa_state: str, **kwargs):
         def _get_slurm_state_with_sacct(job_id, cluster):
             cmd = ["sacct", "-n", "-o", "state%-32"]
             if cluster:
@@ -60,7 +64,8 @@ class SlurmJobRunner(DRMAAJobRunner):
             # Strip whitespaces and the final '+' (if present), only return the first word
             return first_line.strip().rstrip("+").split()[0]
 
-        def _get_slurm_state():
+        def _get_slurm_state() -> str:
+            assert ajs.job_id is not None
             cmd = ["scontrol", "-o"]
             if "." in ajs.job_id:
                 # custom slurm-drmaa-with-cluster-support job id syntax

--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -1,5 +1,14 @@
 import json
 import logging
+from collections.abc import (
+    Callable,
+    Iterable,
+)
+from typing import (
+    Any,
+    TYPE_CHECKING,
+    Union,
+)
 from urllib.parse import (
     urlsplit,
     urlunsplit,
@@ -25,6 +34,11 @@ from galaxy.model import (
 )
 from galaxy.security.idencoding import IdAsLowercaseAlphanumEncodingHelper
 
+if TYPE_CHECKING:
+    from galaxy.managers.context import ProvidesUserContext
+    from galaxy.structured_app import MinimalManagerApp
+    from galaxy.tools import Tool
+
 log = logging.getLogger(__name__)
 
 gxitproxy = Table(
@@ -44,7 +58,7 @@ class InteractiveToolPropagatorSQLAlchemy:
     Propagator for InteractiveToolManager implemented using SQLAlchemy.
     """
 
-    def __init__(self, database_url, encode_id):
+    def __init__(self, database_url: str, encode_id: Callable[[int], str]) -> None:
         """
         Constructor that sets up the propagator using a SQLAlchemy database URL.
 
@@ -55,7 +69,15 @@ class InteractiveToolPropagatorSQLAlchemy:
         self._engine = create_engine(database_url)
         self._encode_id = encode_id
 
-    def save(self, key, key_type, token, host, port, info=None):
+    def save(
+        self,
+        key: str,
+        key_type: str,
+        token: Union[str, None],
+        host: Union[str, None],
+        port: Union[int, None],
+        info: Union[str, None] = None,
+    ) -> None:
         """
         Write out a key, key_type, token, value store that is can be used for coordinating with external resources.
         """
@@ -86,7 +108,7 @@ class InteractiveToolPropagatorSQLAlchemy:
 
             conn.commit()
 
-    def remove(self, **kwd):
+    def remove(self, **kwd) -> None:
         """
         Remove entry from a key, key_type, token, value store that is can be used for coordinating
         with external resources. Remove entries that match all provided key=values
@@ -99,7 +121,7 @@ class InteractiveToolPropagatorSQLAlchemy:
             conn.execute(stmt)
             conn.commit()
 
-    def save_entry_point(self, entry_point):
+    def save_entry_point(self, entry_point: InteractiveToolEntryPoint) -> None:
         """Convenience method to easily save an entry_point."""
         return self.save(
             self._encode_id(entry_point.id),
@@ -115,7 +137,7 @@ class InteractiveToolPropagatorSQLAlchemy:
             ),
         )
 
-    def remove_entry_point(self, entry_point):
+    def remove_entry_point(self, entry_point: InteractiveToolEntryPoint) -> None:
         """Convenience method to easily remove an entry_point."""
         return self.remove(key=self._encode_id(entry_point.id), key_type=entry_point.__class__.__name__.lower())
 
@@ -125,9 +147,8 @@ class InteractiveToolManager:
     Manager for dealing with InteractiveTools
     """
 
-    def __init__(self, app):
+    def __init__(self, app: "MinimalManagerApp") -> None:
         self.app = app
-        self.model = app.model
         self.security = app.security
         self.sa_session = app.model.context
         self.job_manager = app.job_manager
@@ -137,10 +158,12 @@ class InteractiveToolManager:
             self.encoder.encode_id,
         )
 
-    def create_entry_points(self, job, tool, entry_points=None, flush=True):
+    def create_entry_points(
+        self, job: Job, tool: "Tool", entry_points=Union[Iterable[dict[str, Any]], None], flush: bool = True
+    ) -> None:
         entry_points = entry_points or tool.ports
         for entry in entry_points:
-            ep = self.model.InteractiveToolEntryPoint(
+            ep = InteractiveToolEntryPoint(
                 job=job,
                 tool_port=entry["port"],
                 entry_url=entry["url"],
@@ -154,12 +177,9 @@ class InteractiveToolManager:
         if flush:
             self.sa_session.commit()
 
-    def configure_entry_point(self, job, tool_port=None, host=None, port=None, protocol=None):
-        return self.configure_entry_points(
-            job, {tool_port: dict(tool_port=tool_port, host=host, port=port, protocol=protocol)}
-        )
-
-    def configure_entry_points(self, job, ports_dict):
+    def configure_entry_points(
+        self, job: Job, ports_dict: dict[str, dict]
+    ) -> dict[str, list[InteractiveToolEntryPoint]]:
         # There can be multiple entry points that reference the same tool port (could have different entry URLs)
         configured = []
         not_configured = []
@@ -180,13 +200,13 @@ class InteractiveToolManager:
             self.sa_session.commit()
         return dict(not_configured=not_configured, configured=configured)
 
-    def save_entry_point(self, entry_point):
+    def save_entry_point(self, entry_point: InteractiveToolEntryPoint) -> None:
         """
         Writeout a key, key_type, token, value store that is used validating access
         """
         self.propagator.save_entry_point(entry_point)
 
-    def create_interactivetool(self, job, tool, entry_points):
+    def create_interactivetool(self, job: Job, tool: "Tool", entry_points: Iterable[dict[str, Any]]) -> None:
         # create from initial job
         if job and tool:
             self.create_entry_points(job, tool, entry_points)
@@ -195,8 +215,8 @@ class InteractiveToolManager:
                 "Called InteractiveToolManager.create_interactivetool, but job (%s) or tool (%s) is None", job, tool
             )
 
-    def get_nonterminal_for_user_by_trans(self, trans):
-        if trans.user is None and trans.get_galaxy_session() is None:
+    def get_nonterminal_for_user_by_trans(self, trans: "ProvidesUserContext") -> list[InteractiveToolEntryPoint]:
+        if trans.user is None and trans.galaxy_session is None:
             return []
 
         stmt = (
@@ -204,16 +224,17 @@ class InteractiveToolManager:
             .join(Job, InteractiveToolEntryPoint.job_id == Job.id)
             .where(Job.state.in_(Job.non_ready_states))
         )
-        if trans.user:
+        if trans.user is not None:
             stmt = stmt.where(Job.user == trans.user)
         else:
-            stmt = stmt.where(Job.session_id == trans.get_galaxy_session().id)
+            assert trans.galaxy_session is not None  # help mypy
+            stmt = stmt.where(Job.session_id == trans.galaxy_session.id)
         return trans.sa_session.scalars(stmt)
 
-    def can_access_job(self, trans, job):
+    def can_access_job(self, trans: "ProvidesUserContext", job: Union[Job, None]) -> bool:
         if job:
             if trans.user is None:
-                galaxy_session = trans.get_galaxy_session()
+                galaxy_session = trans.galaxy_session
                 if galaxy_session is None or job.session_id != galaxy_session.id:
                     return False
             elif job.user != trans.user:
@@ -222,21 +243,23 @@ class InteractiveToolManager:
             return False
         return True
 
-    def can_access_entry_point(self, trans, entry_point):
+    def can_access_entry_point(self, trans: "ProvidesUserContext", entry_point: InteractiveToolEntryPoint) -> bool:
         if entry_point:
             return self.can_access_job(trans, entry_point.job)
         return False
 
-    def can_access_entry_points(self, trans, entry_points):
+    def can_access_entry_points(
+        self, trans: "ProvidesUserContext", entry_points: Iterable[InteractiveToolEntryPoint]
+    ) -> bool:
         for ep in entry_points:
             if not self.can_access_entry_point(trans, ep):
                 return False
         return True
 
-    def stop(self, trans, entry_point):
+    def stop(self, trans: "ProvidesUserContext", entry_point: InteractiveToolEntryPoint) -> None:
         self.remove_entry_point(entry_point)
         job = entry_point.job
-        if not job.finished:
+        if job and not job.finished:
             log.debug("Stopping Job: %s for InteractiveToolEntryPoint: %s", job, entry_point)
             job.mark_stopped(trans.app.config.track_jobs_in_database)
             # This self.job_manager.stop(job) does nothing without changing job.state, manually or e.g. with .mark_deleted()
@@ -244,20 +267,20 @@ class InteractiveToolManager:
             trans.sa_session.add(job)
             trans.sa_session.commit()
 
-    def remove_entry_points(self, entry_points):
+    def remove_entry_points(self, entry_points: Iterable[InteractiveToolEntryPoint]) -> None:
         if entry_points:
             for entry_point in entry_points:
                 self.remove_entry_point(entry_point, flush=False)
             self.sa_session.commit()
 
-    def remove_entry_point(self, entry_point, flush=True):
+    def remove_entry_point(self, entry_point: InteractiveToolEntryPoint, flush: bool = True) -> None:
         entry_point.deleted = True
         self.sa_session.add(entry_point)
         if flush:
             self.sa_session.commit()
         self.propagator.remove_entry_point(entry_point)
 
-    def target_if_active(self, trans, entry_point):
+    def target_if_active(self, trans, entry_point: InteractiveToolEntryPoint) -> Union[str, None]:
         if entry_point.active and not entry_point.deleted:
             use_it_proxy_host_cfg = (
                 not self.app.config.interactivetools_upstream_proxy and self.app.config.interactivetools_proxy_host
@@ -268,32 +291,33 @@ class InteractiveToolManager:
             url_path = url_parts.path
 
             if entry_point.requires_domain:
-                url_host = f"{self.get_entry_point_subdomain(trans, entry_point)}.{url_host}"
+                url_host = f"{self.get_entry_point_subdomain(entry_point)}.{url_host}"
                 if entry_point.entry_url:
                     url_path = f"{url_path.rstrip('/')}/{entry_point.entry_url.lstrip('/')}"
             else:
-                url_path = self.get_entry_point_path(trans, entry_point)
+                url_path = self.get_entry_point_path(entry_point)
                 if not use_it_proxy_host_cfg:
                     return url_path
 
             return urlunsplit((url_parts.scheme, url_host, url_path, "", ""))
+        return None
 
-    def _get_entry_point_url_elements(self, trans, entry_point):
-        encoder = IdAsLowercaseAlphanumEncodingHelper(trans.security)
+    def _get_entry_point_url_elements(self, entry_point: InteractiveToolEntryPoint) -> tuple[str, str, str, str]:
+        encoder = IdAsLowercaseAlphanumEncodingHelper(self.app.security)
         ep_encoded_id = encoder.encode_id(entry_point.id)
         ep_class_id = entry_point.class_id
         ep_prefix = self.app.config.interactivetools_prefix
         ep_token = entry_point.token
         return ep_encoded_id, ep_class_id, ep_prefix, ep_token
 
-    def get_entry_point_subdomain(self, trans, entry_point):
-        ep_encoded_id, ep_class_id, ep_prefix, ep_token = self._get_entry_point_url_elements(trans, entry_point)
+    def get_entry_point_subdomain(self, entry_point: InteractiveToolEntryPoint) -> str:
+        ep_encoded_id, ep_class_id, ep_prefix, ep_token = self._get_entry_point_url_elements(entry_point)
         return f"{ep_encoded_id}-{ep_token}.{ep_class_id}.{ep_prefix}"
 
-    def get_entry_point_path(self, trans, entry_point):
+    def get_entry_point_path(self, entry_point: InteractiveToolEntryPoint) -> str:
         url_path = "/"
         if not entry_point.requires_domain:
-            ep_encoded_id, ep_class_id, ep_prefix, ep_token = self._get_entry_point_url_elements(trans, entry_point)
+            ep_encoded_id, ep_class_id, ep_prefix, ep_token = self._get_entry_point_url_elements(entry_point)
             path_parts = [
                 part.strip("/")
                 for part in (
@@ -309,9 +333,10 @@ class InteractiveToolManager:
             url_path += entry_point.entry_url.lstrip("/")
         return url_path
 
-    def access_entry_point_target(self, trans, entry_point_id):
-        entry_point = trans.sa_session.get(InteractiveToolEntryPoint, entry_point_id)
-        if self.app.interactivetool_manager.can_access_entry_point(trans, entry_point):
+    def access_entry_point_target(self, trans: "ProvidesUserContext", entry_point_id: int) -> Union[str, None]:
+        entry_point = self.sa_session.get(InteractiveToolEntryPoint, entry_point_id)
+        assert entry_point
+        if self.can_access_entry_point(trans, entry_point):
             if entry_point.active:
                 return self.target_if_active(trans, entry_point)
             elif entry_point.deleted:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3042,7 +3042,7 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"), index=True)
     name: Mapped[Optional[str]] = mapped_column(TEXT)
-    token: Mapped[Optional[str]] = mapped_column(TEXT)
+    token: Mapped[str] = mapped_column(TEXT)
     tool_port: Mapped[Optional[int]]
     host: Mapped[Optional[str]] = mapped_column(TEXT)
     port: Mapped[Optional[int]]
@@ -3051,7 +3051,7 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
     requires_domain: Mapped[Optional[bool]] = mapped_column(default=True)
     requires_path_in_url: Mapped[Optional[bool]] = mapped_column(default=False)
     requires_path_in_header_named: Mapped[Optional[str]] = mapped_column(TEXT)
-    info: Mapped[Optional[bytes]] = mapped_column(MutableJSONType)
+    info: Mapped[Optional[dict]] = mapped_column(MutableJSONType)
     configured: Mapped[Optional[bool]] = mapped_column(default=False)
     deleted: Mapped[Optional[bool]] = mapped_column(default=False)
     created_time: Mapped[Optional[datetime]] = mapped_column(default=now)
@@ -3086,6 +3086,7 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
         requires_path_in_url=False,
         configured=False,
         deleted=False,
+        token: Union[str, None] = None,
         **kwd,
     ):
         super().__init__(**kwd)
@@ -3093,7 +3094,7 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
         self.requires_path_in_url = requires_path_in_url
         self.configured = configured
         self.deleted = deleted
-        self.token = self.token or hex_to_lowercase_alphanum(token_hex(8))
+        self.token = token or hex_to_lowercase_alphanum(token_hex(8))
         self.info = self.info or {}
 
     @property

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from galaxy.managers.folders import FolderManager
     from galaxy.managers.hdas import HDAManager
     from galaxy.managers.histories import HistoryManager
+    from galaxy.managers.interactivetool import InteractiveToolManager
     from galaxy.managers.jobs import JobSearch
     from galaxy.managers.tools import DynamicToolManager
     from galaxy.managers.workflows import (
@@ -115,6 +116,7 @@ class MinimalManagerApp(MinimalApp):
     file_sources: ConfiguredFileSources
     genome_builds: GenomeBuilds
     geographical_server_location_name: str
+    interactivetool_manager: "InteractiveToolManager"
     dataset_collection_manager: "DatasetCollectionManager"
     history_manager: "HistoryManager"
     hda_manager: "HDAManager"
@@ -170,7 +172,6 @@ class StructuredApp(MinimalManagerApp):
     tool_shed_repository_cache: Optional[ToolShedRepositoryCache]
     watchers: "ConfigWatchers"
     workflow_scheduling_manager: Any  # 'galaxy.workflow.scheduling_manager.WorkflowSchedulingManager'
-    interactivetool_manager: Any
     api_keys_manager: Any  # 'galaxy.managers.api_keys.ApiKeyManager'
     visualizations_registry: Any  # 'galaxy.visualization.plugins.registry.VisualizationsRegistry'
     _toolbox_lock: threading.RLock

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -30,6 +30,7 @@ from galaxy.model.none_like import NoneDataset
 from galaxy.security.object_wrapper import wrap_with_safe_string
 from galaxy.structured_app import (
     BasicSharedApp,
+    MinimalManagerApp,
     MinimalToolApp,
 )
 from galaxy.tool_util.data import TabularToolDataTable
@@ -643,7 +644,7 @@ class ToolEvaluator:
             self.__walk_inputs(self.tool.inputs, param_dict, rewrite_unstructured_paths)
 
     def _create_interactivetools_entry_points(self):
-        if hasattr(self.app, "interactivetool_manager"):
+        if isinstance(self.app, MinimalManagerApp):
             self.interactivetools = self._populate_interactivetools_template()
             self.app.interactivetool_manager.create_interactivetool(self.job, self.tool, self.interactivetools)
 
@@ -815,7 +816,8 @@ class ToolEvaluator:
                 matching_eps = [ep for ep in self.job.interactivetool_entry_points if ep.label == entry_point_label]
                 if matching_eps:
                     entry_point = matching_eps[0]
-                    entry_point_path = InteractiveToolManager(self.app).get_entry_point_path(self.app, entry_point)
+                    assert isinstance(self.app, MinimalManagerApp)
+                    entry_point_path = InteractiveToolManager(self.app).get_entry_point_path(entry_point)
                     environment_variable_template = entry_point_path.rstrip("/")
                 else:
                     environment_variable_template = ""


### PR DESCRIPTION
The first 2 commits are from https://github.com/galaxyproject/galaxy/pull/20852 (approved but not merged yet).

Also:
- Fix bug in `KubernetesJobRunner.check_watched_item()` introduced in commit https://github.com/galaxyproject/galaxy/commit/da100d3b274ed077eb40af70d0ff410dbad2ffb2 .
- Drop unused `InteractiveToolManager.configure_entry_point()` method.
- Drop unnecessary `trans` parameter from `_get_entry_point_url_elements()`,  `get_entry_point_subdomain()` and `get_entry_point_path()` methods of `InteractiveToolManager`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
