### PR TITLE
Allow creation of visualizations without dataset

### DIFF
--- a/client/src/api/plugins.ts
+++ b/client/src/api/plugins.ts
@@ -29,16 +29,21 @@ export interface Plugin {
     html: string;
     logo?: string;
     name: string;
+    params?: Record<string, ParamType>;
     target?: string;
     tags?: Array<string>;
     tests?: Array<TestType>;
+}
+
+export interface ParamType {
+    required?: boolean;
 }
 
 export interface PluginData {
     hdas: Array<Dataset>;
 }
 
-export interface ParamType {
+export interface TestParamType {
     ftype?: string;
     label?: string;
     name: string;
@@ -46,7 +51,7 @@ export interface ParamType {
 }
 
 export interface TestType {
-    param: ParamType;
+    param: TestParamType;
 }
 
 export async function fetchPlugins(datasetId?: string): Promise<Array<Plugin>> {

--- a/client/src/components/Visualizations/VisualizationCreate.test.js
+++ b/client/src/components/Visualizations/VisualizationCreate.test.js
@@ -4,10 +4,19 @@ import { createPinia, defineStore, setActivePinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 import { ref } from "vue";
 
-import { fetchPluginHistoryItems } from "@/api/plugins";
+import { fetchPlugin, fetchPluginHistoryItems } from "@/api/plugins";
 
 import VisualizationCreate from "./VisualizationCreate.vue";
 import FormCardSticky from "@/components/Form/FormCardSticky.vue";
+
+const PLUGIN = {
+    name: "scatterplot",
+    description: "A great scatterplot plugin.",
+    html: "Scatterplot Plugin",
+    logo: "/logo.png",
+    help: "Some help text",
+    tags: ["tag1", "tag2"],
+};
 
 jest.mock("vue-router/composables", () => ({
     useRouter: () => ({
@@ -18,20 +27,11 @@ jest.mock("vue-router/composables", () => ({
 jest.mock("@/api/plugins", () => ({
     fetchPlugin: jest.fn(() =>
         Promise.resolve({
-            name: "scatterplot",
-            description: "A great scatterplot plugin.",
-            html: "Scatterplot Plugin",
-            logo: "/logo.png",
-            help: "Some help text",
-            tags: ["tag1", "tag2"],
+            params: { dataset_id: { required: true } },
+            ...PLUGIN,
         }),
     ),
     fetchPluginHistoryItems: jest.fn(() => Promise.resolve({ hdas: [] })),
-}));
-
-jest.mock("./utilities", () => ({
-    getTestExtensions: jest.fn(() => ["txt"]),
-    getTestUrls: jest.fn(() => [{ name: "Example", url: "https://example.com/data.txt" }]),
 }));
 
 let mockedStore;
@@ -94,4 +94,17 @@ it("adds hid to dataset names when fetching history items", async () => {
         { id: "dataset1", name: "101: First Dataset" },
         { id: "dataset2", name: "102: Second Dataset" },
     ]);
+});
+
+it("displays create new visualization option if dataset is not required", async () => {
+    fetchPlugin.mockResolvedValueOnce(PLUGIN);
+    const wrapper = mount(VisualizationCreate, {
+        localVue,
+        propsData: {
+            visualization: "scatterplot",
+        },
+    });
+    await wrapper.vm.$nextTick();
+    const results = await wrapper.vm.doQuery();
+    expect(results).toEqual([{ id: "", name: "Create a new visualization..." }]);
 });

--- a/client/src/components/Visualizations/VisualizationCreate.test.js
+++ b/client/src/components/Visualizations/VisualizationCreate.test.js
@@ -106,5 +106,5 @@ it("displays create new visualization option if dataset is not required", async 
     });
     await wrapper.vm.$nextTick();
     const results = await wrapper.vm.doQuery();
-    expect(results).toEqual([{ id: "", name: "Create a new visualization..." }]);
+    expect(results).toEqual([{ id: "", name: "Open visualization..." }]);
 });

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -32,7 +32,7 @@ const plugin: Ref<Plugin | undefined> = ref();
 
 const extensions = computed(() => getTestExtensions(plugin.value));
 const requiresDataset = computed(() => getRequiresDataset(plugin.value));
-const urlData = computed(() => getTestUrls(plugin.value));
+const testUrls = computed(() => getTestUrls(plugin.value));
 
 function addHidToName(hdas: Array<Dataset>) {
     return hdas.map((entry) => ({ id: entry.id, name: `${entry.hid}: ${entry.name}` }));
@@ -78,7 +78,7 @@ defineExpose({ doQuery });
         :logo="plugin?.logo"
         :name="plugin?.html">
         <template v-slot:buttons>
-            <VisualizationExamples :url-data="urlData" />
+            <VisualizationExamples :url-data="testUrls" />
         </template>
         <div class="my-3">
             <SelectionField

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -82,7 +82,7 @@ defineExpose({ doQuery });
         </template>
         <div class="my-3">
             <SelectionField
-                object-name="Select a dataset..."
+                object-name="Make a selection..."
                 object-title="Select to Visualize"
                 object-type="history_dataset_id"
                 :object-query="doQuery"

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -51,7 +51,8 @@ async function getPlugin() {
 }
 
 function onSelect(dataset: OptionType) {
-    router.push(`/visualizations/display?visualization=${plugin.value?.name}&dataset_id=${dataset.id}`, {
+    const query = dataset.id ? `&dataset_id=${dataset.id}` : "";
+    router.push(`/visualizations/display?visualization=${plugin.value?.name}${query}`, {
         // @ts-ignore
         title: dataset.name,
     });

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -8,7 +8,7 @@ import type { OptionType } from "@/components/SelectionField/types";
 import { useMarkdown } from "@/composables/markdown";
 import { useHistoryStore } from "@/stores/historyStore";
 
-import { getTestExtensions, getTestUrls } from "./utilities";
+import { getRequiresDataset, getTestExtensions, getTestUrls } from "./utilities";
 
 import VisualizationExamples from "./VisualizationExamples.vue";
 import Heading from "@/components/Common/Heading.vue";
@@ -27,11 +27,12 @@ const props = defineProps<{
 }>();
 
 const errorMessage = ref("");
+const formatsVisible = ref(false);
 const plugin: Ref<Plugin | undefined> = ref();
 
-const urlData = computed(() => getTestUrls(plugin.value));
 const extensions = computed(() => getTestExtensions(plugin.value));
-const formatsVisible = ref(false);
+const requiresDataset = computed(() => getRequiresDataset(plugin.value));
+const urlData = computed(() => getTestUrls(plugin.value));
 
 function addHidToName(hdas: Array<Dataset>) {
     return hdas.map((entry) => ({ id: entry.id, name: `${entry.hid}: ${entry.name}` }));
@@ -40,7 +41,11 @@ function addHidToName(hdas: Array<Dataset>) {
 async function doQuery() {
     if (currentHistoryId.value && plugin.value) {
         const data = await fetchPluginHistoryItems(plugin.value.name, currentHistoryId.value);
-        return addHidToName(data.hdas);
+        const entries = addHidToName(data.hdas);
+        if (!requiresDataset.value) {
+            entries.unshift({ id: "", name: "Create a new visualization..." });
+        }
+        return entries;
     } else {
         return [];
     }

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -3,7 +3,7 @@ import { storeToRefs } from "pinia";
 import { computed, onMounted, type Ref, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
-import { type Dataset, fetchPlugin, fetchPluginHistoryItems, type Plugin } from "@/api/plugins";
+import { fetchPlugin, fetchPluginHistoryItems, type Plugin } from "@/api/plugins";
 import type { OptionType } from "@/components/SelectionField/types";
 import { useMarkdown } from "@/composables/markdown";
 import { useHistoryStore } from "@/stores/historyStore";
@@ -34,18 +34,13 @@ const extensions = computed(() => getTestExtensions(plugin.value));
 const requiresDataset = computed(() => getRequiresDataset(plugin.value));
 const testUrls = computed(() => getTestUrls(plugin.value));
 
-function addHidToName(hdas: Array<Dataset>) {
-    return hdas.map((entry) => ({ id: entry.id, name: `${entry.hid}: ${entry.name}` }));
-}
-
 async function doQuery() {
     if (currentHistoryId.value && plugin.value) {
         const data = await fetchPluginHistoryItems(plugin.value.name, currentHistoryId.value);
-        const entries = addHidToName(data.hdas);
-        if (!requiresDataset.value) {
-            entries.unshift({ id: "", name: "Create a new visualization..." });
-        }
-        return entries;
+        return [
+            ...(!requiresDataset.value ? [{ id: "", name: "Create a new visualization..." }] : []),
+            ...data.hdas.map((hda) => ({ id: hda.id, name: `${hda.hid}: ${hda.name}` })),
+        ];
     } else {
         return [];
     }

--- a/client/src/components/Visualizations/VisualizationCreate.vue
+++ b/client/src/components/Visualizations/VisualizationCreate.vue
@@ -38,7 +38,7 @@ async function doQuery() {
     if (currentHistoryId.value && plugin.value) {
         const data = await fetchPluginHistoryItems(plugin.value.name, currentHistoryId.value);
         return [
-            ...(!requiresDataset.value ? [{ id: "", name: "Create a new visualization..." }] : []),
+            ...(!requiresDataset.value ? [{ id: "", name: `Open visualization...` }] : []),
             ...data.hdas.map((hda) => ({ id: hda.id, name: `${hda.hid}: ${hda.name}` })),
         ];
     } else {

--- a/client/src/components/Visualizations/VisualizationFrame.vue
+++ b/client/src/components/Visualizations/VisualizationFrame.vue
@@ -23,16 +23,16 @@ const iframeRef = ref<HTMLIFrameElement | null>(null);
 const srcWithRoot = computed(() => {
     let url = "";
     if (props.visualization === "trackster") {
-        if (props.datasetId) {
-            url = `/visualization/trackster?dataset_id=${props.datasetId}`;
-        } else {
+        if (props.visualizationId) {
             url = `/visualization/trackster?id=${props.visualizationId}`;
+        } else {
+            url = `/visualization/trackster?dataset_id=${props.datasetId}`;
         }
     } else {
-        if (props.datasetId) {
-            url = `/plugins/visualizations/${props.visualization}/show?dataset_id=${props.datasetId}`;
-        } else {
+        if (props.visualizationId) {
             url = `/plugins/visualizations/${props.visualization}/saved?id=${props.visualizationId}`;
+        } else {
+            url = `/plugins/visualizations/${props.visualization}/show?dataset_id=${props.datasetId}`;
         }
     }
 

--- a/client/src/components/Visualizations/VisualizationFrame.vue
+++ b/client/src/components/Visualizations/VisualizationFrame.vue
@@ -32,7 +32,8 @@ const srcWithRoot = computed(() => {
         if (props.visualizationId) {
             url = `/plugins/visualizations/${props.visualization}/saved?id=${props.visualizationId}`;
         } else {
-            url = `/plugins/visualizations/${props.visualization}/show?dataset_id=${props.datasetId}`;
+            const query = props.datasetId ? `?dataset_id=${props.datasetId}` : "";
+            url = `/plugins/visualizations/${props.visualization}/show${query}`;
         }
     }
 

--- a/client/src/components/Visualizations/utilities.test.js
+++ b/client/src/components/Visualizations/utilities.test.js
@@ -1,7 +1,15 @@
-import { getFilename, getTestUrls } from "./utilities";
+import { getFilename, getRequiresDataset, getTestUrls } from "./utilities";
 
 describe("Utility Functions", () => {
-    describe("getTestUrls", () => {
+    describe("getRequiresDataset and getTestUrls", () => {
+        it("return wether the visualization requires a dataset or not", () => {
+            expect(getRequiresDataset({})).toEqual(false);
+            const plugin = {
+                params: { dataset_id: { required: true } },
+            };
+            expect(getRequiresDataset(plugin)).toEqual(true);
+        });
+
         it("returns empty array when plugin is undefined", () => {
             expect(getTestUrls()).toEqual([]);
         });

--- a/client/src/components/Visualizations/utilities.ts
+++ b/client/src/components/Visualizations/utilities.ts
@@ -1,5 +1,9 @@
 import type { Plugin } from "@/api/plugins";
 
+export function getRequiresDataset(plugin?: Plugin): boolean {
+    return plugin?.params?.dataset_id?.required || false;
+}
+
 export function getTestExtensions(plugin?: Plugin): string[] {
     const results: string[] = [];
     if (plugin?.data_sources) {

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -38,7 +38,7 @@ heatmap:
     version: 0.0.15
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
-    version: 0.0.14
+    version: 0.0.15
 kepler:
     package: "@galaxyproject/kepler"
     version: 0.0.3

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -38,7 +38,7 @@ heatmap:
     version: 0.0.15
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
-    version: 0.0.12
+    version: 0.0.14
 kepler:
     package: "@galaxyproject/kepler"
     version: 0.0.3

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -38,7 +38,7 @@ heatmap:
     version: 0.0.15
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
-    version: 0.0.15
+    version: 0.0.16
 kepler:
     package: "@galaxyproject/kepler"
     version: 0.0.3

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -72,15 +72,11 @@ class VisualizationsConfigParser:
             log.info("Visualizations plugin disabled: %s. Skipping...", returned["name"])
             return None
 
-        # record the embeddable flag - defaults to False
-        returned["embeddable"] = False
-        if "embeddable" in xml_tree.attrib:
-            returned["embeddable"] = asbool(xml_tree.attrib.get("embeddable"))
-
-        # record the visible flag - defaults to False
-        returned["hidden"] = False
-        if "hidden" in xml_tree.attrib:
-            returned["hidden"] = asbool(xml_tree.attrib.get("hidden"))
+        # record boolean flags - defaults to False
+        for keyword in ["embeddable", "hidden"]:
+            returned[keyword] = False
+            if keyword in xml_tree.attrib:
+                returned[keyword] = asbool(xml_tree.attrib.get(keyword))
 
         # a (for now) text description of what the visualization does
         description = xml_tree.find("description")

--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -116,6 +116,7 @@ class VisualizationPlugin(ServesTemplatesPluginMixin):
             "tags": self.config.get("tags"),
             "title": self.config.get("title"),
             "target": self.config.get("render_target", "galaxy_main"),
+            "params": self.config.get("params"),
             "embeddable": self.config.get("embeddable"),
             "entry_point": self.config.get("entry_point"),
             "settings": self.config.get("settings"),


### PR DESCRIPTION
This PR adds support for creating visualizations without requiring pre-existing datasets, demonstrated with JupyterLite.

![screencast](https://github.com/user-attachments/assets/fdac3622-e8ee-4f80-8ede-b7dedc4c650a)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
