### PR TITLE
Fix use of function, method and argument names deprecated in pyparsing 3.0.0

### DIFF
--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -14,7 +14,7 @@ from typing import (
 from pyparsing import (
     alphanums,
     CaselessKeyword,
-    infixNotation,
+    infix_notation,
     Keyword,
     opAssoc,
     ParseException,
@@ -25,7 +25,7 @@ from pyparsing import (
 
 log = logging.getLogger(__name__)
 
-ParserElement.enablePackrat()
+ParserElement.enable_packrat()
 
 # Defines the allowed characters that form a valid token.
 # Tokens that don't match this format will raise an exception when found.
@@ -137,8 +137,8 @@ class BooleanExpressionEvaluator:
         action = BoolOperand
         action.evaluator = evaluator
         boolOperand = TRUE | FALSE | QUOTED_STRING | Word(token_format or DEFAULT_TOKEN_FORMAT)
-        boolOperand.setParseAction(action)
-        self.boolExpr: ParserElement = infixNotation(
+        boolOperand.set_parse_action(action)
+        self.boolExpr: ParserElement = infix_notation(
             boolOperand,
             [
                 (NOT_OP, 1, opAssoc.RIGHT, BoolNot),
@@ -150,7 +150,7 @@ class BooleanExpressionEvaluator:
     def evaluate_expression(self, expr: str) -> bool:
         """Given an expression it gets evaluated to True or False using boolean logic."""
         try:
-            res = self.boolExpr.parseString(expr, parseAll=True)[0]
+            res = self.boolExpr.parse_string(expr, parse_all=True)[0]
             return bool(res)
         except ParseException as e:
             log.error(f"BooleanExpressionEvaluator unable to evaluate expression => {expr}", exc_info=e)

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     docutils!=0.17,!=0.17.1
     importlib-resources>=5.10.0;python_version<'3.12'
     packaging
-    pyparsing
+    pyparsing>=3.0.0
     PyYAML
     requests
     Routes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "PyJWT",
     "pykwalify",
     "pylibmagic",
-    "pyparsing",
+    "pyparsing>=3.0.0",
     "pypng",
     "pysam>=0.21",  # for Python 3.11 support on macOS
     "python-dateutil",


### PR DESCRIPTION
See https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#api-changes

Fix the following warning:

```
2025-12-30T22:27:17.9316242Z galaxy/util/bool_expressions.py:28
2025-12-30T22:27:17.9317041Z   /home/runner/work/galaxy/galaxy/galaxy root/packages/util/galaxy/util/bool_expressions.py:28: DeprecationWarning: 'enablePackrat' deprecated - use 'enable_packrat'
2025-12-30T22:27:17.9317841Z     ParserElement.enablePackrat()

2025-12-30T23:59:23.6388944Z tests/util/test_bool_expressions.py: 22 warnings
2025-12-30T23:59:23.6389637Z   /home/runner/work/galaxy/galaxy/galaxy root/packages/util/galaxy/util/bool_expressions.py:140: DeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
2025-12-30T23:59:23.6390347Z     boolOperand.setParseAction(action)

2025-12-30T23:59:23.6390627Z tests/util/test_bool_expressions.py: 22 warnings
2025-12-30T23:59:23.6391539Z   /home/runner/work/galaxy/galaxy/galaxy root/packages/util/galaxy/util/bool_expressions.py:141: DeprecationWarning: 'infixNotation' deprecated - use 'infix_notation'
2025-12-30T23:59:23.6392244Z     self.boolExpr: ParserElement = infixNotation(

2025-12-30T23:59:23.6392536Z tests/util/test_bool_expressions.py: 42 warnings
2025-12-30T23:59:23.6393202Z   /home/runner/work/galaxy/galaxy/galaxy root/packages/util/galaxy/util/bool_expressions.py:153: DeprecationWarning: 'parseString' deprecated - use 'parse_string'
2025-12-30T23:59:23.6393904Z     res = self.boolExpr.parseString(expr, parseAll=True)[0]

2025-12-30T23:59:23.6394219Z tests/util/test_bool_expressions.py: 42 warnings
2025-12-30T23:59:23.6394855Z   /tmp/gxpkgtestenvglfFlt/lib/python3.13/site-packages/pyparsing/util.py:439: DeprecationWarning: 'parseAll' argument is deprecated, use 'parse_all'
2025-12-30T23:59:23.6395450Z     return fn(self, *args, **kwargs)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
