### PR TITLE
[25.1] Remove invocation view connection animations

### DIFF
--- a/client/src/components/Workflow/Editor/WorkflowEdges.vue
+++ b/client/src/components/Workflow/Editor/WorkflowEdges.vue
@@ -14,13 +14,6 @@ const props = defineProps<{
     draggingConnection: TerminalPosition | null;
     draggingTerminal: OutputTerminals | null;
     transform: { x: number; y: number; k: number };
-    /** Stores the step IDs for steps in the invocation which should have a
-     * "breathing" or "flowing" animation applied to their connections.
-     */
-    stepConnectionClasses?: {
-        breathing: number[];
-        flowing: number[];
-    };
 }>();
 
 const { connectionStore } = useWorkflowStores();
@@ -50,19 +43,6 @@ function key(connection: Connection) {
 function id(connection: Connection) {
     return `connection-node-${connection.input.stepId}-input-${connection.input.name}-node-${connection.output.stepId}-output-${connection.output.name}`;
 }
-
-/** Checks the connection's input and output step IDs to determine if a "breathing"
- * or "flowing" class should be applied in the `SVGConnection` component.
- */
-function getConnectionState(connection: Connection, stateType: "breathing" | "flowing") {
-    if (props.stepConnectionClasses) {
-        return (
-            props.stepConnectionClasses[stateType].includes(connection.output.stepId) ||
-            props.stepConnectionClasses[stateType].includes(connection.input.stepId)
-        );
-    }
-    return false;
-}
 </script>
 
 <template>
@@ -70,16 +50,13 @@ function getConnectionState(connection: Connection, stateType: "breathing" | "fl
         <svg class="workflow-edges">
             <SVGConnection
                 v-if="draggingConnection"
-                id="dragging-connection"
                 :connection="draggingConnection[0]"
                 :terminal-position="draggingConnection[1]" />
             <SVGConnection
                 v-for="connection in connections"
                 :id="id(connection)"
                 :key="key(connection)"
-                :connection="connection"
-                :flowing="getConnectionState(connection, 'flowing')"
-                :breathing="getConnectionState(connection, 'breathing')" />
+                :connection="connection" />
         </svg>
     </div>
 </template>

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -4,7 +4,6 @@ import { storeToRefs } from "pinia";
 import { computed, type PropType, provide, reactive, type Ref, ref, watch, watchEffect } from "vue";
 
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
-import { isGraphStep } from "@/composables/useInvocationGraph";
 import { useWorkflowStores } from "@/composables/workflowStores";
 import type { TerminalPosition, XYPosition } from "@/stores/workflowEditorStateStore";
 import type { Step } from "@/stores/workflowStepStore";
@@ -72,24 +71,6 @@ const { viewportBoundingBox, updateViewportBaseBoundingBox } = useViewportBoundi
     transform,
 );
 const { getWorkflowBoundingBox } = useWorkflowBoundingBox();
-
-const stepConnectionClasses = computed<{
-    breathing: number[];
-    flowing: number[];
-}>(() => {
-    const retVal: { breathing: number[]; flowing: number[] } = { breathing: [], flowing: [] };
-    for (const stepId in props.steps) {
-        const step = props.steps[stepId];
-        if (step && isGraphStep(step) && step.state) {
-            if (["queued", "new", "waiting"].includes(step.state)) {
-                retVal.breathing.push(step.id);
-            } else if (step.state === "running") {
-                retVal.flowing.push(step.id);
-            }
-        }
-    }
-    return retVal;
-});
 
 function fitWorkflow(minimumFitZoom = 0.5, maximumFitZoom = 1.0, padding = 50.0) {
     if (!Object.keys(props.steps).length) {
@@ -225,8 +206,7 @@ defineExpose({
                 <WorkflowEdges
                     :transform="transform"
                     :dragging-terminal="draggingTerminal"
-                    :dragging-connection="draggingPosition"
-                    :step-connection-classes="stepConnectionClasses" />
+                    :dragging-connection="draggingPosition" />
                 <WorkflowNode
                     v-for="(step, key) in steps"
                     :id="step.id"

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -366,7 +366,3 @@ export function getHeaderClass(state: string) {
         [`header-${state}`]: !!state,
     };
 }
-
-export function isGraphStep(step: Step | GraphStep): step is GraphStep {
-    return "jobs" in step;
-}


### PR DESCRIPTION
This reverts the changes from commit d34c509b5e7b5e1c3900eaa65ff9acb9e3f78ad1.

The animations were causing jittering as reported in #21136, and the graph view would stutter and glitch when moving around as shown here:

![Image](https://github.com/user-attachments/assets/1b0c3b5c-11c2-407b-8edd-80f2494eba9d)

I think we should work more on this in dev and create better, more performant animations?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
