### PR TITLE
[25.1] Fix shift+click range select not working in history list

### DIFF
--- a/client/src/components/History/HistoryList.vue
+++ b/client/src/components/History/HistoryList.vue
@@ -189,9 +189,9 @@ const {
         );
         await onDeleteHistory();
     },
-    expectedKeyDownClass: "history-card",
+    expectedKeyDownClass: "history-card-in-list",
     getAttributeForRangeSelection(item) {
-        return `g-card-${item.id}`;
+        return `g-card-history-${item.id}`;
     },
 });
 

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -138,7 +138,7 @@ const {
         );
         deleteInModal();
     },
-    expectedKeyDownClass: "workflow-card",
+    expectedKeyDownClass: "workflow-card-in-list",
     getAttributeForRangeSelection(item) {
         return `g-card-${item.id}`;
     },


### PR DESCRIPTION
Also make the `expectedKeyDownClass` more exact.

Fixes https://github.com/galaxyproject/galaxy/issues/21071

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to the history list (and switch to `list` view for best usage, as opposed to `grid` view)
  2. Click on the checkbox to select a history
  3. Now select a history further down, except hold down the `Shift` key
  4. Notice that a range select should happen (all histories in between should be selected)
  5. Repeat the process in the workflow list and confirm that it works the same in both places

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
