### PR TITLE
[25.0] Use a new format tox environment in lint GitHub action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,7 +56,5 @@ jobs:
         run: tox -e lint_docstring_include_list
       - name: Run mypy checks
         run: tox -e mypy
-      - uses: psf/black@stable
-        with:
-          version: ">=25.1.0"
-      - uses: isort/isort-action@v1
+      - name: Run format checks
+        run: tox -e format

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 # hyphens in an environment name are used to delimit factors
 envlist =
     first_startup
+    format
     lint
     lint_docstring_include_list
     mypy
@@ -16,6 +17,8 @@ skipsdist = True
 [testenv]
 commands =
     first_startup: bash .ci/first_startup.sh
+    format: isort --check --diff .
+    format: black --check --diff .
     lint: ruff check .
     # Once we are happy to replace flake8 with ruff, we can replace the next line with `black --check --diff`
     # (since ruff delegates to black for checking/fixing many rules).
@@ -31,6 +34,8 @@ commands =
     test_galaxy_packages_for_pulsar: bash packages/test.sh --for-pulsar
 allowlist_externals =
     bash
+    black
+    isort
     make
 passenv =
     CI
@@ -52,6 +57,7 @@ setenv =
     unit: marker=not external_dependency_management
 deps =
     coverage: coverage
+    format: -rlib/galaxy/dependencies/dev-requirements.txt
     lint,lint_docstring,lint_docstring_include_list: -rlib/galaxy/dependencies/pinned-lint-requirements.txt
     mypy: -rlib/galaxy/dependencies/pinned-typecheck-requirements.txt
     mypy: -rlib/galaxy/dependencies/pinned-requirements.txt


### PR DESCRIPTION
black 25.12.0 has dropped support for Python 3.9 and the psf/black@stable action fails with:

```
Traceback (most recent call last):
  File "/home/runner/work/_actions/psf/black/stable/action/main.py", line 98, in <module>
    def find_black_version_in_array(array: object) -> str | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
