### PR TITLE
[25.1] Add Keyboard Navigation to History Lists

### DIFF
--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -289,8 +289,10 @@ const allowedTitleLines = computed(() => props.titleNLines);
 
 function onKeyDown(event: KeyboardEvent) {
     if ((props.clickable && event.key === "Enter") || event.key === " ") {
+        event.stopPropagation();
         emit("click", event);
     } else if (props.clickable) {
+        event.stopPropagation();
         emit("keydown", event);
     }
 }

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -176,6 +176,11 @@ interface Props {
      * @default "Last updated"
      */
     updateTimeTitle?: string;
+
+    /** Whether this card is highlighted (for example, as a range selection anchor)
+     * @default false
+     */
+    highlighted?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -207,6 +212,7 @@ const props = withDefaults(defineProps<Props>(), {
     updateTime: "",
     updateTimeIcon: () => faEdit,
     updateTimeTitle: "Last updated",
+    highlighted: false,
 });
 
 /**
@@ -310,7 +316,7 @@ function onKeyDown(event: KeyboardEvent) {
         <div
             :id="`g-card-content-${props.id}`"
             class="g-card-content d-flex flex-column justify-content-between h-100 p-2"
-            :class="contentClass">
+            :class="[{ 'g-card-highlighted': props.highlighted }, contentClass]">
             <slot>
                 <div class="d-flex flex-column flex-gapy-1">
                     <div
@@ -699,6 +705,10 @@ function onKeyDown(event: KeyboardEvent) {
 
     &.g-card-published .g-card-content {
         border-left: 0.25rem solid $brand-primary;
+    }
+
+    &.g-card-highlighted .g-card-content {
+        box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
     }
 
     &.g-card-clickable {

--- a/client/src/components/History/HistoryCard.vue
+++ b/client/src/components/History/HistoryCard.vue
@@ -100,6 +100,13 @@ interface Props {
      * @default false
      */
     clickable?: boolean;
+
+    /**
+     * Whether this card is highlighted (for example, as a range selection anchor)
+     * @type {boolean}
+     * @default false
+     */
+    highlighted?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -110,6 +117,7 @@ const props = withDefaults(defineProps<Props>(), {
     selected: false,
     sharedView: false,
     clickable: false,
+    highlighted: false,
 });
 
 const router = useRouter();
@@ -260,6 +268,7 @@ function onKeyDown(event: KeyboardEvent) {
         :max-visible-tags="props.gridView ? 2 : 8"
         :update-time="history.update_time"
         :clickable="props.clickable"
+        :highlighted="props.highlighted"
         @titleClick="onTitleClick"
         @rename="() => router.push(`/histories/rename?id=${history.id}`)"
         @select="isMyHistory(history) && emit('select', history)"

--- a/client/src/components/History/HistoryCard.vue
+++ b/client/src/components/History/HistoryCard.vue
@@ -93,6 +93,13 @@ interface Props {
      * @default false
      */
     sharedView?: boolean;
+
+    /**
+     * Whether the card is clickable for keyboard navigation
+     * @type {boolean}
+     * @default false
+     */
+    clickable?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -102,6 +109,7 @@ const props = withDefaults(defineProps<Props>(), {
     selectable: false,
     selected: false,
     sharedView: false,
+    clickable: false,
 });
 
 const router = useRouter();
@@ -144,6 +152,18 @@ const emit = defineEmits<{
      * @event updateFilter
      */
     (e: "updateFilter", key: string, value: any): void;
+
+    /**
+     * Emitted when a keyboard event occurs on the history card
+     * @event on-key-down
+     */
+    (e: "on-key-down", history: AnyHistoryEntry, event: KeyboardEvent): void;
+
+    /**
+     * Emitted when the history card is clicked
+     * @event on-history-card-click
+     */
+    (e: "on-history-card-click", history: AnyHistoryEntry, event: Event): void;
 }>();
 
 /**
@@ -203,12 +223,25 @@ async function onTagsUpdate(historyId: string, tags: string[]) {
     await historyStore.updateHistory(historyId, { tags: tags });
     emit("refreshList", true, true);
 }
+
+function onClick(event: Event) {
+    if (props.clickable) {
+        emit("on-history-card-click", props.history, event);
+    }
+}
+
+function onKeyDown(event: KeyboardEvent) {
+    if (props.clickable) {
+        emit("on-key-down", props.history, event);
+    }
+}
 </script>
 
 <template>
     <GCard
         :id="`history-${history.id}`"
         :key="history.id"
+        class="history-card"
         :title="historyCardTitle"
         :title-badges="historyCardTitleBadges"
         :title-n-lines="2"
@@ -226,11 +259,14 @@ async function onTagsUpdate(historyId: string, tags: string[]) {
         :tags-editable="userOwnsHistory(currentUser, history)"
         :max-visible-tags="props.gridView ? 2 : 8"
         :update-time="history.update_time"
+        :clickable="props.clickable"
         @titleClick="onTitleClick"
         @rename="() => router.push(`/histories/rename?id=${history.id}`)"
         @select="isMyHistory(history) && emit('select', history)"
         @tagsUpdate="(tags) => onTagsUpdate(history.id, tags)"
-        @tagClick="(tag) => emit('tagClick', tag)">
+        @tagClick="(tag) => emit('tagClick', tag)"
+        @click="onClick"
+        @keydown="onKeyDown">
         <template v-if="props.archivedView && isArchivedHistory(history)" v-slot:titleActions>
             <ExportRecordDOILink :export-record-uri="history.export_record_data?.target_uri" />
         </template>

--- a/client/src/components/History/HistoryCardList.vue
+++ b/client/src/components/History/HistoryCardList.vue
@@ -167,8 +167,8 @@ const emit = defineEmits<{
             :selectable="props.selectable"
             :selected="props.selectedHistoryIds.some((selected) => selected.id === history.id)"
             :clickable="props.clickable"
+            :highlighted="props.rangeSelectAnchor?.id === history.id"
             class="history-card-in-list"
-            :class="{ 'range-select-anchor-history': props.rangeSelectAnchor?.id === history.id }"
             @select="isMyHistory(history) && emit('select', history)"
             @tagClick="(...args) => emit('tagClick', ...args)"
             @refreshList="(...args) => emit('refreshList', ...args)"
@@ -183,13 +183,5 @@ const emit = defineEmits<{
 
 .history-card-list {
     container: cards-list / inline-size;
-
-    .history-card-in-list {
-        &.range-select-anchor-history {
-            &:deep(.g-card-content) {
-                box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
-            }
-        }
-    }
 }
 </style>

--- a/client/src/components/History/HistoryCardList.vue
+++ b/client/src/components/History/HistoryCardList.vue
@@ -23,6 +23,8 @@
  *   @tagClick="onTagClick" />
  */
 
+import type { Ref } from "vue";
+
 import type { AnyHistoryEntry, MyHistory } from "@/api/histories";
 import { isMyHistory } from "@/api/histories";
 
@@ -76,6 +78,26 @@ interface Props {
      * @default []
      */
     selectedHistoryIds?: { id: string }[];
+
+    /**
+     * Whether cards are clickable for navigation
+     * @type {boolean}
+     * @default false
+     */
+    clickable?: boolean;
+
+    /**
+     * Item refs for keyboard navigation
+     * @type {Record<string, Ref<InstanceType<typeof HistoryCard> | null>>}
+     * @default {}
+     */
+    itemRefs?: Record<string, Ref<InstanceType<typeof HistoryCard> | null>>;
+
+    /**
+     * Range select anchor for keyboard navigation
+     * @type {AnyHistoryEntry | undefined}
+     */
+    rangeSelectAnchor?: AnyHistoryEntry;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -83,6 +105,9 @@ const props = withDefaults(defineProps<Props>(), {
     publishedView: false,
     selectable: false,
     selectedHistoryIds: () => [],
+    clickable: false,
+    itemRefs: () => ({}),
+    rangeSelectAnchor: undefined,
 });
 
 /**
@@ -112,14 +137,28 @@ const emit = defineEmits<{
      * @event updateFilter
      */
     (e: "updateFilter", key: string, value: any): void;
+
+    /**
+     * Emitted when a keyboard event occurs on a history card
+     * @event on-key-down
+     */
+    (e: "on-key-down", history: AnyHistoryEntry, event: KeyboardEvent): void;
+
+    /**
+     * Emitted when a history card is clicked
+     * @event on-history-card-click
+     */
+    (e: "on-history-card-click", history: AnyHistoryEntry, event: Event): void;
 }>();
 </script>
 
 <template>
-    <div class="history-card-list d-flex flex-wrap overflow-auto">
+    <div class="history-card-list d-flex flex-wrap overflow-auto pt-1">
         <HistoryCard
             v-for="history in props.histories"
+            :ref="props.itemRefs[history.id]"
             :key="history.id"
+            tabindex="0"
             :history="history"
             :grid-view="props.gridView"
             :shared-view="props.sharedView"
@@ -127,15 +166,30 @@ const emit = defineEmits<{
             :archived-view="props.archivedView"
             :selectable="props.selectable"
             :selected="props.selectedHistoryIds.some((selected) => selected.id === history.id)"
+            :clickable="props.clickable"
+            class="history-card-in-list"
+            :class="{ 'range-select-anchor-history': props.rangeSelectAnchor?.id === history.id }"
             @select="isMyHistory(history) && emit('select', history)"
             @tagClick="(...args) => emit('tagClick', ...args)"
             @refreshList="(...args) => emit('refreshList', ...args)"
-            @updateFilter="(...args) => emit('updateFilter', ...args)" />
+            @updateFilter="(...args) => emit('updateFilter', ...args)"
+            @on-key-down="(...args) => emit('on-key-down', ...args)"
+            @on-history-card-click="(...args) => emit('on-history-card-click', ...args)" />
     </div>
 </template>
 
 <style lang="scss" scoped>
+@import "theme/blue.scss";
+
 .history-card-list {
     container: cards-list / inline-size;
+
+    .history-card-in-list {
+        &.range-select-anchor-history {
+            &:deep(.g-card-content) {
+                box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
+            }
+        }
+    }
 }
 </style>

--- a/client/src/components/History/useHistoryCardActions.ts
+++ b/client/src/components/History/useHistoryCardActions.ts
@@ -47,6 +47,7 @@ export function useHistoryCardActions(
     historyCardExtraActions: CardAction[];
     historyCardSecondaryActions: CardAction[];
     historyCardPrimaryActions: ComputedRef<CardAction[]>;
+    onDeleteHistory: (purge?: boolean) => Promise<void>;
 } {
     const { confirm } = useConfirmDialog();
 
@@ -296,5 +297,5 @@ export function useHistoryCardActions(
         ];
     });
 
-    return { historyCardExtraActions, historyCardSecondaryActions, historyCardPrimaryActions };
+    return { historyCardExtraActions, historyCardSecondaryActions, historyCardPrimaryActions, onDeleteHistory };
 }

--- a/client/src/components/Workflow/List/WorkflowCard.vue
+++ b/client/src/components/Workflow/List/WorkflowCard.vue
@@ -23,6 +23,7 @@ interface Props {
     selected?: boolean;
     selectable?: boolean;
     clickable?: boolean;
+    highlighted?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -36,6 +37,7 @@ const props = withDefaults(defineProps<Props>(), {
     selected: false,
     selectable: false,
     clickable: false,
+    highlighted: false,
 });
 
 const emit = defineEmits<{
@@ -126,7 +128,6 @@ function onKeyDown(event: KeyboardEvent) {
 </script>
 
 <template>
-    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -->
     <GCard
         :id="workflow.id"
         class="workflow-card"
@@ -151,6 +152,7 @@ function onKeyDown(event: KeyboardEvent) {
         :update-time="workflow.update_time"
         :bookmarked="!!workflow.show_in_tool_panel"
         :clickable="props.clickable"
+        :highlighted="props.highlighted"
         @bookmark="() => toggleBookmark(!workflow?.show_in_tool_panel)"
         @rename="emit('rename', props.workflow.id, props.workflow.name)"
         @select="emit('select', workflow)"

--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -109,8 +109,8 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
             :compact="props.compact"
             :current="workflow.id === props.currentWorkflowId"
             :clickable="props.clickable"
+            :highlighted="props.rangeSelectAnchor?.id === workflow.id"
             class="workflow-card-in-list"
-            :class="{ 'range-select-anchor-workfow': props.rangeSelectAnchor?.id === workflow.id }"
             @select="(...args) => emit('select', ...args)"
             @tagClick="(...args) => emit('tagClick', ...args)"
             @refreshList="(...args) => emit('refreshList', ...args)"
@@ -170,12 +170,5 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
 
 .workflow-card-list {
     container: cards-list / inline-size;
-    .workflow-card-in-list {
-        &.range-select-anchor-workfow {
-            &:deep(.g-card-content) {
-                box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
-            }
-        }
-    }
 }
 </style>

--- a/client/src/composables/selectedItems/selectedItems.ts
+++ b/client/src/composables/selectedItems/selectedItems.ts
@@ -333,7 +333,7 @@ export function useSelectedItems<T, ComponentType extends ComponentInstanceExten
                     initKeySelection();
                 } else if (
                     item &&
-                    event.key === "Delete" &&
+                    (event.key === "Delete" || event.key === "Backspace") &&
                     !isSelected(item) &&
                     typeof item === "object" &&
                     "deleted" in item &&


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/21030
xref: https://github.com/galaxyproject/galaxy/pull/19973

This pull request adds keyboard navigation and selection capabilities to the history lists.

* Added `clickable` and `highlighted` props to `GCard` instead of handling them in several components
* Ensured keyboard events stop propagation to avoid unintended side effects during navigation (esp. conflicts with browser extensions).
* Fix capturing the `backspace` key when using a Mac for the delete action

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to one of the history lists
  2. Try to navigate using the arrow up/down or remove the item using the `delete`/`backspace` key

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
