### PR TITLE
Bump up total-perspective-vortex dependency

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -13,7 +13,7 @@ ldap3==2.9.1
 python-pam
 galaxycloudrunner
 pkce
-total-perspective-vortex>=3.1.0,<4
+total-perspective-vortex>=3.1.1,<4
 openai
 # upper version constraint because of https://github.com/galaxyproject/galaxy/issues/20600
 redis>=5.3.0,<6

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -200,7 +200,7 @@ text-unidecode==1.3
 tinydb==4.8.2
 toml==0.10.2
 tomli==2.2.1 ; python_full_version <= '3.11'
-total-perspective-vortex==3.1.0
+total-perspective-vortex==3.1.1
 trio==0.31.0
 trio-websocket==0.12.2
 tuspy==1.1.0

--- a/lib/galaxy/dependencies/pinned-test-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-test-requirements.txt
@@ -149,7 +149,7 @@ text-unidecode==1.3
 tinydb==4.8.2
 toml==0.10.2
 tomli==2.2.1 ; python_full_version <= '3.11'
-total-perspective-vortex==3.1.0
+total-perspective-vortex==3.1.1
 trio==0.31.0
 trio-websocket==0.12.2
 tuspy==1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ test = [
     "seletools",
     "statsd",
     "testfixtures",
-    "total-perspective-vortex>=3.1.0,<4",  # https://github.com/galaxyproject/total-perspective-vortex/pull/166
+    "total-perspective-vortex>=3.1.1,<4",  # https://github.com/galaxyproject/total-perspective-vortex/pull/166
     "tuspy",
     "twill>=3.2.5",  # Python 3.13 support
     "watchdog",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ test = [
     "seletools",
     "statsd",
     "testfixtures",
-    "total-perspective-vortex>=3.1.1,<4",  # https://github.com/galaxyproject/total-perspective-vortex/pull/166
+    "total-perspective-vortex>=3.1.1,<4",  # https://github.com/galaxyproject/total-perspective-vortex/pull/173
     "tuspy",
     "twill>=3.2.5",  # Python 3.13 support
     "watchdog",


### PR DESCRIPTION
To get https://github.com/galaxyproject/total-perspective-vortex/pull/173 and https://github.com/galaxyproject/total-perspective-vortex/pull/171

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
