### PR TITLE
[25.1] Save build date to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -43,7 +43,7 @@ jobs:
         id: buildargs
         run: |
             echo "gitcommit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT 
-            echo "builddate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo "builddate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"  >> $GITHUB_OUTPUT
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The Docker image build date, that is returned as part of the version info on Kubernetes deployments, is not being set.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
