### PR TITLE
[25.1] A better way to designate config_watcher

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -551,6 +551,7 @@ class WorkerProcess(Base, UsesCreateAndUpdateTime):
     hostname: Mapped[Optional[str]] = mapped_column(String(255))
     pid: Mapped[Optional[int]]
     update_time: Mapped[Optional[datetime]] = mapped_column(default=now, onupdate=now)
+    app_type: Mapped[Optional[str]]
 
 
 def cached_id(galaxy_model_object):

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/63dc6cca023f_add_is_webapp_column_to_worker_process.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/63dc6cca023f_add_is_webapp_column_to_worker_process.py
@@ -1,0 +1,34 @@
+"""Add app_type column to worker_process
+
+Revision ID: 63dc6cca023f
+Revises: cd26484899fb
+Create Date: 2025-12-09 20:58:13.954728
+
+"""
+
+from sqlalchemy import (
+    Column,
+    String,
+)
+
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
+
+# revision identifiers, used by Alembic.
+revision = "63dc6cca023f"
+down_revision = "cd26484899fb"
+branch_labels = None
+depends_on = None
+
+table_name = "worker_process"
+column_name = "app_type"
+
+
+def upgrade():
+    add_column(table_name, Column(column_name, String))
+
+
+def downgrade():
+    drop_column(table_name, column_name)


### PR DESCRIPTION
This is an attempt to fix the tool search index rebuild bug that currently happens on Main. This does not fix the same issue on Test because the root cause of the error on Test is different.

On Main, the `rebuild_toolbox_search_index` task is queued on the `main.#` process, which is a webapp process. However, that process is not designated as the `config_watcher`, whereas the `config_watcher` process is not a webapp. As a result, [this](https://github.com/galaxyproject/galaxy/blob/release_25.1/lib/galaxy/queue_worker.py#L251) evaluates to false and the subsequent index build does not happen. This happens because of a mixup in the config watcher designation assignment (the process is selected based on an alphabetical ordering of process names, regardless of application types). This change ensures that only a web app process will be considered for a config_watcher (thank you for the suggestion, @mvdbeek!). I chose to store a boolean value (is or is not a webapp) instead of the application type, because checking for this criteria is straightforward.

The fix will happen upon galaxy restart. Not all records in the `worker_process` table will receive a value for the new column - but that's not a problem: one webapp process will be updated, which is all we need.

This has been tested on a local server with a simplified config reproducing the error on Test (successfully), and on Test (no fix, but no adverse effect either).



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
