### PR TITLE
Fix JupyterLite History Identifier Retrieval Without Dataset

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -38,7 +38,7 @@ heatmap:
     version: 0.0.15
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
-    version: 0.0.16
+    version: 0.0.17
 kepler:
     package: "@galaxyproject/kepler"
     version: 0.0.3


### PR DESCRIPTION
This PR updates the history identifier retrieval logic in JupyterLite to handle cases where a notebook is opened without an associated dataset. Previously, this resulted in an undefined history id in the `gxy` environment. The changes ensure that the history ID is correctly determined or gracefully defaults, improving the user experience when working with standalone notebooks.

See https://github.com/galaxyproject/galaxy-visualizations/pull/101 for more details

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

1. Create a JupyterLite notebook without a dataset
2. Execute:
```
import gxy
print(gxy.get_environment())
```
3. Note that it properly populated the current history

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
