### PR TITLE
[25.1] IGV: Disable 2bit reference genomes

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -41,7 +41,7 @@ hivtrace:
     version: 0.0.0
 igv:
     package: "@galaxyproject/igv"
-    version: 0.0.16
+    version: 0.0.21
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
     version: 0.0.17


### PR DESCRIPTION
Resolves the reference loading issue by listing only fasta-index files and disabling 2bit reference genomes in IGV, addressing #21183. The full fix is under discussion in #21008 and may take longer to implement.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
