### PR TITLE
[25.1] Drop single 'pair' from standard upload UI, preferring lists, or lists of pairs as options for user

### DIFF
--- a/client/src/components/Upload/DefaultBox.vue
+++ b/client/src/components/Upload/DefaultBox.vue
@@ -76,9 +76,7 @@ const queue = ref(createUploadQueue());
 const selectedItemsForModal = ref<HDASummary[]>([]);
 
 const counterNonRunning = computed(() => counterAnnounce.value + counterSuccess.value + counterError.value);
-const creatingPairedType = computed(
-    () => props.isCollection && ["list:paired", "paired"].includes(collectionType.value),
-);
+const creatingPairedType = computed(() => props.isCollection && collectionType.value === "list:paired");
 const enableBuild = computed(
     () =>
         !isRunning.value &&

--- a/client/src/components/Upload/utils.js
+++ b/client/src/components/Upload/utils.js
@@ -14,7 +14,6 @@ export const AUTO_EXTENSION = {
 };
 export const COLLECTION_TYPES = [
     { id: "list", text: "List" },
-    { id: "paired", text: "Pair" },
     { id: "list:paired", text: "List of Pairs" },
 ];
 export const DEFAULT_DBKEY = "?";


### PR DESCRIPTION
…s of pairs as options for user.

Addresses https://github.com/galaxyproject/galaxy/issues/21179


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
