### PR TITLE
[25.0] Avoid potential race condition in replacement_for_connection

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6881,6 +6881,9 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
 
         return self._populated_optimized
 
+    def expire_populated_state(self):
+        required_object_session(self).expire(self, ("populated_state",))
+
     @property
     def allow_implicit_mapping(self):
         return self.collection_type != "record"

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -506,14 +506,18 @@ class WorkflowProgress:
                     # If we are not waiting for elements, there was some
                     # problem creating the collection. Collection will never
                     # be populated.
-                    raise modules.FailWorkflowEvaluation(
-                        why=InvocationFailureCollectionFailed(
-                            reason=FailureReason.collection_failed,
-                            hdca_id=replacement.id,
-                            workflow_step_id=connection.input_step_id,
-                            dependent_workflow_step_id=output_step_id,
+                    # We want to be certain of this however, so refresh attribute ...
+                    replacement.collection.expire_populated_state()
+                    # ... and repeat check to avoid race condition
+                    if not replacement.collection.populated:
+                        raise modules.FailWorkflowEvaluation(
+                            why=InvocationFailureCollectionFailed(
+                                reason=FailureReason.collection_failed,
+                                hdca_id=replacement.id,
+                                workflow_step_id=connection.input_step_id,
+                                dependent_workflow_step_id=output_step_id,
+                            )
                         )
-                    )
 
                 delayed_why = f"dependent collection [{replacement.id}] not yet populated with datasets"
                 raise modules.DelayedWorkflowEvaluation(why=delayed_why)


### PR DESCRIPTION
Might fix the following situation:

<img width="1816" height="631" alt="Screenshot 2025-09-15 at 17 47 58" src="https://github.com/user-attachments/assets/e1816afd-e4ac-4117-806a-ba8f78e8593e" />

The thinking is that `collection.populated_state` might have turned to `OK` between loading the instance from the database and fetching the job_state_summary that determines `waiting_for_elements` in this case.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
