### PR TITLE
[25.1] Fix invocations scroll list cards to show update time

### DIFF
--- a/client/src/components/Workflow/Invocation/InvocationScrollList.vue
+++ b/client/src/components/Workflow/Invocation/InvocationScrollList.vue
@@ -123,7 +123,7 @@ function getInvocationBadges(invocation: WorkflowInvocation) {
                 :title-icon="{ icon: faSitemap }"
                 :title-n-lines="2"
                 title-size="text"
-                :update-time="invocation.create_time"
+                :update-time="invocation.update_time"
                 @title-click="workflowName(invocation.workflow_id)"
                 @click="() => cardClicked(invocation)">
                 <template v-slot:description>

--- a/client/src/components/Workflow/WorkflowAnnotation.test.ts
+++ b/client/src/components/Workflow/WorkflowAnnotation.test.ts
@@ -164,7 +164,7 @@ describe("WorkflowAnnotation renders", () => {
         const { wrapper } = await mountWorkflowAnnotation("invocation");
 
         const timeInfo = wrapper.find(SELECTORS.TIME_INFO);
-        expect(timeInfo.text()).toContain("invoked");
+        expect(timeInfo.text()).toContain("updated");
         expect(timeInfo.find(SELECTORS.DATE).attributes("title")).toBe(INVOCATION_TIME);
     });
 });

--- a/client/src/components/Workflow/WorkflowAnnotation.vue
+++ b/client/src/components/Workflow/WorkflowAnnotation.vue
@@ -49,7 +49,7 @@ const workflowTags = computed(() => {
                 <i v-if="timeElapsed" data-description="workflow annotation time info">
                     <FontAwesomeIcon :icon="faClock" class="mr-1" />
                     <span v-localize>
-                        {{ props.invocationUpdateTime ? "invoked" : "edited" }}
+                        {{ props.invocationUpdateTime ? "updated" : "edited" }}
                     </span>
                     <UtcDate :date="timeElapsed" mode="elapsed" data-description="workflow annotation date" />
                 </i>


### PR DESCRIPTION
As opposed to showing the `create_time`, which is confusing because the tooltips say last updated and the list is also sorted by `update_time`.

We have also replaced "invoked" with "updated" in the top bar in the invocation view since it is more accurate because this is the update time, not the create time (time workflow was invoked).

Fixes https://github.com/galaxyproject/galaxy/issues/21291

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
