### PR TITLE
[25.1] Fix invalid invocation tab handling and unify disabled tab components

### DIFF
--- a/client/src/components/WorkflowInvocationState/TabsDisabledAlert.vue
+++ b/client/src/components/WorkflowInvocationState/TabsDisabledAlert.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
+
+import GLink from "../BaseComponents/GLink.vue";
+
+const props = defineProps<{
+    invocationId: string;
+    tooltip: string;
+}>();
+</script>
+
+<template>
+    <BAlert variant="info" show>
+        <span v-localize>{{ props.tooltip }}</span>
+        View the invocation
+        <GLink :to="`/workflows/invocations/${props.invocationId}`">Overview</GLink>
+        instead.
+    </BAlert>
+</template>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -367,7 +367,7 @@ async function onCancel() {
                 Outputs
             </BNavItem>
             <BNavItem
-                title="Report"
+                :title="!tabsDisabled ? 'Report' : disabledTabTooltip"
                 class="invocation-report-tab"
                 :active="!tabsDisabled && props.tab === 'report'"
                 :to="`/workflows/invocations/${props.invocationId}/report`"
@@ -375,7 +375,7 @@ async function onCancel() {
                 Report
             </BNavItem>
             <BNavItem
-                title="Export"
+                :title="!tabsDisabled ? 'Export' : disabledTabTooltip"
                 class="invocation-export-tab"
                 :active="!tabsDisabled && props.tab === 'export'"
                 :to="`/workflows/invocations/${props.invocationId}/export`"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -369,7 +369,7 @@ async function onCancel() {
             <BNavItem
                 title="Report"
                 class="invocation-report-tab"
-                :active="props.tab === 'report'"
+                :active="!tabsDisabled && props.tab === 'report'"
                 :to="`/workflows/invocations/${props.invocationId}/report`"
                 :disabled="tabsDisabled">
                 Report
@@ -377,7 +377,7 @@ async function onCancel() {
             <BNavItem
                 title="Export"
                 class="invocation-export-tab"
-                :active="props.tab === 'export'"
+                :active="!tabsDisabled && props.tab === 'export'"
                 :to="`/workflows/invocations/${props.invocationId}/export`"
                 :disabled="tabsDisabled">
                 Export

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -85,6 +85,11 @@ const disabledTabTooltip = computed(() => {
     }
 });
 
+/** We are on the default "Overview" tab if the tab prop is not set or is not one of the expected tab values */
+const onOverviewTab = computed(() => {
+    return !props.tab || !["steps", "inputs", "outputs", "report", "export", "metrics", "debug"].includes(props.tab);
+});
+
 const invocation = computed(() => {
     const storedInvocation = invocationStore.getInvocationById(props.invocationId);
     if (invocationLoaded.value && isWorkflowInvocationElementView(storedInvocation)) {
@@ -340,7 +345,7 @@ async function onCancel() {
         </WorkflowAnnotation>
 
         <BNav v-if="props.isFullPage" pills class="mb-2 p-2 bg-light border-bottom">
-            <BNavItem title="Overview" :active="!props.tab" :to="`/workflows/invocations/${props.invocationId}`">
+            <BNavItem title="Overview" :active="onOverviewTab" :to="`/workflows/invocations/${props.invocationId}`">
                 Overview
             </BNavItem>
             <BNavItem
@@ -424,7 +429,7 @@ async function onCancel() {
         </BNav>
 
         <div class="mt-1 d-flex flex-column overflow-auto">
-            <div v-if="!props.tab">
+            <div v-if="onOverviewTab">
                 <WorkflowInvocationOverview
                     class="invocation-overview"
                     :invocation="invocation"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -24,6 +24,7 @@ import WorkflowInvocationSteps from "../Workflow/Invocation/Graph/WorkflowInvoca
 import InvocationReport from "../Workflow/InvocationReport.vue";
 import WorkflowAnnotation from "../Workflow/WorkflowAnnotation.vue";
 import WorkflowNavigationTitle from "../Workflow/WorkflowNavigationTitle.vue";
+import TabsDisabledAlert from "./TabsDisabledAlert.vue";
 import WorkflowInvocationExportOptions from "./WorkflowInvocationExportOptions.vue";
 import WorkflowInvocationFeedback from "./WorkflowInvocationFeedback.vue";
 import WorkflowInvocationInputOutputTabs from "./WorkflowInvocationInputOutputTabs.vue";
@@ -76,7 +77,7 @@ const tabsDisabled = computed(
 const disabledTabTooltip = computed(() => {
     const state = invocationState.value;
     if (state != "scheduled") {
-        return `This workflow is not currently scheduled. The current state is ${state}. Once the workflow is fully scheduled and jobs have complete any disabled tabs will become available.`;
+        return `This workflow is not currently scheduled. The current state is ${state}. Disabled tabs are available if the workflow is fully scheduled and all jobs have completed.`;
     } else if (stateCounts.value && stateCounts.value.runningCount != 0) {
         return `The workflow invocation still contains ${stateCounts.value.runningCount} running job(s). Once these jobs have completed any disabled tabs will become available.`;
     } else {
@@ -451,15 +452,17 @@ async function onCancel() {
                 <BAlert v-if="isSubworkflow" variant="info" show>
                     <span v-localize>Report is not available for subworkflow.</span>
                 </BAlert>
-                <BAlert v-else-if="!invocationStateSuccess" variant="info" show>
-                    <span v-localize>{{ disabledTabTooltip }}</span>
-                </BAlert>
+                <TabsDisabledAlert
+                    v-else-if="tabsDisabled"
+                    :invocation-id="props.invocationId"
+                    :tooltip="disabledTabTooltip" />
                 <InvocationReport v-else :invocation-id="invocation.id" />
             </div>
             <div v-if="props.tab === 'export'">
-                <BAlert v-if="!invocationAndJobTerminal" variant="info" show>
-                    <span v-localize>{{ disabledTabTooltip }}</span>
-                </BAlert>
+                <TabsDisabledAlert
+                    v-if="tabsDisabled"
+                    :invocation-id="props.invocationId"
+                    :tooltip="disabledTabTooltip" />
                 <div v-else>
                     <WorkflowInvocationExportOptions :invocation-id="invocation.id" />
                 </div>


### PR DESCRIPTION
Fixes workflow invocation tab navigation issues:

- Switch to Overview tab when invalid tab is in URL
- Prevent Report/Export tabs from showing as active when disabled
- Create reusable `TabsDisabledAlert` component and render it for a consistent `tabsDisabled` ref

Fixes #21101

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Try out an invalid tab in the URL (`/workflows/invocations/{invocation_id}/invalid`
  2. Notice that we show the default (overview) tab
  3. Next, try manually routing to the report or export tabs when they are disabled (for e.g.: workflow is running/cancelled)
  4. You'll notice that we no longer show the tab as `active` with the doubled active+disabled styling

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
