### PR TITLE
Simplify plugin staging with explicit clean step

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const fs = require("fs-extra");
-const del = require("del");
 const { parallel, series } = require("gulp");
 const child_process = require("child_process");
 const { globSync } = require("glob");
@@ -51,7 +50,7 @@ function stageLibs(callback) {
             const p1 = path.resolve(path.join(PATHS.nodeModules, lib, PATHS.stagedLibraries[lib][0]));
             const p2 = path.resolve(path.join("src", "libs", PATHS.stagedLibraries[lib][1]));
             if (fs.existsSync(p1)) {
-                del.sync(p2);
+                fs.removeSync(p2);
                 fs.createReadStream(p1).pipe(fs.createWriteStream(p2));
             } else {
                 throw new Error(

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -69,22 +69,29 @@ async function icons() {
     await buildIcons("./src/assets/icons.json");
 }
 
+function cleanPlugins(callback) {
+    if (SKIP_VIZ) {
+        console.log("Skipping plugin cleanup (SKIP_VIZ is set)");
+        return callback();
+    }
+
+    const vizStagingDir = path.join(staticPluginDir, "visualizations");
+    console.log(`Cleaning visualization staging directory: ${vizStagingDir}`);
+    fs.removeSync(vizStagingDir);
+    callback();
+}
+
 function stagePlugins(callback) {
     if (SKIP_VIZ) {
         console.log("Skipping plugin staging (SKIP_VIZ is set)");
         return callback();
     }
 
-    fs.ensureDirSync(path.join(staticPluginDir));
+    fs.ensureDirSync(path.join(staticPluginDir, "visualizations"));
 
     // Get visualization directories
-    const visualizationDirs = [
-        path.join(PATHS.pluginBaseDir, "visualizations/*/static"),
-        path.join(PATHS.pluginBaseDir, "visualizations/*/*/static"),
-    ];
-
-    // Flatten the glob patterns to actual directory paths
-    const dirs = [...globSync(visualizationDirs)];
+    const visualizationDirs = path.join(PATHS.pluginBaseDir, "visualizations/*/static");
+    const dirs = globSync(visualizationDirs);
 
     // Process each directory
     const copyPromises = dirs.map((sourceDir) => {
@@ -201,11 +208,12 @@ function forceInstallVisualizations(callback) {
 }
 
 const client = parallel(stageLibs, icons);
-const plugins = series(installVisualizations, stagePlugins);
-const pluginsRebuild = series(forceInstallVisualizations, stagePlugins);
+const plugins = series(installVisualizations, cleanPlugins, stagePlugins);
+const pluginsRebuild = series(forceInstallVisualizations, cleanPlugins, stagePlugins);
 
 module.exports.client = client;
 module.exports.plugins = plugins;
 module.exports.default = parallel(client, plugins);
 module.exports.installVisualizations = installVisualizations;
+module.exports.cleanPlugins = cleanPlugins;
 module.exports.pluginsRebuild = pluginsRebuild;

--- a/client/package.json
+++ b/client/package.json
@@ -183,7 +183,6 @@
     "cpy-cli": "^5.0.0",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^5.0.1",
-    "del": "^6.0.0",
     "eslint": "^8.52.0",
     "eslint-plugin-compat": "^4.2.0",
     "eslint-plugin-import": "^2.28.1",


### PR DESCRIPTION
Adds a separate `cleanPlugins` gulp task that wipes the staging directory before copying, instead of diffing and selectively removing stale plugins. Simpler, more maintainable, follows standard build conventions.

Also removes the nested plugin glob pattern (no longer needed since jqplot/nvd3 removal) and drops the `del` dependency in favor of `fs-extra` which we already use.