### PR TITLE
[25.0] Swap to NPM trusted publishing for prebuilt client

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -51,5 +51,3 @@ jobs:
         if: "!github.event.release.prerelease"
         run: npm publish --provenance --access public
         working-directory: 'client'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We need to swap npm publishing to https://docs.npmjs.com/trusted-publishers.

I have swapped this on the npm side already, and have deleted the (expired, hence failures) token from github.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
