### PR TITLE
[25.0] Fix PUT /api/workflows for user defined tools

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2015,7 +2015,9 @@ class ToolModule(WorkflowModule):
         else:
             step.tool_version = self.tool_version
         if tool_uuid := getattr(self, "tool_uuid", None):
-            step.dynamic_tool = self.trans.app.dynamic_tool_manager.get_tool_by_uuid(tool_uuid)
+            tool = self.trans.app.toolbox.get_tool(tool_uuid=tool_uuid, user=self.trans.user)
+            if tool:
+                step.dynamic_tool = tool.dynamic_tool
         if not detached:
             for k, v in self.post_job_actions.items():
                 pja = self.__to_pja(k, v, step)


### PR DESCRIPTION
This was only working for admin dynamic uuid.
Fixes saving and export of workflows with user defined tools

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
