### PR TITLE
[25.1] Update tool profile version for credentials

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -72,6 +72,10 @@ List of behavior changes associated with profile versions:
 
 - require a valid `data_ref` attribute for `data_column` parameters
 
+### 25.1
+
+- Do not use user preferences to store credentials for tools anymore. Use the new `<credentials>` tag in the `<requirements>` section of the tool XML instead.
+
 ### Examples
 
 A normal tool:


### PR DESCRIPTION
I'm not 100% sure a profile is needed for this so please feel free to close it.

The idea is to make sure the "user settings" workaround is not used anymore after 25.1


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
