### PR TITLE
Track landing request with invocation

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6986,6 +6986,8 @@ export interface components {
             files?: string[] | null;
             /** History Id */
             history_id: unknown;
+            /** Landing Uuid */
+            landing_uuid?: unknown;
             /** Targets */
             targets: unknown;
         };
@@ -11025,6 +11027,8 @@ export interface components {
              * @example 0123456789ABCDEF
              */
             history_id: string;
+            /** Landing Uuid */
+            landing_uuid?: string | null;
             /** Targets */
             targets: (
                 | components["schemas"]["DataElementsTarget"]
@@ -15327,6 +15331,11 @@ export interface components {
              * @default false
              */
             instance: boolean | null;
+            /**
+             * Landing UUID
+             * @description The UUID of the workflow landing request associated with this invocation.
+             */
+            landing_uuid?: string | null;
             /**
              * Legacy
              * @description Indicating if to use legacy workflow invocation.
@@ -22816,6 +22825,11 @@ export interface components {
              */
             id: string;
             /**
+             * Landing UUID
+             * @description The UUID of the workflow landing request associated with this invocation.
+             */
+            landing_uuid?: string | null;
+            /**
              * Model class
              * @description The name of the database model class.
              * @constant
@@ -22878,6 +22892,11 @@ export interface components {
             inputs: {
                 [key: string]: components["schemas"]["InvocationInput"];
             };
+            /**
+             * Landing UUID
+             * @description The UUID of the workflow landing request associated with this invocation.
+             */
+            landing_uuid?: string | null;
             /**
              * Messages
              * @description A list of messages about why the invocation did not succeed.

--- a/client/src/components/Landing/FetchLanding.vue
+++ b/client/src/components/Landing/FetchLanding.vue
@@ -16,6 +16,7 @@ const { currentHistoryId } = storeToRefs(useHistoryStore());
 
 interface Props {
     targets: FetchTargets;
+    landingUuid?: string;
 }
 
 const props = defineProps<Props>();
@@ -41,6 +42,7 @@ async function onExecute() {
     fetchAndWatch({
         targets: request,
         history_id: historyId,
+        landing_uuid: props.landingUuid,
     });
 }
 

--- a/client/src/components/Landing/ToolLanding.vue
+++ b/client/src/components/Landing/ToolLanding.vue
@@ -57,7 +57,7 @@ const fetchTargets = computed<FetchTargets | null>(() => {
             <LoadingSpan message="Loading tool parameters" />
         </div>
         <div v-else-if="claimState.toolId == '__DATA_FETCH__' && fetchTargets" class="h-100">
-            <FetchLanding :targets="fetchTargets" />
+            <FetchLanding :targets="fetchTargets" :landing-uuid="props.uuid" />
         </div>
         <div v-else>
             {{ claimState.requestState }}

--- a/client/src/components/Landing/WorkflowLanding.vue
+++ b/client/src/components/Landing/WorkflowLanding.vue
@@ -46,7 +46,8 @@ claimWorkflow(props.uuid, props.public, props.secret).then(() => {
                 :workflow-id="claimState.workflowId"
                 :prefer-simple-form="true"
                 :request-state="claimState.requestState ?? undefined"
-                :instance="claimState.instance" />
+                :instance="claimState.instance"
+                :landing-uuid="props.uuid" />
         </div>
     </div>
 </template>

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -36,6 +36,7 @@ interface Props {
     requestState?: WorkflowInvocationRequestInputs;
     instance?: boolean;
     isRerun?: boolean;
+    landingUuid?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -46,6 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
     requestState: undefined,
     instance: false,
     isRerun: false,
+    landingUuid: undefined,
 });
 
 const loading = ref(true);
@@ -259,6 +261,7 @@ defineExpose({
                         :can-mutate-current-history="canRunOnHistory"
                         :request-state="requestState"
                         :is-rerun="props.isRerun"
+                        :landing-uuid="props.landingUuid"
                         @submissionSuccess="handleInvocations"
                         @submissionError="handleSubmissionError"
                         @showAdvanced="showAdvanced" />

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -39,6 +39,7 @@ interface Props {
     canMutateCurrentHistory: boolean;
     requestState?: WorkflowInvocationRequestInputs;
     isRerun?: boolean;
+    landingUuid?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -46,6 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
     useJobCache: false,
     requestState: undefined,
     isRerun: false,
+    landingUuid: undefined,
 });
 
 const emit = defineEmits<{
@@ -299,6 +301,9 @@ async function onExecute() {
         require_exact_tool_versions: false,
         version: props.model.runData.version,
     };
+    if (props.landingUuid) {
+        data.landing_uuid = props.landingUuid;
+    }
     if (sendToNewHistory.value) {
         data.new_history_name = props.model.name;
     } else {

--- a/client/src/stores/workflowLandingStore.ts
+++ b/client/src/stores/workflowLandingStore.ts
@@ -9,6 +9,7 @@ interface ClaimState {
     instance: boolean;
     requestState: { [key: string]: unknown } | null;
     errorMessage: string | null;
+    landingUuid: string | null;
 }
 
 export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
@@ -17,6 +18,7 @@ export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
         instance: false,
         requestState: null,
         errorMessage: null,
+        landingUuid: null,
     });
 
     async function claimWorkflow(uuid: string, isPublic: boolean, secret?: string) {
@@ -50,6 +52,7 @@ export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
                 instance: claim.workflow_target_type === "workflow",
                 requestState: claim.request_state,
                 errorMessage: null,
+                landingUuid: uuid,
             };
         } else {
             claimState.value = {
@@ -57,6 +60,7 @@ export const useWorkflowLandingStore = defineStore("workflowLanding", () => {
                 instance: false,
                 requestState: null,
                 errorMessage: errorMessageAsString(claimError),
+                landingUuid: null,
             };
         }
     }

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/e382f8eb5e12_create_landing_request_association_tables.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/e382f8eb5e12_create_landing_request_association_tables.py
@@ -1,0 +1,48 @@
+"""Create landing request association tables
+
+Revision ID: e382f8eb5e12
+Revises: 81362686fd64
+Create Date: 2025-09-26 12:39:25.000000
+
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import (
+    create_table,
+    drop_table,
+)
+
+# revision identifiers, used by Alembic.
+revision = "e382f8eb5e12"
+down_revision = "81362686fd64"
+branch_labels = None
+depends_on = None
+
+# database object names used in this revision
+workflow_association_table = "landing_request_to_workflow_invocation_association"
+tool_association_table = "landing_request_to_tool_request_association"
+
+
+def upgrade():
+    # Create landing_request_to_workflow_invocation_association table
+    create_table(
+        workflow_association_table,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("landing_request_id", sa.Integer, sa.ForeignKey("workflow_landing_request.id"), nullable=False),
+        sa.Column("workflow_invocation_id", sa.Integer, sa.ForeignKey("workflow_invocation.id"), nullable=False),
+    )
+
+    # Create landing_request_to_tool_request_association table
+    create_table(
+        tool_association_table,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("landing_request_id", sa.Integer, sa.ForeignKey("tool_landing_request.id"), nullable=False),
+        sa.Column("tool_request_id", sa.Integer, sa.ForeignKey("tool_request.id"), nullable=False),
+    )
+
+
+def downgrade():
+    # Drop both association tables
+    drop_table(workflow_association_table)
+    drop_table(tool_association_table)

--- a/lib/galaxy/schema/fetch_data.py
+++ b/lib/galaxy/schema/fetch_data.py
@@ -15,6 +15,7 @@ from pydantic import (
     HttpUrl,
     Json,
     TypeAdapter,
+    UUID4,
 )
 from typing_extensions import Literal
 
@@ -270,6 +271,7 @@ class FilesPayload(Model):
 class BaseDataPayload(FetchBaseModel):
     history_id: DecodedDatabaseIdField
     model_config = ConfigDict(extra="allow")
+    landing_uuid: Optional[UUID4] = None
 
     @field_validator("targets", mode="before", check_fields=False)
     @classmethod

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -591,6 +591,11 @@ class WorkflowInvocationCollectionView(Model, WithModelClass):
         default=None, title="UUID", description="Universal unique identifier of the workflow invocation."
     )
     state: InvocationState = Field(default=..., title="Invocation state", description="State of workflow invocation.")
+    landing_uuid: Optional[UUID4] = Field(
+        default=None,
+        title="Landing UUID",
+        description="The UUID of the workflow landing request associated with this invocation.",
+    )
     model_class: INVOCATION_MODEL_CLASS = ModelClassField(INVOCATION_MODEL_CLASS)
 
 

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -10,6 +10,7 @@ from pydantic import (
     AfterValidator,
     Field,
     field_validator,
+    UUID4,
 )
 
 from galaxy.schema.schema import (
@@ -137,6 +138,11 @@ class InvokeWorkflowPayload(GetTargetHistoryPayload):
         False,
         title="Allow tool state corrections",
         description="Indicates if tool state corrections are allowed for workflow invocation.",
+    )
+    landing_uuid: Optional[UUID4] = Field(
+        None,
+        title="Landing UUID",
+        description="The UUID of the workflow landing request associated with this invocation.",
     )
     use_cached_job: Optional[bool] = UseCachedJobField
     parameters_normalized: Optional[bool] = Field(


### PR DESCRIPTION
Contains stub for tool request tracking, once that is merged we could start using it.

Works nicely with a local iwc site

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
