### PR TITLE
Update error message handling for OIDC

### DIFF
--- a/client/src/components/Login/LoginForm.test.ts
+++ b/client/src/components/Login/LoginForm.test.ts
@@ -110,7 +110,7 @@ describe("LoginForm", () => {
         const provider_label = "Provider";
 
         const originalLocation = window.location;
-        jest.spyOn(window, "location", "get").mockImplementation(() => ({
+        const locationSpy = jest.spyOn(window, "location", "get").mockImplementation(() => ({
             ...originalLocation,
             search: `?connect_external_email=${external_email}&connect_external_provider=${provider_id}&connect_external_label=${provider_label}`,
         }));
@@ -150,5 +150,21 @@ describe("LoginForm", () => {
         const postedURL = axiosMock.history.post?.[0]?.url;
         expect(postedURL).toBe("/user/login");
         await flushPromises();
+
+        locationSpy.mockRestore();
+    });
+
+    it("renders message from query params", async () => {
+        const originalUrl = window.location.href;
+        window.history.replaceState(null, "", "/login/start?message=auth-error&status=info");
+
+        const wrapper = await mountLoginForm();
+
+        const alert = wrapper.find(".alert");
+        expect(alert.exists()).toBe(true);
+        expect(alert.text()).toContain("auth-error");
+        expect(alert.classes()).toContain("alert-info");
+
+        window.history.replaceState(null, "", originalUrl);
     });
 });

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -49,21 +49,20 @@ const props = withDefaults(defineProps<Props>(), {
 
 const router = useRouter();
 
-const getUrlParams = () => new URLSearchParams(window.location.search);
-const params = getUrlParams();
+const urlParams = new URLSearchParams(window.location.search);
 
 const login = ref("");
 const password = ref(null);
 const passwordState = ref<boolean | null>(null);
 const loading = ref(false);
-const networkMessage = params.get("message") || "";
+const networkMessage = urlParams.get("message") || "";
 const messageText = ref(networkMessage);
-const statusParam = params.get("status");
+const statusParam = urlParams.get("status");
 const messageVariant = ref<"info" | "danger">(statusParam === "info" ? "info" : "danger");
-const connectExternalEmail = ref(params.get("connect_external_email"));
-const connectExternalLabel = ref(params.get("connect_external_label"));
-const connectExternalProvider = ref(params.get("connect_external_provider"));
-const confirmURL = ref(params.has("confirm") && params.get("confirm") == "true");
+const connectExternalEmail = ref(urlParams.get("connect_external_email"));
+const connectExternalLabel = ref(urlParams.get("connect_external_label"));
+const connectExternalProvider = ref(urlParams.get("connect_external_provider"));
+const confirmURL = ref(urlParams.has("confirm") && urlParams.get("confirm") == "true");
 
 const excludeIdps = computed(() => (connectExternalProvider.value ? [connectExternalProvider.value] : undefined));
 

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -49,18 +49,21 @@ const props = withDefaults(defineProps<Props>(), {
 
 const router = useRouter();
 
-const urlParams = new URLSearchParams(window.location.search);
+const getUrlParams = () => new URLSearchParams(window.location.search);
+const params = getUrlParams();
 
 const login = ref("");
 const password = ref(null);
 const passwordState = ref<boolean | null>(null);
 const loading = ref(false);
-const messageText = ref("");
-const messageVariant = ref<"info" | "danger">("info");
-const connectExternalEmail = ref(urlParams.get("connect_external_email"));
-const connectExternalLabel = ref(urlParams.get("connect_external_label"));
-const connectExternalProvider = ref(urlParams.get("connect_external_provider"));
-const confirmURL = ref(urlParams.has("confirm") && urlParams.get("confirm") == "true");
+const networkMessage = params.get("message") || "";
+const messageText = ref(networkMessage);
+const statusParam = params.get("status");
+const messageVariant = ref<"info" | "danger">(statusParam === "info" ? "info" : "danger");
+const connectExternalEmail = ref(params.get("connect_external_email"));
+const connectExternalLabel = ref(params.get("connect_external_label"));
+const connectExternalProvider = ref(params.get("connect_external_provider"));
+const confirmURL = ref(params.has("confirm") && params.get("confirm") == "true");
 
 const excludeIdps = computed(() => (connectExternalProvider.value ? [connectExternalProvider.value] : undefined));
 

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -5,7 +5,6 @@ OAuth 2.0 and OpenID Connect Authentication and Authorization Controller.
 import datetime
 import json
 import logging
-from urllib.parse import quote
 
 import jwt
 
@@ -126,7 +125,7 @@ class OIDC(JSAppLauncher):
                     "Please try again, and if the problem persists, contact "
                     "the Galaxy instance admin."
                 )
-            redirect_to = trans.url_builder("/login/start", message=error_msg, status="danger")            
+            redirect_to = trans.url_builder("/login/start", message=error_msg, status="danger")
             return trans.response.send_redirect(redirect_to)
         try:
             success, message, (redirect_url, user) = trans.app.authnz_manager.callback(

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -126,7 +126,7 @@ class OIDC(JSAppLauncher):
                     "Please try again, and if the problem persists, contact "
                     "the Galaxy instance admin."
                 )
-            redirect_to = f"{trans.request.url_path + url_for('/')}login/start?message={quote(error_msg, safe='')}&status=danger"
+            redirect_to = trans.url_builder("/login/start", message=error_msg, status="danger")            
             return trans.response.send_redirect(redirect_to)
         try:
             success, message, (redirect_url, user) = trans.app.authnz_manager.callback(


### PR DESCRIPTION
Change OIDC error handling. In case error_description is provided to the callback render that message to the user instead of the default text in Galaxy. Also update the UI to kick the user back to the login screen with the usual error handling

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. configure an OIDC provider
  2. login with a user into the OIDC provider which triggers an error
  3. Observe the error is shown on the login screen. if the callback parameter error_description is not provided, the standard galaxy message is shown.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

<img width="1323" height="429" alt="Screenshot 2025-11-14 at 13 47 57" src="https://github.com/user-attachments/assets/fdb63dff-7a58-4190-b717-b2e309ee55d2" />
