### PR TITLE
Update JupyterLite version to 0.6.4

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -35,7 +35,7 @@ heatmap:
     version: 0.0.15
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
-    version: 0.0.11
+    version: 0.0.12
 kepler:
     package: "@galaxyproject/kepler"
     version: 0.0.3


### PR DESCRIPTION
Updates JupyterLite version to 0.6.4, adds test cases and improves performance of `gxy` utility. See: https://github.com/galaxyproject/galaxy-visualizations/pull/94

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
