### PR TITLE
[25.1] Fix GCard Layout and White Spaces

### DIFF
--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -516,7 +516,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             <BButton
                                                 v-if="(indicator.visible ?? true) && !indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
-                                                :key="indicator.id"
+                                                :key="`${indicator.id}-button`"
                                                 v-b-tooltip.hover.noninteractive
                                                 class="inline-icon-button"
                                                 :title="localize(indicator.title)"
@@ -536,7 +536,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             <FontAwesomeIcon
                                                 v-else-if="(indicator.visible ?? true) && indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
-                                                :key="indicator.id"
+                                                :key="`${indicator.id}-icon`"
                                                 v-b-tooltip.hover.noninteractive
                                                 :title="localize(indicator.title)"
                                                 :icon="indicator.icon"

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -335,33 +335,35 @@ function onKeyDown(event: KeyboardEvent) {
                                             :id="getElementId(props.id, 'title')"
                                             bold
                                             inline
-                                            class="align-items-baseline"
                                             :size="props.titleSize">
-                                            <FontAwesomeIcon
-                                                v-if="props.titleIcon?.icon"
-                                                :icon="props.titleIcon.icon"
-                                                :class="props.titleIcon.class"
-                                                :title="props.titleIcon.title"
-                                                :size="props.titleIcon.size"
-                                                fixed-width />
-                                            <BLink
-                                                v-if="typeof title === 'object'"
-                                                :id="getElementId(props.id, 'title-link')"
-                                                v-b-tooltip.hover.noninteractive
-                                                :title="localize(title.title)"
-                                                :class="{ 'g-card-title-truncate': props.titleNLines }"
-                                                @click.stop.prevent="title.handler">
-                                                {{ title.label }}
-                                            </BLink>
-                                            <template v-else>
-                                                <span
-                                                    :id="getElementId(props.id, 'title-text')"
+                                            <div class="d-flex">
+                                                <FontAwesomeIcon
+                                                    v-if="props.titleIcon?.icon"
+                                                    class="mr-1"
+                                                    :class="props.titleIcon.class"
+                                                    :icon="props.titleIcon.icon"
+                                                    :title="props.titleIcon.title"
+                                                    :size="props.titleIcon.size"
+                                                    fixed-width />
+                                                <BLink
+                                                    v-if="typeof title === 'object'"
+                                                    :id="getElementId(props.id, 'title-link')"
                                                     v-b-tooltip.hover.noninteractive
-                                                    :title="localize(title)"
-                                                    :class="{ 'g-card-title-truncate': props.titleNLines }">
-                                                    {{ title }}
-                                                </span>
-                                            </template>
+                                                    :title="localize(title.title)"
+                                                    :class="{ 'g-card-title-truncate': props.titleNLines }"
+                                                    @click.stop.prevent="title.handler">
+                                                    {{ title.label }}
+                                                </BLink>
+                                                <template v-else>
+                                                    <span
+                                                        :id="getElementId(props.id, 'title-text')"
+                                                        v-b-tooltip.hover.noninteractive
+                                                        :title="localize(title)"
+                                                        :class="{ 'g-card-title-truncate': props.titleNLines }">
+                                                        {{ title }}
+                                                    </span>
+                                                </template>
+                                            </div>
 
                                             <slot name="titleActions">
                                                 <BButton

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -549,16 +549,15 @@ function onKeyDown(event: KeyboardEvent) {
                         </div>
                     </div>
 
-                    <div :id="getElementId(props.id, 'description')">
+                    <div :id="getElementId(props.id, 'description')" class="g-card-description">
                         <slot name="description">
-                            <TextSummary
-                                v-if="props.description && !props.fullDescription"
-                                :id="getElementId(props.id, 'text-summary')"
-                                :description="props.description" />
-                            <div
-                                v-else-if="props.description && props.fullDescription"
-                                class="mb-2"
-                                v-html="renderMarkdown(props.description)" />
+                            <template v-if="props.description">
+                                <TextSummary
+                                    v-if="!props.fullDescription"
+                                    :id="getElementId(props.id, 'text-summary')"
+                                    :description="props.description" />
+                                <div v-else v-html="renderMarkdown(props.description)" />
+                            </template>
                         </slot>
                     </div>
                 </div>
@@ -598,9 +597,13 @@ function onKeyDown(event: KeyboardEvent) {
                             </div>
                         </slot>
 
-                        <div class="align-items-center d-flex flex-gapx-1 justify-content-end ml-auto mt-1">
+                        <div class="align-items-center d-flex flex-gapx-1 justify-content-end ml-auto">
                             <slot name="secondary-actions">
-                                <BButtonGroup :id="getElementId(props.id, 'secondary-actions')" size="sm">
+                                <BButtonGroup
+                                    v-if="props.secondaryActions?.length"
+                                    :id="getElementId(props.id, 'secondary-actions')"
+                                    size="sm"
+                                    class="mt-1">
                                     <template v-for="sa in props.secondaryActions">
                                         <BButton
                                             v-if="sa.visible ?? true"
@@ -630,30 +633,33 @@ function onKeyDown(event: KeyboardEvent) {
 
                             <div :id="getElementId(props.id, 'primary-actions')" class="d-flex flex-gapx-1">
                                 <slot name="primary-actions">
-                                    <template v-for="pa in props.primaryActions">
-                                        <BButton
-                                            v-if="pa.visible ?? true"
-                                            :id="getActionId(props.id, pa.id)"
-                                            :key="pa.id"
-                                            v-b-tooltip.hover.noninteractive
-                                            :disabled="pa.disabled"
-                                            :title="localize(pa.title)"
-                                            :variant="pa.variant || 'primary'"
-                                            :size="pa.size || 'sm'"
-                                            :to="pa.to"
-                                            :href="pa.href"
-                                            :class="{
-                                                'inline-icon-button': pa.inline,
-                                                [String(pa.class)]: pa.class,
-                                            }"
-                                            @click.stop="pa.handler">
-                                            <FontAwesomeIcon
-                                                v-if="pa.icon"
-                                                :icon="pa.icon"
-                                                :size="pa.size || undefined"
-                                                fixed-width />
-                                            {{ localize(pa.label) }}
-                                        </BButton>
+                                    <template v-if="props.primaryActions?.length">
+                                        <template v-for="pa in props.primaryActions">
+                                            <BButton
+                                                v-if="pa.visible ?? true"
+                                                :id="getActionId(props.id, pa.id)"
+                                                :key="pa.id"
+                                                v-b-tooltip.hover.noninteractive
+                                                class="mt-1"
+                                                :disabled="pa.disabled"
+                                                :title="localize(pa.title)"
+                                                :variant="pa.variant || 'primary'"
+                                                :size="pa.size || 'sm'"
+                                                :to="pa.to"
+                                                :href="pa.href"
+                                                :class="{
+                                                    'inline-icon-button': pa.inline,
+                                                    [String(pa.class)]: pa.class,
+                                                }"
+                                                @click.stop="pa.handler">
+                                                <FontAwesomeIcon
+                                                    v-if="pa.icon"
+                                                    :icon="pa.icon"
+                                                    :size="pa.size || undefined"
+                                                    fixed-width />
+                                                {{ localize(pa.label) }}
+                                            </BButton>
+                                        </template>
                                     </template>
                                 </slot>
                             </div>
@@ -739,6 +745,12 @@ function onKeyDown(event: KeyboardEvent) {
             line-height: 1.2;
             white-space: normal;
             text-overflow: unset;
+        }
+
+        .g-card-description {
+            :deep(p) {
+                margin-bottom: 0;
+            }
         }
 
         .g-card-secondary-action-label {

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -335,35 +335,34 @@ function onKeyDown(event: KeyboardEvent) {
                                             :id="getElementId(props.id, 'title')"
                                             bold
                                             inline
+                                            class="d-block"
                                             :size="props.titleSize">
-                                            <div class="d-flex">
-                                                <FontAwesomeIcon
-                                                    v-if="props.titleIcon?.icon"
-                                                    class="mr-1"
-                                                    :class="props.titleIcon.class"
-                                                    :icon="props.titleIcon.icon"
-                                                    :title="props.titleIcon.title"
-                                                    :size="props.titleIcon.size"
-                                                    fixed-width />
-                                                <BLink
-                                                    v-if="typeof title === 'object'"
-                                                    :id="getElementId(props.id, 'title-link')"
+                                            <FontAwesomeIcon
+                                                v-if="props.titleIcon?.icon"
+                                                class="mr-1"
+                                                :class="props.titleIcon.class"
+                                                :icon="props.titleIcon.icon"
+                                                :title="props.titleIcon.title"
+                                                :size="props.titleIcon.size"
+                                                fixed-width />
+                                            <BLink
+                                                v-if="typeof title === 'object'"
+                                                :id="getElementId(props.id, 'title-link')"
+                                                v-b-tooltip.hover.noninteractive
+                                                :title="localize(title.title)"
+                                                :class="{ 'g-card-title-truncate': props.titleNLines }"
+                                                @click.stop.prevent="title.handler">
+                                                {{ title.label }}
+                                            </BLink>
+                                            <template v-else>
+                                                <span
+                                                    :id="getElementId(props.id, 'title-text')"
                                                     v-b-tooltip.hover.noninteractive
-                                                    :title="localize(title.title)"
-                                                    :class="{ 'g-card-title-truncate': props.titleNLines }"
-                                                    @click.stop.prevent="title.handler">
-                                                    {{ title.label }}
-                                                </BLink>
-                                                <template v-else>
-                                                    <span
-                                                        :id="getElementId(props.id, 'title-text')"
-                                                        v-b-tooltip.hover.noninteractive
-                                                        :title="localize(title)"
-                                                        :class="{ 'g-card-title-truncate': props.titleNLines }">
-                                                        {{ title }}
-                                                    </span>
-                                                </template>
-                                            </div>
+                                                    :title="localize(title)"
+                                                    :class="{ 'g-card-title-truncate': props.titleNLines }">
+                                                    {{ title }}
+                                                </span>
+                                            </template>
 
                                             <slot name="titleActions">
                                                 <BButton

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -266,7 +266,7 @@ async function toggleBookmark() {
     bookmarkLoading.value = false;
 }
 
-const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
+const { renderMarkdown } = useMarkdown({ noMargin: true, openLinksInNewPage: true });
 
 /**
  * Helper functions for generating consistent element IDs
@@ -745,12 +745,6 @@ function onKeyDown(event: KeyboardEvent) {
             line-height: 1.2;
             white-space: normal;
             text-overflow: unset;
-        }
-
-        .g-card-description {
-            :deep(p) {
-                margin-bottom: 0;
-            }
         }
 
         .g-card-secondary-action-label {

--- a/client/src/components/Common/TextSummary.vue
+++ b/client/src/components/Common/TextSummary.vue
@@ -13,7 +13,7 @@ interface Props {
     oneLineSummary?: boolean;
     /** If `true`, doesn't show expand/collapse buttons */
     noExpand?: boolean;
-    /** The component to use for the summary, default = `<p>` */
+    /** The component to use for the summary, default = `<span>` */
     component?: string;
     /** If `true`, shows the full text */
     showExpandText?: boolean;

--- a/client/src/components/ScrollList/ScrollList.vue
+++ b/client/src/components/ScrollList/ScrollList.vue
@@ -223,13 +223,13 @@ watch(
                     </slot>
                     <component
                         :is="props.gridView ? 'div' : BListGroup"
+                        class="pt-1"
                         :class="{ 'card-list d-flex flex-wrap': props.gridView }">
                         <!-- Use component wrapper with v-for to provide proper keying while avoiding layout interference -->
                         <component
                             :is="'div'"
                             v-for="(item, index) in items"
                             :key="itemKey(item)"
-                            class=""
                             style="display: contents">
                             <slot name="item" :item="item" :index="index" />
                         </component>

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -92,7 +92,7 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
 </script>
 
 <template>
-    <div class="workflow-card-list d-flex flex-wrap overflow-auto">
+    <div class="workflow-card-list d-flex flex-wrap overflow-auto pt-1">
         <WorkflowCard
             v-for="workflow in workflows"
             :ref="props.itemRefs[workflow.id]"

--- a/client/src/composables/markdown.ts
+++ b/client/src/composables/markdown.ts
@@ -69,6 +69,16 @@ function addRuleHeadingIncreaseLevel(engine: MarkdownIt, increaseBy: number) {
     };
 }
 
+function addRuleNoMargin(engine: MarkdownIt) {
+    engine.renderer.rules.paragraph_open = function (tokens, idx, options, env, self) {
+        const token = tokens[idx];
+        if (token) {
+            token.attrPush(["style", "margin:0"]);
+        }
+        return self.renderToken(tokens, idx, options);
+    };
+}
+
 /**
  * Add a rule that removes newlines after list items.
  */
@@ -138,6 +148,7 @@ interface UseMarkdownOptions {
     openLinksInNewPage?: boolean;
     increaseHeadingLevelBy?: number;
     removeNewlinesAfterList?: boolean;
+    noMargin?: boolean;
 }
 
 type RawMarkdown = string;
@@ -153,6 +164,10 @@ export function useMarkdown(options: UseMarkdownOptions = {}) {
 
     if (options.increaseHeadingLevelBy) {
         addRuleHeadingIncreaseLevel(mdEngine, options.increaseHeadingLevelBy);
+    }
+
+    if (options.noMargin) {
+        addRuleNoMargin(mdEngine);
     }
 
     if (options.removeNewlinesAfterList) {


### PR DESCRIPTION
Closes https://github.com/galaxyproject/galaxy/issues/20997 
This pull request updates the `GCard` component to improve the rendering and layout of descriptions and action buttons. The changes focus on better conditional rendering, improved spacing, and more consistent styling for descriptions and actions.

|Before|After|
|---|---|
|<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/cf4aa8c0-0226-41f7-8404-b10291808413" />|<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/dd87deae-cbd8-40a3-ada4-b629c2828059" />|
|<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/548d2ef0-bd1b-456b-9d5d-279240fbc865" />|<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/81c774e9-31ef-4824-9289-3bfc4cacaf24" />|
|<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/ab3031ac-3797-4ecc-9bc8-a6d7f6f74622" />|<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/7fca4852-f43a-4df6-9e5a-3e815eccbdae" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
