### PR TITLE
Provide more accurate step hints for failing subworkflow steps

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15652,10 +15652,10 @@ export interface components {
              */
             reason: "history_deleted";
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationCancellationReviewFailedResponse */
         InvocationCancellationReviewFailedResponse: {
@@ -15670,10 +15670,10 @@ export interface components {
              */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationCancellationUserRequestResponse */
         InvocationCancellationUserRequestResponse: {
@@ -15683,10 +15683,10 @@ export interface components {
              */
             reason: "user_request";
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationEvaluationWarningWorkflowOutputNotFoundResponse */
         InvocationEvaluationWarningWorkflowOutputNotFoundResponse: {
@@ -15703,10 +15703,10 @@ export interface components {
             /** Workflow step id of step that caused a warning. */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationFailureCollectionFailedResponse */
         InvocationFailureCollectionFailedResponse: {
@@ -15732,10 +15732,10 @@ export interface components {
              */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationFailureDatasetFailedResponse */
         InvocationFailureDatasetFailedResponse: {
@@ -15761,10 +15761,10 @@ export interface components {
              */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationFailureExpressionEvaluationFailedResponse */
         InvocationFailureExpressionEvaluationFailedResponse: {
@@ -15784,10 +15784,10 @@ export interface components {
              */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationFailureJobFailedResponse */
         InvocationFailureJobFailedResponse: {
@@ -15813,10 +15813,10 @@ export interface components {
              */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationFailureOutputNotFoundResponse */
         InvocationFailureOutputNotFoundResponse: {
@@ -15838,10 +15838,10 @@ export interface components {
              */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationFailureWhenNotBooleanResponse */
         InvocationFailureWhenNotBooleanResponse: {
@@ -15861,10 +15861,10 @@ export interface components {
              */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationFailureWorkflowParameterInvalidResponse */
         InvocationFailureWorkflowParameterInvalidResponse: {
@@ -15881,10 +15881,10 @@ export interface components {
             /** Workflow parameter step that failed validation */
             workflow_step_id: number;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationInput */
         InvocationInput: {
@@ -16364,10 +16364,10 @@ export interface components {
              */
             workflow_step_id?: number | null;
             /**
-             * Workflow Step Id Path
+             * Workflow Step Index Path
              * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
              */
-            workflow_step_id_path?: number[] | null;
+            workflow_step_index_path?: number[] | null;
         };
         /** InvocationUpdatePayload */
         InvocationUpdatePayload: {

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -15651,6 +15651,11 @@ export interface components {
              * @enum {string}
              */
             reason: "history_deleted";
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationCancellationReviewFailedResponse */
         InvocationCancellationReviewFailedResponse: {
@@ -15664,6 +15669,11 @@ export interface components {
              * @description Workflow step id of paused step that did not pass review.
              */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationCancellationUserRequestResponse */
         InvocationCancellationUserRequestResponse: {
@@ -15672,6 +15682,11 @@ export interface components {
              * @enum {string}
              */
             reason: "user_request";
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationEvaluationWarningWorkflowOutputNotFoundResponse */
         InvocationEvaluationWarningWorkflowOutputNotFoundResponse: {
@@ -15687,6 +15702,11 @@ export interface components {
             reason: "workflow_output_not_found";
             /** Workflow step id of step that caused a warning. */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationFailureCollectionFailedResponse */
         InvocationFailureCollectionFailedResponse: {
@@ -15711,6 +15731,11 @@ export interface components {
              * @description Workflow step id of step that failed.
              */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationFailureDatasetFailedResponse */
         InvocationFailureDatasetFailedResponse: {
@@ -15735,6 +15760,11 @@ export interface components {
              * @description Workflow step id of step that failed.
              */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationFailureExpressionEvaluationFailedResponse */
         InvocationFailureExpressionEvaluationFailedResponse: {
@@ -15753,6 +15783,11 @@ export interface components {
              * @description Workflow step id of step that failed.
              */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationFailureJobFailedResponse */
         InvocationFailureJobFailedResponse: {
@@ -15777,6 +15812,11 @@ export interface components {
              * @description Workflow step id of step that failed.
              */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationFailureOutputNotFoundResponse */
         InvocationFailureOutputNotFoundResponse: {
@@ -15797,6 +15837,11 @@ export interface components {
              * @description Workflow step id of step that failed.
              */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationFailureWhenNotBooleanResponse */
         InvocationFailureWhenNotBooleanResponse: {
@@ -15815,6 +15860,11 @@ export interface components {
              * @description Workflow step id of step that failed.
              */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationFailureWorkflowParameterInvalidResponse */
         InvocationFailureWorkflowParameterInvalidResponse: {
@@ -15830,6 +15880,11 @@ export interface components {
             reason: "workflow_parameter_invalid";
             /** Workflow parameter step that failed validation */
             workflow_step_id: number;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationInput */
         InvocationInput: {
@@ -16308,6 +16363,11 @@ export interface components {
              * @description Workflow step id of step that failed.
              */
             workflow_step_id?: number | null;
+            /**
+             * Workflow Step Id Path
+             * @description Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).
+             */
+            workflow_step_id_path?: number[] | null;
         };
         /** InvocationUpdatePayload */
         InvocationUpdatePayload: {

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import type { InvocationMessage } from "@/api/invocations";
+import type { InvocationMessage, WorkflowInvocationElementView } from "@/api/invocations";
+import { useInvocationMessageStepData } from "@/composables/useInvocationMessageStepData";
 
 import { INVOCATION_MSG_LEVEL } from "./util";
 
@@ -16,87 +17,265 @@ const FAIL_FRAGMENT = "Invocation scheduling failed because ";
 
 interface Props {
     invocationMessage: InvocationMessage;
+    invocation?: WorkflowInvocationElementView;
 }
 
 const props = defineProps<Props>();
 
+const emit = defineEmits<{
+    (e: "view-step", stepId: number): void;
+    (e: "view-subworkflow-invocation", invocationId: string, stepId: number): void;
+}>();
+
+// Create stable computed refs for the composable to avoid re-fetching on every render
+const invocationId = computed(() => props.invocation?.id || "");
+const pathStepOrderIndices = computed(() => {
+    if (
+        "workflow_step_id_path" in props.invocationMessage &&
+        Array.isArray(props.invocationMessage.workflow_step_id_path)
+    ) {
+        return props.invocationMessage.workflow_step_id_path as number[];
+    }
+    return [];
+});
+const finalStepOrderIndex = computed(() => {
+    if ("workflow_step_id" in props.invocationMessage) {
+        return props.invocationMessage.workflow_step_id as number;
+    }
+    return undefined;
+});
+
+// Use the composable to fetch enriched step data with proper labels for nested subworkflows
+const { stepData, loading, error } = useInvocationMessageStepData(
+    invocationId,
+    pathStepOrderIndices,
+    finalStepOrderIndex,
+);
+
+// Check if we have step path information and can make it clickable
+const hasClickableStepPath = computed(() => {
+    return props.invocation && stepData.value.length > 0 && !loading.value && !error.value;
+});
+
+// Build array of step info for rendering clickable badges from the enriched step data
+const stepPathInfo = computed(() => {
+    return stepData.value.map((step) => ({
+        workflowStepId: step.workflowStepId,
+        invocationStepId: step.invocationStepId,
+        subworkflowInvocationId: step.subworkflowInvocationId,
+        label: step.label,
+        type: step.stepType,
+        isSubworkflow: step.stepType === "subworkflow",
+        isFinalStep: step.isFinalStep,
+        parentInvocationId: step.parentInvocationId,
+    }));
+});
+
+function buildStepPath(message: InvocationMessage): string {
+    if (
+        "workflow_step_id_path" in message &&
+        "workflow_step_id" in message &&
+        message.workflow_step_id_path &&
+        Array.isArray(message.workflow_step_id_path) &&
+        message.workflow_step_id_path.length > 0 &&
+        message.workflow_step_id !== null &&
+        message.workflow_step_id !== undefined
+    ) {
+        // Build path like "Step 2 → Step 5 → Step 9"
+        const pathSteps = (message.workflow_step_id_path as number[]).map((id: number) => `Step ${id + 1}`).join(" → ");
+        return `${pathSteps} → Step ${message.workflow_step_id + 1}`;
+    }
+    if ("workflow_step_id" in message && message.workflow_step_id !== null && message.workflow_step_id !== undefined) {
+        return `step ${message.workflow_step_id + 1}`;
+    }
+    return "";
+}
+
+function handleStepClick(stepInfo: any) {
+    // If this step has a parentInvocationId, it's in a subworkflow
+    if (stepInfo.parentInvocationId) {
+        // Navigate to the parent (subworkflow) invocation and highlight this step
+        emit("view-subworkflow-invocation", stepInfo.parentInvocationId, stepInfo.workflowStepId);
+    }
+    // If this is the final step in a subworkflow, navigate to that subworkflow invocation
+    else if (stepInfo.isFinalStep && stepInfo.subworkflowInvocationId) {
+        emit("view-subworkflow-invocation", stepInfo.subworkflowInvocationId, stepInfo.workflowStepId);
+    }
+    // If this is a subworkflow step in the path, navigate to that subworkflow invocation
+    else if (stepInfo.isSubworkflow && stepInfo.subworkflowInvocationId) {
+        emit("view-subworkflow-invocation", stepInfo.subworkflowInvocationId, 0);
+    }
+    // Otherwise, navigate to the step in the current workflow
+    else {
+        emit("view-step", stepInfo.workflowStepId);
+    }
+}
+
 const levelClass = computed(() => LEVEL_CLASSES[INVOCATION_MSG_LEVEL[props.invocationMessage.reason]]);
 
-const infoString = computed(() => {
+// Compute message parts for rendering with clickable steps
+const messageInfo = computed(() => {
     const invocationMessage = props.invocationMessage;
     const reason = invocationMessage.reason;
+
     if (reason === "user_request") {
-        return `${CANCEL_FRAGMENT} user requested cancellation.`;
+        return { text: `${CANCEL_FRAGMENT} user requested cancellation.`, hasStepPath: false };
     } else if (reason === "history_deleted") {
-        return `${CANCEL_FRAGMENT} the history of the invocation was deleted.`;
+        return { text: `${CANCEL_FRAGMENT} the history of the invocation was deleted.`, hasStepPath: false };
     } else if (reason === "cancelled_on_review") {
-        return `${CANCEL_FRAGMENT} the invocation was paused at step ${
-            invocationMessage.workflow_step_id + 1
-        } and not approved.`;
+        return {
+            text: `${CANCEL_FRAGMENT} the invocation was paused at step ${
+                invocationMessage.workflow_step_id + 1
+            } and not approved.`,
+            hasStepPath: false,
+        };
     } else if (reason === "collection_failed") {
-        return `${FAIL_FRAGMENT} step ${
-            invocationMessage.workflow_step_id + 1
-        } requires a dataset collection created by step ${
-            invocationMessage.dependent_workflow_step_id + 1
-        }, but dataset collection entered a failed state.`;
+        return {
+            text: `${FAIL_FRAGMENT} step ${
+                invocationMessage.workflow_step_id + 1
+            } requires a dataset collection created by step ${
+                invocationMessage.dependent_workflow_step_id + 1
+            }, but dataset collection entered a failed state.`,
+            hasStepPath: false,
+        };
     } else if (reason === "dataset_failed") {
         if (
             invocationMessage.dependent_workflow_step_id !== null &&
             invocationMessage.dependent_workflow_step_id !== undefined
         ) {
-            return `${FAIL_FRAGMENT} step ${
-                invocationMessage.workflow_step_id + 1
-            } requires a dataset created by step ${
-                invocationMessage.dependent_workflow_step_id + 1
-            }, but dataset entered a failed state.`;
+            return {
+                text: `${FAIL_FRAGMENT} step ${
+                    invocationMessage.workflow_step_id + 1
+                } requires a dataset created by step ${
+                    invocationMessage.dependent_workflow_step_id + 1
+                }, but dataset entered a failed state.`,
+                hasStepPath: false,
+            };
         } else {
-            return `${FAIL_FRAGMENT} step ${
-                invocationMessage.workflow_step_id + 1
-            } requires a dataset, but dataset entered a failed state.`;
+            return {
+                text: `${FAIL_FRAGMENT} step ${
+                    invocationMessage.workflow_step_id + 1
+                } requires a dataset, but dataset entered a failed state.`,
+                hasStepPath: false,
+            };
         }
     } else if (reason === "job_failed") {
-        return `${FAIL_FRAGMENT} step ${invocationMessage.workflow_step_id + 1} depends on job(s) created in step ${
-            invocationMessage.dependent_workflow_step_id + 1
-        }, but a job for that step failed.`;
+        return {
+            text: `${FAIL_FRAGMENT} step ${invocationMessage.workflow_step_id + 1} depends on job(s) created in step ${
+                invocationMessage.dependent_workflow_step_id + 1
+            }, but a job for that step failed.`,
+            hasStepPath: false,
+        };
     } else if (reason === "output_not_found") {
-        return `${FAIL_FRAGMENT} step ${invocationMessage.workflow_step_id + 1} depends on output '${
-            invocationMessage.output_name
-        }' of step ${
-            invocationMessage.dependent_workflow_step_id + 1
-        }, but this step did not produce an output of that name.`;
+        return {
+            text: `${FAIL_FRAGMENT} step ${invocationMessage.workflow_step_id + 1} depends on output '${
+                invocationMessage.output_name
+            }' of step ${
+                invocationMessage.dependent_workflow_step_id + 1
+            }, but this step did not produce an output of that name.`,
+            hasStepPath: false,
+        };
     } else if (reason === "expression_evaluation_failed") {
-        return `${FAIL_FRAGMENT} step ${
-            invocationMessage.workflow_step_id + 1
-        } contains an expression that could not be evaluated.`;
+        return {
+            prefix: `${FAIL_FRAGMENT}`,
+            suffix: "contains an expression that could not be evaluated.",
+            hasStepPath: true,
+        };
     } else if (reason === "when_not_boolean") {
-        return `${FAIL_FRAGMENT} step ${
-            invocationMessage.workflow_step_id + 1
-        } is a conditional step and the result of the when expression is not a boolean type.`;
+        return {
+            prefix: `${FAIL_FRAGMENT}`,
+            suffix: "is a conditional step and the result of the when expression is not a boolean type.",
+            hasStepPath: true,
+        };
     } else if (reason === "unexpected_failure") {
-        let atStep = "";
         if (invocationMessage.workflow_step_id !== null && invocationMessage.workflow_step_id !== undefined) {
-            atStep = ` at step ${invocationMessage.workflow_step_id + 1}`;
+            const details = invocationMessage.details ? `: '${invocationMessage.details}'` : ".";
+            return {
+                prefix: `${FAIL_FRAGMENT} an unexpected failure occurred at`,
+                suffix: details,
+                hasStepPath: true,
+            };
         }
-        if (invocationMessage.details) {
-            return `${FAIL_FRAGMENT} an unexpected failure occurred${atStep}: '${invocationMessage.details}'`;
-        }
-        return `${FAIL_FRAGMENT} an unexpected failure occurred${atStep}.`;
+        const details = invocationMessage.details ? `: '${invocationMessage.details}'` : ".";
+        return { text: `${FAIL_FRAGMENT} an unexpected failure occurred${details}`, hasStepPath: false };
     } else if (reason === "workflow_output_not_found") {
-        return `Defined workflow output '${invocationMessage.output_name}' was not found in step ${
-            invocationMessage.workflow_step_id + 1
-        }.`;
+        return {
+            prefix: `Defined workflow output '${invocationMessage.output_name}' was not found in`,
+            suffix: ".",
+            hasStepPath: true,
+        };
     } else if (reason === "workflow_parameter_invalid") {
-        return `Workflow parameter on step ${invocationMessage.workflow_step_id + 1} failed validation: ${
-            invocationMessage.details
-        }`;
+        return {
+            prefix: "Workflow parameter on",
+            suffix: `failed validation: ${invocationMessage.details}`,
+            hasStepPath: true,
+        };
     } else {
-        return reason;
+        return { text: reason, hasStepPath: false };
     }
+});
+
+// Fallback to simple string when no invocation data is available
+const infoString = computed(() => {
+    const info = messageInfo.value;
+    if (info.hasStepPath) {
+        const stepRef = buildStepPath(props.invocationMessage);
+        return `${info.prefix} ${stepRef} ${info.suffix}`;
+    }
+    return info.text || "";
 });
 </script>
 
 <template>
     <div :class="levelClass" style="text-align: center">
-        {{ infoString }}
+        <template v-if="messageInfo.hasStepPath && hasClickableStepPath">
+            <span>{{ messageInfo.prefix }}</span>
+            <span
+                v-for="(stepInfo, index) in stepPathInfo"
+                :key="`step-${index}-${stepInfo.isFinalStep ? 'final' : 'path'}`"
+                class="step-path-container">
+                <button class="step-badge clickable" @click="handleStepClick(stepInfo)">
+                    {{ stepInfo.label }}
+                </button>
+                <span v-if="index < stepPathInfo.length - 1" class="step-arrow"> → </span>
+            </span>
+            <span>{{ messageInfo.suffix }}</span>
+        </template>
+        <template v-else>
+            {{ infoString }}
+        </template>
     </div>
 </template>
+
+<style scoped>
+.step-path-container {
+    display: inline;
+}
+
+.step-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    margin: 0 2px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-weight: 500;
+}
+
+.step-badge.clickable {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.step-badge.clickable:hover {
+    background-color: #0056b3;
+    text-decoration: underline;
+}
+
+.step-arrow {
+    color: inherit;
+    margin: 0 4px;
+}
+</style>

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -31,10 +31,10 @@ const emit = defineEmits<{
 const invocationId = computed(() => props.invocation?.id || "");
 const pathStepOrderIndices = computed(() => {
     if (
-        "workflow_step_id_path" in props.invocationMessage &&
-        Array.isArray(props.invocationMessage.workflow_step_id_path)
+        "workflow_step_index_path" in props.invocationMessage &&
+        Array.isArray(props.invocationMessage.workflow_step_index_path)
     ) {
-        return props.invocationMessage.workflow_step_id_path as number[];
+        return props.invocationMessage.workflow_step_index_path as number[];
     }
     return [];
 });
@@ -73,16 +73,18 @@ const stepPathInfo = computed(() => {
 
 function buildStepPath(message: InvocationMessage): string {
     if (
-        "workflow_step_id_path" in message &&
+        "workflow_step_index_path" in message &&
         "workflow_step_id" in message &&
-        message.workflow_step_id_path &&
-        Array.isArray(message.workflow_step_id_path) &&
-        message.workflow_step_id_path.length > 0 &&
+        message.workflow_step_index_path &&
+        Array.isArray(message.workflow_step_index_path) &&
+        message.workflow_step_index_path.length > 0 &&
         message.workflow_step_id !== null &&
         message.workflow_step_id !== undefined
     ) {
         // Build path like "Step 2 → Step 5 → Step 9"
-        const pathSteps = (message.workflow_step_id_path as number[]).map((id: number) => `Step ${id + 1}`).join(" → ");
+        const pathSteps = (message.workflow_step_index_path as number[])
+            .map((id: number) => `Step ${id + 1}`)
+            .join(" → ");
         return `${pathSteps} → Step ${message.workflow_step_id + 1}`;
     }
     if ("workflow_step_id" in message && message.workflow_step_id !== null && message.workflow_step_id !== undefined) {

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationError.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationError.vue
@@ -34,10 +34,10 @@ const { stepData } = useInvocationMessageStepData(
     computed(() => props.invocation?.id || ""),
     computed(() => {
         if (
-            "workflow_step_id_path" in props.invocationMessage &&
-            Array.isArray(props.invocationMessage.workflow_step_id_path)
+            "workflow_step_index_path" in props.invocationMessage &&
+            Array.isArray(props.invocationMessage.workflow_step_index_path)
         ) {
-            return props.invocationMessage.workflow_step_id_path as number[];
+            return props.invocationMessage.workflow_step_index_path as number[];
         }
         return [];
     }),

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationError.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationError.vue
@@ -25,6 +25,7 @@ const props = defineProps<InvocationMessageProps>();
 
 const emit = defineEmits<{
     (e: "view-step", stepId: number): void;
+    (e: "view-subworkflow-invocation", invocationId: string, stepId: number): void;
 }>();
 
 const workflow = computed(() => {
@@ -97,7 +98,13 @@ function openJobInNewTab(jobId: string) {
 
 <template>
     <div>
-        <InvocationMessageView :invocation-message="props.invocationMessage" />
+        <InvocationMessageView
+            :invocation-message="props.invocationMessage"
+            :invocation="props.invocation"
+            @view-step="emit('view-step', $event)"
+            @view-subworkflow-invocation="
+                (invocationId, stepId) => emit('view-subworkflow-invocation', invocationId, stepId)
+            " />
         <div class="invocation-error-grid d-flex flex-wrap">
             <GCard
                 v-if="dependentWorkflowStep"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationFeedback.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationFeedback.vue
@@ -114,7 +114,8 @@ async function submit(message: string): Promise<string[][] | undefined> {
             <InvocationMessageView
                 v-for="message in props.invocationMessages"
                 :key="message.reason"
-                :invocation-message="message" />
+                :invocation-message="message"
+                :invocation="props.invocation" />
         </div>
 
         <div v-if="steps && stepsWithErrors.length">

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationOverview.vue
@@ -2,6 +2,7 @@
 import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, nextTick, ref } from "vue";
+import { useRouter } from "vue-router/composables";
 
 import type { InvocationMessage, StepJobSummary, WorkflowInvocationElementView } from "@/api/invocations";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
@@ -26,6 +27,7 @@ const props = defineProps<Props>();
 const { workflow, loading, error } = useWorkflowInstance(props.invocation.workflow_id);
 
 const invocationGraph = ref<InstanceType<typeof InvocationGraph> | null>(null);
+const router = useRouter();
 
 // TODO: Refactor so that `storeId` is only defined here, and then used in all children components/composables.
 const storeId = computed(() => `invocation-${props.invocation.id}`);
@@ -40,6 +42,13 @@ async function showStep(stepId: number) {
         graphSelector?.scrollIntoView({ behavior: "smooth", block: "start" });
     }
 }
+
+function showSubworkflowInvocation(invocationId: string, stepId: number) {
+    // Navigate to the subworkflow invocation page
+    // The stepId parameter could be used to highlight a specific step, but for now
+    // we'll just navigate to the subworkflow invocation
+    router.push(`/workflows/invocations/${invocationId}`);
+}
 </script>
 
 <template>
@@ -51,9 +60,10 @@ async function showStep(stepId: number) {
                 :key="message.reason"
                 class="steps-progress my-1 w-100"
                 :invocation-message="message"
-                :invocation="invocation"
+                :invocation="props.invocation"
                 :store-id="storeId"
-                @view-step="showStep" />
+                @view-step="showStep"
+                @view-subworkflow-invocation="showSubworkflowInvocation" />
         </div>
         <!-- Once the workflow for the invocation and step job summaries are loaded, display the graph -->
         <BAlert v-if="loading || !props.stepsJobsSummary" variant="info" show>

--- a/client/src/composables/useInvocationMessageStepData.ts
+++ b/client/src/composables/useInvocationMessageStepData.ts
@@ -57,7 +57,7 @@ function generateStepLabel(orderIndex: number, workflowStep: WorkflowStep): stri
  * the necessary invocation and workflow data to properly display step information in error messages.
  *
  * @param invocationId - The workflow invocation ID
- * @param pathStepOrderIndices - Array of step order indices from workflow_step_id_path
+ * @param pathStepOrderIndices - Array of step order indices from workflow_step_index_path
  * @param finalStepOrderIndex - The failing step order index from workflow_step_id
  * @returns Object containing stepData array, loading state, and error message
  */

--- a/client/src/composables/useInvocationMessageStepData.ts
+++ b/client/src/composables/useInvocationMessageStepData.ts
@@ -1,0 +1,240 @@
+import type { Ref } from "vue";
+import { ref, watch } from "vue";
+
+import { isWorkflowInvocationElementView } from "@/api/invocations";
+import { useInvocationStore } from "@/stores/invocationStore";
+import { useWorkflowStore } from "@/stores/workflowStore";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+export interface EnrichedStepInfo {
+    workflowStepId: number; // Step order_index
+    orderIndex: number; // Same as workflowStepId for clarity
+    label: string; // "Step {orderIndex + 1}" or enriched label with step name/tool
+    stepType?: string; // "tool", "subworkflow", etc.
+    invocationStepId?: string; // Invocation step ID for navigation
+    subworkflowInvocationId?: string | null; // For navigating to subworkflow (can be null)
+    parentInvocationId?: string; // If this step is in a subworkflow, the parent invocation ID
+    isFinalStep?: boolean; // True if this is the failing step
+    subworkflowData?: {
+        // If this is a subworkflow step
+        invocationId: string;
+        workflowId: string;
+        steps: Record<number, unknown>; // Subworkflow step definitions keyed by order_index
+    };
+}
+
+interface WorkflowStep {
+    type: string;
+    label?: string;
+    tool_id?: string;
+    [key: string]: unknown;
+}
+
+/**
+ * Generate a descriptive label for a workflow step
+ */
+function generateStepLabel(orderIndex: number, workflowStep: WorkflowStep): string {
+    let label = `Step ${orderIndex + 1}`;
+    if (workflowStep) {
+        // Try to get label from the workflow step
+        if ("label" in workflowStep && workflowStep.label) {
+            label = `${orderIndex + 1}:${workflowStep.label}`;
+        } else if (workflowStep.type === "tool" && "tool_id" in workflowStep && workflowStep.tool_id) {
+            // Extract tool name from tool_id (e.g., "toolshed.../owner/name/tool" -> "tool")
+            const toolName = workflowStep.tool_id.split("/").pop() || workflowStep.tool_id;
+            label = `${orderIndex + 1}:${toolName}`;
+        } else if (workflowStep.type === "subworkflow") {
+            label = `${orderIndex + 1}:subworkflow`;
+        }
+    }
+    return label;
+}
+
+/**
+ * Composable for fetching enriched step data for workflow invocation error messages.
+ *
+ * This composable takes an invocation ID and arrays of step order indices and eagerly fetches
+ * the necessary invocation and workflow data to properly display step information in error messages.
+ *
+ * @param invocationId - The workflow invocation ID
+ * @param pathStepOrderIndices - Array of step order indices from workflow_step_id_path
+ * @param finalStepOrderIndex - The failing step order index from workflow_step_id
+ * @returns Object containing stepData array, loading state, and error message
+ */
+export function useInvocationMessageStepData(
+    invocationId: Ref<string>,
+    pathStepOrderIndices: Ref<number[]>,
+    finalStepOrderIndex?: Ref<number | undefined>,
+) {
+    const invocationStore = useInvocationStore();
+    const workflowStore = useWorkflowStore();
+
+    const stepData = ref<EnrichedStepInfo[]>([]);
+    const loading = ref(false);
+    const error = ref<string>();
+
+    // Track the last fetched parameters to avoid duplicate fetches
+    let lastFetchedKey = "";
+
+    async function fetchStepData() {
+        if (!invocationId.value) {
+            stepData.value = [];
+            return;
+        }
+
+        // Create a unique key for this fetch to deduplicate requests
+        const fetchKey = `${invocationId.value}:${JSON.stringify(pathStepOrderIndices.value)}:${finalStepOrderIndex?.value}`;
+        if (fetchKey === lastFetchedKey) {
+            // Already fetched this exact data, skip
+            return;
+        }
+        lastFetchedKey = fetchKey;
+
+        loading.value = true;
+        error.value = undefined;
+
+        try {
+            // 1. Fetch parent invocation (uses cache if available)
+            const invocation = await invocationStore.fetchInvocationById({ id: invocationId.value });
+
+            if (!invocation) {
+                throw new Error(`Invocation ${invocationId.value} not found`);
+            }
+
+            // Check if invocation has the detailed view (with steps)
+            if (!isWorkflowInvocationElementView(invocation)) {
+                throw new Error(`Invocation ${invocationId.value} does not have step details. This should not happen.`);
+            }
+
+            // 2. Fetch parent workflow definition
+            // First get the workflow by instance ID to get the stored workflow ID
+            await workflowStore.fetchWorkflowForInstanceIdCached(invocation.workflow_id);
+            const storedWorkflowId = workflowStore.getStoredWorkflowIdByInstanceId(invocation.workflow_id);
+
+            if (!storedWorkflowId) {
+                throw new Error(`Could not find stored workflow ID for instance ${invocation.workflow_id}`);
+            }
+
+            // Now fetch the full workflow using the stored workflow ID
+            const workflow = await workflowStore.getFullWorkflowCached(storedWorkflowId);
+
+            if (!workflow) {
+                throw new Error(`Workflow ${storedWorkflowId} not found`);
+            }
+
+            const enrichedSteps: EnrichedStepInfo[] = [];
+
+            // 3. Process each step in the path (EAGER FETCHING with nested navigation)
+            // The path represents nested subworkflows: each element navigates one level deeper
+            // e.g., [1, 1] means: parent step 1 (subworkflow) -> that subworkflow's step 1
+
+            let currentWorkflow = workflow;
+            let currentInvocation = invocation;
+
+            for (let i = 0; i < pathStepOrderIndices.value.length; i++) {
+                const orderIndex = pathStepOrderIndices.value[i];
+
+                // Type guard: ensure orderIndex is a valid number
+                if (orderIndex === undefined || typeof orderIndex !== "number") {
+                    console.warn(`Invalid order_index at path level ${i}: ${orderIndex}`);
+                    continue;
+                }
+
+                // Look up step in the current workflow level
+                const workflowStep = currentWorkflow.steps[orderIndex] as WorkflowStep | undefined;
+                if (!workflowStep) {
+                    console.warn(`Step with order_index ${orderIndex} not found in workflow at path level ${i}`);
+                    continue;
+                }
+
+                // Get invocation step from current invocation level
+                const invocationStep = currentInvocation.steps[orderIndex];
+
+                // Build basic step info with descriptive label
+                const stepInfo: EnrichedStepInfo = {
+                    workflowStepId: orderIndex,
+                    orderIndex: orderIndex,
+                    label: generateStepLabel(orderIndex, workflowStep),
+                    stepType: workflowStep.type,
+                    invocationStepId: invocationStep?.id,
+                    subworkflowInvocationId: invocationStep?.subworkflow_invocation_id,
+                };
+
+                // EAGER FETCH: If this is a subworkflow, fetch its invocation data for the next level
+                if (workflowStep.type === "subworkflow" && invocationStep?.subworkflow_invocation_id) {
+                    try {
+                        const subInvocation = await invocationStore.fetchInvocationById({
+                            id: invocationStep.subworkflow_invocation_id,
+                        });
+
+                        if (subInvocation && isWorkflowInvocationElementView(subInvocation)) {
+                            // Get the stored workflow ID for the subworkflow
+                            await workflowStore.fetchWorkflowForInstanceIdCached(subInvocation.workflow_id);
+                            const subStoredWorkflowId = workflowStore.getStoredWorkflowIdByInstanceId(
+                                subInvocation.workflow_id,
+                            );
+
+                            if (subStoredWorkflowId) {
+                                const subWorkflow = await workflowStore.getFullWorkflowCached(subStoredWorkflowId);
+
+                                if (subWorkflow) {
+                                    stepInfo.subworkflowData = {
+                                        invocationId: subInvocation.id,
+                                        workflowId: subInvocation.workflow_id,
+                                        steps: subWorkflow.steps,
+                                    };
+
+                                    // Navigate into the subworkflow for the next iteration
+                                    currentWorkflow = subWorkflow;
+                                    currentInvocation = subInvocation;
+                                }
+                            }
+                        }
+                    } catch (subError) {
+                        console.warn(
+                            `Failed to fetch subworkflow invocation ${invocationStep.subworkflow_invocation_id}:`,
+                            subError,
+                        );
+                        // Continue processing even if subworkflow fetch fails
+                    }
+                }
+
+                enrichedSteps.push(stepInfo);
+            }
+
+            // 4. Process the final failing step if provided
+            // The final step is in the currentWorkflow/currentInvocation (which may be a subworkflow)
+            if (finalStepOrderIndex?.value !== undefined) {
+                const finalStepIndex = finalStepOrderIndex.value;
+                const workflowStep = currentWorkflow.steps[finalStepIndex] as WorkflowStep | undefined;
+                const invocationStep = currentInvocation.steps[finalStepIndex];
+
+                if (workflowStep) {
+                    enrichedSteps.push({
+                        workflowStepId: finalStepIndex,
+                        orderIndex: finalStepIndex,
+                        label: generateStepLabel(finalStepIndex, workflowStep),
+                        stepType: workflowStep.type,
+                        invocationStepId: invocationStep?.id,
+                        // If currentInvocation is different from the parent invocation, set parentInvocationId
+                        parentInvocationId: currentInvocation.id !== invocation.id ? currentInvocation.id : undefined,
+                        isFinalStep: true,
+                    });
+                }
+            }
+
+            stepData.value = enrichedSteps;
+        } catch (e) {
+            error.value = errorMessageAsString(e);
+            stepData.value = [];
+        } finally {
+            loading.value = false;
+        }
+    }
+
+    // Auto-fetch when inputs change
+    // Note: We don't use deep: true because we handle deduplication manually via fetchKey
+    watch([invocationId, pathStepOrderIndices, finalStepOrderIndex], fetchStepData, { immediate: true });
+
+    return { stepData, loading, error };
+}

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9886,15 +9886,18 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         return inputs, inputs_by
 
     def add_message(self, message: "InvocationMessageUnion"):
+
+        message_dict = message.dict(
+            exclude_unset=True,
+            exclude={"history_id"},  # history_id comes in through workflow_invocation and isn't persisted in database
+        )
+        # Convert workflow_step_id_path list to JSON string for database storage
+        if "workflow_step_id_path" in message_dict and message_dict["workflow_step_id_path"] is not None:
+            message_dict["workflow_step_id_path"] = message_dict["workflow_step_id_path"]
         self.messages.append(
             WorkflowInvocationMessage(  # type:ignore[abstract]
                 workflow_invocation_id=self.id,
-                **message.dict(
-                    exclude_unset=True,
-                    exclude={
-                        "history_id"
-                    },  # history_id comes in through workflow_invocation and isn't persisted in database
-                ),
+                **message_dict,
             )
         )
 
@@ -9974,6 +9977,7 @@ class WorkflowInvocationMessage(Base, Dictifiable, Serializable):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"))
     hda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"))
     hdca_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_collection_association.id"))
+    workflow_step_id_path: Mapped[Optional[list[int]]] = mapped_column(JSON)
 
     workflow_invocation: Mapped["WorkflowInvocation"] = relationship(back_populates="messages", lazy=True)
     workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(foreign_keys=workflow_step_id, lazy=True)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9891,9 +9891,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
             exclude_unset=True,
             exclude={"history_id"},  # history_id comes in through workflow_invocation and isn't persisted in database
         )
-        # Convert workflow_step_id_path list to JSON string for database storage
-        if "workflow_step_id_path" in message_dict and message_dict["workflow_step_id_path"] is not None:
-            message_dict["workflow_step_id_path"] = message_dict["workflow_step_id_path"]
+        # Convert workflow_step_index_path list to JSON string for database storage
+        if "workflow_step_index_path" in message_dict and message_dict["workflow_step_index_path"] is not None:
+            message_dict["workflow_step_index_path"] = message_dict["workflow_step_index_path"]
         self.messages.append(
             WorkflowInvocationMessage(  # type:ignore[abstract]
                 workflow_invocation_id=self.id,
@@ -9977,7 +9977,7 @@ class WorkflowInvocationMessage(Base, Dictifiable, Serializable):
     job_id: Mapped[Optional[int]] = mapped_column(ForeignKey("job.id"))
     hda_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_association.id"))
     hdca_id: Mapped[Optional[int]] = mapped_column(ForeignKey("history_dataset_collection_association.id"))
-    workflow_step_id_path: Mapped[Optional[list[int]]] = mapped_column(JSON)
+    workflow_step_index_path: Mapped[Optional[list[int]]] = mapped_column(JSON)
 
     workflow_invocation: Mapped["WorkflowInvocation"] = relationship(back_populates="messages", lazy=True)
     workflow_step: Mapped[Optional["WorkflowStep"]] = relationship(foreign_keys=workflow_step_id, lazy=True)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/312602e3191d_add_workflow_step_id_path.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/312602e3191d_add_workflow_step_id_path.py
@@ -1,4 +1,4 @@
-"""Add workflow_step_id_path column to workflow_invocation_message table
+"""Add workflow_step_index_path column to workflow_invocation_message table
 
 Revision ID: 312602e3191d
 Revises: 75b461a2b24a
@@ -20,7 +20,7 @@ depends_on = None
 
 # database object names used in this revision
 table_name = "workflow_invocation_message"
-column_name = "workflow_step_id_path"
+column_name = "workflow_step_index_path"
 
 
 def upgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/312602e3191d_add_workflow_step_id_path.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/312602e3191d_add_workflow_step_id_path.py
@@ -1,0 +1,43 @@
+"""Add workflow_step_id_path column to workflow_invocation_message table
+
+Revision ID: 312602e3191d
+Revises: 75b461a2b24a
+Create Date: 2025-12-27 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
+
+# revision identifiers, used by Alembic.
+revision = "312602e3191d"
+down_revision = "75b461a2b24a"
+branch_labels = None
+depends_on = None
+
+# database object names used in this revision
+table_name = "workflow_invocation_message"
+column_name = "workflow_step_id_path"
+
+
+def upgrade():
+    column = sa.Column(
+        column_name,
+        sa.JSON,
+        nullable=True,  # Allow nulls for existing rows and backward compatibility
+        default=None,  # Default to None if not provided
+    )
+    add_column(
+        table_name,
+        column,
+    )
+
+
+def downgrade():
+    drop_column(
+        table_name,
+        column_name,
+    )

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -117,7 +117,7 @@ class CancelReason(str, Enum):
 
 class InvocationMessageBase(GenericModel):
     reason: Union[CancelReason, FailureReason, WarningReason]
-    workflow_step_id_path: Optional[List[int]] = Field(
+    workflow_step_index_path: Optional[List[int]] = Field(
         None,
         description="Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).",
     )

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -4,6 +4,7 @@ from typing import (
     Annotated,
     Any,
     Generic,
+    List,
     Optional,
     Union,
 )
@@ -116,6 +117,10 @@ class CancelReason(str, Enum):
 
 class InvocationMessageBase(GenericModel):
     reason: Union[CancelReason, FailureReason, WarningReason]
+    workflow_step_id_path: Optional[List[int]] = Field(
+        None,
+        description="Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).",
+    )
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -285,6 +285,15 @@ class WorkflowInvoker:
                     step.log_str(),
                     failure_reason,
                 )
+                if isinstance(e, modules.FailWorkflowEvaluation):
+                    # If this step is a subworkflow, prepend its ID to the path
+                    if step.type == "subworkflow":
+                        error_dict = e.why.model_dump()
+                        current_path = error_dict.get("workflow_step_id_path") or []
+                        current_path.append(step.order_index)
+                        error_dict["workflow_step_id_path"] = current_path
+                        error_class = type(e.why)
+                        e.why = error_class(**error_dict)
                 if isinstance(e, MessageException):
                     # This is the highest level at which we can inject the step id
                     # to provide some more context to the exception.

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -289,9 +289,9 @@ class WorkflowInvoker:
                     # If this step is a subworkflow, prepend its ID to the path
                     if step.type == "subworkflow":
                         error_dict = e.why.model_dump()
-                        current_path = error_dict.get("workflow_step_id_path") or []
+                        current_path = error_dict.get("workflow_step_index_path") or []
                         current_path.append(step.order_index)
-                        error_dict["workflow_step_id_path"] = current_path
+                        error_dict["workflow_step_index_path"] = current_path
                         error_class = type(e.why)
                         e.why = error_class(**error_dict)
                 if isinstance(e, MessageException):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3982,6 +3982,7 @@ steps:
                     "details": "Subworkflow has disconnected required input.",
                     "reason": "unexpected_failure",
                     "workflow_step_id": 0,
+                    "workflow_step_id_path": [0],
                 }
             ]
 
@@ -4036,6 +4037,55 @@ test_data:
                 wait=True,
                 assert_ok=True,
             )
+
+    def test_subworkflow_validation_error_step_path(self):
+        """Test that validation errors from subworkflows include the full step path."""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """
+class: GalaxyWorkflow
+inputs:
+  some_file:
+    type: data
+steps:
+  subworkflow_step:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        subworkflow_input:
+          type: data
+      steps:
+        conditional_step:
+          tool_id: cat1
+          in:
+            input1: subworkflow_input
+          when: $("not_a_boolean")
+    in:
+      subworkflow_input: some_file
+""",
+                test_data="""
+some_file:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+                wait=True,
+                assert_ok=False,
+            )
+            invocation_details = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation_details["state"] == "failed"
+            assert len(invocation_details["messages"]) == 1
+            message = invocation_details["messages"][0]
+            assert message["reason"] == "when_not_boolean"
+            assert message["details"] == "Type is: str"
+            # workflow_step_id should be the conditional_step in the subworkflow
+            # workflow_step_id_path should contain the subworkflow_step from the parent workflow
+            assert "workflow_step_id_path" in message
+            assert message["workflow_step_id_path"] is not None
+            assert len(message["workflow_step_id_path"]) == 1
+            # Verify the path contains the step ID (order_index, not the database id)
+            assert isinstance(message["workflow_step_id_path"][0], int)
+            assert message["workflow_step_id_path"][0] > 0
 
     def test_workflow_request(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_queue")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3982,7 +3982,7 @@ steps:
                     "details": "Subworkflow has disconnected required input.",
                     "reason": "unexpected_failure",
                     "workflow_step_id": 0,
-                    "workflow_step_id_path": [0],
+                    "workflow_step_index_path": [0],
                 }
             ]
 
@@ -4079,13 +4079,13 @@ some_file:
             assert message["reason"] == "when_not_boolean"
             assert message["details"] == "Type is: str"
             # workflow_step_id should be the conditional_step in the subworkflow
-            # workflow_step_id_path should contain the subworkflow_step from the parent workflow
-            assert "workflow_step_id_path" in message
-            assert message["workflow_step_id_path"] is not None
-            assert len(message["workflow_step_id_path"]) == 1
+            # workflow_step_index_path should contain the subworkflow_step from the parent workflow
+            assert "workflow_step_index_path" in message
+            assert message["workflow_step_index_path"] is not None
+            assert len(message["workflow_step_index_path"]) == 1
             # Verify the path contains the step ID (order_index, not the database id)
-            assert isinstance(message["workflow_step_id_path"][0], int)
-            assert message["workflow_step_id_path"][0] > 0
+            assert isinstance(message["workflow_step_index_path"][0], int)
+            assert message["workflow_step_index_path"][0] > 0
 
     def test_workflow_request(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_queue")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -4055,6 +4055,10 @@ steps:
         subworkflow_input:
           type: data
       steps:
+        first_step:
+          tool_id: cat1
+          in:
+            input1: subworkflow_input
         conditional_step:
           tool_id: cat1
           in:
@@ -4078,14 +4082,12 @@ some_file:
             message = invocation_details["messages"][0]
             assert message["reason"] == "when_not_boolean"
             assert message["details"] == "Type is: str"
-            # workflow_step_id should be the conditional_step in the subworkflow
-            # workflow_step_index_path should contain the subworkflow_step from the parent workflow
-            assert "workflow_step_index_path" in message
-            assert message["workflow_step_index_path"] is not None
-            assert len(message["workflow_step_index_path"]) == 1
-            # Verify the path contains the step ID (order_index, not the database id)
-            assert isinstance(message["workflow_step_index_path"][0], int)
-            assert message["workflow_step_index_path"][0] > 0
+            # Validate the complete workflow_step_index_path
+            # workflow_step_index_path tracks the path of subworkflow steps from parent to the subworkflow containing the error
+            # workflow_step_id is the ID of the actual failing step within that subworkflow
+            assert message["workflow_step_index_path"] == [1]
+            # Verify workflow_step_id points to the conditional_step (step 2 in the subworkflow)
+            assert message["workflow_step_id"] == 2
 
     def test_workflow_request(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_queue")


### PR DESCRIPTION
Closes https://github.com/galaxyproject/galaxy/issues/15655

<img width="724" height="716" alt="Screenshot 2025-12-28 at 17 40 41" src="https://github.com/user-attachments/assets/871bb33e-16f9-4692-bcda-6086476aade6" />

Each of the step paths are clickable and navigate to the correct invocation so you can inspect the actual failing step.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
