### PR TITLE
[25.0] Speed up ``ImplicitCollectionJobs.job_list``

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2789,7 +2789,13 @@ class ImplicitCollectionJobs(Base, Serializable):
 
     @property
     def job_list(self):
-        return [icjja.job for icjja in self.jobs]
+        return (
+            required_object_session(self)
+            .query(Job)
+            .join(ImplicitCollectionJobsJobAssociation, Job.id == ImplicitCollectionJobsJobAssociation.job_id)
+            .where(ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id == self.id)
+            .all()
+        )
 
     def _serialize(self, id_encoder, serialization_options):
         rval = dict_for(


### PR DESCRIPTION
Minor tweak, for 100 items this goes from 500ms to 80ms and I assume this becomes more significant the more jobs there are.

No changes to the API, we should probably paginate this and just return relevant fields, but this should address the 12s load time on the backend when you click on a 8000+ job step.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
