### PR TITLE
Allow addressing user defined tools in job config

### DIFF
--- a/doc/source/admin/user_defined_tools.md
+++ b/doc/source/admin/user_defined_tools.md
@@ -89,7 +89,8 @@ These tools can also be exported to disk and loaded like regular tools, enabling
 ## Security considerations
 
 User-defined tools share the same security risks as interactive tools..
-See https://training.galaxyproject.org/training-material/topics/admin/tutorials/interactive-tools/tutorial.html#securing-interactive-tools for an extended discussion.
+See https://training.galaxyproject.org/training-material/topics/admin/tutorials/interactive-tools/tutorial.html#securing-interactive-tools for an extended discussion,
+and see https://github.com/galaxyproject/galaxy/blob/dev/test/integration/embedded_pulsar_job_conf.yml#L29 for a simple example that uses embedded pulsar to isolate mounts and disables network access.
 While the feature is in beta we recommend that only trusted users are allowed to use this feature.
 
 ## Limitations

--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -1160,6 +1160,7 @@ tools:
   # Classes can be used to map groups of tools - the current classes include
   # - local (these special tools that aren't parameterized for remote execution - expression tools, upload, etc..)
   # - requires_galaxy (these special tools require Galaxy's Python environment during execution)
+  # - user_defined (these tools are defined by the user and should be routed to an isolated job execution environment)
   # If a tool matches multiple classes, it will match the first class according to the order listed
   # above in this document (local, requires_galaxy).
   class: local

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -123,7 +123,7 @@ DEFAULT_JOB_SHELL = "/bin/bash"
 DEFAULT_LOCAL_WORKERS = 4
 
 DEFAULT_CLEANUP_JOB = "always"
-VALID_TOOL_CLASSES = ["local", "requires_galaxy"]
+VALID_TOOL_CLASSES = ["local", "requires_galaxy", "user_defined"]
 
 
 class JobDestination(Bunch):

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -157,6 +157,10 @@ class ToolSource(metaclass=ABCMeta):
     def parse_version(self) -> Optional[str]:
         """Parse a version describing the abstract tool."""
 
+    def parse_class(self) -> Optional[str]:
+        """Parse the class of the tool."""
+        return None
+
     def parse_tool_module(self) -> Optional[Tuple[str, str]]:
         """Load Tool class from a custom module. (Optional).
 

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -58,6 +58,9 @@ class YamlToolSource(ToolSource):
     def source_path(self):
         return self._source_path
 
+    def parse_class(self):
+        return self.root_dict.get("class")
+
     def parse_tool_type(self):
         return self.root_dict.get("tool_type")
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -406,6 +406,8 @@ class ToolNotFoundException(Exception):
 
 def create_tool_from_source(app, tool_source: ToolSource, config_file: Optional[StrPath] = None, **kwds):
     # Allow specifying a different tool subclass to instantiate
+    if tool_source.parse_class() == "GalaxyUserTool":
+        return UserDefinedTool(config_file, tool_source, app, **kwds)
     if (tool_module := tool_source.parse_tool_module()) is not None:
         module, cls = tool_module
         mod = __import__(module, globals(), locals(), [cls])
@@ -1405,6 +1407,8 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
                 tool_classes.append("local")
             if self.requires_galaxy_python_environment:
                 tool_classes.append("requires_galaxy")
+            if self.tool_type == "user_defined":
+                tool_classes.append("user_defined")
 
             self.job_tool_configurations = self.app.job_config.get_job_tool_configurations(self_ids, tool_classes)
 
@@ -3155,6 +3159,11 @@ class OutputParameterJSONTool(Tool):
             raise Exception("Must call 'exec_before_job' with 'out_data' containing at least one entry.")
         with open(json_filename, "w") as out:
             out.write(json.dumps(json_params))
+
+
+class UserDefinedTool(Tool):
+    tool_type = "user_defined"
+    requires_js_runtime = True
 
 
 class ExpressionTool(Tool):

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -33,6 +33,7 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     skip_without_tool,
     stage_rules_example,
+    TOOL_WITH_SHELL_COMMAND,
 )
 from ._framework import ApiTestCase
 
@@ -52,29 +53,6 @@ MINIMAL_TOOL_NO_ID = {
     "command": "echo 'Hello World 2' > $output1",
     "inputs": [],
     "outputs": {"output1": {"format": "txt", "type": "data"}},
-}
-
-TOOL_WITH_SHELL_COMMAND = {
-    "id": "basecommand",
-    "name": "Base command tool",
-    "class": "GalaxyUserTool",
-    "container": "busybox",
-    "version": "1.0.0",
-    "shell_command": "cat '$(inputs.input.path)' > output.fastq",
-    "inputs": [
-        {
-            "type": "data",
-            "name": "input",
-            "format": "txt",
-        }
-    ],
-    "outputs": [
-        {
-            "type": "data",
-            "from_work_dir": "output.fastq",
-            "name": "output",
-        }
-    ],
 }
 
 

--- a/lib/galaxy_test/api/test_unprivileged_tools.py
+++ b/lib/galaxy_test/api/test_unprivileged_tools.py
@@ -3,12 +3,10 @@ from galaxy.tool_util_models import UserToolSource
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
-)
-from ._framework import ApiTestCase
-from .test_tools import (
-    TestsTools,
     TOOL_WITH_SHELL_COMMAND,
 )
+from ._framework import ApiTestCase
+from .test_tools import TestsTools
 
 
 class TestUnprivilegedToolsApi(ApiTestCase, TestsTools):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -141,6 +141,29 @@ workflow_str = resource_string(__name__, "data/test_workflow_1.ga")
 # Simple workflow that takes an input and filters with random lines twice in a
 # row - first grabbing 8 lines at random and then 6.
 workflow_random_x2_str = resource_string(__name__, "data/test_workflow_2.ga")
+# example of user defined tool
+TOOL_WITH_SHELL_COMMAND = {
+    "id": "basecommand",
+    "name": "Base command tool",
+    "class": "GalaxyUserTool",
+    "container": "busybox",
+    "version": "1.0.0",
+    "shell_command": "cat '$(inputs.input.path)' > output.fastq",
+    "inputs": [
+        {
+            "type": "data",
+            "name": "input",
+            "format": "txt",
+        }
+    ],
+    "outputs": [
+        {
+            "type": "data",
+            "from_work_dir": "output.fastq",
+            "name": "output",
+        }
+    ],
+}
 
 DEFAULT_TIMEOUT = 60  # Secs to wait for state to turn ok
 

--- a/test/integration/embedded_pulsar_job_conf.yml
+++ b/test/integration/embedded_pulsar_job_conf.yml
@@ -16,7 +16,15 @@ execution:
     pulsar_embed:
       runner: pulsar_embed
       remote_metadata: true
+    user_defined:
+      runner: pulsar_embed
+      remote_metadata: true
+      docker_enabled: true
+      require_container: true
+      docker_net: "none"
 
 tools:
 - class: local
   environment: local
+- class: user_defined
+  environment: user_defined

--- a/test/integration/test_user_defined_tool_job_conf.py
+++ b/test/integration/test_user_defined_tool_job_conf.py
@@ -1,0 +1,59 @@
+"""Integration tests for user defined tools with Pulsar embedded runner."""
+
+import os
+
+from galaxy.tool_util_models import UserToolSource
+from galaxy_test.api.test_tools import TestsTools
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    TOOL_WITH_SHELL_COMMAND,
+)
+from galaxy_test.driver import integration_util
+
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+EMBEDDED_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_job_conf.yml")
+
+
+class TestUserDefinedToolRecommendedJobSetup(integration_util.IntegrationTestCase, TestsTools):
+    """Exercies how user defined tools could be run in production."""
+
+    framework_tool_and_types = True
+    dataset_populator: DatasetPopulator
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
+        config["enable_celery_tasks"] = False
+        config["metadata_strategy"] = "directory"
+        config["admin_users"] = "udt@galaxy.org"
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_user_defined_runs_in_correct_destination(self):
+        with (
+            self.dataset_populator.test_history() as history_id,
+            self.dataset_populator.user_tool_execute_permissions(),
+        ):
+            # Create a new dynamic tool.
+            # This is a shell command tool that will echo the input dataset.
+            dynamic_tool = self.dataset_populator.create_unprivileged_tool(UserToolSource(**TOOL_WITH_SHELL_COMMAND))
+            # Run tool.
+            dataset = self.dataset_populator.new_dataset(history_id=history_id, content="abc")
+            response = self._run(
+                history_id=history_id,
+                tool_uuid=dynamic_tool["uuid"],
+                inputs={"input": {"src": "hda", "id": dataset["id"]}},
+                wait_for_job=True,
+                assert_ok=True,
+            )
+
+            output_content = self.dataset_populator.get_history_dataset_content(history_id)
+            assert output_content == "abc\n"
+            with self._different_user(email="udt@galaxy.org"):
+                destination_params = self._get(f"/api/jobs/{response['jobs'][0]['id']}/destination_params").json()
+
+        assert destination_params["Runner"] == "pulsar_embed"
+        assert destination_params["require_container"]


### PR DESCRIPTION
So you can route them to an isolated and safe job location. Comes with integration test.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
