### PR TITLE
Allow `len(x)` for select and data parameters with `multiple="true"`

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -78,7 +78,7 @@ List of behavior changes associated with profile versions:
 
 ### 26.0
 
-- The ``len`` function applied on optional data parameters without a selected dataset gives ``0``. For smaller profiles ``1``
+- Optional data parameters without a selected dataset are now empty lists, i.e. ``[]``. For smaller profiles it was ``[None]``
 
 ### Examples
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -76,6 +76,10 @@ List of behavior changes associated with profile versions:
 
 - Do not use user preferences to store credentials for tools anymore. Use the new `<credentials>` tag in the `<requirements>` section of the tool XML instead.
 
+### 26.0
+
+- The ``len`` function applied on optional data parameters without a selected dataset gives ``0``. For smaller profiles ``1``
+
 ### Examples
 
 A normal tool:

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -466,9 +466,8 @@ class ToolEvaluator:
         def wrap_input(input_values, input):
             value = input_values[input.name]
             if isinstance(input, DataToolParameter) and input.multiple:
-                dataset_instances = DatasetListWrapper.to_dataset_instances(value)
+                dataset_instances = DatasetListWrapper.to_dataset_instances(value, self.tool.profile)
                 input_values[input.name] = DatasetListWrapper(
-                    input,
                     job_working_directory,
                     dataset_instances,
                     compute_environment=self.compute_environment,

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -511,9 +511,7 @@ class ToolEvaluator:
                     input, value, other_values=param_dict, compute_environment=self.compute_environment
                 )
             else:
-                input_values[input.name] = InputValueWrapper(
-                    input, value, param_dict, profile=self.tool and self.tool.profile or None
-                )
+                input_values[input.name] = InputValueWrapper(input, value, param_dict)
 
         # HACK: only wrap if check_values is not false, this deals with external
         #       tools where the inputs don't even get passed through. These

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -468,6 +468,7 @@ class ToolEvaluator:
             if isinstance(input, DataToolParameter) and input.multiple:
                 dataset_instances = DatasetListWrapper.to_dataset_instances(value)
                 input_values[input.name] = DatasetListWrapper(
+                    input,
                     job_working_directory,
                     dataset_instances,
                     compute_environment=self.compute_environment,

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -118,9 +118,8 @@ class WrappedParameters:
                 values = value
                 self.wrap_values(input.inputs, values, skip_missing_values=skip_missing_values)
             elif isinstance(input, DataToolParameter) and input.multiple:
-                dataset_instances = DatasetListWrapper.to_dataset_instances(value)
+                dataset_instances = DatasetListWrapper.to_dataset_instances(value, self.tool.profile)
                 input_values[input.name] = DatasetListWrapper(
-                    input,
                     None,
                     dataset_instances,
                     datatypes_registry=trans.app.datatypes_registry,

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -149,7 +149,7 @@ class WrappedParameters:
                 )
             else:
                 assert isinstance(input, ToolParameter)
-                input_values[input.name] = InputValueWrapper(input, value, incoming, tool.profile)
+                input_values[input.name] = InputValueWrapper(input, value, incoming)
 
 
 def make_dict_copy(from_dict: dict):

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -120,6 +120,7 @@ class WrappedParameters:
             elif isinstance(input, DataToolParameter) and input.multiple:
                 dataset_instances = DatasetListWrapper.to_dataset_instances(value)
                 input_values[input.name] = DatasetListWrapper(
+                    input,
                     None,
                     dataset_instances,
                     datatypes_registry=trans.app.datatypes_registry,

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -131,7 +131,6 @@ class InputValueWrapper(ToolParameterValueWrapper):
         input: "ToolParameter",
         value: Optional[str],
         other_values: Optional[dict[str, str]] = None,
-        profile: Optional[float] = None,
     ) -> None:
         self.input = input
         if value is None and input.type == "text":

--- a/test/functional/tools/multi_len.xml
+++ b/test/functional/tools/multi_len.xml
@@ -1,12 +1,18 @@
 <tool id="multi_len" name="multi_len" version="1.0.0" profile="26.0">
     <description>test len() parameters allowing multiple</description>
     <command><![CDATA[
-echo 'select_ex #echo len($select_ex) #' > '$output' &&
-echo 'select_ex_optional #echo len($select_ex_optional) #' >> '$output' &&
+echo '|select_ex| = #echo len($select_ex) #' > '$output' &&
+echo '|select_ex_optional| = #echo len($select_ex_optional) #' >> '$output' &&
+#for i, e in enumerate($select_ex_optional)
+    && echo "select_ex_optional: element $i is $e"
+#end for
 
-echo 'data_ex #echo len($data_ex) #' >> '$output' &&
-echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
+echo '|data_ex| = #echo len($data_ex) #' >> '$output' &&
+echo '|data_ex_optional| = #echo len($data_ex_optional) #' >> '$output'
 
+#for i, e in enumerate($data_ex_optional)
+    && echo "data_ex_optional: element $i is $e"
+#end for
     ]]></command>
     <inputs>
         <param name="select_ex" type="select" multiple="true">
@@ -37,10 +43,10 @@ echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
             <param name="data_ex_optional" value="1.tabular,2.tabular"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="select_ex 3" />
-                    <has_line line="select_ex_optional 3" />
-                    <has_line line="data_ex 2" />
-                    <has_line line="data_ex_optional 2" />
+                    <has_line line="|select_ex| = 3" />
+                    <has_line line="|select_ex_optional| = 3" />
+                    <has_line line="|data_ex| = 2" />
+                    <has_line line="|data_ex_optional| = 2" />
                 </assert_contents>
             </output>
         </test>
@@ -51,10 +57,13 @@ echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
             <param name="data_ex_optional" value_json="null"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="select_ex 3" />
-                    <has_line line="select_ex_optional 0" />
-                    <has_line line="data_ex 2" />
-                    <has_line line="data_ex_optional 0" />
+                    <has_line line="|select_ex| = 3" />
+                    <has_line line="|select_ex_optional| = 0" />
+                    <has_line_matching expression="^select_ex_optional: element" negate="true" />
+                    <has_line line="|data_ex| = 2" />
+                    <has_line line="|data_ex_optional| = 0" />
+                    <has_line_matching expression="^data_ex_optional: element" negate="true" />
+                    <has_n_lines n="4"/>
                 </assert_contents>
             </output>
         </test>

--- a/test/functional/tools/multi_len.xml
+++ b/test/functional/tools/multi_len.xml
@@ -1,0 +1,64 @@
+<tool id="multi_len" name="multi_len" version="1.0.0" profile="26.0">
+    <description>test len() parameters allowing multiple</description>
+    <command><![CDATA[
+echo 'select_ex #echo len($select_ex) #' > '$output' &&
+echo 'select_ex_optional #echo len($select_ex_optional) #' >> '$output' &&
+
+echo 'data_ex #echo len($data_ex) #' >> '$output' &&
+echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
+
+    ]]></command>
+    <inputs>
+        <param name="select_ex" type="select" multiple="true">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+        </param>
+        <param name="select_ex_optional" type="select" multiple="true" optional="true">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+        </param>
+        <param name="data_ex" type="data" format="data" multiple="true"/>
+        <param name="data_ex_optional" type="data" format="data" multiple="true" optional="true"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="select_ex" value="1,2,3" />
+            <param name="select_ex_optional" value="1,2,3" />
+            <param name="data_ex" value="1.tabular,2.tabular"/>
+            <param name="data_ex_optional" value="1.tabular,2.tabular"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="select_ex 3" />
+                    <has_line line="select_ex_optional 3" />
+                    <has_line line="data_ex 2" />
+                    <has_line line="data_ex_optional 2" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="select_ex" value="1,2,3" />
+            <param name="select_ex_optional" value_json="null" />
+            <param name="data_ex" value="1.tabular,2.tabular"/>
+            <param name="data_ex_optional" value_json="null"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="select_ex 3" />
+                    <has_line line="select_ex_optional 0" />
+                    <has_line line="data_ex 2" />
+                    <has_line line="data_ex_optional 0" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/multi_len_legacy.xml
+++ b/test/functional/tools/multi_len_legacy.xml
@@ -1,0 +1,64 @@
+<tool id="multi_len_legacy" name="multi_len_legacy" version="1.0.0" profile="25.1">
+    <description>test len() parameters allowing multiple for 25.1</description>
+    <command><![CDATA[
+echo 'select_ex #echo len($select_ex) #' > '$output' &&
+echo 'select_ex_optional #echo len($select_ex_optional) #' >> '$output' &&
+
+echo 'data_ex #echo len($data_ex) #' >> '$output' &&
+echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
+
+    ]]></command>
+    <inputs>
+        <param name="select_ex" type="select" multiple="true">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+        </param>
+        <param name="select_ex_optional" type="select" multiple="true" optional="true">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+        </param>
+        <param name="data_ex" type="data" format="data" multiple="true"/>
+        <param name="data_ex_optional" type="data" format="data" multiple="true" optional="true"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="select_ex" value="1,2,3" />
+            <param name="select_ex_optional" value="1,2,3" />
+            <param name="data_ex" value="1.tabular,2.tabular"/>
+            <param name="data_ex_optional" value="1.tabular,2.tabular"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="select_ex 3" />
+                    <has_line line="select_ex_optional 3" />
+                    <has_line line="data_ex 2" />
+                    <has_line line="data_ex_optional 2" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="select_ex" value="1,2,3" />
+            <param name="select_ex_optional" value_json="null" />
+            <param name="data_ex" value="1.tabular,2.tabular"/>
+            <param name="data_ex_optional" value_json="null"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="select_ex 3" />
+                    <has_line line="select_ex_optional 0" />
+                    <has_line line="data_ex 2" />
+                    <has_line line="data_ex_optional 1" /> <!-- profile behavior giving the length of [None] -->
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/multi_len_legacy.xml
+++ b/test/functional/tools/multi_len_legacy.xml
@@ -1,11 +1,17 @@
 <tool id="multi_len_legacy" name="multi_len_legacy" version="1.0.0" profile="25.1">
     <description>test len() parameters allowing multiple for 25.1</description>
     <command><![CDATA[
-echo 'select_ex #echo len($select_ex) #' > '$output' &&
-echo 'select_ex_optional #echo len($select_ex_optional) #' >> '$output' &&
+echo '|select_ex| = #echo len($select_ex) #' > '$output' &&
+echo '|select_ex_optional| = #echo len($select_ex_optional) #' >> '$output' &&
+#for i, e in enumerate($select_ex_optional)
+    && echo "select_ex_optional: element $i is $e"
+#end for
 
-echo 'data_ex #echo len($data_ex) #' >> '$output' &&
-echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
+echo '|data_ex| = #echo len($data_ex) #' >> '$output' &&
+echo '|data_ex_optional| = #echo len($data_ex_optional) #' >> '$output'
+#for i, e in enumerate($data_ex_optional)
+    && echo "data_ex_optional: element $i is $e"
+#end for
 
     ]]></command>
     <inputs>
@@ -37,10 +43,10 @@ echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
             <param name="data_ex_optional" value="1.tabular,2.tabular"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="select_ex 3" />
-                    <has_line line="select_ex_optional 3" />
-                    <has_line line="data_ex 2" />
-                    <has_line line="data_ex_optional 2" />
+                    <has_line line="|select_ex| = 3" />
+                    <has_line line="|select_ex_optional| = 3" />
+                    <has_line line="|data_ex| = 2" />
+                    <has_line line="|data_ex_optional| = 2" />
                 </assert_contents>
             </output>
         </test>
@@ -51,10 +57,13 @@ echo 'data_ex_optional #echo len($data_ex_optional) #' >> '$output'
             <param name="data_ex_optional" value_json="null"/>
             <output name="output">
                 <assert_contents>
-                    <has_line line="select_ex 3" />
-                    <has_line line="select_ex_optional 0" />
-                    <has_line line="data_ex 2" />
-                    <has_line line="data_ex_optional 1" /> <!-- profile behavior giving the length of [None] -->
+                    <has_line line="|select_ex| = 3" />
+                    <has_line line="|select_ex_optional| = 0" />
+                    <has_line_matching expression="^select_ex_optional: element" negate="true" />
+                    <has_line line="|data_ex| = 2" />
+                    <has_line line="|data_ex_optional| = 1" /> <!-- profile behavior giving the length of [None] -->
+                    <has_line line="data_ex_optional: element 0 is None"/>
+                    <has_n_lines n="5"/>
                 </assert_contents>
             </output>
         </test>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -27,6 +27,8 @@
   <tool file="help_features_rst.xml" />
   <tool file="help_features_markdown.xml" />
   <tool file="select_from_url.xml" />
+  <tool file="multi_len.xml" />
+  <tool file="multi_len_legacy.xml" />
   <tool file="multi_select.xml" />
   <tool file="multi_output.xml" />
   <tool file="multi_output_configured.xml" />


### PR DESCRIPTION
For select parameters `len(str($x).slipt(","))` seemed to be the best solution so far. Now we can just `len($x)`.

Data parameters already had `len()` (via `list`), but returned `1` since it was treated as `[None]` for optional parameters without a value. This behavior is preserved for profile versions. From profile 26 we have `[]`.



## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
