### PR TITLE
Attempt to fix transient failure in list_list_copy

### DIFF
--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1077,7 +1077,7 @@ steps:
         assert len(empty_search_response.json()) == 0
 
     @pytest.mark.require_new_history
-    @transient_failure(issue=21242, potentially_fixed=True)
+    @transient_failure(issue=21242)
     def test_delete_job_with_message(self, history_id):
         # Setup a job that will take a while to run so we can verify our cancelling
         input_dataset_id = self.__history_with_ok_dataset(history_id)


### PR DESCRIPTION
Test wasn't doing what it claimed - not the problem per se but I'd like it to actually test the list:list copy. Also do some book keeping - previous potential fix for test_delete_job_with_message was reported as seen in the wild again so we need to unmark that as potentially_fixed so the error message reverts to not request reporting the issue.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
