### PR TITLE
Allow specifying a command for determining a docker host port

### DIFF
--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -503,6 +503,11 @@ execution:
       # Following command can be used to tweak docker command.
       #docker_cmd: /usr/local/custom_docker/docker
 
+      # Docker containers that expose ports (e.g. Interactive Tools) can
+      # optionally use a command to determine the host port that is exposed. By
+      # default, one is chosen at random (docker run -p <guest_port> ...).
+      #docker_host_port_cmd:
+
       # Following can be used to connect to docker server in different
       # ways (translated as -H argument to docker client).
       #docker_host: unix:///var/run/docker.sock

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -481,6 +481,7 @@ class DockerContainer(Container, HasDockerLikeVolumes):
             set_user=self.prop("set_user", docker_util.DEFAULT_SET_USER),
             run_extra_arguments=self.prop("run_extra_arguments", docker_util.DEFAULT_RUN_EXTRA_ARGUMENTS),
             guest_ports=self.tool_info.guest_ports,
+            host_port_cmd=self.prop("host_port_cmd", None),
             container_name=self.container_name,
             **docker_host_props,
         )

--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -111,6 +111,7 @@ def build_docker_run_command(
     set_user: Optional[str] = DEFAULT_SET_USER,
     host: Optional[str] = DEFAULT_HOST,
     guest_ports: Union[bool, str, List[str]] = False,
+    host_port_cmd: Optional[str] = None,
     container_name: Optional[str] = None,
 ) -> str:
     env_directives = env_directives or []
@@ -129,10 +130,14 @@ def build_docker_run_command(
         # When is True, expose all ports
         command_parts.append("-P")
     elif guest_ports:
+        if host_port_cmd:
+            host_port_cmd = f"$({host_port_cmd}):"
+        else:
+            host_port_cmd = ""
         if not isinstance(guest_ports, list):
             guest_ports = [guest_ports]
         for guest_port in guest_ports:
-            command_parts.extend(["-p", guest_port])
+            command_parts.extend(["-p", f"{host_port_cmd}{guest_port}"])
     if container_name:
         command_parts.extend(["--name", container_name])
     for volume in volumes:


### PR DESCRIPTION
I have an environment where I need to restrict what host ports are selected when running GxITs. The Docker daemon offers no solution for this, when not specified ports are chosen from the range specified by the system-wide `ip_local_port_range` kernel parameter. This PR adds a `docker_host_port_cmd` which can be used to run something that returns a free port, e.g.:

```bash
#!/bin/bash

START=32768
END=32968

for port in $(seq $START $END); do
    if ! ss -ltn 2>/dev/null | awk '{print $4}' | grep -q ":$port\$"; then
        echo $port
        exit 0
    fi
done

echo "No free ports found in range $START-$END" >&2
exit 1
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Enable GxITs and verify functionality
  2. Set `docker_host_port_cmd` to e.g. `echo 11234`
  3. Run a GxIT and verify host port is 11234

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
