### PR TITLE
Add plotly pie charts

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -80,7 +80,7 @@ phylocanvas:
     version: 0.0.11
 plotly:
     package: "@galaxyproject/plotly"
-    version: 0.0.24
+    version: 0.0.25
 plotly_box:
     package: "@galaxyproject/plotly_box"
     version: 0.0.0
@@ -92,7 +92,7 @@ plotly_histogram:
     version: 0.0.0
 plotly_pie:
     package: "@galaxyproject/plotly_pie"
-    version: 0.0.0
+    version: 0.0.2
 plotly_surface:
     package: "@galaxyproject/plotly_surface"
     version: 0.0.0

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -80,7 +80,7 @@ phylocanvas:
     version: 0.0.11
 plotly:
     package: "@galaxyproject/plotly"
-    version: 0.0.22
+    version: 0.0.24
 plotly_box:
     package: "@galaxyproject/plotly_box"
     version: 0.0.0
@@ -89,6 +89,9 @@ plotly_heatmap:
     version: 0.0.1
 plotly_histogram:
     package: "@galaxyproject/plotly_histogram"
+    version: 0.0.0
+plotly_pie:
+    package: "@galaxyproject/plotly_pie"
     version: 0.0.0
 plotly_surface:
     package: "@galaxyproject/plotly_surface"

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -92,7 +92,7 @@ plotly_histogram:
     version: 0.0.0
 plotly_pie:
     package: "@galaxyproject/plotly_pie"
-    version: 0.0.2
+    version: 0.0.3
 plotly_surface:
     package: "@galaxyproject/plotly_surface"
     version: 0.0.0


### PR DESCRIPTION
Add plotly pie charts to Galaxy, see: https://github.com/galaxyproject/galaxy-visualizations/pull/125 for the visualization and https://github.com/galaxyproject/galaxy-visualizations/pull/126 for the automated tests.

![screencast](https://github.com/user-attachments/assets/3f1dbec5-d854-4a70-8acb-9c5b865a2897)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
