### PR TITLE
Add automated npm publishing for client-api package

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -95,3 +95,13 @@ jobs:
         if: (github.event_name == 'workflow_dispatch' && inputs.release_type == 'release') || (github.event_name == 'release' && !github.event.release.prerelease)
         run: npm publish --provenance --access public
         working-directory: 'client'
+      - name: sync client-api version
+        run: npm run sync-version
+        working-directory: 'client-api'
+      - name: build client-api
+        run: npm install && npm run build
+        working-directory: 'client-api'
+      - name: publish client-api
+        if: (github.event_name == 'workflow_dispatch' && inputs.release_type == 'release') || (github.event_name == 'release' && !github.event.release.prerelease)
+        run: npm publish --provenance --access public
+        working-directory: 'client-api'


### PR DESCRIPTION
Adds the `@galaxyproject/galaxy-api-client` package to the automated release workflow so it gets published alongside the main client on releases.

Also fixes the sync-version.js script to correctly handle patch versions (e.g., 25.0.4) - previously it only handled prerelease versions properly.

Backfill publishes for 25.0.4 and 25.1.0 have already been done manually.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
