### PR TITLE
Add Custom Validation for User-Configured Templates

### DIFF
--- a/client/src/api/configTemplates.ts
+++ b/client/src/api/configTemplates.ts
@@ -11,6 +11,7 @@ export type TemplateVariable =
     | components["schemas"]["TemplateVariableInteger"]
     | components["schemas"]["TemplateVariablePathComponent"]
     | components["schemas"]["TemplateVariableBoolean"];
+export type TemplateVariableValidator = components["schemas"]["TemplateVariableValidator"];
 export type TemplateSecret = components["schemas"]["TemplateSecret"];
 export type VariableData = CreateInstancePayload["variables"];
 export type VariableValueType = VariableData[keyof VariableData];

--- a/client/src/api/configTemplates.ts
+++ b/client/src/api/configTemplates.ts
@@ -11,7 +11,10 @@ export type TemplateVariable =
     | components["schemas"]["TemplateVariableInteger"]
     | components["schemas"]["TemplateVariablePathComponent"]
     | components["schemas"]["TemplateVariableBoolean"];
-export type TemplateVariableValidator = components["schemas"]["TemplateVariableValidator"];
+export type TemplateVariableValidator =
+    | components["schemas"]["RegexParameterValidatorModel"]
+    | components["schemas"]["InRangeParameterValidatorModel"]
+    | components["schemas"]["LengthParameterValidatorModel"];
 export type TemplateSecret = components["schemas"]["TemplateSecret"];
 export type VariableData = CreateInstancePayload["variables"];
 export type VariableValueType = VariableData[keyof VariableData];

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -21319,6 +21319,8 @@ export interface components {
              * @constant
              */
             type: "boolean";
+            /** Validators */
+            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
         };
         /** TemplateVariableInteger */
         TemplateVariableInteger: {
@@ -21338,6 +21340,8 @@ export interface components {
              * @constant
              */
             type: "integer";
+            /** Validators */
+            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
         };
         /** TemplateVariablePathComponent */
         TemplateVariablePathComponent: {
@@ -21354,6 +21358,8 @@ export interface components {
              * @constant
              */
             type: "path_component";
+            /** Validators */
+            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
         };
         /** TemplateVariableString */
         TemplateVariableString: {
@@ -21373,6 +21379,32 @@ export interface components {
              * @constant
              */
             type: "string";
+            /** Validators */
+            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
+        };
+        /**
+         * TemplateVariableValidator
+         * @description Validator definition for template variables.
+         */
+        TemplateVariableValidator: {
+            /** Expression */
+            expression?: string | null;
+            /** Max */
+            max?: number | null;
+            /** Message */
+            message: string;
+            /** Min */
+            min?: number | null;
+            /**
+             * Negate
+             * @default false
+             */
+            negate: boolean;
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "regex" | "length" | "range";
         };
         /** TestUpdateInstancePayload */
         TestUpdateInstancePayload: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -21320,7 +21320,13 @@ export interface components {
              */
             type: "boolean";
             /** Validators */
-            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
+            validators?:
+                | (
+                      | components["schemas"]["RegexParameterValidatorModel"]
+                      | components["schemas"]["InRangeParameterValidatorModel"]
+                      | components["schemas"]["LengthParameterValidatorModel"]
+                  )[]
+                | null;
         };
         /** TemplateVariableInteger */
         TemplateVariableInteger: {
@@ -21341,7 +21347,13 @@ export interface components {
              */
             type: "integer";
             /** Validators */
-            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
+            validators?:
+                | (
+                      | components["schemas"]["RegexParameterValidatorModel"]
+                      | components["schemas"]["InRangeParameterValidatorModel"]
+                      | components["schemas"]["LengthParameterValidatorModel"]
+                  )[]
+                | null;
         };
         /** TemplateVariablePathComponent */
         TemplateVariablePathComponent: {
@@ -21359,7 +21371,13 @@ export interface components {
              */
             type: "path_component";
             /** Validators */
-            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
+            validators?:
+                | (
+                      | components["schemas"]["RegexParameterValidatorModel"]
+                      | components["schemas"]["InRangeParameterValidatorModel"]
+                      | components["schemas"]["LengthParameterValidatorModel"]
+                  )[]
+                | null;
         };
         /** TemplateVariableString */
         TemplateVariableString: {
@@ -21380,31 +21398,13 @@ export interface components {
              */
             type: "string";
             /** Validators */
-            validators?: components["schemas"]["TemplateVariableValidator"][] | null;
-        };
-        /**
-         * TemplateVariableValidator
-         * @description Validator definition for template variables.
-         */
-        TemplateVariableValidator: {
-            /** Expression */
-            expression?: string | null;
-            /** Max */
-            max?: number | null;
-            /** Message */
-            message: string;
-            /** Min */
-            min?: number | null;
-            /**
-             * Negate
-             * @default false
-             */
-            negate: boolean;
-            /**
-             * Type
-             * @enum {string}
-             */
-            type: "regex" | "length" | "range";
+            validators?:
+                | (
+                      | components["schemas"]["RegexParameterValidatorModel"]
+                      | components["schemas"]["InRangeParameterValidatorModel"]
+                      | components["schemas"]["LengthParameterValidatorModel"]
+                  )[]
+                | null;
         };
         /** TestUpdateInstancePayload */
         TestUpdateInstancePayload: {

--- a/client/src/components/ConfigTemplates/formUtil.ts
+++ b/client/src/components/ConfigTemplates/formUtil.ts
@@ -6,6 +6,7 @@ import type {
     TemplateSecret,
     TemplateSummary,
     TemplateVariable,
+    TemplateVariableValidator,
     VariableData,
     VariableValueType,
 } from "@/api/configTemplates";
@@ -18,6 +19,7 @@ export interface FormEntry {
     help?: string | null;
     type: string;
     value?: any;
+    validators?: TemplateVariableValidator[];
 }
 
 export function metadataFormEntryName(what: string): FormEntry {
@@ -45,6 +47,7 @@ export function templateVariableFormEntry(variable: TemplateVariable, variableVa
         name: variable.name,
         label: variable.label ?? variable.name,
         help: markup(variable.help || "", true),
+        validators: variable.validators ?? [],
     };
     if (variable.type == "string") {
         const defaultValue = variable.default ?? "";
@@ -55,7 +58,6 @@ export function templateVariableFormEntry(variable: TemplateVariable, variableVa
         };
     } else if (variable.type == "path_component") {
         const defaultValue = variable.default ?? "";
-        // TODO: do extra validation with form somehow...
         return {
             type: "text",
             value: variableValue == undefined ? defaultValue : variableValue,

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -152,7 +152,7 @@ function validateLength(validator, value) {
  * @param{*}      value     - Value to validate
  * @returns{object} Object with isValid boolean and message string
  */
-function validateRange(validator, value) {
+function validateInRange(validator, value) {
     const numericValue = Number(value);
 
     if (isNaN(numericValue)) {
@@ -184,7 +184,7 @@ function validateRange(validator, value) {
 const validatorFunctions = {
     regex: validateRegex,
     length: validateLength,
-    range: validateRange,
+    in_range: validateInRange,
 };
 
 /** Run a single validator

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -247,12 +247,12 @@ describe("form component utilities", () => {
         expect(result).toEqual(["username", "Username must be between 3 and 20 characters"]);
     });
 
-    it("test range validator", () => {
+    it("test in_range validator", () => {
         const index = {
             age: {
                 validators: [
                     {
-                        type: "range",
+                        type: "in_range",
                         min: 18,
                         max: 120,
                         message: "Age must be between 18 and 120",
@@ -285,12 +285,12 @@ describe("form component utilities", () => {
         expect(result).toEqual(["age", "Age must be between 18 and 120"]);
     });
 
-    it("test range validator with non-numeric value", () => {
+    it("test in_range validator with non-numeric value", () => {
         const index = {
             age: {
                 validators: [
                     {
-                        type: "range",
+                        type: "in_range",
                         min: 18,
                         max: 120,
                         message: "Age must be between 18 and 120",

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -134,4 +134,174 @@ describe("form component utilities", () => {
         expect(result["input_b_0"]).toEqual("error_b");
         expect(result["input_c|input_d"]).toEqual("error_d");
     });
+
+    it("test multiple validators", () => {
+        const index = {
+            path: {
+                validators: [
+                    {
+                        type: "regex",
+                        expression: "^.*[^/]$",
+                        message: "Value cannot end with a trailing slash",
+                        negate: false,
+                    },
+                    {
+                        type: "regex",
+                        expression: "^(?!\\s)(?!.*\\s$).*$",
+                        message: "Value cannot have leading or trailing whitespace",
+                        negate: false,
+                    },
+                ],
+            },
+        };
+
+        // Valid path
+        let values = { path: "clean/path" };
+        let result = validateInputs(index, values);
+        expect(result).toEqual(null);
+
+        // Invalid: trailing slash
+        values = { path: "path/" };
+        result = validateInputs(index, values);
+        expect(result).toEqual(["path", "Value cannot end with a trailing slash"]);
+
+        // Invalid: trailing whitespace
+        values = { path: "path " };
+        result = validateInputs(index, values);
+        expect(result).toEqual(["path", "Value cannot have leading or trailing whitespace"]);
+    });
+
+    it("test validators skip empty optional values", () => {
+        const index = {
+            optional_field: {
+                optional: true,
+                validators: [
+                    {
+                        type: "regex",
+                        expression: "^(?!\\s)(?!.*\\s$)(?!.*/$).+$",
+                        message: "Value cannot have leading/trailing spaces or trailing slashes",
+                        negate: false,
+                    },
+                ],
+            },
+        };
+
+        // Empty value should not trigger validator
+        const values = { optional_field: "" };
+        const result = validateInputs(index, values);
+        expect(result).toEqual(null);
+    });
+
+    it("test validators skip null values", () => {
+        const index = {
+            optional_field: {
+                optional: true, // Make it optional so null is allowed
+                validators: [
+                    {
+                        type: "regex",
+                        expression: "^(?!\\s)(?!.*\\s$)(?!.*/$).+$",
+                        message: "Value cannot have leading/trailing spaces or trailing slashes",
+                        negate: false,
+                    },
+                ],
+            },
+        };
+
+        // Null value should not trigger validator for optional fields
+        const values = { optional_field: null };
+        const result = validateInputs(index, values);
+        expect(result).toEqual(null);
+    });
+
+    it("test length validator", () => {
+        const index = {
+            username: {
+                validators: [
+                    {
+                        type: "length",
+                        min: 3,
+                        max: 20,
+                        message: "Username must be between 3 and 20 characters",
+                    },
+                ],
+            },
+        };
+
+        // Valid length
+        let values = { username: "john" };
+        let result = validateInputs(index, values);
+        expect(result).toEqual(null);
+
+        values = { username: "a".repeat(20) };
+        result = validateInputs(index, values);
+        expect(result).toEqual(null);
+
+        // Too short
+        values = { username: "ab" };
+        result = validateInputs(index, values);
+        expect(result).toEqual(["username", "Username must be between 3 and 20 characters"]);
+
+        // Too long
+        values = { username: "a".repeat(21) };
+        result = validateInputs(index, values);
+        expect(result).toEqual(["username", "Username must be between 3 and 20 characters"]);
+    });
+
+    it("test range validator", () => {
+        const index = {
+            age: {
+                validators: [
+                    {
+                        type: "range",
+                        min: 18,
+                        max: 120,
+                        message: "Age must be between 18 and 120",
+                    },
+                ],
+            },
+        };
+
+        // Valid range
+        let values = { age: 25 };
+        let result = validateInputs(index, values);
+        expect(result).toEqual(null);
+
+        values = { age: 18 };
+        result = validateInputs(index, values);
+        expect(result).toEqual(null);
+
+        values = { age: 120 };
+        result = validateInputs(index, values);
+        expect(result).toEqual(null);
+
+        // Too small
+        values = { age: 17 };
+        result = validateInputs(index, values);
+        expect(result).toEqual(["age", "Age must be between 18 and 120"]);
+
+        // Too large
+        values = { age: 121 };
+        result = validateInputs(index, values);
+        expect(result).toEqual(["age", "Age must be between 18 and 120"]);
+    });
+
+    it("test range validator with non-numeric value", () => {
+        const index = {
+            age: {
+                validators: [
+                    {
+                        type: "range",
+                        min: 18,
+                        max: 120,
+                        message: "Age must be between 18 and 120",
+                    },
+                ],
+            },
+        };
+
+        // Non-numeric value
+        const values = { age: "not a number" };
+        const result = validateInputs(index, values);
+        expect(result).toEqual(["age", "Value must be numeric for range validation"]);
+    });
 });

--- a/doc/source/admin/data.md
+++ b/doc/source/admin/data.md
@@ -778,13 +778,13 @@ variables:
         message: "Username must be between 3 and 20 characters"
 ```
 
-#### `range` - Numeric Range Constraints
+#### `in_range` - Numeric Range Constraints
 
 Validates that a numeric value falls within specified bounds.
 
 **Parameters:**
 
-- `type`: Must be `range`
+- `type`: Must be `in_range`
 - `min` (optional): Minimum allowed value (inclusive)
 - `max` (optional): Maximum allowed value (inclusive)
 - `message`: Error message shown when validation fails

--- a/lib/galaxy/files/templates/examples/production_s3fs.yml
+++ b/lib/galaxy/files/templates/examples/production_s3fs.yml
@@ -81,6 +81,13 @@
         store your datasets in. How to setup buckets for your storage will vary from service to service
         but all S3 compatible storage services should have the concept of a bucket to namespace
         a grouping of your data together with.
+      validators:
+        - type: regex
+          expression: '^(?!\s)(?!.*\s$).*$'
+          message: "Bucket name cannot have leading or trailing whitespace"
+        - type: regex
+          expression: '^.*[^/]$'
+          message: "Bucket name cannot end with a slash"
     endpoint_url:
       label: S3-Compatible API Endpoint
       type: string

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -5,8 +5,10 @@ This is capturing code shared by file source templates and object store template
 
 import logging
 import os
-import re
-from collections.abc import Iterable
+from collections.abc import (
+    Iterable,
+    Sequence,
+)
 from typing import (
     Any,
     Callable,
@@ -56,6 +58,7 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
     RequestParameterMissingException,
 )
+from galaxy.tool_util_models.parameter_validators import AnySafeValidatorModel
 from galaxy.util import asbool
 
 log = logging.getLogger(__name__)
@@ -75,22 +78,11 @@ class StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid", coerce_numbers_to_str=True)
 
 
-class TemplateVariableValidator(StrictModel):
-    """Validator definition for template variables."""
-
-    type: Literal["regex", "length", "range"]
-    message: str
-    expression: Optional[str] = None
-    min: Optional[int] = None
-    max: Optional[int] = None
-    negate: bool = False
-
-
 class BaseTemplateVariable(StrictModel):
     name: str
     label: Optional[str] = None
     help: Optional[MarkdownContent]
-    validators: Optional[List[TemplateVariableValidator]] = None
+    validators: Optional[Sequence[AnySafeValidatorModel]] = None
 
 
 class TemplateVariableString(BaseTemplateVariable):
@@ -353,78 +345,15 @@ def find_template_by(templates: List[T], template_id: str, template_version: int
     raise ObjectNotFound(f"Could not find a {what} template with id {template_id} and version {template_version}")
 
 
-def validate_variable_regex(validator: TemplateVariableValidator, value: Any, variable_name: str) -> None:
-    """Validate value against a regular expression pattern."""
-    if not validator.expression:
-        raise RequestParameterInvalidException(
-            f"Regex validator for variable '{variable_name}' is missing 'expression' field"
-        )
-    try:
-        pattern = re.compile(validator.expression)
-        matches = pattern.search(str(value)) is not None
-        is_valid = not matches if validator.negate else matches
-        if not is_valid:
-            raise RequestParameterInvalidException(f"Variable '{variable_name}' failed validation: {validator.message}")
-    except re.error as e:
-        raise RequestParameterInvalidException(f"Invalid regex pattern for variable '{variable_name}': {str(e)}")
-
-
-def validate_variable_length(validator: TemplateVariableValidator, value: Any, variable_name: str) -> None:
-    """Validate value length is within specified bounds."""
-    if validator.min is None and validator.max is None:
-        raise RequestParameterInvalidException(
-            f"Length validator for variable '{variable_name}' must specify 'min' or 'max'"
-        )
-    value_length = len(str(value))
-    is_valid = True
-    if validator.min is not None and value_length < validator.min:
-        is_valid = False
-    if validator.max is not None and value_length > validator.max:
-        is_valid = False
-    if validator.negate:
-        is_valid = not is_valid
-    if not is_valid:
-        raise RequestParameterInvalidException(f"Variable '{variable_name}' failed validation: {validator.message}")
-
-
-def validate_variable_range(validator: TemplateVariableValidator, value: Any, variable_name: str) -> None:
-    """Validate numeric value is within specified range."""
-    if validator.min is None and validator.max is None:
-        raise RequestParameterInvalidException(
-            f"Range validator for variable '{variable_name}' must specify 'min' or 'max'"
-        )
-    try:
-        numeric_value = float(value)
-        is_valid = True
-        if validator.min is not None and numeric_value < validator.min:
-            is_valid = False
-        if validator.max is not None and numeric_value > validator.max:
-            is_valid = False
-        if validator.negate:
-            is_valid = not is_valid
-        if not is_valid:
-            raise RequestParameterInvalidException(f"Variable '{variable_name}' failed validation: {validator.message}")
-    except (ValueError, TypeError):
-        raise RequestParameterInvalidException(f"Variable '{variable_name}' must be numeric for range validation")
-
-
-VARIABLE_VALIDATOR_FUNCTIONS = {
-    "regex": validate_variable_regex,
-    "length": validate_variable_length,
-    "range": validate_variable_range,
-}
-
-
-def _run_variable_validator(validator: TemplateVariableValidator, value: Any, variable_name: str) -> None:
+def _run_variable_validator(validator: AnySafeValidatorModel, value: Any, variable_name: str) -> None:
     """Run a single validator on a variable value.
 
     Raises RequestParameterInvalidException if validation fails.
     """
-    validator_func = VARIABLE_VALIDATOR_FUNCTIONS.get(validator.type)
-    if validator_func:
-        validator_func(validator, value, variable_name)
-    else:
-        raise RequestParameterInvalidException(f"Unknown validator type: {validator.type}")
+    try:
+        validator.statically_validate(value)
+    except ValueError as e:
+        raise RequestParameterInvalidException(f"Variable '{variable_name}' failed validation: {str(e)}")
 
 
 def validate_variable_types(instance: InstanceDefinition, template: Template) -> None:

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -5,10 +5,7 @@ This is capturing code shared by file source templates and object store template
 
 import logging
 import os
-from collections.abc import (
-    Iterable,
-    Sequence,
-)
+from collections.abc import Iterable
 from typing import (
     Any,
     Callable,
@@ -16,6 +13,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
     TypeVar,

--- a/test/unit/util/test_config_template_validation.py
+++ b/test/unit/util/test_config_template_validation.py
@@ -18,6 +18,7 @@ from galaxy.util.config_templates import (
     TemplateVariableInteger,
     TemplateVariablePathComponent,
     TemplateVariableString,
+    TemplateVariableValidator,
     validate_secrets_and_variables,
 )
 
@@ -178,3 +179,220 @@ def assert_validation_throws(instance: TestInstanceDefinition, template: TestTem
     except Exception as e:
         return e
     raise AssertionError("Expected validation error did not occur.")
+
+
+def test_multiple_validators():
+    """Test multiple validators on the same variable."""
+    validators = [
+        TemplateVariableValidator(
+            type="regex",
+            expression=r"^.*[^/]$",
+            message="Value cannot end with a trailing slash",
+        ),
+        TemplateVariableValidator(
+            type="regex",
+            expression=r"^(?!\s)(?!.*\s$).*$",
+            message="Value cannot have leading or trailing whitespace",
+        ),
+    ]
+    template = _template_with_variable(
+        TemplateVariableString(name="path", help=None, type="string", validators=validators)
+    )
+
+    # Valid path
+    instance = _test_instance_with_variables({"path": "clean/path"})
+    validate_secrets_and_variables(instance, template)
+
+    # Invalid: trailing slash (first validator fails)
+    instance = _test_instance_with_variables({"path": "path/"})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+    assert "trailing slash" in str(e)
+
+    # Invalid: trailing whitespace (second validator fails)
+    instance = _test_instance_with_variables({"path": "path "})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+    assert "whitespace" in str(e)
+
+
+def test_regex_validator_negate():
+    """Test regex validation with negate flag."""
+    validator = TemplateVariableValidator(
+        type="regex",
+        expression=r"forbidden",
+        message="Value cannot contain 'forbidden'",
+        negate=True,
+    )
+    template = _template_with_variable(
+        TemplateVariableString(name="username", help=None, type="string", validators=[validator])
+    )
+
+    # Valid: doesn't contain 'forbidden'
+    instance = _test_instance_with_variables({"username": "john_doe"})
+    validate_secrets_and_variables(instance, template)
+
+    # Invalid: contains 'forbidden'
+    instance = _test_instance_with_variables({"username": "forbidden_user"})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+
+
+def test_length_validator():
+    """Test length validation."""
+    validator = TemplateVariableValidator(
+        type="length",
+        min=3,
+        max=10,
+        message="Value must be between 3 and 10 characters",
+    )
+    template = _template_with_variable(
+        TemplateVariableString(name="name", help=None, type="string", validators=[validator])
+    )
+
+    # Valid length
+    instance = _test_instance_with_variables({"name": "test"})
+    validate_secrets_and_variables(instance, template)
+
+    instance = _test_instance_with_variables({"name": "a" * 10})
+    validate_secrets_and_variables(instance, template)
+
+    # Too short
+    instance = _test_instance_with_variables({"name": "ab"})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+
+    # Too long
+    instance = _test_instance_with_variables({"name": "a" * 11})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+
+
+def test_length_validator_min_only():
+    """Test length validation with only minimum."""
+    validator = TemplateVariableValidator(
+        type="length",
+        min=5,
+        message="Value must be at least 5 characters",
+    )
+    template = _template_with_variable(
+        TemplateVariableString(name="description", help=None, type="string", validators=[validator])
+    )
+
+    # Valid: meets minimum
+    instance = _test_instance_with_variables({"description": "12345"})
+    validate_secrets_and_variables(instance, template)
+
+    instance = _test_instance_with_variables({"description": "a" * 100})
+    validate_secrets_and_variables(instance, template)
+
+    # Invalid: too short
+    instance = _test_instance_with_variables({"description": "test"})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+
+
+def test_length_validator_max_only():
+    """Test length validation with only maximum."""
+    validator = TemplateVariableValidator(
+        type="length",
+        max=50,
+        message="Value must be at most 50 characters",
+    )
+    template = _template_with_variable(
+        TemplateVariableString(name="title", help=None, type="string", validators=[validator])
+    )
+
+    # Valid: under maximum
+    instance = _test_instance_with_variables({"title": "Short title"})
+    validate_secrets_and_variables(instance, template)
+
+    instance = _test_instance_with_variables({"title": "a" * 50})
+    validate_secrets_and_variables(instance, template)
+
+    # Invalid: too long
+    instance = _test_instance_with_variables({"title": "a" * 51})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+
+
+def test_range_validator():
+    """Test range validation for numeric values."""
+    validator = TemplateVariableValidator(
+        type="range",
+        min=1,
+        max=100,
+        message="Value must be between 1 and 100",
+    )
+    template = _template_with_variable(
+        TemplateVariableInteger(name="port", help=None, type="integer", validators=[validator])
+    )
+
+    # Valid range
+    instance = _test_instance_with_variables({"port": 80})
+    validate_secrets_and_variables(instance, template)
+
+    instance = _test_instance_with_variables({"port": 1})
+    validate_secrets_and_variables(instance, template)
+
+    instance = _test_instance_with_variables({"port": 100})
+    validate_secrets_and_variables(instance, template)
+
+    # Too small
+    instance = _test_instance_with_variables({"port": 0})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+
+    # Too large
+    instance = _test_instance_with_variables({"port": 101})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+
+
+def test_validators_skip_empty_optional_values():
+    """Test that validators skip empty optional values."""
+    validator = TemplateVariableValidator(
+        type="length",
+        min=3,
+        message="Value must be at least 3 characters",
+    )
+    template = _template_with_variable(
+        TemplateVariableString(name="optional_field", help=None, type="string", default="", validators=[validator])
+    )
+
+    # Empty value should not trigger validator
+    instance = _test_instance_with_variables({"optional_field": ""})
+    validate_secrets_and_variables(instance, template)
+
+
+def test_validators_skip_null_values():
+    """Test that validators skip empty values for optional fields with defaults."""
+    validator = TemplateVariableValidator(
+        type="length",
+        min=3,
+        message="Value must be at least 3 characters",
+    )
+    template = _template_with_variable(
+        TemplateVariableString(name="optional_field", help=None, type="string", default="", validators=[validator])
+    )
+
+    # Empty value should not trigger validator when field has empty default
+    instance = _test_instance_with_variables({})
+    validate_secrets_and_variables(instance, template)
+
+
+def test_invalid_regex_pattern():
+    """Test that invalid regex patterns are handled gracefully."""
+    validator = TemplateVariableValidator(
+        type="regex",
+        expression=r"[invalid(regex",  # Invalid regex
+        message="Test message",
+    )
+    template = _template_with_variable(
+        TemplateVariableString(name="test", help=None, type="string", validators=[validator])
+    )
+
+    instance = _test_instance_with_variables({"test": "value"})
+    e = assert_validation_throws(instance, template)
+    assert isinstance(e, RequestParameterInvalidException)
+    assert "Invalid regex pattern" in str(e)


### PR DESCRIPTION
Closes #20904

This PR adds custom validation to template variables in file source and object store templates, enforcing input constraints with clear error messages.

### Features

**Three validator types:**
- **`regex`**: Pattern matching with optional negation
- **`length`**: String length bounds (min/max)
- **`range`**: Numeric value bounds (min/max)

**Key characteristics:**
- Validators are optional and can be chained
- Skip validation for empty optional fields
- Run on both frontend (immediate feedback) and backend (security)
- Provide clear, customizable error messages

### Example Usage (included in `lib/galaxy/files/templates/examples/production_s3fs.yml`)

```yaml
variables:
  bucket:
    label: Bucket Name
    type: string
    validators:
      - type: regex
        expression: '^(?!\s)(?!.*\s$).*$'
        message: "Bucket name cannot have leading or trailing whitespace"
      - type: regex
        expression: '^.*[^/]$'
        message: "Bucket name cannot end with a slash"
```

<img width="938" height="189" alt="Screenshot from 2025-10-24 13-04-02" src="https://github.com/user-attachments/assets/8e5ce120-230e-48c8-9431-a3a08de4d6f3" />

<img width="938" height="189" alt="Screenshot from 2025-10-24 13-06-06" src="https://github.com/user-attachments/assets/62576dc0-bff3-4de7-8811-884e500814f8" />


This prevents common configuration mistakes and improves the user experience when setting up custom storage connections.



## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
