### PR TITLE
Fix input tags not being copied when using copy_inputs_to_history

### DIFF
--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -436,7 +436,7 @@ def build_workflow_run_configs(
                     if isinstance(content, HistoryDatasetCollectionAssociation):
                         content = content.copy(element_destination=history, flush=False)
                     else:
-                        content = content.copy(flush=False)
+                        content = content.copy(copy_tags=content.tags, flush=False)
                     history.stage_addition(content)
                 input_dict["content"] = content
             except AssertionError:


### PR DESCRIPTION
When workflow inputs are copied to a new history tags and hashtags were not being copied along with the datasets and dataset collections.

Also adds test_copy_inputs_to_history_with_tags to verify that both dataset and dataset collection tags are properly copied when workflow inputs are copied to a new history.

Fixes #18893

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
