### PR TITLE
Replace minio in integration tests with seaweedfs

### DIFF
--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -20,10 +20,10 @@ OBJECT_STORE_CONFIG = string.Template(
     """
 <object_store type="hierarchical" id="primary">
     <backends>
-        <object_store id="swifty" type="generic_s3" weight="1" order="0">
+        <object_store id="swifty" type="boto3" weight="1" order="0">
             <auth access_key="${access_key}" secret_key="${secret_key}" />
-            <bucket name="galaxy" use_reduced_redundancy="False" max_chunk_size="250"/>
-            <connection host="${host}" port="${port}" is_secure="False" conn_path="" multipart="True"/>
+            <bucket name="galaxy" />
+            <connection endpoint_url="http://${host}:${port}" region="us-east-1" />
             <cache path="${temp_directory}/object_store_cache" size="1000" cache_updated_data="${cache_updated_data}" />
             <extra_dir type="job_work" path="${temp_directory}/job_working_directory_swift"/>
             <extra_dir type="temp" path="${temp_directory}/tmp_swift"/>
@@ -361,6 +361,37 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
 def start_seaweedfs(container_name):
     ports = [(OBJECT_STORE_PORT, 8333)]
     docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
+    # Wait for SeaweedFS S3 API to be ready
+    import socket
+    max_attempts = 30
+    for attempt in range(max_attempts):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            sock.connect(("127.0.0.1", OBJECT_STORE_PORT))
+            sock.close()
+            time.sleep(5)  # Give it more time for S3 API to be fully ready
+            break
+        except (socket.error, ConnectionRefusedError):
+            if attempt == max_attempts - 1:
+                raise TimeoutError(f"SeaweedFS did not start within {max_attempts} seconds")
+            time.sleep(1)
+
+    # Create the galaxy bucket
+    try:
+        import boto3
+        from botocore.client import Config
+        s3 = boto3.client(
+            's3',
+            endpoint_url=f"http://127.0.0.1:{OBJECT_STORE_PORT}",
+            aws_access_key_id=OBJECT_STORE_ACCESS_KEY,
+            aws_secret_access_key=OBJECT_STORE_SECRET_KEY,
+            region_name='us-east-1',
+            config=Config(signature_version='s3v4')
+        )
+        s3.create_bucket(Bucket='galaxy')
+    except Exception:
+        pass  # Bucket may already exist
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -8,9 +8,9 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
 OBJECT_STORE_HOST = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_HOST", "127.0.0.1")
-OBJECT_STORE_PORT = int(os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_PORT", 9000))
-OBJECT_STORE_ACCESS_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY", "minioadmin")
-OBJECT_STORE_SECRET_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY", "minioadmin")
+OBJECT_STORE_PORT = int(os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_PORT", 8333))
+OBJECT_STORE_ACCESS_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY", "admin")
+OBJECT_STORE_SECRET_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY", "admin")
 OBJECT_STORE_RUCIO_ACCOUNT = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_RUCIO_ACCOUNT", "root")
 OBJECT_STORE_RUCIO_USERNAME = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_RUCIO_USERNAME", "rucio")
 OBJECT_STORE_RUCIO_RSE_NAME = "TEST"
@@ -162,7 +162,7 @@ class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
     @classmethod
     def setUpClass(cls):
         cls.container_name = f"{cls.__name__}_container"
-        start_minio(cls.container_name)
+        start_seaweedfs(cls.container_name)
         super().setUpClass()
 
     @classmethod
@@ -358,9 +358,9 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
         return True
 
 
-def start_minio(container_name):
-    ports = [(OBJECT_STORE_PORT, 9000)]
-    docker_run("minio/minio:latest", container_name, "server", "/data", ports=ports)
+def start_seaweedfs(container_name):
+    ports = [(OBJECT_STORE_PORT, 8333)]
+    docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -4,6 +4,9 @@ import string
 import subprocess
 import time
 
+import boto3
+from botocore.client import Config
+
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 from galaxy_test.driver.integration_util import (
@@ -362,37 +365,29 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
 def start_seaweedfs(container_name):
     ports = [(OBJECT_STORE_PORT, 8333)]
     docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
-    # Wait for SeaweedFS S3 API to be ready
-    import socket
-    max_attempts = 30
-    for attempt in range(max_attempts):
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(1)
-            sock.connect(("127.0.0.1", OBJECT_STORE_PORT))
-            sock.close()
-            time.sleep(5)  # Give it more time for S3 API to be fully ready
-            break
-        except (socket.error, ConnectionRefusedError):
-            if attempt == max_attempts - 1:
-                raise TimeoutError(f"SeaweedFS did not start within {max_attempts} seconds")
-            time.sleep(1)
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=f"http://127.0.0.1:{OBJECT_STORE_PORT}",
+        aws_access_key_id=OBJECT_STORE_ACCESS_KEY,
+        aws_secret_access_key=OBJECT_STORE_SECRET_KEY,
+        region_name="us-east-1",
+        config=Config(signature_version="s3v4"),
+    )
 
-    # Create the galaxy bucket
-    try:
-        import boto3
-        from botocore.client import Config
-        s3 = boto3.client(
-            's3',
-            endpoint_url=f"http://127.0.0.1:{OBJECT_STORE_PORT}",
-            aws_access_key_id=OBJECT_STORE_ACCESS_KEY,
-            aws_secret_access_key=OBJECT_STORE_SECRET_KEY,
-            region_name='us-east-1',
-            config=Config(signature_version='s3v4')
-        )
-        s3.create_bucket(Bucket='galaxy')
-    except Exception:
-        pass  # Bucket may already exist
+    # Retry bucket creation with exponential backoff
+    for attempt in range(5):
+        try:
+            s3.head_bucket(Bucket="galaxy")
+            break  # Bucket exists
+        except Exception:
+            try:
+                s3.create_bucket(Bucket="galaxy")
+                break  # Bucket created
+            except Exception as e:
+                if attempt < 4:
+                    time.sleep(2**attempt)  # Exponential backoff: 1, 2, 4, 8 seconds
+                else:
+                    raise TimeoutError(f"Failed to create SeaweedFS bucket after {attempt + 1} attempts: {e}")
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -28,10 +28,10 @@ OBJECT_STORE_RUCIO_IMAGE = os.environ.get(
 OBJECT_STORE_CONFIG = string.Template("""
 <object_store type="hierarchical" id="primary">
     <backends>
-        <object_store id="swifty" type="generic_s3" weight="1" order="0">
+        <object_store id="swifty" type="boto3" weight="1" order="0">
             <auth access_key="${access_key}" secret_key="${secret_key}" />
-            <bucket name="galaxy" use_reduced_redundancy="False" max_chunk_size="250"/>
-            <connection host="${host}" port="${port}" is_secure="False" conn_path="" multipart="True"/>
+            <bucket name="galaxy" />
+            <connection endpoint_url="http://${host}:${port}" region="us-east-1" />
             <cache path="${temp_directory}/object_store_cache" size="1000" cache_updated_data="${cache_updated_data}" />
             <extra_dir type="job_work" path="${temp_directory}/job_working_directory_swift"/>
             <extra_dir type="temp" path="${temp_directory}/tmp_swift"/>
@@ -362,6 +362,37 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
 def start_seaweedfs(container_name):
     ports = [(OBJECT_STORE_PORT, 8333)]
     docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
+    # Wait for SeaweedFS S3 API to be ready
+    import socket
+    max_attempts = 30
+    for attempt in range(max_attempts):
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            sock.connect(("127.0.0.1", OBJECT_STORE_PORT))
+            sock.close()
+            time.sleep(5)  # Give it more time for S3 API to be fully ready
+            break
+        except (socket.error, ConnectionRefusedError):
+            if attempt == max_attempts - 1:
+                raise TimeoutError(f"SeaweedFS did not start within {max_attempts} seconds")
+            time.sleep(1)
+
+    # Create the galaxy bucket
+    try:
+        import boto3
+        from botocore.client import Config
+        s3 = boto3.client(
+            's3',
+            endpoint_url=f"http://127.0.0.1:{OBJECT_STORE_PORT}",
+            aws_access_key_id=OBJECT_STORE_ACCESS_KEY,
+            aws_secret_access_key=OBJECT_STORE_SECRET_KEY,
+            region_name='us-east-1',
+            config=Config(signature_version='s3v4')
+        )
+        s3.create_bucket(Bucket='galaxy')
+    except Exception:
+        pass  # Bucket may already exist
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -14,9 +14,9 @@ from galaxy_test.driver.integration_util import (
 )
 
 OBJECT_STORE_HOST = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_HOST", "127.0.0.1")
-OBJECT_STORE_PORT = int(os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_PORT", 9000))
-OBJECT_STORE_ACCESS_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY", "minioadmin")
-OBJECT_STORE_SECRET_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY", "minioadmin")
+OBJECT_STORE_PORT = int(os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_PORT", 8333))
+OBJECT_STORE_ACCESS_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY", "admin")
+OBJECT_STORE_SECRET_KEY = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY", "admin")
 OBJECT_STORE_RUCIO_ACCOUNT = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_RUCIO_ACCOUNT", "root")
 OBJECT_STORE_RUCIO_USERNAME = os.environ.get("GALAXY_INTEGRATION_OBJECT_STORE_RUCIO_USERNAME", "rucio")
 OBJECT_STORE_RUCIO_RSE_NAME = "TEST"
@@ -163,7 +163,7 @@ class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
     @classmethod
     def setUpClass(cls):
         cls.container_name = f"{cls.__name__}_container"
-        start_minio(cls.container_name)
+        start_seaweedfs(cls.container_name)
         super().setUpClass()
 
     @classmethod
@@ -359,9 +359,9 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
         return True
 
 
-def start_minio(container_name):
-    ports = [(OBJECT_STORE_PORT, 9000)]
-    docker_run("minio/minio:latest", container_name, "server", "/data", ports=ports)
+def start_seaweedfs(container_name):
+    ports = [(OBJECT_STORE_PORT, 8333)]
+    docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -6,6 +6,10 @@ import time
 
 import boto3
 from botocore.client import Config
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+)
 
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
@@ -365,29 +369,40 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
 def start_seaweedfs(container_name):
     ports = [(OBJECT_STORE_PORT, 8333)]
     docker_run("chrislusf/seaweedfs:latest", container_name, "server", "-s3", ports=ports)
+    wait_seaweedfs_ready()
+
+
+def wait_seaweedfs_ready(bucket: str = "galaxy", timeout: float = 60) -> None:
+    """Block until the SeaweedFS S3 gateway accepts requests and ``bucket`` exists.
+
+    The gateway comes up a few seconds after the container does, and the object store
+    initialization in Galaxy does not retry, so wait for the whole master -> volume -> filer -> s3
+    chain to be up by creating the bucket through it.
+    """
     s3 = boto3.client(
         "s3",
-        endpoint_url=f"http://127.0.0.1:{OBJECT_STORE_PORT}",
+        endpoint_url=f"http://{OBJECT_STORE_HOST}:{OBJECT_STORE_PORT}",
         aws_access_key_id=OBJECT_STORE_ACCESS_KEY,
         aws_secret_access_key=OBJECT_STORE_SECRET_KEY,
         region_name="us-east-1",
-        config=Config(signature_version="s3v4"),
+        config=Config(signature_version="s3v4", retries={"max_attempts": 1}, connect_timeout=2, read_timeout=5),
     )
-
-    # Retry bucket creation with exponential backoff
-    for attempt in range(5):
+    deadline = time.monotonic() + timeout
+    while True:
         try:
-            s3.head_bucket(Bucket="galaxy")
-            break  # Bucket exists
-        except Exception:
-            try:
-                s3.create_bucket(Bucket="galaxy")
-                break  # Bucket created
-            except Exception as e:
-                if attempt < 4:
-                    time.sleep(2**attempt)  # Exponential backoff: 1, 2, 4, 8 seconds
-                else:
-                    raise TimeoutError(f"Failed to create SeaweedFS bucket after {attempt + 1} attempts: {e}")
+            s3.create_bucket(Bucket=bucket)
+            return
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                return
+            if e.response["ResponseMetadata"]["HTTPStatusCode"] < 500:
+                raise
+            last_error: Exception = e
+        except BotoCoreError as e:
+            last_error = e
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"SeaweedFS S3 gateway not ready after {timeout}s: {last_error}") from last_error
+        time.sleep(0.5)
 
 
 def start_onezone(oz_container_name):

--- a/test/integration/objectstore/test_direct_download_redirect.py
+++ b/test/integration/objectstore/test_direct_download_redirect.py
@@ -3,7 +3,7 @@
 Whole-file downloads of datasets stored in a backing object store with ``enable_direct_download`` set
 are served from the dedicated ``/download`` route via a 302 redirect to a URL the client fetches
 directly from the store, instead of being pulled through Galaxy's cache. The ``/display`` route keeps
-streaming through Galaxy (no redirect). Uses a boto3 object store backed by a disposable minio container.
+streaming through Galaxy (no redirect). Uses a boto3 object store backed by a disposable SeaweedFS container.
 """
 
 import os
@@ -21,7 +21,7 @@ from ._base import (
     OBJECT_STORE_HOST,
     OBJECT_STORE_PORT,
     OBJECT_STORE_SECRET_KEY,
-    start_minio,
+    start_seaweedfs,
 )
 
 BOTO3_DIRECT_DOWNLOAD_CONFIG = string.Template("""
@@ -44,7 +44,7 @@ class TestDirectDownloadRedirectIntegration(BaseObjectStoreIntegrationTestCase):
     @classmethod
     def setUpClass(cls):
         cls.container_name = f"{cls.__name__}_container"
-        start_minio(cls.container_name)
+        start_seaweedfs(cls.container_name)
         super().setUpClass()
 
     @classmethod

--- a/test/integration/objectstore/test_tee_streaming.py
+++ b/test/integration/objectstore/test_tee_streaming.py
@@ -5,7 +5,7 @@ bytes are written into Galaxy's cache on the way past, so the client gets its fi
 instead of waiting for the whole object to be pulled in -- and objects too big for the cache can be
 downloaded at all. Requests that need random access (Range, HEAD) still get a cached file. Runs
 against a boto3 object store and a cloudbridge (cloud) object store, each backed by a disposable
-minio container.
+SeaweedFS container.
 """
 
 import os
@@ -23,7 +23,7 @@ from ._base import (
     OBJECT_STORE_HOST,
     OBJECT_STORE_PORT,
     OBJECT_STORE_SECRET_KEY,
-    start_minio,
+    start_seaweedfs,
 )
 
 BOTO3_TEE_STREAMING_CONFIG = string.Template("""
@@ -69,7 +69,7 @@ class TeeStreamingIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
     @classmethod
     def setUpClass(cls):
         cls.container_name = f"{cls.__name__}_container"
-        start_minio(cls.container_name)
+        start_seaweedfs(cls.container_name)
         super().setUpClass()
 
     @classmethod


### PR DESCRIPTION
xref https://aus.social/@phs/115656665465740246.
seaweedfs looks nice and switch is fairly easy.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
