### PR TITLE
Move database revision tags to separate file

### DIFF
--- a/lib/galaxy/model/migrations/dbrevisions.py
+++ b/lib/galaxy/model/migrations/dbrevisions.py
@@ -1,0 +1,18 @@
+# Update this file with tags for each new release.
+# Note: the key should NOT be a prefix of an existing revision hash in alembic/versions_gxy/.
+# For example, if we have a hash 231xxxxxxxxx and use 231 as the key for release 23.1,
+# then using 231 as a partial revision identifier like `sh manage_db.sh upgrade 231`
+# will map to release 23.1 instead of revision 231xxxxxxxxx.
+
+REVISION_TAGS = {
+    "22.01": "base",
+    "22.05": "186d4835587b",
+    "23.0": "caa7742f7bca",
+    "23.1": "e93c5d0b47a9",
+    "23.2": "8a19186a6ee7",
+    "24.0": "55f02fd8ab6c",
+    "24.1": "04288b6a5b25",
+    "24.2": "a4c3ef999ab5",
+    "25.0": "c716ee82337b",
+    "25.1": "cd26484899fb",
+}

--- a/lib/galaxy/model/migrations/dbscript.py
+++ b/lib/galaxy/model/migrations/dbscript.py
@@ -10,6 +10,7 @@ from galaxy.model.migrations.base import (
     BaseDbScript,
     BaseParserBuilder,
 )
+from galaxy.model.migrations.dbrevisions import REVISION_TAGS
 from galaxy.model.migrations.scripts import (
     get_configuration,
     get_configuration_from_file,
@@ -23,34 +24,6 @@ CONFIG_FILE_ARG = "--galaxy-config"
 CONFIG_DIR_NAME = "config"
 GXY_CONFIG_PREFIX = "GALAXY_CONFIG_"
 TSI_CONFIG_PREFIX = "GALAXY_INSTALL_CONFIG_"
-
-# Update this dict with tags for each new release.
-# Note: the key should NOT be a prefix of an existing revision hash in alembic/versions_gxy/.
-# For example, if we have a hash 231xxxxxxxxx and use 231 as the key for release 23.1,
-# then using 231 as a partial revision identifier like `sh manage_db.sh upgrade 231`
-# will map to release 23.1 instead of revision 231xxxxxxxxx.
-REVISION_TAGS = {
-    "release_22.01": "base",
-    "22.01": "base",
-    "release_22.05": "186d4835587b",
-    "22.05": "186d4835587b",
-    "release_23.0": "caa7742f7bca",
-    "23.0": "caa7742f7bca",
-    "release_23.1": "e93c5d0b47a9",
-    "23.1": "e93c5d0b47a9",
-    "release_23.2": "8a19186a6ee7",
-    "23.2": "8a19186a6ee7",
-    "release_24.0": "55f02fd8ab6c",
-    "24.0": "55f02fd8ab6c",
-    "release_24.1": "04288b6a5b25",
-    "24.1": "04288b6a5b25",
-    "release_24.2": "a4c3ef999ab5",
-    "24.2": "a4c3ef999ab5",
-    "release_25.0": "c716ee82337b",
-    "25.0": "c716ee82337b",
-    "release_25.1": "cd26484899fb",
-    "25.1": "cd26484899fb",
-}
 
 
 class ParserBuilder(BaseParserBuilder):
@@ -81,7 +54,7 @@ class DbScript(BaseDbScript):
         return f"gxy@{revision_id}"
 
     def _revision_tags(self):
-        return REVISION_TAGS
+        return {f"release_{k}": v for k, v in REVISION_TAGS.items()} | REVISION_TAGS
 
     def _set_dburl(self, config_file: Optional[str] = None) -> None:
         gxy_config, tsi_config, _ = get_configuration_from_file(os.getcwd(), config_file)


### PR DESCRIPTION
This change moves `REVISION_TAGS` into a constant-only `dbrevisions.py` file, simplifying maintenance.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
