### PR TITLE
Add main tool CI tests

### DIFF
--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -5,11 +5,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   pull_request:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+      - 'packages/**'
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
@@ -66,16 +68,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-framework-workflows
+          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-framework
       - name: Run tests
         run: ./run_tests.sh --coverage --framework-workflows
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v3
         with:
-          flags: framework
+          flags: framework-workflows
           working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Framework test results (${{ matrix.python-version }})
+          name: Workflow framework test results (${{ matrix.python-version }})
           path: 'galaxy root/run_framework_workflows_tests.html'

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -1,4 +1,4 @@
-name: Tool framework tests
+name: Main tool tests
 on:
   push:
     paths-ignore:
@@ -12,9 +12,6 @@ on:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
       - 'packages/**'
-  schedule:
-    # Run at midnight UTC every Tuesday
-    - cron: '0 0 * * 2'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
@@ -38,10 +35,6 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - if: github.event_name == 'schedule'
-        run: |
-          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
-          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           path: 'galaxy root'
@@ -69,14 +62,14 @@ jobs:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-framework
       - name: Run tests
-        run: ./run_tests.sh --coverage --framework-tools
+        run: ./run_tests.sh --coverage --main_tools
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v3
         with:
-          flags: framework
+          flags: main-tools
           working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: Tool framework test results (${{ matrix.python-version }})
+          name: Main tool test results (${{ matrix.python-version }})
           path: 'galaxy root/run_framework_tests.html'

--- a/tools/filters/gff/gff_filter_by_attribute.py
+++ b/tools/filters/gff/gff_filter_by_attribute.py
@@ -45,6 +45,8 @@ AST_NODE_TYPE_WHITELIST = [
     "UnaryOp",
     "Invert",
     "Not",
+    "UAdd",
+    "USub",
     "NotIn",
     "In",
     "Is",
@@ -52,6 +54,7 @@ AST_NODE_TYPE_WHITELIST = [
     "List",
     "Index",
     "Subscript",
+    "Constant",
     "Name",
 ]
 

--- a/tools/filters/gff/gff_filter_by_feature_count.py
+++ b/tools/filters/gff/gff_filter_by_feature_count.py
@@ -48,6 +48,8 @@ AST_NODE_TYPE_WHITELIST = [
     "UnaryOp",
     "Invert",
     "Not",
+    "UAdd",
+    "USub",
     "NotIn",
     "In",
     "Is",
@@ -55,6 +57,7 @@ AST_NODE_TYPE_WHITELIST = [
     "List",
     "Index",
     "Subscript",
+    "Constant",
     "Name",
 ]
 

--- a/tools/filters/gff/gtf_filter_by_attribute_values_list.py
+++ b/tools/filters/gff/gtf_filter_by_attribute_values_list.py
@@ -55,10 +55,11 @@ def gff_filter(gff_file, attribute_name, ids_file, output_file):
     # Filter GFF file using ids.
     with open(output_file, "w") as output, open(gff_file) as ingff:
         for line in ingff:
-            if not line or line.startswith("#"):
+            if not line.rstrip() or line.startswith("#"):
                 output.write(line)
                 continue
             fields = line.split("\t")
+            assert len(fields) == 9, f"Line should have exactly 9 fields: {line}"
             attributes = parse_gff_attributes(fields[8])
             if attribute_name in attributes and attributes[attribute_name] in ids_dict:
                 output.write(line)

--- a/tools/filters/grep.xml
+++ b/tools/filters/grep.xml
@@ -76,7 +76,8 @@
       <param name="keep_header" value="true"/>
       <output name="out_file1">
         <assert_contents>
-          <not_has_text text="CCDS989.1_cds_0_0_chr1_147962193_r"/>
+          <has_text text="CCDS989.1_cds_0_0_chr1_147962193_r"/>
+          <has_n_lines n="1"></has_n_lines>
         </assert_contents>
       </output>
     </test>

--- a/tools/phenotype_association/ldtools_wrapper.sh
+++ b/tools/phenotype_association/ldtools_wrapper.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-SCRIPT_DIR=$(dirname $0)
+SCRIPT_DIR=$(dirname "$0")
 
 ## pagetag options
 input=
@@ -46,16 +46,7 @@ do
 done
 
 ## run pagetag
-python $SCRIPT_DIR/pagetag.py --rsquare $rsquare --freq $freq "$input" snps.txt neighborhood.txt
-if [ $? -ne 0 ]; then
-	echo "failed: pagetag.py --rsquare $rsquare --freq $freq \"$input\" snps.txt neighborhood.txt"
-	exit 1
-fi
+python "$SCRIPT_DIR/pagetag.py" --rsquare $rsquare --freq $freq "$input" snps.txt neighborhood.txt
 
-## run sentag
-python $SCRIPT_DIR/senatag.py neighborhood.txt snps.txt > "$output"
-if [ $? -ne 0 ]; then
-	echo "failed: senatag.py neighborhood.txt snps.txt"
-	exit 1
-fi
-
+## run senatag
+python "$SCRIPT_DIR/senatag.py" neighborhood.txt snps.txt > "$output"


### PR DESCRIPTION
Similar to https://github.com/galaxyproject/galaxy/pull/15229 , but without linting and not using planemo.
Limited to the tools present in `lib/galaxy/config/sample/tool_conf.xml.sample` , as discussed in https://github.com/galaxyproject/galaxy/pull/20840#issuecomment-3268342215 and following comments.

Also:
- Use the same cached venv for main tools, tool framework and workflow framework tests.
- Fix all failing tool tests, leaving modernisation to https://github.com/galaxyproject/galaxy/pull/20840

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
