### PR TITLE
Tool testing: add min/max attributes to test output collections

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -463,7 +463,6 @@ class TestsOutputCollectionCheckDiscovered(Linter):
                 corresponding_output = output_data_or_collection[name]
                 if corresponding_output.find(".//discover_datasets") is None:
                     continue
-                print(f"{output.attrib}=")
                 if (
                     "count" not in output.attrib
                     and "min" not in output.attrib
@@ -502,7 +501,6 @@ class TestsOutputCollectionCheckDiscoveredNested(Linter):
                 if corresponding_output.get("type", "") in ["list:list", "list:paired"]:
                     nested_elements = output.find("./element/element")
                     elements_with_count = output.xpath("./element[@count or @min or @max]")
-                    print(f"{test_idx} {nested_elements=} {elements_with_count}")
                     if nested_elements is None and not elements_with_count:
                         lint_ctx.error(
                             f"Test {test_idx}: test collection '{name}' must contain nested 'element' tags and/or element children with a 'count/min/max' attribute",

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -426,9 +426,14 @@ class TestsOutputCheckDiscovered(Linter):
                 discover_datasets = corresponding_output.find(".//discover_datasets")
                 if discover_datasets is None:
                     continue
-                if "count" not in output.attrib and output.find("./discovered_dataset") is None:
+                if (
+                    "count" not in output.attrib
+                    and "min" not in output.attrib
+                    and "max" not in output.attrib
+                    and output.find("./discovered_dataset") is None
+                ):
                     lint_ctx.error(
-                        f"Test {test_idx}: test output '{name}' must have a 'count' attribute and/or 'discovered_dataset' children",
+                        f"Test {test_idx}: test output '{name}' must have a 'count/min/max' attribute and/or 'discovered_dataset' children",
                         linter=cls.name(),
                         node=output,
                     )
@@ -456,12 +461,17 @@ class TestsOutputCollectionCheckDiscovered(Linter):
                     continue
                 # - test/collection to outputs/output_collection
                 corresponding_output = output_data_or_collection[name]
-                discover_datasets = corresponding_output.find(".//discover_datasets")
-                if discover_datasets is None:
+                if corresponding_output.find(".//discover_datasets") is None:
                     continue
-                if "count" not in output.attrib and output.find("./element") is None:
+                print(f"{output.attrib}=")
+                if (
+                    "count" not in output.attrib
+                    and "min" not in output.attrib
+                    and "max" not in output.attrib
+                    and output.find("./element") is None
+                ):
                     lint_ctx.error(
-                        f"Test {test_idx}: test collection '{name}' must have a 'count' attribute or 'element' children",
+                        f"Test {test_idx}: test collection '{name}' must have a 'count/min/max' attribute or 'element' children",
                         linter=cls.name(),
                         node=output,
                     )
@@ -491,10 +501,11 @@ class TestsOutputCollectionCheckDiscoveredNested(Linter):
                     continue
                 if corresponding_output.get("type", "") in ["list:list", "list:paired"]:
                     nested_elements = output.find("./element/element")
-                    element_with_count = output.find("./element[@count]")
-                    if nested_elements is None and element_with_count is None:
+                    elements_with_count = output.xpath("./element[@count or @min or @max]")
+                    print(f"{test_idx} {nested_elements=} {elements_with_count}")
+                    if nested_elements is None and not elements_with_count:
                         lint_ctx.error(
-                            f"Test {test_idx}: test collection '{name}' must contain nested 'element' tags and/or element children with a 'count' attribute",
+                            f"Test {test_idx}: test collection '{name}' must contain nested 'element' tags and/or element children with a 'count/min/max' attribute",
                             linter=cls.name(),
                             node=output,
                         )

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -89,6 +89,8 @@ class ToolSourceTestOutputAttributes(TypedDict):
     metric: str
     pin_labels: Optional[Any]
     count: Optional[int]
+    min: Optional[int]
+    max: Optional[int]
     metadata: Dict[str, Any]
     md5: Optional[str]
     checksum: Optional[str]
@@ -865,6 +867,10 @@ class TestCollectionOutputDef:
         else:
             count = attrib.get("count")
         self.count = int(count) if count is not None else None
+        min = attrib.get("min")
+        self.min = int(min) if min is not None else None
+        max = attrib.get("max")
+        self.max = int(max) if max is not None else None
         self.attrib = attrib
         self.element_tests = element_tests
 

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -932,6 +932,7 @@ def __parse_test_attributes(
         max = int(attrib.pop("max"))
     except KeyError:
         pass
+    has_count_assertions = count is not None or min is not None or max is not None
     extra_files: List[Dict[str, Any]] = []
     ftype: Optional[str] = None
     if "ftype" in attrib:
@@ -959,7 +960,7 @@ def __parse_test_attributes(
     has_checksum = md5sum or checksum
     has_nested_tests = extra_files or element_tests or primary_datasets
     has_object = value_object is not VALUE_OBJECT_UNSET
-    if not (assert_list or file or metadata or has_checksum or has_nested_tests or has_object):
+    if not (assert_list or file or metadata or has_checksum or has_nested_tests or has_object or has_count_assertions):
         raise Exception(
             "Test output defines nothing to check (e.g. must have a 'file' check against, assertions to check, metadata or checksum tests, etc...)"
         )

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -922,6 +922,16 @@ def __parse_test_attributes(
         count = int(attrib.pop("count"))
     except KeyError:
         pass
+    min: Optional[int] = None
+    try:
+        min = int(attrib.pop("min"))
+    except KeyError:
+        pass
+    max: Optional[int] = None
+    try:
+        max = int(attrib.pop("max"))
+    except KeyError:
+        pass
     extra_files: List[Dict[str, Any]] = []
     ftype: Optional[str] = None
     if "ftype" in attrib:
@@ -966,6 +976,8 @@ def __parse_test_attributes(
         pin_labels=pin_labels,
         location=location,
         count=count,
+        min=min,
+        max=max,
         metadata=metadata,
         md5=md5sum,
         checksum=checksum,

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1996,6 +1996,16 @@ This is available in Galaxy since release 17.05 and was introduced in [pull requ
         <xs:documentation xml:lang="en">Number or datasets for this output. Should be used for outputs with ``discover_datasets``</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="min" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Minimum number or datasets for this output. Should be used for outputs with ``discover_datasets``</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="max" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Maximum number or datasets for this output. Should be used for outputs with ``discover_datasets``</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="location" type="xs:anyURI" gxdocs:added="23.1">
       <xs:annotation>
         <xs:documentation xml:lang="en">URL that points to a remote output file that will downloaded and used for output comparison.
@@ -2346,6 +2356,16 @@ This value is the same as the value of the ``name`` attribute of the
     <xs:attribute name="count" type="xs:integer">
       <xs:annotation>
         <xs:documentation xml:lang="en">Number of elements in output collection.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="min" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Minimum number of elements in output collection.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="max" type="xs:integer">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Maximum number of elements in output collection.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1996,12 +1996,12 @@ This is available in Galaxy since release 17.05 and was introduced in [pull requ
         <xs:documentation xml:lang="en">Number or datasets for this output. Should be used for outputs with ``discover_datasets``</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="min" type="xs:integer">
+    <xs:attribute name="min" type="xs:integer" gxdocs:added="26.0">
       <xs:annotation>
         <xs:documentation xml:lang="en">Minimum number or datasets for this output. Should be used for outputs with ``discover_datasets``</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max" type="xs:integer">
+    <xs:attribute name="max" type="xs:integer" gxdocs:added="26.0">
       <xs:annotation>
         <xs:documentation xml:lang="en">Maximum number or datasets for this output. Should be used for outputs with ``discover_datasets``</xs:documentation>
       </xs:annotation>
@@ -2358,12 +2358,12 @@ This value is the same as the value of the ``name`` attribute of the
         <xs:documentation xml:lang="en">Number of elements in output collection.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="min" type="xs:integer">
+    <xs:attribute name="min" type="xs:integer" gxdocs:added="26.0">
       <xs:annotation>
         <xs:documentation xml:lang="en">Minimum number of elements in output collection.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max" type="xs:integer">
+    <xs:attribute name="max" type="xs:integer" gxdocs:added="26.0">
       <xs:annotation>
         <xs:documentation xml:lang="en">Maximum number of elements in output collection.</xs:documentation>
       </xs:annotation>

--- a/test/functional/tools/expect_num_outputs.xml
+++ b/test/functional/tools/expect_num_outputs.xml
@@ -159,39 +159,15 @@ true
         </test>
         <test expect_num_outputs="1">
             <param name="produce_discovered_dataset_invisible" value="true" />
-            <output name="discovered_dataset_invisible" min="3" max="3">
-                <expand macro="content_assertion"/>
-                <discovered_dataset designation="2" ftype="txt">
-                    <expand macro="content_assertion"/>
-                </discovered_dataset>
-                <discovered_dataset designation="3" ftype="txt">
-                    <expand macro="content_assertion"/>
-                </discovered_dataset>
-            </output>
+            <output name="discovered_dataset_invisible" min="3" max="3"/>
         </test>
         <test expect_num_outputs="1" expect_test_failure="true">
             <param name="produce_discovered_dataset_invisible" value="true" />
-            <output name="discovered_dataset_invisible" min="4">
-                <expand macro="content_assertion"/>
-                <discovered_dataset designation="2" ftype="txt">
-                    <expand macro="content_assertion"/>
-                </discovered_dataset>
-                <discovered_dataset designation="3" ftype="txt">
-                    <expand macro="content_assertion"/>
-                </discovered_dataset>
-            </output>
+            <output name="discovered_dataset_invisible" min="4"/>
         </test>
         <test expect_num_outputs="1" expect_test_failure="true">
             <param name="produce_discovered_dataset_invisible" value="true" />
-            <output name="discovered_dataset_invisible" max="2">
-                <expand macro="content_assertion"/>
-                <discovered_dataset designation="2" ftype="txt">
-                    <expand macro="content_assertion"/>
-                </discovered_dataset>
-                <discovered_dataset designation="3" ftype="txt">
-                    <expand macro="content_assertion"/>
-                </discovered_dataset>
-            </output>
+            <output name="discovered_dataset_invisible" max="2"/>
         </test>
 
         <!-- discovered datasets invisible -->
@@ -364,20 +340,12 @@ true
             <param name="produce_paired_list" value="true" />
             <output_collection name="paired_list" type="list:paired" min="2" max="2">
                 <element name="p1" min="2" max="2">
-                    <element name="forward" min="1" max="1">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse" min="1" max="1">
-                        <expand macro="content_assertion"/>
-                    </element>
+                    <element name="forward" min="1" max="1"/>
+                    <element name="reverse" min="1" max="1"/>
                 </element>
                 <element name="p2" min="2" max="2">
-                    <element name="forward" min="1" max="1">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse" min="1" max="1">
-                        <expand macro="content_assertion"/>
-                    </element>
+                    <element name="forward" min="1" max="1"/>
+                    <element name="reverse" min="1" max="1"/>
                 </element>
             </output_collection>
         </test>
@@ -385,91 +353,28 @@ true
         <!-- unsuccessful test of min of output_collection -->
         <test expect_num_outputs="1" expect_test_failure="true">
             <param name="produce_paired_list" value="true" />
-            <output_collection name="paired_list" type="list:paired" min="3">
-                <element name="p1">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
-                <element name="p2">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
-            </output_collection>
+            <output_collection name="paired_list" type="list:paired" min="3"/>
         </test>
         <!-- unsuccessful test of max of output_collection -->
         <test expect_num_outputs="1" expect_test_failure="true">
             <param name="produce_paired_list" value="true" />
-            <output_collection name="paired_list" type="list:paired" max="1">
-                <!-- TODO allow testing without all this -->
-                <element name="p1">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
-                <element name="p2">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
-            </output_collection>
+            <output_collection name="paired_list" type="list:paired" max="1"/>
         </test>
 
         <!-- unsuccessful test of min of element -->
         <test expect_num_outputs="1" expect_test_failure="true">
             <param name="produce_paired_list" value="true" />
             <output_collection name="paired_list" type="list:paired" min="2" max="2">
-                <element name="p1" min="3">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
-                <element name="p2" min="3">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
+                <element name="p1" min="3"/>
+                <element name="p2" min="3"/>
             </output_collection>
         </test>
         <!-- unsuccessful test of min of element -->
         <test expect_num_outputs="1" expect_test_failure="true">
             <param name="produce_paired_list" value="true" />
             <output_collection name="paired_list" type="list:paired" min="2" max="2">
-                <element name="p1" max="1">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
-                <element name="p2" max="1">
-                    <element name="forward">
-                        <expand macro="content_assertion"/>
-                    </element>
-                    <element name="reverse">
-                        <expand macro="content_assertion"/>
-                    </element>
-                </element>
+                <element name="p1" max="1"/>
+                <element name="p2" max="1"/>
             </output_collection>
         </test>
 

--- a/test/functional/tools/expect_num_outputs.xml
+++ b/test/functional/tools/expect_num_outputs.xml
@@ -157,6 +157,42 @@ true
                 </discovered_dataset>
             </output>
         </test>
+        <test expect_num_outputs="1">
+            <param name="produce_discovered_dataset_invisible" value="true" />
+            <output name="discovered_dataset_invisible" min="3" max="3">
+                <expand macro="content_assertion"/>
+                <discovered_dataset designation="2" ftype="txt">
+                    <expand macro="content_assertion"/>
+                </discovered_dataset>
+                <discovered_dataset designation="3" ftype="txt">
+                    <expand macro="content_assertion"/>
+                </discovered_dataset>
+            </output>
+        </test>
+        <test expect_num_outputs="1" expect_test_failure="true">
+            <param name="produce_discovered_dataset_invisible" value="true" />
+            <output name="discovered_dataset_invisible" min="4">
+                <expand macro="content_assertion"/>
+                <discovered_dataset designation="2" ftype="txt">
+                    <expand macro="content_assertion"/>
+                </discovered_dataset>
+                <discovered_dataset designation="3" ftype="txt">
+                    <expand macro="content_assertion"/>
+                </discovered_dataset>
+            </output>
+        </test>
+        <test expect_num_outputs="1" expect_test_failure="true">
+            <param name="produce_discovered_dataset_invisible" value="true" />
+            <output name="discovered_dataset_invisible" max="2">
+                <expand macro="content_assertion"/>
+                <discovered_dataset designation="2" ftype="txt">
+                    <expand macro="content_assertion"/>
+                </discovered_dataset>
+                <discovered_dataset designation="3" ftype="txt">
+                    <expand macro="content_assertion"/>
+                </discovered_dataset>
+            </output>
+        </test>
 
         <!-- discovered datasets invisible -->
         <test expect_num_outputs="1">
@@ -322,5 +358,120 @@ true
                 </element>
             </output_collection>
         </test>
+
+        <!-- successful test of min/max of output_collection and elements -->
+        <test expect_num_outputs="1">
+            <param name="produce_paired_list" value="true" />
+            <output_collection name="paired_list" type="list:paired" min="2" max="2">
+                <element name="p1" min="2" max="2">
+                    <element name="forward" min="1" max="1">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse" min="1" max="1">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+                <element name="p2" min="2" max="2">
+                    <element name="forward" min="1" max="1">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse" min="1" max="1">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
+
+        <!-- unsuccessful test of min of output_collection -->
+        <test expect_num_outputs="1" expect_test_failure="true">
+            <param name="produce_paired_list" value="true" />
+            <output_collection name="paired_list" type="list:paired" min="3">
+                <element name="p1">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+                <element name="p2">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
+        <!-- unsuccessful test of max of output_collection -->
+        <test expect_num_outputs="1" expect_test_failure="true">
+            <param name="produce_paired_list" value="true" />
+            <output_collection name="paired_list" type="list:paired" max="1">
+                <!-- TODO allow testing without all this -->
+                <element name="p1">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+                <element name="p2">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
+
+        <!-- unsuccessful test of min of element -->
+        <test expect_num_outputs="1" expect_test_failure="true">
+            <param name="produce_paired_list" value="true" />
+            <output_collection name="paired_list" type="list:paired" min="2" max="2">
+                <element name="p1" min="3">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+                <element name="p2" min="3">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
+        <!-- unsuccessful test of min of element -->
+        <test expect_num_outputs="1" expect_test_failure="true">
+            <param name="produce_paired_list" value="true" />
+            <output_collection name="paired_list" type="list:paired" min="2" max="2">
+                <element name="p1" max="1">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+                <element name="p2" max="1">
+                    <element name="forward">
+                        <expand macro="content_assertion"/>
+                    </element>
+                    <element name="reverse">
+                        <expand macro="content_assertion"/>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
+
     </tests>
 </tool>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -2098,19 +2098,19 @@ def test_tests_discover_outputs(lint_ctx):
     tool_source = get_xml_tool_source(TESTS_DISCOVER_OUTPUTS)
     run_lint_module(lint_ctx, tests, tool_source)
     assert (
-        "Test 3: test output 'data_name' must have a 'count' attribute and/or 'discovered_dataset' children"
+        "Test 3: test output 'data_name' must have a 'count/min/max' attribute and/or 'discovered_dataset' children"
         in lint_ctx.error_messages
     )
     assert (
-        "Test 3: test collection 'collection_name' must have a 'count' attribute or 'element' children"
+        "Test 3: test collection 'collection_name' must have a 'count/min/max' attribute or 'element' children"
         in lint_ctx.error_messages
     )
     assert (
-        "Test 3: test collection 'collection_name' must contain nested 'element' tags and/or element children with a 'count' attribute"
+        "Test 3: test collection 'collection_name' must contain nested 'element' tags and/or element children with a 'count/min/max' attribute"
         in lint_ctx.error_messages
     )
     assert (
-        "Test 5: test collection 'collection_name' must contain nested 'element' tags and/or element children with a 'count' attribute"
+        "Test 5: test collection 'collection_name' must contain nested 'element' tags and/or element children with a 'count/min/max' attribute"
         in lint_ctx.error_messages
     )
     assert len(lint_ctx.error_messages) == 4


### PR DESCRIPTION
Idea from here: https://github.com/galaxyproject/tools-iuc/pull/7551

Also allows test output collections with only count assertions. 

Should we document/enforce that this is available since 26.0?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
