### PR TITLE
Remove defunct custos services

### DIFF
--- a/client/src/components/Login/LoginForm.test.ts
+++ b/client/src/components/Login/LoginForm.test.ts
@@ -42,7 +42,7 @@ describe("LoginForm", () => {
         axiosMock = new MockAdapter(axios);
         server.use(
             http.get("/api/configuration", ({ response }) => {
-                return response.untyped(HttpResponse.json({ oidc: { cilogon: false, custos: false } }));
+                return response.untyped(HttpResponse.json({ oidc: { cilogon: false } }));
             }),
         );
     });

--- a/client/src/components/Register/RegisterForm.vue
+++ b/client/src/components/Register/RegisterForm.vue
@@ -32,7 +32,7 @@ interface Props {
     enableOidc?: boolean;
     mailingJoinAddr?: string;
     oidcIdps?: OIDCConfig;
-    preferOIDCLogin?: boolean;
+    preferOidcLogin?: boolean;
     redirect?: string;
     registrationWarningMessage?: string;
     serverMailConfigured?: boolean;
@@ -59,7 +59,7 @@ const labelSubscribe = ref(localize("Stay in the loop and join the galaxy-announ
 const idpsWithRegistration = computed(() => (props.oidcIdps ? getOIDCIdpsWithRegistration(props.oidcIdps) : {}));
 
 const oidcPreferred = computed(() => {
-    return props.enableOidc && props.preferOIDCLogin;
+    return props.enableOidc && props.preferOidcLogin;
 });
 
 /** This decides if all register options should be displayed in column style

--- a/client/src/components/Register/RegisterForm.vue
+++ b/client/src/components/Register/RegisterForm.vue
@@ -32,7 +32,7 @@ interface Props {
     enableOidc?: boolean;
     mailingJoinAddr?: string;
     oidcIdps?: OIDCConfig;
-    preferCustosLogin?: boolean;
+    preferOIDCLogin?: boolean;
     redirect?: string;
     registrationWarningMessage?: string;
     serverMailConfigured?: boolean;
@@ -58,8 +58,8 @@ const labelSubscribe = ref(localize("Stay in the loop and join the galaxy-announ
 
 const idpsWithRegistration = computed(() => (props.oidcIdps ? getOIDCIdpsWithRegistration(props.oidcIdps) : {}));
 
-const custosPreferred = computed(() => {
-    return props.enableOidc && props.preferCustosLogin;
+const oidcPreferred = computed(() => {
+    return props.enableOidc && props.preferOIDCLogin;
 });
 
 /** This decides if all register options should be displayed in column style
@@ -107,8 +107,8 @@ async function submit() {
 
                 <BForm id="registration" @submit.prevent="submit()">
                     <BCard no-body>
-                        <!-- OIDC and Custos enabled and prioritized: encourage users to use it instead of local registration -->
-                        <span v-if="custosPreferred">
+                        <!-- OIDC enabled and prioritized: encourage users to use it instead of local registration -->
+                        <span v-if="oidcPreferred">
                             <BCardHeader v-b-toggle.accordion-oidc role="button">
                                 Register using institutional account
                             </BCardHeader>
@@ -116,21 +116,21 @@ async function submit() {
                             <BCollapse id="accordion-oidc" visible role="tabpanel" accordion="registration_acc">
                                 <BCardBody>
                                     Create a Galaxy account using an institutional account (e.g.:Google/JHU). This will
-                                    redirect you to your institutional login through Custos.
+                                    redirect you to your institutional login through OIDC.
                                     <ExternalLogin class="mt-2" />
                                 </BCardBody>
                             </BCollapse>
                         </span>
 
                         <!-- Local Galaxy Registration -->
-                        <BCardHeader v-if="!custosPreferred" v-localize>Create a Galaxy account</BCardHeader>
+                        <BCardHeader v-if="!oidcPreferred" v-localize>Create a Galaxy account</BCardHeader>
                         <BCardHeader v-else v-localize v-b-toggle.accordion-register role="button">
                             Or, register with email
                         </BCardHeader>
 
                         <BCollapse
                             id="accordion-register"
-                            :visible="!custosPreferred"
+                            :visible="!oidcPreferred"
                             role="tabpanel"
                             accordion="registration_acc">
                             <BCardBody :class="{ 'd-flex w-100': !registerColumnDisplay }">

--- a/client/src/components/User/ExternalIdentities/ExternalIDHelper.ts
+++ b/client/src/components/User/ExternalIdentities/ExternalIDHelper.ts
@@ -26,7 +26,7 @@ export type OIDCConfigWithRegistration = Record<
 
 /** Return the per-IDP config, minus anything the caller wants to hide. */
 export function getFilteredOIDCIdps(oidcConfig: OIDCConfig, exclude: string[] = []): OIDCConfig {
-    const blacklist = new Set(["cilogon", "custos", ...exclude]);
+    const blacklist = new Set(["cilogon", ...exclude]);
     const filtered: OIDCConfig = {};
     Object.entries(oidcConfig).forEach(([idp, cfg]) => {
         if (!blacklist.has(idp)) {
@@ -51,11 +51,11 @@ export function getOIDCIdpsWithRegistration(oidcConfig: OIDCConfig): OIDCConfigW
 
 /** Do we need to show the institution picker at all? */
 export const getNeedShowCilogonInstitutionList = (cfg: OIDCConfig): boolean => {
-    return Boolean(cfg.cilogon || cfg.custos);
+    return Boolean(cfg.cilogon);
 };
 
 /**
- * Generic OIDC login (all providers *except* CILogon/Custos).
+ * Generic OIDC login (all providers *except* CILogon).
  * Returns the redirect URI Galaxy gives back, or throws.
  */
 export async function submitOIDCLogon(idp: string, redirectParam: string | null = null): Promise<string | null> {
@@ -73,8 +73,8 @@ export async function submitOIDCLogon(idp: string, redirectParam: string | null 
 }
 
 /**
- * CILogon/Custos login.
- * @param idp        "cilogon" | "custos"
+ * CILogon login.
+ * @param idp        "cilogon"
  * @param useIDPHint If true, append ?idphint=
  * @param idpHint    The entityID to hint with (ignored when useIDPHint = false)
  */
@@ -108,7 +108,7 @@ export async function redirectToSingleProvider(config: OIDCConfig): Promise<stri
         throw new Error("OIDC provider key is undefined.");
     }
 
-    if (idp === "cilogon" || idp === "custos") {
+    if (idp === "cilogon") {
         const redirectUri = await submitCILogon(idp, false);
         return redirectUri;
     } else {

--- a/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
@@ -121,7 +121,6 @@ export default {
             doomedItem: null,
             errorMessage: null,
             enable_oidc: galaxy.config.enable_oidc,
-            cilogonOrOIDC: null,
             userEmail: galaxy.user.get("email"),
         };
     },

--- a/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalIdentities.vue
@@ -121,7 +121,7 @@ export default {
             doomedItem: null,
             errorMessage: null,
             enable_oidc: galaxy.config.enable_oidc,
-            cilogonOrCustos: null,
+            cilogonOrOIDC: null,
             userEmail: galaxy.user.get("email"),
         };
     },

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -211,7 +211,6 @@ function getIdpPreference() {
                         <LoadingSpan v-if="loading" message="Signing In" />
                         <span v-else>Sign in with Institutional Credentials*</span>
                     </GButton>
-
                 </div>
 
                 <div v-else>
@@ -222,7 +221,6 @@ function getIdpPreference() {
                             @click="toggleCILogon('cilogon')">
                             Sign in with Institutional Credentials*
                         </GButton>
-
                     </GButtonGroup>
 
                     <BFormGroup v-if="toggleCilogon" class="mt-1">
@@ -248,8 +246,8 @@ function getIdpPreference() {
 
                 <p class="mt-3">
                     <small class="text-muted">
-                        * Galaxy uses CILogon to enable you to log in from this organization. By clicking
-                        'Sign In', you agree to the
+                        * Galaxy uses CILogon to enable you to log in from this organization. By clicking 'Sign In', you
+                        agree to the
                         <a href="https://ca.cilogon.org/policy/privacy">CILogon</a> privacy policy and you agree to
                         share your username, email address, and affiliation with CILogon and Galaxy.
                     </small>

--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -50,7 +50,7 @@ const messageVariant = ref<string | null>(null);
 const cILogonIdps = ref<Idp[]>([]);
 const selected = ref<Idp | null>(null);
 const rememberIdp = ref(false);
-const cilogonOrCustos = ref<"cilogon" | "custos" | null>(null);
+const cilogon = ref<"cilogon" | null>(null);
 const toggleCilogon = ref(false);
 
 const oIDCIdps = computed<OIDCConfig>(() => (isConfigLoaded.value ? config.value.oidc : {}));
@@ -60,22 +60,21 @@ const filteredOIDCIdps = computed(() => getFilteredOIDCIdps(oIDCIdps.value, prop
 const cilogonListShow = computed(() => getNeedShowCilogonInstitutionList(oIDCIdps.value));
 
 const cILogonEnabled = computed(() => oIDCIdps.value.cilogon);
-const custosEnabled = computed(() => oIDCIdps.value.custos);
 
 onMounted(async () => {
     rememberIdp.value = getIdpPreference() !== null;
 
-    // Only fetch CILogonIDPs if custos/cilogon configured
+    // Only fetch CILogonIDPs if cilogon configured
     if (cilogonListShow.value) {
         await getCILogonIdps();
     }
 });
 
-function toggleCILogon(idp: "cilogon" | "custos") {
-    if (cilogonOrCustos.value === idp || cilogonOrCustos.value === null) {
+function toggleCILogon(idp: "cilogon") {
+    if (cilogon.value === idp || cilogon.value === null) {
         toggleCilogon.value = !toggleCilogon.value;
     }
-    cilogonOrCustos.value = toggleCilogon.value ? idp : null;
+    cilogon.value = toggleCilogon.value ? idp : null;
 }
 
 async function clickOIDCLogin(idp: string) {
@@ -186,7 +185,7 @@ function getIdpPreference() {
             <!-- OIDC login-->
             <BForm v-if="cilogonListShow" id="externalLogin" class="cilogon">
                 <div v-if="props.loginPage">
-                    <!--Only Display if CILogon/Custos is configured-->
+                    <!--Only Display if CILogon is configured-->
                     <BFormGroup label="Use existing institutional login">
                         <Multiselect
                             v-model="selected"
@@ -212,31 +211,18 @@ function getIdpPreference() {
                         <LoadingSpan v-if="loading" message="Signing In" />
                         <span v-else>Sign in with Institutional Credentials*</span>
                     </GButton>
-                    <!--convert to v-else-if to allow only one or the other. if both enabled, put the one that should be default first-->
-                    <GButton
-                        v-if="Object.prototype.hasOwnProperty.call(oIDCIdps, 'custos')"
-                        :disabled="loading || selected === null"
-                        @click="clickCILogin('custos')">
-                        <LoadingSpan v-if="loading" message="Signing In" />
-                        <span v-else>Sign in with Custos*</span>
-                    </GButton>
+
                 </div>
 
                 <div v-else>
                     <GButtonGroup class="w-100">
                         <GButton
                             v-if="cILogonEnabled"
-                            :pressed="cilogonOrCustos === 'cilogon'"
+                            :pressed="cilogon === 'cilogon'"
                             @click="toggleCILogon('cilogon')">
                             Sign in with Institutional Credentials*
                         </GButton>
 
-                        <GButton
-                            v-if="custosEnabled"
-                            :pressed="cilogonOrCustos === 'custos'"
-                            @click="toggleCILogon('custos')">
-                            Sign in with Custos*
-                        </GButton>
                     </GButtonGroup>
 
                     <BFormGroup v-if="toggleCilogon" class="mt-1">
@@ -254,18 +240,18 @@ function getIdpPreference() {
                             v-if="toggleCilogon"
                             class="mt-1"
                             :disabled="loading || selected === null"
-                            @click="clickCILogin(cilogonOrCustos)">
-                            Login via {{ cilogonOrCustos === "cilogon" ? "CILogon" : "Custos" }} *
+                            @click="clickCILogin(cilogon)">
+                            Login via CILogon *
                         </GButton>
                     </BFormGroup>
                 </div>
 
                 <p class="mt-3">
                     <small class="text-muted">
-                        * Galaxy uses CILogon via Custos to enable you to log in from this organization. By clicking
+                        * Galaxy uses CILogon to enable you to log in from this organization. By clicking
                         'Sign In', you agree to the
                         <a href="https://ca.cilogon.org/policy/privacy">CILogon</a> privacy policy and you agree to
-                        share your username, email address, and affiliation with CILogon, Custos, and Galaxy.
+                        share your username, email address, and affiliation with CILogon and Galaxy.
                     </small>
                 </p>
             </BForm>

--- a/client/src/components/User/ExternalIdentities/service.js
+++ b/client/src/components/User/ExternalIdentities/service.js
@@ -6,7 +6,7 @@ const getUrl = (path) => getRootFromIndexLink() + path;
 export async function disconnectIdentity(doomed) {
     if (doomed) {
         let url;
-        if (doomed.provider === "custos" || doomed.provider === "cilogon") {
+        if (doomed.provider === "cilogon") {
             url = getUrl(`authnz/${doomed.provider}/disconnect/${doomed.email}`);
         } else {
             url = getUrl(`authnz/${doomed.provider}/disconnect/`);

--- a/client/src/entry/analysis/modules/Login.test.ts
+++ b/client/src/entry/analysis/modules/Login.test.ts
@@ -13,7 +13,7 @@ const configMock = {
     allow_local_account_creation: true,
     enable_oidc: true,
     mailing_join_addr: "mailing_join_addr",
-    prefer_custos_login: true,
+    prefer_oidc_login: true,
     registration_warning_message: "registration_warning_message",
     server_mail_configured: true,
     show_welcome_with_login: true,

--- a/client/src/entry/analysis/modules/Register.test.ts
+++ b/client/src/entry/analysis/modules/Register.test.ts
@@ -61,7 +61,7 @@ describe("Register", () => {
         expect(props.sessionCsrfToken).toBe("session_csrf_token");
         expect(props.enableOidc).toBe(true);
         expect(props.mailingJoinAddr).toBe("mailing_join_addr");
-        expect(props.preferOIDCLogin).toBe(true);
+        expect(props.preferOidcLogin).toBe(true);
         expect(props.serverMailConfigured).toBe(true);
         expect(props.registrationWarningMessage).toBe("registration_warning_message");
         expect(props.termsUrl).toBe("terms_url");

--- a/client/src/entry/analysis/modules/Register.test.ts
+++ b/client/src/entry/analysis/modules/Register.test.ts
@@ -13,7 +13,7 @@ const configMock = {
     allow_local_account_creation: true,
     enable_oidc: true,
     mailing_join_addr: "mailing_join_addr",
-    prefer_custos_login: true,
+    prefer_oidc_login: true,
     registration_warning_message: "registration_warning_message",
     server_mail_configured: true,
     show_welcome_with_login: true,
@@ -61,7 +61,7 @@ describe("Register", () => {
         expect(props.sessionCsrfToken).toBe("session_csrf_token");
         expect(props.enableOidc).toBe(true);
         expect(props.mailingJoinAddr).toBe("mailing_join_addr");
-        expect(props.preferCustosLogin).toBe(true);
+        expect(props.preferOIDCLogin).toBe(true);
         expect(props.serverMailConfigured).toBe(true);
         expect(props.registrationWarningMessage).toBe("registration_warning_message");
         expect(props.termsUrl).toBe("terms_url");

--- a/client/src/entry/analysis/modules/Register.vue
+++ b/client/src/entry/analysis/modules/Register.vue
@@ -21,7 +21,7 @@ const sessionCsrfToken = computed(() => {
             :enable-oidc="config.enable_oidc"
             :mailing-join-addr="config.mailing_join_addr"
             :oidc-idps="config.oidc"
-            :prefer-custos-login="config.prefer_custos_login"
+            :prefer-oidc-login="config.prefer_oidc_login"
             :registration-warning-message="config.registration_warning_message"
             :server-mail-configured="config.server_mail_configured"
             :session-csrf-token="sessionCsrfToken"

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3817,11 +3817,11 @@
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~
-``prefer_custos_login``
+``prefer_oidc_login``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Controls the order of the login page to prefer Custos-based login
+    Controls the order of the login page to prefer OIDC-based login
     and registration.
 :Default: ``false``
 :Type: bool

--- a/doc/source/admin/special_topics/vault.md
+++ b/doc/source/admin/special_topics/vault.md
@@ -12,7 +12,6 @@ There are currently 3 supported backends.
 | Backend     | Description                                                                                                                                                                                                                                                                                                                                   |
 |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | hashicorp   | Hashicorp Vault is a secrets and encryption management system. https://www.vaultproject.io/                                                                                                                                                                                                                                                   |
-| custos      | Custos is an NSF-funded project, backed by open source software that provides science gateways such as Galaxy with single sign-on, group management, and management of secrets such as access keys and OAuth2 access tokens. Custos secrets management is backed by Hashicorp's vault, but provides a convenient, always-on ReST API service. |
 | database    | The database backend stores secrets in an encrypted table in the Galaxy database itself. It is a convenient way to get started with a vault, and while it supports basic key rotation, we recommend using one of the other options in production.                                                                                           |
 
 ## Configuring Galaxy
@@ -36,7 +35,7 @@ path_prefix: /galaxy  # optional
 ...
 ```
 
-The `type` must be a valid backend type: `hashicorp`, `custos`, or `database`. At present, only a single vault backend
+The `type` must be a valid backend type: `hashicorp`, or `database`. At present, only a single vault backend
 is supported. The `path_prefix` property indicates  the root path under which to store all vault keys. If multiple
 Galaxy instances are using the same vault, a prefix can  be used to uniquely identify the Galaxy instance.
 If no path_prefix is provided, the prefix defaults to `/galaxy`.
@@ -49,19 +48,6 @@ path_prefix: /my_galaxy_instance
 vault_address: http://localhost:8200
 vault_token: vault_application_token
 ```
-
-## Vault configuration for Custos
-
-```yaml
-type: custos
-custos_host: service.staging.usecustos.org
-custos_port: 30170
-custos_client_id: custos-jeREDACTEDye-10000001
-custos_client_sec: OGREDACTEDBSUDHn
-```
-
-Obtaining the Custos client id and client secret requires first registering your Galaxy instance with Custos.
-Visit [usecustos.org](http://usecustos.org/) for more information.
 
 ## Vault configuration for database
 

--- a/doc/source/lib/galaxy.authnz.rst
+++ b/doc/source/lib/galaxy.authnz.rst
@@ -9,14 +9,6 @@ galaxy.authnz package
 Submodules
 ----------
 
-galaxy.authnz.custos\_authnz module
------------------------------------
-
-.. automodule:: galaxy.authnz.custos_authnz
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 galaxy.authnz.managers module
 -----------------------------
 

--- a/doc/source/releases/22.05_announce.rst
+++ b/doc/source/releases/22.05_announce.rst
@@ -67,7 +67,7 @@ config/galaxy.yml.sample:galaxy
 -  mapping.galaxy.mapping.log_destination
 -  mapping.galaxy.mapping.log_rotate_count
 -  mapping.galaxy.mapping.log_rotate_size
--  mapping.galaxy.mapping.prefer_custos_login
+-  mapping.galaxy.mapping.prefer_oidc_login
 -  mapping.galaxy.mapping.short_term_storage_cleanup_interval
 -  mapping.galaxy.mapping.short_term_storage_default_duration
 -  mapping.galaxy.mapping.short_term_storage_dir

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2111,9 +2111,9 @@ galaxy:
   # page (even if require_login is true).
   #show_welcome_with_login: false
 
-  # Controls the order of the login page to prefer Custos-based login
+  # Controls the order of the login page to prefer OIDC-based login
   # and registration.
-  #prefer_custos_login: false
+  #prefer_oidc_login: false
 
   # Allow unregistered users to create new local (non-OIDC) accounts
   # (otherwise, they will have to be created by an admin). This option

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -90,39 +90,18 @@ Please mind `http` and `https`.
         <prompt>consent</prompt>
     </provider>
 
-    <provider name="Custos">
-        <url>https://dev.custos.usecustos.org/apiserver/identity-management/v1.0.0/</url>
-        <client_id> ... </client_id>
-        <client_secret> ... </client_secret>
-        <redirect_uri>http://localhost:8080/authnz/custos/callback</redirect_uri>
-        <!-- (Optional): whether to show a create account confirmation page.  This defaults to True for Custos -->
-        <!-- <require_create_confirmation>true</require_create_confirmation> -->
-        <!-- (Optional) Trusted CA certificate file or directory to use when verify Custos authorization server.
-             See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification for more information. -->
-        <!-- <ca_bundle>/path/to/ca_bundle</ca_bundle> -->
-        <!-- (Optional) Override the default Custos well-known URL to point to a different instance -->
-        <!-- <well_known_oidc_config_uri>https://.../.well-known/openid-configuration</well_known_oidc_config_uri> -->
-        <!-- (Optional) Restrict the list of options available for login using CILogon or Custos by including the EntityID for each institution
-             in a separate <allowed_idp> tag. Find the EntityID(s) for your desired institution(s) at https://cilogon.org/idplist/
-             Note: the <allowed_idp>'s for Custos should match those for CILogon if both are enabled.-->
-        <!-- <allowed_idp>https://github.com/login/oauth/authorize</allowed_idp> -->
-        <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
-        <!-- <enable_idp_logout>false</enable_idp_logout> -->
-    </provider>
-
     <provider name="CILogon">
         <url>https://cilogon.org/authorize</url>
         <client_id> ... </client_id>
         <client_secret> ... </client_secret>
         <redirect_uri>http://localhost:8080/authnz/cilogon/callback</redirect_uri>
-        <!-- (Optional) Trusted CA certificate file or directory to use when verify Custos authorization server.
+        <!-- (Optional) Trusted CA certificate file or directory to use when verifying the CILogon authorization server.
              See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification for more information. -->
         <!-- <ca_bundle>/path/to/ca_bundle</ca_bundle> -->
-        <!-- (Optional) Override the default Custos well-known URL to point to a different instance -->
+        <!-- (Optional) Override the default well-known URL to point to a different instance -->
         <!-- <well_known_oidc_config_uri>https://.../.well-known/openid-configuration</well_known_oidc_config_uri> -->
-        <!-- (Optional) Restrict the list of options available for login using CILogon or Custos by including the EntityID for each institution
-             in a separate <allowed_idp> tag. Find the EntityID(s) for your desired institution(s) at https://cilogon.org/idplist/
-             Note: the <allowed_idp>'s for CILogon should match those for Custos if both are enabled.-->
+        <!-- (Optional) Restrict the list of options available for login using CILogon by including the EntityID for each institution
+             in a separate <allowed_idp> tag. Find the EntityID(s) for your desired institution(s) at https://cilogon.org/idplist/ -->
         <!-- <allowed_idp>https://github.com/login/oauth/authorize</allowed_idp> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
         <!-- <enable_idp_logout>false</enable_idp_logout> -->
@@ -140,10 +119,10 @@ Please mind `http` and `https`.
         <!-- <label>My provider name</label> -->
         <!-- (Optional): whether to show a create account confirmation page -->
         <!-- <require_create_confirmation>false</require_create_confirmation> -->
-        <!-- (Optional) Trusted CA certificate file or directory to use when verify Custos authorization server.
+        <!-- (Optional) Trusted CA certificate file or directory to use when verifying the keycloak authorization server.
              See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification for more information. -->
         <!-- <ca_bundle>/path/to/ca_bundle</ca_bundle> -->
-        <!-- (Optional) Override the default Custos well-known URL to point to a different instance -->
+        <!-- (Optional) Override the default well-known URL to point to a different instance -->
         <!-- <well_known_oidc_config_uri>https://.../.well-known/openid-configuration</well_known_oidc_config_uri> -->
         <!-- (Optional) Override the default idp hint -->
         <!-- <idphint>cilogon</idphint> -->

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2815,7 +2815,7 @@ mapping:
           Show the site's welcome page (see welcome_url) alongside the login page
           (even if require_login is true).
 
-      prefer_cilogon_login:
+      prefer_oidc_login:
         type: bool
         default: false
         required: False

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2815,12 +2815,12 @@ mapping:
           Show the site's welcome page (see welcome_url) alongside the login page
           (even if require_login is true).
 
-      prefer_custos_login:
+      prefer_cilogon_login:
         type: bool
         default: false
         required: False
         desc: |
-          Controls the order of the login page to prefer Custos-based login and registration.
+          Controls the order of the login page to prefer OIDC-based login and registration.
 
       allow_local_account_creation:
         type: bool

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -308,9 +308,6 @@ class ConditionalDependencies:
         # See notes in ./conditional-requirements.txt for more information.
         return os.environ.get("GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT") == "1"
 
-    def check_custos_sdk(self):
-        return "custos" == self.vault_type
-
     def check_hvac(self):
         return "hashicorp" == self.vault_type
 

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -37,7 +37,6 @@ huggingface_hub
 
 # Vault backend
 hvac
-custos-sdk
 
 # Chronos client
 chronos-python==1.2.1

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -149,7 +149,7 @@ class ConfigSerializer(base.ModelSerializer):
             "single_user": _config_is_truthy,
             "enable_oidc": _use_config,
             "oidc": _use_config,
-            "prefer_custos_login": _use_config,
+            "prefer_oidc_login": _use_config,
             "enable_quotas": _use_config,
             "remote_user_logout_href": _use_config,
             "post_user_logout_href": _use_config,

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -44,7 +44,7 @@ class OIDC(JSAppLauncher):
             rtv.append(
                 {"id": trans.app.security.encode_id(authnz.id), "provider": authnz.provider, "email": authnz.uid}
             )
-        # Add cilogon and custos identities
+        # Add cilogon and keycloak identities
         for token in trans.user.custos_auth:
             # for purely displaying the info to user, we bypass verification of
             # signature, audience, and expiration as that's potentially useful

--- a/test/unit/app/authnz/test_custos_authnz.py
+++ b/test/unit/app/authnz/test_custos_authnz.py
@@ -68,7 +68,7 @@ class TestCustosAuthnz(TestCase):
             }
         )
         self.custos_authnz = custos_authnz.CustosAuthFactory.GetCustosBasedAuthProvider(
-            "Custos",
+            "keycloak",
             {"VERIFY_SSL": True},
             {
                 "url": self._get_idp_url(),
@@ -308,7 +308,7 @@ class TestCustosAuthnz(TestCase):
     def test_authenticate_sets_env_var_when_localhost_redirect(self):
         """Verify that OAUTHLIB_INSECURE_TRANSPORT var is set with localhost redirect."""
         self.custos_authnz = custos_authnz.CustosAuthFactory.GetCustosBasedAuthProvider(
-            "Custos",
+            "keycloak",
             {"VERIFY_SSL": True},
             {
                 "url": self._get_idp_url(),
@@ -661,7 +661,7 @@ class TestCustosAuthnz(TestCase):
 
     def test_disconnect_when_no_associated_provider(self):
         self.trans.user = User()
-        success, message, redirect_uri = self.custos_authnz.disconnect("Custos", self.trans, "/")
+        success, message, redirect_uri = self.custos_authnz.disconnect("keycloak", self.trans, "/")
         assert 0 == len(self.trans.sa_session.deleted)
         assert not self.trans.sa_session.commit_called
         assert not success
@@ -692,7 +692,7 @@ class TestCustosAuthnz(TestCase):
         )
         self.trans.user.custos_auth = [custos_authnz_token1, custos_authnz_token2]
 
-        success, message, redirect_uri = self.custos_authnz.disconnect("Custos", self.trans, "/")
+        success, message, redirect_uri = self.custos_authnz.disconnect("keycloak", self.trans, "/")
 
         assert 0 == len(self.trans.sa_session.deleted)
         assert not self.trans.sa_session.commit_called

--- a/test/unit/app/dependencies/test_deps.py
+++ b/test/unit/app/dependencies/test_deps.py
@@ -30,9 +30,6 @@ runners:
   runner1:
     load: job_runner_A
 """
-VAULT_CONF_CUSTOS = """
-type: custos
-"""
 VAULT_CONF_HASHICORP = """
 type: hashicorp
 """
@@ -102,17 +99,6 @@ def test_yaml_jobconf_runners():
         assert "job_runner_A" in cds.job_runners
 
 
-def test_vault_custos_configured():
-    with _config_context() as cc:
-        vault_conf = cc.write_config("vault_conf.yml", VAULT_CONF_CUSTOS)
-        config = {
-            "vault_config_file": vault_conf,
-        }
-        cds = cc.get_cond_deps(config=config)
-        assert cds.check_custos_sdk()
-        assert not cds.check_hvac()
-
-
 def test_vault_hashicorp_configured():
     with _config_context() as cc:
         vault_conf = cc.write_config("vault_conf.yml", VAULT_CONF_HASHICORP)
@@ -121,7 +107,6 @@ def test_vault_hashicorp_configured():
         }
         cds = cc.get_cond_deps(config=config)
         assert cds.check_hvac()
-        assert not cds.check_custos_sdk()
 
 
 @pytest.mark.parametrize(

--- a/test/unit/data/security/fixtures/vault_conf_custos.yml
+++ b/test/unit/data/security/fixtures/vault_conf_custos.yml
@@ -1,6 +1,0 @@
-type: custos
-path_prefix: /my_galaxy_instance
-custos_host: service.staging.usecustos.org
-custos_port: 30170
-custos_client_id: ${custos_client_id}
-custos_client_sec: ${custos_client_secret}

--- a/test/unit/data/security/test_vault.py
+++ b/test/unit/data/security/test_vault.py
@@ -110,30 +110,3 @@ class TestDatabaseVault(AbstractTestCases.VaultTestBase):
         vault = VaultFactory.from_app(app)
         with self.assertRaises(InvalidToken):
             vault.read_secret("my/incorrect/secret")
-
-
-VAULT_CONF_CUSTOS = os.path.join(os.path.dirname(__file__), "fixtures/vault_conf_custos.yml")
-
-
-@pytest.mark.skipif(
-    not os.environ.get("CUSTOS_CLIENT_ID") or not os.environ.get("CUSTOS_CLIENT_SECRET"),
-    reason="CUSTOS_CLIENT_ID and CUSTOS_CLIENT_SECRET env vars not set",
-)
-class TestCustosVault(AbstractTestCases.VaultTestBase):
-    def setUp(self) -> None:
-        with (
-            tempfile.NamedTemporaryFile(mode="w", prefix="vault_custos", delete=False) as tempconf,
-            open(VAULT_CONF_CUSTOS) as f,
-        ):
-            content = string.Template(f.read()).safe_substitute(
-                custos_client_id=os.environ.get("CUSTOS_CLIENT_ID"),
-                custos_client_secret=os.environ.get("CUSTOS_CLIENT_SECRET"),
-            )
-            tempconf.write(content)
-            self.vault_temp_conf = tempconf.name
-        config = GalaxyDataTestConfig(vault_config_file=self.vault_temp_conf)
-        app = GalaxyDataTestApp(config=config)
-        self.vault = VaultFactory.from_app(app)
-
-    def tearDown(self) -> None:
-        os.remove(self.vault_temp_conf)


### PR DESCRIPTION
The custos service is no longer maintained and therefore, both the custos auth provider and the custos vault are now defunct. This PR removes code that relies on these services.

These are some preliminary changes required to address: https://github.com/galaxyproject/galaxy/issues/20789


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
