### PR TITLE
Add OMERO File Source Plugin

### DIFF
--- a/client/src/api/fileSources.ts
+++ b/client/src/api/fileSources.ts
@@ -70,6 +70,10 @@ export const templateTypes: FileSourceTypesDetail = {
         icon: faHubspot,
         message: "This is a file repository plugin that connects with the Hugging Face Hub.",
     },
+    omero: {
+        icon: faNetworkWired,
+        message: "This is a file repository plugin that connects with an OMERO server.",
+    },
 };
 
 export const FileSourcesValidFilters = {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -11882,7 +11882,8 @@ export interface components {
                 | "zenodo"
                 | "rspace"
                 | "dataverse"
-                | "huggingface";
+                | "huggingface"
+                | "omero";
             /** Variables */
             variables?:
                 | (
@@ -23040,7 +23041,8 @@ export interface components {
                 | "zenodo"
                 | "rspace"
                 | "dataverse"
-                | "huggingface";
+                | "huggingface"
+                | "omero";
             /** Uri Root */
             uri_root: string;
             /**

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -336,6 +336,9 @@ class ConditionalDependencies:
     def check_huggingface_hub(self):
         return "huggingface" in self.file_sources
 
+    def check_omero_py(self):
+        return "omero" in self.file_sources
+
 
 def optional(config_file=None):
     if not config_file:

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -34,6 +34,7 @@ fs-basespace # type: basespace
 fs-azureblob # type: azure
 rspace-client>=2.6.1,<3  # type: rspace
 huggingface_hub
+omero-py #type: omero # Requires manual installation of additional dependencies, see https://omero.readthedocs.io/en/stable/developers/Python.html#omero-python-language-bindings
 
 # Vault backend
 hvac

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -6,6 +6,8 @@ from typing import (
     Union,
 )
 
+from PIL import Image as PILImage
+
 from galaxy.exceptions import (
     AuthenticationFailed,
     ObjectNotFound,
@@ -533,7 +535,6 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
         Exports the first channel (C=0) and first timepoint (T=0) across all Z-planes.
         This preserves the full Z-stack for 3D analysis while keeping the export manageable.
         """
-        from PIL import Image as PILImage
 
         pixels = image.getPrimaryPixels()
         size_z = image.getSizeZ()

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -8,6 +8,10 @@ from typing import (
 
 from omero.gateway import BlitzGateway
 
+from galaxy.exceptions import (
+    AuthenticationFailed,
+    ObjectNotFound,
+)
 from galaxy.files.models import (
     AnyRemoteEntry,
     BaseFileSourceConfiguration,
@@ -62,7 +66,10 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             secure=True,
         )
         if not conn.connect():
-            raise Exception("Could not connect to OMERO server")
+            raise AuthenticationFailed(
+                f"Could not connect to OMERO server at {context.config.host}:{context.config.port}. "
+                "Please verify your credentials and server address."
+            )
 
         try:
             conn.c.enableKeepAlive(60)  # type: ignore[union-attr]
@@ -240,7 +247,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
         image = omero.getObject("Image", image_id)
 
         if not image:
-            raise Exception(f"Image with ID {image_id} not found")
+            raise ObjectNotFound(f"Image with ID {image_id} not found in OMERO server")
 
         return image
 

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -1,0 +1,299 @@
+from datetime import datetime
+from typing import (
+    Optional,
+    Union,
+)
+
+from omero.gateway import BlitzGateway
+
+from galaxy.files.models import (
+    AnyRemoteEntry,
+    BaseFileSourceConfiguration,
+    BaseFileSourceTemplateConfiguration,
+    FilesSourceRuntimeContext,
+    RemoteDirectory,
+    RemoteFile,
+)
+from galaxy.files.sources import (
+    BaseFilesSource,
+    PluginKind,
+)
+from galaxy.util.config_templates import TemplateExpansion
+
+
+class OmeroFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
+    username: Union[str, TemplateExpansion]
+    password: Union[str, TemplateExpansion]
+    host: Union[str, TemplateExpansion]
+    port: Union[int, TemplateExpansion]
+
+
+class OmeroFileSourceConfiguration(BaseFileSourceConfiguration):
+    username: str
+    password: str
+    host: str
+    port: int
+
+
+class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, OmeroFileSourceConfiguration]):
+    plugin_type = "omero"
+    plugin_kind = PluginKind.rfs
+
+    template_config_class = OmeroFileSourceTemplateConfiguration
+    resolved_config_class = OmeroFileSourceConfiguration
+
+    def __init__(self, template_config: OmeroFileSourceTemplateConfiguration):
+        super().__init__(template_config)
+
+    def _open_connection(self, context: FilesSourceRuntimeContext[OmeroFileSourceConfiguration]) -> BlitzGateway:
+        return BlitzGateway(
+            username=context.config.username,
+            passwd=context.config.password,
+            host=context.config.host,
+            port=context.config.port,
+            secure=True,
+        )
+
+    def _list(
+        self,
+        context: FilesSourceRuntimeContext[OmeroFileSourceConfiguration],
+        path="/",
+        recursive=False,
+        write_intent: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query: Optional[str] = None,
+        sort_by: Optional[str] = None,
+    ) -> tuple[list[AnyRemoteEntry], int]:
+        """
+        List OMERO objects in a hierarchical structure:
+        - Projects as directories at root level
+        - Datasets as directories within projects
+        - Images as files within datasets
+
+        Path format:
+        - "/" or "" - lists all projects
+        - "/project_<id>" - lists datasets in a project
+        - "/project_<id>/dataset_<id>" - lists images in a dataset
+        """
+        omero = self._open_connection(context)
+        if not omero.connect():
+            raise Exception("Could not connect to OMERO server")
+
+        try:
+            path_parts = self._parse_path(path)
+            results = self._list_entries_for_path(omero, path_parts)
+            return results, len(results)
+        finally:
+            omero.close()
+
+    def _parse_path(self, path: str) -> list[str]:
+        """Parse and normalize the path into components."""
+        return [p for p in path.strip("/").split("/") if p]
+
+    def _list_entries_for_path(self, omero: BlitzGateway, path_parts: list[str]) -> list[AnyRemoteEntry]:
+        """List entries based on the path depth."""
+        if len(path_parts) == 0:
+            return self._list_projects(omero)
+        elif len(path_parts) == 1:
+            return self._list_datasets(omero, path_parts[0])
+        elif len(path_parts) == 2:
+            return self._list_images(omero, path_parts[0], path_parts[1])
+        return []
+
+    def _list_projects(self, omero: BlitzGateway) -> list[AnyRemoteEntry]:
+        """List all projects as directories at root level."""
+        results: list[AnyRemoteEntry] = []
+        for project in omero.getObjects("Project"):
+            project_path = f"project_{project.getId()}"
+            results.append(
+                RemoteDirectory(
+                    name=project.getName() or f"Project {project.getId()}",
+                    uri=self.uri_from_path(project_path),
+                    path=project_path,
+                )
+            )
+        return results
+
+    def _list_datasets(self, omero: BlitzGateway, project_id_str: str) -> list[AnyRemoteEntry]:
+        """List datasets within a project."""
+        if not project_id_str.startswith("project_"):
+            return []
+
+        project_id = self._extract_id(project_id_str, "project_")
+        project = omero.getObject("Project", project_id)
+        if not project:
+            return []
+
+        results: list[AnyRemoteEntry] = []
+        for dataset in project.listChildren():
+            dataset_path = f"{project_id_str}/dataset_{dataset.getId()}"
+            results.append(
+                RemoteDirectory(
+                    name=dataset.getName() or f"Dataset {dataset.getId()}",
+                    uri=self.uri_from_path(dataset_path),
+                    path=dataset_path,
+                )
+            )
+        return results
+
+    def _list_images(self, omero: BlitzGateway, project_id_str: str, dataset_id_str: str) -> list[AnyRemoteEntry]:
+        """List images within a dataset."""
+        if not dataset_id_str.startswith("dataset_"):
+            return []
+
+        dataset_id = self._extract_id(dataset_id_str, "dataset_")
+        dataset = omero.getObject("Dataset", dataset_id)
+        if not dataset:
+            return []
+
+        results: list[AnyRemoteEntry] = []
+        for image in dataset.listChildren():
+            image_path = f"{project_id_str}/{dataset_id_str}/image_{image.getId()}"
+            results.append(self._create_remote_file_for_image(image, image_path))
+        return results
+
+    def _create_remote_file_for_image(self, image, image_path: str) -> RemoteFile:
+        """Create a RemoteFile entry for an OMERO image."""
+        ctime = image.getDate()
+        ctime_str = ctime.isoformat() if ctime else datetime.now().isoformat()
+
+        estimated_size = self._estimate_image_size(image)
+
+        return RemoteFile(
+            name=image.getName() or f"Image {image.getId()}",
+            size=estimated_size,
+            ctime=ctime_str,
+            uri=self.uri_from_path(image_path),
+            path=image_path,
+        )
+
+    def _estimate_image_size(self, image) -> int:
+        """Estimate the size of an OMERO image based on pixel dimensions and type."""
+        pixels = image.getPrimaryPixels()
+        dimensions = (
+            pixels.getSizeX(),
+            pixels.getSizeY(),
+            pixels.getSizeZ(),
+            pixels.getSizeC(),
+            pixels.getSizeT(),
+        )
+        pixel_type = pixels.getPixelsType().getValue()
+        bytes_per_pixel = self._get_bytes_per_pixel(pixel_type)
+
+        total_pixels = 1
+        for dim in dimensions:
+            total_pixels *= dim
+
+        return total_pixels * bytes_per_pixel
+
+    def _get_bytes_per_pixel(self, pixel_type: str) -> int:
+        """Determine bytes per pixel based on pixel type."""
+        if "int16" in pixel_type or "uint16" in pixel_type:
+            return 2
+        elif "int32" in pixel_type or "uint32" in pixel_type or "float" in pixel_type:
+            return 4
+        elif "double" in pixel_type:
+            return 8
+        return 1
+
+    def _extract_id(self, id_str: str, prefix: str) -> int:
+        """Extract numeric ID from a prefixed string."""
+        return int(id_str.replace(prefix, ""))
+
+    def _realize_to(
+        self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[OmeroFileSourceConfiguration]
+    ):
+        """
+        Download an OMERO image to a local file.
+
+        This method attempts to download the original imported file to preserve
+        the original format. If the original file is not available, it falls back
+        to exporting pixel data.
+
+        The source_path should be in format: project_<id>/dataset_<id>/image_<id>
+        """
+        omero = self._open_connection(context)
+        if not omero.connect():
+            raise Exception("Could not connect to OMERO server")
+
+        try:
+            image = self._get_image_from_path(omero, source_path)
+            self._download_image(image, native_path)
+        finally:
+            omero.close()
+
+    def _get_image_from_path(self, omero: BlitzGateway, source_path: str):
+        """Extract and retrieve an OMERO image from a path."""
+        path_parts = self._parse_path(source_path)
+
+        if len(path_parts) != 3 or not path_parts[2].startswith("image_"):
+            raise ValueError(
+                f"Invalid image path: {source_path}. Expected format: project_<id>/dataset_<id>/image_<id>"
+            )
+
+        image_id = self._extract_id(path_parts[2], "image_")
+        image = omero.getObject("Image", image_id)
+
+        if not image:
+            raise Exception(f"Image with ID {image_id} not found")
+
+        return image
+
+    def _download_image(self, image, native_path: str):
+        """Download an OMERO image using the best available method."""
+        if self._try_download_original_file(image, native_path):
+            return
+
+        self._export_pixel_data(image, native_path)
+
+    def _try_download_original_file(self, image, native_path: str) -> bool:
+        """Attempt to download the original imported file. Returns True if successful."""
+        if image.countFilesetFiles() == 0:
+            return False
+
+        for orig_file in image.getImportedImageFiles():
+            self._write_file_in_chunks(orig_file, native_path)
+            return True  # Only download the first file
+
+        return False
+
+    def _write_file_in_chunks(self, orig_file, native_path: str):
+        """Write an OMERO file to disk in chunks."""
+        with open(native_path, "wb") as f:
+            for chunk in orig_file.getFileInChunks():
+                f.write(chunk)
+
+    def _export_pixel_data(self, image, native_path: str):
+        """Export pixel data as TIFF or fallback to thumbnail."""
+        try:
+            self._export_as_tiff(image, native_path)
+        except Exception:
+            self._export_as_thumbnail(image, native_path)
+
+    def _export_as_tiff(self, image, native_path: str):
+        """Export a single plane of the image as TIFF."""
+        from PIL import Image as PILImage
+
+        pixels = image.getPrimaryPixels()
+        z = image.getSizeZ() // 2 if image.getSizeZ() > 1 else 0
+        plane = pixels.getPlane(z, 0, 0)
+        img = PILImage.fromarray(plane)
+        img.save(native_path, format="TIFF")
+
+    def _export_as_thumbnail(self, image, native_path: str):
+        """Export the rendered thumbnail as final fallback."""
+        img_data = image.getThumbnail()
+        with open(native_path, "wb") as f:
+            f.write(img_data)
+
+    def _write_from(
+        self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[OmeroFileSourceConfiguration]
+    ):
+        """
+        Uploading to OMERO is not supported in this implementation.
+        """
+        raise NotImplementedError("Uploading files to OMERO is not supported.")
+
+
+__all__ = ("OmeroFileSource",)

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -272,14 +272,28 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             self._export_as_thumbnail(image, native_path)
 
     def _export_as_tiff(self, image, native_path: str):
-        """Export a single plane of the image as TIFF."""
+        """Export all Z-planes of the image as a multi-page TIFF.
+
+        Exports the first channel (C=0) and first timepoint (T=0) across all Z-planes.
+        This preserves the full Z-stack for 3D analysis while keeping the export manageable.
+        """
         from PIL import Image as PILImage
 
         pixels = image.getPrimaryPixels()
-        z = image.getSizeZ() // 2 if image.getSizeZ() > 1 else 0
-        plane = pixels.getPlane(z, 0, 0)
-        img = PILImage.fromarray(plane)
-        img.save(native_path, format="TIFF")
+        size_z = image.getSizeZ()
+
+        planes = []
+        for z in range(size_z):
+            plane_data = pixels.getPlane(z, 0, 0)
+            planes.append(PILImage.fromarray(plane_data))
+
+        if planes:
+            planes[0].save(
+                native_path,
+                format="TIFF",
+                save_all=True,
+                append_images=planes[1:] if len(planes) > 1 else [],
+            )
 
     def _export_as_thumbnail(self, image, native_path: str):
         """Export the rendered thumbnail as final fallback."""

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -75,7 +75,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             )
 
         try:
-            conn.c.enableKeepAlive(60)  # type: ignore[union-attr]
+            conn.c.enableKeepAlive(60)
             yield conn
         finally:
             conn.close()
@@ -142,7 +142,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
     def _count_projects(self, conn: BlitzGateway, query: Optional[str] = None) -> int:
         """Count all projects using efficient HQL query."""
         query_service = conn.getQueryService()
-        params = omero.sys.ParametersI()  # type: ignore[attr-defined]
+        params = omero.sys.ParametersI()
         hql = "select count(p) from Project p"
         if query:
             hql += " where lower(p.name) like :query"
@@ -156,7 +156,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             return 0
         project_id = self._extract_id(project_id_str, "project_")
         query_service = conn.getQueryService()
-        params = omero.sys.ParametersI()  # type: ignore[attr-defined]
+        params = omero.sys.ParametersI()
         params.addId(project_id)
         hql = (
             "select count(d) from Dataset d "
@@ -174,7 +174,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             return 0
         dataset_id = self._extract_id(dataset_id_str, "dataset_")
         query_service = conn.getQueryService()
-        params = omero.sys.ParametersI()  # type: ignore[attr-defined]
+        params = omero.sys.ParametersI()
         params.addId(dataset_id)
         hql = (
             "select count(i) from Image i "
@@ -221,7 +221,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
     ) -> list[AnyRemoteEntry]:
         """List projects matching query using HQL for server-side filtering."""
         query_service = conn.getQueryService()
-        params = omero.sys.ParametersI()  # type: ignore[attr-defined]
+        params = omero.sys.ParametersI()
         params.addString("query", f"%{query.lower()}%")
         if limit is not None:
             params.page(offset or 0, limit)
@@ -290,7 +290,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
     ) -> list[AnyRemoteEntry]:
         """List datasets matching query using HQL for server-side filtering."""
         query_service = conn.getQueryService()
-        params = omero.sys.ParametersI()  # type: ignore[attr-defined]
+        params = omero.sys.ParametersI()
         params.addId(project_id)
         params.addString("query", f"%{query.lower()}%")
         if limit is not None:
@@ -360,7 +360,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
     ) -> list[AnyRemoteEntry]:
         """List images matching query using HQL for server-side filtering."""
         query_service = conn.getQueryService()
-        params = omero.sys.ParametersI()  # type: ignore[attr-defined]
+        params = omero.sys.ParametersI()
         params.addId(dataset_id)
         params.addString("query", f"%{query.lower()}%")
         if limit is not None:
@@ -379,9 +379,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             results.append(self._create_remote_file_for_image(image, image_path))
         return results
 
-    def _build_pagination_opts(
-        self, limit: Optional[int] = None, offset: Optional[int] = None
-    ) -> dict[str, int]:
+    def _build_pagination_opts(self, limit: Optional[int] = None, offset: Optional[int] = None) -> dict[str, int]:
         """Build OMERO pagination options dictionary."""
         opts: dict[str, int] = {}
         if limit is not None:
@@ -494,7 +492,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
                 return True  # Only download the first file
 
             return False
-        except omero.SecurityViolation:  # type: ignore[attr-defined]
+        except omero.SecurityViolation:
             # Download restricted (common on public repositories like IDR)
             return False
 

--- a/lib/galaxy/files/templates/examples/omero_server.yml
+++ b/lib/galaxy/files/templates/examples/omero_server.yml
@@ -1,0 +1,33 @@
+- id: omero-server
+  version: 0
+  name: OMERO Server
+  description: |
+      Connect to an OMERO server to browse and import images stored there. You can connect to IDR (https://idr.openmicroscopy.org/) or to your own OMERO server instance.
+      When connecting to IDR, you can use the public credentials (username: "public", password: "public").
+  configuration:
+      type: omero
+      username: "{{ variables.username }}"
+      password: "{{ secrets.password }}"
+      host: "{{ variables.host }}"
+      port: "{{ variables.port }}"
+      writable: false
+  variables:
+      host:
+          label: Server Host
+          type: string
+          help: Host of the OMERO Server to connect to. For example, to connect to IDR use idr.openmicroscopy.org.
+          default: idr.openmicroscopy.org
+      port:
+          label: Port
+          type: integer
+          help: Port used to connect to the OMERO server.
+          default: 4064
+      username:
+          label: Username
+          type: string
+          help: Username to connect with.
+  secrets:
+      password:
+          label: Password
+          help: |
+              Password to connect to OMERO server with.

--- a/lib/galaxy/files/templates/examples/omero_server.yml
+++ b/lib/galaxy/files/templates/examples/omero_server.yml
@@ -1,9 +1,9 @@
 - id: omero-server
   version: 0
-  name: OMERO Server
+  name: OMERO
   description: |
-      Connect to an OMERO server to browse and import images stored there. You can connect to IDR (https://idr.openmicroscopy.org/) or to your own OMERO server instance.
-      When connecting to IDR, you can use the public credentials (username: "public", password: "public").
+      Connect to an **[OMERO](https://www.openmicroscopy.org/omero/)** server to browse and import images stored there. You can connect to the [Image Data Resource (IDR)](https://idr.openmicroscopy.org/) or to your own OMERO server instance.
+      When connecting to **[IDR](https://idr.openmicroscopy.org/)**, you can use the public credentials (username: "**public**", password: "**public**").
   configuration:
       type: omero
       username: "{{ variables.username }}"
@@ -15,7 +15,7 @@
       host:
           label: Server Host
           type: string
-          help: Host of the OMERO Server to connect to. For example, to connect to IDR use idr.openmicroscopy.org.
+          help: Host of the OMERO Server to connect to. For example, to connect to the IDR use idr.openmicroscopy.org.
           default: idr.openmicroscopy.org
       port:
           label: Port

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -46,6 +46,7 @@ FileSourceTemplateType = Literal[
     "rspace",
     "dataverse",
     "huggingface",
+    "omero",
 ]
 
 
@@ -311,6 +312,26 @@ class HuggingFaceFileSourceConfiguration(StrictModel):
     endpoint: Optional[str] = None
 
 
+class OmeroFileSourceTemplateConfiguration(StrictModel):
+    type: Literal["omero"]
+    username: Union[str, TemplateExpansion]
+    password: Union[str, TemplateExpansion]
+    host: Union[str, TemplateExpansion]
+    port: Union[int, TemplateExpansion] = 4064
+    writable: Union[bool, TemplateExpansion] = False
+    template_start: Optional[str] = None
+    template_end: Optional[str] = None
+
+
+class OmeroFileSourceConfiguration(StrictModel):
+    type: Literal["omero"]
+    username: str
+    password: str
+    host: str
+    port: int = 4064
+    writable: bool = False
+
+
 FileSourceTemplateConfiguration = Annotated[
     Union[
         PosixFileSourceTemplateConfiguration,
@@ -327,6 +348,7 @@ FileSourceTemplateConfiguration = Annotated[
         RSpaceFileSourceTemplateConfiguration,
         DataverseFileSourceTemplateConfiguration,
         HuggingFaceFileSourceTemplateConfiguration,
+        OmeroFileSourceTemplateConfiguration,
     ],
     Field(discriminator="type"),
 ]
@@ -347,6 +369,7 @@ FileSourceConfiguration = Annotated[
         RSpaceFileSourceConfiguration,
         DataverseFileSourceConfiguration,
         HuggingFaceFileSourceConfiguration,
+        OmeroFileSourceConfiguration,
     ],
     Field(discriminator="type"),
 ]
@@ -425,6 +448,7 @@ TypesToConfigurationClasses: dict[FileSourceTemplateType, type[FileSourceConfigu
     "rspace": RSpaceFileSourceConfiguration,
     "dataverse": DataverseFileSourceConfiguration,
     "huggingface": HuggingFaceFileSourceConfiguration,
+    "omero": OmeroFileSourceConfiguration,
 }
 
 


### PR DESCRIPTION
This PR introduces a new file source plugin that enables Galaxy users to browse and import microscopy images from [OMERO](https://www.openmicroscopy.org/omero/) servers.

### Features

- **Hierarchical browsing**: Navigate OMERO's Project → Dataset → Image structure
- **Server-side pagination**: Efficient browsing of large collections using HQL queries
- **Server-side search**: Filter projects, datasets, and images by name on the server
- **Smart image download**:
    - Attempts to download original imported files first (preserves original format with some limitations)
    - Falls back to multi-page TIFF export with all Z-planes when originals unavailable
    - Gracefully handles restricted repositories (e.g., IDR) that block original file access

> [!WARNING]
> **Multi-file formats are currently not supported.** Microscopy formats that consist of multiple files (e.g., some proprietary formats) cannot be downloaded in their original form. In most cases, images will be converted and downloaded as generated multi-page TIFF files containing all Z-planes when possible.

### Configuration

Requires OMERO credentials (username, password, host, port) configured via file source templates.

### Dependencies

- **`omero-py`** - OMERO Python client
    - ⚠️ Requires manual installation of **Zeroc IcePy** as a prerequisite. See [OMERO Python bindings documentation](https://omero.readthedocs.io/en/stable/developers/Python.html#omero-python-language-bindings) for installation instructions.
- **`Pillow`** - For TIFF export fallback

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Install the `omero-py` dependency following the instructions in https://omero.readthedocs.io/en/stable/developers/Python.html#omero-python-language-bindings
  - Add the new file source template to your `config/file_source_templates.yml` file:
     ```
     - include: ./lib/galaxy/files/templates/examples/omero_server.yml
     ```
  - Start the Galaxy server and create a new OMERO file source in your user preferences -> Manage Your Repositories
    <img width="948" height="127" alt="image" src="https://github.com/user-attachments/assets/af725e14-2dbd-4cda-9620-64c7fb4f9b5b" />
  - Use the IDR connection settings or the ones from your own OMERO instance.   
    <img width="975" height="758" alt="image" src="https://github.com/user-attachments/assets/74dca95d-5018-47f5-8b11-972d4986c832" />

  - Browse your newly added integration from the Upload dialog using "Choose from repository" and selecting your integration.


https://github.com/user-attachments/assets/dba96666-c2f8-43d0-9d02-dbe810c91cc2



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
