### PR TITLE
Fix jest tests -- wait for async calls in grid list

### DIFF
--- a/client/src/components/Grid/GridList.test.js
+++ b/client/src/components/Grid/GridList.test.js
@@ -140,7 +140,7 @@ describe("GridList", () => {
         const wrapper = createTarget({
             gridConfig: testGrid,
         });
-        await wrapper.vm.$nextTick();
+        await flushPromises();
         for (const [fieldIndex, field] of Object.entries(testGrid.fields)) {
             expect(wrapper.find(`[data-description='grid header ${fieldIndex}']`).text()).toBe(field.title);
         }
@@ -150,7 +150,7 @@ describe("GridList", () => {
         const wrapper = createTarget({
             gridConfig: testGrid,
         });
-        await wrapper.vm.$nextTick();
+        await flushPromises();
         const dropdown = wrapper.find("[data-description='grid cell 0-2']");
         const dropdownItems = dropdown.findAll(".dropdown-item");
         expect(dropdownItems.at(0).text()).toBe("operation-title-1");
@@ -186,7 +186,7 @@ describe("GridList", () => {
             gridConfig: testGrid,
             limit: 2,
         });
-        await wrapper.vm.$nextTick();
+        await flushPromises();
         const pageLinks = wrapper.findAll(".page-link");
         await pageLinks.at(4).trigger("click");
         expect(wrapper.find("[data-description='grid cell 0-0']").text()).toBe("id-5");


### PR DESCRIPTION
This fixes the currently failing GridList tests -- one tick isn't enough!

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
