### PR TITLE
[25.1] Fix downloading subworkflows without stored workflow

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1242,9 +1242,16 @@ class WorkflowContentsManager(UsesAnnotations):
         """Get workflow scheduling resource parameters for this user and workflow or None if not configured."""
         return self._resource_mapper_function(trans=trans, stored_workflow=stored, workflow=workflow)
 
-    def _workflow_to_dict_editor(self, trans, stored, workflow, tooltip=True, is_subworkflow=False):
+    def _workflow_to_dict_editor(
+        self,
+        trans,
+        stored: Optional[StoredWorkflow],
+        workflow: Workflow,
+        tooltip: bool = True,
+        is_subworkflow: bool = False,
+    ):
         # Pack workflow data into a dictionary and return
-        data = {}
+        data: dict[str, Any] = {}
         data["name"] = workflow.name
         data["steps"] = {}
         data["upgrade_messages"] = {}
@@ -1258,7 +1265,9 @@ class WorkflowContentsManager(UsesAnnotations):
         data["source_metadata"] = workflow.source_metadata
         data["annotation"] = self.get_item_annotation_str(trans.sa_session, trans.user, stored) or ""
         data["comments"] = [comment.to_dict() for comment in workflow.comments]
-        data["tags"] = stored.make_tag_string_list()
+        if stored:
+            # subworkflow may not have StoredWorkflow
+            data["tags"] = stored.make_tag_string_list()
 
         output_label_index = set()
         input_step_types = set(workflow.input_step_types)


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/21222

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
