### PR TITLE
[25.1] Record input parameter invocation inputs

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1029,13 +1029,6 @@ class InputModule(WorkflowModule):
                     step_outputs["input_ds_copy"] = new_hdca
                 else:
                     raise Exception("Unknown history content encountered")
-        # If coming from UI - we haven't registered invocation inputs yet,
-        # so do that now so dependent steps can be recalculated. In the future
-        # everything should come in from the API and this can be eliminated.
-        if not invocation.has_input_for_step(step.id):
-            content = next(iter(step_outputs.values()))
-            if content and content is not NO_REPLACEMENT:
-                invocation.add_input(content, step.id)
         progress.set_outputs_for_input(invocation_step, step_outputs)
         return None
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -623,6 +623,12 @@ class WorkflowProgress:
 
         if step.label and step.type == "parameter_input" and "output" in outputs:
             self.runtime_replacements[step.label] = str(outputs["output"])
+        invocation = invocation_step.workflow_invocation
+        if not invocation.has_input_for_step(step.id):
+            content = outputs.get("output", NO_REPLACEMENT)
+            if content is not NO_REPLACEMENT:
+                log.info("ADDING INPUT FOR STEP %s: %s", step.id, content, exc_info=True)
+                invocation.add_input(content, step.id)
         self.set_step_outputs(invocation_step, outputs, already_persisted=already_persisted)
 
     def effective_replacement_dict(self):

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -94,8 +94,7 @@ class TestWorkflowProgress(TestCase):
                 workflow_invocation_step.state = "scheduled"
                 workflow_invocation_step.workflow_step = self._step(i)
                 assert step_id == self._step(i).id
-                # workflow_invocation_step.workflow_invocation = self.invocation
-                self.invocation.steps.append(workflow_invocation_step)
+                workflow_invocation_step.workflow_invocation = self.invocation
 
             workflow_invocation_step_state = model.WorkflowRequestStepState()
             workflow_invocation_step_state.workflow_step_id = step_id
@@ -111,6 +110,7 @@ class TestWorkflowProgress(TestCase):
         else:
             workflow_invocation_step = model.WorkflowInvocationStep()
             workflow_invocation_step.workflow_step = self._step(index)
+            workflow_invocation_step.workflow_invocation = self.invocation
             return workflow_invocation_step
 
     def test_connect_data_input(self):
@@ -211,6 +211,7 @@ class TestWorkflowProgress(TestCase):
         subworkflow_invocation_step.workflow_step_id = subworkflow_input_step.id
         subworkflow_invocation_step.state = "new"
         subworkflow_invocation_step.workflow_step = subworkflow_input_step
+        subworkflow_invocation_step.workflow_invocation = subworkflow_invocation
 
         subworkflow_progress.set_outputs_for_input(subworkflow_invocation_step)
 


### PR DESCRIPTION
also for subworkflow inputs. Fixes the test in in the f34b5e37abd2d917519d2d22af0f58bc2cf1ec27 and
also means that inputs are properly recorded, something that's always been unavailable for subworkflow invocations.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
