### PR TITLE
[25.1] Restore job.get_param_values

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2031,6 +2031,21 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             self.state_history.append(JobStateHistory(self))
             return True
 
+    def get_param_values(self, app, ignore_errors=False):
+        """
+        Read encoded parameter values from the database and turn back into a
+        dict of tool parameter values.
+        """
+        param_dict = self.raw_param_dict()
+        tool = app.toolbox.get_tool(
+            self.tool_id,
+            tool_version=self.tool_version,
+            tool_uuid=self.dynamic_tool and self.dynamic_tool.uuid,
+            user=self.user,
+        )
+        param_dict = tool.params_from_strings(param_dict, app, ignore_errors=ignore_errors)
+        return param_dict
+
     def raw_param_dict(self):
         param_dict = {p.name: p.value for p in self.parameters}
         return param_dict

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -130,6 +130,7 @@ from sqlalchemy.orm.collections import attribute_keyed_dict
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import FromClause
 from typing_extensions import (
+    deprecated,
     Literal,
     NotRequired,
     Protocol,
@@ -2031,6 +2032,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             self.state_history.append(JobStateHistory(self))
             return True
 
+    @deprecated("Use tool.get_param_values(job) instead")
     def get_param_values(self, app, ignore_errors=False):
         """
         Read encoded parameter values from the database and turn back into a

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2036,14 +2036,13 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         Read encoded parameter values from the database and turn back into a
         dict of tool parameter values.
         """
-        param_dict = self.raw_param_dict()
         tool = app.toolbox.get_tool(
             self.tool_id,
             tool_version=self.tool_version,
             tool_uuid=self.dynamic_tool and self.dynamic_tool.uuid,
             user=self.user,
         )
-        param_dict = tool.params_from_strings(param_dict, app, ignore_errors=ignore_errors)
+        param_dict = tool.get_param_values(self, ignore_errors=ignore_errors)
         return param_dict
 
     def raw_param_dict(self):


### PR DESCRIPTION
I think it's pretty disruptive for TPV, we can consider removing this for the next cycle.

Fixes https://github.com/galaxyproject/galaxy/issues/21125

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
