### PR TITLE
[25.0] Fix direct tool execution not using the latest version

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -799,7 +799,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
 
                 # if we don't have a lineage_map for this tool we need to sort by version,
                 # so that the last tool in rval is the newest tool.
-                rval.sort(key=lambda t: t.version)
+                rval.sort(key=lambda t: t.version_object)
             if rval:
                 if get_all_versions:
                     return rval

--- a/test/functional/tools/multiple_versions_sorting_v110.xml
+++ b/test/functional/tools/multiple_versions_sorting_v110.xml
@@ -1,0 +1,11 @@
+<tool id="multiple_versions_sorted" name="multiple_versions_sorted" version="1.10">
+    <command><![CDATA[
+        echo "Version 1.10" > '$out_file1'
+    ]]></command>
+    <inputs>
+        <param name="inttest" value="1" type="integer" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+</tool>

--- a/test/functional/tools/multiple_versions_sorting_v19.xml
+++ b/test/functional/tools/multiple_versions_sorting_v19.xml
@@ -1,0 +1,11 @@
+<tool id="multiple_versions_sorted" name="multiple_versions_sorted" version="1.9">
+    <command><![CDATA[
+        echo "Version 1.9" > '$out_file1'
+    ]]></command>
+    <inputs>
+        <param name="inttest" value="1" type="integer" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -251,6 +251,8 @@
     <tool file="multiple_versions_v01galaxy6.xml" />
     <tool file="multiple_versions_v02.xml" />
   </section>
+  <tool file="multiple_versions_sorting_v19.xml" />
+  <tool file="multiple_versions_sorting_v110.xml" />
 
   <tool file="multiple_versions_changes_v01.xml" />
   <tool file="multiple_versions_changes_v02.xml" />


### PR DESCRIPTION
xref #21237

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Load the test tools ``GALAXY_SKIP_CLIENT_BUILD=1 GALAXY_RUN_WITH_TEST_TOOLS=1 sh run.sh`` and find the multiple_versions_sorting tool. Verify previously this would load version 1.9 and after this change it loads 1.10.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
