### PR TITLE
Set default option to make datasets accessible only to individual users when sharing histories with particular users

### DIFF
--- a/client/src/components/Sharing/UserSharing.vue
+++ b/client/src/components/Sharing/UserSharing.vue
@@ -126,7 +126,7 @@ const noChanges = computed(() => {
 const canChangeCount = computed(() => props.item.extra?.can_change.length ?? 0);
 const cannotChangeCount = computed(() => props.item.extra?.cannot_change.length ?? 0);
 
-const selectedSharingOption = ref<ShareOption>("make_public");
+const selectedSharingOption = ref<ShareOption>("make_accessible_to_shared");
 
 function onUpdatePermissions() {
     emit("share", sharingCandidatesAsEmails.value, selectedSharingOption.value);


### PR DESCRIPTION
Closes #20847

This seems like the sensible default when sharing an item with individual users.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #20847

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
