### PR TITLE
Add workflow dispatch to artifact building workflow

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -2,9 +2,41 @@ name: Publish release artifacts
 on:
   release:
     types: [released, prereleased]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'create release or prerelease artifact ?'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+        - release
+        - prerelease
+      release_tag:
+        description: 'Specify tag to build for'
+        required: true
+        type: string
 jobs:
+  check-permissions:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if user can create releases
+        run: |
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$PERMISSION" != "admin" ]]; then
+            echo "Error: Only repository admins can manually trigger release artifacts"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-and-publish-pypi:
-    if: github.repository_owner == 'galaxyproject'
+    if: |
+      github.repository_owner == 'galaxyproject' &&
+      (github.event_name == 'release' ||
+       (github.event_name == 'workflow_dispatch' && !cancelled() && !failure()))
+    needs: [check-permissions]
     name: Build and Publish to PyPI
     runs-on: ubuntu-latest
     strategy:
@@ -13,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
           persist-credentials: false
       - uses: actions/setup-python@v6
         with:
@@ -26,17 +59,23 @@ jobs:
           galaxy-release-util build-and-upload --no-confirm
         env:
             TWINE_USERNAME: __token__
-            TWINE_PASSWORD: ${{ github.event.release.prerelease && secrets.PYPI_TEST_TOKEN || secrets.PYPI_MAIN_TOKEN }}
-            TWINE_REPOSITORY_URL: ${{ github.event.release.prerelease && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+            TWINE_PASSWORD: ${{ (github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease') || (github.event_name == 'release' && github.event.release.prerelease) && secrets.PYPI_TEST_TOKEN || secrets.PYPI_MAIN_TOKEN }}
+            TWINE_REPOSITORY_URL: ${{ (github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease') || (github.event_name == 'release' && github.event.release.prerelease) && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
 
   build-and-publish-npm:
-    if: github.repository_owner == 'galaxyproject'
+    if: |
+      github.repository_owner == 'galaxyproject' &&
+      (github.event_name == 'release' ||
+       (github.event_name == 'workflow_dispatch' && !cancelled() && !failure()))
+    needs: [check-permissions]
     name: Build and Publish to NPM
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat client/.node_version)" >> $GITHUB_OUTPUT
@@ -49,7 +88,10 @@ jobs:
       - name: build client
         run: yarn && yarn build-production
         working-directory: 'client'
+      # Ensure npm 11.5.1 or later for trusted publishing
+      - run: npm install -g npm@latest
+        working-directory: 'client'
       - name: publish client
-        if: "!github.event.release.prerelease"
+        if: (github.event_name == 'workflow_dispatch' && inputs.release_type == 'release') || (github.event_name == 'release' && !github.event.release.prerelease)
         run: npm publish --provenance --access public
         working-directory: 'client'


### PR DESCRIPTION
And also update npm. May fix the client publishing and should make it easier to backfill old releases.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
