### PR TITLE
More use of base64 to improve test stability.

### DIFF
--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -3013,9 +3013,8 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("metadata_bam")
     def test_run_deferred_dataset_with_metadata_options_filter(self, history_id):
-        details = self.dataset_populator.create_deferred_hda(
-            history_id, "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bam", ext="bam"
-        )
+        url_1 = self.dataset_populator.base64_url_for_test_file("1.bam")
+        details = self.dataset_populator.create_deferred_hda(history_id, url_1, ext="bam")
         inputs = {"input_bam": dataset_to_param(details), "ref_names": "chrM"}
         run_response = self.dataset_populator.run_tool(tool_id="metadata_bam", inputs=inputs, history_id=history_id)
         output = run_response["outputs"][0]
@@ -3028,9 +3027,8 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("pileup")
     def test_metadata_validator_on_deferred_input(self, history_id):
-        deferred_bam_details = self.dataset_populator.create_deferred_hda(
-            history_id, "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bam", ext="bam"
-        )
+        url_1 = self.dataset_populator.base64_url_for_test_file("1.bam")
+        deferred_bam_details = self.dataset_populator.create_deferred_hda(history_id, url_1, ext="bam")
         fasta1_contents = open(self.get_filename("1.fasta")).read()
         fasta = self.dataset_populator.new_dataset(history_id, content=fasta1_contents)
         inputs = {"input1": dataset_to_param(deferred_bam_details), "reference": dataset_to_param(fasta)}
@@ -3123,10 +3121,11 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("cat1")
     def test_run_deferred_mapping(self, history_id: str):
+        url_1 = self.dataset_populator.base64_url_for_test_file("4.bed")
         elements = [
             {
                 "src": "url",
-                "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
+                "url": url_1,
                 "info": "my cool bed",
                 "deferred": True,
                 "ext": "bed",
@@ -3163,10 +3162,11 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("cat_list")
     def test_run_deferred_list_multi_data_reduction(self, history_id: str):
+        url_1 = self.dataset_populator.base64_url_for_test_file("4.bed")
         elements = [
             {
                 "src": "url",
-                "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
+                "url": url_1,
                 "info": "my cool bed",
                 "deferred": True,
                 "ext": "bed",


### PR DESCRIPTION
I think each usage we catch should improve the reliability of all the tests that still hit Github since we're less likely to hit rate limits and such. 

xref https://github.com/jmchilton/galaxy/actions/runs/19865852088/job/56928306462

```
FAILED lib/galaxy_test/api/test_tools.py::TestToolsApi::test_allow_uri_if_protocol_on_collection_with_deferred - AssertionError: Final state - error - not okay. Full response: {'model_class': 'History', 'id': '47dd087789ea7ece', 'name': 'test_history', 'deleted': False, 'purged': False, 'archived': False, 'url': '/api/histories/47dd087789ea7ece', 'published': False, 'count': 6, 'annotation': None, 'tags': [], 'update_time': '2025-12-02T17:19:23.358756', 'preferred_object_store_id': None, 'contents_url': '/api/histories/47dd087789ea7ece/contents', 'size': 182, 'user_id': 'adb5f5c93f827949', 'create_time': '2025-12-02T17:19:19.595928', 'importable': False, 'slug': None, 'username': 'user--bx--psu--edu', 'username_and_slug': None, 'genome_build': None, 'state': 'error', 'state_ids': {'new': [], 'upload': [], 'queued': [], 'running': [], 'ok': ['0a0a5bcd98edfdcc'], 'empty': [], 'error': ['ea20eed3125afe51'], 'paused': [], 'setting_metadata': [], 'failed_metadata': [], 'deferred': ['b533467cdeb50a18', '50c3a241189ab841'], 'discarded': []}, 'state_details': {'new': 0, 'upload': 0, 'queued': 0, 'running': 0, 'ok': 1, 'empty': 0, 'error': 1, 'paused': 0, 'setting_metadata': 0, 'failed_metadata': 0, 'deferred': 2, 'discarded': 0}}
``` 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
