### PR TITLE
Likely fix for transiently failing published histories test.

### DIFF
--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -29,6 +29,7 @@ from galaxy.selenium.axe_results import assert_baseline_accessible
 from galaxy.selenium.context import GalaxySeleniumContext
 from galaxy.selenium.has_driver import DEFAULT_AXE_SCRIPT_URL
 from galaxy.selenium.navigates_galaxy import (
+    exception_seems_to_indicate_transition,
     NavigatesGalaxy,
     retry_during_transitions,
 )
@@ -223,8 +224,17 @@ def selenium_test(f):
     return func_wrapper
 
 
+def exception_is_assertion_or_transition(e: Exception) -> bool:
+    """Drive the retry_assertion_during_transitions decorator.
+
+    Reuse logic for checking for transition exceptions but also retry
+    if there is an assertion error.
+    """
+    return exception_seems_to_indicate_transition(e) or isinstance(e, AssertionError)
+
+
 retry_assertion_during_transitions = partial(
-    retry_during_transitions, exception_check=lambda e: isinstance(e, AssertionError)
+    retry_during_transitions, exception_check=exception_is_assertion_or_transition
 )
 
 


### PR DESCRIPTION
The failing error:

```
self = <galaxy_test.selenium.test_histories_published.TestPublishedHistories object at 0x7f4ae3449e80>

    @selenium_test
    def test_published_histories_username_filter(self):
        self._login()
        self.navigate_to_published_histories()
        username = self.user2_email.split("@")[0]
        self.components.published_histories.search_input.wait_for_and_send_keys(f"user:{username}")
>       self.assert_histories_present([self.history2_name])
```

https://github.com/galaxyproject/galaxy/actions/runs/17589373422/job/49966327341?pr=20880

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
