### PR TITLE
Fix Playwright CI

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -72,7 +72,8 @@ jobs:
         working-directory: 'galaxy root'
       - name: Install Playwright
         run: |
-          . .venv/bin/activate && playwright install chromium --with-deps
+          . .venv/bin/activate
+          playwright install chromium --with-deps
         working-directory: 'galaxy root'
       - name: Restore client cache
         uses: actions/cache@v4

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -56,8 +56,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'galaxy root/requirements.txt'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Get full Python version
         id: full-python-version
         shell: bash
@@ -67,10 +67,12 @@ jobs:
         with:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-playwright
+      - name: Install dependencies
+        run: ./scripts/common_startup.sh --dev-wheels --skip-client-build
+        working-directory: 'galaxy root'
       - name: Install Playwright
         run: |
-          pip install 'playwright==1.55.0'
-          playwright install chromium --with-deps
+          . .venv/bin/activate && playwright install chromium --with-deps
         working-directory: 'galaxy root'
       - name: Restore client cache
         uses: actions/cache@v4


### PR DESCRIPTION
Apparently playwright install has to be from the same version of playwright as the runtime. So this uses the version of the dependency in Galaxy to take care of that and it also updates the action for our switch uv. 

Huge thanks to @nsoranzo for catching the problem and giving advice on the CI files. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
