### PR TITLE
[25.1] Fix copy export download link for old exports

### DIFF
--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -292,6 +292,7 @@ const breadcrumbItems = computed(() => [
                 :records="previousExportRecords"
                 class="mt-3"
                 @onDownload="downloadFromRecord"
+                @onCopyDownloadLink="copyDownloadLinkFromRecord"
                 @onReimport="reimportFromRecord" />
         </GModal>
     </div>


### PR DESCRIPTION
Fixes #21080

The copy event handler was missing.


https://github.com/user-attachments/assets/7eba3249-330c-45ac-ac06-b35efc181fc1



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
