### PR TITLE
[25.0] Harden proxy redirect validation

### DIFF
--- a/lib/galaxy_test/api/test_proxy.py
+++ b/lib/galaxy_test/api/test_proxy.py
@@ -1,3 +1,9 @@
+from unittest.mock import (
+    AsyncMock,
+    MagicMock,
+    patch,
+)
+
 import pytest
 
 from galaxy.util.unittest_utils import skip_if_github_down
@@ -88,3 +94,80 @@ class TestProxyApi(ApiTestCase):
         assert len(response.content) > 0
         # Verify content-encoding header was properly filtered out (no double decompression)
         assert "content-encoding" not in response.headers
+
+    @patch("galaxy.webapps.galaxy.api.proxy.httpx.AsyncClient")
+    def test_proxy_validates_redirects(self, mock_client_class):
+        """Test that redirects are validated."""
+        # Create mock responses - redirect to a local file (invalid scheme)
+        redirect_response = MagicMock()
+        redirect_response.status_code = 302
+        redirect_response.headers = {"location": "file://internal-server/secret-files"}
+        redirect_response.aclose = AsyncMock()
+
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_client.request = AsyncMock(return_value=redirect_response)
+        mock_client.aclose = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        # Attempt to proxy a URL that redirects to file:// (should be blocked)
+        response = self._get("proxy?url=https://evil.com/redirect")
+
+        # Should fail with 400 Bad Request due to invalid redirect URL scheme
+        self._assert_status_code_is(response, 400)
+        assert "Invalid URL format" in response.json()["err_msg"]
+
+    @patch("galaxy.webapps.galaxy.api.proxy.httpx.AsyncClient")
+    def test_proxy_follows_valid_redirects(self, mock_client_class):
+        """Test that valid redirects are followed after validation."""
+        # Create mock responses
+        redirect_response = MagicMock()
+        redirect_response.status_code = 301
+        redirect_response.headers = {"location": "https://example.com/final"}
+        redirect_response.aclose = AsyncMock()
+
+        final_response = MagicMock()
+        final_response.status_code = 200
+        final_response.headers = {"content-type": "text/plain"}
+        final_response.aclose = AsyncMock()
+
+        # Create async generator for streaming
+        async def mock_stream():
+            yield b"test content"
+
+        final_response.aiter_bytes = mock_stream
+
+        # Setup mock client to return redirect first, then final response
+        mock_client = MagicMock()
+        mock_client.request = AsyncMock(side_effect=[redirect_response, final_response])
+        mock_client.aclose = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        # Proxy a URL that redirects to a valid external URL
+        response = self._get("proxy?url=https://example.com/redirect")
+
+        # Should succeed and follow the redirect
+        self._assert_status_code_is_ok(response)
+        assert b"test content" in response.content
+
+    @patch("galaxy.webapps.galaxy.api.proxy.httpx.AsyncClient")
+    def test_proxy_blocks_too_many_redirects(self, mock_client_class):
+        """Test that excessive redirects are blocked to prevent redirect loops."""
+        # Create a mock response that always redirects
+        redirect_response = MagicMock()
+        redirect_response.status_code = 302
+        redirect_response.headers = {"location": "https://example.com/loop"}
+        redirect_response.aclose = AsyncMock()
+
+        # Setup mock client
+        mock_client = MagicMock()
+        mock_client.request = AsyncMock(return_value=redirect_response)
+        mock_client.aclose = AsyncMock()
+        mock_client_class.return_value = mock_client
+
+        # Attempt to proxy a URL that loops redirects
+        response = self._get("proxy?url=https://example.com/loop")
+
+        # Should fail with 400 Bad Request due to too many redirects
+        self._assert_status_code_is(response, 400)
+        assert "Too many redirects" in response.json()["err_msg"]


### PR DESCRIPTION
Requires #21184

This ensures all subsequent redirects are validated in the proxy endpoint and avoids possible redirect loops.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
