### PR TITLE
[25.1] Improve tempdir cleanup in integration tests

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -246,6 +246,7 @@ class CondaContext(installable.InstallableContext):
             env["CONDARC"] = self.condarc_override
         cmd_string = shlex_join(cmd)
         kwds: Dict[str, Any] = {}
+        conda_exec_home: Optional[str] = None
         try:
             if stdout_path:
                 kwds["stdout"] = open(stdout_path, "w")

--- a/lib/galaxy_test/driver/integration_setup.py
+++ b/lib/galaxy_test/driver/integration_setup.py
@@ -4,7 +4,6 @@ Test classes that should be shared between test scenarios.
 
 import os
 import shutil
-from tempfile import mkdtemp
 from typing import ClassVar
 
 from galaxy_test.driver.driver_util import GalaxyTestDriver
@@ -79,8 +78,7 @@ class PosixFileSourceSetup:
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        temp_dir = os.path.realpath(mkdtemp())
-        cls._test_driver.temp_directories.append(temp_dir)
+        temp_dir = cls._test_driver.mkdtemp()
         cls.root_dir = os.path.join(temp_dir, "root")
 
         file_sources_config_file = create_file_source_config_file_on(

--- a/lib/galaxy_test/driver/uses_shed.py
+++ b/lib/galaxy_test/driver/uses_shed.py
@@ -71,8 +71,7 @@ class UsesShed(UsesShedApi):
     @classmethod
     def configure_shed_and_conda(cls, config):
         cls.configure_shed(config)
-        cls.conda_tmp_prefix = tempfile.mkdtemp()
-        cls._test_driver.temp_directories.append(cls.conda_tmp_prefix)
+        cls.conda_tmp_prefix = cls._test_driver.mkdtemp()
         config["conda_auto_init"] = True
         config["conda_auto_install"] = True
         config["conda_prefix"] = os.environ.get("GALAXY_TEST_CONDA_PREFIX") or os.path.join(

--- a/test/integration/test_chained_dynamic_destinations.py
+++ b/test/integration/test_chained_dynamic_destinations.py
@@ -1,7 +1,6 @@
 """Integration tests for chained dynamic job destinations."""
 
 import os
-import tempfile
 
 from galaxy_test.base.populators import skip_without_tool
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
@@ -14,7 +13,7 @@ class TestChainedDynamicDestinationIntegration(BaseJobEnvironmentIntegrationTest
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.jobs_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = CHAINED_DYNDESTS_JOB_CONFIG
 

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -108,21 +108,17 @@ class AbstractTestCases:
         job_plugin: ClassVar[str]
 
         @classmethod
-        def setUpClass(cls):
-            cls.container_name = f"{cls.__name__}_container"
-            cls.jobs_directory = cls._test_driver.mkdtemp()
-            cls.remote_connection = start_ssh_docker(
-                container_name=cls.container_name, jobs_directory=cls.jobs_directory, image=cls.image
-            )
-            super().setUpClass()
-
-        @classmethod
         def tearDownClass(cls):
             stop_ssh_docker(cls.container_name, cls.remote_connection)
             super().tearDownClass()
 
         @classmethod
         def handle_galaxy_config_kwds(cls, config):
+            cls.container_name = f"{cls.__name__}_container"
+            cls.jobs_directory = cls._test_driver.mkdtemp()
+            cls.remote_connection = start_ssh_docker(
+                container_name=cls.container_name, jobs_directory=cls.jobs_directory, image=cls.image
+            )
             config["jobs_directory"] = cls.jobs_directory
             config["file_path"] = cls.jobs_directory
             config["job_config_file"] = cli_job_config(

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -110,7 +110,7 @@ class AbstractTestCases:
         @classmethod
         def setUpClass(cls):
             cls.container_name = f"{cls.__name__}_container"
-            cls.jobs_directory = tempfile.mkdtemp()
+            cls.jobs_directory = cls._test_driver.mkdtemp()
             cls.remote_connection = start_ssh_docker(
                 container_name=cls.container_name, jobs_directory=cls.jobs_directory, image=cls.image
             )

--- a/test/integration/test_coexecution.py
+++ b/test/integration/test_coexecution.py
@@ -249,7 +249,7 @@ class TestCoexecution(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases)
     @classmethod
     def setUpClass(cls) -> None:
         # realpath for docker deployed in a VM on Mac, also done in driver_util.
-        cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
+        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
         super().setUpClass()
 
 

--- a/test/integration/test_coexecution.py
+++ b/test/integration/test_coexecution.py
@@ -246,12 +246,6 @@ class TestCoexecution(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases)
         super().setUp()
         self.dataset_populator = KubernetesDatasetPopulator(self.galaxy_interactor)
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        # realpath for docker deployed in a VM on Mac, also done in driver_util.
-        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
-        super().setUpClass()
-
 
 @integration_util.skip_unless_kubernetes()
 class TestKubernetesStagingContainerIntegration(CancelsJob, TestCoexecution):
@@ -260,6 +254,7 @@ class TestKubernetesStagingContainerIntegration(CancelsJob, TestCoexecution):
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config) -> None:
+        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
         config["jobs_directory"] = cls.jobs_directory
         config["file_path"] = cls.jobs_directory
         cls.job_config_file = job_config(CONTAINERIZED_TEMPLATE, cls.jobs_directory)

--- a/test/integration/test_container_resolvers.py
+++ b/test/integration/test_container_resolvers.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-from tempfile import mkdtemp
 from typing import (
     Any,
     ClassVar,
@@ -148,8 +147,7 @@ class DockerContainerResolverTestCase(IntegrationTestCase):
         if not cls.allow_conda_fallback:
             disable_dependency_resolution(config)
         else:
-            cls.conda_tmp_prefix = mkdtemp()
-            cls._test_driver.temp_directories.append(cls.conda_tmp_prefix)
+            cls.conda_tmp_prefix = cls._test_driver.mkdtemp()
             config["use_cached_dependency_manager"] = True
             config["conda_auto_init"] = True
             config["conda_auto_install"] = True

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -1,7 +1,6 @@
 """Integration tests for realtime tools."""
 
 import os
-import tempfile
 from typing import (
     Any,
     Optional,
@@ -204,7 +203,7 @@ class TestKubeInteractiveToolsRemoteProxyIntegration(AbstractTestCases.BaseInter
     @classmethod
     def setUpClass(cls) -> None:
         # realpath for docker deployed in a VM on Mac, also done in driver_util.
-        cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
+        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
         super().setUpClass()
 
     @classmethod

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -201,13 +201,8 @@ class TestKubeInteractiveToolsRemoteProxyIntegration(AbstractTestCases.BaseInter
     jobs_directory: str
 
     @classmethod
-    def setUpClass(cls) -> None:
-        # realpath for docker deployed in a VM on Mac, also done in driver_util.
-        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
-        super().setUpClass()
-
-    @classmethod
     def handle_galaxy_config_kwds(cls, config) -> None:
+        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
         interactivetools_map = os.environ.get("GALAXY_TEST_K8S_EXTERNAL_PROXY_MAP")
         interactivetools_proxy_host = os.environ.get("GALAXY_TEST_K8S_EXTERNAL_PROXY_HOST")
         if not interactivetools_map or not interactivetools_proxy_host:

--- a/test/integration/test_job_environments.py
+++ b/test/integration/test_job_environments.py
@@ -2,7 +2,6 @@
 
 import collections
 import os
-import tempfile
 
 from galaxy_test.base.populators import (
     DatasetPopulator,
@@ -72,7 +71,7 @@ class TestDefaultJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.jobs_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = SIMPLE_JOB_CONFIG_FILE  # Ensure no Docker for these tests
 
@@ -125,7 +124,7 @@ class TestEmbeddedPulsarDefaultJobEnvironmentIntegration(BaseJobEnvironmentInteg
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.jobs_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
 
@@ -155,7 +154,7 @@ class TestTmpDirToTrueJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTes
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.jobs_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = SETS_TMP_DIR_TO_TRUE_JOB_CONFIG
 
@@ -173,7 +172,7 @@ class TestTmpDirAsShellCommandJobEnvironmentIntegration(BaseJobEnvironmentIntegr
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.jobs_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = SETS_TMP_DIR_AS_EXPRESSION_JOB_CONFIG
 
@@ -191,8 +190,8 @@ class TestSharedHomeJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTestC
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.jobs_directory = tempfile.mkdtemp()
-        cls.shared_home_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
+        cls.shared_home_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = SIMPLE_JOB_CONFIG_FILE  # Ensure no Docker for these tests
         config["shared_home_dir"] = cls.shared_home_directory
@@ -228,7 +227,7 @@ class TestJobIOEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.jobs_directory = tempfile.mkdtemp()
+        cls.jobs_directory = cls._test_driver.mkdtemp()
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = IO_INJECTION_JOB_CONFIG_FILE
 

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -185,7 +185,7 @@ class TestKubernetesIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJob
     @classmethod
     def setUpClass(cls) -> None:
         # realpath for docker deployed in a VM on Mac, also done in driver_util.
-        cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
+        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
         volumes = [
             (cls.jobs_directory, "jobs-directory-volume", "jobs-directory-claim"),
             (TOOL_DIR, "tool-directory-volume", "tool-directory-claim"),

--- a/test/integration/test_remote_files.py
+++ b/test/integration/test_remote_files.py
@@ -1,7 +1,6 @@
 import operator
 import os
 import shutil
-from tempfile import mkdtemp
 from typing import ClassVar
 from unittest import SkipTest
 from urllib.parse import urlparse
@@ -37,8 +36,7 @@ class ConfiguresRemoteFilesIntegrationTestCase(integration_util.IntegrationTestC
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        root = os.path.realpath(mkdtemp())
-        cls._test_driver.temp_directories.append(root)
+        root = os.path.realpath(cls._test_driver.mkdtemp())
         cls.root = root
         cls.library_dir = os.path.join(root, "library")
         cls.user_library_dir = os.path.join(root, "user_library")

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -1,7 +1,6 @@
 """Integration tests for dependency resolution."""
 
 import os
-from tempfile import mkdtemp
 from typing import ClassVar
 
 from galaxy_test.base.populators import DatasetPopulator
@@ -19,8 +18,7 @@ class TestCondaResolutionIntegration(integration_util.IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
-        cls.conda_tmp_prefix = mkdtemp()
-        cls._test_driver.temp_directories.append(cls.conda_tmp_prefix)
+        cls.conda_tmp_prefix = cls._test_driver.mkdtemp()
         config["use_cached_dependency_manager"] = True
         config["conda_auto_init"] = True
         config["conda_prefix"] = os.path.join(cls.conda_tmp_prefix, "conda")

--- a/test/integration/test_tool_data_delete.py
+++ b/test/integration/test_tool_data_delete.py
@@ -30,7 +30,6 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase):
         cls.temp_tool_data_dir = cls.temp_config_dir("tool-data")
         cls.temp_tool_data_tables_file = os.path.join(cls.temp_tool_data_dir, "sample_tool_data_tables.xml")
         shutil.copytree(SOURCE_TOOL_DATA_DIRECTORY, cls.temp_tool_data_dir)
-        cls._test_driver.temp_directories.append(cls.temp_tool_data_dir)
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):

--- a/test/integration/test_vault_file_source.py
+++ b/test/integration/test_vault_file_source.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 from galaxy.model.db.user import get_user_by_email
 from galaxy.security.vault import UserVaultWrapper
@@ -21,7 +20,7 @@ class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase, integ
         super().handle_galaxy_config_kwds(config)
         cls._configure_database_vault(config)
         config["file_sources_config_file"] = FILE_SOURCES_VAULT_CONF
-        config["user_library_import_symlink_allowlist"] = os.path.realpath(tempfile.mkdtemp())
+        config["user_library_import_symlink_allowlist"] = os.path.realpath(cls._test_driver.mkdtemp())
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
May help with integration tests running out if disk space, as in https://github.com/galaxyproject/galaxy/actions/runs/20463596759/job/58801809519#step:13:8928

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
