### PR TITLE
[25.1] Tighter API for tool run tagging.

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -395,9 +395,9 @@ export default {
                 tool_id: this.formConfig.id,
                 tool_version: this.formConfig.version,
                 tool_uuid: this.toolUuid,
+                __tags: this.tags,
                 inputs: {
                     ...this.formData,
-                    __tags: this.tags,
                 },
             };
             if (this.useEmail) {

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2203,6 +2203,7 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
         preferred_object_store_id: Optional[str] = DEFAULT_PREFERRED_OBJECT_STORE_ID,
         credentials_context: Optional[CredentialsContext] = None,
         input_format: InputFormatT = "legacy",
+        tags: Optional[list[str]] = None,
     ):
         """
         Process incoming parameters for this tool from the dict `incoming`,
@@ -2236,7 +2237,6 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
 
         # Reserved global tags parameter. Applies to all tool outputs.
         # This may change in the future if per-output tags are introduced.
-        tags = incoming.get("__tags", [])
         if tags:
             tag_handler = trans.tag_handler
             for _, hda in execution_tracker.output_datasets:

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -331,6 +331,7 @@ class ToolsService(ServiceBase):
         input_format = cast(Literal["legacy", "21.01"], input_format)
         if "data_manager_mode" in payload:
             incoming["__data_manager_mode"] = payload["data_manager_mode"]
+        tags = payload.get("__tags")
         vars = tool.handle_input(
             trans,
             incoming,
@@ -339,6 +340,7 @@ class ToolsService(ServiceBase):
             input_format=input_format,
             preferred_object_store_id=preferred_object_store_id,
             credentials_context=CredentialsContext(root=credentials_context) if credentials_context else None,
+            tags=tags,
         )
 
         new_pja_flush = False

--- a/lib/galaxy_test/api/test_tool_output_tagging.py
+++ b/lib/galaxy_test/api/test_tool_output_tagging.py
@@ -27,7 +27,6 @@ class TestToolOutputTaggingApi(ApiTestCase):
             "history_id": history_id,
             "inputs": {
                 "input1": {"values": [{"src": "hda", "id": hda["id"]}]},
-                "__tags": ["t1", "t2"],
             },
             "input_format": "21.01",
             "__tags": ["t1", "t2"],
@@ -54,7 +53,6 @@ class TestToolOutputTaggingApi(ApiTestCase):
                     "batch": True,
                     "values": [{"src": "hdca", "id": hdca["id"]}],
                 },
-                "__tags": ["m1", "m2"],
             },
             "input_format": "21.01",
             "__tags": ["m1", "m2"],


### PR DESCRIPTION
Should deal with https://github.com/galaxyproject/galaxy/issues/20961.

Looking at the implementation - this feature seems like it will just not work with dynamically discovered tool outputs of any kind and is taking up a lot of real estate in the tool form. We should minimize it and hide it somehow - but for now I wanted to cleanup the API before we do a release - and while this API doesn't work with dynamic outputs it certainly could be made to. 

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Use the feature and make sure it still works.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
