### PR TITLE
[25.0] Add missing enable_beta_tool_formats config option

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5842,4 +5842,16 @@
 :Type: int
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_beta_tool_formats``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Enable user defined tools. In order to enable users to use this
+    feature create a role of type `Custom Tool Execution` in the admin
+    user interface and assign users or groups to this role.
+:Default: ``false``
+:Type: bool
+
+
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5847,9 +5847,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable user defined tools. In order to enable users to use this
-    feature create a role of type `Custom Tool Execution` in the admin
-    user interface and assign users or groups to this role.
+    Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
+    for user defined tools.
 :Default: ``false``
 :Type: bool
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -23,7 +23,8 @@ gravity:
   # Process manager to use.
   # ``supervisor`` is the default process manager when Gravity is invoked as a non-root user.
   # ``systemd`` is the default when Gravity is invoked as root.
-  # Valid options are: supervisor, systemd
+  # ``multiprocessing`` is the default when Gravity is invoked as the foreground shortcut ``galaxy`` instead of ``galaxyctl``
+  # Valid options are: supervisor, systemd, multiprocessing
   # process_manager:
 
   # What command to write to the process manager configs
@@ -3103,4 +3104,9 @@ galaxy:
   # default) if enable_failed_jobs_working_directory_cleanup is
   # ``true``. Runs in a Celery task.
   #failed_jobs_working_directory_cleanup_interval: 86400
+
+  # Enable user defined tools. In order to enable users to use this
+  # feature create a role of type `Custom Tool Execution` in the admin
+  # user interface and assign users or groups to this role.
+  #enable_beta_tool_formats: false
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -3105,8 +3105,7 @@ galaxy:
   # ``true``. Runs in a Celery task.
   #failed_jobs_working_directory_cleanup_interval: 86400
 
-  # Enable user defined tools. In order to enable users to use this
-  # feature create a role of type `Custom Tool Execution` in the admin
-  # user interface and assign users or groups to this role.
+  # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
+  # for user defined tools.
   #enable_beta_tool_formats: false
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4301,3 +4301,10 @@ mapping:
         default: 86400
         desc: |
           The interval in seconds between attempts to delete all failed Galaxy job's working directories from the filesystem (every 24 hours by default) if enable_failed_jobs_working_directory_cleanup is ``true``. Runs in a Celery task.
+ 
+      enable_beta_tool_formats:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable user defined tools. In order to enable users to use this feature create a role of type `Custom Tool Execution` in the admin user interface and assign users or groups to this role.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4307,4 +4307,4 @@ mapping:
         default: false
         required: false
         desc: |
-          Enable user defined tools. In order to enable users to use this feature create a role of type `Custom Tool Execution` in the admin user interface and assign users or groups to this role.
+          Enable beta tool formats (yaml, cwl, ...) which is a prerequisite for user defined tools.


### PR DESCRIPTION
I would suggest 25.0 because user defined tools were also mentioned in the release notes. But I'm fine with any release, juts let me know if another release it preferred.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
