### PR TITLE
Add service account support for Google Cloud Storage client initialization

### DIFF
--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -1,6 +1,7 @@
 try:
     from fs_gcsfs import GCSFS
     from google.cloud.storage import Client
+    from google.oauth2 import service_account
     from google.oauth2.credentials import Credentials
 except ImportError:
     GCSFS = None
@@ -24,6 +25,7 @@ class GoogleCloudStorageFileSourceTemplateConfiguration(BaseFileSourceTemplateCo
     root_path: Union[str, TemplateExpansion, None] = None
     project: Union[str, TemplateExpansion, None] = None
     anonymous: Union[bool, TemplateExpansion, None] = True
+    service_account_json: Union[str, TemplateExpansion, None] = None
     token: Union[str, TemplateExpansion, None] = None
     token_uri: Union[str, TemplateExpansion, None] = None
     client_id: Union[str, TemplateExpansion, None] = None
@@ -36,6 +38,7 @@ class GoogleCloudStorageFileSourceConfiguration(BaseFileSourceConfiguration):
     root_path: Optional[str] = None
     project: Optional[str] = None
     anonymous: Optional[bool] = True
+    service_account_json: Optional[str] = None
     token: Optional[str] = None
     token_uri: Optional[str] = None
     client_id: Optional[str] = None
@@ -62,6 +65,9 @@ class GoogleCloudStorageFilesSource(
         config = context.config
         if config.anonymous:
             client = Client.create_anonymous_client()
+        elif config.service_account_json:
+            credentials = service_account.Credentials.from_service_account_file(config.service_account_json)
+            client = Client(project=config.project, credentials=credentials)
         elif config.token:
             client = Client(
                 project=config.project,


### PR DESCRIPTION
Can we squint at this and call it a bug so we can target to 25.1?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
