### PR TITLE
Update requirements of sort1 tool

### DIFF
--- a/tools/filters/sorter.xml
+++ b/tools/filters/sorter.xml
@@ -1,9 +1,9 @@
 <tool id="sort1" name="Sort" version="1.2.0">
     <description>data in ascending or descending order</description>
     <requirements>
-        <requirement type="package" version="2.14">grep</requirement>
-        <requirement type="package" version="4.4">sed</requirement>
-        <requirement type="package" version="8.31">coreutils</requirement>
+        <requirement type="package" version="3.11">grep</requirement>
+        <requirement type="package" version="4.9">sed</requirement>
+        <requirement type="package" version="9.5">coreutils</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 ## Sorts tabular data on one or more columns. All comments of the file are


### PR DESCRIPTION
Otherwise the conda environment for it fails to solve with the following error:

```
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package grep-2.14-h470a237_2 is excluded by strict repo priority
```

This is due to the fact that grep 2.14 is only available on the bioconda channel, while newer versions are on conda-forge, which has a higher priority.

Reported by @mvdbeek in https://github.com/galaxyproject/galaxy/pull/20876/files#r2336209775 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
