### PR TITLE
Avoid overscroll behavior

### DIFF
--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -62,6 +62,7 @@ $fa-font-path: "../../../node_modules/@fortawesome/fontawesome-free/webfonts/";
 // ==== Basic styles ====
 body {
     @extend .m-2;
+    overscroll-behavior: none;
 }
 
 .unselectable {


### PR DESCRIPTION
This PR disables overscroll behavior and prevents unintended back/forward navigation caused by scroll gestures. This improves stability and reduces frustration, ensuring a consistent flow.

To reproduce: navigate to a view that allows horizontal scrolling (e.g., the Multi-History View). Scroll to the far left using a trackpad and continue scrolling. The page will navigate to the previous URL. Example:

![chira](https://github.com/user-attachments/assets/275aad80-5e44-46af-b28a-285d6676dbcb)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
