### PR TITLE
Plumbing for tracking potential fixes for transient failures (and a fix demonstrating it)

### DIFF
--- a/lib/galaxy/util/unittest_utils/__init__.py
+++ b/lib/galaxy/util/unittest_utils/__init__.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from functools import wraps
 from typing import (
     Callable,
@@ -59,15 +60,25 @@ def skip_unless_environ(env_var: str) -> Union[Callable[[Callable[P, T]], Callab
     return pytest.mark.skip(f"{env_var} must be set for this test")
 
 
-def transient_failure(issue: int) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def transient_failure(issue: int, potentially_fixed: bool = False) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Mark test as known transient failure with GitHub issue tracking.
 
     This decorator catches exceptions from tests and rewraps them with a marker
     indicating this is a known transient failure. This allows automated tooling
     to categorize failures and helps reviewers quickly identify flaky tests.
 
+    Please create an issue on Github to track each transient failure.
+
+    If a potential fix is implemented, set potentially_fixed=True to
+    indicate that the failure may have been resolved. This will update the
+    displayed error message and help us know if the issue can be potentially
+    closed after a month of not being reported.
+
     Args:
         issue: GitHub issue number tracking this transient failure
+        potentially_fixed: If True, indicates that the underlying issue may have been fixed,
+            and the test failure comment will require the PR reviewer to report
+            potential failures on the tracking issue and remove potentially_fixed.
 
     Example:
         @transient_failure(issue=12345)
@@ -82,7 +93,18 @@ def transient_failure(issue: int) -> Callable[[Callable[P, T]], Callable[P, T]]:
             try:
                 return func(*args, **kwargs)
             except Exception as e:
-                msg = f"TRANSIENT FAILURE [Issue #{issue}]: {str(e)}"
+                if potentially_fixed:
+                    current_datetime = datetime.now().isoformat()
+                    report_this = (
+                        "We have previously implemented a potential fix for this issue, "
+                        "if you are seeing this failure in CI on a recently branched commit, please report it on the tracking issue "
+                        f"https://github.com/galaxyproject/galaxy/issues/{issue} including the comment "
+                        f"'This issue is not fixed and was last seen at {current_datetime}' so we can mark the previous fix as insufficient."
+                    )
+                else:
+                    report_this = "This is known issue and doesn't need to be reported."
+
+                msg = f"KNOWN TRANSIENT FAILURE [Issue #{issue}] [{report_this}]: {str(e)}"
                 # Try to preserve exception type, fallback to plain Exception
                 try:
                     raise type(e)(msg) from e

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1082,7 +1082,7 @@ steps:
     def test_delete_job_with_message(self, history_id):
         # Setup a job that will take a while to run so we can verify our cancelling
         input_dataset_id = self.__history_with_ok_dataset(history_id)
-        inputs = json.dumps({"input1": {"src": "hda", "id": input_dataset_id}, "sleep_time": 60 })
+        inputs = json.dumps({"input1": {"src": "hda", "id": input_dataset_id}, "sleep_time": 60})
         tool_run_payload = dict(
             tool_id="cat_data_and_sleep",
             inputs=inputs,
@@ -1092,8 +1092,8 @@ steps:
         tool_response = self._post("tools", data=tool_run_payload)
         assert_status_code_is_ok(tool_response)
         tool_response_json = tool_response.json()
-        assert "jobs" in tool_response.json()
-        assert "outputs" in tool_response.json()
+        assert "jobs" in tool_response_json
+        assert "outputs" in tool_response_json
         job_id = tool_response_json["jobs"][0]["id"]
         output_dataset_id = tool_response_json["outputs"][0]["id"]
         # delete the job with message

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1078,22 +1078,39 @@ steps:
         assert len(empty_search_response.json()) == 0
 
     @pytest.mark.require_new_history
+    @transient_failure(issue=21242, potentially_fixed=True)
     def test_delete_job_with_message(self, history_id):
+        # Setup a job that will take a while to run so we can verify our cancelling
         input_dataset_id = self.__history_with_ok_dataset(history_id)
-        inputs = json.dumps({"input1": {"src": "hda", "id": input_dataset_id}})
-        search_payload = self._search_payload(history_id=history_id, tool_id="cat1", inputs=inputs)
+        inputs = json.dumps({"input1": {"src": "hda", "id": input_dataset_id}, "sleep_time": 60 })
+        tool_run_payload = dict(
+            tool_id="cat_data_and_sleep",
+            inputs=inputs,
+            history_id=history_id,
+        )
         # create a job
-        tool_response = self._post("tools", data=search_payload).json()
-        job_id = tool_response["jobs"][0]["id"]
-        output_dataset_id = tool_response["outputs"][0]["id"]
+        tool_response = self._post("tools", data=tool_run_payload)
+        assert_status_code_is_ok(tool_response)
+        tool_response_json = tool_response.json()
+        assert "jobs" in tool_response.json()
+        assert "outputs" in tool_response.json()
+        job_id = tool_response_json["jobs"][0]["id"]
+        output_dataset_id = tool_response_json["outputs"][0]["id"]
         # delete the job with message
         expected_message = "test message"
         delete_job_response = self._delete(f"jobs/{job_id}", data={"message": expected_message}, json=True)
         self._assert_status_code_is(delete_job_response, 200)
-        # Check the output dataset is deleted and the info field contains the message
-        dataset_details = self._get(f"histories/{history_id}/contents/{output_dataset_id}").json()
-        assert dataset_details["deleted"] is True
-        assert dataset_details["misc_info"] == expected_message
+
+        def check():
+            # Check the output dataset is deleted and the info field contains the message
+            dataset_details = self._get(f"histories/{history_id}/contents/{output_dataset_id}").json()
+            if dataset_details["deleted"] is not True:
+                return False
+            if dataset_details["misc_info"] != expected_message:
+                return False
+            return True
+
+        assert wait_on(check, "dataset to be deleted with message")
 
     @pytest.mark.require_new_history
     def test_destination_params(self, history_id):


### PR DESCRIPTION
#21227 introduced a test decorator that takes in an issue number and modifies test failure messages to tell the reviewer of CI results that the errored test is known to be a transiently failing test. This extends that idea a bit by adding a potentially_fixed argument to the decorator. When that flag is on - we don't expect to see the transiently failing test error messages anymore so if they do occur the message is updated to ask the PR reviewer to update the target issue on Github with a message about it being seen again. We can then PR to remove that flag until the next potential fix is conjured. Since I have been labelling all these transient failure issues with ``transient-test-error`` - it should be easy to automate the checking of these issues every few months and closing the issue out if dev has this flag on and if no-one has reported being seen again.

This error flow makes a lot of sense to me but I'd love some buy in for the idea. Ping @nsoranzo (you reviewed the last PR) and @jdavcs (I know you care a lot about testing). 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
