### PR TITLE
[25.1] Fix horizontal scrolling w/ GButton in input-group-append

### DIFF
--- a/client/src/components/BaseComponents/GButton.vue
+++ b/client/src/components/BaseComponents/GButton.vue
@@ -317,3 +317,13 @@ const buttonElementRef = useResolveElement(buttonRef);
     }
 }
 </style>
+
+<style lang="scss">
+// Fix for GButton inside Bootstrap input-group-append
+// Prevents horizontal scrolling issues caused by flex layout conflicts
+// This must be unscoped to target Bootstrap's input-group-append
+.input-group-append .g-button {
+    flex-shrink: 0;
+    overflow: hidden;
+}
+</style>


### PR DESCRIPTION
Should fix https://github.com/galaxyproject/galaxy/issues/21004.  

Make sure to test in chrome.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
