### PR TITLE
Add a dedicated `ToolFormTags` component for tool form output tags

### DIFF
--- a/client/src/components/Form/Elements/FormTags.vue
+++ b/client/src/components/Form/Elements/FormTags.vue
@@ -1,25 +1,24 @@
 <script setup lang="ts">
+import { computed } from "vue";
+
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
-interface Props {
-    value?: string[];
+const props = defineProps<{
+    value?: string;
     placeholder?: string;
-}
-
-const props = withDefaults(defineProps<Props>(), {
-    value: () => [],
-    placeholder: "Add tags",
-});
-
-const emit = defineEmits<{
-    (e: "input", value: string[]): void;
 }>();
 
+const emit = defineEmits<{
+    (e: "input", value: string): void;
+}>();
+
+const valueArray = computed(() => props.value?.split(",").map((v) => v.trim()) ?? []);
+
 function onInput(tags: string[]) {
-    emit("input", tags);
+    emit("input", tags.join(","));
 }
 </script>
 
 <template>
-    <StatelessTags :value="value" :placeholder="props.placeholder" @input="onInput" />
+    <StatelessTags :value="valueArray" :placeholder="props.placeholder" @input="onInput"></StatelessTags>
 </template>

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -81,15 +81,8 @@
                     v-model="dataManagerMode"
                     :options="bundleOptions"
                     title="Create dataset bundle instead of adding data table to loc file ?"></FormSelect>
+                <ToolFormTags :tags.sync="tags" />
             </div>
-            <FormElement
-                id="tags"
-                :attributes="{ optional: true }"
-                :value="tags"
-                title="Output tags"
-                type="tags"
-                help="Enter tags to apply to the output datasets in your history (e.g., 'sample1'). Tags starting with '#' (e.g., '#sample1') will propagate to datasets derived from these outputs. Tags help you organize and search your history."
-                @input="updateTags" />
             <template v-slot:buttons>
                 <ButtonSpinner
                     id="execute"
@@ -136,6 +129,7 @@ import ToolRecommendation from "../ToolRecommendation";
 import { getToolFormData, submitJob, updateToolFormData } from "./services";
 import ToolCard from "./ToolCard";
 
+import ToolFormTags from "./ToolFormTags.vue";
 import FormSelect from "@/components/Form/Elements/FormSelect.vue";
 
 export default {
@@ -147,6 +141,7 @@ export default {
         FormElement,
         FormSelect,
         ToolEntryPoints,
+        ToolFormTags,
         ToolRecommendation,
         Heading,
     },
@@ -462,9 +457,6 @@ export default {
                     }
                 },
             );
-        },
-        updateTags(newTags) {
-            this.tags = newTags;
         },
     },
 };

--- a/client/src/components/Tool/ToolFormTags.vue
+++ b/client/src/components/Tool/ToolFormTags.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import StatelessTags from "../TagsMultiselect/StatelessTags.vue";
+
+const props = defineProps<{
+    tags: string[];
+}>();
+
+const emit = defineEmits<{
+    (e: "update:tags", value: string[]): void;
+}>();
+</script>
+
+<template>
+    <div class="ui-form-element section-row">
+        <div class="ui-form-title">
+            <span class="ui-form-title-text">
+                <label for="tool-form-tags">Output Tags</label>
+            </span>
+        </div>
+        <div id="tool-form-tags" class="ui-form-field">
+            <StatelessTags :value="props.tags" placeholder="Add tags" @input="emit('update:tags', $event)" />
+        </div>
+        <span class="ui-form-info form-text text-muted">
+            Enter tags to apply to the output datasets in your history (e.g., 'sample1'). Tags starting with '#' (e.g.,
+            '#sample1') will propagate to datasets derived from these outputs. Tags help you organize and search your
+            history.
+        </span>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import "../Form/_form-elements.scss";
+</style>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20944

<img width="933" height="863" alt="image" src="https://github.com/user-attachments/assets/f0f8de1a-343d-4326-8f0b-48e5f506247c" />


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to any tool run form
  2. At the bottom in the additional options, add a tag or more
  3. Execute the tool, the output content items in the history will have the tag(s) you set

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
