### PR TITLE
Change invocation step state display selector to fix styling

### DIFF
--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -204,7 +204,9 @@ function stepClicked(nodeId: number | null) {
                     @mouseover="showSideOverlay = true"
                     @mouseleave="showSideOverlay = false">
                     <BCard no-body>
-                        <div v-if="activeNodeId !== null && showSideOverlay" class="overlay overlay-left" />
+                        <div
+                            v-if="activeNodeId !== null && showSideOverlay"
+                            class="graph-scroll-overlay overlay-left" />
                         <WorkflowGraph
                             ref="workflowGraph"
                             class="invocation-graph"
@@ -218,7 +220,9 @@ function stepClicked(nodeId: number | null) {
                             is-invocation
                             readonly
                             @stepClicked="stepClicked" />
-                        <div v-if="activeNodeId !== null && showSideOverlay" class="overlay overlay-right" />
+                        <div
+                            v-if="activeNodeId !== null && showSideOverlay"
+                            class="graph-scroll-overlay overlay-right" />
                     </BCard>
                 </div>
             </div>
@@ -289,11 +293,13 @@ function stepClicked(nodeId: number | null) {
     }
 }
 
-.overlay {
+.graph-scroll-overlay {
     bottom: 0;
     width: 1.5rem;
     background: $gray-200;
     opacity: 0.5;
+    position: absolute;
+    height: 100%;
     &.overlay-left {
         z-index: 1;
     }

--- a/client/src/components/WorkflowInvocationState/InvocationStepStateDisplay.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationStepStateDisplay.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
     <span
         class="d-flex align-items-center"
         data-description="invocation step state counter"
-        :data-state="state"
+        :data-step-state="state"
         :data-count="jobCount">
         <FontAwesomeIcon
             v-if="iconClasses[props.state]"

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1052,7 +1052,7 @@ invocations:
       selector: '//span[contains(@class, "content-title name")][text()="${element_identifier}"]'
     step_output_collection_element_datatype: '[data-step="${order_index}"] .invocation-step-output-collection-details .not-loading .datatype .value'
     step_job_details: '[data-step="${order_index}"] .invocation-step-job-details'
-    step_job_details_state_counter: '[data-description="invocation step state counter"][data-state="${state}"]'
+    step_job_details_state_counter: '[data-description="invocation step state counter"][data-step-state="${state}"]'
     step_job_information: '[data-step="${order_index}"] .invocation-step-job-details .info_data_table'
     step_job_information_tool_id: '[data-step="${order_index}"] .invocation-step-job-details .info_data_table #galaxy-tool-id'
     export_tab: '.invocation-export-tab'


### PR DESCRIPTION
We added a `data-state` selenium selector for the `InvocationStepStateDisplay.vue` component in https://github.com/galaxyproject/galaxy/pull/21058:

https://github.com/galaxyproject/galaxy/blob/be1ff8ce8ae22adcc8c19e53e45f8fb7ed55b1f1/client/src/components/WorkflowInvocationState/InvocationStepStateDisplay.vue#L13-L19

That unfortunately adds CSS styling from `base.scss` to the text in there:

<img width="983" height="279" alt="image" src="https://github.com/user-attachments/assets/e871ca60-adc5-4992-a8f7-54f30beac119" />

This is the scss:

https://github.com/galaxyproject/galaxy/blob/be1ff8ce8ae22adcc8c19e53e45f8fb7ed55b1f1/client/src/style/scss/base.scss#L158-L163

Therefore, I have changed the selector to `data-step-state`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
