### PR TITLE
Add visualization navigation guard

### DIFF
--- a/client/src/components/Visualizations/VisualizationFrame.vue
+++ b/client/src/components/Visualizations/VisualizationFrame.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { onBeforeRouteLeave } from "vue-router/composables";
 
 import { withPrefix } from "@/utils/redirect";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
-const emit = defineEmits(["load", "update:confirmation"]);
+const emit = defineEmits(["load"]);
 
 export interface Props {
     datasetId?: string;
@@ -61,7 +61,6 @@ function setupChangeDetection() {
             const markAsChanged = () => {
                 if (!hasUnsavedChanges.value) {
                     hasUnsavedChanges.value = true;
-                    emit("update:confirmation", true);
                 }
             };
 
@@ -97,6 +96,7 @@ onMounted(() => {
     window.addEventListener("beforeunload", (e) => {
         if (hasUnsavedChanges.value) {
             e.preventDefault();
+            e.returnValue = "";
         }
     });
 });

--- a/client/src/components/Visualizations/VisualizationFrame.vue
+++ b/client/src/components/Visualizations/VisualizationFrame.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { onBeforeRouteLeave } from "vue-router/composables";
 
 import { withPrefix } from "@/utils/redirect";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
-const emit = defineEmits(["load"]);
+const emit = defineEmits(["load", "update:confirmation"]);
 
 export interface Props {
     datasetId?: string;
@@ -16,6 +17,8 @@ export interface Props {
 const props = defineProps<Props>();
 
 const isLoading = ref(true);
+const hasUnsavedChanges = ref(false);
+const iframeRef = ref<HTMLIFrameElement | null>(null);
 
 const srcWithRoot = computed(() => {
     let url = "";
@@ -39,7 +42,64 @@ const srcWithRoot = computed(() => {
 function handleLoad() {
     isLoading.value = false;
     emit("load");
+    setupChangeDetection();
 }
+
+function setupChangeDetection() {
+    const iframe = iframeRef.value;
+    if (!iframe?.contentWindow) {
+        return;
+    }
+
+    setTimeout(() => {
+        try {
+            const iframeDoc = iframe.contentDocument;
+            if (!iframeDoc) {
+                return;
+            }
+
+            const markAsChanged = () => {
+                if (!hasUnsavedChanges.value) {
+                    hasUnsavedChanges.value = true;
+                    emit("update:confirmation", true);
+                }
+            };
+
+            // Monitor DOM changes (skip initial load)
+            setTimeout(() => {
+                const observer = new MutationObserver(() => markAsChanged());
+                observer.observe(iframeDoc.body, {
+                    childList: true,
+                    subtree: true,
+                    characterData: true,
+                });
+            }, 2000);
+
+            // Monitor user input
+            ["input", "change", "keyup", "paste"].forEach((type) => {
+                iframeDoc.addEventListener(type, markAsChanged, true);
+            });
+        } catch (e) {
+            console.warn("Cannot monitor iframe for changes:", e);
+        }
+    }, 1000);
+}
+
+onBeforeRouteLeave((to, from, next) => {
+    if (hasUnsavedChanges.value && !window.confirm("Unsaved changes will be lost. Continue?")) {
+        next(false);
+    } else {
+        next();
+    }
+});
+
+onMounted(() => {
+    window.addEventListener("beforeunload", (e) => {
+        if (hasUnsavedChanges.value) {
+            e.preventDefault();
+        }
+    });
+});
 </script>
 
 <template>
@@ -49,6 +109,7 @@ function handleLoad() {
         </div>
         <iframe
             id="galaxy_visualization"
+            ref="iframeRef"
             :src="srcWithRoot"
             class="center-frame"
             frameborder="0"


### PR DESCRIPTION
Fixes #20878 

Adds navigation guards to prevent users from accidentally losing unsaved work in visualizations like JupyterLite. Implements both Vue Router guards (for in-app navigation) and beforeunload handlers (for browser back/forward/refresh)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
