### PR TITLE
Add an easy to access/obvious button to hide history panel

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faExchangeAlt, faPlus, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { faChevronRight, faExchangeAlt, faPlus, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BButtonGroup } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
@@ -10,6 +10,7 @@ import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 
+import GButton from "@/components/BaseComponents/GButton.vue";
 import HistoryOptions from "@/components/History/HistoryOptions.vue";
 import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
 
@@ -21,6 +22,10 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
     minimal: false,
 });
+
+const emit = defineEmits<{
+    (e: "show", showPanel: boolean): void;
+}>();
 
 const historyStore = useHistoryStore();
 const { histories, changingCurrentHistory } = storeToRefs(historyStore);
@@ -45,7 +50,10 @@ function userTitle(title: string) {
         <nav
             :class="{ 'd-flex justify-content-between mx-3 my-2': !props.minimal }"
             aria-label="current history management">
-            <h2 v-if="!props.minimal" class="m-1 h-sm">History</h2>
+            <GButton v-if="!props.minimal" size="small" transparent @click="emit('show', false)">
+                <FontAwesomeIcon fixed-width :icon="faChevronRight" />
+                <span>History</span>
+            </GButton>
 
             <BButtonGroup>
                 <BButton

--- a/client/src/components/History/Index.vue
+++ b/client/src/components/History/Index.vue
@@ -10,6 +10,10 @@ import CurrentCollection from "@/components/History/CurrentCollection/Collection
 import HistoryNavigation from "@/components/History/CurrentHistory/HistoryNavigation.vue";
 import HistoryPanel from "@/components/History/CurrentHistory/HistoryPanel.vue";
 
+const emit = defineEmits<{
+    (e: "show", showPanel: boolean): void;
+}>();
+
 const userStore = useUserStore();
 const historyStore = useHistoryStore();
 
@@ -37,7 +41,7 @@ function onViewCollection(collection: CollectionEntry, currentOffset?: number) {
             :filterable="true"
             @view-collection="onViewCollection">
             <template v-slot:navigation>
-                <HistoryNavigation :history="currentHistory" />
+                <HistoryNavigation :history="currentHistory" @show="(val) => emit('show', val)" />
             </template>
         </HistoryPanel>
 

--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -83,6 +83,10 @@ const sideClasses = computed(() => ({
     left: props.side === "left",
     right: props.side === "right",
 }));
+
+defineExpose({
+    show,
+});
 </script>
 
 <template>

--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -16,11 +16,19 @@ const router = useRouter();
 const showCenter = ref(false);
 const { showPanels } = usePanels();
 
+const historyPanel = ref(null);
+
 const { historyPanelWidth } = storeToRefs(useUserStore());
 
 // methods
 function hideCenter() {
     showCenter.value = false;
+}
+
+function onShow(showPanel) {
+    if (historyPanel.value) {
+        historyPanel.value.show = showPanel;
+    }
 }
 
 function onLoad() {
@@ -48,8 +56,8 @@ onUnmounted(() => {
                 <router-view :key="$route.fullPath" class="h-100" />
             </div>
         </div>
-        <FlexPanel v-if="showPanels" side="right" :reactive-width.sync="historyPanelWidth">
-            <HistoryIndex />
+        <FlexPanel v-if="showPanels" ref="historyPanel" side="right" :reactive-width.sync="historyPanelWidth">
+            <HistoryIndex @show="onShow" />
         </FlexPanel>
         <DragAndDropModal />
     </div>


### PR DESCRIPTION
This is not something high priority, or something we _have to do_, but just a pet-peeve of mine that hiding the history is not very obvious? So, this is very optional and I can close this if we disagree.

| Before | After |
| ---- | ---- |
| ![firefox_sG0qwxwleG](https://github.com/user-attachments/assets/fb9246db-6875-47a7-93aa-ab3868695b7b) | ![firefox_BtdWpYTW7o](https://github.com/user-attachments/assets/57a2b979-1a56-4a36-898c-b845f4210102) |
| <img width="641" height="861" alt="lFxwkHdEEX" src="https://github.com/user-attachments/assets/c8976cce-2233-44ac-a48e-2f5980d578cc" /> | <img width="641" height="861" alt="firefox_Xqmfhcuf2G" src="https://github.com/user-attachments/assets/4a957bf2-a59e-40cd-9082-6a3122a58f76" /> |

**Note that the existing way to hide the panel still works!**

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
