### PR TITLE
Don't set OAUTHLIB_INSECURE_TRANSPORT setting in user_data

### DIFF
--- a/lib/galaxy/authnz/oidc.py
+++ b/lib/galaxy/authnz/oidc.py
@@ -12,7 +12,6 @@ Specific providers (Keycloak, CILogon, etc.) should inherit from this class.
 """
 
 import logging
-import os
 
 from pkce import generate_pkce_pair
 from social_core.backends.open_id_connect import OpenIdConnectAuth
@@ -84,18 +83,3 @@ class GalaxyOpenIdConnect(OpenIdConnectAuth):
                     pass
 
         return params
-
-    def user_data(self, access_token, *args, **kwargs):
-        """
-        Fetch user data from the userinfo endpoint.
-
-        Override to enable localhost development mode with relaxed SSL requirements.
-        For security, this ONLY applies to http://localhost: URLs.
-        """
-        # Allow insecure transport ONLY for HTTP (not HTTPS) localhost development
-        if self.redirect_uri and self.redirect_uri.startswith("http://localhost:"):
-            if os.environ.get("OAUTHLIB_INSECURE_TRANSPORT") != "1":
-                log.warning("Setting OAUTHLIB_INSECURE_TRANSPORT to '1' for localhost development")
-                os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
-
-        return super().user_data(access_token, *args, **kwargs)

--- a/test/integration/oidc/test_auth_oidc.py
+++ b/test/integration/oidc/test_auth_oidc.py
@@ -107,7 +107,7 @@ class AbstractTestCases:
         # regex to find the action attribute on the HTML login page
         #   returned by Keycloak
         REGEX_KEYCLOAK_LOGIN_ACTION = re.compile(r"action=\"(.*?)\"\s+")
-        REGEX_GALAXY_CSRF_TOKEN = re.compile(r"session_csrf_token\": \"(.*)\"")
+        REGEX_GALAXY_CSRF_TOKEN = re.compile(r"session_csrf_token = \"(.*)\"")
         container_name: ClassVar[str]
         backend_config_file: ClassVar[str]
         provider_name: ClassVar[str]
@@ -212,7 +212,6 @@ class TestGalaxyOIDCLoginIntegration(AbstractTestCases.BaseKeycloakIntegrationTe
     This test now uses the unified PSA-based Keycloak backend.
     """
 
-    REGEX_GALAXY_CSRF_TOKEN = re.compile(r"session_csrf_token = \"(.*)\"")
     provider_name = "keycloak"
 
     @classmethod

--- a/test/unit/authnz/test_oidc_backends.py
+++ b/test/unit/authnz/test_oidc_backends.py
@@ -288,42 +288,6 @@ class TestJWKSSupport:
         assert result == [{"kid": "key1", "kty": "RSA"}]
 
 
-class TestLocalhostDevelopmentMode:
-    """Test localhost development mode handling."""
-
-    @patch.dict("os.environ", {}, clear=True)
-    def test_localhost_sets_insecure_transport(self):
-        """Should set OAUTHLIB_INSECURE_TRANSPORT for localhost."""
-        import os
-
-        from galaxy.authnz.oidc import GalaxyOpenIdConnect
-
-        strategy = MockStrategy()
-        backend = KeycloakOpenIdConnect(strategy, redirect_uri="http://localhost:8080/callback")
-
-        # Mock parent's user_data to avoid actual API calls
-        with patch.object(GalaxyOpenIdConnect.__bases__[0], "user_data", return_value={}):
-            backend.user_data({"access_token": "test"})
-
-        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT") == "1"
-
-    def test_https_does_not_set_insecure_transport(self):
-        """Should not set OAUTHLIB_INSECURE_TRANSPORT for non-localhost HTTP."""
-        # Test the logic: only http://localhost: URLs should set the env var
-        test_cases = [
-            ("https://example.com/callback", False),
-            ("https://localhost:8080/callback", False),
-            ("http://example.com/callback", False),
-            ("http://localhost:8080/callback", True),
-            ("http://localhost:80/callback", True),
-        ]
-
-        for redirect_uri, should_set_env in test_cases:
-            # Check if the condition in the backend would trigger
-            should_set = redirect_uri and redirect_uri.startswith("http://localhost:")
-            assert should_set == should_set_env, f"Logic error for {redirect_uri}"
-
-
 class TestBackendInstantiation:
     """Test backend instantiation and configuration."""
 


### PR DESCRIPTION
This PR:
1. Remove setting OAUTHLIB_INSECURE_TRANSPORT in code. Admins wishing to test insecure localhost redirect endpoints will need to set the environment variable OAUTHLIB_INSECURE_TRANSPORT manually.
2. Removes unnecessary test code
3. Fixes an error when parsing session token

Fixes: https://github.com/galaxyproject/galaxy/pull/21234#discussion_r2614442820

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
