### PR TITLE
Fix differentiation between single handler and handler tag

### DIFF
--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -319,7 +319,7 @@ class ConfiguresHandlers:
     @property
     def handler_tags(self):
         """Get an iterable of all configured handler tags."""
-        return filter(lambda k: isinstance(self.handlers[k], list), self.handlers.keys())
+        return filter(lambda k: self.handlers[k] != [k], self.handlers.keys())
 
     @property
     def self_handler_tags(self):


### PR DESCRIPTION
The type annotations and associated fixes (specifically [this](https://github.com/galaxyproject/galaxy/commit/5b74f082998b14b6a52d20ef4ef17b8c08b0e243#diff-c8de350bd47896bc9c105e2ef12677e27d4042bc295d1faaf14b296d546eb6f5L45-R80) in #21171 made it so the handler check couldn't determine between a handler tag (self.handlers value is a list) vs. a handler id (self.handlers value is a tuple), meaning that `self_handler_tags()` would include the current handler's ID in with the handler tags. This in turn breaks job grabbing since the current handler ID is included in the query for jobs needing to be grabbed, instead of just the tag(s).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
