### PR TITLE
Ensure that conversion_key is defined

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2042,14 +2042,13 @@ class DirectoryModelExportStore(ModelExportStore):
                 as_dict["extra_files_path"] = extra_files_path
             return
 
+        conversion = self.dataset_implicit_conversions.get(dataset)
+        conversion_key = self.serialization_options.get_identifier(self.security, conversion) if conversion else None
+
         if file_name:
             if not os.path.exists(dir_path):
                 os.makedirs(dir_path)
 
-            conversion = self.dataset_implicit_conversions.get(dataset)
-            conversion_key = (
-                self.serialization_options.get_identifier(self.security, conversion) if conversion else None
-            )
             target_filename = get_export_dataset_filename(
                 as_dict["name"], as_dict["extension"], as_dict["encoded_id"], conversion_key=conversion_key
             )


### PR DESCRIPTION
It seems to be possible that `file_name` is not available but `extra_files_path` is. We could either exclude the `extra_files_path` from serialization if the `file_name` is not available or at least ensure that `conversion_key` is unconditionally defined.

Throws:
`UnboundLocalError: local variable 'conversion_key' referenced before assignment`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
