### PR TITLE
[25.1] Usability fixes for sample sheet selection. 

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9392,6 +9392,11 @@ export interface components {
              * @description The type of the collection, can be `list`, `paired`, or define subcollections using `:` as separator like `list:paired` or `list:list`.
              */
             collection_type: string;
+            /**
+             * Column Definitions
+             * @description Column definitions for sample sheet collections.
+             */
+            column_definitions?: components["schemas"]["SampleSheetColumnDefinition"][] | null;
             /** Contents Url */
             contents_url?: string | null;
             /**

--- a/client/src/components/Collections/wizard/SelectCollection.vue
+++ b/client/src/components/Collections/wizard/SelectCollection.vue
@@ -17,15 +17,37 @@ interface Props {
 
 const props = defineProps<Props>();
 
+function getCompatibleSourceTypes(sampleSheetType: string): string[] | undefined {
+    if (sampleSheetType === "sample_sheet") {
+        return ["list", "sample_sheet"];
+    }
+    if (sampleSheetType === "sample_sheet:paired") {
+        return ["list:paired", "sample_sheet:paired"];
+    }
+    if (sampleSheetType === "sample_sheet:paired_or_unpaired") {
+        return [
+            "list",
+            "list:paired",
+            "list:paired_or_unpaired",
+            "sample_sheet",
+            "sample_sheet:paired",
+            "sample_sheet:paired_or_unpaired",
+        ];
+    }
+    if (sampleSheetType === "sample_sheet:record") {
+        return ["list:record", "sample_sheet:record"];
+    }
+    return undefined;
+}
+
 function inputDialog() {
-    const collectionType = props.collectionType;
+    const compatibleTypes = getCompatibleSourceTypes(props.collectionType);
     datasetCollectionDialog(
         (data: SelectionItem) => {
             targetCollection.value = data.id;
         },
         {
-            // TODO: use this in that dialog.
-            collectionType: collectionType,
+            collectionTypes: compatibleTypes,
         },
     );
 }

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -13,6 +13,7 @@ import {
     isDCE,
     isHDCA,
     isHistoryItem,
+    type SampleSheetColumnDefinition,
 } from "@/api";
 import type { CollectionType } from "@/api/datasetCollections";
 import type { HistoryContentType } from "@/api/datasets";
@@ -374,8 +375,8 @@ function handleIncoming(incoming: Record<string, unknown> | Record<string, unkno
         }
         if (
             values.some((v) => {
-                const { historyContentType, collectionType } = getElementAttributes(v);
-                return !canAcceptSrc(historyContentType, collectionType);
+                const { historyContentType, collectionType, columnDefinitions } = getElementAttributes(v);
+                return !canAcceptSrc(historyContentType, collectionType, columnDefinitions);
             })
         ) {
             return false;
@@ -545,11 +546,13 @@ function getElementAttributes(element: HistoryOrCollectionItem): {
     newSrc: string;
     datasetCollectionDataset: HDAObject | undefined;
     collectionType?: string;
+    columnDefinitions?: SampleSheetColumnDefinition[] | null;
 } {
     let historyContentType: HistoryContentType;
     let newSrc: string;
     let datasetCollectionDataset: HDAObject | undefined;
     let collectionType: string | undefined;
+    let columnDefinitions: SampleSheetColumnDefinition[] | null | undefined;
     if (isDCE(element)) {
         if (isDatasetElement(element)) {
             historyContentType = "dataset";
@@ -561,11 +564,14 @@ function getElementAttributes(element: HistoryOrCollectionItem): {
             // we already know it is a collection element by this point
             if (isCollectionElement(element)) {
                 collectionType = element.object.collection_type;
+                columnDefinitions = element.object.column_definitions;
             }
         }
     } else {
         historyContentType = element.history_content_type;
         collectionType = "collection_type" in element && element.collection_type ? element.collection_type : undefined;
+        columnDefinitions =
+            "column_definitions" in element ? (element.column_definitions as SampleSheetColumnDefinition[]) : undefined;
         newSrc =
             "src" in element && typeof element.src === "string"
                 ? element.src
@@ -573,10 +579,44 @@ function getElementAttributes(element: HistoryOrCollectionItem): {
                   ? SOURCE.COLLECTION
                   : SOURCE.DATASET;
     }
-    return { historyContentType, newSrc, datasetCollectionDataset, collectionType };
+    return { historyContentType, newSrc, datasetCollectionDataset, collectionType, columnDefinitions };
 }
 
-function canAcceptSrc(historyContentType: "dataset" | "dataset_collection", collectionType?: string) {
+/**
+ * Check if collection's column definitions exactly match required column definitions.
+ * Requires same number of columns, same names in same order, and matching types.
+ */
+function columnDefinitionsCompatible(
+    collectionColumns: SampleSheetColumnDefinition[] | null | undefined,
+    requiredColumns: SampleSheetColumnDefinition[] | undefined,
+): boolean {
+    if (!requiredColumns || requiredColumns.length === 0) {
+        return true;
+    }
+    if (!collectionColumns) {
+        return false;
+    }
+    // Must have same number of columns
+    if (collectionColumns.length !== requiredColumns.length) {
+        return false;
+    }
+    // Check each column matches in order
+    for (let i = 0; i < requiredColumns.length; i++) {
+        if (collectionColumns[i]!.name !== requiredColumns[i]!.name) {
+            return false;
+        }
+        if (collectionColumns[i]!.type !== requiredColumns[i]!.type) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function canAcceptSrc(
+    historyContentType: "dataset" | "dataset_collection",
+    collectionType?: string,
+    columnDefinitions?: SampleSheetColumnDefinition[] | null,
+) {
     if (historyContentType === "dataset") {
         // HDA can only be fed into data parameters, not collection parameters
         if (props.type === "data") {
@@ -604,9 +644,25 @@ function canAcceptSrc(historyContentType: "dataset" | "dataset_collection", coll
             return true;
         } else {
             if (props.collectionTypes.includes(collectionType as CollectionType)) {
+                // Check column_definitions compatibility for sample sheets
+                if (
+                    props.extendedCollectionType?.columnDefinitions &&
+                    !columnDefinitionsCompatible(columnDefinitions, props.extendedCollectionType.columnDefinitions)
+                ) {
+                    $emit("alert", "dataset collection has incompatible column definitions for this parameter.");
+                    return false;
+                }
                 return true;
             }
             if (props.collectionTypes.some((element) => collectionType.endsWith(element))) {
+                // Check column_definitions compatibility for sample sheets
+                if (
+                    props.extendedCollectionType?.columnDefinitions &&
+                    !columnDefinitionsCompatible(columnDefinitions, props.extendedCollectionType.columnDefinitions)
+                ) {
+                    $emit("alert", "dataset collection has incompatible column definitions for this parameter.");
+                    return false;
+                }
                 return true;
             } else {
                 $emit(
@@ -683,12 +739,12 @@ function onDragEnter(evt: DragEvent) {
         for (const item of eventData) {
             if (isHistoryOrCollectionItem(item)) {
                 const extensions = getExtensionsForItem(item);
-                const { historyContentType, collectionType } = getElementAttributes(item);
+                const { historyContentType, collectionType, columnDefinitions } = getElementAttributes(item);
 
                 if (extensions && !canAcceptDatatype(extensions)) {
                     highlightingState = "warning";
                     $emit("alert", `${extensions} is not an acceptable format for this parameter.`);
-                } else if (!canAcceptSrc(historyContentType, collectionType)) {
+                } else if (!canAcceptSrc(historyContentType, collectionType, columnDefinitions)) {
                     highlightingState = "warning";
                     // `canAcceptSrc` already alerts if false so no need to alert again
                 }

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -564,7 +564,11 @@ function getElementAttributes(element: HistoryOrCollectionItem): {
             // we already know it is a collection element by this point
             if (isCollectionElement(element)) {
                 collectionType = element.object.collection_type;
-                columnDefinitions = element.object.column_definitions;
+                // Cast needed: schema has two structurally identical SampleSheetColumnDefinition types
+                columnDefinitions = element.object.column_definitions as
+                    | SampleSheetColumnDefinition[]
+                    | null
+                    | undefined;
             }
         }
     } else {

--- a/client/src/components/Form/Elements/FormData/types.ts
+++ b/client/src/components/Form/Elements/FormData/types.ts
@@ -89,6 +89,7 @@ export type DataOption = {
     name: string;
     src: string;
     tags: Array<string>;
+    column_definitions?: SampleSheetColumnDefinition[] | null;
 };
 
 export function isDataOption(item: object): item is DataOption {

--- a/client/src/components/SelectionDialog/DatasetCollectionDialog.vue
+++ b/client/src/components/SelectionDialog/DatasetCollectionDialog.vue
@@ -13,12 +13,14 @@ interface HistoryItem {
     name: string;
     created_time: string;
     hid: number;
+    collection_type?: string;
 }
 
 interface Props {
     callback?: (results: SelectionItem) => void;
     history: string;
     modalStatic?: boolean;
+    collectionTypes?: string[];
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -56,7 +58,13 @@ function load() {
     axios
         .get(url)
         .then((response) => {
-            const collection_instances = response.data.sort((a: HistoryItem, b: HistoryItem) => b.hid - a.hid);
+            let collection_instances = response.data.sort((a: HistoryItem, b: HistoryItem) => b.hid - a.hid);
+            if (props.collectionTypes?.length) {
+                collection_instances = collection_instances.filter(
+                    (item: HistoryItem) =>
+                        item.collection_type && props.collectionTypes!.includes(item.collection_type),
+                );
+            }
             items.value = collection_instances.map((item: HistoryItem) => {
                 return {
                     id: item.id,

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -668,6 +668,7 @@ workflows:
     share_button: '[id^="g-card-action-workflow-share-"]'
     download_button: '[id^="g-card-action-workflow-download-"]'
     run_button: '[id^="g-card-action-workflow-run-"]'
+    run_button_by_id: '#g-card-action-workflow-run-${id}'
     edit_button: '[id^="g-card-action-workflow-edit-"]'
     rename_input: '#workflow-name-input'
     workflow_drop_down: '[id^="g-card-extra-actions-"]'

--- a/lib/galaxy/model/dataset_collections/types/sample_sheet_util.py
+++ b/lib/galaxy/model/dataset_collections/types/sample_sheet_util.py
@@ -165,3 +165,41 @@ def validate_column_value(
             validator.statically_validate(column_value)
         except ValueError as e:
             raise RequestParameterInvalidException(str(e))
+
+
+def column_definitions_compatible(
+    collection_columns: Optional[SampleSheetColumnDefinitions],
+    required_columns: Optional[SampleSheetColumnDefinitions],
+) -> bool:
+    """Check if collection's column definitions exactly match required column definitions.
+
+    A collection is compatible when:
+    - Same number of columns
+    - Same column names in same order
+    - Column types match exactly
+    - Validators/restrictions are not compared (used for value validation only)
+
+    Args:
+        collection_columns: The column definitions from the collection
+        required_columns: The column definitions required by the parameter
+
+    Returns:
+        True if compatible, False otherwise
+    """
+    if not required_columns:
+        return True
+    if not collection_columns:
+        return False
+
+    # Must have same number of columns
+    if len(collection_columns) != len(required_columns):
+        return False
+
+    # Check each column matches in order
+    for collection_col, required_col in zip(collection_columns, required_columns):
+        if collection_col["name"] != required_col["name"]:
+            return False
+        if collection_col["type"] != required_col["type"]:
+            return False
+
+    return True

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1067,6 +1067,9 @@ class DCObject(Model, WithModelClass):
     elements_datatypes: set[str] = Field(
         ..., description="A set containing all the different element datatypes in the collection."
     )
+    column_definitions: Optional[SampleSheetColumnDefinitions] = Field(
+        None, description="Column definitions for sample sheet collections."
+    )
 
 
 class DCESummary(Model, WithModelClass):

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1838,6 +1838,11 @@ class NavigatesGalaxy(HasDriver):
             self.send_enter(tag_area)
         self.send_escape(tag_area)
 
+    def workflow_run_with_id(self, workflow_id: str):
+        self.workflow_index_open()
+        self.components.workflows.run_button_by_id(id=workflow_id).wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
     def workflow_run_with_name(self, name: str):
         self.workflow_index_open()
         self.workflow_index_search_for(name)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -50,6 +50,7 @@ from galaxy.model.dataset_collections.adapters import (
     TransientCollectionAdapterDatasetInstanceElement,
     validate_collection_adapter_src_dict,
 )
+from galaxy.model.dataset_collections.types.sample_sheet_util import column_definitions_compatible
 from galaxy.schema.fetch_data import FilesPayload
 from galaxy.tool_util.parameters.factory import get_color_value
 from galaxy.tool_util.parser import get_input_source as ensure_input_source
@@ -2528,6 +2529,11 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             match = dataset_collection_matcher.hdca_match(dataset_collection_instance)
             if not match:
                 continue
+            # Filter sample sheet collections by column_definitions compatibility
+            if self._column_definitions:
+                collection_cols = dataset_collection_instance.collection.column_definitions
+                if not column_definitions_compatible(collection_cols, self._column_definitions):
+                    continue
             yield dataset_collection_instance, match.implicit_conversion
 
     def match_multirun_collections(self, trans, history, dataset_collection_matcher):
@@ -2658,6 +2664,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
                     "name": name,
                     "src": "hdca",
                     "tags": [t.user_tname if not t.value else f"{t.user_tname}:{t.value}" for t in hdca.tags],
+                    "column_definitions": hdca.collection.column_definitions,
                 }
             )
 
@@ -2681,6 +2688,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
                     "name": name,
                     "src": "hdca",
                     "tags": [t.user_tname if not t.value else f"{t.user_tname}:{t.value}" for t in hdca.tags],
+                    "column_definitions": hdca.collection.column_definitions,
                 }
             )
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -3330,6 +3330,10 @@ class BaseDatasetCollectionPopulator:
         return hdca_id
 
     def create_list_of_pairs_in_history(self, history_id, **kwds):
+        upload_kwds = {}
+        if "name" in kwds:
+            upload_kwds["name"] = kwds.pop("name")
+
         return self.upload_collection(
             history_id,
             "list:paired",
@@ -3342,6 +3346,7 @@ class BaseDatasetCollectionPopulator:
                     ],
                 }
             ],
+            **upload_kwds,
         )
 
     def create_list_of_list_in_history(self, history_id: str, **kwds):

--- a/lib/galaxy_test/selenium/test_workflow_run_inputs.py
+++ b/lib/galaxy_test/selenium/test_workflow_run_inputs.py
@@ -2,7 +2,6 @@
 
 from .framework import (
     managed_history,
-    selenium_only,
     selenium_test,
     SeleniumTestCase,
 )
@@ -15,7 +14,6 @@ class TestWorkflowRunInputs(SeleniumTestCase):
 
     ensure_registered = True
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     @managed_history
     def test_sample_sheet_from_existing_filters_on_collection_type(self):

--- a/lib/galaxy_test/selenium/test_workflow_run_inputs.py
+++ b/lib/galaxy_test/selenium/test_workflow_run_inputs.py
@@ -1,0 +1,85 @@
+"""Selenium tests for workflow run input selection and filtering."""
+
+from .framework import (
+    managed_history,
+    selenium_only,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+INPUT_LABEL = "input1"
+
+
+class TestWorkflowRunInputs(SeleniumTestCase):
+    """Tests for workflow run input collection filtering."""
+
+    ensure_registered = True
+
+    @selenium_only("Not yet migrated to support Playwright backend")
+    @selenium_test
+    @managed_history
+    def test_sample_sheet_from_existing_filters_on_collection_type(self):
+        """Verify collection selection dialog only shows compatible types."""
+        workflow_run = self.components.workflow_run
+        sample_sheet = workflow_run.input.sample_sheet
+
+        # 1. Create fixtures - for each test one that matches the filter and one that does.
+        history_id = self.current_history_id()
+        flat_list_id = self.dataset_collection_populator.create_list_in_history(
+            history_id, name="flat_list", wait=True
+        ).json()["output_collections"][0]["id"]
+        paired_list_id = self.dataset_collection_populator.create_list_of_pairs_in_history(
+            history_id, name="paired_list", wait=True
+        ).json()["output_collections"][0]["id"]
+
+        # 2. Navigate home to see complete collections
+        self.home()
+
+        # 3. Setup workflow with sample_sheet:paired input
+        id = self._setup_sample_sheet_paired_workflow()
+        self.workflow_run_with_id(id)
+        self._open_collection_selection_dialog()
+
+        # 5. Assert compatible collection IS present
+        sample_sheet.collection_selection(id=paired_list_id).wait_for_present()
+
+        # 6. Assert incompatible collection is NOT present
+        sample_sheet.collection_selection(id=flat_list_id).assert_absent()
+
+        # 7. Repeat with inverted checks for flat sample_sheet
+        id = self._setup_sample_sheet_flat_workflow()
+        self.workflow_run_with_id(id)
+        self._open_collection_selection_dialog()
+        sample_sheet.collection_selection(id=flat_list_id).wait_for_present()
+        sample_sheet.collection_selection(id=paired_list_id).assert_absent()
+
+    def _open_collection_selection_dialog(self):
+        """Open collection selection dialog for given input."""
+        workflow_run = self.components.workflow_run
+        input = workflow_run.input._(label=INPUT_LABEL)
+        input.upload.wait_for_and_click()
+        sample_sheet = workflow_run.input.sample_sheet
+        sample_sheet._.wait_for_present()
+        sample_sheet.data_import_source_from(source="collection").wait_for_and_click()
+        sample_sheet.wizard_next_button.wait_for_and_click()
+        return sample_sheet
+
+    def _setup_sample_sheet_paired_workflow(self):
+        """Create minimal workflow with sample_sheet:paired input."""
+        return self._setup_single_input_workflow(collection_type="sample_sheet:paired")
+
+    def _setup_sample_sheet_flat_workflow(self):
+        """Create minimal workflow with sample_sheet (flat) input."""
+        return self._setup_single_input_workflow(collection_type="sample_sheet")
+
+    def _setup_single_input_workflow(self, collection_type: str):
+        workflow_content = f"""
+class: GalaxyWorkflow
+inputs:
+    {INPUT_LABEL}:
+        type: collection
+        collection_type: {collection_type}
+steps: []
+"""
+        workflow_id = self.workflow_populator.upload_yaml_workflow(workflow_content)
+        return workflow_id

--- a/test/unit/data/dataset_collections/test_sample_sheet_util.py
+++ b/test/unit/data/dataset_collections/test_sample_sheet_util.py
@@ -4,6 +4,7 @@ import pytest
 
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.model.dataset_collections.types.sample_sheet_util import (
+    column_definitions_compatible as real_column_definitions_compatible,
     validate_column_definitions as real_validate_column_definitions,
     validate_row as real_validate_row,
 )
@@ -21,6 +22,11 @@ def validate_column_definitions(column_definitions: Any):
     # for testing allow various incompatible data structures to be sent in to assure
     # they fail properly.
     real_validate_column_definitions(column_definitions)
+
+
+def column_definitions_compatible(collection_columns: Any, required_columns: Any) -> bool:
+    # for testing allow various incompatible data structures to be sent in
+    return real_column_definitions_compatible(collection_columns, required_columns)
 
 
 def test_sample_sheet_validation_skipped_on_empty_definitions():
@@ -203,3 +209,109 @@ def test_column_definitions_do_not_allow_special_characters_in_column_name():
 
     with pytest.raises(RequestParameterInvalidException):
         validate_column_definitions(column_definitions)
+
+
+# Tests for column_definitions_compatible function
+
+
+def test_column_definitions_compatible_missing_required_column():
+    """Collection without required column is incompatible."""
+    required_cols = [{"name": "treatment", "type": "string", "optional": False}]
+    collection_cols = [{"name": "replicate", "type": "int", "optional": False}]
+    assert column_definitions_compatible(collection_cols, required_cols) is False
+
+
+def test_column_definitions_compatible_collection_has_no_columns():
+    """Collection with no columns can't satisfy requirements."""
+    required_cols = [{"name": "treatment", "type": "string", "optional": False}]
+    assert column_definitions_compatible(None, required_cols) is False
+    assert column_definitions_compatible([], required_cols) is False
+
+
+def test_column_definitions_compatible_exact_match():
+    """Collection with exact same columns is compatible."""
+    cols = [
+        {"name": "treatment", "type": "string", "optional": False},
+        {"name": "replicate", "type": "int", "optional": False},
+    ]
+    assert column_definitions_compatible(cols, cols) is True
+
+
+def test_column_definitions_compatible_superset_not_allowed():
+    """Collection with extra columns beyond required is incompatible.
+
+    This maybe (probably?) should be allowed - this test is verifying current behavior not
+    defining the spec per se.
+    """
+    required_cols = [{"name": "treatment", "type": "string", "optional": False}]
+    collection_cols = [
+        {"name": "treatment", "type": "string", "optional": False},
+        {"name": "replicate", "type": "int", "optional": False},
+        {"name": "batch", "type": "string", "optional": True},
+    ]
+    assert column_definitions_compatible(collection_cols, required_cols) is False
+
+
+def test_column_definitions_compatible_type_mismatch():
+    """Column with wrong type is incompatible."""
+    required_cols = [{"name": "replicate", "type": "int", "optional": False}]
+    collection_cols = [{"name": "replicate", "type": "string", "optional": False}]
+    assert column_definitions_compatible(collection_cols, required_cols) is False
+
+
+def test_column_definitions_compatible_multiple_columns():
+    """All required columns must be present with correct types."""
+    required_cols = [
+        {"name": "treatment", "type": "string", "optional": False},
+        {"name": "replicate", "type": "int", "optional": False},
+    ]
+    # Missing replicate
+    collection_cols_1 = [{"name": "treatment", "type": "string", "optional": False}]
+    assert column_definitions_compatible(collection_cols_1, required_cols) is False
+
+    # Has both with correct types
+    collection_cols_2 = [
+        {"name": "treatment", "type": "string", "optional": False},
+        {"name": "replicate", "type": "int", "optional": False},
+    ]
+    assert column_definitions_compatible(collection_cols_2, required_cols) is True
+
+    # Has both but replicate has wrong type
+    collection_cols_3 = [
+        {"name": "treatment", "type": "string", "optional": False},
+        {"name": "replicate", "type": "float", "optional": False},
+    ]
+    assert column_definitions_compatible(collection_cols_3, required_cols) is False
+
+
+def test_column_definitions_compatible_ignores_validators():
+    """Validators/restrictions are not compared - only name and type matter*.
+
+    * Optional probably should matter but I don't think it does currently.
+    """
+    required_cols = [
+        {
+            "name": "treatment",
+            "type": "string",
+            "optional": False,
+            "restrictions": ["control", "treated"],
+            "validators": [{"type": "length", "min": 5}],
+        }
+    ]
+    # Collection has same column but no restrictions/validators
+    collection_cols = [{"name": "treatment", "type": "string", "optional": False}]
+    assert column_definitions_compatible(collection_cols, required_cols) is True
+
+
+def test_column_definitions_compatible_order_must_match():
+    """Columns must appear in the same order."""
+    required_cols = [
+        {"name": "treatment", "type": "string", "optional": False},
+        {"name": "replicate", "type": "int", "optional": False},
+    ]
+    # Same columns but different order
+    collection_cols = [
+        {"name": "replicate", "type": "int", "optional": False},
+        {"name": "treatment", "type": "string", "optional": False},
+    ]
+    assert column_definitions_compatible(collection_cols, required_cols) is False


### PR DESCRIPTION
Fixes two spiritually connected issues with no actual overlap between the fixes or parts of code touched.

Fixes https://github.com/galaxyproject/galaxy/issues/21206 - with selenium testing.

Fixes https://github.com/galaxyproject/galaxy/issues/21472 with manual UI testing but some interesting unit tests describing how to match columns. 

<img width="1693" height="614" alt="Screenshot 2025-12-22 at 11 09 02 AM" src="https://github.com/user-attachments/assets/f88e7d3d-6060-4c77-9933-d877f74511b2" />

I think the fix for https://github.com/galaxyproject/galaxy/issues/21472 is maybe too stringent - the columns have no match name and order and count. Conceptually the supplied sample sheet should be able to contain extra columns but I guess this could easily break workflows that extract the sample sheet as is to a table if extra metadata is appended to derivatives of the table during an analysis and then are referenced by column number. Perhaps the check isn't too stringent but we should have something like implicit converters to create the correct subset of the sample sheet to supply at the workflow input.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
