### PR TITLE
Replace tuswsgi with tuspyserver

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -68,7 +68,7 @@ edam-ontology==1.25.2
 email-validator==2.3.0
 et-xmlfile==2.0.0
 exceptiongroup==1.3.0 ; python_full_version < '3.11'
-fastapi-slim==0.118.3
+fastapi==0.118.3
 filelock==3.19.1 ; python_full_version < '3.10'
 filelock==3.20.0 ; python_full_version >= '3.10'
 fissix==24.4.24

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -224,7 +224,7 @@ tomli==2.3.0 ; python_full_version < '3.11'
 tornado==6.5.2
 tqdm==4.67.1
 tuspy==1.1.0
-tuswsgi==0.5.5
+tuspyserver==4.2.0
 typing-extensions==4.15.0
 typing-inspection==0.4.2
 tzdata==2025.2

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -11,7 +11,6 @@ from typing import Optional
 from urllib.parse import urljoin
 
 from paste import httpexceptions
-from tuswsgi import TusMiddleware
 
 import galaxy.app
 import galaxy.datatypes.registry
@@ -1084,30 +1083,6 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         from galaxy.web.framework.middleware.translogger import TransLogger
 
         app = wrap_if_allowed(app, stack, TransLogger)
-    # TUS upload middleware
-    app = wrap_if_allowed(
-        app,
-        stack,
-        TusMiddleware,
-        kwargs={
-            "upload_path": urljoin(f"{application_stack.config.galaxy_url_prefix}/", "api/upload/resumable_upload"),
-            "tmp_dir": application_stack.config.tus_upload_store or application_stack.config.new_file_path,
-            "max_size": application_stack.config.maximum_upload_file_size,
-        },
-    )
-    # TUS upload middleware for job files....
-    app = wrap_if_allowed(
-        app,
-        stack,
-        TusMiddleware,
-        kwargs={
-            "upload_path": urljoin(f"{application_stack.config.galaxy_url_prefix}/", "api/job_files/resumable_upload"),
-            "tmp_dir": application_stack.config.tus_upload_store_job_files
-            or application_stack.config.tus_upload_store
-            or application_stack.config.new_file_path,
-            "max_size": application_stack.config.maximum_upload_file_size,
-        },
-    )
     # X-Forwarded-Host handling
     app = wrap_if_allowed(app, stack, XForwardedHostMiddleware)
     # Request ID middleware

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -8,7 +8,6 @@ import sys
 import threading
 import traceback
 from typing import Optional
-from urllib.parse import urljoin
 
 from paste import httpexceptions
 

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -170,9 +170,8 @@ def get_openapi_schema() -> dict[str, Any]:
 def include_tus(app: FastAPI, gx_app):
     config = gx_app.config
     root_path = "" if config.galaxy_url_prefix == "/" else config.galaxy_url_prefix
-    prefix = urljoin(root_path, "api/upload/resumable_upload")
     upload_tus_router = create_tus_router(
-        prefix=prefix,
+        prefix=urljoin(root_path, "api/upload/resumable_upload"),
         files_dir=config.tus_upload_store or config.new_file_path,
         max_size=config.maximum_upload_file_size,
     )

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -1,6 +1,7 @@
 from typing import (
     Any,
 )
+from urllib.parse import urljoin
 
 from a2wsgi import WSGIMiddleware
 from fastapi import (
@@ -9,6 +10,7 @@ from fastapi import (
 )
 from fastapi.openapi.constants import REF_TEMPLATE
 from starlette.middleware.cors import CORSMiddleware
+from tuspyserver import create_tus_router
 
 from galaxy.schema.generics import CustomJsonSchema
 from galaxy.version import VERSION
@@ -165,6 +167,24 @@ def get_openapi_schema() -> dict[str, Any]:
     )
 
 
+def include_tus(app: FastAPI, gx_app):
+    config = gx_app.config
+    root_path = "" if config.galaxy_url_prefix == "/" else config.galaxy_url_prefix
+    prefix = urljoin(root_path, "api/upload/resumable_upload")
+    upload_tus_router = create_tus_router(
+        prefix=prefix,
+        files_dir=config.tus_upload_store or config.new_file_path,
+        max_size=config.maximum_upload_file_size,
+    )
+    job_files_tus_router = create_tus_router(
+        prefix=urljoin(root_path, "api/job_files/resumable_upload"),
+        files_dir=config.tus_upload_store_job_files or config.tus_upload_store or config.new_file_path,
+        max_size=config.maximum_upload_file_size,
+    )
+    app.include_router(upload_tus_router)
+    app.include_router(job_files_tus_router)
+
+
 def initialize_fast_app(gx_wsgi_webapp, gx_app):
     root_path = "" if gx_app.config.galaxy_url_prefix == "/" else gx_app.config.galaxy_url_prefix
     app = get_fastapi_instance(root_path=root_path)
@@ -178,6 +198,7 @@ def initialize_fast_app(gx_wsgi_webapp, gx_app):
     include_legacy_openapi(app, gx_app)
     wsgi_handler = WSGIMiddleware(gx_wsgi_webapp)
     gx_app.haltables.append(("WSGI Middleware threadpool", wsgi_handler.executor.shutdown))
+    include_tus(app, gx_app)
     app.mount("/", wsgi_handler)  # type: ignore[arg-type]
     if gx_app.config.galaxy_url_prefix != "/":
         parent_app = FastAPI()

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
     starlette
     starlette-context
-    tuswsgi
+    tuspyserver
     typing-extensions
     uvicorn
     uvloop>=0.21.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "docutils!=0.17,!=0.17.1",
     "dparse",
     "edam-ontology",
-    "fastapi-slim>=0.111.0,!=0.119.*,!=0.120.0,!=0.120.1,!=0.120.2",  # https://github.com/fastapi/fastapi/pull/13918
+    "fastapi>=0.111.0,!=0.119.*,!=0.120.0,!=0.120.1,!=0.120.2",  # https://github.com/fastapi/fastapi/pull/13918
     "fissix",
     "fs",
     "future>=1.0.0",  # Python 3.12 support
@@ -256,9 +256,6 @@ keep-runtime-typing = true
 constraint-dependencies = [
     "limits>=2.5.0",  # prefer not downgrading this to upgrading packaging
     "scipy>=1.14.1; python_version>='3.10'",  # Python 3.13 support
-]
-override-dependencies = [
-    "fastapi; sys_platform == 'never'",
 ]
 default-groups = []
 extra-index-url = ["https://wheels.galaxyproject.org/simple"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,8 @@ dependencies = [
     "starlette-context",
     "svgwrite",
     "tifffile",
-    "tuswsgi",
     "typing-extensions",
+    "tuspyserver",
     "uvicorn!=0.28.0",  # https://github.com/galaxyproject/galaxy/issues/17669
     "uvloop>=0.21.0",  # Python 3.13 support
     "WebOb>=1.8.9",  # Python 3.13 support
@@ -256,6 +256,9 @@ keep-runtime-typing = true
 constraint-dependencies = [
     "limits>=2.5.0",  # prefer not downgrading this to upgrading packaging
     "scipy>=1.14.1; python_version>='3.10'",  # Python 3.13 support
+]
+override-dependencies = [
+    "fastapi; sys_platform == 'never'",
 ]
 default-groups = []
 extra-index-url = ["https://wheels.galaxyproject.org/simple"]


### PR DESCRIPTION
This should resolve https://github.com/galaxyproject/galaxy/issues/21031 ... not having a middleware implementation of tus should also be more performant.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
