### PR TITLE
Implement a workflow for AI-assisted Selenium test case creation.

### DIFF
--- a/lib/galaxy/selenium/context.py
+++ b/lib/galaxy/selenium/context.py
@@ -64,9 +64,25 @@ class GalaxySeleniumContextImpl(GalaxySeleniumContext):
         self.url = from_dict.get("local_galaxy_url", "http://localhost:8080")
         self.target_url_from_selenium = from_dict.get("selenium_galaxy_url", self.url)
         self.timeout_multiplier = from_dict.get("timeout_multiplier", 1)
+        # Optional properties...
+        self.login_email = from_dict.get("login_email", "")
+        self.login_password = from_dict.get("login_password", "")
 
     def _screenshot_path(self, label, extension=".png"):
         return label + extension
+
+    # mirror TestWithSelenium method for doing this but use the config.
+    def login(self):
+        if self.login_email:
+            assert self.login_password, "If login_email is set, a password must be set also with login_password"
+            self.home()
+            self.submit_login(
+                email=self.login_email,
+                password=self.login_password,
+                assert_valid=True,
+            )
+        else:
+            self.register()
 
 
 def init(config=None, clazz=GalaxySeleniumContextImpl) -> GalaxySeleniumContext:

--- a/lib/galaxy_test/selenium/.claude/README.md
+++ b/lib/galaxy_test/selenium/.claude/README.md
@@ -1,0 +1,159 @@
+# Claude Code Configuration for Galaxy Selenium Tests
+
+This directory contains Claude Code configuration and slash commands for working with Galaxy's Selenium test suite.
+
+## CLAUDE.md
+
+The `CLAUDE.md` file in the parent directory (`../CLAUDE.md`) provides comprehensive documentation about Galaxy Selenium testing conventions. It includes:
+
+- Test structure and base classes
+- Common patterns (login, navigation, data upload)
+- Decorator usage (`@selenium_test`, `@managed_history`, `@requires_admin`)
+- Component system access
+- Helper methods and wait types
+- Accessibility testing guidelines
+- Complete test templates for different scenarios
+
+**Purpose**: This file serves as context for Claude Code when writing or modifying Selenium tests, ensuring consistency with Galaxy's testing conventions.
+
+## Slash Commands
+
+### Direct Test Creation
+
+#### `/new-selenium-test`
+
+Bootstrap a new Selenium test file from scratch.
+
+**Usage:**
+```
+/new-selenium-test <feature description>
+```
+
+**Examples:**
+```
+/new-selenium-test workflow import with accessibility testing
+/new-selenium-test admin user management features
+/new-selenium-test dataset metadata editing with managed history
+```
+
+**What it does:**
+- Creates a new test file with proper structure
+- Includes appropriate imports and decorators
+- Follows Galaxy naming conventions
+- Uses correct template based on requirements
+- Asks clarifying questions if needed
+
+#### `/add-selenium-test`
+
+Add new test methods to an existing Selenium test file.
+
+**Usage:**
+```
+/add-selenium-test <description and target file>
+```
+
+**Examples:**
+```
+/add-selenium-test Add a test for tag filtering to test_history_panel.py
+/add-selenium-test Add admin test for user deletion to test_admin_app.py
+/add-selenium-test Add dataset copy test with managed history to test_dataset_edit.py
+```
+
+**What it does:**
+- Reads existing file to match style
+- Adds properly structured test methods
+- Updates imports if necessary
+- Maintains consistency with existing code
+
+### Interactive Jupyter Workflow
+
+For complex tests or when you need to explore the DOM interactively, use the Jupyter notebook workflow:
+
+#### `/setup-selenium-test-notebook`
+
+Create a Jupyter notebook for interactively prototyping a Selenium test.
+
+**Usage:**
+```
+/setup-selenium-test-notebook <feature description OR GitHub PR>
+```
+
+**Examples (text mode):**
+```
+/setup-selenium-test-notebook dataset metadata editing
+/setup-selenium-test-notebook workflow import from URL
+/setup-selenium-test-notebook admin user quota management
+```
+
+**Examples (GitHub PR mode):**
+```
+/setup-selenium-test-notebook https://github.com/galaxyproject/galaxy/pull/12345
+/setup-selenium-test-notebook #12345
+/setup-selenium-test-notebook 12345
+```
+
+**What it does:**
+- Fetches PR context (if PR mode): description, screenshots, author
+- Launches research subagent to find similar existing tests
+- Creates a prototype notebook in `jupyter/` directory
+- Includes PR context, example code, and starter code
+- Prints complete setup instructions
+
+**Workflow:**
+1. Run `/setup-selenium-test-notebook <feature>` to create notebook
+2. Follow printed instructions to start Jupyter
+3. Prototype test interactively with screenshots
+4. Run `/extract-selenium-test` when done to convert to test file
+
+#### `/extract-selenium-test`
+
+Extract test code from a Jupyter notebook and convert to a proper test file.
+
+**Usage:**
+```
+/extract-selenium-test <notebook path or description>
+```
+
+**Examples:**
+```
+/extract-selenium-test from jupyter/test_prototype_dataset_metadata.ipynb
+/extract-selenium-test jupyter/test_prototype_workflow_import.ipynb as test_workflow_import
+/extract-selenium-test notebook test_prototype_admin_users.ipynb
+```
+
+**What it does:**
+- Reads notebook cells (skipping initialization)
+- Transforms `gx_selenium_context` to `self`
+- Detects required decorators and attributes
+- Creates properly structured Pytest test file for the Selenium test suite
+- Groups related cells into test methods
+
+## Getting Started
+
+### Quick Start (Direct Creation)
+
+For straightforward tests with known requirements:
+
+1. **Read `../CLAUDE.md`** to understand Galaxy Selenium testing conventions
+2. **Use `/new-selenium-test <description>`** to create a new test file
+3. **Use `/add-selenium-test <description>`** to extend an existing test file
+4. **Run** with `pytest lib/galaxy_test/selenium/test_<your_file>.py`
+
+### Interactive Development (Jupyter Workflow)
+
+For complex tests or DOM exploration:
+
+1. **Create notebook**: `/setup-selenium-test-notebook <description>`
+2. **Start Galaxy & Jupyter** following the printed instructions
+3. **Prototype interactively** in the notebook with live screenshots
+4. **Extract to test**: `/extract-selenium-test <notebook_path>`
+5. **Run** with `pytest lib/galaxy_test/selenium/test_<your_file>.py`
+
+## Tips
+
+- **Be specific** in command descriptions (mention admin access, managed history, etc.)
+- **Use Jupyter workflow** when you need to explore the DOM or iterate quickly
+- **Use direct creation** when you know exactly what needs to be tested
+- Commands will **ask clarifying questions** if your request is ambiguous
+- **Review generated code** to ensure it meets your specific needs
+- **Reference existing tests** in the parent directory for patterns and examples

--- a/lib/galaxy_test/selenium/.claude/commands/add-selenium-test.md
+++ b/lib/galaxy_test/selenium/.claude/commands/add-selenium-test.md
@@ -1,0 +1,91 @@
+---
+description: Add a new test method to an existing Galaxy Selenium test file
+---
+
+The user input can be provided directly or as a command argument - you **MUST** consider it before proceeding.
+
+User input:
+
+$ARGUMENTS
+
+## Context
+
+You are adding a new test method to an existing Selenium test file in the Galaxy test suite. Read the CLAUDE.md file in this directory for complete context on Galaxy Selenium testing conventions.
+
+## Task
+
+Add one or more new test methods to an existing test file based on the user's description. The user should specify:
+- Which test file to modify (e.g., `test_history_panel.py`)
+- What scenario(s) to test
+- Any special requirements (managed history, admin access, etc.)
+
+## Requirements
+
+1. **Read CLAUDE.md** in the current directory for full context
+
+2. **Read the target test file** to understand:
+   - Existing class structure and attributes
+   - Import statements already present
+   - Coding style and patterns used
+   - Helper methods defined in the class
+
+3. **Match the existing style**:
+   - Use same patterns as other methods in the class
+   - Follow same naming conventions
+   - Maintain consistent indentation and spacing
+   - Add similar docstrings
+
+4. **Add necessary imports** if new decorators/modules are needed:
+   - `managed_history` if using `@managed_history`
+   - `requires_admin` if using `@requires_admin`
+   - Any other decorators from `galaxy.selenium.navigates_galaxy`
+
+5. **Use appropriate decorators**:
+   - Always use `@selenium_test`
+   - Add `@managed_history` if the test needs predictable HIDs
+   - Add `@requires_admin` if testing admin features
+   - Add `@edit_details` or other navigation decorators as needed
+
+6. **Follow test structure**:
+   - Clear, descriptive method name: `test_<specific_scenario>`
+   - Docstring explaining what is being tested
+   - Proper setup and navigation
+   - Clear assertions
+   - Screenshots if helpful (use `self.screenshot("description")`)
+
+7. **Respect class attributes**:
+   - If class has `ensure_registered = True`, user is already logged in
+   - If class has `run_as_admin = True`, tests run as admin
+   - Use these to simplify test setup
+
+## Output
+
+1. **Confirm the target**:
+   - Which file will be modified
+   - What test method(s) will be added
+
+2. **Add the test method(s)** to the appropriate class
+
+3. **Update imports** if needed
+
+4. **Explain what was added**:
+   - What the new test does
+   - Why certain decorators were used
+   - How it fits with existing tests
+   - How to run just this new test
+
+## Example Usage
+
+```
+/add-test Add a test for tag filtering to test_history_panel.py
+/add-test Add admin test for user deletion to test_admin_app.py
+/add-test Add dataset copy test with managed history to test_dataset_edit.py
+```
+
+## Notes
+
+- Always read the existing file first to match its style
+- Don't duplicate existing test scenarios
+- Keep tests independent and focused
+- Consider edge cases and error conditions
+- Add accessibility tests where appropriate

--- a/lib/galaxy_test/selenium/.claude/commands/extract-selenium-test.md
+++ b/lib/galaxy_test/selenium/.claude/commands/extract-selenium-test.md
@@ -1,0 +1,118 @@
+---
+description: Extract test code from a Jupyter notebook and convert it to a proper Selenium test file
+---
+
+The user input can be provided directly or as a command argument - you **MUST** consider it before proceeding.
+
+User input:
+
+$ARGUMENTS
+
+## Context
+
+After prototyping a Selenium test interactively in a Jupyter notebook, this command extracts the test code and converts it into a proper test file following Galaxy's Selenium testing conventions.
+
+## Task
+
+Extract test cells from a Jupyter notebook and create a properly structured Selenium test file.
+
+## Requirements
+
+1. **Read the target notebook** specified by the user (e.g., `jupyter/test_prototype_<name>.ipynb`)
+
+2. **Read CLAUDE.md** for full context on Galaxy Selenium test conventions
+
+3. **Identify test cells** - Extract all cells after the initialization cell (cell 2):
+   - Skip the parameters cell (cell 0)
+   - Skip the initialization cell (cell 1)
+   - Extract cells 2+ which contain the test implementation
+
+4. **Transform notebook code to test code**:
+   - Replace `gx_selenium_context.` with `self.`
+   - Remove screenshot calls or keep them if desired for debugging
+   - Group related operations into logical test methods
+   - Add proper decorators (`@selenium_test`, `@managed_history`, etc.)
+   - Add docstrings to test methods
+
+5. **Determine test structure** from the notebook code:
+   - Does it need `ensure_registered = True`? (if it calls `register()` or `login()`)
+   - Does it need `run_as_admin = True`? (if it calls `admin_login()`)
+   - Does it need `@managed_history`? (if it works with datasets/HIDs)
+   - Does it need `@requires_admin`? (if testing admin features)
+
+6. **Create proper test file**:
+   - Add appropriate imports
+   - Create test class with correct name
+   - Add class attributes as needed
+   - Create test methods from notebook cells
+   - Group related cells into single test methods
+   - Split unrelated operations into separate test methods
+
+7. **Handle special cases**:
+   - If notebook uses `dataset_populator`, keep those patterns
+   - If notebook uses `current_history_id()`, consider `@managed_history`
+   - If notebook has multiple distinct scenarios, create multiple test methods
+   - Convert inline assertions to proper pytest assertions
+
+8. **File naming**: Ask user for feature name if not clear from notebook name
+
+## Output
+
+1. **Analyze the notebook** and report:
+   - Number of test cells found
+   - Key operations detected (login, upload, navigation, etc.)
+   - Recommended test structure (basic/managed history/admin)
+
+2. **Ask for confirmation** if structure is ambiguous:
+   - Should this be one test method or multiple?
+   - What should the test methods be named?
+   - Should screenshots be kept or removed?
+
+3. **Create the test file** at `test_<feature_name>.py` with:
+   - Proper imports
+   - Correctly structured test class
+   - Appropriate decorators and attributes
+   - Well-named test methods with docstrings
+   - Transformed code (gx_selenium_context → self)
+
+4. **Report completion**:
+   ```
+   ✓ Extracted test from notebook: jupyter/test_prototype_<name>.ipynb
+   ✓ Created test file: test_<feature_name>.py
+
+   Test structure:
+   - Class: Test<FeatureName>
+   - Attributes: [ensure_registered, run_as_admin, etc.]
+   - Methods: test_method_1, test_method_2, ...
+
+   To run the test:
+   pytest lib/galaxy_test/selenium/test_<feature_name>.py
+
+   Or run a specific test:
+   pytest lib/galaxy_test/selenium/test_<feature_name>.py::Test<FeatureName>::test_method_1
+   ```
+
+5. **Provide review guidance**:
+   - Suggest reviewing for proper wait/sleep patterns
+   - Recommend adding assertions if few were found
+   - Suggest accessibility testing if not present
+   - Note any hardcoded values that should be parameterized
+
+## Example Usage
+
+```
+/extract-test from jupyter/test_prototype_dataset_metadata.ipynb
+/extract-test jupyter/test_prototype_workflow_import.ipynb as test_workflow_import
+/extract-test notebook test_prototype_admin_users.ipynb
+```
+
+## Notes
+
+- Read CLAUDE.md for complete context on test conventions
+- The notebook's initialization cells (0-1) are never included in the test
+- Multiple notebook cells can be combined into a single test method if related
+- Distinct scenarios should become separate test methods
+- The command should intelligently detect patterns (admin, managed history, etc.)
+- Preserve the logic but adapt to test framework conventions
+- Remove debug-only code (print statements, excessive screenshots)
+- Keep test-relevant screenshots if they help document expected states

--- a/lib/galaxy_test/selenium/.claude/commands/new-selenium-test.md
+++ b/lib/galaxy_test/selenium/.claude/commands/new-selenium-test.md
@@ -1,0 +1,105 @@
+---
+description: Bootstrap a new Galaxy Selenium test file with proper structure and conventions
+---
+
+The user input can be provided directly or as a command argument - you **MUST** consider it before proceeding.
+
+User input:
+
+$ARGUMENTS
+
+## Context
+
+You are creating a new Selenium test file for the Galaxy web application. Read the CLAUDE.md file in this directory for complete context on:
+- Test structure and conventions
+- Available decorators and their purposes
+- Common patterns and helper methods
+- Component system usage
+- Example templates
+
+## Task
+
+Create a new Selenium test file based on the user's description. The user may specify:
+- Feature name (e.g., "dataset permissions", "workflow import")
+- Test scenarios to include
+- Whether it needs admin access (`run_as_admin = True`)
+- Whether it needs managed history (`@managed_history`)
+- Accessibility testing requirements
+
+## Requirements
+
+1. **Read CLAUDE.md** in the current directory for full context on Galaxy Selenium testing conventions
+
+2. **Determine the appropriate template** based on requirements:
+   - Basic test (most common)
+   - Test with managed history (for predictable dataset HIDs)
+   - Admin test (requires `run_as_admin = True`)
+   - Combination of the above
+
+3. **Generate the test file** with:
+   - Proper imports from `.framework`
+   - Class name following `Test<FeatureName>` convention
+   - Appropriate class attributes (`ensure_registered`, `run_as_admin`)
+   - Well-named test methods using `test_<scenario>` pattern
+   - Proper decorators (`@selenium_test`, `@managed_history`, `@requires_admin`)
+   - Docstrings for each test method
+   - Common patterns from existing tests
+
+4. **File naming**: `test_<feature_name>.py` (lowercase with underscores)
+
+5. **Include common elements**:
+   - Navigation (`self.home()`)
+   - Component access via `self.components.*`
+   - Proper wait/sleep patterns
+   - Assertions (`self.assert_no_error_message()`, etc.)
+   - Accessibility tests where appropriate
+
+6. **For dataset/history tests**:
+   - Use `@managed_history` decorator
+   - Upload test data with `self.perform_upload(self.get_filename("1.txt"))`
+   - Wait for datasets with `self.history_panel_wait_for_hid_ok(hid)`
+   - Reference datasets by predictable HID (1, 2, 3...)
+
+7. **For admin tests**:
+   - Add `run_as_admin = True` class attribute
+   - Use `@requires_admin` decorator
+   - Include `self.admin_login()` and `self.admin_open()`
+   - Import from `galaxy_test.base.decorators import requires_admin`
+
+8. **Best practices**:
+   - Keep tests focused and independent
+   - Use descriptive test method names
+   - Add comments for complex interactions
+   - Follow existing code style in this directory
+   - Consider accessibility testing (`assert_no_axe_violations_with_impact_of_at_least`)
+
+## Output
+
+1. **Ask clarifying questions** if the user's request is ambiguous:
+   - Does this need admin access?
+   - Does this need managed history for dataset testing?
+   - What specific scenarios should be tested?
+   - Should accessibility testing be included?
+
+2. **Create the test file** at `/Users/jxc755/workspace/galaxy/lib/galaxy_test/selenium/test_<feature_name>.py`
+
+3. **Explain the structure**:
+   - Which template was used and why
+   - Key components and patterns included
+   - How to run the test
+   - Any additional setup needed
+
+## Example Usage
+
+```
+/new-test workflow import with accessibility testing
+/new-test admin user management features
+/new-test dataset metadata editing with managed history
+```
+
+## Notes
+
+- Reference CLAUDE.md for comprehensive examples and patterns
+- Look at similar existing tests in this directory for inspiration
+- Ensure all imports are correct and from the right modules
+- The test should be immediately runnable with pytest

--- a/lib/galaxy_test/selenium/.claude/commands/setup-selenium-test-notebook.md
+++ b/lib/galaxy_test/selenium/.claude/commands/setup-selenium-test-notebook.md
@@ -1,0 +1,196 @@
+---
+description: Create a Jupyter notebook for interactively prototyping a new Selenium test
+---
+
+The user input can be provided directly or as a command argument - you **MUST** consider it before proceeding.
+
+User input:
+
+$ARGUMENTS
+
+## Context
+
+Galaxy Selenium tests can be prototyped interactively in Jupyter notebooks. The notebook environment provides:
+- Full access to the Selenium test infrastructure
+- Screenshot capabilities with inline display
+- Interactive DOM exploration
+- Rapid iteration without restarting Galaxy or re-running costly intermediate steps such as data upload.
+
+This command supports two modes:
+1. **Text description** - User provides a feature description
+2. **GitHub PR** - User provides a PR URL or number (fetches description and screenshots)
+
+## Task
+
+Create a new Jupyter notebook for prototyping a Selenium test. Input can be:
+- A text description of the feature
+- A GitHub PR URL (e.g., `https://github.com/galaxyproject/galaxy/pull/12345`)
+- A PR number (e.g., `#12345` or `12345`)
+
+## Requirements
+
+1. **Determine input mode**:
+   - If input contains GitHub URL or PR number (#), use PR mode
+   - Otherwise, use text description mode
+
+2. **PR Mode - Fetch PR information** (if applicable):
+   - Use `gh pr view <number> --json title,body,author` to get PR metadata
+   - Extract feature description from PR title and body
+   - Look for screenshots in PR body (markdown image syntax)
+   - If screenshots found, note their URLs for reference in notebook
+   - Use PR description as basis for feature understanding
+
+3. **Research similar tests** - Do a quick search in this directory only:
+   - Use Glob to find test files: `*.py` in current directory
+   - Use Grep to search for keywords related to the feature
+   - Read 1-2 most relevant test files
+   - Extract key patterns: component usage, helper methods, decorators
+   - Note which components are used (e.g., `self.components.history_panel.*`)
+   - Keep this step fast and focused
+
+4. **Create the notebook file** at `jupyter/test_prototype_<feature_name>.ipynb` with 4-5 cells:
+
+   **Cell 1** (tagged 'parameters'):
+   ```python
+   # Cell is tagged with 'parameters' so it can be parameterized with papermill,
+   # if config not overridden ./galaxy_selenium_context.yml can also be populated.
+   config = None
+   ```
+
+   **Cell 2** (initialization):
+   ```python
+   from galaxy_test.selenium.jupyter_context import init
+   gx_selenium_context = init(config)
+   ```
+
+   **Cell 3** (PR context - ONLY if PR mode):
+   ```python
+   # Testing PR #<number>: <PR title>
+   # Author: <author>
+   #
+   # Description:
+   # <PR body text>
+   #
+   # Screenshots in PR:
+   # - <screenshot URL 1>
+   # - <screenshot URL 2>
+   #
+   # You can compare your gx_selenium_context.screenshot() output with PR screenshots
+   ```
+
+   **Cell 4** (reference examples from similar tests):
+   ```python
+   # Similar test examples for reference:
+   #
+   # From test_<similar_file_1>.py:
+   # <relevant code snippets showing component usage>
+   #
+   # From test_<similar_file_2>.py:
+   # <more relevant code snippets>
+   #
+   # Components available:
+   # - self.components.<component_name>.<method>
+   # [List relevant components based on research]
+   ```
+
+   **Cell 5** (test prototype - add helpful starter code):
+   ```python
+   # Prototype your test here
+   # gx_selenium_context provides all the methods from SeleniumTestCase
+
+   # Example starter code based on feature description
+   ```
+
+5. **Add starter code** to the final cell based on the feature requirements:
+   - Login if needed: `gx_selenium_context.login()`
+   - Navigation: `gx_selenium_context.home()`
+   - Dataset creation if needed: `gx_selenium_context.dataset_populator.new_dataset(history_id)`
+   - Screenshots: `gx_selenium_context.screenshot("description")`
+   - Admin access if needed: `gx_selenium_context.admin_login()`
+   - Component access examples
+   - Comments suggesting what to implement
+
+6. **Check configuration** - Verify `jupyter/galaxy_selenium_context.yml` exists:
+   - If missing, inform user to copy from `galaxy_selenium_context.yml.sample`
+   - Explain they need to configure `login_email`, `login_password`, and optionally `admin_api_key`
+
+## Implementation Steps
+
+1. **Detect input mode and fetch PR if needed**:
+   - Check if input contains PR URL or number
+   - If PR mode: Use `gh pr view <number> --json title,body,author` to fetch PR data
+   - Extract feature description from PR content
+   - Parse PR body for screenshot URLs (markdown image syntax: `![...](url)`)
+
+2. **Search for similar tests** directly (no subagent):
+   - Use Grep to search for keywords in test files in current directory
+   - Example: search for "storage", "dashboard", "chart", etc. based on feature
+   - Identify 1-2 relevant files from grep results
+   - Read those files
+   - Extract key patterns: decorators used, components accessed, helper methods called
+   - Identify relevant code snippets (5-15 lines) showing component usage
+   - Keep this fast - just find the most obviously related tests
+
+3. **Create the notebook file** with:
+   - Standard initialization cells
+   - PR context cell (if PR mode)
+   - Similar test examples cell
+   - Starter code cell
+
+4. **Print setup instructions**:
+   ```
+   ✓ Created prototype notebook: jupyter/test_prototype_<feature_name>.ipynb
+   [If PR mode: ✓ Loaded context from PR #<number>: <title>]
+   [If PR mode: ✓ Found <N> screenshots in PR for reference]
+
+   To start prototyping:
+
+   1. Ensure Galaxy is running:
+      Terminal 1: GALAXY_SKIP_CLIENT_BUILD=1 GALAXY_RUN_WITH_TEST_TOOLS=1 sh run.sh
+      Terminal 2: make client-dev-server
+
+   2. Check configuration (first time only):
+      - Copy jupyter/galaxy_selenium_context.yml.sample to jupyter/galaxy_selenium_context.yml
+      - Edit it with your test user credentials and admin API key
+
+   3. Start Jupyter (from repo root):
+      . .venv/bin/activate
+      pip install jupyter  # first time only
+      make serve-selenium-notebooks
+
+   4. Open the notebook in Jupyter:
+      jupyter/test_prototype_<feature_name>.ipynb
+
+   5. Run cells interactively to prototype your test
+      - Screenshots will display inline
+      - You can inspect the DOM, try different selectors
+      - Iterate quickly without restarting
+      - Components selectors defined in lib/galaxy/navigation/navigation.yml
+        will be dynamically reloaded in this mode.
+
+   6. When done, use /extract-test to convert to a test file
+   ```
+
+## Example Usage
+
+**Text description mode:**
+```
+/setup-selenium-test-notebook dataset metadata editing
+/setup-selenium-test-notebook workflow import from URL
+/setup-selenium-test-notebook admin user quota management
+```
+
+**GitHub PR mode:**
+```
+/setup-selenium-test-notebook https://github.com/galaxyproject/galaxy/pull/12345
+/setup-selenium-test-notebook #12345
+/setup-selenium-test-notebook 12345
+```
+
+## Notes
+
+- The notebook uses `JupyterTestContextImpl` which provides the "same" interface as `SeleniumTestCase`
+- All methods from `NavigatesGalaxy` are available on `gx_selenium_context`
+- Screenshots are displayed inline in Jupyter for immediate feedback
+- Configuration is read from `jupyter/galaxy_selenium_context.yml` if present
+- After prototyping, use `/extract-test` to convert notebook cells into a proper test file

--- a/lib/galaxy_test/selenium/CLAUDE.md
+++ b/lib/galaxy_test/selenium/CLAUDE.md
@@ -1,0 +1,282 @@
+# Galaxy Selenium Test Suite
+
+This directory contains Selenium-based end-to-end tests for the Galaxy web interface.
+
+## Test Structure
+
+All Selenium tests follow these conventions:
+
+### Base Class and Decorators
+
+```python
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+)
+
+class TestYourFeature(SeleniumTestCase):
+    @selenium_test
+    def test_your_scenario(self):
+        # Test implementation
+```
+
+### Key Components
+
+- **Base class**: All test classes inherit from `SeleniumTestCase`
+- **Test decorator**: All test methods use the `@selenium_test` decorator
+- **Framework module**: `framework.py` provides the base testing infrastructure
+- **Component system**: Use `self.components` to access page object selectors
+
+## Common Patterns
+
+### User Registration and Login
+
+```python
+# Ensure user is registered before running tests
+class TestYourFeature(SeleniumTestCase):
+    ensure_registered = True  # Add this class attribute
+
+    # Or register manually in a test
+    @selenium_test
+    def test_with_login(self):
+        email = self._get_random_email()
+        self.register(email)
+        self.submit_login(email, assert_valid=True)
+```
+
+### Navigation
+
+```python
+self.home()  # Navigate to home page
+self.history_panel_wait_for_history_loaded()  # Wait for history to load
+```
+
+### Component Access
+
+```python
+# Access UI components via the component system
+self.components.masthead.login_masthead_button.wait_for_and_click()
+self.components.history_panel.name_edit_input.wait_for_visible()
+```
+
+### Accessibility Testing
+
+```python
+# Test for accessibility violations
+self.components.login.form.assert_no_axe_violations_with_impact_of_at_least("moderate")
+
+# With exceptions for specific rules
+VIOLATION_EXCEPTIONS = ["heading-order", "label"]
+self.components.history_panel._.assert_no_axe_violations_with_impact_of_at_least(
+    "moderate", VIOLATION_EXCEPTIONS
+)
+```
+
+### Data Upload
+
+```python
+# Upload test data
+self.perform_upload(self.get_filename("1.txt"))
+self.wait_for_history()
+
+# Wait for specific dataset
+self.history_panel_wait_for_hid_ok(1)
+```
+
+### Assertions with Retry Logic
+
+```python
+from .framework import retry_assertion_during_transitions
+
+@retry_assertion_during_transitions
+def assert_something(self):
+    # Assertion that might fail during UI transitions
+    assert condition
+```
+
+### Fresh History with @managed_history
+
+Use the `@managed_history` decorator when you need a clean history for your test. This ensures predictable HIDs (History Item IDs) for uploaded datasets, starting from 1.
+
+```python
+from .framework import (
+    managed_history,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+class TestHistoryFeature(SeleniumTestCase):
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_with_fresh_history(self):
+        # Upload files with predictable HIDs
+        self.perform_upload(self.get_filename("1.txt"))
+        self.history_panel_wait_for_hid_ok(1)  # First upload is HID 1
+
+        self.perform_upload(self.get_filename("2.txt"))
+        self.history_panel_wait_for_hid_ok(2)  # Second upload is HID 2
+
+        # Now you can reliably reference datasets by HID
+        self.history_panel_click_item_title(hid=1, wait=True)
+```
+
+**Key benefits of @managed_history:**
+- Creates a fresh history before the test runs
+- HIDs start at 1 and increment predictably
+- No interference from previous test data
+- Makes tests more reliable and maintainable
+
+### Testing Admin Functionality
+
+For tests that require admin access, add `run_as_admin = True` as a class attribute and use the `@requires_admin` decorator:
+
+```python
+from galaxy_test.base.decorators import requires_admin
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+)
+
+class TestAdminFeature(SeleniumTestCase):
+    run_as_admin = True  # This makes the test run with admin privileges
+
+    @selenium_test
+    @requires_admin
+    def test_admin_functionality(self):
+        self.admin_login()  # Login as admin user
+        self.admin_open()   # Navigate to admin panel
+
+        # Access admin components
+        admin_component = self.components.admin
+        admin_component.index.some_feature.wait_for_and_click()
+
+        # Test admin-specific functionality
+```
+
+**Admin test requirements:**
+- `run_as_admin = True` class attribute
+- `@requires_admin` decorator on test methods
+- Use `self.admin_login()` to authenticate as admin
+- Use `self.admin_open()` to navigate to admin panel
+
+## File Naming
+
+- Test files: `test_<feature_name>.py`
+- Test classes: `Test<FeatureName>`
+- Test methods: `test_<specific_scenario>`
+
+## Helper Methods Available
+
+Common methods from `SeleniumTestCase`:
+
+- `self.home()` - Navigate to home
+- `self.register(email, password=None)` - Register new user
+- `self.submit_login(email, password=None, assert_valid=True)` - Login
+- `self.logout_if_needed()` - Logout if logged in
+- `self.is_logged_in()` - Check login status
+- `self.assert_error_message()` - Assert error message displayed
+- `self.assert_no_error_message()` - Assert no error message
+- `self._get_random_email()` - Generate random test email
+- `self._get_random_name(prefix="")` - Generate random name
+- `self.sleep_for(wait_type)` - Sleep for specified wait type
+- `self.wait_for_history()` - Wait for history panel to load
+- `self.perform_upload(filepath)` - Upload a file
+- `self.history_panel_wait_for_hid_ok(hid)` - Wait for dataset to be OK
+
+## Wait Types
+
+```python
+self.sleep_for(self.wait_types.UX_RENDER)       # UI rendering delay
+self.sleep_for(self.wait_types.UX_TRANSITION)   # UI transition delay
+```
+
+## Test Data Files
+
+- Test data files are accessed via `self.get_filename("filename")`
+- Common test files include simple text files, tabular data, etc.
+
+## Example Test Templates
+
+### Basic Test Template
+
+```python
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestNewFeature(SeleniumTestCase):
+    ensure_registered = True
+
+    @selenium_test
+    def test_basic_scenario(self):
+        """Test description goes here."""
+        self.home()
+        # Test implementation
+        self.assert_no_error_message()
+
+    @selenium_test
+    def test_accessibility(self):
+        """Test accessibility compliance."""
+        self.components.your_feature._.assert_no_axe_violations_with_impact_of_at_least("moderate")
+```
+
+### Template with Managed History
+
+```python
+from .framework import (
+    managed_history,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestDatasetFeature(SeleniumTestCase):
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_with_datasets(self):
+        """Test with predictable dataset HIDs."""
+        # Upload test data
+        self.perform_upload(self.get_filename("1.txt"))
+        self.history_panel_wait_for_hid_ok(1)
+
+        # Interact with dataset by HID
+        self.history_panel_click_item_title(hid=1, wait=True)
+        # Further test logic...
+```
+
+### Admin Test Template
+
+```python
+from galaxy_test.base.decorators import requires_admin
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestAdminFeature(SeleniumTestCase):
+    run_as_admin = True
+
+    @selenium_test
+    @requires_admin
+    def test_admin_panel(self):
+        """Test admin functionality."""
+        self.admin_login()
+        self.admin_open()
+
+        admin_component = self.components.admin
+        # Test admin-specific features...
+```
+
+## Additional Resources
+
+- `framework.py` - Base test framework and utilities
+- `conftest.py` - Pytest fixtures and configuration
+- `jupyter_context.py` - Jupyter notebook testing utilities
+- Page objects and navigation helpers are in `galaxy.selenium.navigates_galaxy`

--- a/lib/galaxy_test/selenium/jupyter/__init__.py
+++ b/lib/galaxy_test/selenium/jupyter/__init__.py
@@ -101,7 +101,7 @@ terminal sessions.
 ::
 
     $ GALAXY_SKIP_CLIENT_BUILD=1 GALAXY_RUN_WITH_TEST_TOOLS=1 sh run.sh
-    $ make client-watch
+    $ make client-dev-server
 
 Copy ``lib/galaxy_test/selenium/jupyter/galaxy_selenium.yml.sample`` to
 ``lib/galaxy_test/selenium/jupyter/galaxy_selenium.yml`` and specify a


### PR DESCRIPTION
# Automated Test Cases - Bad!

AI generated test cases are noisy and generally just bad - this is not that. The context that would be needed to pull in our whole client codebase, all the test functions, etc.. would be huge. Repeated re-running of tests as it guessed and checked would be painfully slow.

A semi-automated approach I looked into was recording a script and having an AI convert it into Selenium commands - it wasn't very promising at all though.

The selectors chosen don't really seem great and obviously most test cases can be bootstrapped and setup with a huge mountain of existing test helpers we've already had - reducing all of that to just sequences of Selectors would result in a ton of duplication, unreadable code, and less robustness (our helpers have a  lot of good retry logic, adaptive waiting, rich debug messages, etc...).

# AI Assistance in Building Test Cases - Good!

The semi-automatic approach that I think is more promising is to have the AI agent setup a rich environment for manually testing the UI and then provide a mechanism for turning that exploration directly into a test case. I've implemented that hear using [claude slash commands](https://docs.claude.com/en/docs/claude-code/slash-commands).

This PR adds a Claude slash command ``/setup-selenium-test-notebook <feature description OR GitHub PR>``. It can take a description of the feature to test or just be given a PR.

It will setup a Jupyter notebook with cells filled out for setting up the Selenium environment and talking with Galaxy. It tells the user about the config file they need to setup if it isn't present to talk with a standing development server of Galaxy and tells the user how to run Jupyter. All this part is based on my prior work in https://github.com/galaxyproject/galaxy/pull/11177.

The agent will pull down the PR description and try to come up with an idea for how to test it. The manual testing instructions we already provide are great for this. It will also "research" the code base and find related tests and will provide potentially relevant code from existing tests as Markdown comments right in the notebook - so you have a good idea of what helpers and components are already implemented that might help with the task of testing the PR.

Some screenshots from the Notebook they setup for me for testing https://github.com/galaxyproject/galaxy/pull/20886.

<img width="1120" height="691" alt="Screenshot 2025-10-10 at 11 54 48 AM" src="https://github.com/user-attachments/assets/d6fb3240-f531-44dd-952a-6e9585936cae" />

<img width="815" height="891" alt="Screenshot 2025-10-10 at 11 55 00 AM" src="https://github.com/user-attachments/assets/e088ea37-c56a-4529-a6e0-4ccf83921b3f" />

<img width="1177" height="792" alt="Screenshot 2025-10-10 at 11 55 15 AM" src="https://github.com/user-attachments/assets/a0cbbde7-2461-459b-b77c-0deca6c216e9" />

I think it generated some existing code for preconditions that worked pretty good out of the box - the stuff unlike the existing stuff in the test framework came in commented form. It didn't pretend to know things it didn't - it was kind of refreshing.

The agent seems smart enough to reason about when a managed history annotation is needed and how to deal with user login, etc...

Developing in Jupyter is nice because it can sustain a persistent connection to the browser automation application. You don't have to re-run the whole test - you can work a line or two at a time with cells and preserve progress and just re-run what is needed as components are annotated, etc...

I think the screenshots are a cool part of the framework we have - and these will appear right inside the notebook.

After the notebook test case is ready go, claude seems pretty good at converting it directly to a test case. This can be done with '/extract-selenium-test <notebook path or description>'

I generated the test case for the test in https://github.com/galaxyproject/galaxy/pull/21040 and it worked on the first try for me (I did move it into an existing file because I thought that is where it belonged - so that was a manual step - but no big deal).

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Pay for Claude and try out the workflow described above.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
