### PR TITLE
Replace deprecated ``codecs.open()``

### DIFF
--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -13,7 +13,6 @@ context specific processing.
 
 import abc
 import base64
-import codecs
 import logging
 import os
 import re
@@ -851,7 +850,7 @@ def to_pdf_raw(basic_markdown: str, css_paths: Optional[list[str]] = None) -> by
     directory = tempfile.mkdtemp("gxmarkdown")
     index = os.path.join(directory, "index.html")
     try:
-        output_file = codecs.open(index, "w", encoding="utf-8", errors="xmlcharrefreplace")
+        output_file = open(index, "w", encoding="utf-8", errors="xmlcharrefreplace")
         output_file.write(as_html)
         output_file.close()
         html = weasyprint.HTML(filename=index)


### PR DESCRIPTION
with ``open()``. See https://github.com/galaxyproject/galaxy/issues/16854 .

https://docs.python.org/3.14/whatsnew/3.14.html#deprecated https://docs.python.org/3.14/library/codecs.html#codecs.open

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
