### PR TITLE
Remove 2-D assertion in IoU to allow 3-D or n-D images

### DIFF
--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -530,7 +530,7 @@ def intersection_over_union(
     This is particularly useful when specific image regions must always be labeled with a designated label value (e.g., the image background is often labeled with 0 or -1).
     """
     assert mask1.dtype == mask2.dtype
-    assert mask1.ndim == mask2.ndim == 2
+    assert mask1.ndim == mask2.ndim
     assert mask1.shape == mask2.shape
     for label in pin_labels or []:
         count = sum(label in mask for mask in (mask1, mask2))


### PR DESCRIPTION
removing the 2-d assertion in IoU function to allow 2-D or n-D images.

related to https://github.com/usegalaxy-eu/galaxy/pull/332

@kostrykin 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
