### PR TITLE
Attempt to fix transiently failing tests that click this tab.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -2249,21 +2249,17 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
     def history_panel_item_edit(self, hid):
         self.display_dataset(hid)
 
-        # Find and click the Edit tab - using a more reliable selector
-        # BVue generates '.nav-item a' elements with a title attribute matching the tab title
-        edit_tab_button = self.wait_for_selector_clickable(
-            ".nav-item[title='Edit dataset attributes and metadata'] > a.nav-link"
-        )
-        edit_tab_button.click()
+        @retry_during_transitions
+        def _click_edit_tab():
+            self.components.dataset_view.edit_tab.wait_for_and_click()
 
-        # Wait for the edit attributes panel to be visible
+        _click_edit_tab()
         self.components.edit_dataset_attributes._.wait_for_visible()
 
     def display_dataset(self, hid):
         item = self.history_panel_item_component(hid=hid)
         item.display_button.wait_for_and_click()
-        # Wait for the DatasetView component to load
-        self.wait_for_selector_visible(".dataset-view")
+        self.components.dataset_view._.wait_for_visible()
 
     def show_dataset_details(self, hid):
         self.display_dataset(hid)


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/actions/runs/19834413655/job/56828939914?pr=21335

```

=================================== FAILURES ===================================
_________ TestDataset.test_history_dataset_update_annotation_and_info __________

self = <galaxy_test.selenium.test_dataset.TestDataset object at 0x7f9ab6852e50>

    @selenium_test
    @managed_history
    def test_history_dataset_update_annotation_and_info(self):
        history_entry = self.perform_single_upload(self.get_filename("1.txt"))
        hid = history_entry.hid
        self.wait_for_history()
        self.history_panel_wait_for_hid_ok(hid)
        self.history_panel_item_edit(hid=hid)
        edit_dataset_attributes = self.components.edit_dataset_attributes
        annotation_component = edit_dataset_attributes.annotation_input
        annotation_component.wait_for_and_clear_and_send_keys(TEST_ANNOTATION)

        info_component = edit_dataset_attributes.info_input
        info_component.wait_for_and_clear_and_send_keys(TEST_INFO)

        edit_dataset_attributes.save_button.wait_for_and_click()
        edit_dataset_attributes.alert.wait_for_visible()

        # assert success message, name updated in form and in history panel
        assert edit_dataset_attributes.alert.has_class("alert-success")

        # reopen and check that attributes are updated
        self.home()
>       self.history_panel_item_edit(hid=hid)
```

```
E           playwright._impl._errors.Error: ElementHandle.click: Element is not attached to the DOM
E           Call log:
E             - attempting click action
E               - waiting for element to be visible, enabled and stable
```

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
