### PR TITLE
[25.1] Restore .get_metadata function

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5198,6 +5198,11 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         # Needs to accept a MetadataCollection, a bunch, or a dict
         self._metadata = self.metadata.make_dict_copy(bunch)
 
+    def get_metadata(self) -> "galaxy.model.metadata.MetadataCollection":
+        # Alias for backwards compatibility with .get_metadata() calls in jbrowse/jbrowse2
+        # https://github.com/galaxyproject/tools-iuc/blob/4095773348da6faeb6096f58785b66898b09befa/tools/jbrowse2/jbrowse2.xml#L88
+        return self.metadata
+
     @property
     def set_metadata_requires_flush(self):
         return self.metadata.requires_dataset_id


### PR DESCRIPTION
Broken in 4956f208748b08e191fa4910360dbc8fff60cb00

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
