### PR TITLE
Add tool_shed_url config for explicit hostname setting

### DIFF
--- a/lib/galaxy/config/schemas/tool_shed_config_schema.yml
+++ b/lib/galaxy/config/schemas/tool_shed_config_schema.yml
@@ -46,6 +46,16 @@ mapping:
           Allow pushing directly to mercurial repositories directly
           and without authentication.
 
+      tool_shed_url:
+        type: str
+        required: false
+        desc: |
+          The base URL of the Tool Shed server used for generating clone URLs
+          and repository hostnames. If set, this value will be used instead of
+          deriving the URL from the incoming request.
+
+          Example: https://toolshed.g2.bx.psu.edu
+
       file_path:
         type: str
         default: database/community_files

--- a/lib/tool_shed/context.py
+++ b/lib/tool_shed/context.py
@@ -148,6 +148,11 @@ class SessionRequestContextImpl(SessionRequestContext):
 
     @property
     def repositories_hostname(self) -> str:
+        # Use configured tool_shed_url if available
+        tool_shed_url = self.app.config.tool_shed_url
+        if tool_shed_url:
+            return tool_shed_url.rstrip("/")
+        # Fall back to request-based URL
         return str(self.request.base).rstrip("/")
 
     @property

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -34,6 +34,11 @@ log = logging.getLogger(__name__)
 class ToolShedGalaxyWebTransaction(GalaxyWebTransaction):
     @property
     def repositories_hostname(self) -> str:
+        # Use configured tool_shed_url if available
+        tool_shed_url = self.app.config.tool_shed_url
+        if tool_shed_url:
+            return tool_shed_url.rstrip("/")
+        # Fall back to request-based URL
         return url_for("/", qualified=True).rstrip("/")
 
     def get_or_create_default_history(self):


### PR DESCRIPTION
Allows admins to set a fixed base URL for clone URLs and repository hostnames, useful when behind proxies or needing a specific public URL.

I tried some unit tests for this and they were not to my taste - https://gist.github.com/jmchilton/7a1af593c45091d51ccc9b390d562079. 

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Merge
  2. Deploy to test tool shed.
  3. Run a local proxy for the frontend.
  4. Regenerate metadata and make sure it works.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
