### PR TITLE
[25.0] Fix select field cut off in dataset view

### DIFF
--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -318,6 +318,7 @@ watch(
     flex-direction: column;
     overflow: hidden;
     overflow-y: auto;
+    height: 100%;
 }
 
 .auto-download-message {


### PR DESCRIPTION
The `.tab-content-panel` class was not full height of the container, and therefore, selects were being cut off below the content height. Changed it to 100% height and selects work fine now.

Fixes https://github.com/galaxyproject/galaxy/issues/20817

| Before | After |
| ---- | ---- |
| <img width="1400" height="567" alt="firefox_3b55pHhn7n" src="https://github.com/user-attachments/assets/e0d90d76-6edd-4a91-b03f-7ab9a55fcedd" /> | <img width="1400" height="567" alt="ccpEsX4GJQ" src="https://github.com/user-attachments/assets/b47aa927-bfc5-4b7d-9d25-e2cb41a8890f" /> |


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
