### PR TITLE
[24.2] Fix ``test_multiple_decorators`` unit test for FastAPI 0.118.0

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: medyagh/setup-minikube@latest
         with:
           driver: none
-          kubernetes-version: '1.23.0'
+          kubernetes-version: '1.28.0'
       - name: Check pods
         run: kubectl get pods -A
       - uses: actions/checkout@v4

--- a/test/unit/webapps/api/test_cbv.py
+++ b/test/unit/webapps/api/test_cbv.py
@@ -70,12 +70,14 @@ def test_method_order_preserved() -> None:
 
     app = FastAPI()
     app.include_router(router)
+    client = TestClient(app)
 
-    assert TestClient(app).get("/test").json() == 1
-    assert TestClient(app).get("/other").json() == 2
+    assert client.get("/test").json() == 1
+    assert client.get("/other").json() == 2
 
 
 def test_multiple_decorators() -> None:
+    app = FastAPI()
     router = APIRouter()
 
     @cbv(router)
@@ -90,7 +92,9 @@ def test_multiple_decorators() -> None:
                 return {"item_query": item_query}
             return []
 
-    client = TestClient(router)
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
 
     assert client.get("/items").json() == []
     assert client.get("/items/1").json() == {"item_path": "1"}


### PR DESCRIPTION
Fix the following error in test_galaxy_packages (which started using the new FastAPI 0.118.0):

FAILED tests/webapps/api/test_cbv.py::test_multiple_decorators - AssertionError: fastapi_middleware_astack not found in request scope

xref. https://github.com/fastapi/fastapi/issues/14128

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
