### PR TITLE
[25.1] Makes "set as current" the primary action in history list

### DIFF
--- a/client/src/components/History/useHistoryCardActions.ts
+++ b/client/src/components/History/useHistoryCardActions.ts
@@ -248,25 +248,6 @@ export function useHistoryCardActions(
                 visible: history.value.deleted && !history.value.purged && isMyHistory(history.value),
             },
             {
-                id: "switch",
-                title: localize("Set as current history"),
-                label: localize("Set as Current"),
-                variant: "outline-primary",
-                icon: faExchangeAlt,
-                handler: () => historyStore.setCurrentHistory(String(history.value.id)),
-                visible:
-                    (isMyHistory(history.value) || archivedView) && historyStore.currentHistoryId !== history.value.id,
-            },
-            {
-                title: "current history",
-                id: "current",
-                label: "Current",
-                variant: "outline-primary",
-                disabled: true,
-                visible:
-                    (isMyHistory(history.value) || archivedView) && historyStore.currentHistoryId === history.value.id,
-            },
-            {
                 id: "import-copy",
                 label: localize("Import Copy"),
                 title: localize("Import a new copy of this history from the associated export record"),
@@ -291,8 +272,27 @@ export function useHistoryCardActions(
                 label: localize("View"),
                 title: localize("View this history"),
                 icon: faEye,
-                variant: "primary",
+                variant: "outline-primary",
                 to: `/histories/view?id=${history.value.id}`,
+            },
+            {
+                id: "switch",
+                title: localize("Set as current history"),
+                label: localize("Set as Current"),
+                variant: "primary",
+                icon: faExchangeAlt,
+                handler: () => historyStore.setCurrentHistory(String(history.value.id)),
+                visible:
+                    (isMyHistory(history.value) || archivedView) && historyStore.currentHistoryId !== history.value.id,
+            },
+            {
+                title: "current history",
+                id: "current",
+                label: "Current",
+                variant: "outline-primary",
+                disabled: true,
+                visible:
+                    (isMyHistory(history.value) || archivedView) && historyStore.currentHistoryId === history.value.id,
             },
         ];
     });


### PR DESCRIPTION
Addresses https://github.com/galaxyproject/galaxy/issues/20867#issuecomment-3474067038

| Before | After |
|--------|-------|
| <img width="488" height="135" alt="image" src="https://github.com/user-attachments/assets/e8281179-a637-4526-ac97-0a05ef2f4b1e" />   | <img width="488" height="135" alt="image" src="https://github.com/user-attachments/assets/add02523-1b72-4fb2-8057-565173ce8810" />  |





## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
