### PR TITLE
[25.1] Don't show the "view sheet" button for non-sample sheet collections. 

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -22,6 +22,10 @@ const showCollectionDetailsUrl = computed(() =>
 );
 const disableDownload = props.dsc.populated_state !== "ok";
 
+const hasSampleSheet = computed(() => {
+    return props.dsc.collection_type && props.dsc.collection_type.startsWith("sample_sheet");
+});
+
 const sheetUrl = computed(() => {
     return `${getAppRoot()}collection/${props.dsc.id}/sheet`;
 });
@@ -68,7 +72,7 @@ function onDownload() {
                     <span>Run Job Again</span>
                 </b-button>
                 <b-button
-                    v-if="sheetUrl"
+                    v-if="hasSampleSheet && sheetUrl"
                     class="rounded-0 text-decoration-none"
                     size="sm"
                     variant="link"


### PR DESCRIPTION
I saw this somewhere a in release testing artifact but I don't know where that is now. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
