### PR TITLE
Assorted tool shed fixes.

### DIFF
--- a/lib/tool_shed/webapp/frontend/CLAUDE.md
+++ b/lib/tool_shed/webapp/frontend/CLAUDE.md
@@ -1,0 +1,75 @@
+# Tool Shed 2.0 Frontend
+
+Vue 3 + TypeScript frontend for the Galaxy Tool Shed.
+
+## Stack
+- **Framework**: Vue 3 (Composition API + Options API mix)
+- **Build**: Vite 4
+- **UI**: Quasar 2
+- **State**: Pinia stores
+- **API**: openapi-fetch with generated TypeScript types
+- **Router**: vue-router 4
+
+## Structure
+```
+src/
+├── api/           # API wrapper functions
+├── components/    # Vue components
+│   ├── pages/     # Route-level page components
+│   └── help/      # Help section components
+├── schema/        # OpenAPI-generated types + client
+├── stores/        # Pinia stores (auth, categories, repository, users)
+├── main.ts        # App entry
+├── router.ts      # Vue Router setup
+└── routes.ts      # Route definitions
+```
+
+## Development
+
+```shell
+# Start dev server (port 4040)
+yarn dev
+
+# Build
+yarn build
+
+# Typecheck
+yarn typecheck
+
+# Lint
+yarn lint
+
+# Format
+yarn format
+```
+
+Backend must be running with `TOOL_SHED_API_VERSION=v2`:
+```shell
+# From galaxy root
+TOOL_SHED_API_VERSION=v2 ./run_tool_shed.sh
+```
+
+For rapid local dev with bootstrapped data:
+```shell
+TOOL_SHED_CONFIG_OVERRIDE_BOOTSTRAP_ADMIN_API_KEY=tsadminkey \
+TOOL_SHED_CONFIG_CONFIG_HG_FOR_DEV=1 \
+TOOL_SHED_VITE_PORT=4040 \
+TOOL_SHED_API_VERSION=v2 \
+./run_tool_shed.sh
+```
+
+## API Pattern
+API calls use openapi-fetch typed client via `ToolShedApi()` in `src/schema/client.ts`:
+```typescript
+import { ToolShedApi } from "@/schema"
+const { data } = await ToolShedApi().GET("/api/repositories", { params: { query: params } })
+```
+
+## Key Components
+- `ShedToolbar.vue` - Main navigation toolbar
+- `RepositoryPage.vue` - Single repository view
+- `LandingPage.vue` - Homepage
+- `PaginatedRepositoriesGrid.vue` - Repository listing grid
+
+## Path Alias
+`@/` maps to `src/` directory.

--- a/lib/tool_shed/webapp/frontend/CLAUDE.md
+++ b/lib/tool_shed/webapp/frontend/CLAUDE.md
@@ -73,3 +73,33 @@ const { data } = await ToolShedApi().GET("/api/repositories", { params: { query:
 
 ## Path Alias
 `@/` maps to `src/` directory.
+
+## Accessibility (WCAG 2.1 AA)
+
+### Key Patterns
+- **Skip link**: `App.vue` - hidden until focused, targets `#main-content`
+- **Landmarks**: `role="banner"` on header, `role="main"` on page container
+- **Live regions**: `ErrorBanner.vue` uses `role="alert"`, `LoadingDiv.vue` uses `role="status"`
+- **Icon buttons**: Use `aria-label` not `title` for accessible names
+- **Focus indicators**: Global `:focus-visible` styles in `App.vue`
+
+### Components with ARIA
+| Component | ARIA Attrs |
+|-----------|------------|
+| `App.vue` | Skip link, landmarks, focus CSS |
+| `ShedToolbar.vue` | `aria-label` on icon buttons, `aria-haspopup` on dropdowns |
+| `ErrorBanner.vue` | `role="alert"`, `aria-live="assertive"` |
+| `LoadingDiv.vue` | `role="status"`, `aria-live="polite"` |
+| `RepositoryExplore.vue` | `aria-label` on FAB and icon buttons |
+| `PaginatedRepositoriesGrid.vue` | `aria-label` on table |
+
+### Quasar Notes
+- `q-btn-dropdown` auto-manages `aria-expanded`
+- `q-select` has built-in label association
+- Use `aria-label` on icon-only `q-btn` components
+- FABs (`q-fab`) need explicit `aria-label` on trigger
+
+### Notification System
+- `util.ts` `notify()` - uses Quasar Notify (toast messages)
+- `ErrorBanner.vue` - inline persistent errors with dismiss
+- `LoadingDiv.vue` - spinner with status message

--- a/lib/tool_shed/webapp/frontend/README.md
+++ b/lib/tool_shed/webapp/frontend/README.md
@@ -19,6 +19,8 @@ If you want to target an external V2 tool shed API run
 TOOL_SHED_URL=https://testtoolshed.g2.bx.psu.edu CHANGE_ORIGIN=true yarn vite dev
 ```
 
+To login when targeting an external backend, you need to get the `session_csrf_token` cookie set first. Visit `/backend_session` in your browser before logging in - this proxies to the backend's root route which sets the required cookie.
+
 Note that you still need a local backend to generate the graphql schema.
 
 To run a local toolshed patched for rapid bootstrapping and in local Vite dev server mode

--- a/lib/tool_shed/webapp/frontend/src/App.vue
+++ b/lib/tool_shed/webapp/frontend/src/App.vue
@@ -1,10 +1,11 @@
 <template>
     <div>
+        <a href="#main-content" class="skip-link">Skip to main content</a>
         <q-layout view="hHh lpR fFf">
-            <q-header elevated>
+            <q-header elevated role="banner">
                 <ShedToolbar title="Galaxy Tool Shed" />
             </q-header>
-            <q-page-container>
+            <q-page-container id="main-content" role="main">
                 <router-view />
             </q-page-container>
         </q-layout>
@@ -24,6 +25,26 @@ export default defineComponent({
 </script>
 
 <style lang="sass">
+// Skip link - visually hidden until focused
+.skip-link
+  position: absolute
+  top: -40px
+  left: 0
+  background: $primary
+  color: white
+  padding: 8px 16px
+  z-index: 9999
+  text-decoration: none
+  font-weight: bold
+  border-radius: 0 0 4px 0
+  &:focus
+    top: 0
+
+// Focus indicators for keyboard navigation
+*:focus-visible
+  outline: 3px solid $accent !important
+  outline-offset: 2px
+
 // A choice, provides more contrast but is ultimately a bit
 // too programmer app circa 2005?
 //body

--- a/lib/tool_shed/webapp/frontend/src/components/ErrorBanner.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/ErrorBanner.vue
@@ -28,7 +28,14 @@ const effectiveShow = computed(() => props.error && show.value)
 
 <template>
     <div class="q-pa-md q-gutter-sm">
-        <q-banner inline-actions rounded class="bg-negative text-white" v-if="effectiveShow">
+        <q-banner
+            inline-actions
+            rounded
+            class="bg-negative text-white"
+            role="alert"
+            aria-live="assertive"
+            v-if="effectiveShow"
+        >
             <strong>{{ props.error }}</strong>
             <template #action>
                 <q-btn flat label="Dismiss" @click="dismiss" />

--- a/lib/tool_shed/webapp/frontend/src/components/LoadingDiv.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/LoadingDiv.vue
@@ -9,7 +9,7 @@ withDefaults(defineProps<LoadingProps>(), {
 </script>
 
 <template>
-    <div class="q-pa-md">
+    <div class="q-pa-md" role="status" aria-live="polite" aria-busy="true">
         <div class="fit q-gutter-md row">
             <q-spinner color="info" size="4em" :thickness="10" />
             <span class="loading-message text-info" style="font-size: 2em"

--- a/lib/tool_shed/webapp/frontend/src/components/LoginForm.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/LoginForm.vue
@@ -2,6 +2,8 @@
 import { ref } from "vue"
 import { AUTH_FORM_INPUT_PROPS } from "@/constants"
 import { useAuthStore } from "@/stores"
+import { errorMessageAsString } from "@/util"
+import ErrorBanner from "@/components/ErrorBanner.vue"
 
 interface LoginFormProps {
     initialLogin?: string | null
@@ -13,14 +15,21 @@ const props = withDefaults(defineProps<LoginFormProps>(), {
 
 const login = ref(props.initialLogin || "")
 const password = ref("")
+const errorMessage = ref<string | null>(null)
 
 async function onLogin() {
+    errorMessage.value = null
     const authStore = useAuthStore()
-    return authStore.login(login.value, password.value)
+    try {
+        await authStore.login(login.value, password.value)
+    } catch (e) {
+        errorMessage.value = errorMessageAsString(e)
+    }
 }
 </script>
 <template>
     <q-form class="q-gutter-md" action="#" @submit.prevent="onLogin">
+        <error-banner v-if="errorMessage" :error="errorMessage" @dismiss="errorMessage = null" />
         <q-input v-bind="AUTH_FORM_INPUT_PROPS" v-model="login" type="text" label="Username / Email" name="login" />
         <q-input v-bind="AUTH_FORM_INPUT_PROPS" v-model="password" type="password" label="Password" name="password" />
         <q-card-actions class="q-px-md">

--- a/lib/tool_shed/webapp/frontend/src/components/PaginatedRepositoriesGrid.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/PaginatedRepositoriesGrid.vue
@@ -53,7 +53,7 @@ const initialPage = computed(() => {
 const pagination = ref({
     page: initialPage.value,
     rowsNumber: undefined as number | undefined,
-    rowsPerPage: rowsPerPage,
+    rowsPerPage: rowsPerPage.value,
 })
 
 const INDEX_COLUMN: QTableColumn = {
@@ -145,6 +145,11 @@ watch(
     }
 )
 
+// Sync rowsPerPage when route query changes
+watch(rowsPerPage, (newVal) => {
+    pagination.value.rowsPerPage = newVal
+})
+
 onMounted(() => {
     makeRequest()
 })
@@ -192,7 +197,7 @@ onMounted(() => {
                     class="disable-hover-hack"
                 >
                     <q-td colspan="100%">
-                        <span class="text-weight-regular q-ml-md text-grey">
+                        <span class="text-weight-regular q-ml-md text-grey description-truncate">
                             {{ props.row.description }}
                         </span>
                     </q-td>
@@ -205,6 +210,14 @@ onMounted(() => {
 <style>
 .disable-hover-hack > td::before {
     background: rgba(0, 0, 0, 0) !important;
+}
+
+.description-truncate {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
 }
 </style>
 <!-- https://codepen.io/smolinari/pen/bGVxKPE -->

--- a/lib/tool_shed/webapp/frontend/src/components/PaginatedRepositoriesGrid.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/PaginatedRepositoriesGrid.vue
@@ -163,6 +163,7 @@ onMounted(() => {
             :rows-per-page-options="[rowsPerPage]"
             :no-data-label="noDataLabel"
             hide-header
+            :aria-label="title"
             @request="onRequest"
         >
             <template #top>

--- a/lib/tool_shed/webapp/frontend/src/components/PaginatedRepositoriesGrid.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/PaginatedRepositoriesGrid.vue
@@ -147,7 +147,7 @@ onMounted(() => {
                         <span class="text-weight-bold">
                             <repository-link :id="props.row.id" :name="props.row.name" :owner="props.row.owner" />
                         </span>
-                        <repository-explore :repository="props.row" :dense="true" />
+                        <repository-explore :repository="props.row" :dense="true" :show-details-link="true" />
                     </q-td>
                 </q-tr>
                 <q-tr

--- a/lib/tool_shed/webapp/frontend/src/components/RepositoryActions.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RepositoryActions.vue
@@ -33,7 +33,14 @@ type Emits = {
 const emits = defineEmits<Emits>()
 </script>
 <template>
-    <q-fab class="q-px-sm" color="secondary" text-color="primary" icon="settings" direction="down">
+    <q-fab
+        class="q-px-sm"
+        color="secondary"
+        text-color="primary"
+        icon="settings"
+        direction="down"
+        aria-label="Repository settings"
+    >
         <q-fab-action color="primary" icon="history" @click="resetMetadata" label="Reset Metadata" />
         <q-fab-action
             color="primary"

--- a/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
@@ -14,11 +14,13 @@ interface RepositoryExploreProps {
     repository: Repository
     currentRevision?: string | null
     dense?: boolean
+    showDetailsLink?: boolean
 }
 
 const props = withDefaults(defineProps<RepositoryExploreProps>(), {
     currentRevision: null,
     dense: false,
+    showDetailsLink: false,
 })
 
 const changelog = computed(() => `/repos/${props.repository.owner}/${[props.repository.name]}/shortlog`)
@@ -38,7 +40,12 @@ const buttonProperties = computed(() => {
 </script>
 <template>
     <q-fab class="q-px-md" color="secondary" text-color="primary" icon="explore" direction="down" v-if="!dense">
-        <q-fab-action icon="sym_r_overview" label="Details" @click="goToRepository(props.repository.id)" />
+        <q-fab-action
+            v-if="showDetailsLink"
+            icon="sym_r_overview"
+            label="Details"
+            @click="goToRepository(props.repository.id)"
+        />
         <!-- receipt_long? -->
         <q-fab-action icon="difference" label="Changelog" @click="navigate(changelog)" />
         <q-fab-action icon="list" label="Contents" @click="navigate(contents)" />

--- a/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
@@ -39,7 +39,15 @@ const buttonProperties = computed(() => {
 })
 </script>
 <template>
-    <q-fab class="q-px-md" color="secondary" text-color="primary" icon="explore" direction="down" v-if="!dense">
+    <q-fab
+        class="q-px-md"
+        color="secondary"
+        text-color="primary"
+        icon="explore"
+        direction="down"
+        aria-label="Explore repository"
+        v-if="!dense"
+    >
         <q-fab-action
             v-if="showDetailsLink"
             icon="sym_r_overview"
@@ -56,14 +64,28 @@ const buttonProperties = computed(() => {
             v-bind="buttonProperties"
             icon="sym_r_overview"
             title="Details"
+            aria-label="Details"
             @click="goToRepository(props.repository.id)"
         />
-        <q-btn v-bind="buttonProperties" icon="difference" title="Changelog" @click="navigate(changelog)" />
-        <q-btn v-bind="buttonProperties" icon="list" title="Contents" @click="navigate(contents)" />
+        <q-btn
+            v-bind="buttonProperties"
+            icon="difference"
+            title="Changelog"
+            aria-label="Changelog"
+            @click="navigate(changelog)"
+        />
+        <q-btn
+            v-bind="buttonProperties"
+            icon="list"
+            title="Contents"
+            aria-label="Contents"
+            @click="navigate(contents)"
+        />
         <q-btn
             v-bind="buttonProperties"
             icon="home"
             title="Homepage"
+            aria-label="Homepage"
             @click="navigate(repository.homepage_url)"
             v-if="repository.homepage_url"
         />
@@ -71,6 +93,7 @@ const buttonProperties = computed(() => {
             v-bind="buttonProperties"
             icon="code"
             title="Development Repository"
+            aria-label="Development Repository"
             @click="navigate(repository.remote_repository_url)"
             v-if="repository.remote_repository_url"
         />

--- a/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RepositoryExplore.vue
@@ -22,7 +22,7 @@ const props = withDefaults(defineProps<RepositoryExploreProps>(), {
 })
 
 const changelog = computed(() => `/repos/${props.repository.owner}/${[props.repository.name]}/shortlog`)
-const contents = computed(() => `/repos/${props.repository.owner}/${[props.repository.name]}/rev/tip`)
+const contents = computed(() => `/repos/${props.repository.owner}/${[props.repository.name]}/file/tip`)
 function navigate(location: string | null | undefined) {
     if (location) {
         window.location.href = location

--- a/lib/tool_shed/webapp/frontend/src/components/RepositoryHealth.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RepositoryHealth.vue
@@ -14,7 +14,14 @@ const installableColor = computed(() => (props.downloadable ? "green" : "red"))
 const props = defineProps<RepositoryHealthProps>()
 </script>
 <template>
-    <q-fab class="q-px-sm" color="secondary" text-color="primary" icon="troubleshoot" direction="down">
+    <q-fab
+        class="q-px-sm"
+        color="secondary"
+        text-color="primary"
+        icon="troubleshoot"
+        direction="down"
+        aria-label="Repository health"
+    >
         <q-fab-action color="secondary" text-color="black" icon="download" label="Downlodable">
             <q-badge :color="installableColor" rounded floating />
         </q-fab-action>

--- a/lib/tool_shed/webapp/frontend/src/components/RevisionActions.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RevisionActions.vue
@@ -53,7 +53,15 @@ type Emits = {
 const emits = defineEmits<Emits>()
 </script>
 <template>
-    <q-fab padding="sm" class="q-px-md" color="secondary" text-color="primary" icon="settings" direction="up">
+    <q-fab
+        padding="sm"
+        class="q-px-md"
+        color="secondary"
+        text-color="primary"
+        icon="settings"
+        direction="up"
+        aria-label="Revision settings"
+    >
         <q-fab-action
             color="primary"
             icon="history"

--- a/lib/tool_shed/webapp/frontend/src/components/SelectUser.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/SelectUser.vue
@@ -24,11 +24,13 @@ const allOptions = computed(() => users?.value.map((u) => u.username))
 const options = ref(allOptions.value)
 const selected = ref(null)
 
-const emit = defineEmits(["selectedUser"])
+const emit = defineEmits(["selectedUser", "cleared"])
 
 watch(selected, (user) => {
     if (user) {
         emit("selectedUser", user)
+    } else if (props.persistSelection) {
+        emit("cleared")
     }
     if (!props.persistSelection) {
         selected.value = null
@@ -52,11 +54,13 @@ const hideSelected = computed(() => !props.persistSelection)
         :dense="dense"
         filled
         use-input
+        clearable
         :hide-selected="hideSelected"
         :label="label"
         v-model="selected"
         input-debounce="0"
         @filter="filterFn"
+        @keyup.delete="selected = null"
         :options="options"
     />
 </template>

--- a/lib/tool_shed/webapp/frontend/src/components/ShedToolbar.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/ShedToolbar.vue
@@ -15,10 +15,10 @@ void authStore.setup()
 const admin = computed(() => authStore.user && authStore.user.is_admin)
 </script>
 <template>
-    <q-toolbar class="bg-primary glossy text-white">
+    <q-toolbar class="bg-primary glossy text-white" role="navigation" aria-label="Main navigation">
         <q-toolbar-title>
             <q-avatar rounded>
-                <router-link to="/">
+                <router-link to="/" aria-label="Tool Shed Home">
                     <img alt="Tool Shed Logo" src="/static/favicon.ico" />
                 </router-link>
             </q-avatar>
@@ -27,7 +27,7 @@ const admin = computed(() => authStore.user && authStore.user.is_admin)
                 {{ title }}
             </span>
         </q-toolbar-title>
-        <q-btn-dropdown stretch flat label="Explore">
+        <q-btn-dropdown stretch flat label="Explore" aria-haspopup="menu">
             <q-list>
                 <q-item-label header>Repositories</q-item-label>
                 <q-item clickable v-close-popup tabindex="0" to="/repositories_by_category">
@@ -55,7 +55,7 @@ const admin = computed(() => authStore.user && authStore.user.is_admin)
                 -->
             </q-list>
         </q-btn-dropdown>
-        <q-btn-dropdown stretch flat :label="authStore.user.username" v-if="authStore.user">
+        <q-btn-dropdown stretch flat :label="authStore.user.username" aria-haspopup="menu" v-if="authStore.user">
             <q-list>
                 <q-item clickable v-close-popup tabindex="0" to="/user/api_key">
                     <q-item-section>
@@ -71,7 +71,7 @@ const admin = computed(() => authStore.user && authStore.user.is_admin)
                 </q-item>
             </q-list>
         </q-btn-dropdown>
-        <q-btn-dropdown stretch flat label="Admin" v-if="admin">
+        <q-btn-dropdown stretch flat label="Admin" aria-haspopup="menu" v-if="admin">
             <q-list>
                 <q-item-label header>Admin Tools</q-item-label>
                 <q-item clickable v-close-popup tabindex="0" to="/admin">
@@ -101,9 +101,20 @@ const admin = computed(() => authStore.user && authStore.user.is_admin)
             icon="logout"
             @click="authStore.logout()"
             title="Logout"
+            aria-label="Logout"
             v-if="authStore.user"
         />
-        <q-btn class="q-mx-sm toolbar-login" flat round dense icon="login" to="/login" title="Login" v-else />
-        <q-btn class="q-mx-sm toolbar-help" flat round dense icon="help" to="/help" title="Help" />
+        <q-btn
+            class="q-mx-sm toolbar-login"
+            flat
+            round
+            dense
+            icon="login"
+            to="/login"
+            title="Login"
+            aria-label="Login"
+            v-else
+        />
+        <q-btn class="q-mx-sm toolbar-help" flat round dense icon="help" to="/help" title="Help" aria-label="Help" />
     </q-toolbar>
 </template>

--- a/lib/tool_shed/webapp/frontend/src/components/pages/RepositoriesByOwners.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/pages/RepositoriesByOwners.vue
@@ -17,6 +17,10 @@ const username = ref<string | null>(props.username)
 function onSelectUser(usernameStr: string) {
     username.value = usernameStr
 }
+
+function onCleared() {
+    username.value = null
+}
 </script>
 <template>
     <page-container>
@@ -25,6 +29,7 @@ function onSelectUser(usernameStr: string) {
             label="Select user to browse owner properties"
             v-if="!props.username"
             @selected-user="onSelectUser"
+            @cleared="onCleared"
             class="q-ma-md"
             :dense="false"
         >

--- a/lib/tool_shed/webapp/frontend/src/components/pages/RepositoriesBySearch.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/pages/RepositoriesBySearch.vue
@@ -87,7 +87,7 @@ watch(
 </script>
 <template>
     <page-container>
-        <q-input debounce="20" filled v-model="searchQuery" label="Search Repositories" />
+        <q-input debounce="1000" filled v-model="searchQuery" label="Search Repositories" />
         <PaginatedRepositoriesGrid
             ref="grid"
             v-if="searchQuery && searchQuery.length > 1"

--- a/lib/tool_shed/webapp/frontend/src/stores/auth.store.ts
+++ b/lib/tool_shed/webapp/frontend/src/stores/auth.store.ts
@@ -23,20 +23,16 @@ export const useAuthStore = defineStore({
         },
         async login(username: string, password: string) {
             const token = ensureCookie("session_csrf_token")
-            ToolShedApi()
-                .PUT("/api_internal/login", {
-                    body: {
-                        login: username,
-                        password: password,
-                        session_csrf_token: token,
-                    },
-                })
-                .then(async () => {
-                    // We need to do this outside the router to get updated
-                    // cookies and hence csrf token.
-                    window.location.href = "/login_success"
-                })
-                .catch(notifyOnCatch)
+            await ToolShedApi().PUT("/api_internal/login", {
+                body: {
+                    login: username,
+                    password: password,
+                    session_csrf_token: token,
+                },
+            })
+            // We need to do this outside the router to get updated
+            // cookies and hence csrf token.
+            window.location.href = "/login_success"
         },
         async logout() {
             const token = ensureCookie("session_csrf_token")

--- a/lib/tool_shed/webapp/frontend/vite.config.ts
+++ b/lib/tool_shed/webapp/frontend/vite.config.ts
@@ -27,6 +27,18 @@ export default defineConfig({
                 changeOrigin: process.env.CHANGE_ORIGIN ? !process.env.CHANGE_ORIGIN : true,
                 secure: !process.env.CHANGE_ORIGIN,
             },
+            "/api_internal": {
+                target: process.env.TOOL_SHED_URL || "http://127.0.0.1:9009",
+                changeOrigin: process.env.CHANGE_ORIGIN ? !process.env.CHANGE_ORIGIN : true,
+                secure: !process.env.CHANGE_ORIGIN,
+            },
+            // Proxy backend root to get session_csrf_token cookie - visit /backend_session first
+            "/backend_session": {
+                target: process.env.TOOL_SHED_URL || "http://127.0.0.1:9009",
+                changeOrigin: process.env.CHANGE_ORIGIN ? !process.env.CHANGE_ORIGIN : true,
+                secure: !process.env.CHANGE_ORIGIN,
+                rewrite: () => "/",
+            },
         },
     },
 })


### PR DESCRIPTION
## Tool Shed 2.1 Frontend Bug Fixes

Fixes several UI bugs reported in the new Tool Shed frontend.

### Changes

- **#21410**: Fix issue.
- **#21411**: Fix issue.
- **#21409**: Handle API errors in tool version page - show error message with metadata reset guidance instead of infinite spinner
- **#21403**: Fix search results race condition - discard stale results when newer search initiated
- **#21404**: Persist search query and page in URL for browser back/forward and shareable links
- **#21413**: Partial fix - add clearable button and delete key to owner select widget
- Increase search debounce (costly backend search)
- Add CLAUDE.md for frontend dev context

More changes after that:

**WCAG 2.1 AA accessibility improvements for Tool Shed frontend** (xref #21412)
- Add skip link and ARIA landmarks to App.vue
- Add `role="alert"` and `aria-live="assertive"` to ErrorBanner
- Add `role="status"` and `aria-live="polite"` to LoadingDiv
- Add `aria-haspopup` and `aria-label` to toolbar buttons/dropdowns
- Add `aria-label` to FABs in RepositoryExplore, RepositoryActions, RevisionActions, RepositoryHealth
- Add `aria-label` to PaginatedRepositoriesGrid table
- Add global `:focus-visible` styles

**Add accessible error announcements to login form**  (xref #21412)
- Use ErrorBanner in LoginForm for screen reader announcements
- Change auth.store.ts to throw errors instead of swallowing with notifyOnCatch

**Add proxy for external backend login in dev mode**
- Add `/api_internal` and `/backend_session` proxies in vite.config.ts
- `/backend_session` rewrites to backend root to set session_csrf_token cookie

I had Cursor exercise the UI and offer up random usability improvements

**Fix pagination "len" label bug and add description truncation**
- Fix rowsPerPage computed ref not unwrapped in pagination object
- Add watcher to sync rowsPerPage when route query changes
- Add CSS ellipsis truncation for long repository descriptions


## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Deploy to test toolshed from my branch, review each linked issue and navigate to the test toolshed and see if it is fixed 🤷‍♀️.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
