### PR TITLE
Update dependencies for IGV and Plotly

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -731,12 +731,17 @@ visualization:
 
 igv:
   selectors:
-    _: ".igv-container"
+    _: '.igv-container'
     shadow_host: '#viewport'
-    current_genome: '.igv-current-genome'
-    settings_button: button.n-button
-    save_button: '[data-description="sidepanel save button"]'
+    confirm_button:
+      type: xpath
+      selector: '(//button[text()=" OK "])[1]'
+    current_genome: '[title="Human (hg18)"]'
+    default_genome: '[title="Human (GRCh38/hg38)"]'
+    expand_button: '[data-description="sidebutton expand"]'
     name_input: '.n-input__input input'
+    save_button: '[data-description="sidebutton save"]'
+    settings_tab: '.n-tabs-tab[data-name="settings"]'
 
 trs_search:
   selectors:

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -736,8 +736,7 @@ igv:
     confirm_button:
       type: xpath
       selector: '(//button[text()=" OK "])[1]'
-    current_genome: '[title="Human (hg18)"]'
-    default_genome: '[title="Human (GRCh38/hg38)"]'
+    selected_genome: '[title="${title}"]'
     expand_button: '[data-description="sidebutton expand"]'
     name_input: '.n-input__input input'
     save_button: '[data-description="sidebutton save"]'

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -44,7 +44,7 @@ hyphyvision:
     version: 0.0.3
 igv:
     package: "@galaxyproject/igv"
-    version: 0.0.23
+    version: 0.0.25
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
     version: 0.0.28
@@ -68,7 +68,7 @@ niivue:
     version: 0.0.17
 nora:
     package: "@galaxyproject/nora"
-    version: 1.2.2
+    version: 1.2.4
 openlayers:
     package: "@galaxyproject/openlayers"
     version: 0.0.6
@@ -83,7 +83,7 @@ phylocanvas:
     version: 0.0.11
 plotly:
     package: "@galaxyproject/plotly"
-    version: 0.0.25
+    version: 0.0.28
 plotly_box:
     package: "@galaxyproject/plotly_box"
     version: 0.0.0

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -10,6 +10,8 @@ from .framework import (
 )
 
 HG18_DBKEY_TEXT = "Human Mar. 2006 (NCBI36/hg18) (hg18)"
+HG18_TITLE = "Human (hg18)"
+HG38_TITLE = "Human (GRCh38/hg38)"
 
 
 class TestVisualizationsAnonymous(SeleniumTestCase):
@@ -79,7 +81,7 @@ class TestVisualizations(SeleniumTestCase):
             igv.confirm_button.wait_for_and_click()
             igv.expand_button.wait_for_and_click()
             igv.settings_tab.wait_for_and_click()
-            igv.default_genome.wait_for_present()
+            igv.selected_genome(title=HG38_TITLE).wait_for_present()
             self.screenshot("visualization_plugin_igv_default_genome")
 
         dataset_component = self.history_panel_ensure_showing_item_details(hid)
@@ -93,7 +95,7 @@ class TestVisualizations(SeleniumTestCase):
             igv.confirm_button.assert_absent_or_hidden()
             igv.expand_button.wait_for_and_click()
             igv.settings_tab.wait_for_and_click()
-            igv.current_genome.wait_for_present()
+            igv.selected_genome(title=HG18_TITLE).wait_for_present()
             self.screenshot("visualization_plugin_igv_current_genome")
 
             igv.name_input.wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -102,7 +102,6 @@ class TestVisualizations(SeleniumTestCase):
 
         self.navigate_to_saved_visualizations()
 
-
     def _wait_for_igv_container(self):
         igv = self.components.igv
         self.sleep_for(self.wait_types.UX_TRANSITION)

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -76,39 +76,33 @@ class TestVisualizations(SeleniumTestCase):
 
         with self.visualization_panel():
             self._wait_for_igv_container()
-            self.screenshot("visualization_plugin_igv_landing_default_genome")
-            current_genome_text = self._igv_current_genome()
-            assert IGV_DEFAULT_GENOME in current_genome_text
+            igv = self.components.igv
+            igv.confirm_button.wait_for_and_click()
+            igv.expand_button.wait_for_and_click()
+            igv.settings_tab.wait_for_and_click()
+            igv.default_genome.wait_for_present()
+            self.screenshot("visualization_plugin_igv_default_genome")
 
         dataset_component = self.history_panel_ensure_showing_item_details(hid)
         dataset_component.dbkey.wait_for_and_click()
         self.edit_dataset_dbkey(HG18_DBKEY_TEXT)
-
         self.show_dataset_visualization(hid, visualization_id="igv")
 
         with self.visualization_panel():
             self._wait_for_igv_container()
-            current_genome_text = self._igv_current_genome()
-            self.screenshot("visualization_plugin_igv_landing_genome_from_dbkey_apimel3")
-            assert "hg18" in current_genome_text
-
             igv = self.components.igv
-            igv.save_button.assert_absent_or_hidden()
-            igv.settings_button.wait_for_and_click()
-            self.sleep_for(self.wait_types.UX_TRANSITION)
+            igv.confirm_button.assert_absent_or_hidden()
+            igv.expand_button.wait_for_and_click()
+            igv.settings_tab.wait_for_and_click()
+            igv.current_genome.wait_for_present()
+            self.screenshot("visualization_plugin_igv_current_genome")
+
             igv.name_input.wait_for_and_clear_aggressive_and_send_keys("igv with hg18")
             igv.save_button.wait_for_and_click()
             self.sleep_for(self.wait_types.UX_TRANSITION)
 
         self.navigate_to_saved_visualizations()
 
-    def _igv_current_genome(self):
-        igv = self.components.igv
-        element = igv.shadow_host.wait_for_present()
-        shadow_root = element.shadow_root
-        igv_current_genome = self.navigation.igv.selectors.current_genome
-        current_genome_element = shadow_root.find_element(*igv_current_genome.component_locator)
-        return current_genome_element.text
 
     def _wait_for_igv_container(self):
         igv = self.components.igv

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -9,7 +9,6 @@ from .framework import (
     SeleniumTestCase,
 )
 
-IGV_DEFAULT_GENOME = "hg38"
 HG18_DBKEY_TEXT = "Human Mar. 2006 (NCBI36/hg18) (hg18)"
 
 

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -96,7 +96,9 @@ class TestVisualizations(SeleniumTestCase):
             igv.current_genome.wait_for_present()
             self.screenshot("visualization_plugin_igv_current_genome")
 
-            igv.name_input.wait_for_and_clear_aggressive_and_send_keys("igv with hg18")
+            igv.name_input.wait_for_and_click()
+            igv.name_input.wait_for_and_clear_and_send_keys("igv with hg18")
+
             igv.save_button.wait_for_and_click()
             self.sleep_for(self.wait_types.UX_TRANSITION)
 


### PR DESCRIPTION
Updates igv.js to 3.7.1, plotly.js-dist to 3.3.1, and fixes a minor icon rendering issue for Nora when Galaxy is served with prefix. Additionally it updates the Charts UI package to vue 3.5.26, naive-ui 2.43.2 tailwind 4.1.18.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
