### PR TITLE
[25.1] Remove ref and polish release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,7 @@ on:
       - 'release_*'
   pull_request_target:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: dev
           sparse-checkout: |
             lib/galaxy/version.py
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -35,7 +35,36 @@ jobs:
           echo "version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           echo "Galaxy release version: ${RELEASE_VERSION}"
 
+      - name: Check if we should update draft
+        id: check-draft
+        run: |
+          VERSION="${{ inputs.version || steps.galaxy-version.outputs.version }}"
+
+          # Check if this version is already published
+          PUBLISHED=$(gh release view "v${VERSION}" --json isDraft --jq '.isDraft' 2>/dev/null || echo "not_found")
+
+          if [ "$PUBLISHED" = "false" ]; then
+            echo "Published release v${VERSION} already exists. Skipping."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check if a draft exists for a DIFFERENT version (only one draft at a time)
+          EXISTING_DRAFT=$(gh release list --limit 50 --json tagName,isDraft --jq '.[] | select(.isDraft == true) | .tagName' | head -1)
+
+          if [ -n "$EXISTING_DRAFT" ] && [ "$EXISTING_DRAFT" != "v${VERSION}" ]; then
+            echo "Draft release $EXISTING_DRAFT already exists (for different version). Skipping v${VERSION}."
+            echo "Only one draft release at a time is supported."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Proceeding with draft for v${VERSION}."
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: release-drafter/release-drafter@v6
+        if: steps.check-draft.outputs.skip == 'false'
         with:
           config-name: release-drafter.yml
           version: ${{ steps.galaxy-version.outputs.version }}


### PR DESCRIPTION
We realized that the release drafter checks out whatever version is on dev instead of the release branch that we want to target.

@mvdbeek Does this make sense?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
