### PR TITLE
[25.0] Fix optional param unset in RO-Crate export

### DIFF
--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -525,6 +525,12 @@ class WorkflowRunCrateProfileBuilder:
             )
         )
         crate.mainEntity.append_to("input", formal_param)
+
+        # Handle case where output_value is None (e.g., optional parameter not provided)
+        output_value = None
+        if step.output_value:
+            output_value = step.output_value.value
+
         return crate.add(
             ContextEntity(
                 crate,
@@ -532,7 +538,7 @@ class WorkflowRunCrateProfileBuilder:
                 properties={
                     "@type": "PropertyValue",
                     "name": f"{param_id}",
-                    "value": step.output_value.value,
+                    "value": output_value,
                     "exampleOfWork": {"@id": formal_param.id},
                 },
             )


### PR DESCRIPTION
Fixes #21158



## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
