### PR TITLE
[25.1] Add missing more-itertools dependency

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -116,6 +116,7 @@ markupsafe==3.0.3
 mdurl==0.1.2
 mercurial==7.1.1
 mistune==3.0.2
+more-itertools==10.8.0
 mrcfile==1.5.4
 msal==1.34.0
 msgpack==1.1.1

--- a/lib/galaxy/tools/execution_helpers.py
+++ b/lib/galaxy/tools/execution_helpers.py
@@ -79,8 +79,8 @@ def on_text_for_numeric_ids(ids: Optional[list[int]], prefix: Optional[str] = No
     # and once as param_name1.
     groups = []
     unique_ids = sorted(set(ids))
-    for group in consecutive_groups(unique_ids):
-        group = list(group)
+    for group_it in consecutive_groups(unique_ids):
+        group = list(group_it)
         if len(group) == 1:
             groups.append(str(group[0]))
         elif len(group) == 2:

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     Markdown
     MarkupSafe
     mercurial>=6.8.2
+    more-itertools
     nodejs-wheel>=22,<23
     packaging
     paramiko!=2.9.0,!=2.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "MarkupSafe",
     "mercurial>=6.8.2",  # Python 3.13 support
     "mrcfile",
+    "more-itertools",
     "msal",
     "nodejs-wheel>=22,<23",
     "numpy>=1.26.0",  # Python 3.12 support


### PR DESCRIPTION
First use added in commit https://github.com/galaxyproject/galaxy/commit/8f7271d67d4b880f0ffe413e8e726afe1b31c344 .

Fix the following error in package tests:
```
Traceback:
/opt/hostedtoolcache/Python/3.9.23/x64/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
galaxy/tools/__init__.py:129: in <module>
    from galaxy.tools.actions import (
galaxy/tools/actions/__init__.py:47: in <module>
    from galaxy.tools.execute import (
galaxy/tools/execute.py:32: in <module>
    from galaxy.tools.execution_helpers import (
galaxy/tools/execution_helpers.py:10: in <module>
    from more_itertools import consecutive_groups
E   ModuleNotFoundError: No module named 'more_itertools'
```

Also:
- Fix type annotation errors emerged after adding the dependency.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
