### PR TITLE
[25.1] Filter out failed_metadata HDAs from job cache

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -778,6 +778,8 @@ class JobSearch:
                     e.history_dataset_association_id.isnot(None),
                 ),
                 or_(b.deleted == false(), c.deleted == false()),
+                # Exclude HDAs where _state is set (_state is NULL when metadata is OK)
+                c._state.is_(None),
             )
         )
         return stmt
@@ -897,7 +899,11 @@ class JobSearch:
         signature_elements_select = signature_elements_select.join(
             _hda_cte_ref, _hda_cte_ref.id == _leaf_cte_ref.hda_id
         )
-        signature_elements_select = signature_elements_select.where(_hdca_target_cte_ref.id == v)
+        signature_elements_select = signature_elements_select.where(
+            _hdca_target_cte_ref.id == v,
+            # Exclude leaf HDAs where _state is set (_state is NULL when metadata is OK)
+            _hda_cte_ref._state.is_(None),
+        )
         signature_elements_cte = signature_elements_select.cte(
             safe_label_or_none(f"signature_elements_{k}_{value_index}")
         )
@@ -1135,7 +1141,11 @@ class JobSearch:
             _leaf_target_dce_ref = _dce_target_level_list[-1]
             reference_dce_signature_elements_select = reference_dce_signature_elements_select.join(
                 _hda_target_ref, _hda_target_ref.id == _leaf_target_dce_ref.hda_id
-            ).where(_dce_target_root_ref.id == v)
+            ).where(
+                _dce_target_root_ref.id == v,
+                # Exclude leaf HDAs where _state is set (_state is NULL when metadata is OK)
+                _hda_target_ref._state.is_(None),
+            )
             reference_dce_signature_elements_cte = reference_dce_signature_elements_select.cte(
                 safe_label_or_none(f"ref_dce_sig_els_{k}_{value_index}")
             )
@@ -1389,6 +1399,8 @@ class JobSearch:
                     a.name == k,
                     dce_left.element_identifier == dce_right.element_identifier,
                     hda_left.dataset_id == hda_right.dataset_id,  # Direct dataset_id comparison
+                    # Exclude HDAs where _state is set (_state is NULL when metadata is OK)
+                    hda_right._state.is_(None),
                 )
             )
             used_ids.append(labeled_col)

--- a/test/integration/test_job_cache.py
+++ b/test/integration/test_job_cache.py
@@ -1,0 +1,159 @@
+from sqlalchemy import select
+
+from galaxy.model import HistoryDatasetAssociation
+from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
+    DatasetPopulator,
+)
+from galaxy_test.driver import integration_util
+
+
+class TestJobCacheFiltering(integration_util.IntegrationTestCase):
+    """Integration tests for job cache filtering based on HDA state."""
+
+    dataset_populator: DatasetPopulator
+    dataset_collection_populator: DatasetCollectionPopulator
+    require_admin_user = True
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+
+    @property
+    def sa_session(self):
+        return self._app.model.session
+
+    def test_job_cache_excludes_failed_metadata_hda(self):
+        """Test that job cache lookup excludes HDAs in failed_metadata state.
+
+        When an HDA is in failed_metadata state, even if a previous job ran
+        successfully with that same HDA data, the cache should not be used
+        because the HDA is now in an invalid state.
+        """
+        with self.dataset_populator.test_history() as history_id:
+            # Create a dataset and run a job with it (this creates a cache entry)
+            hda = self.dataset_populator.new_dataset(history_id, content="test content")
+            hda_id = hda["id"]
+            inputs = {"input1": {"src": "hda", "id": hda_id}}
+
+            # Run the first job without cache - this creates the cache entry
+            first_run = self.dataset_populator.run_tool(
+                tool_id="cat1",
+                inputs=inputs,
+                history_id=history_id,
+            )
+            first_job_id = first_run["jobs"][0]["id"]
+            self.dataset_populator.wait_for_job(first_job_id)
+
+            # Run the same job with caching enabled - should use cached job
+            cached_run = self.dataset_populator.run_tool(
+                tool_id="cat1",
+                inputs=inputs,
+                history_id=history_id,
+                use_cached_job=True,
+            )
+            cached_job_id = cached_run["jobs"][0]["id"]
+            self.dataset_populator.wait_for_job(cached_job_id)
+
+            # Verify job was cached (copied_from_job_id should be set)
+            cached_job_details = self.dataset_populator.get_job_details(cached_job_id, full=True).json()
+            assert cached_job_details["copied_from_job_id"] == first_job_id, "Second run should have used cached job"
+
+            # Now set the input HDA to failed_metadata state
+            database_id = self._get(f"configuration/decode/{hda_id}").json()["decoded_id"]
+            hda_model = self.sa_session.scalar(
+                select(HistoryDatasetAssociation).where(HistoryDatasetAssociation.id == database_id)
+            )
+            assert hda_model
+            hda_model.state = HistoryDatasetAssociation.states.FAILED_METADATA
+            self.sa_session.add(hda_model)
+            self.sa_session.commit()
+
+            # Run the same job again with caching enabled
+            # This time, cache should NOT be used because input HDA is in failed_metadata state
+            # The tool will also fail validation since the HDA is in an invalid state
+            third_run = self.dataset_populator.run_tool_raw(
+                tool_id="cat1",
+                inputs=inputs,
+                history_id=history_id,
+                use_cached_job=True,
+            ).json()
+
+            # The response should contain an error since the HDA is in failed_metadata state
+            # Most importantly, the cache should NOT have been used - if it were,
+            # the job would have succeeded by copying from the cached job
+            assert (
+                "errors" in third_run and third_run["errors"]
+            ), "Tool should fail when input HDA is in failed_metadata state"
+            assert "failed_metadata" in str(third_run["errors"]), "Error should mention failed_metadata state"
+
+    def test_job_cache_excludes_failed_metadata_hdca_element(self):
+        """Test that job cache lookup excludes HDCAs with elements in failed_metadata state.
+
+        When a leaf HDA in an HDCA is in failed_metadata state, the cache should
+        not return a match for that collection.
+        """
+        with self.dataset_populator.test_history() as history_id:
+            # Create a dataset collection with two elements
+            create_response = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["content1\n", "content2\n"], wait=True
+            ).json()
+            hdca_id = create_response["output_collections"][0]["id"]
+
+            # Get the first element's HDA ID
+            hdca_details = self.dataset_populator.get_history_collection_details(history_id, content_id=hdca_id)
+            first_element_hda_id = hdca_details["elements"][0]["object"]["id"]
+
+            inputs = {"input1": {"src": "hdca", "id": hdca_id}}
+
+            # Run the first job without cache - this creates the cache entry
+            first_run = self.dataset_populator.run_tool(
+                tool_id="cat_list",
+                inputs=inputs,
+                history_id=history_id,
+            )
+            first_job_id = first_run["jobs"][0]["id"]
+            self.dataset_populator.wait_for_job(first_job_id)
+
+            # Run the same job with caching enabled - should use cached job
+            cached_run = self.dataset_populator.run_tool(
+                tool_id="cat_list",
+                inputs=inputs,
+                history_id=history_id,
+                use_cached_job=True,
+            )
+            cached_job_id = cached_run["jobs"][0]["id"]
+            self.dataset_populator.wait_for_job(cached_job_id)
+
+            # Verify job was cached (copied_from_job_id should be set)
+            cached_job_details = self.dataset_populator.get_job_details(cached_job_id, full=True).json()
+            assert cached_job_details["copied_from_job_id"] == first_job_id, "Second run should have used cached job"
+
+            # Now set one of the collection element's HDA to failed_metadata state
+            database_id = self._get(f"configuration/decode/{first_element_hda_id}").json()["decoded_id"]
+            hda_model = self.sa_session.scalar(
+                select(HistoryDatasetAssociation).where(HistoryDatasetAssociation.id == database_id)
+            )
+            assert hda_model
+            hda_model.state = HistoryDatasetAssociation.states.FAILED_METADATA
+            self.sa_session.add(hda_model)
+            self.sa_session.commit()
+
+            # Run the same job again with caching enabled
+            # This time, cache should NOT be used because a leaf HDA is in failed_metadata state
+            # The tool will also fail validation since one of the HDAs is in an invalid state
+            third_run = self.dataset_populator.run_tool_raw(
+                tool_id="cat_list",
+                inputs=inputs,
+                history_id=history_id,
+                use_cached_job=True,
+            ).json()
+
+            # The response should contain an error since one of the HDAs is in failed_metadata state
+            # Most importantly, the cache should NOT have been used - if it were,
+            # the job would have succeeded by copying from the cached job
+            assert (
+                "errors" in third_run and third_run["errors"]
+            ), "Tool should fail when HDCA element is in failed_metadata state"
+            assert "failed_metadata" in str(third_run["errors"]), "Error should mention failed_metadata state"


### PR DESCRIPTION
HDAs where _state is set (indicating failed_metadata or setting_metadata) were not being filtered out when looking for cached jobs. This change adds checks to require _state to be NULL (which indicates metadata is OK) in the following cache lookup methods:

- _build_stmt_for_hda: filters the requested input HDA
- _build_stmt_for_hdca: filters leaf HDAs in the reference collection
- _build_stmt_for_dce: filters leaf HDAs in both collection and direct HDA cases

Also adds integration tests to verify that job cache lookups correctly exclude HDAs and HDCA elements in failed_metadata state.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
