### PR TITLE
Add genomes api endpoint to serve fasta indexes

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -1379,6 +1379,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/genomes/{id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return sequence data for download */
+        get: operations["download_api_genomes__id__download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/genomes/{id}/indexes": {
         parameters: {
             query?: never;
@@ -1386,7 +1403,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Return all available indexes for a genome id for provided type */
+        /** Return all available indexes for a genome id */
         get: operations["indexes_api_genomes__id__indexes_get"];
         put?: never;
         post?: never;
@@ -26954,6 +26971,8 @@ export interface operations {
             query?: {
                 /** @description If true, return genome keys with chromosome lengths */
                 chrom_info?: boolean;
+                /** @description If true, return genome ids of available indexes */
+                indexes?: boolean;
             };
             header?: {
                 /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -27050,11 +27069,51 @@ export interface operations {
             };
         };
     };
+    download_api_genomes__id__download_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description Genome ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sequence data file */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
     indexes_api_genomes__id__indexes_get: {
         parameters: {
             query?: {
-                /** @description Index type */
-                type?: string;
                 /** @description Format */
                 format?: string;
             };
@@ -27070,7 +27129,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Indexes for a genome id for provided type */
+            /** @description Indexes for a genome id */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -27102,8 +27161,6 @@ export interface operations {
     sequences_api_genomes__id__sequences_get: {
         parameters: {
             query?: {
-                /** @description If true, return reference data */
-                reference?: boolean;
                 /** @description Limits size of returned data */
                 chrom?: string;
                 /** @description Limits size of returned data */

--- a/lib/galaxy/webapps/galaxy/api/genomes.py
+++ b/lib/galaxy/webapps/galaxy/api/genomes.py
@@ -55,6 +55,10 @@ FormatQueryParam: str = Query(None, title="Format", description="Format")
 
 ReferenceQueryParam: bool = Query(None, title="Reference", description="If true, return reference data")
 
+IndexTypeQueryParam: str = Query(
+    "fasta_indexes", title="Index type", description="Index type"  # currently this is the only supported index type
+)
+
 
 def get_id(base, format):
     if format:
@@ -105,6 +109,7 @@ class FastAPIGenomes:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         id: str = IdPathParam,
+        type: str = IndexTypeQueryParam,
         format: str = FormatQueryParam,
     ) -> Response:
         id = get_id(id, format)


### PR DESCRIPTION
This PR extends the genomes API to allow byte-range access to FASTA index files (.fai) and to list dbkeys that have FASTA indexes. This is needed for genome browsers like IGV that use range-based retrieval for sequence data. It adds a new `/api/genomes/{id}/download` endpoint and updates the manager for sequence and index retrieval.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
