### PR TITLE
[25.1] Don't create extra watchers when switching tabs

### DIFF
--- a/client/src/composables/resourceWatcher.ts
+++ b/client/src/composables/resourceWatcher.ts
@@ -111,7 +111,7 @@ export function useResourceWatcher<T = unknown>(
     function updateThrottle() {
         if (document.visibilityState === "visible") {
             currentPollingInterval = shortPollingInterval;
-            startWatchingResource();
+            startWatchingResourceIfNeeded();
         } else {
             currentPollingInterval = enableBackgroundPolling ? longPollingInterval : undefined;
         }


### PR DESCRIPTION
Suggested fix from @mvdbeek. This is causing way more polling of `current_history_json` than there should be.

I'm applying directly to the usegalaxy_25.1 so we can keep this PR open for a bit if we have more to add later.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
