### PR TITLE
Update revision tags for release 25.1

### DIFF
--- a/lib/galaxy/model/migrations/dbscript.py
+++ b/lib/galaxy/model/migrations/dbscript.py
@@ -48,8 +48,8 @@ REVISION_TAGS = {
     "24.2": "a4c3ef999ab5",
     "release_25.0": "c716ee82337b",
     "25.0": "c716ee82337b",
-    "release_25.1": "e382f8eb5e12",
-    "25.1": "e382f8eb5e12",
+    "release_25.1": "cd26484899fb",
+    "25.1": "cd26484899fb",
 }
 
 


### PR DESCRIPTION
Revise the revision tags to reflect the correct commit hash for release 25.1, as https://github.com/galaxyproject/galaxy/pull/19084 has been merged. related commit: https://github.com/galaxyproject/galaxy/commit/9fbe539125a77b6b6bc0b8f58942c43ac132b3b7

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
