### PR TITLE
[25.0] Fix refresh token expiration retrieval logic

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -213,8 +213,8 @@ class PSAAuthnz(IdentityProvider):
         return (
             extra_data.get("expires", None)
             or extra_data.get("expires_in", None)
-            or extra_data["refresh_token"].get("expires", None)
-            or extra_data["refresh_token"].get("expires_in", None)
+            or (extra_data.get("refresh_token") or {}).get("expires", None)
+            or (extra_data.get("refresh_token") or {}).get("expires_in", None)
         )
 
     def authenticate(self, trans, idphint=None):


### PR DESCRIPTION
Fixes the following traceback when refresh_token is None:
Oct 31 01:14:47 dev galaxyctl[3357277]: Traceback (most recent call last):
Oct 31 01:14:47 dev galaxyctl[3357277]:   File "/mnt/galaxy/galaxy-app/lib/galaxy/authnz/managers.py", line 306, in refresh_expiring_oidc_tokens_for_provider
Oct 31 01:14:47 dev galaxyctl[3357277]:     refreshed = backend.refresh(trans, auth)
Oct 31 01:14:47 dev galaxyctl[3357277]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 31 01:14:47 dev galaxyctl[3357277]:   File "/mnt/galaxy/galaxy-app/lib/galaxy/authnz/psa_authnz.py", line 206, in refresh
Oct 31 01:14:47 dev galaxyctl[3357277]:     expires = self._try_to_locate_refresh_token_expiration(user_authnz_token.extra_data)
Oct 31 01:14:47 dev galaxyctl[3357277]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 31 01:14:47 dev galaxyctl[3357277]:   File "/mnt/galaxy/galaxy-app/lib/galaxy/authnz/psa_authnz.py", line 228, in _try_to_locate_refresh_token_expiration
Oct 31 01:14:47 dev galaxyctl[3357277]:     or extra_data["refresh_token"].get("expires", None)
Oct 31 01:14:47 dev galaxyctl[3357277]:        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 31 01:14:47 dev galaxyctl[3357277]: AttributeError: 'NoneType' object has no attribute 'get'


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
