### PR TITLE
Use nodejs-wheel to install node

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -54,11 +54,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -51,9 +51,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -37,11 +37,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - name: Clone galaxyproject/galaxy-test-data
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -34,9 +34,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - name: Clone galaxyproject/galaxy-test-data
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -46,11 +46,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -43,9 +43,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -37,11 +37,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -34,9 +34,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -49,11 +49,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -46,9 +46,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -47,9 +47,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -50,11 +50,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -55,9 +55,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -58,11 +58,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -68,9 +68,6 @@ jobs:
         with:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration-selenium
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - name: Restore client cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -71,11 +71,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - name: Restore client cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -39,9 +39,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -42,11 +42,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -35,11 +35,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - name: Cache pip dir
         uses: actions/cache@v4
         with:

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -32,9 +32,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v4
         with:

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -48,11 +48,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -45,9 +45,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -29,9 +29,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -32,11 +32,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -57,11 +57,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -54,9 +54,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -27,11 +27,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -24,9 +24,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -40,9 +40,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -43,11 +43,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -39,9 +39,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -42,11 +42,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -31,11 +31,6 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
-        with:
-          node-version: ${{ steps.node-version.outputs.version }}
-          cache: 'yarn'
-          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -28,9 +28,6 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Read Node.js version
-        id: node-version
-        run: echo "version=$(cat 'galaxy root/client/.node_version')" >> $GITHUB_OUTPUT
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -180,19 +180,15 @@ skip-client: ## Run only the server, skipping the client build.
 
 node-deps: ## Install NodeJS dependencies.
 ifndef YARN
-	@echo $(NO_YARN_MSG)
-	false;
-else
-	$(IN_VENV) yarn install $(YARN_INSTALL_OPTS)
+	npm install -g yarn;
 endif
+	$(IN_VENV) yarn install $(YARN_INSTALL_OPTS)
 
 client-node-deps: ## Install NodeJS dependencies for the client.
 ifndef YARN
-	@echo $(NO_YARN_MSG)
-	false;
-else
-	$(IN_VENV) cd client && yarn install $(YARN_INSTALL_OPTS)
+	npm install -g yarn;
 endif
+	$(IN_VENV) cd client && yarn install $(YARN_INSTALL_OPTS)
 
 format-xsd:
 	xmllint --format --output galaxy-tmp.xsd lib/galaxy/tool_util/xsd/galaxy.xsd

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -124,7 +124,7 @@ mypy-extensions==1.1.0
 networkx==3.2.1 ; python_full_version < '3.10'
 networkx==3.4.2 ; python_full_version == '3.10.*'
 networkx==3.5 ; python_full_version >= '3.11'
-nodeenv==1.9.1
+nodejs-wheel==22.13.0
 numpy==2.0.2 ; python_full_version < '3.10'
 numpy==2.2.6 ; python_full_version == '3.10.*'
 numpy==2.3.3 ; python_full_version >= '3.11'

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     Markdown
     MarkupSafe
     mercurial>=6.8.2
-    nodejs-wheel==22.13.0
+    nodejs-wheel>=22,<23
     packaging
     paramiko!=2.9.0,!=2.9.1
     pebble

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     Markdown
     MarkupSafe
     mercurial>=6.8.2
+    nodejs-wheel==22.13.0
     packaging
     paramiko!=2.9.0,!=2.9.1
     pebble

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "mercurial>=6.8.2",  # Python 3.13 support
     "mrcfile",
     "msal",
-    "nodejs-wheel==22.13.0",  # track client/.node_version
+    "nodejs-wheel==22",
     "numpy>=1.26.0",  # Python 3.12 support
     "numpy>=2.1.0 ; python_version>='3.10'",  # Python 3.13 support
     "openpyxl>=3.1.5",  # Minimum version ever tested with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "mercurial>=6.8.2",  # Python 3.13 support
     "mrcfile",
     "msal",
-    "nodeenv",
+    "nodejs-wheel==22.13.0",  # track client/.node_version
     "numpy>=1.26.0",  # Python 3.12 support
     "numpy>=2.1.0 ; python_version>='3.10'",  # Python 3.13 support
     "openpyxl>=3.1.5",  # Minimum version ever tested with

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -10,9 +10,7 @@ CREATE_VENV=1
 COPY_SAMPLE_FILES=1
 SET_VENV=1
 SKIP_CLIENT_BUILD=${GALAXY_SKIP_CLIENT_BUILD:-0}
-SKIP_NODE=${GALAXY_SKIP_NODE:-0}
 INSTALL_PREBUILT_CLIENT=${GALAXY_INSTALL_PREBUILT_CLIENT:-0}
-NODE_VERSION=${GALAXY_NODE_VERSION:-"$(cat client/.node_version)"}
 : "${YARN_INSTALL_OPTS:=--network-timeout 300000 --check-files}"
 : "${GALAXY_CONDA_PYTHON_VERSION:=3.9}"
 
@@ -28,7 +26,6 @@ for arg in "$@"; do
     [ "$arg" = "--stop-daemon" ] && FETCH_WHEELS=0
     [ "$arg" = "--skip-samples" ] && COPY_SAMPLE_FILES=0
     [ "$arg" = "--skip-client-build" ] && SKIP_CLIENT_BUILD=1
-    [ "$arg" = "--skip-node" ] && SKIP_NODE=1
 done
 
 SAMPLES="
@@ -195,23 +192,6 @@ if [ $FETCH_WHEELS -eq 1 ]; then
             pip uninstall -y psycopg2 psycopg2-binary
         fi
         echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url "${GALAXY_WHEELS_INDEX_URL}" --extra-index-url "${PYPI_INDEX_URL}"
-    fi
-fi
-
-# Install node if not installed
-if [ $SKIP_NODE -eq 0 ]; then
-    if ! command -v node >/dev/null || [ "$(node --version)" != "v${NODE_VERSION}" ]; then
-        if [ -n "$CONDA_DEFAULT_ENV" ] && [ -n "$CONDA_EXE" ]; then
-            echo "Installing node into '$CONDA_DEFAULT_ENV' Conda environment with conda."
-            $CONDA_EXE install --yes --override-channels --channel conda-forge --name "$CONDA_DEFAULT_ENV" nodejs="$NODE_VERSION"
-        elif [ -n "$VIRTUAL_ENV" ]; then
-            echo "Installing node into $VIRTUAL_ENV with nodeenv."
-            if [ -d "${VIRTUAL_ENV}/lib/node_modules" ]; then
-                echo "Removing old ${VIRTUAL_ENV}/lib/node_modules directory."
-                rm -rf "${VIRTUAL_ENV}/lib/node_modules"
-            fi
-            nodeenv -n "$NODE_VERSION" -p
-        fi
     fi
 fi
 


### PR DESCRIPTION
nodeenv has various issues like https://github.com/ekalinin/nodeenv/pull/388, and fetching the node installation via pypi seems easier for packaged galaxy as well.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
