### PR TITLE
[25.1] Fix Huggingface timestamp parsing when `last_commit` is missing

### DIFF
--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -104,7 +104,7 @@ class HuggingFaceFilesSource(
 
     def _extract_timestamp(self, info: dict) -> Optional[str]:
         """Extract timestamp from Hugging Face file info to use it in the RemoteFile entry."""
-        last_commit: dict = info.get("last_commit", {})
+        last_commit: dict = info.get("last_commit") or {}
         return last_commit.get("date")
 
     def _get_file_hashes(self, info: dict) -> Optional[list[RemoteFileHash]]:


### PR DESCRIPTION
Fixes #21069

It seems the `last_commit` is not always returned by the API when browsing files in the Huggingface repository. This ensures that even if the 'last_commit' is None or absent, the files are correctly listed, although without date or timestamp.


https://github.com/user-attachments/assets/1864fc56-a250-46f3-a44a-feb0a746caba



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
