### PR TITLE
[25.1] Allow collection builder to be invoked consecutively

### DIFF
--- a/client/src/components/Collections/ListWizard.vue
+++ b/client/src/components/Collections/ListWizard.vue
@@ -19,6 +19,7 @@ import { showHid } from "./common/useCollectionCreator";
 import type { WhichListBuilder } from "./ListWizard/types";
 import { useAutoPairing } from "./usePairing";
 
+import LoadingSpan from "../LoadingSpan.vue";
 import ListCollectionCreator from "./ListCollectionCreator.vue";
 import WhichBuilder from "./ListWizard/WhichBuilder.vue";
 import PairedOrUnpairedListCollectionCreator from "./PairedOrUnpairedListCollectionCreator.vue";
@@ -199,16 +200,22 @@ function onRuleState(newRuleState: boolean) {
 <template>
     <div v-if="currentHistoryId">
         <div v-if="creationError">
-            <BAlert variant="danger">
+            <BAlert variant="danger" show>
                 {{ creationError }}
             </BAlert>
         </div>
         <div v-if="collectionCreated">
             <BAlert variant="success" show> Collection created and it has been added to your history. </BAlert>
         </div>
-        <div v-else-if="!selectedItems">Loading...</div>
+        <div v-else-if="!selectedItems">
+            <BAlert variant="info" show>
+                <LoadingSpan />
+            </BAlert>
+        </div>
         <div v-else-if="selectedItems.length == 0">
-            <p>Select datasets from history panel to use the Galaxy list building wizard.</p>
+            <BAlert variant="info" show>
+                Select datasets from the history panel to use the Galaxy list building wizard.
+            </BAlert>
         </div>
         <GenericWizard v-else :use="wizard" :is-busy="isBusy" :submit-button-label="buildButtonLabel" @submit="submit">
             <div v-if="wizard.isCurrent('which-builder')">

--- a/client/src/components/Collections/ListWizard/WhichBuilder.vue
+++ b/client/src/components/Collections/ListWizard/WhichBuilder.vue
@@ -34,7 +34,7 @@ function toggleAdvanced() {
                     <b>Flat List</b>
                 </BCardTitle>
                 <div>
-                    This options creates a simple flat list of files. If your data isn't nested and does not contained
+                    This option creates a simple flat list of files. If your data isn't nested and does not contained
                     paired datasets, this is the the option to choose.
                 </div>
             </BCard>
@@ -47,8 +47,8 @@ function toggleAdvanced() {
                     <b>List of Paired Datasets</b>
                 </BCardTitle>
                 <div>
-                    This options creates a uniform list of paired datasets, use this option if all of your data should
-                    be paired off.
+                    This option creates a uniform list of paired datasets, use this option if all of your data should be
+                    paired off.
                 </div>
             </BCard>
             <BCard

--- a/client/src/components/Collections/wizard/WhichWorkbookCollectionType.vue
+++ b/client/src/components/Collections/wizard/WhichWorkbookCollectionType.vue
@@ -26,8 +26,8 @@ defineProps<Props>();
                     <b>Flat List</b>
                 </BCardTitle>
                 <div>
-                    This options creates a simple flat list of files. If your data isn't nested and does not contained
-                    paired datasets, this is the the option to choose.
+                    This option creates a simple flat list of files. If your data isn't nested and does not contained
+                    paired datasets, this is the option to choose.
                 </div>
             </BCard>
             <BCard
@@ -39,8 +39,8 @@ defineProps<Props>();
                     <b>List of Paired Datasets</b>
                 </BCardTitle>
                 <div>
-                    This options creates a uniform list of paired datasets, use this option if all of your data should
-                    be paired off.
+                    This option creates a uniform list of paired datasets, use this option if all of your data should be
+                    paired off.
                 </div>
             </BCard>
         </BCardGroup>

--- a/client/src/components/Common/Wizard/GenericWizard.vue
+++ b/client/src/components/Common/Wizard/GenericWizard.vue
@@ -344,6 +344,11 @@ const bodyStyle = computed(() => {
         .card-header {
             border-radius: 0;
         }
+
+        &:hover {
+            border-color: lighten($brand-primary, 20%);
+            cursor: pointer;
+        }
     }
 }
 </style>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -303,7 +303,10 @@ export default {
             const { setSelectedItems } = useCollectionBuilderItemSelection();
             const selection = Array.from(this.contentSelection.values());
             setSelectedItems(selection);
-            this.$router.push({ path: `/collection/new_list?advanced=${advanced}` });
+
+            // vue-router 4 supports a native force push with clean URLs, but we're using a __vkey__
+            // bit as a workaround to allow the builder to be invoked consecutively
+            this.$router.push({ path: `/collection/new_list?advanced=${advanced}` }, { force: true });
         },
         // Selected content manipulation, hide/show/delete/purge
         hideSelected() {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -304,9 +304,13 @@ export default {
             const selection = Array.from(this.contentSelection.values());
             setSelectedItems(selection);
 
-            // vue-router 4 supports a native force push with clean URLs, but we're using a __vkey__
-            // bit as a workaround to allow the builder to be invoked consecutively
-            this.$router.push({ path: `/collection/new_list?advanced=${advanced}` }, { force: true });
+            if (this.$route.path === "/collection/new_list") {
+                // vue-router 4 supports a native force push with clean URLs, but we're using a __vkey__
+                // bit as a workaround to allow the builder to be invoked consecutively
+                this.$router.push({ path: `/collection/new_list?advanced=${advanced}` }, { force: true });
+            } else {
+                this.$router.push(`/collection/new_list?advanced=${advanced}`);
+            }
         },
         // Selected content manipulation, hide/show/delete/purge
         hideSelected() {

--- a/client/src/entry/analysis/router-push.js
+++ b/client/src/entry/analysis/router-push.js
@@ -15,7 +15,16 @@ export function patchRouterPush(VueRouter) {
         // add key to location to force component refresh
         const { title, force, preventWindowManager } = options;
         if (force) {
-            location = addSearchParams(location, { __vkey__: Date.now() });
+            // since location can either be string or object, we need to pass the string url to addSearchParams
+            if (typeof location === "string") {
+                location = addSearchParams(location, { __vkey__: Date.now() });
+            } else if (typeof location === "object") {
+                // convert to string version addSearchParams can handle
+                let url = this.resolve(location).href;
+                url = addSearchParams(url, { __vkey__: Date.now() });
+                // convert back to object version
+                location = this.resolve(url).route;
+            }
         }
         // verify if confirmation is required
         if (this.confirmation) {


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/21066

| Before 🔴 | After 🟢 |
| ---- | ---- |
| <video src="https://github.com/user-attachments/assets/5fa8f06c-8b37-4905-9a98-0da71b7dc59f" /> | <video src="https://github.com/user-attachments/assets/4ee199bb-ffb6-4eb1-b522-0527e857c1e6" /> |
| We were using a base route `/collection/new_list?` which was not being reset on every time we tried to invoke the collection builder again in the history panel. | Now, we use a `force: true` router.push hack (already being used in `ContentItem`, we will replace it when we switch to vue-router 4's clean force pushes) to ensure every time the builder is invoked, the builder is refreshed with the latest selected items. |

Other changes include:
- Improved styling on wizard cards (cursor-pointer on hover and border color change on hover)
- Fixed minor grammar/spell errors
- Improved alerts for the collection builder (converted plain text to alert where needed, added loading span etc.)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
