### PR TITLE
Load tools dynamically from database

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -358,7 +358,12 @@ class MinimalGalaxyApplication(BasicSharedApp, HaltableContainer, SentryClientMi
 
         self.dynamic_tool_manager = DynamicToolManager(self)
         self._toolbox_lock = threading.RLock()
-        self._toolbox = tools.ToolBox(self.config.tool_configs, self.config.tool_path, self)
+        if self.is_webapp:
+            self._toolbox = tools.ToolBox(self.config.tool_configs, self.config.tool_path, self)
+        else:
+            from galaxy.tools.toolbox.toolbox_adapter import DatabaseToolBox
+
+            self._toolbox = DatabaseToolBox(self.config.tool_configs, self.config.tool_path, self)
         galaxy_root_dir = os.path.abspath(self.config.root)
         file_path = os.path.abspath(self.config.file_path)
         app_info = AppInfo(

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -755,9 +755,8 @@ class Registry:
         # We need to be able to add a job to the queue to set metadata. The queue will currently only accept jobs with an associated
         # tool.  We'll load a special tool to be used for Auto-Detecting metadata; this is less than ideal, but effective
         # Properly building a tool without relying on parsing an XML file is near difficult...so we bundle with Galaxy.
-        set_meta_tool = toolbox.load_hidden_lib_tool(
-            os.path.abspath(os.path.join(os.path.dirname(__file__), "set_metadata_tool.xml"))
-        )
+        toolbox.load_hidden_lib_tool(os.path.abspath(os.path.join(os.path.dirname(__file__), "set_metadata_tool.xml")))
+        set_meta_tool = toolbox.get_tool("__SET_METADATA__")
         self.set_external_metadata_tool = cast("SetMetadataTool", set_meta_tool)
         self.log.debug("Loaded external metadata tool: %s", self.set_external_metadata_tool.id)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1392,6 +1392,17 @@ class ToolSource(Base, Dictifiable, RepresentById):
     id: Mapped[int] = mapped_column(primary_key=True)
     hash: Mapped[Optional[str]] = mapped_column(Unicode(255))
     source: Mapped[dict] = mapped_column(JSONType)
+    tool_source_class: Mapped[str]
+
+
+class GalaxyToolSourceAssociation(Base, RepresentById):
+    __tablename__ = "galaxy_tool_source_association"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    tool_id: Mapped[str] = mapped_column(Unicode(255))
+    tool_source_id: Mapped[int] = mapped_column(ForeignKey("tool_source.id"), index=True)
+    tool_source: Mapped[ToolSource] = relationship()
+    tool_dir: Mapped[Optional[str]] = mapped_column(Unicode(255))
 
 
 class ToolRequest(Base, Dictifiable, RepresentById):

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/27044275d420_add_galaxy_tool_source_association_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/27044275d420_add_galaxy_tool_source_association_table.py
@@ -1,0 +1,48 @@
+"""Add GalaxyToolSourceAssociation table
+
+Revision ID: 27044275d420
+Revises: 1d1d7bf6ac02
+Create Date: 2025-11-11 13:47:57.306214
+
+"""
+
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+)
+
+from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrations.util import (
+    add_column,
+    create_table,
+    drop_column,
+    drop_table,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "27044275d420"
+down_revision = "1d1d7bf6ac02"
+branch_labels = None
+depends_on = None
+
+galaxy_tool_source_association_table = "galaxy_tool_source_association"
+
+
+def upgrade():
+    with transaction():
+        create_table(
+            galaxy_tool_source_association_table,
+            Column("id", Integer, primary_key=True),
+            Column("tool_id", TrimmedString(255)),
+            Column("tool_dir", TrimmedString(255)),
+            Column("tool_source_id", Integer, ForeignKey("tool_source.id")),
+        )
+        add_column("tool_source", Column("tool_source_class", TrimmedString(255)))
+
+
+def downgrade():
+    with transaction():
+        drop_table(galaxy_tool_source_association_table)
+        drop_column("tool_source", "tool_source_class")

--- a/lib/galaxy/tools/special_tools.py
+++ b/lib/galaxy/tools/special_tools.py
@@ -14,4 +14,5 @@ SPECIAL_TOOLS = {
 def load_lib_tools(toolbox):
     for name, path in SPECIAL_TOOLS.items():
         tool = toolbox.load_hidden_lib_tool(os.path.abspath(os.path.join(os.path.dirname(__file__), path)))
-        log.debug("Loaded %s tool: %s", name, tool.id)
+        if tool:
+            log.debug("Loaded %s tool: %s", name, tool.id)

--- a/lib/galaxy/tools/toolbox/toolbox_adapter.py
+++ b/lib/galaxy/tools/toolbox/toolbox_adapter.py
@@ -1,0 +1,127 @@
+import os
+from os import PathLike
+from typing import (
+    List,
+    Literal,
+    Optional,
+    overload,
+    TYPE_CHECKING,
+    Union,
+)
+from uuid import UUID
+
+from sqlalchemy import select
+
+from galaxy.model import (
+    DynamicTool,
+    GalaxyToolSourceAssociation,
+    ToolSource,
+    User,
+)
+from galaxy.tool_util.deps import (
+    build_dependency_manager,
+    NullDependencyManager,
+)
+from galaxy.tool_util.toolbox import AbstractToolBox
+from galaxy.tools import (
+    create_tool_from_representation,
+    Tool,
+)
+
+
+class DatabaseToolBox(AbstractToolBox):
+
+    def __init__(
+        self,
+        config_filenames: List[str],
+        tool_root_dir,
+        app,
+        view_sources=None,
+        default_panel_view="default",
+        save_integrated_tool_panel: bool = True,
+    ) -> None:
+        super().__init__(
+            config_filenames, tool_root_dir, app, view_sources, default_panel_view, save_integrated_tool_panel
+        )
+        self._init_dependency_manager()
+
+    def load_tool(
+        self, config_file: str | PathLike[str], guid=None, tool_shed_repository=None, use_cached: bool = False, **kwds
+    ) -> Tool:
+        pass
+
+    def register_tool(self, tool: Tool) -> None:
+        pass
+
+    def create_dynamic_tool(self, dynamic_tool: DynamicTool) -> Tool:
+        return super().create_dynamic_tool(dynamic_tool)
+
+    def _init_integrated_tool_panel(self, config):
+        pass
+
+    def _init_tools_from_configs(self, config):
+        pass
+
+    def tool_tag_manager(self):
+        pass
+
+    def _init_dependency_manager(self):
+        use_tool_dependency_resolution = getattr(self.app, "use_tool_dependency_resolution", True)
+        if not use_tool_dependency_resolution:
+            self.dependency_manager = NullDependencyManager()
+            return
+        app_config_dict = self.app.config.config_dict
+        conf_file = app_config_dict.get("dependency_resolvers_config_file")
+        default_tool_dependency_dir = os.path.join(
+            self.app.config.data_dir, self.app.config.schema.defaults["tool_dependency_dir"]
+        )
+        self.dependency_manager = build_dependency_manager(
+            app_config_dict=app_config_dict,
+            conf_file=conf_file,
+            default_tool_dependency_dir=default_tool_dependency_dir,
+        )
+
+    @overload
+    def get_tool(
+        self,
+        tool_id: Optional[str] = None,
+        tool_version: Optional[str] = None,
+        tool_uuid: Optional[Union[UUID, str]] = None,
+        get_all_versions: Literal[False] = False,
+        exact: Optional[bool] = False,
+        user: Optional["User"] = None,
+    ) -> Optional["Tool"]: ...
+
+    @overload
+    def get_tool(
+        self,
+        tool_id: Optional[str] = None,
+        tool_version: Optional[str] = None,
+        tool_uuid: Optional[Union[UUID, str]] = None,
+        get_all_versions: Literal[True] = True,
+        exact: Optional[bool] = False,
+        user: Optional["User"] = None,
+    ) -> list["Tool"]: ...
+
+    def get_tool(
+        self,
+        tool_id: Optional[str] = None,
+        tool_version: Optional[str] = None,
+        tool_uuid: Optional[Union[UUID, str]] = None,
+        get_all_versions: Optional[bool] = False,
+        exact: Optional[bool] = False,
+        user: Optional["User"] = None,
+    ) -> Union[Optional["Tool"], list["Tool"]]:
+        if tool_id:
+            stmt = (
+                select(ToolSource.source, ToolSource.tool_source_class, GalaxyToolSourceAssociation.tool_dir)
+                .join(GalaxyToolSourceAssociation, ToolSource.id == GalaxyToolSourceAssociation.tool_source_id)
+                .where(GalaxyToolSourceAssociation.tool_id == tool_id)
+            )
+            row = self.app.model.session.execute(stmt).one_or_none()
+            if row:
+                source, tool_source_class, tool_dir = row
+                return create_tool_from_representation(
+                    app=self.app, raw_tool_source=source, tool_dir=tool_dir, tool_source_class=tool_source_class
+                )
+        return


### PR DESCRIPTION
... if process is not a webapp (currently). At this point just a hack to see if this works at all for job handlers (it seems so ?).
This could eventually also work for the webapp minus the endpoints that actually require all tools in the toolbox, which could become a separate server.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
