### PR TITLE
Fix container

### DIFF
--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -61,10 +61,10 @@ meta = json.loads(meta_str)
 tag, tag_value = next(iter(meta.items()))
 rev, rev_value = next(iter(tag_value.items()))
 cmd = "${images_cmd}"
-proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, text=True)
 stdo, stde = proc.communicate()
 found = False
-for line in stdo.split(b"\n"):
+for line in stdo.split("\n"):
     line = line.strip()
     if line:
         try:

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -69,7 +69,7 @@ for line in stdo.split("\n"):
     if line:
         try:
             img = json.loads(line)
-            if img.get("Repository") == tag and img.get("Tag") == rev and img.get("ID") == rev_value:
+            if img.get("Repository") == repository and img.get("Tag") == tag and img.get("ID") == id:
                 found = True
                 break
         except (json.JSONDecodeError, ValueError):

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -58,8 +58,8 @@ import tarfile
 t = tarfile.TarFile("${cached_image_file}")
 meta_str = t.extractfile('repositories').read()
 meta = json.loads(meta_str)
-tag, tag_value = next(iter(meta.items()))
-rev, rev_value = next(iter(tag_value.items()))
+repository, tag_value = next(iter(meta.items()))
+tag, id = next(iter(tag_value.items()))
 cmd = "${images_cmd}"
 proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, text=True)
 stdo, stde = proc.communicate()

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -189,7 +189,7 @@ def list_docker_cached_mulled_images(
     if resolution_cache is not None and cache_key in resolution_cache:
         images_and_versions = resolution_cache.get(cache_key)
     else:
-        command = build_docker_images_command(truncate=True, sudo=False, to_str=False)
+        command = build_docker_images_command(truncate=True, format="json", sudo=False, to_str=False)
         try:
             output = unicodify(subprocess.check_output(command)).strip()
         except subprocess.CalledProcessError:

--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -64,7 +64,9 @@ def build_docker_cache_command(image: str, **kwds) -> str:
 
 
 def build_docker_images_command(truncate=True, **kwds) -> Union[str, List[str]]:
-    args = ["--no-trunc"] if not truncate else []
+    args = ["--format", "json"]
+    if not truncate:
+        args.insert(0, "--no-trunc")
     return command_shell("images", args, **kwds)
 
 

--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -63,10 +63,12 @@ def build_docker_cache_command(image: str, **kwds) -> str:
     return cache_command
 
 
-def build_docker_images_command(truncate=True, **kwds) -> Union[str, List[str]]:
-    args = ["--format", "json"]
+def build_docker_images_command(truncate=True, format: Optional[str] = None, **kwds) -> Union[str, List[str]]:
+    args = []
     if not truncate:
-        args.insert(0, "--no-trunc")
+        args.append("--no-trunc")
+    if format:
+        args.extend(["--format", format])
     return command_shell("images", args, **kwds)
 
 


### PR DESCRIPTION
Docker 29.0 changed the output format of docker images, breaking the text-based column parsing in `list_docker_cached_mulled_images()`. This caused Galaxy to fail finding cached mulled containers.

This update will parse the json output.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

Xref: https://github.com/galaxyproject/galaxy/pull/21276