### PR TITLE
[25.1] Improve _touch_collection_update_time_cte performance

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4727,26 +4727,32 @@ class Dataset(Base, StorableObject, Serializable):
             literal(0).label("depth_level"),
         ]
 
-        # Create a single base query that covers both HDA and LDDA cases using OR conditions
-        base_query = (
+        # Create separate base queries for HDA and LDDA cases and union them
+        # We need to wrap the union in a subquery to use it as the anchor for the recursive CTE
+        union_query = (
             select(*base_columns)
             .select_from(
-                DatasetCollectionElement.__table__.outerjoin(
+                DatasetCollectionElement.__table__.join(
                     HistoryDatasetAssociation.__table__, DatasetCollectionElement.hda_id == HistoryDatasetAssociation.id
-                ).outerjoin(
-                    LibraryDatasetDatasetAssociation.__table__,
-                    DatasetCollectionElement.ldda_id == LibraryDatasetDatasetAssociation.id,
                 )
             )
-            .where(
-                or_(
-                    HistoryDatasetAssociation.dataset_id == self.id,
-                    LibraryDatasetDatasetAssociation.dataset_id == self.id,
+            .where(HistoryDatasetAssociation.dataset_id == self.id)
+            .union(
+                select(*base_columns)
+                .select_from(
+                    DatasetCollectionElement.__table__.join(
+                        LibraryDatasetDatasetAssociation.__table__,
+                        DatasetCollectionElement.ldda_id == LibraryDatasetDatasetAssociation.id,
+                    )
                 )
+                .where(LibraryDatasetDatasetAssociation.dataset_id == self.id)
             )
-        )
+        ).subquery()
 
-        # Create the recursive CTE from the single base query
+        # Select from the union subquery to create a proper base query for the CTE
+        base_query = select(union_query.c.collection_id, union_query.c.depth_level)
+
+        # Create the recursive CTE from the base query
         collection_hierarchy_cte = base_query.cte(name="collection_hierarchy", recursive=True)
 
         # Create aliases for the recursive part


### PR DESCRIPTION
by avoiding left outer join.
The extra subquery is an sqlalchemy artifact optimized away by the query planner.

The improved query is this:

```sql
WITH RECURSIVE collection_hierarchy(collection_id, depth_level) AS (
    SELECT dataset_collection_element.dataset_collection_id AS collection_id, 0 AS depth_level
    FROM dataset_collection_element
    JOIN history_dataset_association ON dataset_collection_element.hda_id = history_dataset_association.id
    WHERE history_dataset_association.dataset_id = 134996190

    UNION

    SELECT dataset_collection_element.dataset_collection_id AS collection_id, 0 AS depth_level
    FROM dataset_collection_element
    JOIN library_dataset_dataset_association ON dataset_collection_element.ldda_id = library_dataset_dataset_association.id
    WHERE library_dataset_dataset_association.dataset_id = 134996190
    UNION ALL

    SELECT parent_dce.dataset_collection_id AS collection_id, ch.depth_level + 1 AS depth_level
    FROM dataset_collection_element AS parent_dce
    INNER JOIN collection_hierarchy AS ch ON parent_dce.child_collection_id = ch.collection_id
    WHERE ch.depth_level < 50
)
SELECT collection_id
FROM collection_hierarchy
ORDER BY collection_id;
```

while before it was:

```sql
WITH RECURSIVE collection_hierarchy(collection_id, depth_level) AS (
    SELECT dataset_collection_element.dataset_collection_id AS collection_id, 0 AS depth_level
    FROM dataset_collection_element
    LEFT OUTER JOIN history_dataset_association ON dataset_collection_element.hda_id = history_dataset_association.id
    LEFT OUTER JOIN library_dataset_dataset_association ON dataset_collection_element.ldda_id = library_dataset_dataset_association.id
    WHERE history_dataset_association.dataset_id = 134996190 OR library_dataset_dataset_association.dataset_id = 134996190

    UNION ALL

    SELECT parent_dce.dataset_collection_id AS collection_id, ch.depth_level + 1 AS depth_level
    FROM dataset_collection_element AS parent_dce, collection_hierarchy AS ch
    WHERE parent_dce.child_collection_id = ch.collection_id AND ch.depth_level < 50
)
SELECT collection_id
FROM collection_hierarchy
ORDER BY collection_id
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
