### PR TITLE
Fix counterintuitive behavior of has_n_cols for csv

### DIFF
--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -38,6 +38,8 @@ except ImportError:
     tifffile = None  # type: ignore[assignment, unused-ignore]
 
 
+from packaging.version import Version
+
 from galaxy.tool_util.parser.util import (
     DEFAULT_DELTA,
     DEFAULT_DELTA_FRAC,
@@ -75,6 +77,7 @@ def verify(
     keep_outputs_dir: Optional[str] = None,
     verify_extra_files: Optional[Callable] = None,
     mode="file",
+    profile: Optional[str] = None,
 ):
     """Verify the content of a test output using test definitions described by attributes.
 
@@ -99,8 +102,10 @@ def verify(
     assertions = attributes.get("assert_list", None)
     if assertions is not None:
         try:
-            # Auto-detect separator based on file type
-            sep = "," if attributes.get("ftype") == "csv" else "\t"
+            # Auto-detect separator based on file type for profile >= 26.0
+            sep: Optional[str] = None
+            if profile and Version(profile) >= Version("26.0"):
+                sep = "," if attributes.get("ftype") == "csv" else "\t"
             verify_assertions(output_content, attributes["assert_list"], attributes.get("decompress", False), sep=sep)
         except AssertionError as err:
             errmsg = f"{item_label} different than expected\n"

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -99,7 +99,9 @@ def verify(
     assertions = attributes.get("assert_list", None)
     if assertions is not None:
         try:
-            verify_assertions(output_content, attributes["assert_list"], attributes.get("decompress", False))
+            # Auto-detect separator based on file type
+            sep = "," if attributes.get("ftype") == "csv" else "\t"
+            verify_assertions(output_content, attributes["assert_list"], attributes.get("decompress", False), sep=sep)
         except AssertionError as err:
             errmsg = f"{item_label} different than expected\n"
             errmsg += unicodify(err)

--- a/lib/galaxy/tool_util/verify/_types.py
+++ b/lib/galaxy/tool_util/verify/_types.py
@@ -38,6 +38,7 @@ RequiredLocFileT = List[str]
 class ToolTestDescriptionDict(TypedDict):
     tool_id: str
     tool_version: Optional[str]
+    profile: NotRequired[Optional[str]]
     name: str
     test_index: int
     inputs: ExpandedToolInputsJsonified

--- a/lib/galaxy/tool_util/verify/asserts/__init__.py
+++ b/lib/galaxy/tool_util/verify/asserts/__init__.py
@@ -41,7 +41,7 @@ for assertion_module_name in assertion_module_names:
 assertion_functions: Dict[str, Callable] = {k: v[1] for (k, v) in assertion_module_and_functions.items()}
 
 
-def verify_assertions(data: bytes, assertion_description_list: list, decompress: bool = False):
+def verify_assertions(data: bytes, assertion_description_list: list, decompress: bool = False, sep: str = None):
     """This function takes a list of assertions and a string to check
     these assertions against."""
     if decompress:
@@ -51,10 +51,10 @@ def verify_assertions(data: bytes, assertion_description_list: list, decompress:
             with get_fileobj(tmpfh.name, mode="rb", compressed_formats=None) as fh:
                 data = fh.read()
     for assertion_description in assertion_description_list:
-        verify_assertion(data, assertion_description)
+        verify_assertion(data, assertion_description, sep=sep)
 
 
-def verify_assertion(data: bytes, assertion_description):
+def verify_assertion(data: bytes, assertion_description, sep: str = None):
     tag = assertion_description["tag"]
     assert_function_name = "assert_" + tag
     assert_function = assertion_functions.get(assert_function_name)
@@ -102,6 +102,10 @@ def verify_assertion(data: bytes, assertion_description):
 
     if "children" in assert_function_args:
         args["children"] = assertion_description["children"]
+
+    # Only set sep if the assertion accepts it and it's not already specified in XML
+    if "sep" in assert_function_args and sep is not None and "sep" not in assertion_description["attributes"]:
+        args["sep"] = sep
 
     # TODO: Verify all needed function arguments are specified.
     assert_function(**args)

--- a/lib/galaxy/tool_util/verify/asserts/__init__.py
+++ b/lib/galaxy/tool_util/verify/asserts/__init__.py
@@ -8,6 +8,7 @@ from tempfile import NamedTemporaryFile
 from typing import (
     Callable,
     Dict,
+    Optional,
     Tuple,
 )
 
@@ -41,7 +42,7 @@ for assertion_module_name in assertion_module_names:
 assertion_functions: Dict[str, Callable] = {k: v[1] for (k, v) in assertion_module_and_functions.items()}
 
 
-def verify_assertions(data: bytes, assertion_description_list: list, decompress: bool = False, sep: str = None):
+def verify_assertions(data: bytes, assertion_description_list: list, decompress: bool = False, sep: Optional[str] = None):
     """This function takes a list of assertions and a string to check
     these assertions against."""
     if decompress:
@@ -54,7 +55,7 @@ def verify_assertions(data: bytes, assertion_description_list: list, decompress:
         verify_assertion(data, assertion_description, sep=sep)
 
 
-def verify_assertion(data: bytes, assertion_description, sep: str = None):
+def verify_assertion(data: bytes, assertion_description, sep: Optional[str] = None):
     tag = assertion_description["tag"]
     assert_function_name = "assert_" + tag
     assert_function = assertion_functions.get(assert_function_name)

--- a/lib/galaxy/tool_util/verify/asserts/__init__.py
+++ b/lib/galaxy/tool_util/verify/asserts/__init__.py
@@ -42,7 +42,9 @@ for assertion_module_name in assertion_module_names:
 assertion_functions: Dict[str, Callable] = {k: v[1] for (k, v) in assertion_module_and_functions.items()}
 
 
-def verify_assertions(data: bytes, assertion_description_list: list, decompress: bool = False, sep: Optional[str] = None):
+def verify_assertions(
+    data: bytes, assertion_description_list: list, decompress: bool = False, sep: Optional[str] = None
+):
     """This function takes a list of assertions and a string to check
     these assertions against."""
     if decompress:

--- a/lib/galaxy/tool_util/verify/asserts/tabular.py
+++ b/lib/galaxy/tool_util/verify/asserts/tabular.py
@@ -13,7 +13,9 @@ from ._types import (
 )
 from ._util import _assert_number
 
-Sep = Annotated[str, AssertionParameter("Separator defining columns, default: tab (or comma for csv)")]
+Sep = Annotated[
+    str, AssertionParameter("Separator defining columns, default: tab (or comma for csv with profile >= 26.0)")
+]
 Comment = Annotated[
     str,
     AssertionParameter(
@@ -55,8 +57,8 @@ def assert_has_n_columns(
 
     Optionally a column separator (``sep``) and comment character(s)
     can be specified (``comment``, default is empty string). The first non-comment
-    line is used for determining the number of columns. The default separator is
-    tab for most tabular data types, but comma for csv files.
+    line is used for determining the number of columns. For tools with profile >= 26.0,
+    the default separator is tab for most tabular data types, but comma for csv files.
     """
     first_line = get_first_line(output, comment)
     n_columns = len(first_line.split(sep))

--- a/lib/galaxy/tool_util/verify/asserts/tabular.py
+++ b/lib/galaxy/tool_util/verify/asserts/tabular.py
@@ -13,7 +13,7 @@ from ._types import (
 )
 from ._util import _assert_number
 
-Sep = Annotated[str, AssertionParameter("Separator defining columns, default: tab")]
+Sep = Annotated[str, AssertionParameter("Separator defining columns, default: tab (or comma for csv)")]
 Comment = Annotated[
     str,
     AssertionParameter(
@@ -53,9 +53,10 @@ def assert_has_n_columns(
     Number of columns can optionally also be specified with ``delta``. Alternatively the
     range of expected occurences can be specified by ``min`` and/or ``max``.
 
-    Optionally a column separator (``sep``, default is ``\t``) `and comment character(s)
+    Optionally a column separator (``sep``) and comment character(s)
     can be specified (``comment``, default is empty string). The first non-comment
-    line is used for determining the number of columns.
+    line is used for determining the number of columns. The default separator is
+    tab for most tabular data types, but comma for csv files.
     """
     first_line = get_first_line(output, comment)
     n_columns = len(first_line.split(sep))

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -140,6 +140,7 @@ class ValidToolTestDict(TypedDict):
     error: Literal[False]
     tool_id: str
     tool_version: str
+    profile: NotRequired[Optional[str]]
     test_index: int
 
 
@@ -147,6 +148,7 @@ class InvalidToolTestDict(TypedDict):
     error: Literal[True]
     tool_id: str
     tool_version: str
+    profile: NotRequired[Optional[str]]
     test_index: int
     inputs: Any
     exception: str
@@ -303,7 +305,13 @@ class GalaxyInteractorApi:
         return response.json()
 
     def verify_output_collection(
-        self, output_collection_def, output_collection_id, history, tool_id, tool_version=None
+        self,
+        output_collection_def,
+        output_collection_id,
+        history,
+        tool_id,
+        tool_version=None,
+        profile: Optional[str] = None,
     ):
         data_collection = self._get(
             f"dataset_collections/{output_collection_id}", data={"instance_type": "history"}
@@ -319,6 +327,7 @@ class GalaxyInteractorApi:
                     attributes=element_attrib,
                     tool_id=tool_id,
                     tool_version=tool_version,
+                    profile=profile,
                 )
             except AssertionError as e:
                 raise AssertionError(
@@ -327,7 +336,17 @@ class GalaxyInteractorApi:
 
         verify_collection(output_collection_def, data_collection, verify_dataset)
 
-    def verify_output(self, history_id, jobs, output_data, output_testdef, tool_id, maxseconds, tool_version=None):
+    def verify_output(
+        self,
+        history_id,
+        jobs,
+        output_data,
+        output_testdef,
+        tool_id,
+        maxseconds,
+        tool_version=None,
+        profile: Optional[str] = None,
+    ):
         outfile = output_testdef.outfile
         attributes = output_testdef.attributes
         name = output_testdef.name
@@ -342,6 +361,7 @@ class GalaxyInteractorApi:
                 attributes=attributes,
                 tool_id=tool_id,
                 tool_version=tool_version,
+                profile=profile,
             )
         except AssertionError as e:
             raise AssertionError(f"Output {name}: {str(e)}")
@@ -378,6 +398,7 @@ class GalaxyInteractorApi:
                     primary_attributes,
                     tool_id=tool_id,
                     tool_version=tool_version,
+                    profile=profile,
                 )
             except AssertionError as e:
                 raise AssertionError(f"Primary output {name}: {str(e)}")
@@ -386,7 +407,9 @@ class GalaxyInteractorApi:
         for job in jobs:
             self.wait_for_job(job["id"], history_id, maxseconds)
 
-    def verify_output_dataset(self, history_id, hda_id, outfile, attributes, tool_id, tool_version=None):
+    def verify_output_dataset(
+        self, history_id, hda_id, outfile, attributes, tool_id, tool_version=None, profile: Optional[str] = None
+    ):
         fetcher = self.__dataset_fetcher(history_id)
         test_data_downloader = self.__test_data_downloader(tool_id, tool_version, attributes)
         verify_hid(
@@ -396,6 +419,7 @@ class GalaxyInteractorApi:
             dataset_fetcher=fetcher,
             test_data_downloader=test_data_downloader,
             keep_outputs_dir=self.keep_outputs_dir,
+            profile=profile,
         )
         self._verify_metadata(history_id, hda_id, attributes)
 
@@ -1300,6 +1324,7 @@ def verify_hid(
     test_data_downloader,
     dataset_fetcher=None,
     keep_outputs_dir: Optional[str] = None,
+    profile: Optional[str] = None,
 ):
     assert dataset_fetcher is not None
 
@@ -1322,6 +1347,7 @@ def verify_hid(
         get_filecontent=test_data_downloader,
         keep_outputs_dir=keep_outputs_dir,
         verify_extra_files=verify_extra_files,
+        profile=profile,
     )
 
 
@@ -1757,6 +1783,7 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                     tool_id=job["tool_id"],
                     maxseconds=maxseconds,
                     tool_version=testdef.tool_version,
+                    profile=testdef.profile,
                 )
             except Exception as e:
                 register_exception(e)
@@ -1816,7 +1843,11 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
             # the job completed so re-hit the API for more information.
             data_collection_id = data_collection_list[name]["id"]
             galaxy_interactor.verify_output_collection(
-                output_collection_def, data_collection_id, history, job["tool_id"]
+                output_collection_def,
+                data_collection_id,
+                history,
+                job["tool_id"],
+                profile=testdef.profile,
             )
         except Exception as e:
             register_exception(e)
@@ -1993,6 +2024,7 @@ class ToolTestDescription:
     name: str
     tool_id: str
     tool_version: Optional[str]
+    profile: Optional[str]
     test_index: int
     num_outputs: Optional[int]
     stdout: Optional[AssertionList]
@@ -2041,6 +2073,7 @@ class ToolTestDescription:
         self.request_schema = json_dict.get("request_schema", None)
         self.tool_id = json_dict["tool_id"]
         self.tool_version = json_dict.get("tool_version")
+        self.profile = json_dict.get("profile")
         self.maxseconds = json_dict.get("maxseconds")
 
     def test_data(self):
@@ -2067,6 +2100,7 @@ class ToolTestDescription:
             "test_index": self.test_index,
             "tool_id": self.tool_id,
             "tool_version": self.tool_version,
+            "profile": self.profile,
             "required_files": self.required_files,
             "required_data_tables": self.required_data_tables,
             "required_loc_files": self.required_loc_files,

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -135,6 +135,7 @@ def _description_from_tool_source(
 
     tool_id, tool_version = _tool_id_and_version(tool_source, tool_guid)
     processed_test_dict: Union[ValidToolTestDict, InvalidToolTestDict]
+    profile = tool_source.parse_profile()
     try:
         processed_inputs = _process_raw_inputs(
             tool_source,
@@ -144,7 +145,6 @@ def _description_from_tool_source(
             required_data_tables,
             required_loc_files,
         )
-        profile = tool_source.parse_profile()
         processed_test_dict = ValidToolTestDict(
             {
                 "inputs": processed_inputs,
@@ -172,7 +172,6 @@ def _description_from_tool_source(
             }
         )
     except Exception:
-        profile = tool_source.parse_profile()
         processed_test_dict = InvalidToolTestDict(
             {
                 "tool_id": tool_id,

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -144,6 +144,7 @@ def _description_from_tool_source(
             required_data_tables,
             required_loc_files,
         )
+        profile = tool_source.parse_profile()
         processed_test_dict = ValidToolTestDict(
             {
                 "inputs": processed_inputs,
@@ -164,16 +165,19 @@ def _description_from_tool_source(
                 "required_loc_files": required_loc_files,
                 "tool_id": tool_id,
                 "tool_version": tool_version,
+                "profile": profile,
                 "test_index": test_index,
                 "maxseconds": maxseconds,
                 "error": False,
             }
         )
     except Exception:
+        profile = tool_source.parse_profile()
         processed_test_dict = InvalidToolTestDict(
             {
                 "tool_id": tool_id,
                 "tool_version": tool_version,
+                "profile": profile,
                 "test_index": test_index,
                 "inputs": {},
                 "error": True,

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2606,9 +2606,10 @@ For instance, ``<has_n_columns n="3"/>``. The assertion tests only the first lin
 Number of columns can optionally also be specified with ``delta``. Alternatively the
 range of expected occurences can be specified by ``min`` and/or ``max``.
 
-Optionally a column separator (``sep``, default is ``       ``) `and comment character(s)
+Optionally a column separator (``sep``) and comment character(s)
 can be specified (``comment``, default is empty string). The first non-comment
-line is used for determining the number of columns.
+line is used for determining the number of columns. The default separator is
+tab for most tabular data types, but comma for csv files.
 
 $attribute_list::5]]></xs:documentation>
         </xs:annotation>
@@ -2635,7 +2636,7 @@ $attribute_list::5]]></xs:documentation>
           </xs:attribute>
           <xs:attribute name="sep" type="xs:string" use="optional">
             <xs:annotation>
-              <xs:documentation xml:lang="en"><![CDATA[Separator defining columns, default: tab]]></xs:documentation>
+              <xs:documentation xml:lang="en"><![CDATA[Separator defining columns, default: tab (or comma for csv)]]></xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="comment" type="xs:string" use="optional">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2608,8 +2608,8 @@ range of expected occurences can be specified by ``min`` and/or ``max``.
 
 Optionally a column separator (``sep``) and comment character(s)
 can be specified (``comment``, default is empty string). The first non-comment
-line is used for determining the number of columns. The default separator is
-tab for most tabular data types, but comma for csv files.
+line is used for determining the number of columns. For tools with profile >= 26.0,
+the default separator is tab for most tabular data types, but comma for csv files.
 
 $attribute_list::5]]></xs:documentation>
         </xs:annotation>
@@ -2636,7 +2636,7 @@ $attribute_list::5]]></xs:documentation>
           </xs:attribute>
           <xs:attribute name="sep" type="xs:string" use="optional">
             <xs:annotation>
-              <xs:documentation xml:lang="en"><![CDATA[Separator defining columns, default: tab (or comma for csv)]]></xs:documentation>
+              <xs:documentation xml:lang="en"><![CDATA[Separator defining columns, default: tab (or comma for csv with profile >= 26.0)]]></xs:documentation>
             </xs:annotation>
           </xs:attribute>
           <xs:attribute name="comment" type="xs:string" use="optional">

--- a/test/unit/tool_util/test_verify_function.py
+++ b/test/unit/tool_util/test_verify_function.py
@@ -93,3 +93,79 @@ def test_sim_size_failure_still_updates(tmp_path):
     assert assertion_error
     assert (tmp_path / filename).exists()
     assert (tmp_path / filename).open("rb").read() == b"expected"
+
+
+def test_csv_ftype_auto_sep():
+    """test that ftype='csv' automatically sets separator for has_n_columns assertion"""
+    item_label = "csv test"
+    output_content = b"col1,col2,col3\n"
+    attributes = {
+        "ftype": "csv",
+        "assert_list": [
+            {
+                "tag": "has_n_columns",
+                "attributes": {"n": "3"},
+                "children": [],
+            }
+        ],
+    }
+    
+    # This should pass because ftype="csv" triggers sep="," auto-detection
+    verify(
+        item_label,
+        output_content,
+        attributes=attributes,
+        filename=None,
+        get_filecontent=t_data_downloader_for(output_content),
+    )
+
+
+def test_tabular_ftype_auto_sep():
+    """test that ftype='tabular' uses tab separator for has_n_columns assertion"""
+    item_label = "tabular test"
+    output_content = b"col1\tcol2\tcol3\n"
+    attributes = {
+        "ftype": "tabular",
+        "assert_list": [
+            {
+                "tag": "has_n_columns",
+                "attributes": {"n": "3"},
+                "children": [],
+            }
+        ],
+    }
+    
+    # This should pass because ftype="tabular" triggers sep="\t" (default)
+    verify(
+        item_label,
+        output_content,
+        attributes=attributes,
+        filename=None,
+        get_filecontent=t_data_downloader_for(output_content),
+    )
+
+
+def test_csv_ftype_explicit_sep_override():
+    """test that explicit sep in assertion overrides ftype='csv' auto-detection"""
+    item_label = "csv with explicit sep test"
+    # Tab-separated data (not comma-separated!)
+    output_content = b"col1\tcol2\tcol3\n"
+    attributes = {
+        "ftype": "csv",  # ftype is csv but data is actually tab-separated
+        "assert_list": [
+            {
+                "tag": "has_n_columns",
+                "attributes": {"n": "3", "sep": "\t"},  # Explicit sep overrides
+                "children": [],
+            }
+        ],
+    }
+    
+    # This should pass because explicit sep="\t" overrides the ftype="csv" auto-detection
+    verify(
+        item_label,
+        output_content,
+        attributes=attributes,
+        filename=None,
+        get_filecontent=t_data_downloader_for(output_content),
+    )

--- a/test/unit/tool_util/test_verify_function.py
+++ b/test/unit/tool_util/test_verify_function.py
@@ -109,7 +109,7 @@ def test_csv_ftype_auto_sep():
             }
         ],
     }
-    
+
     # This should pass because ftype="csv" triggers sep="," auto-detection
     verify(
         item_label,
@@ -134,7 +134,7 @@ def test_tabular_ftype_auto_sep():
             }
         ],
     }
-    
+
     # This should pass because ftype="tabular" triggers sep="\t" (default)
     verify(
         item_label,
@@ -160,7 +160,7 @@ def test_csv_ftype_explicit_sep_override():
             }
         ],
     }
-    
+
     # This should pass because explicit sep="\t" overrides the ftype="csv" auto-detection
     verify(
         item_label,

--- a/test/unit/tool_util/test_verify_function.py
+++ b/test/unit/tool_util/test_verify_function.py
@@ -95,9 +95,9 @@ def test_sim_size_failure_still_updates(tmp_path):
     assert (tmp_path / filename).open("rb").read() == b"expected"
 
 
-def test_csv_ftype_auto_sep():
-    """test that ftype='csv' automatically sets separator for has_n_columns assertion"""
-    item_label = "csv test"
+def test_csv_ftype_auto_sep_profile_26():
+    """For profile >= 26.0, ftype='csv' automatically sets separator for has_n_columns."""
+    item_label = "csv test profile 26.0"
     output_content = b"col1,col2,col3\n"
     attributes = {
         "ftype": "csv",
@@ -110,14 +110,48 @@ def test_csv_ftype_auto_sep():
         ],
     }
 
-    # This should pass because ftype="csv" triggers sep="," auto-detection
+    # With profile >= 26.0, ftype="csv" triggers sep="," auto-detection
     verify(
         item_label,
         output_content,
         attributes=attributes,
         filename=None,
         get_filecontent=t_data_downloader_for(output_content),
+        profile="26.0",
     )
+
+
+def test_csv_ftype_auto_sep_legacy_profile():
+    """Without profile, default behavior still uses tab separator for has_n_columns."""
+    item_label = "csv test legacy profile"
+    output_content = b"col1,col2,col3\n"
+    attributes = {
+        "ftype": "csv",
+        "assert_list": [
+            {
+                "tag": "has_n_columns",
+                "attributes": {"n": "3"},
+                "children": [],
+            }
+        ],
+    }
+
+    # Without a profile, sep auto-detection is not applied, so the default
+    # separator remains a tab character. Splitting a comma-separated line on
+    # tabs yields 1 column instead of 3, so this should raise an AssertionError.
+    raised = False
+    try:
+        verify(
+            item_label,
+            output_content,
+            attributes=attributes,
+            filename=None,
+            get_filecontent=t_data_downloader_for(output_content),
+        )
+    except AssertionError:
+        raised = True
+
+    assert raised
 
 
 def test_tabular_ftype_auto_sep():


### PR DESCRIPTION
basically encountered counterintuitive behavior where has_n_columns assertion in tests for a tool that output csv kept failing saying it only saw 1 column in the file. delimiter apparently defaults to tab for csv ftype. apparently i can explicitly set sep for csv to make this work, which is great, outside the fact i had no idea i needed to. id rather not need to, so this pr represents a proposal to change the delimiter based on ftype. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
