### PR TITLE
Avoid missing field value failure in data tables

### DIFF
--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -547,8 +547,6 @@ class TabularToolDataTable(ToolDataTable):
                 if empty_field_value is not None:
                     self.empty_field_values[name] = empty_field_value
         assert "value" in self.columns, "Required 'value' column missing from column def"
-        if "name" not in self.columns:
-            self.columns["name"] = self.columns["value"]
 
     def extend_data_with(self, filename: str, errors: Optional[ErrorListT] = None) -> None:
         here = os.path.dirname(os.path.abspath(filename))

--- a/test/functional/tool-data/testbeta.loc
+++ b/test/functional/tool-data/testbeta.loc
@@ -1,1 +1,1 @@
-newvalue	/private/var/folders/_g/g4jwh5zn7tqfkvzprm2l3p7r0000gn/T/tmpgIldpH/tmp1_p5YA/tmpYyEtCB/database/data_manager_tool-dataP247gI/testbeta/newvalue/newvalue.txt
+newvalue	${__HERE__}/data1/entry.txt


### PR DESCRIPTION
Resolves #21183. Exploring options to resolve a failure caused by injecting an empty `name` column into the data table. Because only the column name was added without corresponding field data, the column list becomes longer than the field list. As a result, when searching for a column such as `path`, the returned index is shifted by one, leading to an out-of-range error when accessing the corresponding field value. `twobit` data tables do not include a name field, and since the `path` field is the last column, any attempt to access it for downloading data from IGV results in a failure. In my view, the correct approach is to avoid injecting an empty `name` column, since a `value` column is already required and guaranteed to exist. Consumers of this API endpoint should instead fall back to the `value` column or whichever column or index they prefer.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
