### PR TITLE
[25.1] Fix `TERMINAL_STATES` array has a duplicate state

### DIFF
--- a/client/src/api/jobs.ts
+++ b/client/src/api/jobs.ts
@@ -17,7 +17,7 @@ export type JobMessage =
 
 export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting", "paused", "resubmitted", "stop"];
 export const ERROR_STATES = ["error", "deleted", "deleting"];
-export const TERMINAL_STATES = ["ok", "skipped", "stop", "stopping", "skipped"].concat(ERROR_STATES);
+export const TERMINAL_STATES = ["ok", "skipped", "stop", "stopping"].concat(ERROR_STATES);
 
 interface JobDef {
     tool_id: string;


### PR DESCRIPTION
The array has `skipped` listed twice. This was causing the bug where we would over-count jobs in the progress bar in the invocation view:

Fixes https://github.com/galaxyproject/galaxy/issues/21266

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
