### PR TITLE
Include format in internal json model

### DIFF
--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -543,6 +543,7 @@ class DataInternalJson(StrictModel):
     nameext: Annotated[
         Optional[str], Field(description="The basename extension such that nameroot + nameext == basename")
     ]
+    format: Annotated[str, Field(description="The datatype extension of the file, e.g. 'txt', 'bam', 'fastq.gz'.")]
     # "secondaryFiles": List[Any],
     checksum: Optional[str]
     size: int


### PR DESCRIPTION
This model represents what is available when templating user defined tools and expression tools, format has been available for some time.

<img width="1135" height="342" alt="Screenshot 2025-09-18 at 15 41 59" src="https://github.com/user-attachments/assets/8a23ee8d-8ca2-4918-8b00-e518da5e0b1a" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
