### PR TITLE
Various fixes around ascp file source

### DIFF
--- a/client/src/utils/url.ts
+++ b/client/src/utils/url.ts
@@ -30,6 +30,7 @@ export const URI_PREFIXES = [
     "dataverse://",
     "elabftw://",
     "zip://",
+    "ascp://",
 ];
 
 export function isUrl(content: string): boolean {

--- a/doc/source/admin/data.md
+++ b/doc/source/admin/data.md
@@ -455,6 +455,8 @@ Example configuration for EBI SRA downloads:
     -----BEGIN RSA PRIVATE KEY-----
     <YOUR ACTUAL SSH PRIVATE KEY CONTENT>
     -----END RSA PRIVATE KEY-----
+  # SSH key passphrase. https://embl.service-now.com/kb?id=kb_article_view&sys_kb_id=4cc60cf8c398a610bf313dfc0501314c#mcetoc_1idpn4k0to
+  ssh_key_passphrase: sample_passphrase
 ```
 
 The plugin is **download-only** and supports automatic retry with exponential backoff for transient 

--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -91,6 +91,8 @@
     -----BEGIN RSA PRIVATE KEY-----
     <YOUR ACTUAL SSH PRIVATE KEY CONTENT>
     -----END RSA PRIVATE KEY-----
+  # SSH key passphrase. https://embl.service-now.com/kb?id=kb_article_view&sys_kb_id=4cc60cf8c398a610bf313dfc0501314c#mcetoc_1idpn4k0to
+  ssh_key_passphrase: sample_passphrase
   # Note: This plugin is download-only (writable: false, browsable: false)
 
 # Example: Custom Aspera endpoint with encryption enabled

--- a/lib/galaxy/files/sources/ascp.py
+++ b/lib/galaxy/files/sources/ascp.py
@@ -23,7 +23,10 @@ The implementation is extensible to support future enhancements such as:
 """
 
 import logging
-from typing import Union
+from typing import (
+    Optional,
+    Union,
+)
 
 from galaxy.files.models import (
     FilesSourceRuntimeContext,
@@ -56,7 +59,7 @@ class AscpFilesSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfigura
 
     ascp_path: Union[str, TemplateExpansion] = "ascp"
     ssh_key_content: Union[str, TemplateExpansion]  # SSH key content as string (required)
-    ssh_key_passphrase: Union[str, TemplateExpansion]  # Passphrase for the SSH key (required)
+    ssh_key_passphrase: Union[str, TemplateExpansion, None] = None  # Passphrase for the SSH key (required)
     user: Union[str, TemplateExpansion]  # Required field
     host: Union[str, TemplateExpansion]  # Required field
     rate_limit: Union[str, TemplateExpansion] = "300m"
@@ -81,7 +84,7 @@ class AscpFilesSourceConfiguration(FsspecBaseFileSourceConfiguration):
 
     ascp_path: str = "ascp"
     ssh_key_content: str  # SSH key content as string (required)
-    ssh_key_passphrase: str  # Passphrase for the SSH key (required)
+    ssh_key_passphrase: Optional[str] = None  # Passphrase for the SSH key (optional)
     user: str  # Required field
     host: str  # Required field
     rate_limit: str = "300m"

--- a/lib/galaxy/files/sources/ascp.py
+++ b/lib/galaxy/files/sources/ascp.py
@@ -40,7 +40,6 @@ from galaxy.util.config_templates import TemplateExpansion
 log = logging.getLogger(__name__)
 
 PLUGIN_TYPE = "ascp"
-REQUIRED_PACKAGE = "ascp"  # Note: This is the binary, not a Python package
 
 
 class AscpFilesSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
@@ -57,6 +56,7 @@ class AscpFilesSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfigura
 
     ascp_path: Union[str, TemplateExpansion] = "ascp"
     ssh_key_content: Union[str, TemplateExpansion]  # SSH key content as string (required)
+    ssh_key_passphrase: Union[str, TemplateExpansion]  # Passphrase for the SSH key (required)
     user: Union[str, TemplateExpansion]  # Required field
     host: Union[str, TemplateExpansion]  # Required field
     rate_limit: Union[str, TemplateExpansion] = "300m"
@@ -81,6 +81,7 @@ class AscpFilesSourceConfiguration(FsspecBaseFileSourceConfiguration):
 
     ascp_path: str = "ascp"
     ssh_key_content: str  # SSH key content as string (required)
+    ssh_key_passphrase: str  # Passphrase for the SSH key (required)
     user: str  # Required field
     host: str  # Required field
     rate_limit: str = "300m"
@@ -129,7 +130,7 @@ class AscpFilesSource(FsspecFilesSource[AscpFilesSourceTemplateConfiguration, As
 
     plugin_type = PLUGIN_TYPE
     required_module = AscpFileSystem
-    required_package = REQUIRED_PACKAGE
+    required_package = "fsspec"  # Dummy requirement, need no external package
 
     template_config_class = AscpFilesSourceTemplateConfiguration
     resolved_config_class = AscpFilesSourceConfiguration
@@ -158,6 +159,7 @@ class AscpFilesSource(FsspecFilesSource[AscpFilesSourceTemplateConfiguration, As
         return AscpFileSystem(
             ascp_path=config.ascp_path,
             ssh_key=config.ssh_key_content,
+            ssh_key_passphrase=config.ssh_key_passphrase,
             user=config.user,
             host=config.host,
             rate_limit=config.rate_limit,

--- a/lib/galaxy/files/sources/ascp_fsspec.py
+++ b/lib/galaxy/files/sources/ascp_fsspec.py
@@ -56,7 +56,7 @@ class AscpFileSystem(AbstractFileSystem):
     Args:
         ascp_path: Path to the ascp binary (default: "ascp")
         ssh_key: SSH private key content as a string (required)
-        ssh_key_passphrase: SSH private key passphrase as a string (required)
+        ssh_key_passphrase: SSH private key passphrase as a string
         user: Username for ascp connection (e.g., "era-fasp")
         host: Hostname (e.g., "fasp.sra.ebi.ac.uk")
         rate_limit: Transfer rate limit (default: "300m")
@@ -74,7 +74,7 @@ class AscpFileSystem(AbstractFileSystem):
     def __init__(
         self,
         ssh_key: str,
-        ssh_key_passphrase: str,
+        ssh_key_passphrase: Optional[str] = None,
         ascp_path: str = "ascp",
         user: Optional[str] = None,
         host: Optional[str] = None,
@@ -248,8 +248,11 @@ class AscpFileSystem(AbstractFileSystem):
 
             log.debug(f"Executing ascp command (key path hidden): {self._sanitize_cmd_for_log(cmd)}")
 
-            env = os.environ.copy()
-            env["ASPERA_SCP_PASS"] = self.ssh_key_passphrase
+            if self.ssh_key_passphrase:
+                env = os.environ.copy()
+                env["ASPERA_SCP_PASS"] = self.ssh_key_passphrase
+            else:
+                env = None
             # Execute ascp
             result = subprocess.run(
                 cmd,

--- a/lib/galaxy/files/sources/ascp_fsspec.py
+++ b/lib/galaxy/files/sources/ascp_fsspec.py
@@ -56,6 +56,7 @@ class AscpFileSystem(AbstractFileSystem):
     Args:
         ascp_path: Path to the ascp binary (default: "ascp")
         ssh_key: SSH private key content as a string (required)
+        ssh_key_passphrase: SSH private key passphrase as a string (required)
         user: Username for ascp connection (e.g., "era-fasp")
         host: Hostname (e.g., "fasp.sra.ebi.ac.uk")
         rate_limit: Transfer rate limit (default: "300m")
@@ -72,8 +73,9 @@ class AscpFileSystem(AbstractFileSystem):
 
     def __init__(
         self,
+        ssh_key: str,
+        ssh_key_passphrase: str,
         ascp_path: str = "ascp",
-        ssh_key: Optional[str] = None,
         user: Optional[str] = None,
         host: Optional[str] = None,
         rate_limit: str = "300m",
@@ -99,6 +101,7 @@ class AscpFileSystem(AbstractFileSystem):
         super().__init__(**kwargs)
         self.ascp_path = ascp_path
         self.ssh_key = ssh_key
+        self.ssh_key_passphrase = ssh_key_passphrase
         self.user = user
         self.host = host
         self.rate_limit = rate_limit
@@ -118,7 +121,15 @@ class AscpFileSystem(AbstractFileSystem):
                 "Please ensure ascp is installed and accessible in your PATH."
             )
 
-    def _get_file(self, rpath: str, lpath: str, **kwargs: Any) -> None:
+    def isdir(self, path):
+        """Is this entry directory-like?"""
+        return False
+
+    def isfile(self, path):
+        """Is this entry file-like?"""
+        return True
+
+    def get_file(self, rpath: str, lpath: str, **kwargs: Any) -> None:
         """Download a file from remote path to local path using ascp with retry logic.
 
         This method handles:
@@ -237,12 +248,15 @@ class AscpFileSystem(AbstractFileSystem):
 
             log.debug(f"Executing ascp command (key path hidden): {self._sanitize_cmd_for_log(cmd)}")
 
+            env = os.environ.copy()
+            env["ASPERA_SCP_PASS"] = self.ssh_key_passphrase
             # Execute ascp
             result = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 check=False,  # We'll handle errors manually
+                env=env,
             )
 
             if result.returncode != 0:

--- a/test/unit/files/test_ascp.py
+++ b/test/unit/files/test_ascp.py
@@ -25,6 +25,8 @@ rlojfBFH/3NO/Nvjg0d7vMkzU5Pq9LHlvK+9CmhJXzLzlFdWxXVVqwxLLvJGEZvD
 class TestAscpFileSystem:
     """Tests for the AscpFileSystem fsspec implementation."""
 
+    # These are all AI generated, feel free to remove and add tests that don't mock out everything.
+
     def test_initialization(self):
         """Test that AscpFileSystem can be instantiated with valid parameters."""
         with patch("shutil.which", return_value="/usr/bin/ascp"):

--- a/test/unit/files/test_ascp.py
+++ b/test/unit/files/test_ascp.py
@@ -13,6 +13,7 @@ import pytest
 from galaxy.exceptions import MessageException
 from galaxy.files.sources.ascp import AscpFilesSource
 from galaxy.files.sources.ascp_fsspec import AscpFileSystem
+from ._util import configured_file_sources
 
 # Test SSH key (dummy key for testing)
 TEST_SSH_KEY = """-----BEGIN RSA PRIVATE KEY-----
@@ -30,6 +31,7 @@ class TestAscpFileSystem:
             fs = AscpFileSystem(
                 ascp_path="ascp",
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 rate_limit="300m",
@@ -51,6 +53,7 @@ class TestAscpFileSystem:
                 AscpFileSystem(
                     ascp_path="ascp",
                     ssh_key=TEST_SSH_KEY,
+                    ssh_key_passphrase="abcdefg",
                     user="test-user",
                     host="test.example.com",
                 )
@@ -60,6 +63,7 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="default-user",
                 host="default.example.com",
             )
@@ -74,6 +78,7 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="default-user",
                 host="default.example.com",
             )
@@ -87,6 +92,7 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="default-user",
                 host="default.example.com",
             )
@@ -113,6 +119,7 @@ class TestAscpFileSystem:
             fs = AscpFileSystem(
                 ascp_path="ascp",
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 rate_limit="300m",
@@ -121,7 +128,7 @@ class TestAscpFileSystem:
             )
 
             # Execute
-            fs._get_file("/remote/path/file.txt", "/local/path/file.txt")
+            fs.get_file("/remote/path/file.txt", "/local/path/file.txt")
 
             # Verify
             mock_mkstemp.assert_called_once()
@@ -157,12 +164,13 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
 
             with pytest.raises(MessageException, match="Authentication failed"):
-                fs._get_file("/remote/path/file.txt", "/local/path/file.txt")
+                fs.get_file("/remote/path/file.txt", "/local/path/file.txt")
 
             # Verify cleanup happened
             mock_unlink.assert_called_once()
@@ -182,12 +190,13 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
 
             with pytest.raises(MessageException, match="Remote file not found"):
-                fs._get_file("/remote/path/file.txt", "/local/path/file.txt")
+                fs.get_file("/remote/path/file.txt", "/local/path/file.txt")
 
     @patch("subprocess.run")
     @patch("tempfile.mkstemp")
@@ -204,12 +213,13 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
 
             with pytest.raises(MessageException, match="Network error"):
-                fs._get_file("/remote/path/file.txt", "/local/path/file.txt")
+                fs.get_file("/remote/path/file.txt", "/local/path/file.txt")
 
     @patch("subprocess.run")
     @patch("tempfile.mkstemp")
@@ -234,12 +244,13 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
 
             with pytest.raises(MessageException, match="Authentication failed"):
-                fs._get_file("/remote/path/file.txt", "/local/path/file.txt")
+                fs.get_file("/remote/path/file.txt", "/local/path/file.txt")
 
             # Verify cleanup was attempted
             mock_unlink.assert_called_once_with("/tmp/test_key.key")
@@ -249,6 +260,7 @@ class TestAscpFileSystem:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
@@ -261,29 +273,18 @@ class TestAscpFileSystem:
             assert "ascp" in sanitized
             assert "300m" in sanitized
 
-    def test_missing_ssh_key(self):
-        """Test that _get_file fails when SSH key is not provided."""
-        with patch("shutil.which", return_value="/usr/bin/ascp"):
-            fs = AscpFileSystem(
-                ssh_key=None,
-                user="test-user",
-                host="test.example.com",
-            )
-
-            with pytest.raises(MessageException, match="SSH key is required"):
-                fs._get_file("/remote/path/file.txt", "/local/path/file.txt")
-
     def test_missing_user_or_host(self):
         """Test that _get_file fails when user or host is not provided."""
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user=None,
                 host=None,
             )
 
             with pytest.raises(MessageException, match="User and host must be specified"):
-                fs._get_file("/remote/path/file.txt", "/local/path/file.txt")
+                fs.get_file("/remote/path/file.txt", "/local/path/file.txt")
 
 
 class TestAscpFilesSource:
@@ -300,6 +301,7 @@ class TestAscpFilesSource:
             "id": "test_ascp",
             "label": "Test Aspera",
             "ssh_key_content": TEST_SSH_KEY,
+            "ssh_key_passphrase": "abcdefg",
             "user": "test-user",
             "host": "test.example.com",
         }
@@ -328,12 +330,12 @@ class TestAscpFilesSource:
             "id": "test_ascp",
             "label": "Test Aspera",
             "ssh_key_content": TEST_SSH_KEY,
+            "ssh_key_passphrase": "abcdefg",
             "user": "test-user",
             "host": "test.example.com",
         }
 
         with patch("shutil.which", return_value="/usr/bin/ascp"):
-            from ._util import configured_file_sources
 
             with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
                 import yaml
@@ -359,8 +361,6 @@ class TestAscpFilesSource:
                 "user": "test-user",
                 "host": "test.example.com",
             }
-
-            from ._util import configured_file_sources
 
             with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
                 import yaml
@@ -389,6 +389,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 max_retries=3,
@@ -418,7 +419,7 @@ class TestAscpRetryLogic:
                         with patch("os.chmod"):
                             with patch("os.unlink"):
                                 with patch("time.sleep") as mock_sleep:
-                                    fs._get_file("/remote/file.txt", "/local/file.txt")
+                                    fs.get_file("/remote/file.txt", "/local/file.txt")
 
                                     # Should have been called 3 times
                                     assert call_count == 3
@@ -430,6 +431,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 max_retries=3,
@@ -452,7 +454,7 @@ class TestAscpRetryLogic:
                         with patch("os.chmod"):
                             with patch("os.unlink"):
                                 with pytest.raises(MessageException, match="Authentication failed"):
-                                    fs._get_file("/remote/file.txt", "/local/file.txt")
+                                    fs.get_file("/remote/file.txt", "/local/file.txt")
 
                                 # Should only be called once (no retry)
                                 assert call_count == 1
@@ -462,6 +464,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 max_retries=2,
@@ -490,7 +493,7 @@ class TestAscpRetryLogic:
                         with patch("os.chmod"):
                             with patch("os.unlink"):
                                 with patch("time.sleep"):
-                                    fs._get_file("/remote/file.txt", "/local/file.txt")
+                                    fs.get_file("/remote/file.txt", "/local/file.txt")
 
                                     # First attempt should NOT have -k flag
                                     assert "-k" not in captured_commands[0]
@@ -505,6 +508,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 max_retries=2,
@@ -531,7 +535,7 @@ class TestAscpRetryLogic:
                         with patch("os.chmod"):
                             with patch("os.unlink"):
                                 with patch("time.sleep"):
-                                    fs._get_file("/remote/file.txt", "/local/file.txt")
+                                    fs.get_file("/remote/file.txt", "/local/file.txt")
 
                                     # Neither attempt should have -k flag
                                     assert "-k" not in captured_commands[0]
@@ -542,6 +546,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 max_retries=2,
@@ -567,7 +572,7 @@ class TestAscpRetryLogic:
                             with patch("os.unlink"):
                                 with patch("time.sleep"):
                                     with pytest.raises(MessageException, match="Network error"):
-                                        fs._get_file("/remote/file.txt", "/local/file.txt")
+                                        fs.get_file("/remote/file.txt", "/local/file.txt")
 
                                     # Should have tried max_retries times
                                     assert call_count == 2
@@ -577,6 +582,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
                 max_retries=4,
@@ -599,7 +605,7 @@ class TestAscpRetryLogic:
                             with patch("os.unlink"):
                                 with patch("time.sleep") as mock_sleep:
                                     with pytest.raises(MessageException):
-                                        fs._get_file("/remote/file.txt", "/local/file.txt")
+                                        fs.get_file("/remote/file.txt", "/local/file.txt")
 
                                     # Check delay progression: 2^1=2, 2^2=4, 2^3=8 (capped at 10)
                                     sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
@@ -612,6 +618,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
@@ -634,6 +641,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
@@ -648,6 +656,7 @@ class TestAscpRetryLogic:
         with patch("shutil.which", return_value="/usr/bin/ascp"):
             fs = AscpFileSystem(
                 ssh_key=TEST_SSH_KEY,  # Pass key content
+                ssh_key_passphrase="abcdefg",
                 user="test-user",
                 host="test.example.com",
             )
@@ -660,7 +669,7 @@ class TestAscpRetryLogic:
                     with patch("os.fdopen"):
                         with patch("os.chmod"):
                             with patch("os.unlink") as mock_unlink:
-                                fs._get_file("/remote/file.txt", "/local/file.txt")
+                                fs.get_file("/remote/file.txt", "/local/file.txt")
 
                                 # Verify temp file was created
                                 mock_mkstemp.assert_called_once()


### PR DESCRIPTION
- Add an ascp handler to the frontend, so users can paste ascp:// urls
- Add ssh key passphrase config option, without this downloads hang waiting for password
- Bypass is_dir / is_file checks, they'll always fail. We assume files for now.
- Implement top-level get_file. `_get_file` would require implementing `get_info` which doesn't really make sense for this file source.

Deployments will likely require a layout that contains
```
bin/ascp
etc/aspera-license
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
