### PR TITLE
[24.2]  Fix role.description bug

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -241,11 +241,13 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         for role in user.all_roles():
             if self.app.config.redact_username_during_deletion:
                 role.name = role.name.replace(user.username, uname_hash)
-                role.description = role.description.replace(user.username, uname_hash)
+                if role.description:
+                    role.description = role.description.replace(user.username, uname_hash)
 
             if self.app.config.redact_email_during_deletion:
                 role.name = role.name.replace(user.email, email_hash)
-                role.description = role.description.replace(user.email, email_hash)
+                if role.description:
+                    role.description = role.description.replace(user.email, email_hash)
             self.session().add(role)
         private_role.name = email_hash
         private_role.description = f"Private Role for {email_hash}"


### PR DESCRIPTION
Fix #20818

Role descrition can be `None`: a private role does not have a description.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. To test this, you should enable gdpr: `enable_beta_gdpr: true`
  2. Add user, delete user, purge user: observe no error. Try the same without this commit: observe error.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
