### PR TITLE
Selenium testing for new unified history export.

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -554,6 +554,7 @@ files_dialog:
 
 history_export:
   selectors:
+    # legacy history export (when STS and Celery are not enabled)
     export_link: '.export-link'
     running: '.history-export-component .loading-icon'
     generated_export_link: '.generated-export-link'
@@ -566,6 +567,15 @@ history_export:
     name_input: '.export-to-remote-file #name'
     export_button: '.export-button'
     success_message: '.history-export-component .alert-success'
+
+    # modern legacy export - unified with invocation export - these 
+    # selectors should be kept in sync with invocation selectors
+    export_output_format: '[data-history-export-format="${type}"] .card-body'
+    export_destination: '[data-history-export-destination="${destination}"] .card-body'
+    wizard_next_button: '.wizard-actions .go-next-btn'
+    wizard_export_button: '.wizard-actions .go-next-btn.btn-primary'
+    export_download_link: '.download-link'
+
 
 history_export_tasks:
   selectors:

--- a/lib/galaxy_test/selenium/test_history_export.py
+++ b/lib/galaxy_test/selenium/test_history_export.py
@@ -1,0 +1,95 @@
+from .framework import (
+    managed_history,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestHistoryExport(SeleniumTestCase):
+    """Test basic history export functionality.
+
+    Tests the history export wizard workflow for exporting histories
+    to different formats and destinations.
+    """
+
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_history_native_export_to_file(self):
+        """Test exporting a history to a file in the native tar.gz format with temporary download link.
+
+        This mirrors invocation export testing in test_workflow_run::test_workflow_export_file_native
+        """
+        # Upload test content to the history
+        self.perform_upload_of_pasted_content("my cool content")
+        self.history_panel_wait_for_hid_ok(1)
+
+        # Navigate home and initiate history export
+        self.home()
+        self.click_history_option_export_to_file()
+        history_export = self.components.history_export
+
+        self.screenshot("history_export_formats")
+        # Step 1: Select export format (tar.gz)
+        history_export.export_output_format(type="tar.gz").wait_for_and_click()
+        history_export.wizard_next_button.wait_for_and_click()
+
+        # Step 2: Select download destination (temporary download link)
+        download_option = history_export.export_destination(destination="download")
+        download_option.wait_for_present()
+        download_option.wait_for_and_click()
+        self.screenshot("history_export_native_destinations")
+        history_export.wizard_next_button.wait_for_and_click()
+
+        # Step 3: Complete the export
+        export_button = history_export.wizard_export_button
+        export_button.wait_for_present()
+        self.screenshot("history_export_native_download_options")
+        export_button.wait_for_and_click()
+
+        # Wait for export to be prepared
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.screenshot("history_export_native_preparing_download")
+        history_export.export_download_link.wait_for_present()
+        self.screenshot("history_export_native_download_ready")
+
+    @selenium_test
+    @managed_history
+    def test_history_rocrate_export_to_file(self):
+        """Test exporting a history to an rocrate with temporary download link.
+
+        This mirrors invocation export testing in test_workflow_run::test_workflow_export_file_rocrate
+        """
+        # Upload test content to the history
+        self.perform_upload_of_pasted_content("my cool content")
+        self.history_panel_wait_for_hid_ok(1)
+
+        # Navigate home and initiate history export
+        self.home()
+        self.click_history_option_export_to_file()
+        history_export = self.components.history_export
+
+        self.screenshot("history_export_formats")
+        # Step 1: Select export format (rocrate)
+        history_export.export_output_format(type="rocrate").wait_for_and_click()
+        history_export.wizard_next_button.wait_for_and_click()
+
+        # Step 2: Select download destination (temporary download link)
+        download_option = history_export.export_destination(destination="download")
+        download_option.wait_for_present()
+        download_option.wait_for_and_click()
+        self.screenshot("history_export_rocrate_destinations")
+        history_export.wizard_next_button.wait_for_and_click()
+
+        # Step 3: Complete the export
+        export_button = history_export.wizard_export_button
+        export_button.wait_for_present()
+        self.screenshot("history_export_rocrate_download_options")
+        export_button.wait_for_and_click()
+
+        # Wait for export to be prepared
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.screenshot("history_export_rocrate_preparing_download")
+        history_export.export_download_link.wait_for_present()
+        self.screenshot("history_export_rocrate_download_ready")

--- a/test/integration_selenium/test_history_export_legacy.py
+++ b/test/integration_selenium/test_history_export_legacy.py
@@ -4,7 +4,15 @@ from .framework import (
 )
 
 
-class TestHistoryExport(SeleniumIntegrationTestCase):
+class TestLegacyHistoryExport(SeleniumIntegrationTestCase):
+    """Test legacy history export for when celery is disabled.
+
+    If Celery is enabled, a wizard will be setup and STS will serve downloads,
+    this is tested in test_history_export.py in the main selenium test suite.
+
+    This current test needs to disable celery in order for the test to work
+    so it is an integration test and we disable celery in handle_galaxy_config_kwds.
+    """
     ensure_registered = True
 
     @classmethod


### PR DESCRIPTION
Basic tests for https://github.com/galaxyproject/galaxy/pull/20666. Largely mirroring workflow export tests added for 24.2 release testing in https://github.com/galaxyproject/galaxy/pull/19262.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
