### PR TITLE
[25.1] Add Release Drafter GitHub Action integration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,26 +1,15 @@
 # Release Drafter Configuration for Galaxy
 # Implements YY.N.P versioning scheme using existing Galaxy labels
+#
+# IMPORTANT: Galaxy's versioning scheme is YY.N.P where:
+# - YY = Two-digit year (25 for 2025)
+# - N = Feature release number (0, 1, 2... - typically 2-3 per year)
+# - P = Patch/point release number (0, 1, 2, 3...)
+#
+# Year transitions (24→25) must be handled manually when creating releases.
 
-# Version configuration
-version-template: '$MAJOR.$MINOR.$PATCH'
 name-template: 'Galaxy $RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-
-# Version resolver based on existing Galaxy labels
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-      - 'kind/feature'
-      - 'kind/enhancement'
-  patch:
-    labels:
-      - 'kind/bug'
-      - 'kind/refactoring'
-  default: patch
 
 # Categories for organizing release notes using existing Galaxy labels
 categories:
@@ -28,154 +17,67 @@ categories:
     labels:
       - 'major'
       - 'highlight'
-    collapse-after: 5
   - title: '🚀 New Features'
     labels:
       - 'kind/feature'
-    collapse-after: 10
   - title: '🔧 Enhancements'
     labels:
       - 'kind/enhancement'
-    collapse-after: 10
   - title: '🐛 Bug Fixes'
     labels:
       - 'kind/bug'
-    collapse-after: 15
   - title: '🔒 Security Updates'
     labels:
       - 'area/security'
-    collapse-after: 5
   - title: '⚡ Performance'
     labels:
       - 'area/performance'
-    collapse-after: 10
   - title: '🧰 Refactoring'
     labels:
       - 'kind/refactoring'
-    collapse-after: 15
   - title: '📚 Documentation'
     labels:
       - 'area/documentation'
-    collapse-after: 10
   - title: '🔧 Admin & Configuration'
     labels:
       - 'area/admin'
       - 'area/configuration'
-    collapse-after: 10
   - title: '🛠️ API Changes'
     labels:
       - 'area/API'
-    collapse-after: 10
   - title: '🧪 Testing'
     labels:
       - 'area/testing'
       - 'area/testing/api'
       - 'area/testing/integration'
       - 'area/testing/selenium'
-    collapse-after: 15
   - title: '🏗️ Infrastructure & Dependencies'
     labels:
       - 'area/dependencies'
       - 'area/client-build'
-    collapse-after: 10
-  - title: '🔬 Tools & Datatypes'
-    labels:
-      - 'area/tools'
-      - 'area/datatypes'
-      - 'area/tool-framework'
-      - 'area/tool-dependencies'
-    collapse-after: 15
-  - title: '📊 Workflows'
-    labels:
-      - 'area/workflows'
-      - 'area/workflows/editor'
-      - 'area/workflows/reports'
-      - 'area/workflows/subworkflows'
-    collapse-after: 10
-  - title: '🎨 UI/UX'
-    labels:
-      - 'area/UI-UX'
-    collapse-after: 10
-  - title: '📂 Histories & Libraries'
-    labels:
-      - 'area/histories'
-      - 'area/libraries'
-    collapse-after: 10
 
 # Exclude certain labels from release notes
 exclude-labels:
   - 'triage'
   - 'procedures'
   - 'planning'
-  - 'minor'
   - 'merge'
   - 'status/needs feedback'
   - 'status/planning'
 
 # Template for each change line
-change-template: '- $TITLE (@$AUTHOR) (#$NUMBER)'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 
 # Characters to escape in titles
 change-title-escapes: '\<*_&'
 
-# Sort configuration
-sort-by: 'merged_at'
-sort-direction: 'descending'
+# Version is read from lib/galaxy/version.py by the workflow
+# No version-resolver needed since Galaxy manages versions manually
 
 # Template for the release body
 template: |
-  ## What's Changed
+  ## Changes in $RESOLVED_VERSION
 
   $CHANGES
 
-  ## Contributors
-
-  $CONTRIBUTORS
-
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
-
-# Auto-labeler configuration to help with Galaxy's labeling system
-autolabeler:
-  - label: 'area/documentation'
-    files:
-      - '*.md'
-      - '*.rst'
-      - 'doc/**/*'
-      - 'docs/**/*'
-  - label: 'area/dependencies'
-    files:
-      - 'requirements*.txt'
-      - '*requirements.txt'
-      - 'setup.py'
-      - 'setup.cfg'
-      - 'pyproject.toml'
-      - 'packages/*/requirements.txt'
-  - label: 'area/client-build'
-    files:
-      - 'client/package.json'
-      - 'client/yarn.lock'
-      - 'client/package-lock.json'
-      - 'client/webpack.config.js'
-      - 'client/.babelrc'
-  - label: 'area/testing'
-    files:
-      - 'test/**/*'
-      - 'tests/**/*'
-      - '**/test_*.py'
-      - '**/*_test.py'
-      - 'client/tests/**/*'
-  - label: 'area/API'
-    files:
-      - 'lib/galaxy/webapi/**/*'
-      - 'lib/galaxy/web/api/**/*'
-  - label: 'area/workflows'
-    files:
-      - 'lib/galaxy/workflow/**/*'
-      - 'client/src/components/Workflow/**/*'
-  - label: 'area/tools'
-    files:
-      - 'tools/**/*'
-      - 'lib/galaxy/tools/**/*'
-  - label: 'area/datatypes'
-    files:
-      - 'lib/galaxy/datatypes/**/*'
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,181 @@
+# Release Drafter Configuration for Galaxy
+# Implements YY.N.P versioning scheme using existing Galaxy labels
+
+# Version configuration
+version-template: '$MAJOR.$MINOR.$PATCH'
+name-template: 'Galaxy $RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Version resolver based on existing Galaxy labels
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'kind/feature'
+      - 'kind/enhancement'
+  patch:
+    labels:
+      - 'kind/bug'
+      - 'kind/refactoring'
+  default: patch
+
+# Categories for organizing release notes using existing Galaxy labels
+categories:
+  - title: '🎉 Major Changes'
+    labels:
+      - 'major'
+      - 'highlight'
+    collapse-after: 5
+  - title: '🚀 New Features'
+    labels:
+      - 'kind/feature'
+    collapse-after: 10
+  - title: '🔧 Enhancements'
+    labels:
+      - 'kind/enhancement'
+    collapse-after: 10
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'kind/bug'
+    collapse-after: 15
+  - title: '🔒 Security Updates'
+    labels:
+      - 'area/security'
+    collapse-after: 5
+  - title: '⚡ Performance'
+    labels:
+      - 'area/performance'
+    collapse-after: 10
+  - title: '🧰 Refactoring'
+    labels:
+      - 'kind/refactoring'
+    collapse-after: 15
+  - title: '📚 Documentation'
+    labels:
+      - 'area/documentation'
+    collapse-after: 10
+  - title: '🔧 Admin & Configuration'
+    labels:
+      - 'area/admin'
+      - 'area/configuration'
+    collapse-after: 10
+  - title: '🛠️ API Changes'
+    labels:
+      - 'area/API'
+    collapse-after: 10
+  - title: '🧪 Testing'
+    labels:
+      - 'area/testing'
+      - 'area/testing/api'
+      - 'area/testing/integration'
+      - 'area/testing/selenium'
+    collapse-after: 15
+  - title: '🏗️ Infrastructure & Dependencies'
+    labels:
+      - 'area/dependencies'
+      - 'area/client-build'
+    collapse-after: 10
+  - title: '🔬 Tools & Datatypes'
+    labels:
+      - 'area/tools'
+      - 'area/datatypes'
+      - 'area/tool-framework'
+      - 'area/tool-dependencies'
+    collapse-after: 15
+  - title: '📊 Workflows'
+    labels:
+      - 'area/workflows'
+      - 'area/workflows/editor'
+      - 'area/workflows/reports'
+      - 'area/workflows/subworkflows'
+    collapse-after: 10
+  - title: '🎨 UI/UX'
+    labels:
+      - 'area/UI-UX'
+    collapse-after: 10
+  - title: '📂 Histories & Libraries'
+    labels:
+      - 'area/histories'
+      - 'area/libraries'
+    collapse-after: 10
+
+# Exclude certain labels from release notes
+exclude-labels:
+  - 'triage'
+  - 'procedures'
+  - 'planning'
+  - 'minor'
+  - 'merge'
+  - 'status/needs feedback'
+  - 'status/planning'
+
+# Template for each change line
+change-template: '- $TITLE (@$AUTHOR) (#$NUMBER)'
+
+# Characters to escape in titles
+change-title-escapes: '\<*_&'
+
+# Sort configuration
+sort-by: 'merged_at'
+sort-direction: 'descending'
+
+# Template for the release body
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+
+# Auto-labeler configuration to help with Galaxy's labeling system
+autolabeler:
+  - label: 'area/documentation'
+    files:
+      - '*.md'
+      - '*.rst'
+      - 'doc/**/*'
+      - 'docs/**/*'
+  - label: 'area/dependencies'
+    files:
+      - 'requirements*.txt'
+      - '*requirements.txt'
+      - 'setup.py'
+      - 'setup.cfg'
+      - 'pyproject.toml'
+      - 'packages/*/requirements.txt'
+  - label: 'area/client-build'
+    files:
+      - 'client/package.json'
+      - 'client/yarn.lock'
+      - 'client/package-lock.json'
+      - 'client/webpack.config.js'
+      - 'client/.babelrc'
+  - label: 'area/testing'
+    files:
+      - 'test/**/*'
+      - 'tests/**/*'
+      - '**/test_*.py'
+      - '**/*_test.py'
+      - 'client/tests/**/*'
+  - label: 'area/API'
+    files:
+      - 'lib/galaxy/webapi/**/*'
+      - 'lib/galaxy/web/api/**/*'
+  - label: 'area/workflows'
+    files:
+      - 'lib/galaxy/workflow/**/*'
+      - 'client/src/components/Workflow/**/*'
+  - label: 'area/tools'
+    files:
+      - 'tools/**/*'
+      - 'lib/galaxy/tools/**/*'
+  - label: 'area/datatypes'
+    files:
+      - 'lib/galaxy/datatypes/**/*'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -30,10 +30,11 @@ jobs:
       - name: Read Galaxy version
         id: galaxy-version
         run: |
-          # Extract VERSION_MAJOR from version.py
-          VERSION_MAJOR=$(grep "VERSION_MAJOR" lib/galaxy/version.py | cut -d'"' -f2)
-          echo "version=${VERSION_MAJOR}.0" >> $GITHUB_OUTPUT
-          echo "Galaxy version: ${VERSION_MAJOR}.0"
+          # Extract VERSION_MAJOR from version.py (e.g., "25.1")
+          VERSION_MAJOR=$(grep '^VERSION_MAJOR' lib/galaxy/version.py | cut -d'"' -f2)
+          RELEASE_VERSION="${VERSION_MAJOR}.0"
+          echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Galaxy release version: ${RELEASE_VERSION}"
 
       - uses: release-drafter/release-drafter@v6
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,7 @@ on:
       - dev
       - master
       - 'release_*'
-  pull_request:
-    types: [opened, reopened, synchronize]
+      - 'release-drafter-integration'
   pull_request_target:
     types: [opened, reopened, synchronize]
 
@@ -19,21 +18,26 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: github.repository == 'dannon/galaxy'
     runs-on: ubuntu-latest
     steps:
-      - name: Calculate Year Version
-        id: year
-        run: |
-          # Get current year in YY format
-          YEAR=$(date +%y)
-          echo "year=${YEAR}" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          sparse-checkout: |
+            lib/galaxy/version.py
 
-          # Get the latest release to check if year transition is needed
-          # This is optional and can be enhanced with actual API calls
+      - name: Read Galaxy version
+        id: galaxy-version
+        run: |
+          # Extract VERSION_MAJOR from version.py
+          VERSION_MAJOR=$(grep "VERSION_MAJOR" lib/galaxy/version.py | cut -d'"' -f2)
+          echo "version=${VERSION_MAJOR}.0" >> $GITHUB_OUTPUT
+          echo "Galaxy version: ${VERSION_MAJOR}.0"
 
       - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
-          disable-autolabeler: false
+          version: ${{ steps.galaxy-version.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,6 @@ on:
       - dev
       - master
       - 'release_*'
-      - 'release-drafter-integration'
   pull_request_target:
     types: [opened, reopened, synchronize]
 
@@ -18,7 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: github.repository == 'dannon/galaxy'
+    if: github.repository == 'galaxyproject/galaxy'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,39 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - dev
+      - master
+      - 'release_*'
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate Year Version
+        id: year
+        run: |
+          # Get current year in YY format
+          YEAR=$(date +%y)
+          echo "year=${YEAR}" >> $GITHUB_OUTPUT
+
+          # Get the latest release to check if year transition is needed
+          # This is optional and can be enhanced with actual API calls
+
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds automated release note drafting using the release-drafter action similar to what we use for brc-analytics.

Versioning is a little messier since we don't actually follow semver, but this *should* read the version from `lib/galaxy/version.py`.  Categorizes PRs using existing Galaxy labels (kind/feature, kind/bug, etc.)

The action will automatically maintain a draft release with organized change notes based on merged PRs.

@ahmedhamidawan 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
