### PR TITLE
[25.1] IGV disable 2bit genome references served by Galaxy

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -41,7 +41,7 @@ hivtrace:
     version: 0.0.0
 igv:
     package: "@galaxyproject/igv"
-    version: 0.0.16
+    version: 0.0.18
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
     version: 0.0.17


### PR DESCRIPTION
(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
