### PR TITLE
[25.0] Fix collection element sorting in extended_metadata

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -10656,6 +10656,11 @@ export interface components {
              * @enum {string}
              */
             sort_key: "filename" | "name" | "designation" | "dbkey";
+            /**
+             * Sort Reverse
+             * @default false
+             */
+            sort_reverse: boolean;
             /** Visible */
             visible: boolean;
         };

--- a/lib/galaxy/tool_util/parser/output_collection_def.py
+++ b/lib/galaxy/tool_util/parser/output_collection_def.py
@@ -159,6 +159,7 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
     discover_via = "pattern"
     sort_key: SortKeyT
     sort_comp: SortCompT
+    sort_reverse: bool
     pattern: str
 
     def __init__(self, **kwargs):
@@ -169,20 +170,25 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
         if pattern in NAMED_PATTERNS:
             pattern = NAMED_PATTERNS[pattern]
         self.pattern = pattern
-        self.sort_by = sort_by = kwargs.get("sort_by", DEFAULT_SORT_BY)
-        if sort_by.startswith("reverse_"):
-            self.sort_reverse = True
-            sort_by = sort_by[len("reverse_") :]
+        if "sort_by" not in kwargs and "sort_key" in kwargs and "sort_comp" in kwargs and "sort_reverse" in kwargs:
+            self.sort_reverse = kwargs["sort_reverse"]
+            self.sort_comp = kwargs["sort_comp"]
+            self.sort_key = kwargs["sort_key"]
         else:
-            self.sort_reverse = False
-        if "_" in sort_by:
-            sort_comp, sort_by = sort_by.split("_", 1)
-            assert sort_comp in ["lexical", "numeric"]
-        else:
-            sort_comp = DEFAULT_SORT_COMP
-        assert sort_by in ["filename", "name", "designation", "dbkey"]
-        self.sort_key = sort_by
-        self.sort_comp = sort_comp
+            self.sort_by = sort_by = kwargs.get("sort_by", DEFAULT_SORT_BY)
+            if sort_by.startswith("reverse_"):
+                self.sort_reverse = True
+                sort_by = sort_by[len("reverse_") :]
+            else:
+                self.sort_reverse = False
+            if "_" in sort_by:
+                sort_comp, sort_by = sort_by.split("_", 1)
+                assert sort_comp in ["lexical", "numeric"]
+            else:
+                sort_comp = DEFAULT_SORT_COMP
+            assert sort_by in ["filename", "name", "designation", "dbkey"]
+            self.sort_key = sort_by
+            self.sort_comp = sort_comp
 
     def to_model(self) -> FilePatternDatasetCollectionDescriptionModel:
         return FilePatternDatasetCollectionDescriptionModel(
@@ -198,6 +204,7 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
             sort_comp=self.sort_comp,
             pattern=self.pattern,
             sort_by=self.sort_by,
+            sort_reverse=self.sort_reverse,
         )
 
     @property

--- a/lib/galaxy/tool_util_models/tool_outputs.py
+++ b/lib/galaxy/tool_util_models/tool_outputs.py
@@ -63,6 +63,7 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
     discover_via: Literal["pattern"]
     sort_key: SortKeyT
     sort_comp: SortCompT
+    sort_reverse: bool = False
     pattern: str
 
 

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -1649,6 +1649,11 @@ export interface components {
              * @enum {string}
              */
             sort_key: "filename" | "name" | "designation" | "dbkey"
+            /**
+             * Sort Reverse
+             * @default false
+             */
+            sort_reverse: boolean
             /** Visible */
             visible: boolean
         }

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -44,6 +44,7 @@ TEST_TOOL_IDS = [
     "implicit_conversion",
     "environment_variables",
     "all_output_types",
+    "discover_sort_by",
 ]
 
 


### PR DESCRIPTION
Fixes the last set of framework tests for pulsar + extended metadata, but this is also broken for local runners with extended metadata.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
