### PR TITLE
[25.1] Fix workbook download link

### DIFF
--- a/client/src/components/Collections/wizard/UploadFetchWorkbook.vue
+++ b/client/src/components/Collections/wizard/UploadFetchWorkbook.vue
@@ -2,6 +2,8 @@
 import { BCardGroup } from "bootstrap-vue";
 import { computed } from "vue";
 
+import { withPrefix } from "@/utils/redirect";
+
 import type { ParsedFetchWorkbookForCollectionCollectionType, RulesCreatingWhat } from "./types";
 
 import CardDownloadWorkbook from "./CardDownloadWorkbook.vue";
@@ -25,7 +27,7 @@ const emit = defineEmits(["workbookContents"]);
 const generateWorkbookHref = computed(() => {
     let type;
     if (props.creatingWhat === "datasets") {
-        type = "dataset";
+        type = "datasets";
     } else if (props.includeCollectionName) {
         type = "collections";
     } else {
@@ -36,7 +38,7 @@ const generateWorkbookHref = computed(() => {
     if (type === "collection" || type === "collections") {
         url = `${url}&collection_type=${props.collectionType}`;
     }
-    return url;
+    return withPrefix(url);
 });
 </script>
 


### PR DESCRIPTION
The datasets version didn't work and none of it worked when Galaxy is served on a prefix. Selenium tests that caught these fixes are in #14073. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage. (or it will have coverage in dev). 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
