### PR TITLE
[24.1] Pin requirements in packages/ for breaking changes in newer versions. 

### DIFF
--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     pysam>=0.21
     rocrate
     social-auth-core>=4.5.0
-    # Galaxy 25.1 should lock this because of type changes - this change and comment and should
+    # Galaxy 25.1 should lock this because of type changes - this change and comment should
     # not reach the dev branch.
     # https://github.com/galaxyproject/galaxy/commit/9216f92d11cda636ddec20bef407d510e1d6cce5
     SQLAlchemy>=2.0,<2.0.44

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -58,7 +58,10 @@ install_requires =
     pysam>=0.21
     rocrate
     social-auth-core>=4.5.0
-    SQLAlchemy>=2.0,<2.1
+    # Galaxy 25.1 should lock this because of type changes - this change and comment and should
+    # not reach the dev branch.
+    # https://github.com/galaxyproject/galaxy/commit/9216f92d11cda636ddec20bef407d510e1d6cce5
+    SQLAlchemy>=2.0,<2.0.44
     tifffile
     typing-extensions
     WebOb

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     Babel
     Cheetah3
     # https://github.com/galaxyproject/galaxy/pull/21043/commits/7608bf6854314108712d9a2a6a5804816181ee38
-    # Fix for 25.1 - this shouldn't reach merged into the dev branch.
+    # Fix for 25.1 - this shouldn't reach the dev branch.
     fastapi>=0.101.0,<0.119.0
     gunicorn
     gxformat2

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -43,7 +43,9 @@ install_requires =
     apispec
     Babel
     Cheetah3
-    fastapi>=0.101.0
+    # https://github.com/galaxyproject/galaxy/pull/21043/commits/7608bf6854314108712d9a2a6a5804816181ee38
+    # Fix for 25.1 - this shouldn't reach merged into the dev branch.
+    fastapi>=0.101.0,<0.119.0
     gunicorn
     gxformat2
     importlib-resources;python_version<'3.9'


### PR DESCRIPTION
Trying to fix 25.1's CI.

Fixed in dev https://github.com/galaxyproject/galaxy/commit/9216f92d11cda636ddec20bef407d510e1d6cce5 and https://github.com/galaxyproject/galaxy/pull/21043/commits/7608bf6854314108712d9a2a6a5804816181ee38 - 25.1 is correctly pinned though in the monorepo so I think we need to pin these package dependencies to prevent newer breaking changes from being introduced here.

@nsoranzo Any chance you'd be willing to let us consider sql alchemy part of the public interface of galaxy-data? I want to avoid all of this duplication:

```
(.venv) jxc755@E1-054863 galaxy % grep -r SQLAlchemy packages | grep setup.cfg
packages/app/setup.cfg:    SQLAlchemy>=2.0,<2.1
packages/web_stack/setup.cfg:    SQLAlchemy>=2.0,<2.1
packages/web_framework/setup.cfg:    SQLAlchemy>=2.0,<2.1
packages/job_execution/setup.cfg:    SQLAlchemy>=2.0,<2.1
packages/web_apps/setup.cfg:    SQLAlchemy>=2.0,<2.1
packages/tool_shed/setup.cfg:    SQLAlchemy>=2.0,<2.1
packages/data/setup.cfg:    SQLAlchemy>=2.0,<2.0.44
```

I feel like galaxy-data's setup.cfg should define the sqlalchemy version we use. Maybe it would be sufficient to just drop the version pins for all the packages except galaxy-data - maybe its pinning would be sufficient. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
