### PR TITLE
Don't crash if ``themes_config_file_by_host`` option is empty

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -600,7 +600,7 @@ class CommonConfigurationMixin:
     """Shared configuration settings code for Galaxy and ToolShed."""
 
     sentry_dsn: str
-    config_dict: dict[str, str]
+    config_dict: dict[str, Any]
 
     @property
     def admin_users(self):
@@ -1253,11 +1253,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
 
         self.themes = {}
 
-        if "themes_config_file_by_host" in self.config_dict:
+        if themes_config_file_by_host := self.config_dict.get("themes_config_file_by_host", {}):
             self.themes_by_host = {}
             resolve_to_dir = self.schema.paths_to_resolve["themes_config_file"]
             resolve_dir_path = getattr(self, resolve_to_dir)
-            for host, file_name in self.config_dict["themes_config_file_by_host"].items():
+            for host, file_name in themes_config_file_by_host.items():
                 self.themes_by_host[host] = {}
                 file_path = self._in_dir(resolve_dir_path, file_name)
                 _load_theme(file_path, self.themes_by_host[host])


### PR DESCRIPTION
Fix the following traceback:

```
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/config/__init__.py", line 761, in __init__
    self._process_config(kwargs)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/config/__init__.py", line 1260, in _process_config
    for host, file_name in self.config_dict["themes_config_file_by_host"].items():
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'items'
```

when building container image, see e.g.
https://github.com/galaxyproject/galaxy/actions/runs/17621047735/job/50066611961#step:9:1466

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Add:
     
     ```yaml
     themes_config_file_by_host: >
     ```
     
     to `config/galaxy.yml`
   2. Start Galaxy

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
