### PR TITLE
[25.1] Drop fastapi extra dep from sentry-sdk

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -2,7 +2,7 @@
 psycopg2-binary==2.9.10
 mysqlclient
 fluent-logger
-sentry-sdk[fastapi]
+sentry-sdk
 pbs_python
 drmaa
 statsd


### PR DESCRIPTION
It brings in the latest fastapi which breaks 

```
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     self.app.wsgi()
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/gunicorn/app/base.py", line 66, in wsgi
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     self.callable = self.load()
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:                     ^^^^^^^^^^^
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     return self.load_wsgiapp()
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:            ^^^^^^^^^^^^^^^^^^^
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     return util.import_app(self.app_uri)
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/gunicorn/util.py", line 370, in import_app
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     mod = importlib.import_module(module)
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/deps/_conda/envs/__python@3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     return _bootstrap._gcd_import(name[level:], package, level)
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/webapps/galaxy/fast_factory.py", line 50, in <module>
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     from .fast_app import initialize_fast_app
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/webapps/galaxy/fast_app.py", line 23, in <module>
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     from galaxy.webapps.openapi.utils import get_openapi
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:   File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/webapps/openapi/utils.py", line 13, in <module>
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]:     from fastapi._compat import (
Oct 23 11:33:47 galaxy-main1 galaxyctl[1227720]: ImportError: cannot import name 'GenerateJsonSchema' from 'fastapi._compat' (/cvmfs/main.galaxyproject.org/venv/lib/python3.11/site-packages/fastapi/_compat/__init__.py)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
