### PR TITLE
Use focus/blur to prevent prop updates from changing `FormText` values while typing

### DIFF
--- a/client/src/components/Form/Elements/FormText.test.js
+++ b/client/src/components/Form/Elements/FormText.test.js
@@ -67,7 +67,7 @@ describe("FormText", () => {
         expect(el.props("value")).toEqual("field_1");
         await wrapper.setProps({ multiple: true });
         const elMultiple = wrapper.find("textarea");
-        expect(elMultiple.props("value")).toEqual("field_1\nfield_2\nfield_3\n");
+        expect(elMultiple.props("value")).toEqual("field_1\nfield_2\nfield_3");
     });
 
     it("should be able to accept an empty array as value", async () => {

--- a/client/src/components/Form/Elements/FormText.vue
+++ b/client/src/components/Form/Elements/FormText.vue
@@ -8,7 +8,9 @@
                 :class="['ui-text-area', cls]"
                 :readonly="readonly"
                 :placeholder="placeholder"
-                :style="style" />
+                :style="style"
+                @focus="onFocus"
+                @blur="onBlur" />
             <b-form-input
                 v-else
                 :id="id"
@@ -19,7 +21,9 @@
                 :state="showState ? (!currentValue ? (optional ? null : false) : true) : null"
                 :style="style"
                 :type="acceptedTypes"
-                :list="`${id}-datalist`" />
+                :list="`${id}-datalist`"
+                @focus="onFocus"
+                @blur="onBlur" />
             <datalist v-if="datalist && !inputArea" :id="`${id}-datalist`">
                 <option v-for="data in datalist" :key="data.value" :label="data.label" :value="data.value" />
             </datalist>
@@ -83,25 +87,28 @@ export default {
             default: null,
         },
     },
+    data() {
+        return {
+            isFocused: false,
+            localValue: "",
+        };
+    },
     computed: {
         acceptedTypes() {
             return ["text", "password"].includes(this.type) ? this.type : "text";
         },
         currentValue: {
             get() {
-                const v = this.value ?? "";
-                if (Array.isArray(v)) {
-                    if (v.length === 0) {
-                        return "";
-                    }
-                    return this.multiple
-                        ? this.value.reduce((str_value, v) => str_value + String(v) + "\n", "")
-                        : String(this.value[0]);
+                // If focused, return local value to prevent external updates from resetting user input
+                if (this.isFocused) {
+                    return this.localValue;
                 }
-                return String(v);
+                return this.valueToString(this.value);
             },
             set(newVal, oldVal) {
                 if (newVal !== oldVal) {
+                    // Store the local value while editing
+                    this.localValue = newVal;
                     this.$emit("input", newVal);
                 }
             },
@@ -116,6 +123,45 @@ export default {
                       "border-color": this.color,
                   }
                 : null;
+        },
+    },
+    watch: {
+        value(newValue) {
+            // Only update localValue from prop when not focused
+            if (!this.isFocused) {
+                this.localValue = this.valueToString(newValue);
+            }
+        },
+    },
+    mounted() {
+        // Initialize localValue with the initial prop value
+        this.localValue = this.valueToString(this.value);
+    },
+    methods: {
+        /**
+         * Converts the `FormText` value to a string representation.
+         * Handles arrays for multiple inputs and single values.
+         */
+        valueToString(v) {
+            const val = v ?? "";
+            if (Array.isArray(val)) {
+                if (val.length === 0) {
+                    return "";
+                }
+                return this.multiple
+                    ? val.reduce((str_value, item) => str_value + String(item) + "\n", "")
+                    : String(val[0]);
+            }
+            return String(val);
+        },
+        onFocus() {
+            // Set focus state to prevent external updates
+            this.isFocused = true;
+        },
+        onBlur() {
+            // When field loses focus, sync with the latest prop value
+            this.isFocused = false;
+            this.localValue = this.valueToString(this.value);
         },
     },
 };

--- a/client/src/components/Form/Elements/FormText.vue
+++ b/client/src/components/Form/Elements/FormText.vue
@@ -148,9 +148,7 @@ export default {
                 if (val.length === 0) {
                     return "";
                 }
-                return this.multiple
-                    ? val.reduce((str_value, item) => str_value + String(item) + "\n", "")
-                    : String(val[0]);
+                return this.multiple ? val.join("\n") : String(val[0]);
             }
             return String(val);
         },

--- a/client/src/components/Workflow/Editor/Forms/FormInputCollection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormInputCollection.vue
@@ -87,11 +87,21 @@ const isRecordType = computed(() => {
     return collectionType == "record" || collectionType == "list:record" || collectionType == "sample_sheet:record";
 });
 
+/** Debounce timer to prevent constant object creation while typing */
+let columnDefinitionsTimer: ReturnType<typeof setTimeout> | null = null;
+
 function onColumnDefinitions(newColumnDefinitions: SampleSheetColumnDefinitions) {
-    const state = cleanToolState();
-    console.log(newColumnDefinitions);
-    state.column_definitions = newColumnDefinitions;
-    emit("onChange", state);
+    // If existing timer, clear it to prevent emitting the value while the user is still typing
+    if (columnDefinitionsTimer) {
+        clearTimeout(columnDefinitionsTimer);
+    }
+
+    columnDefinitionsTimer = setTimeout(() => {
+        const state = cleanToolState();
+        state.column_definitions = newColumnDefinitions;
+        emit("onChange", state);
+        columnDefinitionsTimer = null;
+    }, 500);
 }
 
 const formatsAsList = computed(() => {

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -328,18 +328,18 @@ steps:
         node.title.wait_for_and_click()
         columns = self.components.tool_form.parameter_textarea(parameter="col")
         textarea_columns = columns.wait_for_visible()
-        assert textarea_columns.get_attribute("value") == "1\n2\n3\n"
+        assert textarea_columns.get_attribute("value") == "1\n2\n3"
         column_names = self.components.tool_form.parameter_textarea(parameter="col_names")
         textarea_column_names = column_names.wait_for_visible()
-        assert textarea_column_names.get_attribute("value") == "a\nb\nc\n"
+        assert textarea_column_names.get_attribute("value") == "a\nb\nc"
         self.sleep_for(self.wait_types.UX_RENDER)
-        self.set_text_element(columns, "4\n5\n6\n")
+        self.set_text_element(columns, "4\n5\n6")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_workflow_has_changes_and_save()
         self.driver.refresh()
         node.title.wait_for_and_click()
         textarea_columns = columns.wait_for_visible()
-        assert textarea_columns.get_attribute("value") == "4\n5\n6\n"
+        assert textarea_columns.get_attribute("value") == "4\n5\n6"
 
     @selenium_test
     def test_integer_input(self):


### PR DESCRIPTION
We have a bug where in the workflow editor, while typing in a text form element, the value can get unexpectedly trimmed or reset because of the `build_module` API call updating the values. Using a combination of blur and focus to prevent prop values from replacing currently typed values is a solution to this.

Fixes https://github.com/galaxyproject/galaxy/issues/21205

| Before 🔴 |
| ---- |
| <video src="https://github.com/user-attachments/assets/99bffde5-9b34-41ac-a954-bd60808d3acf" /> |

| After 🟢 _(out of date: no longer using a debounce)_ |
| ---- |
| <video src="https://github.com/user-attachments/assets/46754df8-c634-44d6-9cd0-6be423d7f06b" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
