### PR TITLE
[25.1] Fix GCS file source to handle virtual directories without marker objects

### DIFF
--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -7,7 +7,6 @@ except ImportError:
     GCSFS = None
 
 import os
-from datetime import datetime
 from typing import (
     Optional,
     Union,
@@ -71,9 +70,7 @@ class GoogleCloudStorageFilesSource(
         if config.anonymous:
             client = Client.create_anonymous_client()
         elif config.service_account_json:
-            credentials = service_account.Credentials.from_service_account_file(
-                config.service_account_json
-            )
+            credentials = service_account.Credentials.from_service_account_file(config.service_account_json)
             client = Client(project=config.project, credentials=credentials)
         elif config.token:
             client = Client(
@@ -136,15 +133,11 @@ class GoogleCloudStorageFilesSource(
             for page in page_iterator_dirs.pages:
                 for dir_prefix in page.prefixes:
                     # Remove the parent prefix and trailing slash to get just the dir name
-                    dir_name = dir_prefix[len(prefix):].rstrip("/")
+                    dir_name = dir_prefix[len(prefix) :].rstrip("/")
                     if dir_name:
                         full_path = os.path.join("/", normalized_path, dir_name) if normalized_path else f"/{dir_name}"
                         uri = self.uri_from_path(full_path)
-                        entries.append(RemoteDirectory(
-                            name=dir_name,
-                            uri=uri,
-                            path=full_path
-                        ))
+                        entries.append(RemoteDirectory(name=dir_name, uri=uri, path=full_path))
 
             # Second iterator: Get files from blobs
             page_iterator_files = bucket.list_blobs(prefix=prefix, delimiter=delimiter)
@@ -154,7 +147,7 @@ class GoogleCloudStorageFilesSource(
                     continue
 
                 # Get just the filename (remove prefix)
-                file_name = blob.name[len(prefix):]
+                file_name = blob.name[len(prefix) :]
                 if file_name:
                     full_path = os.path.join("/", normalized_path, file_name) if normalized_path else f"/{file_name}"
                     uri = self.uri_from_path(full_path)
@@ -164,13 +157,9 @@ class GoogleCloudStorageFilesSource(
                     if blob.time_created:
                         ctime = blob.time_created.isoformat()
 
-                    entries.append(RemoteFile(
-                        name=file_name,
-                        size=blob.size or 0,
-                        ctime=ctime,
-                        uri=uri,
-                        path=full_path
-                    ))
+                    entries.append(
+                        RemoteFile(name=file_name, size=blob.size or 0, ctime=ctime, uri=uri, path=full_path)
+                    )
 
             # Apply query filter if provided
             if query:

--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -1,6 +1,7 @@
 try:
     from fs_gcsfs import GCSFS
     from google.cloud.storage import Client
+    from google.oauth2 import service_account
     from google.oauth2.credentials import Credentials
 except ImportError:
     GCSFS = None
@@ -24,6 +25,7 @@ class GoogleCloudStorageFileSourceTemplateConfiguration(BaseFileSourceTemplateCo
     root_path: Union[str, TemplateExpansion, None] = None
     project: Union[str, TemplateExpansion, None] = None
     anonymous: Union[bool, TemplateExpansion, None] = True
+    service_account_json: Union[str, TemplateExpansion, None] = None
     token: Union[str, TemplateExpansion, None] = None
     token_uri: Union[str, TemplateExpansion, None] = None
     client_id: Union[str, TemplateExpansion, None] = None
@@ -36,6 +38,7 @@ class GoogleCloudStorageFileSourceConfiguration(BaseFileSourceConfiguration):
     root_path: Optional[str] = None
     project: Optional[str] = None
     anonymous: Optional[bool] = True
+    service_account_json: Optional[str] = None
     token: Optional[str] = None
     token_uri: Optional[str] = None
     client_id: Optional[str] = None
@@ -62,6 +65,9 @@ class GoogleCloudStorageFilesSource(
         config = context.config
         if config.anonymous:
             client = Client.create_anonymous_client()
+        elif config.service_account_json:
+            credentials = service_account.Credentials.from_service_account_file(config.service_account_json)
+            client = Client(project=config.project, credentials=credentials)
         elif config.token:
             client = Client(
                 project=config.project,

--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -212,5 +212,25 @@ class GoogleCloudStorageFilesSource(
             with open(native_path, "wb") as write_file:
                 blob.download_to_file(write_file)
 
+    def _write_from(
+        self,
+        target_path: str,
+        native_path: str,
+        context: FilesSourceRuntimeContext[GoogleCloudStorageFileSourceConfiguration],
+    ):
+        """
+        Override to upload files directly to GCS, bypassing fs_gcsfs's directory marker checks.
+        """
+        with self._open_fs(context) as fs_handle:
+            bucket = fs_handle.bucket
+
+            # Convert path to GCS blob key
+            normalized_path = target_path.strip("/")
+
+            # Create blob and upload
+            blob = bucket.blob(normalized_path)
+            with open(native_path, "rb") as read_file:
+                blob.upload_from_file(read_file)
+
 
 __all__ = ("GoogleCloudStorageFilesSource",)

--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -6,15 +6,20 @@ try:
 except ImportError:
     GCSFS = None
 
+import os
+from datetime import datetime
 from typing import (
     Optional,
     Union,
 )
 
 from galaxy.files.models import (
+    AnyRemoteEntry,
     BaseFileSourceConfiguration,
     BaseFileSourceTemplateConfiguration,
     FilesSourceRuntimeContext,
+    RemoteDirectory,
+    RemoteFile,
 )
 from galaxy.util.config_templates import TemplateExpansion
 from ._pyfilesystem2 import PyFilesystem2FilesSource
@@ -66,7 +71,9 @@ class GoogleCloudStorageFilesSource(
         if config.anonymous:
             client = Client.create_anonymous_client()
         elif config.service_account_json:
-            credentials = service_account.Credentials.from_service_account_file(config.service_account_json)
+            credentials = service_account.Credentials.from_service_account_file(
+                config.service_account_json
+            )
             client = Client(project=config.project, credentials=credentials)
         elif config.token:
             client = Client(
@@ -82,6 +89,104 @@ class GoogleCloudStorageFilesSource(
 
         handle = GCSFS(bucket_name=config.bucket_name, root_path=config.root_path or "", retry=0, client=client)
         return handle
+
+    def _list(
+        self,
+        context: FilesSourceRuntimeContext[GoogleCloudStorageFileSourceConfiguration],
+        path="/",
+        recursive=False,
+        write_intent: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query: Optional[str] = None,
+        sort_by: Optional[str] = None,
+    ) -> tuple[list[AnyRemoteEntry], int]:
+        """
+        Override base class _list to work around fs_gcsfs limitation with virtual directories.
+
+        GCS doesn't require directory marker objects, but fs_gcsfs's getinfo() requires them.
+        This implementation uses the GCS API directly to list blobs, bypassing the problematic
+        getinfo() validation that fails for virtual directories.
+        """
+        if recursive:
+            # For recursive listing, fall back to the base implementation
+            return super()._list(context, path, recursive, write_intent, limit, offset, query, sort_by)
+
+        # Open filesystem to get access to the bucket
+        with self._open_fs(context) as fs_handle:
+            # Access the bucket from the GCSFS object
+            bucket = fs_handle.bucket
+
+            # Convert path to GCS prefix format
+            # Remove leading/trailing slashes and add trailing slash for directory prefix
+            normalized_path = path.strip("/")
+            if normalized_path:
+                prefix = normalized_path + "/"
+            else:
+                prefix = ""
+
+            # List blobs with delimiter to get immediate children only (non-recursive)
+            delimiter = "/"
+
+            # Collect directories (prefixes) and files (blobs)
+            entries: list[AnyRemoteEntry] = []
+
+            # First iterator: Get directories from prefixes
+            page_iterator_dirs = bucket.list_blobs(prefix=prefix, delimiter=delimiter)
+            for page in page_iterator_dirs.pages:
+                for dir_prefix in page.prefixes:
+                    # Remove the parent prefix and trailing slash to get just the dir name
+                    dir_name = dir_prefix[len(prefix):].rstrip("/")
+                    if dir_name:
+                        full_path = os.path.join("/", normalized_path, dir_name) if normalized_path else f"/{dir_name}"
+                        uri = self.uri_from_path(full_path)
+                        entries.append(RemoteDirectory(
+                            name=dir_name,
+                            uri=uri,
+                            path=full_path
+                        ))
+
+            # Second iterator: Get files from blobs
+            page_iterator_files = bucket.list_blobs(prefix=prefix, delimiter=delimiter)
+            for blob in page_iterator_files:
+                # Skip directory marker objects (empty blobs ending with /)
+                if blob.name.endswith("/"):
+                    continue
+
+                # Get just the filename (remove prefix)
+                file_name = blob.name[len(prefix):]
+                if file_name:
+                    full_path = os.path.join("/", normalized_path, file_name) if normalized_path else f"/{file_name}"
+                    uri = self.uri_from_path(full_path)
+
+                    # Convert blob metadata to RemoteFile
+                    ctime = None
+                    if blob.time_created:
+                        ctime = blob.time_created.isoformat()
+
+                    entries.append(RemoteFile(
+                        name=file_name,
+                        size=blob.size or 0,
+                        ctime=ctime,
+                        uri=uri,
+                        path=full_path
+                    ))
+
+            # Apply query filter if provided
+            if query:
+                query_lower = query.lower()
+                entries = [e for e in entries if query_lower in e.name.lower()]
+
+            # Get total count before pagination
+            total_count = len(entries)
+
+            # Apply pagination
+            if offset is not None or limit is not None:
+                start = offset or 0
+                end = start + limit if limit is not None else None
+                entries = entries[start:end]
+
+            return entries, total_count
 
 
 __all__ = ("GoogleCloudStorageFilesSource",)


### PR DESCRIPTION
Builds on https://github.com/galaxyproject/galaxy/pull/21027.

This fixes issues with Google Cloud Storage file sources when directories don't have marker objects.  https://gist.github.com/dannon/a563da931058ada3fa0d1679f25c9e69 demonstrates the issue.

## Background

GCS doesn't require directory marker objects (empty blobs with trailing `/`) -
directories can exist purely as prefixes. However, `fs_gcsfs` expects these
markers to exist and fails with `ResourceNotFound` when trying to access
virtual directories, even though the directories work fine with `gsutil`.

For the MoTrPAC buckets we're working with, adding thousands of marker objects
isn't practical, so we need to work around this limitation in code.

## Changes

Override `_list()`, `_realize_to()`, and `_write_from()` to use the GCS client
API directly instead of going through `fs_gcsfs`. This bypasses the problematic
`getinfo()` checks that require directory markers.

- **Browsing** - Use `bucket.list_blobs()` with delimiter to list directories
  and files
- **Downloads** - Use `blob.download_to_file()` directly
- **Uploads** - Use `blob.upload_from_file()` directly

## Testing

Tested with MoTrPAC buckets that have virtual directories:
- Browsing directories without markers
- Downloading files from virtual directories

Directories with markers continue to work as before.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
