### PR TITLE
Fix content wrapping in cards and preference title

### DIFF
--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -53,7 +53,7 @@ const element = computed(() => {
 </script>
 
 <template>
-    <div v-if="props.separator" class="separator heading">
+    <div v-if="props.separator" class="separator heading word-wrap-break">
         <GButton v-if="collapsible" transparent size="small" icon-only inline @click="$emit('click')">
             <FontAwesomeIcon v-if="collapsed" fixed-width :icon="faAngleDoubleDown" />
             <FontAwesomeIcon v-else fixed-width :icon="faAngleDoubleUp" />
@@ -75,7 +75,7 @@ const element = computed(() => {
     <component
         :is="element"
         v-else
-        class="heading"
+        class="heading word-wrap-break"
         :class="[
             sizeClass,
             props.bold ? 'font-weight-bold' : '',
@@ -95,12 +95,6 @@ const element = computed(() => {
 
 <style lang="scss" scoped>
 @import "scss/theme/blue.scss";
-
-.heading {
-    overflow-wrap: break-word;
-    white-space: normal;
-    word-break: break-word;
-}
 
 // prettier-ignore
 h1, h2, h3, h4, h5, h6 {

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -97,7 +97,9 @@ const element = computed(() => {
 @import "scss/theme/blue.scss";
 
 .heading {
-    word-break: break-all;
+    overflow-wrap: break-word;
+    white-space: normal;
+    word-break: break-word;
 }
 
 // prettier-ignore

--- a/client/src/components/User/UserDetailsElement.vue
+++ b/client/src/components/User/UserDetailsElement.vue
@@ -45,6 +45,7 @@ const getStoragePercentageClass = (percentage: number) => {
                     <FontAwesomeIcon :icon="faAt" class="user-details-icon p-2" />
                     <span
                         id="user-preferences-current-email"
+                        class="word-wrap-break"
                         v-b-tooltip.hover.noninteractive
                         title="Your email address">
                         {{ userEmail }}

--- a/client/src/components/User/UserDetailsElement.vue
+++ b/client/src/components/User/UserDetailsElement.vue
@@ -35,14 +35,14 @@ const getStoragePercentageClass = (percentage: number) => {
         <div class="user-details d-flex flex-gapx-1 flex-gapy-1 w-100 justify-content-between">
             <div class="d-flex align-items-center flex-gapx-1">
                 <div class="d-flex align-items-center flex-gapx-1 mr-5">
-                    <FontAwesomeIcon :icon="faUser" class="user-details-icon" />
+                    <FontAwesomeIcon :icon="faUser" class="user-details-icon p-2" />
                     <span v-b-tooltip.hover.noninteractive title="Your username (public name)">
                         {{ userUsername }}
                     </span>
                 </div>
 
                 <div class="d-flex align-items-center flex-gapx-1">
-                    <FontAwesomeIcon :icon="faAt" class="user-details-icon" />
+                    <FontAwesomeIcon :icon="faAt" class="user-details-icon p-2" />
                     <span
                         id="user-preferences-current-email"
                         v-b-tooltip.hover.noninteractive
@@ -95,10 +95,10 @@ const getStoragePercentageClass = (percentage: number) => {
 
         .user-details-icon {
             color: $brand-primary;
-            font-size: 1rem;
-            border: 1px solid $brand-primary;
-            border-radius: 0.75rem;
-            padding: 0.5rem;
+            font-size: $h5-font-size;
+            border: $border-default;
+            border-color: $brand-primary;
+            border-radius: $border-radius-extralarge;
         }
     }
 }

--- a/client/src/components/User/UserDetailsElement.vue
+++ b/client/src/components/User/UserDetailsElement.vue
@@ -45,8 +45,8 @@ const getStoragePercentageClass = (percentage: number) => {
                     <FontAwesomeIcon :icon="faAt" class="user-details-icon p-2" />
                     <span
                         id="user-preferences-current-email"
-                        class="word-wrap-break"
                         v-b-tooltip.hover.noninteractive
+                        class="word-wrap-break"
                         title="Your email address">
                         {{ userEmail }}
                     </span>

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -155,8 +155,7 @@ onMounted(async () => {
         <BreadcrumbHeading :items="breadcrumbItems" />
 
         <Heading h2 size="sm">
-            This page allows you to manage your user preferences. You can change your email address, password, and other
-            settings here.
+            Manage your user preferences on this page, including email address, password, and other settings.
         </Heading>
 
         <BAlert :variant="messageVariant" :show="!!message">

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -154,7 +154,7 @@ onMounted(async () => {
     <div class="d-flex flex-column">
         <BreadcrumbHeading :items="breadcrumbItems" />
 
-        <Heading h2 size="md">
+        <Heading h2 size="sm">
             This page allows you to manage your user preferences. You can change your email address, password, and other
             settings here.
         </Heading>

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -44,15 +44,16 @@
     overflow-y: auto !important;
 }
 
-// utility class to set word wrap to normal
-.word-wrap-normal {
-    word-wrap: normal;
-}
-
+// utility class to wrap words or break if necessary
 .word-wrap-break {
     overflow-wrap: break-word;
     white-space: normal;
     word-break: break-word;
+}
+
+// utility class to set word wrap to normal
+.word-wrap-normal {
+    word-wrap: normal;
 }
 
 // utility class to set white space wrapping to normal

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -49,6 +49,12 @@
     word-wrap: normal;
 }
 
+.word-wrap-break {
+    overflow-wrap: break-word;
+    white-space: normal;
+    word-break: break-word;
+}
+
 // utility class to set white space wrapping to normal
 .white-space-normal {
     white-space: normal;


### PR DESCRIPTION
Corrects invalid wrapping of card contents, replaces custom styles that break theming with theme variables, and reduces info text size in user preferences.

xref #20997

### User Preferences:

Before:
<img width="1067" height="607" alt="Screenshot 2025-10-07 at 8 37 01 AM" src="https://github.com/user-attachments/assets/4c0f5d00-c1c9-4b0e-9219-9e7bb665d23f" />

Now:
<img width="1067" height="607" alt="Screenshot 2025-10-07 at 8 40 07 AM" src="https://github.com/user-attachments/assets/de609a7a-8e16-4490-a469-100645c5ed57" />

### Workflow List

Before:
<img width="1067" height="607" alt="Screenshot 2025-10-07 at 8 41 53 AM" src="https://github.com/user-attachments/assets/2aae847a-3fda-4e8d-8514-04123acc3a02" />

Now:
<img width="1067" height="607" alt="Screenshot 2025-10-07 at 8 41 04 AM" src="https://github.com/user-attachments/assets/fd7e6877-90c9-42c0-84e6-3e55a424f4ce" />

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
