### PR TITLE
[25.1] Add 2 net utilities to the min image

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -150,12 +150,14 @@ RUN set -xe; \
         locales \
         vim-tiny \
         nano-tiny \
+        netcat-openbsd \
         curl \
         procps \
         less \
         bzip2 \
         tini \
         nodejs \
+        wget \
     && update-alternatives --install /usr/bin/nano nano /bin/nano-tiny 0 \
     && update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 0 \
     && echo "set nocompatible\nset backspace=indent,eol,start" >> /usr/share/vim/vimrc.tiny \


### PR DESCRIPTION
The new deployment model being developed for AnVIL requires these two packages due to file permissions.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
