### PR TITLE
[25.1] Apply tool test timeout only once

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -305,7 +305,6 @@ class GalaxyInteractorApi:
         attributes = output_testdef.attributes
         name = output_testdef.name
         expected_count = attributes.get("count")
-        self.wait_for_jobs(history_id, jobs, maxseconds)
         hid = self.__output_id(output_data)
         # TODO: Twill version verifies dataset is 'ok' in here.
         try:


### PR DESCRIPTION
during tool tests the `wait_for_job` function which waits for a result or a timeout (given eg by planemo or DEFAULT_TOOL_TEST_WAIT) was applied twice:

1. in `_verify_outputs`
2. in `verify_output` (which is called by `_verify_outputs` **for each output**

this made the waiting time at least twice as large as expected.

I removed the call from the 2nd.

This was already included here https://github.com/galaxyproject/galaxy/pull/14667 but I closed it because I had no answer for the question of @mvdbeek https://github.com/galaxyproject/galaxy/pull/14667#discussion_r1043557244

The answer is: because timeout exceptions are caught https://github.com/galaxyproject/galaxy/blob/ea934db65fe61aaa2994edb84caf11f13f264416/lib/galaxy/tool_util/verify/interactor.py#L1702 and just registered. Alternative to the current change we could introduce a special case for timeout exceptions, e.g. register and abort?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
