### PR TITLE
[25.1] Fix keyed cache fetching over and over if fetched value is 0

### DIFF
--- a/client/src/composables/keyedCache.test.ts
+++ b/client/src/composables/keyedCache.test.ts
@@ -57,6 +57,25 @@ describe("useKeyedCache", () => {
         expect(fetchItem).not.toHaveBeenCalled();
     });
 
+    it("should not fetch if the stored item is 0 (or any falsy value)", async () => {
+        const id = "1";
+        const item = 0;
+
+        fetchItem.mockResolvedValue(item);
+
+        const { storedItems, getItemById, isLoadingItem } = useKeyedCache<number>(fetchItem);
+
+        storedItems.value[id] = item;
+
+        expect(isLoadingItem.value(id)).toBeFalsy();
+
+        getItemById.value(id);
+
+        expect(isLoadingItem.value(id)).toBeFalsy();
+        expect(storedItems.value[id]).toEqual(item);
+        expect(fetchItem).not.toHaveBeenCalled();
+    });
+
     it("should fetch the item regardless of whether it is already stored if shouldFetch returns true", async () => {
         const id = "1";
         const item = { id: id, name: "Item 1" };

--- a/client/src/composables/keyedCache.ts
+++ b/client/src/composables/keyedCache.ts
@@ -27,7 +27,7 @@ type ShouldFetchHandler<T> = (item?: T) => boolean;
  * Returns true if the item is not defined.
  * @param item The item to check.
  */
-const fetchIfAbsent = <T>(item?: T) => !item;
+const fetchIfAbsent = <T>(item?: T) => item === undefined;
 
 /**
  * A composable that provides a simple key-value cache for items fetched from the server.


### PR DESCRIPTION
Spotted this in the workflow list, where we would keep fetching `/api/workflows/{workflow_id}/counts` over and over for workflows that had 0 invocations. We check for `item === undefined` now as opposed to `!item`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
