### PR TITLE
[25.1] Mark user creation API endpoint as admin-only

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -596,6 +596,7 @@ class FastAPIUsers:
         "/api/users",
         name="create_user",
         summary="Create a new Galaxy user. Only admins can create users for now.",
+        require_admin=True,
     )
     def create(
         self,


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/21148


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
