### PR TITLE
Attempt to fix transient API test failure for jobs search.

### DIFF
--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -772,12 +772,12 @@ steps:
         search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=copied_inputs)
         self._search(search_payload, expected_search_count=1)
         # Now we delete the original input HDA that was used -- we should still be able to find the job
-        delete_respone = self._delete(f"histories/{history_id}/contents/{dataset_id}")
-        self._assert_status_code_is_ok(delete_respone)
+        delete_response = self._delete(f"histories/{history_id}/contents/{dataset_id}")
+        self._assert_status_code_is_ok(delete_response)
         self._search(search_payload, expected_search_count=1)
         # Now we also delete the copy -- we shouldn't find a job
-        delete_respone = self._delete(f"histories/{new_history_id}/contents/{new_dataset_id}")
-        self._assert_status_code_is_ok(delete_respone)
+        delete_response = self._delete(f"histories/{new_history_id}/contents/{new_dataset_id}")
+        self._assert_status_code_is_ok(delete_response)
         self._search(search_payload, expected_search_count=0)
 
     @pytest.mark.require_new_history
@@ -802,8 +802,8 @@ steps:
         inputs = json.dumps({"input1": {"src": "hda", "id": dataset_id}})
         tool_response = self._job_search(tool_id="cat1", history_id=history_id, inputs=inputs)
         output_id = tool_response.json()["outputs"][0]["id"]
-        delete_respone = self._delete(f"histories/{history_id}/contents/{output_id}")
-        self._assert_status_code_is_ok(delete_respone)
+        delete_response = self._delete(f"histories/{history_id}/contents/{output_id}")
+        self._assert_status_code_is_ok(delete_response)
         search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
 
@@ -846,8 +846,8 @@ steps:
         # We delete the ouput (this is a HDA, as multi_data_param reduces collections)
         # and use the correct input job definition, the job should not be found
         output_id = tool_response.json()["outputs"][0]["id"]
-        delete_respone = self._delete(f"histories/{history_id}/contents/{output_id}")
-        self._assert_status_code_is_ok(delete_respone)
+        delete_response = self._delete(f"histories/{history_id}/contents/{output_id}")
+        self._assert_status_code_is_ok(delete_response)
         search_payload = self._search_payload(history_id=history_id, tool_id="multi_data_param", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
 
@@ -868,7 +868,7 @@ steps:
         self._search(search_payload, expected_search_count=1)
         # We delete a single tool output, no job should be returned
         delete_response = self._delete(f"histories/{history_id}/contents/datasets/{output_id}")
-        self._assert_status_code_is_ok(delete_respone)
+        self._assert_status_code_is_ok(delete_response)
         search_payload = self._search_payload(history_id=history_id, tool_id="collection_creates_list", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
         tool_response = self._job_search(tool_id="collection_creates_list", history_id=history_id, inputs=inputs)
@@ -906,12 +906,12 @@ steps:
         )
         self._search(search_payload, expected_search_count=1)
         # Now we delete the original input HDCA that was used -- we should still be able to find the job
-        delete_respone = self._delete(f"histories/{history_id}/contents/dataset_collections/{list_id_a}")
-        self._assert_status_code_is_ok(delete_respone)
+        delete_response = self._delete(f"histories/{history_id}/contents/dataset_collections/{list_id_a}")
+        self._assert_status_code_is_ok(delete_response)
         self._search(search_payload, expected_search_count=1)
         # Now we also delete the copy -- we shouldn't find a job
-        delete_respone = self._delete(f"histories/{history_id}/contents/dataset_collections/{new_list_a}")
-        self._assert_status_code_is_ok(delete_respone)
+        delete_response = self._delete(f"histories/{history_id}/contents/dataset_collections/{new_list_a}")
+        self._assert_status_code_is_ok(delete_response)
         self._search(search_payload, expected_search_count=0)
 
     @pytest.mark.require_new_history

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -860,17 +860,22 @@ steps:
             }
         )
         tool_response = self._job_search(tool_id="collection_creates_list", history_id=history_id, inputs=inputs)
-        output_id = tool_response.json()["outputs"][0]["id"]
+        output_dict = tool_response.json()["outputs"][0]
+        assert output_dict["history_content_type"] == "dataset"
+        output_id = output_dict["id"]
+        # Wait for job search to register the job, make sure initial conditions set.
+        search_payload = self._search_payload(history_id=history_id, tool_id="collection_creates_list", inputs=inputs)
+        self._search(search_payload, expected_search_count=1)
         # We delete a single tool output, no job should be returned
-        delete_respone = self._delete(f"histories/{history_id}/contents/{output_id}")
+        delete_response = self._delete(f"histories/{history_id}/contents/datasets/{output_id}")
         self._assert_status_code_is_ok(delete_respone)
         search_payload = self._search_payload(history_id=history_id, tool_id="collection_creates_list", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
         tool_response = self._job_search(tool_id="collection_creates_list", history_id=history_id, inputs=inputs)
         output_collection_id = tool_response.json()["output_collections"][0]["id"]
         # We delete a collection output, no job should be returned
-        delete_respone = self._delete(f"histories/{history_id}/contents/dataset_collections/{output_collection_id}")
-        self._assert_status_code_is_ok(delete_respone)
+        delete_response = self._delete(f"histories/{history_id}/contents/dataset_collections/{output_collection_id}")
+        self._assert_status_code_is_ok(delete_response)
         search_payload = self._search_payload(history_id=history_id, tool_id="collection_creates_list", inputs=inputs)
         self._search(search_payload, expected_search_count=0)
 


### PR DESCRIPTION
I don't really think this will fix the problem - this seems like a deep bug in Galaxy to me but it might be worth attempting. The two things I did here is wait on the testing initial condition (the job search can find the job before we delete the dataset) in case there is a race condition of some sort and then use the more precise dataset deletion route in case there is a clash between collections and datasets. I think we defer to the dataset so this second thing probably won't help but I think the more precise endpoint simplifies the test and ensures this isn't the problem.

The error:

```
=================================== FAILURES ===================================
__________________ TestJobsApi.test_search_delete_hdca_output __________________

self = <galaxy_test.api.test_jobs.TestJobsApi object at 0x7f1c8c4c7160>
history_id = '3fac04e22af259c6'

    @pytest.mark.require_new_history
    def test_search_delete_hdca_output(self, history_id):
        list_id_a = self.__history_with_ok_collection(collection_type="list", history_id=history_id)
        inputs = json.dumps(
            {
                "input1": {"src": "hdca", "id": list_id_a},
            }
        )
        tool_response = self._job_search(tool_id="collection_creates_list", history_id=history_id, inputs=inputs)
        output_id = tool_response.json()["outputs"][0]["id"]
        # We delete a single tool output, no job should be returned
        delete_respone = self._delete(f"histories/{history_id}/contents/{output_id}")
        self._assert_status_code_is(delete_respone, 200)
        search_payload = self._search_payload(history_id=history_id, tool_id="collection_creates_list", inputs=inputs)
        self._search(search_payload, expected_search_count=0)
>       tool_response = self._job_search(tool_id="collection_creates_list", history_id=history_id, inputs=inputs)

delete_respone = <Response [200]>
history_id = '3fac04e22af259c6'
inputs     = '{"input1": {"src": "hdca", "id": "c34129969476e859"}}'
list_id_a  = 'c34129969476e859'
output_id  = '6a392b789966ae78'
search_payload = {'history_id': '3fac04e22af259c6',
 'inputs': '{"input1": {"src": "hdca", "id": "c34129969476e859"}}',
 'state': 'ok',
 'tool_id': 'collection_creates_list'}
self       = <galaxy_test.api.test_jobs.TestJobsApi object at 0x7f1c8c4c7160>
tool_response = <Response [200]>

lib/galaxy_test/api/test_jobs.py:869: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/galaxy_test/api/test_jobs.py:1143: in _job_search
    self._search(search_payload, expected_search_count=1)
        empty_search_response = <Response [200]>
        history_id = '3fac04e22af259c6'
        inputs     = '{"input1": {"src": "hdca", "id": "c34129969476e859"}}'
        search_payload = {'history_id': '3fac04e22af259c6',
 'inputs': '{"input1": {"src": "hdca", "id": "c34129969476e859"}}',
 'state': 'ok',
 'tool_id': 'collection_creates_list'}
        self       = <galaxy_test.api.test_jobs.TestJobsApi object at 0x7f1c8c4c7160>
        tool_id    = 'collection_creates_list'
        tool_response = <Response [200]>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <galaxy_test.api.test_jobs.TestJobsApi object at 0x7f1c8c4c7160>
payload = {'history_id': '3fac04e22af259c6', 'inputs': '{"input1": {"src": "hdca", "id": "c34129969476e859"}}', 'state': 'ok', 'tool_id': 'collection_creates_list'}
expected_search_count = 1

    def _search(self, payload, expected_search_count=1):
        # in case job and history aren't updated at exactly the same
        # time give time to wait
        for _ in range(5):
            search_count = self._search_count(payload)
            if search_count == expected_search_count:
                break
            time.sleep(1)
>       assert (
            search_count == expected_search_count
        ), f"expected to find {expected_search_count} jobs, got {search_count} jobs"
E       AssertionError: expected to find 1 jobs, got 0 jobs
E       assert 0 == 1

_          = 4
expected_search_count = 1
payload    = {'history_id': '3fac04e22af259c6',
 'inputs': '{"input1": {"src": "hdca", "id": "c34129969476e859"}}',
 'state': 'ok',
 'tool_id': 'collection_creates_list'}
search_count = 0
self       = <galaxy_test.api.test_jobs.TestJobsApi object at 0x7f1c8c4c7160>

lib/galaxy_test/api/test_jobs.py:1158: AssertionError
```

https://github.com/jmchilton/galaxy/actions/runs/17649451626/job/50156222351

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
