### PR TITLE
Log task execution errors with log.exception

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -185,7 +185,7 @@ def galaxy_task(*args, action=None, **celery_task_kwd):
                 log.info(message)
                 return rval
             except Exception:
-                log.warning(f"Celery task execution failed for {desc} {timer}")
+                log.exception(f"Celery task execution failed for {desc} {timer} {args}, {kwds}")
                 raise
             finally:
                 # Close and remove any open session this task has created


### PR DESCRIPTION
Gives us much more informative errors, like
```
galaxy.celery ERROR 2025-09-29 11:34:34,547 [pN:main,p:13126,tN:Thread-9 (start)] Celery task execution failed for queue_jobs to queuing up submitted jobs queue_jobs to queuing up submitted jobs (3.958 ms) (), {'request': QueueJobs(tool_source=ToolSource(raw_tool_source='{"class": "GalaxyUserTool", "id": "cat_user_defined", "version": "0.1", "name": "cat_user_defined", "description": "concatenates a file", "container": "busybox", "shell_command": "cat \'$(inputs.input1.path)\' > output.txt", "inputs": [{"name": "input1", "type": "data", "format": "txt"}], "outputs": [{"name": "output1", "type": "data", "format": "txt", "from_work_dir": "output.txt"}], "tests": [{"inputs": [], "outputs": [{"name": "output1", "value": "simple_line.txt", "attributes": {"extra_files": [], "metadata": {}, "assert_list": null, "compare": "diff", "lines_diff": 0, "delta": 10000, "delta_frac": null, "sort": false, "decompress": false}}], "output_collections": [], "command": null, "stdout": null, "stderr": null, "expect_exit_code": null, "expect_failure": false, "expect_test_failure": false}]}', tool_dir='/Users/mvandenb/src/galaxy/test/functional/tools', tool_source_class='YamlToolSource'), tool_request_id=1, user=RequestUser(user_id=2), use_cached_jobs=False, rerun_remap_job_id=None)}
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/lagom/wrapping.py", line 46, in _error_handling_func
    return func(*args, **kwargs)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/celery/tasks.py", line 354, in queue_jobs
    tool = cached_create_tool_from_representation(
        app=app,
    ...<2 lines>...
        tool_source_class=request.tool_source.tool_source_class,
    )
  File "/Users/mvandenb/src/galaxy/lib/galaxy/celery/tasks.py", line 89, in cached_create_tool_from_representation
    return create_tool_from_representation(
        app=app, raw_tool_source=raw_tool_source, tool_dir=tool_dir, tool_source_class=tool_source_class
    )
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 446, in create_tool_from_representation
    return create_tool_from_source(app, tool_source=tool_source, tool_dir=tool_dir)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 421, in create_tool_from_source
    return UserDefinedTool(config_file, tool_source, app, **kwds)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 1095, in __init__
    raise e
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 1092, in __init__
    self.parse(tool_source, guid=guid, dynamic=dynamic)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 1436, in parse
    self.parse_tests()
    ~~~~~~~~~~~~~~~~^^
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 1580, in parse_tests
    test_descriptions = parse_tool_test_descriptions(self.tool_source, self.id)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/verify/parse.py", line 68, in parse_tool_test_descriptions
    raw_tests_dict: ToolSourceTests = tool_source.parse_tests_to_dict()
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/parser/yaml.py", line 252, in parse_tests_to_dict
    tests.append(_parse_test(i, test_dict))
                 ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/parser/yaml.py", line 324, in _parse_test
    test_dict["command"] = __to_test_assert_list(test_dict.get("command", []))
                           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/parser/yaml.py", line 346, in to_test_assert_list
    for assertion in assertions:
                     ^^^^^^^^^^
TypeError: 'NoneType' object is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/celery/__init__.py", line 183, in wrapper
    rval = app.magic_partial(func)(*args, **kwds)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/lagom/wrapping.py", line 29, in _bound_func
    return inner_func(*bound_args, **bound_kwargs)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/lagom/wrapping.py", line 54, in _error_handling_func
    raise UnableToInvokeBoundFunction(str(error), unresolvable_deps)
lagom.exceptions.UnableToInvokeBoundFunction: 'NoneType' object is not iterable. The container could not construct the following types:
celery.app.trace ERROR 2025-09-29 11:34:34,557 [pN:main,p:13126,tN:Thread-9 (start)] Task galaxy.celery.tasks.queue_jobs[0309192e-c36e-4fa4-ab0d-a9a3fdc1a3e3] raised unexpected: TypeError("'NoneType' object is not iterable. The container could not construct the following types: ")
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
                 ~~~^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/lib/galaxy/celery/__init__.py", line 183, in wrapper
    rval = app.magic_partial(func)(*args, **kwds)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/lagom/wrapping.py", line 29, in _bound_func
    return inner_func(*bound_args, **bound_kwargs)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/lagom/wrapping.py", line 54, in _error_handling_func
    raise UnableToInvokeBoundFunction(str(error), unresolvable_deps)
TypeError: 'NoneType' object is not iterable. The container could not construct the following types:
```

Instead of just
```
lagom.exceptions.UnableToInvokeBoundFunction: 'NoneType' object is not iterable. The container could not construct the following types:
celery.app.trace ERROR 2025-09-29 11:34:34,557 [pN:main,p:13126,tN:Thread-9 (start)] Task galaxy.celery.tasks.queue_jobs[0309192e-c36e-4fa4-ab0d-a9a3fdc1a3e3] raised unexpected: TypeError("'NoneType' object is not iterable. The container could not construct the following types: ")
```

Alternative to #20969 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
