### PR TITLE
Fix the docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
 .k8s_ci.Dockerfile
-.venv
-database
-node_modules
+.ci/
+.venv/
+.tox/
+.git/
+database/
+packages/
+client/node_modules/
+test-data/
+doc/
+*.log

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -58,12 +58,12 @@ RUN set -xe; \
 # Remove context from previous build; copy current context; run playbook
 WORKDIR /tmp/ansible
 RUN rm -rf *
-ENV LC_ALL en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 RUN git clone --depth 1 --branch $GALAXY_PLAYBOOK_BRANCH $GALAXY_PLAYBOOK_REPO galaxy-docker
 WORKDIR /tmp/ansible/galaxy-docker
 RUN ansible-galaxy install -r requirements.yml -p roles --force-with-deps
 
-# Copy just the Galaxy source code that we need
+# Copy just the Galaxy source code we need
 COPY client/ $SERVER_DIR/client
 COPY client-api/ $SERVER_DIR/client-api
 COPY config/ $SERVER_DIR/config
@@ -81,7 +81,7 @@ COPY Makefile *.sh $SERVER_DIR
 FROM stage1 AS server_build
 ARG SERVER_DIR
 
-RUN ansible-playbook -i localhost, playbook.yml -v -e "{galaxy_build_client: false}" -e galaxy_virtualenv_command=virtualenv
+RUN ansible-playbook -i localhost, playbook.yml -v -e "{galaxy_build_client: false, galaxy_additional_venv_packages: false, galaxy_virtualenv_command: virtualenv}"
 
 # Remove build artifacts + files not needed in container
 WORKDIR $SERVER_DIR
@@ -103,7 +103,7 @@ RUN find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 FROM stage1 AS client_build
 ARG SERVER_DIR
 
-RUN ansible-playbook -i localhost, playbook.yml -v --tags "galaxy_build_client" -e galaxy_virtualenv_command=virtualenv
+RUN ansible-playbook -i localhost, playbook.yml -v --tags "galaxy_build_client" -e "{galaxy_additional_venv_packages: false, galaxy_virtualenv_command: virtualenv}"
 
 WORKDIR $SERVER_DIR
 RUN rm -rf \

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -181,6 +181,7 @@ RUN set -xe; \
       && chown $GALAXY_USER:$GALAXY_USER $ROOT_DIR -R
 
 WORKDIR $ROOT_DIR
+
 # Copy galaxy files to final image
 # The chown value MUST be hardcoded (see https://github.com/moby/moby/issues/35018)
 COPY --chown=$GALAXY_USER:$GALAXY_USER --from=server_build $ROOT_DIR .

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -58,7 +58,6 @@ RUN set -xe; \
 # Remove context from previous build; copy current context; run playbook
 WORKDIR /tmp/ansible
 RUN rm -rf *
-ENV LC_ALL=en_US.UTF-8
 RUN git clone --depth 1 --branch $GALAXY_PLAYBOOK_BRANCH $GALAXY_PLAYBOOK_REPO galaxy-docker
 WORKDIR /tmp/ansible/galaxy-docker
 RUN ansible-galaxy install -r requirements.yml -p roles --force-with-deps

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1272,7 +1272,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             if isinstance(themes_by_host_value, str):
                 # If it's an empty/whitespace string or just braces, treat as empty dict
                 stripped = themes_by_host_value.strip()
-                if not stripped or stripped in ('{}', '{ }'):
+                if not stripped or stripped in ("{}", "{ }"):
                     themes_by_host_value = {}
                 else:
                     # Log a warning for unexpected string values


### PR DESCRIPTION
Improvements to the Docker build and some defensive programming to counter a problem with the [Ansible Galaxy playbook](https://github.com/galaxyproject/ansible-galaxy/issues/231)

When themes are disabled, either by setting `galaxy_manage_themes: false `or if there are no `galaxy_themes_subdomains`, the use of the YAML folded block scalar operator (`>`) causes the variable `themes_config_file_by_host` to evaluate to the string `"{ }"` rather than to an empty dictionary. This causes Galaxy's config parser to fail when it tries to call `.items()` on a string object.  While the root cause of the problem is in the Ansible playbook, a misconfiguration should not cause Galaxy to crash which in turn breaks the Docker builds.

Cannot be merged until https://github.com/galaxyproject/galaxy-docker-k8s/pull/40 is merged.

Closes #21089 

Friends with:
1. https://github.com/galaxyproject/galaxy-docker-k8s/pull/40
1. https://github.com/galaxyproject/ansible-galaxy/pull/234

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
