### PR TITLE
[25.1] Resolve possible symlink before establishing tool file location

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1016,10 +1016,10 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
         tool_dir: Optional[StrPath] = None,
     ):
         """Load a tool from the config named by `config_file`"""
-        self.config_file = config_file
+        self.config_file = os.path.realpath(config_file) if config_file else None
         # Determine the full path of the directory where the tool config is
-        if config_file is not None:
-            tool_dir = tool_dir or os.path.dirname(config_file)
+        if self.config_file is not None:
+            tool_dir = tool_dir or os.path.dirname(self.config_file)
         self.tool_dir = tool_dir
 
         self.app = app
@@ -1085,7 +1085,7 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
         try:
             self.parse(tool_source, guid=guid, dynamic=dynamic)
         except Exception as e:
-            global_tool_errors.add_error(config_file, "Tool Loading", e)
+            global_tool_errors.add_error(self.config_file, "Tool Loading", e)
             raise e
         mem_optimize = getattr(self.tool_source, "mem_optimize", None)
         if mem_optimize is not None:

--- a/test/functional/tools/for_tours/filtering.py
+++ b/test/functional/tools/for_tours/filtering.py
@@ -1,1 +1,0 @@
-../../../../tools/stats/filtering.py


### PR DESCRIPTION
I don't think this is a security issue because adding entries to the tool config files is controlled by admins.

Fixes pulsar tests that fail after required_files was added to the Filter1 tool. Also allows dropping the the symlink to the tool script.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
