### PR TITLE
[25.1] Add PNTS datatype for 3D Tiles Point Cloud

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -148,6 +148,7 @@
     </datatype>
     <datatype extension="pnts" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" display_in_upload="true" description="3D Tiles Point Cloud (PNTS) binary format for Cesium visualization" description_url="https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/PointCloud">
         <infer_from suffix="pnts" />
+    </datatype>
     <datatype extension="d3_hierarchy" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true"/>
     <datatype extension="cytoscapejson" type="galaxy.datatypes.text:CytoscapeJson" mimetype="application/json" display_in_upload="true" description="Cytoscape JSON format for network visualization, typically containing 'nodes' and 'edges' in a JSON object." description_url="https://js.cytoscape.org/#notation/elements-json" />
     <datatype extension="freq.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="True" description="A JSON-formatted array of objects containing longitude, latitude, and frequency attributes."/>

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -146,6 +146,8 @@
     <datatype extension="laz" type="galaxy.datatypes.binary:Binary" mimetype="application/vnd.laszip" subclass="true" display_in_upload="true" description="LAZ is an open format for lossless compression of LAS." description_url="https://downloads.rapidlasso.de/doc/laszip.pdf">
         <infer_from suffix="laz" />
     </datatype>
+    <datatype extension="pnts" type="galaxy.datatypes.binary:Binary" mimetype="application/octet-stream" display_in_upload="true" description="3D Tiles Point Cloud (PNTS) binary format for Cesium visualization" description_url="https://github.com/CesiumGS/3d-tiles/tree/main/specification/TileFormats/PointCloud">
+        <infer_from suffix="pnts" />
     <datatype extension="d3_hierarchy" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true"/>
     <datatype extension="cytoscapejson" type="galaxy.datatypes.text:CytoscapeJson" mimetype="application/json" display_in_upload="true" description="Cytoscape JSON format for network visualization, typically containing 'nodes' and 'edges' in a JSON object." description_url="https://js.cytoscape.org/#notation/elements-json" />
     <datatype extension="freq.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="True" description="A JSON-formatted array of objects containing longitude, latitude, and frequency attributes."/>


### PR DESCRIPTION
I have added a new datatype for the visualization of point clouds.
Example file is added: https://github.com/galaxyproject/galaxy-test-data/pull/79
Please let me know if you need any further tests.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
