### PR TITLE
Clean up code with pyupgrade

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -9403,6 +9403,38 @@ export interface components {
              */
             username: string;
         };
+        /** CreatorOrganization */
+        CreatorOrganization: {
+            /** Address */
+            address?: string | null;
+            /** Alternate Name */
+            alternateName?: string | null;
+            /**
+             * Class
+             * @default Organization
+             */
+            class: string;
+            /** Email */
+            email?: string | null;
+            /** Fax Number */
+            faxNumber?: string | null;
+            /**
+             * Identifier
+             * @description Identifier (typically an orcid.org ID)
+             */
+            identifier?: string | null;
+            /** Image URL */
+            image?: string | null;
+            /**
+             * Name
+             * @description The name of the creator.
+             */
+            name?: string | null;
+            /** Telephone */
+            telephone?: string | null;
+            /** URL */
+            url?: string | null;
+        };
         /** CredentialPayload */
         CredentialPayload: {
             /**
@@ -21850,9 +21882,7 @@ export interface components {
              * Creator
              * @description Additional information about the creator (or multiple creators) of this workflow.
              */
-            creator?:
-                | (components["schemas"]["Person"] | components["schemas"]["galaxy__schema__schema__Organization"])[]
-                | null;
+            creator?: (components["schemas"]["Person"] | components["schemas"]["CreatorOrganization"])[] | null;
             /**
              * Creator deleted
              * @description Whether the creator of this Workflow has been deleted.
@@ -24969,38 +24999,6 @@ export interface components {
             filename?: string | null;
             /** name */
             name?: string | null;
-        };
-        /** Organization */
-        galaxy__schema__schema__Organization: {
-            /** Address */
-            address?: string | null;
-            /** Alternate Name */
-            alternateName?: string | null;
-            /**
-             * Class
-             * @default Organization
-             */
-            class: string;
-            /** Email */
-            email?: string | null;
-            /** Fax Number */
-            faxNumber?: string | null;
-            /**
-             * Identifier
-             * @description Identifier (typically an orcid.org ID)
-             */
-            identifier?: string | null;
-            /** Image URL */
-            image?: string | null;
-            /**
-             * Name
-             * @description The name of the creator.
-             */
-            name?: string | null;
-            /** Telephone */
-            telephone?: string | null;
-            /** URL */
-            url?: string | null;
         };
     };
     responses: never;

--- a/client/src/api/workflows.ts
+++ b/client/src/api/workflows.ts
@@ -3,7 +3,7 @@ import { rethrowSimple } from "@/utils/simple-error";
 
 import { GalaxyApi } from "./client";
 
-export type Creator = components["schemas"]["Person"] | components["schemas"]["galaxy__schema__schema__Organization"];
+export type Creator = components["schemas"]["Person"] | components["schemas"]["CreatorOrganization"];
 export type StoredWorkflowDetailed = components["schemas"]["StoredWorkflowDetailed"];
 export type WorkflowStepTyped = StoredWorkflowDetailed["steps"][number];
 

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -12,8 +12,6 @@ from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
-    Dict,
-    List,
     Optional,
     TYPE_CHECKING,
     Union,
@@ -99,8 +97,8 @@ class AgentResponse:
         content: str,
         confidence: Union[str, ConfidenceLevel],
         agent_type: str,
-        suggestions: Optional[List[ActionSuggestion]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        suggestions: Optional[list[ActionSuggestion]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         reasoning: Optional[str] = None,
     ):
         self.content = content
@@ -194,7 +192,7 @@ class BaseGalaxyAgent(ABC):
 
         return None
 
-    async def process(self, query: str, context: Optional[Dict[str, Any]] = None) -> AgentResponse:
+    async def process(self, query: str, context: Optional[dict[str, Any]] = None) -> AgentResponse:
         """
         Process a query and return structured response.
 
@@ -291,7 +289,7 @@ class BaseGalaxyAgent(ABC):
         # This should never be reached, but just in case
         raise last_exception or Exception("Max retries exhausted")
 
-    def _prepare_prompt(self, query: str, context: Dict[str, Any]) -> str:
+    def _prepare_prompt(self, query: str, context: dict[str, Any]) -> str:
         """Prepare the full prompt including context."""
         prompt_parts = [query]
 
@@ -303,7 +301,7 @@ class BaseGalaxyAgent(ABC):
 
         return "\n".join(prompt_parts)
 
-    def _format_response(self, result: Any, query: str, context: Dict[str, Any]) -> AgentResponse:
+    def _format_response(self, result: Any, query: str, context: dict[str, Any]) -> AgentResponse:
         """Convert pydantic-ai result to AgentResponse."""
         # Default implementation - subclasses can override
         content = str(result.data) if hasattr(result, "data") else str(result)
@@ -521,7 +519,7 @@ class BaseGalaxyAgent(ABC):
         query: str,
         ctx,
         usage=None,
-        context: Optional[Dict[str, Any]] = None,
+        context: Optional[dict[str, Any]] = None,
     ) -> str:
         """
         Centralized helper method for calling other agents from within tool functions.
@@ -622,7 +620,7 @@ class SimpleGalaxyAgent(BaseGalaxyAgent):
             system_prompt=self.get_system_prompt(),
         )
 
-    def _format_response(self, result: Any, query: str, context: Dict[str, Any]) -> AgentResponse:
+    def _format_response(self, result: Any, query: str, context: dict[str, Any]) -> AgentResponse:
         """Format simple text response."""
         content = str(result.data) if hasattr(result, "data") else str(result)
 
@@ -653,7 +651,7 @@ class SimpleGalaxyAgent(BaseGalaxyAgent):
         else:
             return ConfidenceLevel.MEDIUM
 
-    def _extract_suggestions(self, content: str) -> List[ActionSuggestion]:
+    def _extract_suggestions(self, content: str) -> list[ActionSuggestion]:
         """Extract action suggestions from response content."""
         suggestions = []
 

--- a/lib/galaxy/agents/custom_tool.py
+++ b/lib/galaxy/agents/custom_tool.py
@@ -6,7 +6,6 @@ import logging
 from pathlib import Path
 from typing import (
     Any,
-    Dict,
     Optional,
 )
 
@@ -61,7 +60,7 @@ class CustomToolAgent(BaseGalaxyAgent):
         prompt_path = Path(__file__).parent / "prompts" / "custom_tool_structured.md"
         return prompt_path.read_text()
 
-    async def process(self, query: str, context: Optional[Dict[str, Any]] = None) -> AgentResponse:
+    async def process(self, query: str, context: Optional[dict[str, Any]] = None) -> AgentResponse:
         """Process tool creation request."""
         # Check model capabilities first
         capability_error = self._validate_model_capabilities()

--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -7,8 +7,6 @@ import re
 from pathlib import Path
 from typing import (
     Any,
-    Dict,
-    List,
     Literal,
     Optional,
 )
@@ -38,8 +36,8 @@ class ErrorAnalysisResult(BaseModel):
     error_category: str  # e.g., "tool_configuration", "input_data", "parameters"
     error_severity: str  # "low", "medium", "high", "critical"
     likely_cause: str
-    solution_steps: List[str]
-    alternative_approaches: List[str] = []
+    solution_steps: list[str]
+    alternative_approaches: list[str] = []
     confidence: ConfidenceLiteral
     requires_admin: bool = False
 
@@ -78,7 +76,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
         prompt_path = Path(__file__).parent / "prompts" / "error_analysis.md"
         return prompt_path.read_text()
 
-    async def get_job_details(self, job_id: int) -> Dict[str, Any]:
+    async def get_job_details(self, job_id: int) -> dict[str, Any]:
         """
         Get comprehensive job information for error analysis.
 
@@ -115,7 +113,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
             log.warning(f"Error getting job details for {job_id}: {e}")
             return {"error": f"Failed to retrieve job details: {str(e)}"}
 
-    async def get_tool_info(self, tool_id: str) -> Dict[str, Any]:
+    async def get_tool_info(self, tool_id: str) -> dict[str, Any]:
         """Get tool metadata and documentation."""
         if not self.deps.toolbox:
             return {"error": "Toolbox not available"}
@@ -137,7 +135,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
             log.warning(f"Error getting tool info for {tool_id}: {e}")
             return {"error": f"Failed to retrieve tool info: {str(e)}"}
 
-    async def search_error_patterns(self, error_text: str) -> List[Dict[str, Any]]:
+    async def search_error_patterns(self, error_text: str) -> list[dict[str, Any]]:
         """
         Search for similar error patterns using keyword-based heuristics.
 
@@ -196,7 +194,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
             log.warning(f"Error searching patterns: {e}")
             return []
 
-    async def process(self, query: str, context: Optional[Dict[str, Any]] = None) -> AgentResponse:
+    async def process(self, query: str, context: Optional[dict[str, Any]] = None) -> AgentResponse:
         """
         Process an error analysis request.
 
@@ -266,7 +264,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
             log.warning(f"Error analysis value error: {e}")
             return self._get_fallback_response(query, str(e))
 
-    def _format_job_context(self, job_details: Dict[str, Any]) -> str:
+    def _format_job_context(self, job_details: dict[str, Any]) -> str:
         """Format job details for context."""
         parts = []
 
@@ -310,7 +308,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
 
         return "\n".join(parts)
 
-    def _create_suggestions(self, analysis: ErrorAnalysisResult) -> List[ActionSuggestion]:
+    def _create_suggestions(self, analysis: ErrorAnalysisResult) -> list[ActionSuggestion]:
         """Create action suggestions from analysis result."""
         suggestions = []
 
@@ -369,7 +367,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
         CONFIDENCE: high
         """
 
-    def _parse_simple_response(self, response_text: str) -> Dict[str, Any]:
+    def _parse_simple_response(self, response_text: str) -> dict[str, Any]:
         """Parse simple text response into structured format."""
         # Extract structured information from text
         error_type = re.search(r"ERROR_TYPE:\s*([^\n]+)", response_text, re.IGNORECASE)

--- a/lib/galaxy/agents/orchestrator.py
+++ b/lib/galaxy/agents/orchestrator.py
@@ -8,8 +8,6 @@ import re
 from pathlib import Path
 from typing import (
     Any,
-    Dict,
-    List,
     Optional,
 )
 
@@ -41,7 +39,7 @@ def _create_error_response(agent_name: str, error_msg: str, is_timeout: bool = F
 class AgentPlan(BaseModel):
     """Simple plan for which agents to call."""
 
-    agents: List[str]  # List of agent names to call
+    agents: list[str]  # List of agent names to call
     sequential: bool = False  # True if agents should run in sequence
     reasoning: str
 
@@ -83,7 +81,7 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
         prompt_path = Path(__file__).parent / "prompts" / "orchestrator.md"
         return prompt_path.read_text()
 
-    async def process(self, query: str, context: Optional[Dict[str, Any]] = None) -> AgentResponse:
+    async def process(self, query: str, context: Optional[dict[str, Any]] = None) -> AgentResponse:
         """
         Process an orchestration request and coordinate multiple agents.
 
@@ -189,8 +187,8 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
         return self._get_agent_config("agent_timeout", 60.0)
 
     async def _execute_sequential(
-        self, agents: List[str], query: str, context: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, AgentResponse]:
+        self, agents: list[str], query: str, context: Optional[dict[str, Any]] = None
+    ) -> dict[str, AgentResponse]:
         """Execute agents sequentially with timeout protection."""
         from galaxy.agents import agent_registry
 
@@ -223,8 +221,8 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
         return responses
 
     async def _execute_parallel(
-        self, agents: List[str], query: str, context: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, AgentResponse]:
+        self, agents: list[str], query: str, context: Optional[dict[str, Any]] = None
+    ) -> dict[str, AgentResponse]:
         """Execute agents in parallel with timeout protection."""
         from galaxy.agents import agent_registry
 
@@ -253,7 +251,7 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
 
         return dict(results)
 
-    def _combine_responses(self, responses: Dict[str, AgentResponse], reasoning: str) -> str:
+    def _combine_responses(self, responses: dict[str, AgentResponse], reasoning: str) -> str:
         """Combine multiple agent responses into a single coherent response."""
         if not responses:
             return "No agent responses received."

--- a/lib/galaxy/agents/registry.py
+++ b/lib/galaxy/agents/registry.py
@@ -4,10 +4,7 @@ Agent registry for managing available AI agents.
 
 import logging
 from typing import (
-    Dict,
-    List,
     Optional,
-    Type,
 )
 
 from .base import (
@@ -23,14 +20,14 @@ class AgentRegistry:
 
     def __init__(self):
         """Initialize empty registry."""
-        self._agents: Dict[str, Type[BaseGalaxyAgent]] = {}
-        self._agent_metadata: Dict[str, Dict] = {}
+        self._agents: dict[str, type[BaseGalaxyAgent]] = {}
+        self._agent_metadata: dict[str, dict] = {}
 
     def register(
         self,
         agent_type: str,
-        agent_class: Type[BaseGalaxyAgent],
-        metadata: Optional[Dict] = None,
+        agent_class: type[BaseGalaxyAgent],
+        metadata: Optional[dict] = None,
     ):
         """
         Register an agent type.
@@ -90,15 +87,15 @@ class AgentRegistry:
         """Check if an agent type is registered."""
         return agent_type in self._agents
 
-    def list_agents(self) -> List[str]:
+    def list_agents(self) -> list[str]:
         """Get list of registered agent types."""
         return list(self._agents.keys())
 
-    def get_agent_metadata(self, agent_type: str) -> Dict:
+    def get_agent_metadata(self, agent_type: str) -> dict:
         """Get metadata for an agent type."""
         return self._agent_metadata.get(agent_type, {})
 
-    def get_agent_info(self, agent_type: str) -> Dict:
+    def get_agent_info(self, agent_type: str) -> dict:
         """
         Get comprehensive information about an agent.
 
@@ -119,7 +116,7 @@ class AgentRegistry:
             "description": getattr(agent_class, "__doc__", "").strip() if agent_class.__doc__ else None,
         }
 
-    def list_agent_info(self) -> List[Dict]:
+    def list_agent_info(self) -> list[dict]:
         """Get information for all registered agents."""
         return [self.get_agent_info(agent_type) for agent_type in self._agents.keys()]
 
@@ -133,7 +130,7 @@ def get_global_registry() -> AgentRegistry:
     return _global_registry
 
 
-def register_agent(agent_type: str, agent_class: Type[BaseGalaxyAgent], metadata: Optional[Dict] = None):
+def register_agent(agent_type: str, agent_class: type[BaseGalaxyAgent], metadata: Optional[dict] = None):
     """Register an agent in the global registry."""
     _global_registry.register(agent_type, agent_class, metadata)
 

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -7,8 +7,6 @@ import re
 from pathlib import Path
 from typing import (
     Any,
-    Dict,
-    List,
     Literal,
     Optional,
 )
@@ -36,7 +34,7 @@ class RoutingDecision(BaseModel):
     """Structured decision from the router agent."""
 
     primary_agent: str
-    secondary_agents: List[str] = []
+    secondary_agents: list[str] = []
     complexity: str  # "simple" or "complex"
     confidence: ConfidenceLiteral = "medium"
     reasoning: str
@@ -77,7 +75,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
         prompt_path = Path(__file__).parent / "prompts" / "router.md"
         return prompt_path.read_text()
 
-    async def route_query(self, query: str, context: Optional[Dict[str, Any]] = None) -> RoutingDecision:
+    async def route_query(self, query: str, context: Optional[dict[str, Any]] = None) -> RoutingDecision:
         """
         Route a query to appropriate agent(s).
 
@@ -131,7 +129,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
             log.warning(f"Router agent value error, using fallback: {e}")
             return self._fallback_routing(query, context)
 
-    def _fallback_routing(self, query: str, context: Optional[Dict[str, Any]] = None) -> RoutingDecision:
+    def _fallback_routing(self, query: str, context: Optional[dict[str, Any]] = None) -> RoutingDecision:
         """Fallback routing when AI router fails - uses intent-based heuristics."""
         query_lower = query.lower()
 
@@ -210,7 +208,7 @@ For specific tools, please also cite the individual tool publications.""",
             direct_response="",
         )
 
-    async def process(self, query: str, context: Optional[Dict[str, Any]] = None) -> AgentResponse:
+    async def process(self, query: str, context: Optional[dict[str, Any]] = None) -> AgentResponse:
         """
         Process a routing request and return guidance.
 

--- a/lib/galaxy/authnz/cilogon.py
+++ b/lib/galaxy/authnz/cilogon.py
@@ -32,8 +32,7 @@ class CILogonOpenIdConnect(GalaxyOpenIdConnect):
         params = super().auth_params(state)
 
         # Add CILogon IDP hint (default: "cilogon")
-        idphint = self.setting("IDPHINT", "cilogon")
-        if idphint:
+        if idphint := self.setting("IDPHINT", "cilogon"):
             params["idphint"] = idphint
 
         return params
@@ -49,8 +48,7 @@ class CILogonOpenIdConnect(GalaxyOpenIdConnect):
         https://cilogon.org/authorize -> https://cilogon.org
         """
         # Check if custom URL is configured
-        base_url = self.setting("URL")
-        if base_url:
+        if base_url := self.setting("URL"):
             # Backwards compatibility: CILogon URL is sometimes given with /authorize
             # Remove it to get the correct openid configuration endpoint
             if base_url.endswith("/authorize"):

--- a/lib/galaxy/authnz/keycloak.py
+++ b/lib/galaxy/authnz/keycloak.py
@@ -28,8 +28,7 @@ class KeycloakOpenIdConnect(GalaxyOpenIdConnect):
         params = super().auth_params(state)
 
         # Add Keycloak IDP hint (default: "oidc")
-        idphint = self.setting("IDPHINT", "oidc")
-        if idphint:
+        if idphint := self.setting("IDPHINT", "oidc"):
             params["kc_idp_hint"] = idphint
 
         return params
@@ -44,8 +43,7 @@ class KeycloakOpenIdConnect(GalaxyOpenIdConnect):
         This allows administrators to configure the full Keycloak realm URL.
         """
         # Check if custom URL is configured
-        base_url = self.setting("URL")
-        if base_url:
+        if base_url := self.setting("URL"):
             # Remove potential trailing slash
             return base_url.rstrip("/")
         # Fall back to default OIDC endpoint discovery

--- a/lib/galaxy/files/sources/_fsspec.py
+++ b/lib/galaxy/files/sources/_fsspec.py
@@ -5,6 +5,7 @@ import os
 from typing import (
     Annotated,
     Any,
+    cast,
     ClassVar,
     Optional,
     TypeVar,
@@ -12,7 +13,6 @@ from typing import (
 
 from fsspec import AbstractFileSystem
 from pydantic import Field
-from typing_extensions import cast
 
 from galaxy.exceptions import (
     AuthenticationRequired,

--- a/lib/galaxy/files/sources/azureflat.py
+++ b/lib/galaxy/files/sources/azureflat.py
@@ -74,8 +74,7 @@ class AzureFlatFilesSource(
 
     def _adapt_entry_path(self, filesystem_path: str) -> str:
         result = filesystem_path
-        container_name = self.template_config.container_name
-        if container_name:
+        if container_name := self.template_config.container_name:
             prefix = f"{container_name}/"
             if filesystem_path.startswith(prefix):
                 result = filesystem_path.replace(prefix, "", 1)
@@ -147,9 +146,8 @@ class AzureFlatFilesSource(
         return f"{container_name}{adjusted_path}"
 
     def score_url_match(self, url: str):
-        container_name = self.template_config.container_name
         result = 0
-        if container_name:
+        if container_name := self.template_config.container_name:
             prefix = f"az://{container_name}"
             if url.startswith(f"{prefix}/") or url == prefix:
                 result = len(prefix)

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -1,7 +1,7 @@
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from typing import (
-    Iterator,
     Optional,
     Union,
 )

--- a/lib/galaxy/files/validate/script.py
+++ b/lib/galaxy/files/validate/script.py
@@ -13,8 +13,6 @@ import os
 import sys
 import traceback
 from typing import (
-    Dict,
-    List,
     Optional,
 )
 
@@ -116,7 +114,7 @@ def find_galaxy_config(config_file: Optional[str] = None) -> Optional[str]:
     return None
 
 
-def load_file_sources_config(config_path: str) -> List[Dict]:
+def load_file_sources_config(config_path: str) -> list[dict]:
     """Load file sources configuration from YAML file"""
     try:
         with open(config_path) as f:
@@ -132,7 +130,7 @@ def load_file_sources_config(config_path: str) -> List[Dict]:
 
 
 def validate_file_source_config(
-    file_source_config: Dict,
+    file_source_config: dict,
     plugin_loader: FileSourcePluginLoader,
     file_sources_config: FileSourcePluginsConfig,
     verbose: bool = False,

--- a/lib/galaxy/managers/agents.py
+++ b/lib/galaxy/managers/agents.py
@@ -3,7 +3,6 @@
 import logging
 from typing import (
     Any,
-    Dict,
     Optional,
 )
 
@@ -66,7 +65,7 @@ class AgentService:
         query: str,
         trans: ProvidesUserContext,
         user: User,
-        context: Optional[Dict[str, Any]] = None,
+        context: Optional[dict[str, Any]] = None,
     ) -> AgentResponse:
         """Execute a specific agent and return response."""
         deps = self.create_dependencies(trans, user)
@@ -114,7 +113,7 @@ class AgentService:
         query: str,
         trans: ProvidesUserContext,
         user: User,
-        context: Optional[Dict[str, Any]] = None,
+        context: Optional[dict[str, Any]] = None,
         agent_type: str = "auto",
     ) -> AgentResponse:
         """Route query to appropriate agent and execute. Uses router if agent_type is 'auto'."""

--- a/lib/galaxy/managers/chat.py
+++ b/lib/galaxy/managers/chat.py
@@ -1,7 +1,5 @@
 from typing import (
     Any,
-    Dict,
-    List,
     Optional,
     Union,
 )
@@ -82,7 +80,7 @@ class ChatManager:
         import json
 
         # Handle both string responses and full agent response objects
-        conversation_data: Dict[str, Any]
+        conversation_data: dict[str, Any]
         if isinstance(response_data, str):
             conversation_data = {
                 "query": query,
@@ -240,7 +238,7 @@ class ChatManager:
 
     def get_chat_history(
         self, trans: ProvidesUserContext, exchange_id: int, format_for_pydantic_ai: bool = False
-    ) -> Union[List[Dict[str, Any]], List[ModelMessage]]:
+    ) -> Union[list[dict[str, Any]], list[ModelMessage]]:
         """
         Get the chat history for a specific exchange, optionally formatted for pydantic-ai.
 
@@ -260,7 +258,7 @@ class ChatManager:
 
         if not format_for_pydantic_ai:
             # Format as simple role/content dictionaries
-            messages: List[Dict[str, Any]] = []
+            messages: list[dict[str, Any]] = []
             for msg in chat_exchange.messages:
                 try:
                     # Parse the JSON to get query and response
@@ -277,7 +275,7 @@ class ChatManager:
             return messages
         else:
             # Format for pydantic-ai
-            pydantic_messages: List[ModelMessage] = []
+            pydantic_messages: list[ModelMessage] = []
             for msg in chat_exchange.messages:
                 try:
                     data = json.loads(msg.message)
@@ -291,7 +289,7 @@ class ChatManager:
 
     def get_user_chat_history(
         self, trans: ProvidesUserContext, limit: int = 50, include_job_chats: bool = False
-    ) -> List[ChatExchange]:
+    ) -> list[ChatExchange]:
         """
         Get all chat exchanges for a user.
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -11,7 +11,6 @@ from typing import (
     Any,
     cast,
     Optional,
-    Tuple,
     TYPE_CHECKING,
     Union,
 )
@@ -1990,7 +1989,7 @@ class JobSubmitter:
 
     def dereference(
         self, trans: WorkRequestContext, tool: Tool, request: QueueJobs, tool_request: ToolRequest
-    ) -> Tuple[RequestInternalDereferencedToolState, list[DereferencedDatasetPair]]:
+    ) -> tuple[RequestInternalDereferencedToolState, list[DereferencedDatasetPair]]:
         new_hdas: list[DereferencedDatasetPair] = []
 
         def dereference_collection_callback(data_request: DataRequestCollectionUri) -> DataRequestInternalHdca:

--- a/lib/galaxy/managers/tours.py
+++ b/lib/galaxy/managers/tours.py
@@ -1,7 +1,6 @@
 import os
 from typing import (
     Any,
-    Dict,
     Optional,
 )
 
@@ -57,9 +56,9 @@ class TourGenerator:
         self._trans = trans
         self._tool: Tool = self._get_and_ensure_tool(tool_id, tool_version)
         self._use_datasets = True
-        self._data_inputs: Dict[str, Any] = {}
+        self._data_inputs: dict[str, Any] = {}
         self._tour: Optional[TourDetails] = None
-        self._hids: Dict[str, Any] = {}
+        self._hids: dict[str, Any] = {}
         self._test: ToolTestDescription
         self._upload_test_data(performs_upload=performs_upload)
         self._generate_tour(performs_upload=performs_upload)
@@ -234,7 +233,7 @@ class TourGenerator:
                                 if test_option == option[1]:
                                     params.append(option[0])
                     # Conditional param cases
-                    cases: Dict[str, str] = {}
+                    cases: dict[str, str] = {}
                     for case in input.cases:
                         if case.inputs is not None:
                             for key, value in case.inputs.items():

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1146,8 +1146,7 @@ ON CONFLICT
 
     def get_oidc_tokens(self, provider_backend):
         tokens = {"id": None, "access": None, "refresh": None}
-        auth = self._get_social_auth(provider_backend)
-        if auth:
+        if auth := self._get_social_auth(provider_backend):
             tokens["access"] = auth.extra_data.get("access_token", None)
             tokens["refresh"] = auth.extra_data.get("refresh_token", None)
             tokens["id"] = auth.extra_data.get("id_token", None)

--- a/lib/galaxy/model/dataset_collections/subcollections.py
+++ b/lib/galaxy/model/dataset_collections/subcollections.py
@@ -1,5 +1,4 @@
 from typing import (
-    List,
     TYPE_CHECKING,
     Union,
 )
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
     )
 
 
-SplitReturnType = List[Union["DatasetCollectionElement", "PromoteCollectionElementToCollectionAdapter"]]
+SplitReturnType = list[Union["DatasetCollectionElement", "PromoteCollectionElementToCollectionAdapter"]]
 
 
 def split_dataset_collection_instance(

--- a/lib/galaxy/model/dereference.py
+++ b/lib/galaxy/model/dereference.py
@@ -1,9 +1,8 @@
 import logging
 import os.path
+from collections.abc import Sequence
 from typing import (
-    List,
     Optional,
-    Sequence,
     Union,
 )
 
@@ -169,7 +168,7 @@ def derefence_collection_to_model(
 def get_replacement_dataset(
     session: Session,
     user: Optional[User],
-    dataset_sources: List[DatasetSource],
+    dataset_sources: list[DatasetSource],
     dataset_hashes: Sequence[Union[DatasetHash, DatasetSourceHash]],
     extension: str,
     object_store_id: str,

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -5,8 +5,6 @@ Pydantic schemas for AI agent responses and requests.
 from enum import Enum
 from typing import (
     Any,
-    Dict,
-    List,
     Optional,
 )
 
@@ -40,7 +38,7 @@ class ActionSuggestion(BaseModel):
 
     action_type: ActionType = Field(description="Type of action to take")
     description: str = Field(description="Human-readable description of the action")
-    parameters: Dict[str, Any] = Field(default_factory=dict, description="Parameters for the action")
+    parameters: dict[str, Any] = Field(default_factory=dict, description="Parameters for the action")
     confidence: ConfidenceLevel = Field(description="Confidence in this suggestion")
     priority: int = Field(default=1, description="Priority level (1=high, 2=medium, 3=low)")
 
@@ -51,8 +49,8 @@ class AgentResponse(BaseModel):
     content: str = Field(description="Main response content")
     confidence: ConfidenceLevel = Field(description="Confidence in the response")
     agent_type: str = Field(description="Type of agent that generated this response")
-    suggestions: List[ActionSuggestion] = Field(default_factory=list, description="Actionable suggestions")
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    suggestions: list[ActionSuggestion] = Field(default_factory=list, description="Actionable suggestions")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     reasoning: Optional[str] = Field(default=None, description="Explanation of the agent's reasoning")
 
 
@@ -61,7 +59,7 @@ class AgentQueryRequest(BaseModel):
 
     query: str = Field(description="The user's question or request")
     agent_type: str = Field(default="auto", description="Preferred agent type ('auto' for routing)")
-    context: Dict[str, Any] = Field(default_factory=dict, description="Additional context for the query")
+    context: dict[str, Any] = Field(default_factory=dict, description="Additional context for the query")
     stream: bool = Field(default=False, description="Whether to stream the response")
 
 
@@ -69,7 +67,7 @@ class AgentQueryResponse(BaseModel):
     """Response from an AI agent query."""
 
     response: AgentResponse = Field(description="The agent's response")
-    routing_info: Optional[Dict[str, Any]] = Field(
+    routing_info: Optional[dict[str, Any]] = Field(
         default=None, description="Information about how the query was routed"
     )
     processing_time: Optional[float] = Field(default=None, description="Time taken to process the query in seconds")
@@ -83,13 +81,13 @@ class AvailableAgent(BaseModel):
     description: str = Field(description="Description of the agent's capabilities")
     enabled: bool = Field(description="Whether the agent is currently enabled")
     model: Optional[str] = Field(default=None, description="LLM model used by the agent")
-    specialties: List[str] = Field(default_factory=list, description="Areas of specialization")
+    specialties: list[str] = Field(default_factory=list, description="Areas of specialization")
 
 
 class AgentListResponse(BaseModel):
     """Response listing available agents."""
 
-    agents: List[AvailableAgent] = Field(description="List of available agents")
+    agents: list[AvailableAgent] = Field(description="List of available agents")
     total_count: int = Field(description="Total number of agents")
 
 
@@ -97,7 +95,7 @@ class RoutingDecision(BaseModel):
     """Decision made by the router agent."""
 
     primary_agent: str = Field(description="Primary agent to handle the query")
-    secondary_agents: List[str] = Field(default_factory=list, description="Additional agents that might help")
+    secondary_agents: list[str] = Field(default_factory=list, description="Additional agents that might help")
     complexity: str = Field(description="Query complexity assessment")
     confidence: ConfidenceLevel = Field(description="Confidence in the routing decision")
     reasoning: str = Field(description="Explanation for the routing choice")
@@ -126,10 +124,10 @@ class ErrorAnalysisResponse(BaseModel):
 
     error_category: ErrorCategory = Field(description="Classification of the error")
     likely_cause: str = Field(description="Most probable cause of the error")
-    solution_steps: List[str] = Field(description="Step-by-step solution")
-    alternative_approaches: List[str] = Field(default_factory=list, description="Alternative solutions")
+    solution_steps: list[str] = Field(description="Step-by-step solution")
+    alternative_approaches: list[str] = Field(default_factory=list, description="Alternative solutions")
     confidence: ConfidenceLevel = Field(description="Confidence in the analysis")
-    related_documentation: List[str] = Field(default_factory=list, description="Relevant documentation links")
+    related_documentation: list[str] = Field(default_factory=list, description="Relevant documentation links")
     requires_admin: bool = Field(default=False, description="Whether admin intervention is needed")
 
 
@@ -138,7 +136,7 @@ class DatasetAnalysisRequest(BaseModel):
 
     dataset_id: str = Field(description="Galaxy dataset identifier")
     analysis_type: str = Field(default="comprehensive", description="Type of analysis to perform")
-    focus_areas: List[str] = Field(default_factory=list, description="Specific areas to focus on")
+    focus_areas: list[str] = Field(default_factory=list, description="Specific areas to focus on")
 
 
 class QualityIssue(BaseModel):
@@ -155,9 +153,9 @@ class DatasetAnalysisResponse(BaseModel):
     """Response from dataset quality analysis."""
 
     quality_score: float = Field(description="Overall quality score (0.0 to 1.0)")
-    issues_found: List[QualityIssue] = Field(description="List of quality issues detected")
-    recommendations: List[str] = Field(description="General recommendations for improvement")
-    preprocessing_steps: List[str] = Field(description="Suggested preprocessing steps")
+    issues_found: list[QualityIssue] = Field(description="List of quality issues detected")
+    recommendations: list[str] = Field(description="General recommendations for improvement")
+    preprocessing_steps: list[str] = Field(description="Suggested preprocessing steps")
     confidence: ConfidenceLevel = Field(description="Confidence in the analysis")
 
 
@@ -165,8 +163,8 @@ class WorkflowOptimizationRequest(BaseModel):
     """Request for workflow optimization."""
 
     workflow_id: Optional[str] = Field(default=None, description="Galaxy workflow identifier")
-    workflow_structure: Optional[Dict[str, Any]] = Field(default=None, description="Workflow structure data")
-    performance_goals: List[str] = Field(default_factory=list, description="Optimization goals")
+    workflow_structure: Optional[dict[str, Any]] = Field(default=None, description="Workflow structure data")
+    performance_goals: list[str] = Field(default_factory=list, description="Optimization goals")
 
 
 class OptimizationSuggestion(BaseModel):
@@ -182,9 +180,9 @@ class OptimizationSuggestion(BaseModel):
 class WorkflowOptimizationResponse(BaseModel):
     """Response from workflow optimization analysis."""
 
-    optimization_suggestions: List[OptimizationSuggestion] = Field(description="List of optimization suggestions")
-    performance_improvements: List[str] = Field(description="Expected performance improvements")
-    bottlenecks_identified: List[str] = Field(description="Identified bottlenecks")
+    optimization_suggestions: list[OptimizationSuggestion] = Field(description="List of optimization suggestions")
+    performance_improvements: list[str] = Field(description="Expected performance improvements")
+    bottlenecks_identified: list[str] = Field(description="Identified bottlenecks")
     estimated_time_savings: Optional[str] = Field(default=None, description="Estimated time savings")
     confidence: ConfidenceLevel = Field(description="Confidence in the analysis")
 
@@ -196,7 +194,7 @@ class AgentMetrics(BaseModel):
     total_queries: int = Field(description="Total number of queries processed")
     success_rate: float = Field(description="Success rate (0.0 to 1.0)")
     average_response_time: float = Field(description="Average response time in seconds")
-    confidence_distribution: Dict[str, int] = Field(description="Distribution of confidence levels")
+    confidence_distribution: dict[str, int] = Field(description="Distribution of confidence levels")
     last_update: str = Field(description="Last update timestamp")
 
 
@@ -208,7 +206,7 @@ class AgentStatus(BaseModel):
     health_status: str = Field(description="Health status (healthy, degraded, unavailable)")
     last_response_time: Optional[float] = Field(default=None, description="Last response time in seconds")
     error_rate: float = Field(description="Recent error rate")
-    model_info: Dict[str, Any] = Field(default_factory=dict, description="Information about the underlying model")
+    model_info: dict[str, Any] = Field(default_factory=dict, description="Information about the underlying model")
 
 
 class SystemStatus(BaseModel):
@@ -216,6 +214,6 @@ class SystemStatus(BaseModel):
 
     total_agents: int = Field(description="Total number of registered agents")
     healthy_agents: int = Field(description="Number of healthy agents")
-    agent_statuses: List[AgentStatus] = Field(description="Status of each agent")
+    agent_statuses: list[AgentStatus] = Field(description="Status of each agent")
     system_health: str = Field(description="Overall system health")
     last_check: str = Field(description="Last health check timestamp")

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -4,7 +4,6 @@ from typing import (
     Annotated,
     Any,
     Generic,
-    List,
     Optional,
     Union,
 )
@@ -117,7 +116,7 @@ class CancelReason(str, Enum):
 
 class InvocationMessageBase(GenericModel):
     reason: Union[CancelReason, FailureReason, WarningReason]
-    workflow_step_index_path: Optional[List[int]] = Field(
+    workflow_step_index_path: Optional[list[int]] = Field(
         None,
         description="Path of workflow step IDs from parent workflow through subworkflows (excludes the failing step itself).",
     )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2608,7 +2608,7 @@ class Creator(Model):
     )
 
 
-class Organization(Creator):
+class CreatorOrganization(Creator):
     class_: str = Field(
         "Organization",
         alias="class",
@@ -2825,7 +2825,7 @@ class WorkflowToExport(Model):
         title="UUID",
         description="Universal unique identifier of the workflow.",
     )
-    creator: Optional[list[Union[Person, Organization]]] = Field(
+    creator: Optional[list[Union[Person, CreatorOrganization]]] = Field(
         None,
         title="Creator",
         description=("Additional information about the creator (or multiple creators) of this workflow."),

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -15,11 +15,11 @@ from pydantic import (
 
 from galaxy.schema.schema import (
     AnnotationField,
+    CreatorOrganization,
     InputDataCollectionStep,
     InputDataStep,
     InputParameterStep,
     Model,
-    Organization,
     PauseStep,
     Person,
     StoredWorkflowSummary,
@@ -222,7 +222,7 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
     inputs: dict[int, WorkflowInput] = Field(
         {}, title="Inputs", description="A dictionary containing information about all the inputs of the workflow."
     )
-    creator: Optional[list[Union[Person, Organization]]] = Field(
+    creator: Optional[list[Union[Person, CreatorOrganization]]] = Field(
         None,
         title="Creator",
         description=("Additional information about the creator (or multiple creators) of this workflow."),

--- a/lib/galaxy/selenium/has_driver_protocol.py
+++ b/lib/galaxy/selenium/has_driver_protocol.py
@@ -5,10 +5,10 @@ allowing NavigatesGalaxy to work with either backend via composition.
 """
 
 from abc import abstractmethod
+from contextlib import AbstractContextManager
 from typing import (
     Any,
     Callable,
-    ContextManager,
     Generic,
     Literal,
     Optional,
@@ -467,7 +467,7 @@ class HasDriverProtocol(Protocol, Generic[WaitTypeT]):
 
     # Alert handling
     @abstractmethod
-    def accept_alert(self) -> "ContextManager[None]":
+    def accept_alert(self) -> AbstractContextManager[None]:
         """
         Return a context manager for accepting browser alert dialogs.
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -10,14 +10,16 @@ import os
 import re
 import tarfile
 import tempfile
-from collections.abc import MutableMapping
+from collections.abc import (
+    MutableMapping,
+    Sequence,
+)
 from pathlib import Path
 from typing import (
     Any,
     cast,
     NamedTuple,
     Optional,
-    Sequence,
     TYPE_CHECKING,
     Union,
 )

--- a/lib/galaxy/tools/execution_helpers.py
+++ b/lib/galaxy/tools/execution_helpers.py
@@ -96,16 +96,13 @@ def on_text_for_dataset_and_collections(
     collection_hids: Optional[list[int]] = None,
     element_ids: Optional[list[str]] = None,
 ) -> str:
-    on_text_datasets = on_text_for_numeric_ids(dataset_hids, "dataset")
-    on_text_collection = on_text_for_numeric_ids(collection_hids, "collection")
-    on_text_elements = on_text_for_names(element_ids)
 
     on_text = []
-    if on_text_datasets:
+    if on_text_datasets := on_text_for_numeric_ids(dataset_hids, "dataset"):
         on_text.append(on_text_datasets)
-    if on_text_collection:
+    if on_text_collection := on_text_for_numeric_ids(collection_hids, "collection"):
         on_text.append(on_text_collection)
-    if on_text_elements:
+    if on_text_elements := on_text_for_names(element_ids):
         on_text.append(on_text_elements)
 
     if len(on_text) == 0:

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     cast,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -290,7 +289,7 @@ def visit_input_values(
 
 def check_param(
     trans, param: ToolParameter, incoming_value, param_values, simple_errors: bool = True
-) -> Tuple[Any, Union[str, ValueError, None]]:
+) -> tuple[Any, Union[str, ValueError, None]]:
     """
     Check the value of a single parameter `param`. The value in
     `incoming_value` is converted from its HTML encoding and validated.

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -7,12 +7,14 @@ for some activity such as queuing up jobs or scheduling workflows.
 import logging
 import os
 import random
-from collections.abc import Sequence
+from collections.abc import (
+    Iterable,
+    Sequence,
+)
 from enum import Enum
 from typing import (
     Any,
     Callable,
-    Iterable,
     Protocol,
     TYPE_CHECKING,
     TypeVar,

--- a/lib/galaxy/webapps/galaxy/api/agents.py
+++ b/lib/galaxy/webapps/galaxy/api/agents.py
@@ -4,7 +4,6 @@ import logging
 import time
 from typing import (
     Any,
-    Dict,
     Optional,
 )
 
@@ -129,7 +128,7 @@ class AgentAPI:
         self,
         query: str = Body(..., description="Description of the error or problem"),
         job_id: Optional[DecodedDatabaseIdField] = Body(None, description="Job ID for context"),
-        error_details: Optional[Dict[str, Any]] = Body(None, description="Additional error details"),
+        error_details: Optional[dict[str, Any]] = Body(None, description="Additional error details"),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
     ) -> AgentResponse:
@@ -169,7 +168,7 @@ class AgentAPI:
     async def create_custom_tool(
         self,
         query: str = Body(..., description="Description of the tool to create"),
-        context: Optional[Dict[str, Any]] = Body(None, description="Additional context for tool creation"),
+        context: Optional[dict[str, Any]] = Body(None, description="Additional context for tool creation"),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
     ) -> AgentResponse:

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -7,8 +7,6 @@ import logging
 from typing import (
     Annotated,
     Any,
-    Dict,
-    List,
     Optional,
     Union,
 )
@@ -166,7 +164,7 @@ class ChatAPI:
         try:
             if HAS_AGENTS:
                 # Build context with conversation history
-                full_context: Dict[str, Any] = query_context.copy() if query_context else {}
+                full_context: dict[str, Any] = query_context.copy() if query_context else {}
 
                 # If we have an exchange_id, ALWAYS load conversation history from database (source of truth)
                 if exchange_id:
@@ -232,7 +230,7 @@ class ChatAPI:
         limit: int = Query(default=50, description="Maximum number of chats to return"),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Get user's chat history."""
         if not user:
             return []
@@ -275,7 +273,7 @@ class ChatAPI:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """Clear user's chat history (non-job chats only)."""
         if not user:
             return {"message": "No user logged in"}
@@ -325,7 +323,7 @@ class ChatAPI:
         feedback: int = Body(..., description="Feedback value: 0 for negative, 1 for positive"),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Set feedback for a general chat exchange."""
         chat_exchange = self.chat_manager.set_feedback_for_exchange(trans, exchange_id, feedback)
         return {
@@ -339,7 +337,7 @@ class ChatAPI:
         exchange_id: int,
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Get all messages for a specific chat exchange."""
         exchange = self.chat_manager.get_exchange_by_id(trans, exchange_id)
         if not exchange:
@@ -416,7 +414,7 @@ class ChatAPI:
     def _call_openai_directly(self, query: str, system_prompt: str, username: str) -> str:
         """Direct OpenAI API call as fallback"""
         try:
-            messages: List[Dict[str, str]] = [
+            messages: list[dict[str, str]] = [
                 {"role": "system", "content": system_prompt},
                 {
                     "role": "system",
@@ -451,7 +449,7 @@ class ChatAPI:
         trans: ProvidesUserContext,
         user: User,
         job=None,
-        context: Optional[Dict[str, Any]] = None,
+        context: Optional[dict[str, Any]] = None,
     ) -> str:
         """Get response using the new agent system (legacy method for compatibility)."""
         result = await self._get_agent_response_full(query, agent_type, trans, user, job, context)
@@ -464,7 +462,7 @@ class ChatAPI:
         trans: ProvidesUserContext,
         user: User,
         job=None,
-        context: Optional[Dict[str, Any]] = None,
+        context: Optional[dict[str, Any]] = None,
     ) -> AgentResponse:
         """Get full agent response with metadata and suggestions."""
         # Prepare context - merge passed context with job context

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -343,8 +343,7 @@ class FetchTools:
         trans: ProvidesUserContext = DependsOnTrans,
         tool_landing_request: CreateToolLandingRequestPayload = Body(...),
     ) -> ToolLandingRequest:
-        tool_id = tool_landing_request.tool_id
-        if tool_id in PROTECTED_TOOLS:
+        if (tool_id := tool_landing_request.tool_id) in PROTECTED_TOOLS:
             raise exceptions.RequestParameterInvalidException(
                 f"Cannot execute tool [{tool_id}] directly, must use alternative endpoint."
             )

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -114,13 +114,11 @@ class ToolRunner(BaseUIController):
         if len(params) > 0:
             trans.log_event(f"Tool params: {str(params)}", tool_id=tool_id)
         status_text = "You can check the status of queued jobs in the History panel."
-        job_errors = vars.get("job_errors")
-        num_jobs = vars.get("num_jobs")
-        if job_errors:
+        if job_errors := vars.get("job_errors"):
             errors = "\n".join(f"- {job_error}" for job_error in job_errors)
             message = f"There were errors setting up {len(job_errors)} submitted job(s):\n{errors}"
             return trans.show_error_message(message)
-        if num_jobs > 1:
+        if (num_jobs := vars.get("num_jobs")) > 1:
             message = f"{num_jobs} jobs have been successfully added to the queue. {status_text}"
         else:
             message = f"A job has been successfully added to the queue. {status_text}"

--- a/lib/galaxy/webapps/galaxy/services/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/services/_fetch_util.py
@@ -34,8 +34,7 @@ def validate_and_normalize_targets(trans, payload, set_internal_fields=True):
       as needed for each upload.
     """
     targets = payload.get("targets", [])
-    landing_uuid = payload.get("landing_uuid")
-    if landing_uuid:
+    if landing_uuid := payload.get("landing_uuid"):
         payload["landing_uuid"] = str(landing_uuid)
 
     for target in targets:

--- a/lib/galaxy/webapps/galaxy/services/credentials.py
+++ b/lib/galaxy/webapps/galaxy/services/credentials.py
@@ -437,8 +437,7 @@ class CredentialsService:
 
         user_cred_map, group_map, cred_map = self.credentials_manager.index_credentials(existing_user_credentials)
 
-        user_credentials = user_cred_map.get((service_name, service_version))
-        if user_credentials:
+        if user_credentials := user_cred_map.get((service_name, service_version)):
             user_credentials_id = user_credentials.id
         else:
             user_credentials_id = self.credentials_manager.add_user_credentials(

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -241,9 +241,8 @@ class JobsService(ServiceBase):
     def create(self, trans: ProvidesHistoryContext, job_request: JobRequest) -> JobCreateResponse:
         tool_run_reference = ToolRunReference(job_request.tool_id, job_request.tool_uuid, job_request.tool_version)
         tool = validate_tool_for_running(trans, tool_run_reference)
-        history_id = job_request.history_id
         target_history = None
-        if history_id is not None:
+        if (history_id := job_request.history_id) is not None:
             target_history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
         inputs = job_request.inputs
         strict = job_request.strict

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1160,8 +1160,7 @@ class InputDataCollectionModule(InputModule):
                 fields=fields,
             )
             collection_type_description.validate()
-        column_definitions = state.get("column_definitions")
-        if column_definitions:
+        if column_definitions := state.get("column_definitions"):
             validate_column_definitions(column_definitions)
         return None
 

--- a/lib/galaxy_test/api/test_tool_execution.py
+++ b/lib/galaxy_test/api/test_tool_execution.py
@@ -3,7 +3,6 @@
 import base64
 from typing import (
     Any,
-    Dict,
 )
 
 import requests
@@ -234,13 +233,13 @@ class TestToolExecution(ApiTestCase):
             content = self.dataset_populator.get_history_dataset_content(history_id, dataset=job_output["dataset"])
             assert content == "Hello World!\nIt is me - a collection!\n"
 
-    def _assert_request_validates(self, tool_id: str, history_id: str, inputs: Dict[str, Any]):
+    def _assert_request_validates(self, tool_id: str, history_id: str, inputs: dict[str, Any]):
         response = self._run(tool_id, history_id, inputs)
         assert response.status_code == 200
 
-    def _assert_request_invalid(self, tool_id: str, history_id: str, inputs: Dict[str, Any]):
+    def _assert_request_invalid(self, tool_id: str, history_id: str, inputs: dict[str, Any]):
         response = self._run(tool_id, history_id, inputs)
         assert response.status_code == 400
 
-    def _run(self, tool_id: str, history_id: str, inputs: Dict[str, Any]) -> requests.Response:
+    def _run(self, tool_id: str, history_id: str, inputs: dict[str, Any]) -> requests.Response:
         return self.dataset_populator.tool_request_raw(tool_id, inputs, history_id)

--- a/lib/galaxy_test/api/test_tool_output_tagging.py
+++ b/lib/galaxy_test/api/test_tool_output_tagging.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from galaxy_test.base.api_asserts import assert_status_code_is
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
@@ -14,7 +12,7 @@ class TestToolOutputTaggingApi(ApiTestCase):
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
-    def _assert_tags(self, history_id: str, hda_id: str, expected: List[str]):
+    def _assert_tags(self, history_id: str, hda_id: str, expected: list[str]):
         details = self.dataset_populator.get_history_dataset_details(history_id, dataset_id=hda_id)
         assert sorted(details["tags"]) == sorted(expected)
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -4044,8 +4044,7 @@ class DescribeFailure:
         return self
 
     def with_error_containing(self, message: str) -> Self:
-        actual_text = self._response.text
-        if message not in actual_text:
+        if message not in (actual_text := self._response.text):
             if self._tool_request:
                 state_message = self._tool_request["state_message"]
                 if message not in state_message:
@@ -4203,8 +4202,7 @@ class DescribeToolExecution:
     def assert_has_n_jobs(self, n: int) -> Self:
         self._assert_executed_ok()
         jobs = self._jobs
-        num_jobs = len(jobs)
-        if num_jobs != n:
+        if (num_jobs := len(jobs)) != n:
             raise AssertionError(f"Expected tool execution to produce {n} jobs but it produced {num_jobs}")
         return self
 

--- a/lib/tool_shed/context.py
+++ b/lib/tool_shed/context.py
@@ -149,8 +149,7 @@ class SessionRequestContextImpl(SessionRequestContext):
     @property
     def repositories_hostname(self) -> str:
         # Use configured tool_shed_url if available
-        tool_shed_url = self.app.config.tool_shed_url
-        if tool_shed_url:
+        if tool_shed_url := self.app.config.tool_shed_url:
             return tool_shed_url.rstrip("/")
         # Fall back to request-based URL
         return str(self.request.base).rstrip("/")

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -35,8 +35,7 @@ class ToolShedGalaxyWebTransaction(GalaxyWebTransaction):
     @property
     def repositories_hostname(self) -> str:
         # Use configured tool_shed_url if available
-        tool_shed_url = self.app.config.tool_shed_url
-        if tool_shed_url:
+        if tool_shed_url := self.app.config.tool_shed_url:
             return tool_shed_url.rstrip("/")
         # Fall back to request-based URL
         return url_for("/", qualified=True).rstrip("/")

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
     PyYAML
     requests
     Routes
+    slowapi
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
     starlette
     starlette-context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,7 @@ select = ["E", "F", "B", "C4", "G", "ISC", "NPY", "UP"]
 # E402 module level import not at top of file # TODO, we would like to improve this.
 # E501 is line length (delegated to black)
 # G* are TODOs
-# UP006 and UP035 are PEP 585 type annotations
-ignore = ["B008", "B9", "E402", "E501", "G001", "G002", "G004", "UP006", "UP035"]
+ignore = ["B008", "B9", "E402", "E501", "G001", "G002", "G004"]
 
 [tool.ruff.lint.flake8-comprehensions]
 allow-dict-calls-with-keyword-arguments = true
@@ -242,17 +241,19 @@ keep-runtime-typing = true
 "lib/galaxy/schema/drs/*" = ["UP"]
 "lib/tool_shed_client/schema/trs.py" = ["UP"]
 "lib/tool_shed_client/schema/trs_service_info.py" = ["UP"]
-# Don't check some pyupgrade rules on packages for Pulsar, which need to stay compatible with Python 3.7
-"lib/galaxy/exceptions/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"lib/galaxy/job_metrics/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"lib/galaxy/objectstore/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"lib/galaxy/tool_util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"lib/galaxy/util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"scripts/check_python.py" = ["UP006", "UP007", "UP010", "UP032", "UP033", "UP035", "UP036"]
-"test/unit/job_metrics/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"test/unit/objectstore/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"test/unit/tool_util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
-"test/unit/util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036"]
+# Don't check some pyupgrade rules on packages for Pulsar, which need to stay compatible with Python 3.8
+"lib/galaxy/exceptions/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"lib/galaxy/job_metrics/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"lib/galaxy/objectstore/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"lib/galaxy/tool_util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"lib/galaxy/tool_util_models/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"lib/galaxy/util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"scripts/check_python.py" = ["UP006", "UP007", "UP010", "UP032", "UP033", "UP035", "UP036", "UP045"]
+"test/unit/job_metrics/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"test/unit/objectstore/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"test/unit/tool_util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"test/unit/tool_util_models/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
+"test/unit/util/*" = ["UP006", "UP007", "UP033", "UP035", "UP036", "UP045"]
 
 [tool.uv]
 constraint-dependencies = [

--- a/scripts/tool_shed/fix_tool_config_paths.py
+++ b/scripts/tool_shed/fix_tool_config_paths.py
@@ -92,8 +92,7 @@ def construct_new_path(old_path, repository, current_file_path):
     expected_repo_path = repository.hg_repository_path(current_file_path)
 
     # Extract the portion after "repo_{id}/" to get the relative tool path
-    repo_pattern = f"repo_{repository.id}/"
-    if repo_pattern in old_path:
+    if (repo_pattern := f"repo_{repository.id}/") in old_path:
         # Split on the repo pattern and take everything after it
         relative_tool_path = old_path.split(repo_pattern, 1)[1]
         new_path = os.path.join(expected_repo_path, relative_tool_path)
@@ -102,9 +101,8 @@ def construct_new_path(old_path, repository, current_file_path):
     # Fallback: try to extract using regex pattern for hash_dirs/repo_id/file
     # Pattern matches: .../000/repo_123/tool.xml or .../000/123/456/repo_789/tool.xml
     pattern = r".*/(\d+/)*(repo_\d+/.*)"
-    match = re.search(pattern, old_path)
 
-    if match:
+    if match := re.search(pattern, old_path):
         # Extract everything from "repo_" onward
         repo_relative = match.group(2)  # e.g., "repo_123/filtering.xml"
 

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -60,14 +60,11 @@ class AgentIntegrationTestCase(IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         # AI/LLM configuration for agent tests
-        ai_api_key = os.environ.get("GALAXY_TEST_AI_API_KEY")
-        ai_api_base_url = os.environ.get("GALAXY_TEST_AI_API_BASE_URL")
-        ai_model = os.environ.get("GALAXY_TEST_AI_MODEL")
-        if ai_api_key:
+        if ai_api_key := os.environ.get("GALAXY_TEST_AI_API_KEY"):
             config["ai_api_key"] = ai_api_key
-        if ai_api_base_url:
+        if ai_api_base_url := os.environ.get("GALAXY_TEST_AI_API_BASE_URL"):
             config["ai_api_base_url"] = ai_api_base_url
-        if ai_model:
+        if ai_model := os.environ.get("GALAXY_TEST_AI_MODEL"):
             config["ai_model"] = ai_model
 
 

--- a/test/unit/app/managers/test_landing.py
+++ b/test/unit/app/managers/test_landing.py
@@ -1,6 +1,5 @@
 from typing import (
     cast,
-    List,
 )
 from uuid import uuid4
 
@@ -61,7 +60,7 @@ class MockToolbox:
 class MockTool:
 
     @property
-    def parameters(self) -> List[ToolParameterT]:
+    def parameters(self) -> list[ToolParameterT]:
         return [DataParameterModel(type="data", name="input1")]
 
 

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -17,7 +17,6 @@ and those that do not.
 import os
 from typing import (
     Any,
-    Dict,
 )
 from unittest import mock
 from unittest.mock import (
@@ -187,7 +186,7 @@ class TestAgentUnitMocked:
             test_agent: Any = Agent(  # type: ignore[call-overload]
                 "test-router",
                 model=test_model,
-                output_type=Dict[str, Any],
+                output_type=dict[str, Any],
             )
             mock_create.return_value = test_agent
 


### PR DESCRIPTION
by runnig:

```shell
make pyupgrade
ruff check --fix .
make format
```

Basically same as https://github.com/galaxyproject/galaxy/pull/20642 for code that have been merged since.

Also update ruff configuration to:
- Enable UP006 and UP035 error codes for PEP 585 type annotations
- Ignore UP045 for the packages which need to stay compatible with Python 3.8
- Add tool-util-models paths to those that need to stay compatible with Python 3.8

Also 2 bug fixes:
- Rename `Organization` class to resolve ambiguity in the API schema
- Add missing slowapi dependencies to galaxy-web-apps package

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
