### PR TITLE
[25.0] Fix job cache deleted output subquery

### DIFF
--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1148,13 +1148,7 @@ steps:
         return search_payload
 
     def _search(self, payload, expected_search_count=1):
-        # in case job and history aren't updated at exactly the same
-        # time give time to wait
-        for _ in range(5):
-            search_count = self._search_count(payload)
-            if search_count == expected_search_count:
-                break
-            time.sleep(1)
+        search_count = self._search_count(payload)
         assert (
             search_count == expected_search_count
         ), f"expected to find {expected_search_count} jobs, got {search_count} jobs"


### PR DESCRIPTION
(Hopefully) replaces https://github.com/galaxyproject/galaxy/pull/20898 ?
Might also fix some other reports of job cache not picking up jobs that I couldn't reproduce locally before (ping @bgruening ). 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
