### PR TITLE
Migrate rate limiter tests from Jest to Vitest

### DIFF
--- a/client/src/api/client/rateLimiter.test.ts
+++ b/client/src/api/client/rateLimiter.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { MessageException } from "@/api";
 import { GalaxyApi } from "@/api/client";
 import { useServerMock } from "@/api/client/__mocks__";
@@ -7,11 +9,11 @@ import { DEFAULT_CONFIG } from "./rateLimiter";
 const { server, http } = useServerMock();
 
 /** Spy to count number of times a 429 response is returned */
-const mock429ResponseSpy = jest.fn();
+const mock429ResponseSpy = vi.fn();
 
 describe("Rate Limiter Middleware", () => {
-    let consoleWarnSpy: jest.SpyInstance;
-    let consoleErrorSpy: jest.SpyInstance;
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
     /** Helper to verify that there is a 429 response without retries */
     function ensure429AndNoRetries(response: Response, error: MessageException | undefined) {
@@ -29,8 +31,8 @@ describe("Rate Limiter Middleware", () => {
     }
 
     beforeEach(() => {
-        consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
-        consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+        consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     });
     afterEach(() => {
         consoleWarnSpy.mockRestore();


### PR DESCRIPTION
After merge forward from 25.1

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
