### PR TITLE
[25.1] Use corepack to link yarn into $VIRTUALENV/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,13 +180,13 @@ skip-client: ## Run only the server, skipping the client build.
 
 node-deps: ## Install NodeJS dependencies.
 ifndef YARN
-	npm install -g yarn;
+	corepack enable yarn;
 endif
 	$(IN_VENV) yarn install $(YARN_INSTALL_OPTS)
 
 client-node-deps: ## Install NodeJS dependencies for the client.
 ifndef YARN
-	npm install -g yarn;
+	corepack enable yarn;
 endif
 	$(IN_VENV) cd client && yarn install $(YARN_INSTALL_OPTS)
 

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -238,8 +238,8 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
             echo "Installing yarn into '$CONDA_DEFAULT_ENV' Conda environment with conda."
             $CONDA_EXE install --yes --override-channels --channel conda-forge --name "$CONDA_DEFAULT_ENV" 'yarn<2'
         elif [ -n "$VIRTUAL_ENV" ] && in_venv "$(command -v npm)"; then
-            echo "Installing yarn into $VIRTUAL_ENV with npm."
-            npm install --global yarn
+            echo "Installing yarn into $VIRTUAL_ENV with corepack."
+            corepack enable yarn
         else
             echo "Installing yarn locally with npm."
             npm install yarn


### PR DESCRIPTION
`npm install -g yarn` via npm shipped by `nodejs-wheel` doesn't link the yarn binary into `$VIRTUALENV/bin`.
Missed this because of pre-installed yarn in the github images

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
ensure you have no `yarn` binary on PATH, then
```shell
rm -rf .venv
uv venv .venv
source .venv/bin/activate
uv pip install -r requirements.txt  # installs node and corepack
make client
```
before that the client build would fail because there's no yarn available.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
