### PR TITLE
Make jupyterlite default visualization for ipynb

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -667,6 +667,7 @@
     </datatype>
     <!-- End RGenetics Datatypes -->
     <datatype extension="ipynb" type="galaxy.datatypes.text:Ipynb" display_in_upload="true">
+        <visualization plugin="jupyterlite" />
         <infer_from suffix="ipynb" />
     </datatype>
     <datatype extension="json" type="galaxy.datatypes.text:Json" display_in_upload="true">


### PR DESCRIPTION
This PR configures jupyterlite as default viewer for ipynb notebooks.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
