### PR TITLE
Fix various bugs/hacks with tool_data_table handling.

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -72,11 +72,6 @@ log = get_logger(__name__)
 
 
 @lru_cache
-def setup_data_table_manager(app):
-    app._configure_tool_data_tables(from_shed_config=False)
-
-
-@lru_cache
 def cached_create_tool_from_representation(app: MinimalManagerApp, raw_tool_source: str):
     return create_tool_from_representation(app=app, raw_tool_source=raw_tool_source, tool_source_class="XmlToolSource")
 
@@ -448,7 +443,6 @@ def import_data_bundle(
     tool_data_file_path: Optional[str] = None,
     task_user_id: Optional[int] = None,
 ):
-    setup_data_table_manager(app)
     if src == "uri":
         assert uri
         tool_data_import_manager.import_data_bundle_by_uri(config, uri, tool_data_file_path=tool_data_file_path)

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -204,7 +204,6 @@ def reload_data_managers(app, **kwargs):
     reload_timer = util.ExecutionTimer()
 
     log.debug("Executing data managers reload on '%s'", app.config.server_name)
-    app._configure_tool_data_tables(from_shed_config=False)
     reload_tool_data_tables(app)
     reload_count = app.data_managers._reload_count + 1
     app.data_managers = DataManagers(app, None, reload_count)

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -80,7 +80,10 @@ class BasicSharedApp(Container):
     auth_manager: AuthManager
     security_agent: Any
     quota_agent: QuotaAgent
-    tool_data_tables: "ToolDataTableManager"
+
+    @property
+    def tool_data_tables(self) -> "ToolDataTableManager":
+        raise NotImplementedError()
 
     @property
     def toolbox(self) -> "ToolBox":
@@ -95,9 +98,12 @@ class MinimalToolApp(Protocol):
     config: Any
     datatypes_registry: Registry
     object_store: BaseObjectStore
-    tool_data_tables: "ToolDataTableManager"
     file_sources: ConfiguredFileSources
     security: IdEncodingHelper
+
+    @property
+    def tool_data_tables(self) -> "ToolDataTableManager":
+        raise NotImplementedError()
 
 
 class MinimalApp(BasicSharedApp):

--- a/lib/galaxy/tool_shed/galaxy_install/client.py
+++ b/lib/galaxy/tool_shed/galaxy_install/client.py
@@ -56,6 +56,8 @@ class InstallationTarget(HasToolBox, Protocol[ToolBoxType]):
     config: Any
     installed_repository_manager: "InstalledRepositoryManager"
     _toolbox_lock: threading.RLock
-    tool_data_tables: ToolDataTableManager
+
+    @property
+    def tool_data_tables(self) -> ToolDataTableManager: ...
 
     def wait_for_toolbox_reload(self, old_toolbox: ToolBoxType) -> None: ...

--- a/lib/galaxy/tool_shed/unittest_utils/__init__.py
+++ b/lib/galaxy/tool_shed/unittest_utils/__init__.py
@@ -222,7 +222,7 @@ class StandaloneInstallationTarget(InstallationTarget):
         config.shed_tools_dir = str(tool_root_dir)
         self.watchers = Watchers(self)
         self.reload_toolbox()
-        self.tool_data_tables = ToolDataTableManager(
+        self._tool_data_tables = ToolDataTableManager(
             tool_data_path=self.config.tool_data_path,
             config_filename=self.config.shed_tool_data_table_config,
             other_config_dict=self.config,
@@ -230,6 +230,10 @@ class StandaloneInstallationTarget(InstallationTarget):
         dependency_dir = target_directory / "_dependencies"
         dependency_dir.mkdir()
         self.installed_repository_manager = InstalledRepositoryManager(self)
+
+    @property
+    def tool_data_tables(self) -> ToolDataTableManager:
+        return self._tool_data_tables
 
     @property
     def tool_dependency_dir(self) -> Optional[str]:

--- a/lib/galaxy/tool_util/parser/output_actions.py
+++ b/lib/galaxy/tool_util/parser/output_actions.py
@@ -27,7 +27,8 @@ class ToolOutputActionAppConfig(Protocol):
 
 
 class ToolOutputActionApp(Protocol):
-    tool_data_tables: Any  # TODO after refactor "ToolDataTableManager"
+    @property
+    def tool_data_tables(self) -> Any: ...  # TODO after refactor "ToolDataTableManager"
 
     @property
     def config(self) -> ToolOutputActionAppConfig: ...  # https://github.com/python/mypy/issues/7041

--- a/lib/galaxy/tools/remote_tool_eval.py
+++ b/lib/galaxy/tools/remote_tool_eval.py
@@ -66,10 +66,14 @@ class ToolApp(MinimalToolApp):
         self.datatypes_registry = datatypes_registry
         self.object_store = object_store
         self.genome_builds = GenomeBuilds(self)
-        self.tool_data_tables = tool_data_table_manager
+        self._tool_data_tables = tool_data_table_manager
         self.file_sources = file_sources
         self.biotools_metadata_source = None
         self.security = None  # type: ignore[assignment]
+
+    @property
+    def tool_data_tables(self) -> ToolDataTableManager:
+        return self._tool_data_tables
 
 
 def main(TMPDIR, WORKING_DIRECTORY, IMPORT_STORE_DIRECTORY) -> None:

--- a/lib/tool_shed/structured_app.py
+++ b/lib/tool_shed/structured_app.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 from galaxy.structured_app import BasicSharedApp
 
 if TYPE_CHECKING:
-    from galaxy.tools.data import ToolDataTableManager
     from tool_shed.managers.model_cache import ModelCache
     from tool_shed.repository_registry import RegistryInterface
     from tool_shed.repository_types.registry import Registry as RepositoryTypesRegistry
@@ -19,4 +18,3 @@ class ToolShedApp(BasicSharedApp):
     hgweb_config_manager: "HgWebConfigManager"
     security_agent: "CommunityRBACAgent"
     model_cache: "ModelCache"
-    tool_data_tables: "ToolDataTableManager"

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -88,8 +88,8 @@ class UniverseApplication(ToolShedApp, SentryClientMixin, HaltableContainer):
         self.tag_handler = CommunityTagHandler(self.model.context)
         # Initialize the Tool Shed tool data tables.  Never pass a configuration file here
         # because the Tool Shed should always have an empty dictionary!
-        self.tool_data_tables = galaxy.tools.data.ToolDataTableManager(self.config.tool_data_path)
-        self.genome_builds = GenomeBuilds(self)
+        self._tool_data_tables = galaxy.tools.data.ToolDataTableManager(self.config.tool_data_path)
+        self._genome_builds = GenomeBuilds(self)
         self.auth_manager = self._register_singleton(auth.AuthManager, auth.AuthManager(self.config))
         # Citation manager needed to load tools.
         self.citations_manager = self._register_singleton(CitationsManager, CitationsManager(self))
@@ -114,6 +114,14 @@ class UniverseApplication(ToolShedApp, SentryClientMixin, HaltableContainer):
         #  used for cachebusting -- refactor this into a *SINGLE* UniverseApplication base.
         self.server_starttime = int(time.time())
         log.debug("Tool shed hgweb.config file is: %s", self.hgweb_config_manager.hgweb_config)
+
+    @property
+    def tool_data_tables(self) -> galaxy.tools.data.ToolDataTableManager:
+        return self._tool_data_tables
+
+    @property
+    def genome_builds(self) -> GenomeBuilds:
+        return self._genome_builds
 
 
 # Global instance of the universe app.


### PR DESCRIPTION
These two hacks in tasks and queue_worker are a bit ugly - this is cleaner. We also specify these attributes are available on the protocol for the simpler apps so they should be available without needing to call these configure methods.

Needed for #20935.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
