### PR TITLE
Restrict collection of dynamic working dir output to specified directory in pulsar

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -223,7 +223,7 @@ protobuf==5.29.5 ; python_full_version < '3.10'
 protobuf==6.33.3 ; python_full_version >= '3.10'
 prov==1.5.1
 psutil==7.2.1
-pulsar-galaxy-lib==0.15.12
+pulsar-galaxy-lib==0.15.13
 py-key-value-aio==0.3.0 ; python_full_version >= '3.10'
 py-key-value-shared==0.3.0 ; python_full_version >= '3.10'
 pyasn1==0.6.1

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -55,6 +55,8 @@ from galaxy.jobs.runners import (
 )
 from galaxy.model.base import check_database_connection
 from galaxy.tool_util.deps import dependencies
+from galaxy.tool_util.parser.output_collection_def import FilePatternDatasetCollectionDescription
+from galaxy.tool_util.parser.output_objects import ToolOutput
 from galaxy.util import (
     galaxy_directory,
     specs,
@@ -81,6 +83,7 @@ MINIMUM_PULSAR_VERSIONS = {
     "_default_": Version("0.7.0.dev3"),
     "remote_metadata": Version("0.8.0"),
     "remote_container_handling": Version("0.9.1.dev0"),  # probably 0.10 ultimately?
+    "dataset_collector_descriptions": Version("0.15.13.dev0"),  # Support for directory-aware pattern matching
 }
 
 NO_REMOTE_GALAXY_FOR_METADATA_MESSAGE = "Pulsar misconfiguration - Pulsar client configured to set metadata remotely, but remote Pulsar isn't properly configured with a galaxy_home directory."
@@ -467,7 +470,7 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 command_line=command_line,
                 input_files=input_files,
                 client_inputs=client_inputs,  # Only one of these input defs should be non-None
-                client_outputs=self.__client_outputs(client, job_wrapper),
+                client_outputs=self.__client_outputs(client, job_wrapper, remote_job_config),
                 working_directory=job_wrapper.tool_working_directory,
                 metadata_directory=metadata_directory,
                 tool=job_wrapper.tool if job_wrapper.tool and job_wrapper.tool.tool_dir else None,
@@ -727,7 +730,8 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 log.debug("Setting exit code for stopped job {job_wrapper.job_id} to 0 (was {exit_code})")
                 exit_code = 0
             cleanup_job = job_wrapper.cleanup_job
-            client_outputs = self.__client_outputs(client, job_wrapper)
+            # Pass run_results as remote_job_config for version detection
+            client_outputs = self.__client_outputs(client, job_wrapper, run_results)
             finish_args = dict(
                 client=client,
                 job_completed_normally=completed_normally,
@@ -854,7 +858,9 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         )
         return job_state
 
-    def __client_outputs(self, client: "BaseJobClient", job_wrapper: "MinimalJobWrapper") -> ClientOutputs:
+    def __client_outputs(
+        self, client: "BaseJobClient", job_wrapper: "MinimalJobWrapper", remote_job_config
+    ) -> ClientOutputs:
         metadata_directory = os.path.join(job_wrapper.working_directory, "metadata")
         metadata_strategy = job_wrapper.get_destination_configuration("metadata_strategy", None)
         assert job_wrapper.tool is not None
@@ -863,6 +869,18 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         tool_provided_metadata_style = tool.provided_metadata_style
 
         dynamic_outputs = None  # use default
+        dataset_collector_descriptions = []
+
+        # Check if Pulsar version supports dataset collector descriptions (>= 0.15.13)
+        pulsar_version = PulsarJobRunner.pulsar_version(remote_job_config)
+        supports_dataset_collectors = pulsar_version >= MINIMUM_PULSAR_VERSIONS["dataset_collector_descriptions"]
+        if supports_dataset_collectors:
+            log.debug(f"Pulsar version {pulsar_version} supports dataset collector descriptions")
+        else:
+            log.debug(
+                f"Pulsar version {pulsar_version} does not support dataset collector descriptions, using legacy pattern matching"
+            )
+
         if metadata_strategy == "extended" and PulsarJobRunner.__remote_metadata(client):
             # if Pulsar is doing remote metadata and the remote metadata is extended,
             # we only need to recover the final model store.
@@ -872,8 +890,38 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         else:
             # otherwise collect everything we might need
             dynamic_outputs = DEFAULT_DYNAMIC_COLLECTION_PATTERN[:]
-            # grab discovered outputs...
-            dynamic_outputs.extend(job_wrapper.tool.output_discover_patterns)
+
+            # Collect dataset collector descriptions for proper pattern matching in Pulsar
+            # These will be used for pattern matching with full support for directory, recurse, match_relative_path
+            # Only if Pulsar version supports it (>= 0.15.13)
+            # Only include FilePatternDatasetCollectionDescription - ToolProvidedMetadataDatasetCollection
+            # uses the dynamic_file_sources mechanism (galaxy.json) and has no patterns for file matching
+            if supports_dataset_collectors:
+                for output in job_wrapper.tool.outputs.values():
+                    if isinstance(output, ToolOutput):
+                        dataset_collector_descriptions.extend(
+                            [
+                                desc.to_dict()
+                                for desc in output.dataset_collector_descriptions
+                                if isinstance(desc, FilePatternDatasetCollectionDescription)
+                            ]
+                        )
+                for output_collection in job_wrapper.tool.output_collections.values():
+                    collector_descs = output_collection.structure.dataset_collector_descriptions
+                    if collector_descs:
+                        dataset_collector_descriptions.extend(
+                            [
+                                desc.to_dict()
+                                for desc in collector_descs
+                                if isinstance(desc, FilePatternDatasetCollectionDescription)
+                            ]
+                        )
+
+            # Only add raw patterns to dynamic_outputs if we don't have dataset collector descriptions
+            # (dataset collectors provide more precise matching with directory restrictions)
+            else:
+                # grab discovered outputs...
+                dynamic_outputs.extend(job_wrapper.tool.output_discover_patterns)
             # grab tool provided metadata (galaxy.json) also...
             dynamic_outputs.append(re.escape(tool_provided_metadata_file_path))
             output_files = self.get_output_files(job_wrapper)
@@ -892,6 +940,7 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             version_file=job_wrapper.get_version_string_path(),
             dynamic_outputs=dynamic_outputs,
             dynamic_file_sources=dynamic_file_sources,
+            dataset_collector_descriptions=dataset_collector_descriptions,
         )
         return client_outputs
 

--- a/test/functional/tools/collection_split_on_column.xml
+++ b/test/functional/tools/collection_split_on_column.xml
@@ -1,5 +1,6 @@
 <tool id="collection_split_on_column" name="collection_split_on_column" version="0.1.0">
   <command>
+    cp $input1 do_not_collect_me.txt;
     mkdir outputs; cd outputs; awk '{ print \$2 > (\$1 ".Tabular") }' $input1
   </command>
   <inputs>


### PR DESCRIPTION
... so we don't collect irrelevant outputs. Depends on https://github.com/galaxyproject/pulsar/pull/432

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
