### PR TITLE
[25.1] Fix exception message to enable debugging of missing dataset issue.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7414,7 +7414,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
                         flush=False, element_destination=history
                     )
             else:
-                raise ValueError("Cannot replace {type(replacement.element_object)}")
+                raise ValueError(f"Cannot replace {type(replacement.element_object)}")
 
     def replace_failed_elements(self, replacements):
         stmt = self._build_nested_collection_attributes_stmt(


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/21255

>> I've seen this recently as well, by any chance is the info column on these HDAs Cannot replace {type(replacement.element_object)}?

> yes

## How to test the changes?

Cannot - otherwise I think we would understand the problem with https://github.com/galaxyproject/galaxy/issues/21255. I think after this at least we would have some clues about what the bad replacement is.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
