### PR TITLE
Cross product tools: Fix typos in help section

### DIFF
--- a/lib/galaxy/tools/cross_product_flat.xml
+++ b/lib/galaxy/tools/cross_product_flat.xml
@@ -82,8 +82,8 @@ How to use this tool
 
 Running input lists through this tool produces new dataset lists (described in detail below) that when using
 the same natural element-wise matching "map over" semantics described above produce every combination of the
-elements of the two lists compared against each other. Running a tool with these two outputs instead of the inital
-two input produces a list of the comparison of each combination of pairs from the respective inputs.
+elements of the two lists compared against each other. Running a tool with these two outputs instead of the initial
+two inputs produces a list of the comparison of each combination of pairs from the respective inputs.
 
 .. image:: ${static_path}/images/tools/collection_ops/flat_crossproduct_output.png
   :alt: The Flat Cartesian Product of Two Collections

--- a/lib/galaxy/tools/cross_product_nested.xml
+++ b/lib/galaxy/tools/cross_product_nested.xml
@@ -86,8 +86,8 @@ How to use this tool
 
 Running input lists through this tool produces new list structures (described in detail below) that when using
 the same natural element-wise matching "map over" semantics described above produce every combination of the
-elements of the two lists compared against each other. Running a tool with these two outputs instead of the inital
-two input produces a nested list structure where the jth element of the inner list of the ith element of the outer
+elements of the two lists compared against each other. Running a tool with these two outputs instead of the initial
+two inputs produces a nested list structure where the jth element of the inner list of the ith element of the outer
 list is a comparison of the ith element of the first list to the jth element of the second list. 
 Put more simply, the result is a nested list where the identifiers of an element describe which inputs were
 matched to produce the comparison output found at that element. 
@@ -105,9 +105,9 @@ has length ``n`` and dataset elements identified as ``a1``, ``a2``, ... ``an`` a
 has length ``m`` and dataset elements identified as ``b1``, ``b2``, ... ``bm``, then this tool
 produces a pair of output nested lists (specifically of the ``list:list`` collection type) where
 the outer list is of length ``n`` and each inner list has a length of ``m`` (a ``n X m`` nested list). The jth element
-inside the outer list's ith element is a pseudo copy of the ith dataset of ``inputa``. One
+inside the outer list's ith element is a pseudo copy of the ith dataset of ``input_a``. One
 way to think about the output nested lists is as matrices. Here is a diagram of the first output
-showing the element identifiers of the outer and inner lists along with the what dataset is being
+showing the element identifiers of the outer and inner lists along with dataset identifiers being
 "copied" into this new collection.
 
 .. image:: ${static_path}/images/tools/collection_ops/nested_cross_product_out_1.png
@@ -116,8 +116,8 @@ showing the element identifiers of the outer and inner lists along with the what
 
 The second output is a nested list of pseudo copies of the elements of ``input_b`` instead of 
 ``input_a``. In particular the outer list is again of length ``n`` and each inner list is again
-of lenth ``m`` but this time the jth element inside the outer list's ith element is a pseudo copy
-of the jth dataset of ``inputb``. Here is the matrix of these outputs.
+of length ``m`` but this time the jth element inside the outer list's ith element is a pseudo copy
+of the jth dataset of ``input_b``. Here is the matrix of these outputs.
 
 .. image:: ${static_path}/images/tools/collection_ops/nested_cross_product_out_2.png
   :alt: Nested Cross Product Second Output

--- a/lib/galaxy/tools/model_operation_macros.xml
+++ b/lib/galaxy/tools/model_operation_macros.xml
@@ -6,12 +6,12 @@
     <token name="@QUOTA_USAGE_NOTE@">This tool will create new history datasets copied from your input collections but your quota usage will not increase.</token>
     <token name="@CROSS_PRODUCT_INTRO@"><![CDATA[
 This tool organizes two dataset lists so that Galaxy's normal collection processing produces
-an all-vs-all style analyses of the initial inputs when applied to the outputs of this tool.
+an all-vs-all style analysis of the initial inputs when applied to the outputs of this tool.
 
 While a description of what it does standalone is technical and math heavy, how
 it works within an ad-hoc analysis or workflow can be quite straight forward and hopefully is easier
 to understand. For this reason, the next section describes how to use this tool in context and
-the technical details follow after that. Hopefully, the "how it works" details aren't nessecary to
+the technical details follow after that. Hopefully, the "how it works" details aren't necessary to
 understand the "how to use it" details of this tool - at least for simple things.
 ]]>
 </token>
@@ -19,7 +19,7 @@ understand the "how to use it" details of this tool - at least for simple things
 
 This tool can be used in and out of workflows, but workflows will be used to illustrate the ordering of
 tools and connections between them. Imagine a tool that compares two individual datasets and how
-that might be connected to list inputs in a workflow. This simiple case is shown below:
+that might be connected to list inputs in a workflow. This simple case is shown below:
 
 .. image:: ${static_path}/images/tools/collection_ops/dot_product.png
   :alt: The Dot Product of Two Collections


### PR DESCRIPTION
Fixing some typos in the help section of flat cross product and nested cross product tools,

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
