### PR TITLE
Annotates archive explorer tests as Selenium-only

### DIFF
--- a/lib/galaxy_test/selenium/test_archive_explorer.py
+++ b/lib/galaxy_test/selenium/test_archive_explorer.py
@@ -74,6 +74,7 @@ class TestArchiveExplorer(SeleniumTestCase, UsesHistoryItemAssertions):
         self.wait_for_loading_indicator_to_finish()
         self.expect_preview_title_to_be("Simple Workflow")
 
+    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_search_filters_files(self):
         self.login()
@@ -90,6 +91,7 @@ class TestArchiveExplorer(SeleniumTestCase, UsesHistoryItemAssertions):
         visible_cards = self.get_visible_item_cards()
         assert len(visible_cards) == 1
 
+    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_select_all_functionality(self):
         self.login()


### PR DESCRIPTION
Pending Playwright support, not sure yet what is needed to make them compatible :thinking: 

This should avoid these CI failures for now:

```
FAILED lib/galaxy_test/selenium/test_archive_explorer.py::TestArchiveExplorer::test_search_filters_files - playwright._impl._errors.TimeoutError: ElementHandle.click: Timeout 30000ms exceeded.
Call log:
  - attempting click action
    2 × waiting for element to be visible, enabled and stable
      - element is not visible
    - retrying click action
    - waiting 20ms
    2 × waiting for element to be visible, enabled and stable
      - element is not visible
    - retrying click action
      - waiting 100ms
    56 × waiting for element to be visible, enabled and stable
       - element is not visible
     - retrying click action
       - waiting 500ms
FAILED lib/galaxy_test/selenium/test_archive_explorer.py::TestArchiveExplorer::test_select_all_functionality - playwright._impl._errors.TimeoutError: ElementHandle.click: Timeout 30000ms exceeded.
Call log:
  - attempting click action
    2 × waiting for element to be visible, enabled and stable
      - element is not visible
    - retrying click action
    - waiting 20ms
    2 × waiting for element to be visible, enabled and stable
      - element is not visible
    - retrying click action
      - waiting 100ms
    55 × waiting for element to be visible, enabled and stable
       - element is not visible
     - retrying click action
       - waiting 500ms
    - waiting for element to be visible, enabled and stable
```



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
