### PR TITLE
Add support for workflow landing requests using simple URLs

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9257,7 +9257,7 @@ export interface components {
              * Workflow Target Type
              * @enum {string}
              */
-            workflow_target_type: "stored_workflow" | "workflow" | "trs_url";
+            workflow_target_type: "stored_workflow" | "workflow" | "trs_url" | "url";
         };
         /** CreatedEntryResponse */
         CreatedEntryResponse: {
@@ -24678,7 +24678,7 @@ export interface components {
              * Workflow Target Type
              * @enum {string}
              */
-            workflow_target_type: "stored_workflow" | "workflow" | "trs_url";
+            workflow_target_type: "stored_workflow" | "workflow" | "trs_url" | "url";
         };
         /** WriteInvocationStoreToPayload */
         WriteInvocationStoreToPayload: {

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -4132,7 +4132,7 @@ class CreateToolLandingRequestPayload(Model):
 
 class CreateWorkflowLandingRequestPayload(Model):
     workflow_id: str
-    workflow_target_type: Literal["stored_workflow", "workflow", "trs_url"]
+    workflow_target_type: Literal["stored_workflow", "workflow", "trs_url", "url"]
     request_state: Optional[dict[str, Any]] = None
     client_secret: Optional[str] = None
     public: bool = Field(
@@ -4158,7 +4158,7 @@ class ToolLandingRequest(Model):
 class WorkflowLandingRequest(Model):
     uuid: UuidField
     workflow_id: str
-    workflow_target_type: Literal["stored_workflow", "workflow", "trs_url"]
+    workflow_target_type: Literal["stored_workflow", "workflow", "trs_url", "url"]
     request_state: dict[str, Any]
     state: LandingRequestState
     origin: Optional[HttpUrl] = None


### PR DESCRIPTION
Previously, workflow landing requests could only be created using trs_url, stored_workflow_id, or workflow_id. This change adds support for creating workflow landing requests using arbitrary URLs pointing to workflow files.

Changes:
- Add "url" as a new workflow_target_type in schema
- Update LandingRequestManager to handle URL workflow sources
- Add get_or_create_workflow_from_url() method to WorkflowContentsManager to fetch and import workflows from URLs using the file sources framework
- Add test using base64:// encoding to verify URL-based workflow imports

This enables workflows to be loaded from various sources including base64://, http://, https://, and other supported URL schemes.

Requested by @bgruening 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
