### PR TITLE
[25.1] Properly parse build info from requirement info

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -718,7 +718,14 @@ def requirement_to_conda_targets(requirement: "ToolRequirement") -> Optional[Con
     conda_target = None
     if requirement.type == "package":
         assert requirement.name
-        conda_target = CondaTarget(requirement.name, version=requirement.version)
+        version = requirement.version
+        build = None
+        if version:
+            if "=" in version:
+                version, build = version.split("=")
+            elif "--" in version:
+                version, build = version.split("--")
+        conda_target = CondaTarget(requirement.name, version=version, build=build)
     return conda_target
 
 

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -714,17 +714,26 @@ def build_isolated_environment(
             shutil.rmtree(tempdir)
 
 
+def split_version_build(version: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Split version string into version and build.
+
+    Handles '=' separator (conda format) and '--' separator (mulled format).
+    """
+    if not version:
+        return version, None
+    build = None
+    if "=" in version:
+        version, build = version.split("=")
+    elif "--" in version:
+        version, build = version.split("--")
+    return version, build
+
+
 def requirement_to_conda_targets(requirement: "ToolRequirement") -> Optional[CondaTarget]:
     conda_target = None
     if requirement.type == "package":
         assert requirement.name
-        version = requirement.version
-        build = None
-        if version:
-            if "=" in version:
-                version, build = version.split("=")
-            elif "--" in version:
-                version, build = version.split("--")
+        version, build = split_version_build(requirement.version)
         conda_target = CondaTarget(requirement.name, version=version, build=build)
     return conda_target
 
@@ -740,4 +749,5 @@ __all__ = (
     "install_conda",
     "install_conda_target",
     "requirements_to_conda_targets",
+    "split_version_build",
 )

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -37,6 +37,7 @@ from galaxy.tool_util.deps.conda_util import (
     best_search_result,
     CondaContext,
     CondaTarget,
+    split_version_build,
 )
 from galaxy.util import (
     commands,
@@ -527,12 +528,8 @@ def add_single_image_arguments(parser):
 def target_str_to_targets(targets_raw: str) -> List[CondaTarget]:
     def parse_target(target_str: str) -> CondaTarget:
         if "=" in target_str:
-            package_name, version = target_str.split("=", 1)
-            build = None
-            if "=" in version:
-                version, build = version.split("=")
-            elif "--" in version:
-                version, build = version.split("--")
+            package_name, version_str = target_str.split("=", 1)
+            version, build = split_version_build(version_str)
             target = build_target(package_name, version, build)
         else:
             target = build_target(target_str)


### PR DESCRIPTION
the function is used by `planemo container_register` which results in wrong v2 hashes if requirement versions contain build info (where "wrong" means inconsistent to the results obtained by the `mulled-*` utility scripts of the `tool-util` package)

xref https://github.com/galaxyproject/galaxy/pull/18522

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
