### PR TITLE
Adds IGV.js Visualization

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -36,6 +36,9 @@ h5web:
 heatmap:
     package: "@galaxyproject/heatmap"
     version: 0.0.15
+igv:
+    package: "@galaxyproject/igv"
+    version: 0.0.10
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
     version: 0.0.17


### PR DESCRIPTION
Requires: #20949 for access to Galaxy-served genomes.

This PR integrates IGV.js into Galaxy.

- Enables users to view multiple-tracks in various formats.
- Utilizes metadata indices and byte-range requests.
- Supports both IGV-provided genomes and Galaxy-served genomes in 2bit and fa/fai formats.
- Automatically matches dataset database keys against available genomes.

See: https://github.com/galaxyproject/galaxy-visualizations/pull/99

![screencast](https://github.com/user-attachments/assets/e530c91b-d72a-49e5-8799-fac929d14da0)

Tested with:
-  [x] bam+bai
-  [x] bed
-  [x] bigwig
-  [x] cram+crai
-  [x] gff
-  [x] gtf
-  [x] vcf
-  [x] vcf_bgzip
-  [ ] ...?


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
