### PR TITLE
Apply overscroll behavior setting to html

### DIFF
--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -60,9 +60,13 @@ $fa-font-path: "../../../node_modules/@fortawesome/fontawesome-free/webfonts/";
 }
 
 // ==== Basic styles ====
+html,
+body {
+    overscroll-behavior: none;
+}
+
 body {
     @extend .m-2;
-    overscroll-behavior: none;
 }
 
 .unselectable {


### PR DESCRIPTION
Turns out #20908 is not sufficient for Firefox. It is recommended to apply the overscroll behavior to html and body.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
