### PR TITLE
[25.0] Bump up integration test k8s version

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           driver: none
-          kubernetes-version: '1.23.0'
+          kubernetes-version: '1.28.0'
       - name: Check pods
         run: kubectl get pods -A
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/actions/runs/17613950194/job/50042268475?pr=20887#step:7:97
```
/home/runner/bin/minikube start --driver none --kubernetes-version 1.23.0 --wait all
* minikube v1.37.0 on Ubuntu 24.04
! Specified Kubernetes version 1.23.0 is less than the oldest supported version: v1.28.0. Use `minikube config defaults kubernetes-version` for details.
! You can force an unsupported Kubernetes version via the --force flag

X Exiting due to K8S_OLD_UNSUPPORTED: Kubernetes 1.23.0 is not supported by this release of minikube
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
