### PR TITLE
Extend startup probe timeout

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -169,6 +169,9 @@ jobs:
           --set persistence.accessMode="ReadWriteOnce" \
           --set resources.requests.memory=0Mi,resources.requests.cpu=0m \
           --set image.tag=${{ needs.build.outputs.tag }} \
+          --set webHandlers.startupProbe.initialDelaySeconds=120 \
+          --set webHandlers.startupProbe.periodSeconds=15 \
+          --set webHandlers.startupProbe.failureThreshold=72 \
           --wait \
           --timeout=1200s
       - name: Debug deployment on failure


### PR DESCRIPTION
The issue identified in #21262 causes the startup probe to fail which leads to Kubernetes restarting the pod leading to a death loop until the job times out.

This PR extends the startup probe timeout to 20 minutes: an initial delay of two minutes and then it checks every 15 seconds for 18 minutes (72 failures).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
