### PR TITLE
Limit admin requirement of selected tool data api endpoints

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4584,7 +4584,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get details of a given data table
+         * Get details of a data table. For non-administrators, base directories in the path column are masked as '/.../'.
          * @description Get details of a given tool data table.
          */
         get: operations["show_api_tool_data__table_name__get"];
@@ -4609,7 +4609,7 @@ export interface paths {
         };
         /**
          * Get information about a particular field in a tool data table
-         * @description Reloads a data table and return its details.
+         * @description Displays information about a data table field.
          */
         get: operations["show_field_api_tool_data__table_name__fields__field_name__get"];
         put?: never;
@@ -4628,7 +4628,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get information about a particular field in a tool data table
+         * Get files associated with a particular field in a tool data table
          * @description Download a file associated with the data table field.
          */
         get: operations["download_field_file_api_tool_data__table_name__fields__field_name__files__file_name__get"];
@@ -38069,7 +38069,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description A description of the given data table and its content */
+            /** @description A description of the given data table and its content. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -38211,7 +38211,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Information about a data table field */
+            /** @description Request file associated with tool data table entry */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -4584,7 +4584,7 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get details of a data table. For non-administrators, base directories in the path column are masked as '/.../'.
+         * Get details of a data table. For non-administrators, base directories in the path column are stripped, leaving only the basename.
          * @description Get details of a given tool data table.
          */
         get: operations["show_api_tool_data__table_name__get"];

--- a/lib/galaxy/managers/tool_data.py
+++ b/lib/galaxy/managers/tool_data.py
@@ -77,7 +77,9 @@ class ToolDataManager:
         """Get the absolute path to a given file name in the table field"""
         field_value = self._data_table_field(table_name, field_name)
         if table_name not in PUBLIC_TABLES and not trans.user_is_admin:
-            raise exceptions.AdminRequiredException(f"Only administrators can download files from '{table_name}'.")
+            raise exceptions.AdminRequiredException(
+                f"Only administrators can download files from data table {table_name}."
+            )
         base_dir = Path(field_value.get_base_dir())
         full_path = base_dir / file_name
         if str(full_path) not in field_value.get_files():

--- a/lib/galaxy/managers/tool_data.py
+++ b/lib/galaxy/managers/tool_data.py
@@ -57,7 +57,7 @@ class ToolDataManager:
             path_index = element_view["columns"].index("path") if "path" in element_view["columns"] else None
             if path_index is not None:
                 element_view["fields"] = [
-                    [f"/.../{basename(field[path_index])}" if i == path_index else field[i] for i in range(len(field))]
+                    [basename(field[path_index]) if i == path_index else field[i] for i in range(len(field))]
                     for field in element_view["fields"]
                 ]
         return ToolDataDetails.model_construct(**element_view)

--- a/lib/galaxy/webapps/galaxy/api/tool_data.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_data.py
@@ -85,7 +85,7 @@ class FastAPIToolData:
 
     @router.get(
         "/api/tool_data/{table_name}",
-        summary="Get details of a data table. For non-administrators, base directories in the path column are masked as '/.../'.",
+        summary="Get details of a data table. For non-administrators, base directories in the path column are stripped, leaving only the basename.",
         response_description="A description of the given data table and its content.",
         public=True,
     )

--- a/lib/galaxy/webapps/galaxy/api/tool_data.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_data.py
@@ -10,6 +10,7 @@ from pydantic import (
 )
 
 from galaxy.celery.tasks import import_data_bundle
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.tool_data import ToolDataManager
 from galaxy.schema.schema import (
     AsyncTaskResultSummary,
@@ -25,6 +26,7 @@ from galaxy.webapps.base.api import GalaxyFileResponse
 from galaxy.webapps.galaxy.services.base import async_task_summary
 from . import (
     depends,
+    DependsOnTrans,
     Router,
 )
 
@@ -41,6 +43,12 @@ ToolDataTableFieldName = Path(
     ...,  # Mark this field as required
     title="Field name",
     description="The name of the tool data table field",
+)
+
+ToolDataTableFieldFileName = Path(
+    ...,
+    title="File name",
+    description="The name of a file associated with this data table field",
 )
 
 
@@ -77,13 +85,15 @@ class FastAPIToolData:
 
     @router.get(
         "/api/tool_data/{table_name}",
-        summary="Get details of a given data table",
-        response_description="A description of the given data table and its content",
-        require_admin=True,
+        summary="Get details of a data table. For non-administrators, base directories in the path column are masked as '/.../'.",
+        response_description="A description of the given data table and its content.",
+        public=True,
     )
-    async def show(self, table_name: str = ToolDataTableName) -> ToolDataDetails:
+    async def show(
+        self, trans: ProvidesUserContext = DependsOnTrans, table_name: str = ToolDataTableName
+    ) -> ToolDataDetails:
         """Get details of a given tool data table."""
-        return self.tool_data_manager.show(table_name)
+        return self.tool_data_manager.show(trans, table_name)
 
     @router.get(
         "/api/tool_data/{table_name}/reload",
@@ -106,28 +116,25 @@ class FastAPIToolData:
         table_name: str = ToolDataTableName,
         field_name: str = ToolDataTableFieldName,
     ) -> ToolDataField:
-        """Reloads a data table and return its details."""
+        """Displays information about a data table field."""
         return self.tool_data_manager.show_field(table_name, field_name)
 
     @router.get(
         "/api/tool_data/{table_name}/fields/{field_name}/files/{file_name}",
-        summary="Get information about a particular field in a tool data table",
-        response_description="Information about a data table field",
+        summary="Get files associated with a particular field in a tool data table",
+        response_description="Request file associated with tool data table entry",
         response_class=GalaxyFileResponse,
-        require_admin=True,
+        public=True,
     )
     def download_field_file(
         self,
+        trans: ProvidesUserContext = DependsOnTrans,
         table_name: str = ToolDataTableName,
         field_name: str = ToolDataTableFieldName,
-        file_name: str = Path(
-            ...,  # Mark this field as required
-            title="File name",
-            description="The name of a file associated with this data table field",
-        ),
+        file_name: str = ToolDataTableFieldFileName,
     ):
         """Download a file associated with the data table field."""
-        path = self.tool_data_manager.get_field_file_path(table_name, field_name, file_name)
+        path = self.tool_data_manager.get_field_file_path(trans, table_name, field_name, file_name)
         return GalaxyFileResponse(str(path))
 
     @router.delete(

--- a/lib/galaxy_test/api/test_tool_data.py
+++ b/lib/galaxy_test/api/test_tool_data.py
@@ -41,7 +41,7 @@ class TestToolDataApi(ApiTestCase):
         first_entry = data_table["fields"][0]
         assert first_entry[0] == "data1"
         assert first_entry[1] == "data1name"
-        assert first_entry[2].endswith("/.../entry.txt")
+        assert first_entry[2].endswith("entry.txt")
 
     def test_show_field(self):
         show_field_response = self._get("tool_data/testalpha/fields/data1", admin=True)

--- a/lib/galaxy_test/api/test_tool_data.py
+++ b/lib/galaxy_test/api/test_tool_data.py
@@ -41,7 +41,7 @@ class TestToolDataApi(ApiTestCase):
         first_entry = data_table["fields"][0]
         assert first_entry[0] == "data1"
         assert first_entry[1] == "data1name"
-        assert first_entry[2].endswith("entry.txt")
+        assert first_entry[2] == "entry.txt"
 
     def test_show_field(self):
         show_field_response = self._get("tool_data/testalpha/fields/data1", admin=True)

--- a/lib/galaxy_test/api/test_tool_data.py
+++ b/lib/galaxy_test/api/test_tool_data.py
@@ -26,13 +26,22 @@ class TestToolDataApi(ApiTestCase):
     def test_show(self):
         show_response = self._get("tool_data/testalpha", admin=True)
         self._assert_status_code_is(show_response, 200)
-        print(show_response.content)
         data_table = show_response.json()
         assert data_table["columns"] == ["value", "name", "path"]
         first_entry = data_table["fields"][0]
         assert first_entry[0] == "data1"
         assert first_entry[1] == "data1name"
         assert first_entry[2].endswith("test/functional/tool-data/data1/entry.txt")
+
+    def test_show_anon(self):
+        show_response = self._get("tool_data/testalpha")
+        self._assert_status_code_is(show_response, 200)
+        data_table = show_response.json()
+        assert data_table["columns"] == ["value", "name", "path"]
+        first_entry = data_table["fields"][0]
+        assert first_entry[0] == "data1"
+        assert first_entry[1] == "data1name"
+        assert first_entry[2].endswith("/.../entry.txt")
 
     def test_show_field(self):
         show_field_response = self._get("tool_data/testalpha/fields/data1", admin=True)
@@ -47,6 +56,14 @@ class TestToolDataApi(ApiTestCase):
         self._assert_status_code_is(show_field_response, 200)
         content = show_field_response.text
         assert content == "This is data 1.", content
+
+    def test_download_field_file_anon_raises_404(self):
+        show_field_response = self._get("tool_data/twobit/fields/data1/files/entry.txt")
+        self._assert_status_code_is(show_field_response, 404)
+
+    def test_download_field_file_anon_raises_403(self):
+        show_field_response = self._get("tool_data/testalpha/fields/data1/files/entry.txt")
+        self._assert_status_code_is(show_field_response, 403)
 
     def test_reload(self):
         show_response = self._get("tool_data/test_fasta_indexes/reload", admin=True)

--- a/lib/galaxy_test/api/test_tool_data.py
+++ b/lib/galaxy_test/api/test_tool_data.py
@@ -19,7 +19,6 @@ class TestToolDataApi(ApiTestCase):
     def test_list(self):
         index_response = self._get("tool_data", admin=True)
         self._assert_status_code_is(index_response, 200)
-        print(index_response.content)
         index = index_response.json()
         assert "testalpha" in [operator.itemgetter("name")(_) for _ in index]
 
@@ -60,15 +59,18 @@ class TestToolDataApi(ApiTestCase):
     def test_download_field_file_anon_raises_404(self):
         show_field_response = self._get("tool_data/twobit/fields/data1/files/entry.txt")
         self._assert_status_code_is(show_field_response, 404)
+        err_msg = show_field_response.json()["err_msg"]
+        assert err_msg == "No such field data1 in data table twobit."
 
     def test_download_field_file_anon_raises_403(self):
         show_field_response = self._get("tool_data/testalpha/fields/data1/files/entry.txt")
         self._assert_status_code_is(show_field_response, 403)
+        err_msg = show_field_response.json()["err_msg"]
+        assert err_msg == "Only administrators can download files from data table testalpha."
 
     def test_reload(self):
         show_response = self._get("tool_data/test_fasta_indexes/reload", admin=True)
         self._assert_status_code_is(show_response, 200)
-        print(show_response.content)
         data_table = show_response.json()
         assert data_table["columns"] == ["value", "dbkey", "name", "path"]
 


### PR DESCRIPTION
This PR relaxes the admin requirement for the tool_data endpoint.

It makes the following two GET routes accessible to all users:

1. /api/tool_data/{table_name}
Base path is stripped for anonymous users

2. /api/tool_data/{table_name}/fields/{field_name}/files/{file_name}
File downloads are limited to the tables `fasta_indexes` and `twobit`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
