### PR TITLE
[25.0] Fix `InvalidRequestError` when saving workflow step with dynamic tool

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2007,7 +2007,7 @@ class ToolModule(WorkflowModule):
 
     # ---- Saving in various forms ------------------------------------------
 
-    def save_to_step(self, step, detached=False):
+    def save_to_step(self, step: WorkflowStep, detached=False):
         super().save_to_step(step, detached=detached)
         step.tool_id = self.tool_id
         if self.tool:
@@ -2017,7 +2017,7 @@ class ToolModule(WorkflowModule):
         if tool_uuid := getattr(self, "tool_uuid", None):
             tool = self.trans.app.toolbox.get_tool(tool_uuid=tool_uuid, user=self.trans.user)
             if tool:
-                step.dynamic_tool = tool.dynamic_tool
+                step.dynamic_tool_id = tool.dynamic_tool.id
         if not detached:
             for k, v in self.post_job_actions.items():
                 pja = self.__to_pja(k, v, step)


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/20987

Fixes:
```
ERROR    galaxy.web.framework.decorators:decorators.py:355 Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/web/framework/decorators.py", line 340, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/workflows.py", line 312, in create
    return self.__api_import_new_workflow(trans, payload, **kwd)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/workflows.py", line 625, in __api_import_new_workflow
    workflow, missing_tool_tups = self._workflow_from_dict(
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/workflows.py", line 690, in _workflow_from_dict
    created_workflow = workflow_contents_manager.build_workflow_from_raw_description(
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/managers/workflows.py", line 707, in build_workflow_from_raw_description
    trans.sa_session.add(stored)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.9/site-packages/sqlalchemy/orm/scoping.py", line 380, in add
    return self._proxied.add(instance, _warn=_warn)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 3481, in add
    self._save_or_update_state(state)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 3511, in _save_or_update_state
    self._save_or_update_impl(st_)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 4203, in _save_or_update_impl
    self._update_impl(state)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 4192, in _update_impl
    self.identity_map.add(state)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.9/site-packages/sqlalchemy/orm/identity.py", line 195, in add
    raise sa_exc.InvalidRequestError(
sqlalchemy.exc.InvalidRequestError: Can't attach instance <DynamicTool at 0x7feeb0e85910>; another instance with key (<class 'galaxy.model.DynamicTool'>, (5,), None) is already present in this session.
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
