### PR TITLE
Selenium test for the new storage delete confirm dialog.

### DIFF
--- a/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
@@ -151,7 +151,8 @@ function drawChart() {
         .attr("y", (d) => yScale(d.value) - xAxisHeight)
         .attr("width", xScale.bandwidth())
         .attr("height", (d) => chartHeight - yScale(d.value))
-        .attr("fill", (d) => entryColor(d));
+        .attr("fill", (d) => entryColor(d))
+        .attr("data-label", (d) => d.label);
 
     return bars;
 }

--- a/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
@@ -142,6 +142,7 @@ function onUndelete(datasetId: string) {
         <div v-else>
             <BarChart
                 v-if="topNDatasetsBySizeData"
+                data-description="chart history top datasets by size"
                 :description="
                     localize(
                         `These are the ${numberOfDatasetsToDisplay} datasets that take the most space in this history. Click on a bar to see more information about the dataset.`,
@@ -223,6 +224,7 @@ function onUndelete(datasetId: string) {
 
             <BarChart
                 v-if="activeVsDeletedTotalSizeData"
+                data-description="chart history datasets by active"
                 :title="localize('Active vs Deleted Total Size')"
                 :description="
                     localize(

--- a/client/src/components/User/DiskUsage/Visualizations/util.ts
+++ b/client/src/components/User/DiskUsage/Visualizations/util.ts
@@ -61,6 +61,7 @@ export function useDatasetsToDisplay() {
                 okVariant: "danger",
                 okTitle: localize("Permanently delete"),
                 cancelTitle: localize("Cancel"),
+                dialogClass: "confirm-delete-dataset-dialog",
             },
         );
         if (!confirmed) {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -356,6 +356,10 @@ history_panel:
 history_storage:
   selectors:
     _: '.history-storage-overview'
+    top_datasets_by_size: "[data-description='chart history top datasets by size']"
+    dataset_by_size: "[data-description='chart history top datasets by size'] rect[data-label='${name}']"
+    dataset_by_size_delete: '#g-card-action-delete-selected-item-actions-dataset'
+    confirm_delete: '.confirm-delete-dataset-dialog .btn-danger'
 
 storage_dashboard:
   selectors:

--- a/lib/galaxy_test/selenium/test_history_storage.py
+++ b/lib/galaxy_test/selenium/test_history_storage.py
@@ -19,13 +19,19 @@ UPLOAD_DATA = {
     "bytes12": "moocow1235",
 }
 
+UPLOAD_DATA_3 = {
+    "small": "a",
+    "medium": "aaaaa",
+    "big": "aaaaaaaaaa",
+}
 
-class TestHistorySharing(SeleniumTestCase):
+
+class TestHistoryStorage(SeleniumTestCase):
     ensure_registered = True
 
     @selenium_test
     @managed_history
-    def test_history_storage(self):
+    def test_history_storage_accessibility(self):
         self.perform_upload_of_pasted_content(UPLOAD_DATA)
         self.history_panel_wait_for_hid_visible(11)
         self.wait_for_history()
@@ -34,6 +40,8 @@ class TestHistorySharing(SeleniumTestCase):
         self.screenshot("history_storage")
         self.components.history_storage._.assert_no_axe_violations_with_impact_of_at_least("critical")
 
+        # this is testing the global storage dashboard for the user - should be separated out
+        # but I think it stuck them together so there is an existing history with data.
         self.home()
         self.components.masthead.storage_dashboard_link.wait_for_and_click()
         self.screenshot("storage_dashboard")
@@ -46,3 +54,30 @@ class TestHistorySharing(SeleniumTestCase):
         self.components.storage_dashboard.explore_usage_link.wait_for_and_click()
         self.screenshot("storage_dashboard_manage_explore_usage_landing")
         self.assert_baseline_accessibility()
+
+    @selenium_test
+    @managed_history
+    def test_delete_dataset_from_storage_view(self):
+        """Test deleting a dataset from the history storage overview."""
+        # Upload test data with different sizes
+        self.perform_upload_of_pasted_content(UPLOAD_DATA_3)
+        self.wait_for_history()
+
+        # Navigate to history storage overview
+        self.home()
+        self.components.history_panel.storage_overview.wait_for_and_click()
+        self.components.history_storage._.wait_for_visible()
+        self.components.history_storage.top_datasets_by_size.wait_for_visible()
+
+        # Click on the largest dataset
+        self.components.history_storage.dataset_by_size(name="big").wait_for_and_click()
+        self.screenshot("history_storage_active_dataset")
+
+        # Delete the dataset
+        self.components.history_storage.dataset_by_size_delete.wait_for_and_click()
+        self.screenshot("history_storage_confirm_delete")
+        self.components.history_storage.confirm_delete.wait_for_and_click()
+
+        # Verify dataset is removed from storage view
+        self.components.history_storage.dataset_by_size(name="big").wait_for_absent()
+        self.screenshot("history_storage_post_delete")


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/pull/20070

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
