### PR TITLE
[25.1] [igv] Allow selection of genomes from history fasta/2bit

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -44,7 +44,7 @@ hyphyvision:
     version: 0.0.0
 igv:
     package: "@galaxyproject/igv"
-    version: 0.0.16
+    version: 0.0.23
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
     version: 0.0.17


### PR DESCRIPTION
Allows users to select custom genomes from history fasta and 2bit files.

![screencast](https://github.com/user-attachments/assets/044ad7bf-1267-4d63-90ba-056db2dc68a7)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
