### PR TITLE
[25.0] Fix has_size assertion 

### DIFF
--- a/lib/galaxy/tool_util/verify/asserts/size.py
+++ b/lib/galaxy/tool_util/verify/asserts/size.py
@@ -36,7 +36,7 @@ def assert_has_size(
         size = value
     _assert_number(
         output_size,
-        value,
+        size,
         delta,
         min,
         max,

--- a/test/unit/tool_util/verify/test_asserts.py
+++ b/test/unit/tool_util/verify/test_asserts.py
@@ -8,6 +8,7 @@ try:
     import h5py
 except ImportError:
     h5py = None
+import pytest
 
 from galaxy.tool_util.parser.xml import __parse_assert_list_from_elem
 from galaxy.tool_util.verify import asserts
@@ -489,15 +490,17 @@ with tempfile.NamedTemporaryFile(mode="w", delete=False) as txttmp:
     GZA100 = gzip.compress(A100)
 
 
-def test_has_size_success():
+@pytest.mark.parametrize("size_attrib", ["size", "value"])
+def test_has_size_success(size_attrib):
     """test has_size"""
-    a = run_assertions(SIZE_HAS_SIZE_ASSERTION.format(size_attrib="size", value=10), TEXT_DATA_HAS_TEXT)
+    a = run_assertions(SIZE_HAS_SIZE_ASSERTION.format(size_attrib=size_attrib, value=10), TEXT_DATA_HAS_TEXT)
     assert len(a) == 0
 
 
-def test_has_size_failure():
+@pytest.mark.parametrize("size_attrib", ["size", "value"])
+def test_has_size_failure(size_attrib):
     """test has_size .. negative test"""
-    a = run_assertions(SIZE_HAS_SIZE_ASSERTION.format(size_attrib="value", value="10"), TEXT_DATA_HAS_TEXT * 2)
+    a = run_assertions(SIZE_HAS_SIZE_ASSERTION.format(size_attrib=size_attrib, value="10"), TEXT_DATA_HAS_TEXT * 2)
     assert "Expected file size of 10+-0 found 20" in a
     assert len(a) == 1
 


### PR DESCRIPTION
assertions using size have been useless so far since we just used value in the comparison :(

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
