### PR TITLE
Add `select all`, simple search and pagination to Zip file selector

### DIFF
--- a/client/src/components/ImportData/zip/ZipFileSelector.vue
+++ b/client/src/components/ImportData/zip/ZipFileSelector.vue
@@ -207,12 +207,14 @@ function onSearch(value: string) {
 </template>
 
 <style scoped lang="scss">
+@import "theme/blue.scss";
+
 .zip-file-selector {
     .zip-file-selector-footer {
         display: flex;
         justify-content: center;
         padding: 1rem 0;
-        border-top: 1px solid #dee2e6;
+        border-top: 1px solid $brand-secondary;
     }
 }
 </style>

--- a/client/src/components/ImportData/zip/ZipFileSelector.vue
+++ b/client/src/components/ImportData/zip/ZipFileSelector.vue
@@ -192,7 +192,7 @@ function onSearch(value: string) {
             No files found matching "{{ searchQuery }}". Try a different search term.
         </BAlert>
 
-        <div v-if="showPagination" class="zip-file-selector-footer mt-3">
+        <div v-if="showPagination" class="d-flex justify-content-center py-3 mt-3">
             <BPagination
                 :value="currentPage"
                 :total-rows="totalItems"
@@ -205,16 +205,3 @@ function onSearch(value: string) {
         </div>
     </div>
 </template>
-
-<style scoped lang="scss">
-@import "theme/blue.scss";
-
-.zip-file-selector {
-    .zip-file-selector-footer {
-        display: flex;
-        justify-content: center;
-        padding: 1rem 0;
-        border-top: 1px solid $brand-secondary;
-    }
-}
-</style>

--- a/client/src/components/ImportData/zip/ZipImportSummary.vue
+++ b/client/src/components/ImportData/zip/ZipImportSummary.vue
@@ -111,10 +111,12 @@ const fileBadges: CardBadge[] = [
 </template>
 
 <style scoped lang="scss">
+@import "theme/blue.scss";
+
 .zip-summary-footer {
     display: flex;
     justify-content: center;
     padding: 1rem 0;
-    border-top: 1px solid #dee2e6;
+    border-top: 1px solid $brand-secondary;
 }
 </style>

--- a/client/src/components/ImportData/zip/ZipImportSummary.vue
+++ b/client/src/components/ImportData/zip/ZipImportSummary.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { faFile, faNetworkWired } from "@fortawesome/free-solid-svg-icons";
+import { BPagination } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { CardBadge } from "@/components/Common/GCard.types";
+import { usePagination } from "@/composables/pagination";
 import type { ImportableFile } from "@/composables/zipExplorer";
 import { bytesToString } from "@/utils/utils";
 
@@ -26,6 +28,13 @@ const regularFiles = computed(() => {
 const totalFileSize = computed(() => {
     return regularFiles.value.reduce((total, file) => total + file.size, 0);
 });
+
+const allItems = computed(() => [...workflowFiles.value, ...regularFiles.value]);
+
+const { currentPage, itemsPerPage, paginatedItems, totalItems, showPagination, onPageChange } = usePagination(allItems);
+
+const paginatedWorkflows = computed(() => paginatedItems.value.filter((item) => item.type === "workflow"));
+const paginatedFiles = computed(() => paginatedItems.value.filter((item) => item.type === "file"));
 
 const workflowBadges: CardBadge[] = [
     {
@@ -54,7 +63,7 @@ const fileBadges: CardBadge[] = [
     <div class="w-100">
         <div class="d-flex flex-grow-1">
             <GCard
-                v-if="workflowFiles.length > 0"
+                v-if="paginatedWorkflows.length > 0"
                 id="zip-workflows-summary"
                 title="Workflows to Import"
                 title-size="md"
@@ -63,13 +72,13 @@ const fileBadges: CardBadge[] = [
                 <template v-slot:description>
                     <p v-localize>The following workflows will be imported from the archive into your account.</p>
                     <div class="d-flex flex-wrap">
-                        <ZipFileEntrySummaryCard v-for="file in workflowFiles" :key="file.path" :file="file" />
+                        <ZipFileEntrySummaryCard v-for="file in paginatedWorkflows" :key="file.path" :file="file" />
                     </div>
                 </template>
             </GCard>
 
             <GCard
-                v-if="regularFiles.length > 0"
+                v-if="paginatedFiles.length > 0"
                 id="zip-files-summary"
                 title="Files to Import"
                 title-size="md"
@@ -81,10 +90,31 @@ const fileBadges: CardBadge[] = [
                         <b>currently active Galaxy history</b>.
                     </p>
                     <div class="d-flex flex-wrap">
-                        <ZipFileEntrySummaryCard v-for="file in regularFiles" :key="file.path" :file="file" />
+                        <ZipFileEntrySummaryCard v-for="file in paginatedFiles" :key="file.path" :file="file" />
                     </div>
                 </template>
             </GCard>
         </div>
+
+        <div v-if="showPagination" class="zip-summary-footer mt-3">
+            <BPagination
+                :value="currentPage"
+                :total-rows="totalItems"
+                :per-page="itemsPerPage"
+                align="center"
+                size="sm"
+                first-number
+                last-number
+                @change="onPageChange" />
+        </div>
     </div>
 </template>
+
+<style scoped lang="scss">
+.zip-summary-footer {
+    display: flex;
+    justify-content: center;
+    padding: 1rem 0;
+    border-top: 1px solid #dee2e6;
+}
+</style>

--- a/client/src/components/ImportData/zip/ZipImportSummary.vue
+++ b/client/src/components/ImportData/zip/ZipImportSummary.vue
@@ -96,7 +96,7 @@ const fileBadges: CardBadge[] = [
             </GCard>
         </div>
 
-        <div v-if="showPagination" class="zip-summary-footer mt-3">
+        <div v-if="showPagination" class="d-flex justify-content-center py-3 mt-3">
             <BPagination
                 :value="currentPage"
                 :total-rows="totalItems"
@@ -109,14 +109,3 @@ const fileBadges: CardBadge[] = [
         </div>
     </div>
 </template>
-
-<style scoped lang="scss">
-@import "theme/blue.scss";
-
-.zip-summary-footer {
-    display: flex;
-    justify-content: center;
-    padding: 1rem 0;
-    border-top: 1px solid $brand-secondary;
-}
-</style>

--- a/client/src/components/ImportData/zip/views/GalaxyZipView.vue
+++ b/client/src/components/ImportData/zip/views/GalaxyZipView.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { BPagination } from "bootstrap-vue";
 import { computed } from "vue";
 
+import { usePagination } from "@/composables/pagination";
 import { type GalaxyZipExplorer, getImportableFiles } from "@/composables/zipExplorer";
 
 import Heading from "@/components/Common/Heading.vue";
@@ -11,12 +13,42 @@ const props = defineProps<{
 }>();
 
 const files = computed(() => getImportableFiles(props.explorer));
+
+const {
+    currentPage,
+    itemsPerPage,
+    paginatedItems: paginatedFiles,
+    showPagination,
+    onPageChange,
+} = usePagination(files);
 </script>
 
 <template>
-    <div class="rocrate-explorer">
+    <div class="galaxy-zip-explorer">
         <Heading size="lg">Galaxy Export Archive Summary</Heading>
         <Heading size="md">Files</Heading>
-        <ZipFileEntryCard v-for="file in files" :key="file.path" :file="file" />
+
+        <ZipFileEntryCard v-for="file in paginatedFiles" :key="file.path" :file="file" />
+
+        <div v-if="showPagination" class="galaxy-zip-footer mt-3">
+            <BPagination
+                :value="currentPage"
+                :total-rows="files.length"
+                :per-page="itemsPerPage"
+                align="center"
+                size="sm"
+                first-number
+                last-number
+                @change="onPageChange" />
+        </div>
     </div>
 </template>
+
+<style scoped lang="scss">
+.galaxy-zip-footer {
+    display: flex;
+    justify-content: center;
+    padding: 1rem 0;
+    border-top: 1px solid #dee2e6;
+}
+</style>

--- a/client/src/components/ImportData/zip/views/GalaxyZipView.vue
+++ b/client/src/components/ImportData/zip/views/GalaxyZipView.vue
@@ -45,10 +45,12 @@ const {
 </template>
 
 <style scoped lang="scss">
+@import "theme/blue.scss";
+
 .galaxy-zip-footer {
     display: flex;
     justify-content: center;
     padding: 1rem 0;
-    border-top: 1px solid #dee2e6;
+    border-top: 1px solid $brand-secondary;
 }
 </style>

--- a/client/src/components/ImportData/zip/views/GalaxyZipView.vue
+++ b/client/src/components/ImportData/zip/views/GalaxyZipView.vue
@@ -30,7 +30,7 @@ const {
 
         <ZipFileEntryCard v-for="file in paginatedFiles" :key="file.path" :file="file" />
 
-        <div v-if="showPagination" class="galaxy-zip-footer mt-3">
+        <div v-if="showPagination" class="d-flex justify-content-center py-3 mt-3">
             <BPagination
                 :value="currentPage"
                 :total-rows="files.length"
@@ -43,14 +43,3 @@ const {
         </div>
     </div>
 </template>
-
-<style scoped lang="scss">
-@import "theme/blue.scss";
-
-.galaxy-zip-footer {
-    display: flex;
-    justify-content: center;
-    padding: 1rem 0;
-    border-top: 1px solid $brand-secondary;
-}
-</style>

--- a/client/src/components/ImportData/zip/views/RegularZipView.vue
+++ b/client/src/components/ImportData/zip/views/RegularZipView.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { BPagination } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { CardBadge } from "@/components/Common/GCard.types";
+import { usePagination } from "@/composables/pagination";
 import { getImportableFiles, type IZipExplorer } from "@/composables/zipExplorer";
 
 import GCard from "@/components/Common/GCard.vue";
@@ -13,6 +15,14 @@ const props = defineProps<{
 
 const files = computed(() => getImportableFiles(props.explorer));
 
+const {
+    currentPage,
+    itemsPerPage,
+    paginatedItems: paginatedFiles,
+    showPagination,
+    onPageChange,
+} = usePagination(files);
+
 const zipFileBadges: CardBadge[] = [
     {
         id: "file-count",
@@ -23,13 +33,40 @@ const zipFileBadges: CardBadge[] = [
 </script>
 
 <template>
-    <GCard
-        id="regular-zip-summary-card"
-        title="List of files contained in the archive"
-        title-size="md"
-        :badges="zipFileBadges">
-        <template v-slot:description>
-            <ZipFileEntrySummaryCard v-for="file in files" :key="file.path" :file="file" :selectable="false" />
-        </template>
-    </GCard>
+    <div>
+        <GCard
+            id="regular-zip-summary-card"
+            title="List of files contained in the archive"
+            title-size="md"
+            :badges="zipFileBadges">
+            <template v-slot:description>
+                <ZipFileEntrySummaryCard
+                    v-for="file in paginatedFiles"
+                    :key="file.path"
+                    :file="file"
+                    :selectable="false" />
+            </template>
+        </GCard>
+
+        <div v-if="showPagination" class="regular-zip-footer mt-3">
+            <BPagination
+                :value="currentPage"
+                :total-rows="files.length"
+                :per-page="itemsPerPage"
+                align="center"
+                size="sm"
+                first-number
+                last-number
+                @change="onPageChange" />
+        </div>
+    </div>
 </template>
+
+<style scoped lang="scss">
+.regular-zip-footer {
+    display: flex;
+    justify-content: center;
+    padding: 1rem 0;
+    border-top: 1px solid #dee2e6;
+}
+</style>

--- a/client/src/components/ImportData/zip/views/RegularZipView.vue
+++ b/client/src/components/ImportData/zip/views/RegularZipView.vue
@@ -48,7 +48,7 @@ const zipFileBadges: CardBadge[] = [
             </template>
         </GCard>
 
-        <div v-if="showPagination" class="regular-zip-footer mt-3">
+        <div v-if="showPagination" class="d-flex justify-content-center py-3 mt-3">
             <BPagination
                 :value="currentPage"
                 :total-rows="files.length"
@@ -61,14 +61,3 @@ const zipFileBadges: CardBadge[] = [
         </div>
     </div>
 </template>
-
-<style scoped lang="scss">
-@import "theme/blue.scss";
-
-.regular-zip-footer {
-    display: flex;
-    justify-content: center;
-    padding: 1rem 0;
-    border-top: 1px solid $brand-secondary;
-}
-</style>

--- a/client/src/components/ImportData/zip/views/RegularZipView.vue
+++ b/client/src/components/ImportData/zip/views/RegularZipView.vue
@@ -63,10 +63,12 @@ const zipFileBadges: CardBadge[] = [
 </template>
 
 <style scoped lang="scss">
+@import "theme/blue.scss";
+
 .regular-zip-footer {
     display: flex;
     justify-content: center;
     padding: 1rem 0;
-    border-top: 1px solid #dee2e6;
+    border-top: 1px solid $brand-secondary;
 }
 </style>

--- a/client/src/composables/pagination.test.ts
+++ b/client/src/composables/pagination.test.ts
@@ -1,0 +1,86 @@
+import { computed, ref } from "vue";
+
+import { usePagination } from "./pagination";
+
+describe("usePagination", () => {
+    it("should paginate items with default settings", () => {
+        const items = ref([1, 2, 3, 4, 5]);
+        const { paginatedItems, currentPage, itemsPerPage } = usePagination(items);
+
+        expect(currentPage.value).toBe(1);
+        expect(itemsPerPage.value).toBe(24);
+        expect(paginatedItems.value).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("should paginate items correctly across multiple pages", () => {
+        const items = ref(Array.from({ length: 50 }, (_, i) => i + 1));
+        const { paginatedItems, currentPage, onPageChange } = usePagination(items, { itemsPerPage: 10 });
+
+        expect(paginatedItems.value).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        onPageChange(2);
+        expect(currentPage.value).toBe(2);
+        expect(paginatedItems.value).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+
+        onPageChange(5);
+        expect(currentPage.value).toBe(5);
+        expect(paginatedItems.value).toEqual([41, 42, 43, 44, 45, 46, 47, 48, 49, 50]);
+    });
+
+    it("should show pagination only when items exceed page size", () => {
+        const items = ref([1, 2, 3]);
+        const { showPagination } = usePagination(items, { itemsPerPage: 5 });
+
+        expect(showPagination.value).toBe(false);
+
+        items.value = Array.from({ length: 10 }, (_, i) => i + 1);
+        expect(showPagination.value).toBe(true);
+    });
+
+    it("should reset to first page", () => {
+        const items = ref(Array.from({ length: 30 }, (_, i) => i + 1));
+        const { currentPage, onPageChange, resetPage } = usePagination(items, { itemsPerPage: 10 });
+
+        onPageChange(3);
+        expect(currentPage.value).toBe(3);
+
+        resetPage();
+        expect(currentPage.value).toBe(1);
+    });
+
+    it("should compute total items correctly", () => {
+        const items = ref([1, 2, 3]);
+        const { totalItems } = usePagination(items);
+
+        expect(totalItems.value).toBe(3);
+
+        items.value = [...items.value, 4, 5];
+        expect(totalItems.value).toBe(5);
+    });
+
+    it("should work with computed items", () => {
+        const baseItems = ref([1, 2, 3, 4, 5, 6]);
+        const filteredItems = computed(() => baseItems.value.filter((item) => item > 3));
+        const { paginatedItems, totalItems } = usePagination(filteredItems, { itemsPerPage: 2 });
+
+        expect(totalItems.value).toBe(3);
+        expect(paginatedItems.value).toEqual([4, 5]);
+    });
+
+    it("should handle empty items array", () => {
+        const items = ref<number[]>([]);
+        const { paginatedItems, totalItems, showPagination } = usePagination(items);
+
+        expect(paginatedItems.value).toEqual([]);
+        expect(totalItems.value).toBe(0);
+        expect(showPagination.value).toBe(false);
+    });
+
+    it("should handle last page with fewer items", () => {
+        const items = ref(Array.from({ length: 25 }, (_, i) => i + 1));
+        const { paginatedItems, onPageChange } = usePagination(items, { itemsPerPage: 10 });
+
+        onPageChange(3);
+        expect(paginatedItems.value).toEqual([21, 22, 23, 24, 25]);
+    });
+});

--- a/client/src/composables/pagination.ts
+++ b/client/src/composables/pagination.ts
@@ -1,0 +1,85 @@
+import { computed, type ComputedRef, type Ref, ref } from "vue";
+
+/**
+ * Options for configuring pagination
+ */
+export interface UsePaginationOptions {
+    /** Number of items per page (default: 24) */
+    itemsPerPage?: number;
+}
+
+/**
+ * Return type for the usePagination composable
+ */
+export interface UsePaginationReturn<T> {
+    /** Current page number (1-indexed) */
+    currentPage: Ref<number>;
+    /** Number of items per page */
+    itemsPerPage: Ref<number>;
+    /** Paginated subset of items for the current page */
+    paginatedItems: ComputedRef<T[]>;
+    /** Total number of items */
+    totalItems: ComputedRef<number>;
+    /** Whether pagination should be shown (total items > items per page) */
+    showPagination: ComputedRef<boolean>;
+    /** Handler for page change events */
+    onPageChange: (page: number) => void;
+    /** Reset to first page */
+    resetPage: () => void;
+}
+
+/**
+ * Composable for client-side pagination of items
+ *
+ * @example
+ * ```typescript
+ * const items = ref([...]);
+ * const { paginatedItems, currentPage, showPagination, onPageChange } = usePagination(items);
+ *
+ * // In template:
+ * <ItemCard v-for="item in paginatedItems" :key="item.id" :item="item" />
+ * <BPagination v-if="showPagination" :value="currentPage" @change="onPageChange" />
+ * ```
+ *
+ * @param items - Reactive array of items to paginate
+ * @param options - Pagination configuration options
+ * @returns Pagination state and controls
+ */
+export function usePagination<T>(
+    items: Ref<T[]> | ComputedRef<T[]>,
+    options: UsePaginationOptions = {},
+): UsePaginationReturn<T> {
+    const { itemsPerPage: initialItemsPerPage = 24 } = options;
+
+    const currentPage = ref(1);
+    const itemsPerPage = ref(initialItemsPerPage);
+
+    const totalItems = computed(() => items.value.length);
+
+    const paginatedItems = computed(() => {
+        const offset = (currentPage.value - 1) * itemsPerPage.value;
+        const start = Math.max(0, offset);
+        const end = Math.min(items.value.length, offset + itemsPerPage.value);
+        return items.value.slice(start, end);
+    });
+
+    const showPagination = computed(() => totalItems.value > itemsPerPage.value);
+
+    function onPageChange(page: number) {
+        currentPage.value = page;
+    }
+
+    function resetPage() {
+        currentPage.value = 1;
+    }
+
+    return {
+        currentPage,
+        itemsPerPage,
+        paginatedItems,
+        totalItems,
+        showPagination,
+        onPageChange,
+        resetPage,
+    };
+}

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -234,7 +234,7 @@ history_panel:
       metadata_file_download: '${_} [data-description="download ${metadata_name}"]'
 
       dataset_operations: '${_} .dataset-actions'
-      
+
       expiration_indicator_badge: '${_} .expiration-indicator .badge'
 
   # re-usable history editor, scoped for use in different layout scenarios (multi, etc.)
@@ -1397,6 +1397,8 @@ zip_import_wizard:
     selected_workflows_to_import_count_badge: '#g-card-badge-workflow-count-zip-workflows-summary'
     wizard_next_button: '.wizard-actions .go-next-btn'
     wizard_import_button: '.wizard-actions .go-next-btn.btn-primary'
+    search_input: '.zip-file-selector-search input'
+    select_all_checkbox: '.list-header-select-all'
     select_file:
       type: xpath
       selector: "//div[@role='button' and contains(@id, 'g-card-${file_path}')]"

--- a/lib/galaxy_test/selenium/test_archive_explorer.py
+++ b/lib/galaxy_test/selenium/test_archive_explorer.py
@@ -71,6 +71,35 @@ class TestArchiveExplorer(SeleniumTestCase, UsesHistoryItemAssertions):
         self.wait_for_loading_indicator_to_finish()
         self.expect_preview_title_to_be("Simple Workflow")
 
+    @selenium_test
+    def test_search_filters_files(self):
+        self.login()
+        self.ensure_empty_history()
+        self.explore_local_zip(self.get_filename("example-bag.zip"))
+        self.expect_total_number_of_files_to_be(8)
+        self.go_to_next_step()
+
+        visible_cards = self.get_visible_item_cards()
+        assert len(visible_cards) == 8
+
+        self.search_for("README")
+
+        visible_cards = self.get_visible_item_cards()
+        assert len(visible_cards) == 1
+
+    @selenium_test
+    def test_select_all_functionality(self):
+        self.login()
+        self.ensure_empty_history()
+        self.explore_local_zip(self.get_filename("example-bag.zip"))
+        self.expect_total_number_of_files_to_be(8)
+        self.go_to_next_step()
+
+        self.select_all_files()
+
+        self.go_to_next_step()
+        self.expect_number_of_files_to_import(8)
+
     # Helper methods
     # ------------------------------------------------------------------
     def ensure_empty_history(self):
@@ -98,6 +127,18 @@ class TestArchiveExplorer(SeleniumTestCase, UsesHistoryItemAssertions):
         file_entry = self.components.zip_import_wizard.select_file(file_path=file_path)
         file_entry.wait_for_and_click()
         return file_entry
+
+    def select_all_files(self):
+        self.components.zip_import_wizard.select_all_checkbox.wait_for_and_click()
+
+    def get_visible_item_cards(self):
+        visible_cards = self.driver.find_elements(By.CSS_SELECTOR, ".zip-file-selector .g-card")
+        return visible_cards
+
+    def search_for(self, search_query: str):
+        search_input = self.components.zip_import_wizard.search_input.wait_for_visible()
+        search_input.send_keys(search_query)
+        self.sleep_for(self.wait_types.UX_RENDER)
 
     def expect_total_number_of_files_to_be(self, file_count: int):
         zip_file_count_badge = self.components.zip_import_wizard.zip_file_count_badge


### PR DESCRIPTION
Closes #20934

- The `select all` button will select the currently visible elements of the page.
- A simple search box will filter the elements by name, path, and/or description if available.
- Includes a client-side pagination composable.

https://github.com/user-attachments/assets/42ac336b-485b-4c20-9926-4ea685e4a3c5

<img width="902" height="745" alt="Screenshot from 2025-10-20 23-52-08" src="https://github.com/user-attachments/assets/6cf0a250-6517-49c6-83e1-9915aa933940" />


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
