### PR TITLE
[25.0] Fix fastapi package conflict

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -64,7 +64,6 @@ edam-ontology==1.25.2
 email-validator==2.2.0
 exceptiongroup==1.2.2 ; python_full_version < '3.11'
 fastapi==0.115.12
-fastapi-slim==0.115.12
 filelock==3.18.0
 fissix==24.4.24
 frozenlist==1.6.0

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -63,6 +63,7 @@ dparse==0.6.4
 edam-ontology==1.25.2
 email-validator==2.2.0
 exceptiongroup==1.2.2 ; python_full_version < '3.11'
+fastapi==0.115.12
 fastapi-slim==0.115.12
 filelock==3.18.0
 fissix==24.4.24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "dparse",
     "edam-ontology",
     "fastapi>=0.111.0",
-    "fastapi-slim>=0.111.0",
     "fissix",
     "fs",
     "future>=1.0.0",  # Python 3.12 support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "docutils!=0.17,!=0.17.1",
     "dparse",
     "edam-ontology",
+    "fastapi>=0.111.0",
     "fastapi-slim>=0.111.0",
     "fissix",
     "fs",


### PR DESCRIPTION
Just install both ...

Otherwise we pull in unpinned fastapi via the package dependencies, or at the latest when installing anything that has a dependency on fastapi.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
