### PR TITLE
[25.0] Improves zip file type detection for uploads under windows

### DIFF
--- a/client/src/composables/zipExplorer.ts
+++ b/client/src/composables/zipExplorer.ts
@@ -310,7 +310,7 @@ export function validateLocalZipFile(file?: File | null): string {
 }
 
 export function isLocalZipFile(file?: File | null): boolean {
-    return Boolean(file) && file?.type === "application/zip";
+    return Boolean(file) && (file?.type === "application/zip" || file?.type === "application/x-zip-compressed");
 }
 
 export async function isRemoteZipFile(url: string): Promise<boolean> {


### PR DESCRIPTION
Recognizes both "application/zip" and "application/x-zip-compressed" MIME types to support windows uploads and prevent
false negatives when validating local zip files.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
