### PR TITLE
Preserve assistant messages with tool calls

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7964,15 +7964,15 @@ export interface components {
              * @constant
              */
             type: "function";
+        } & {
+            [key: string]: unknown;
         };
         /** ChatToolFunction */
         ChatToolFunction: {
             /** Name */
             name: string;
-            /** Parameters */
-            parameters: {
-                [key: string]: unknown;
-            };
+        } & {
+            [key: string]: unknown;
         };
         /** CheckForUpdatesResponse */
         CheckForUpdatesResponse: {

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -204,10 +204,10 @@ class FastAPIAI:
             client = AsyncOpenAI(**client_kwargs)
         except Exception as e:
             log.debug("Failed to initialize OpenAI client.", exc_info=e)
-            return self.create_error("Failed to initialize AI client.", 500)
+            return self.create_error("Failed to initialize OpenAI client.", 500)
 
         # Connect to ai provider
-        log.info(f"Proxying to {ai_model}, tokens: {max_tokens}")
+        log.info(f"Proxying to {ai_model}, tokens: {max_tokens}.")
         try:
             response = await client.chat.completions.create(
                 max_tokens=max_tokens,

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -20,7 +20,10 @@ from fastapi.responses import (
     JSONResponse,
     StreamingResponse,
 )
-from openai import AsyncOpenAI
+from openai import (
+    APIError,
+    AsyncOpenAI,
+)
 from openai._streaming import AsyncStream
 from openai.types.chat import (
     ChatCompletion,
@@ -218,7 +221,7 @@ class FastAPIAI:
                 tools=tools,
                 top_p=TOP_P,
             )
-        except Exception as e:
+        except APIError as e:
             log.debug("Failed to complete OpenAI request.", exc_info=e)
             status_code = getattr(e, "status_code", 500)
             if hasattr(e, "body") and isinstance(e.body, dict):

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -77,13 +77,11 @@ class ChatMessage(BaseModel):
     role: Literal["assistant", "system", "tool", "user"]
     content: Optional[str] = None
     tool_calls: Optional[list[dict[str, Any]]] = None
-
     model_config = dict(extra="allow")
 
 
 class ChatToolFunction(BaseModel):
     name: str
-    parameters: dict[str, Any]
     model_config = dict(extra="allow")
 
 
@@ -98,7 +96,6 @@ class ChatCompletionRequest(BaseModel):
     tools: Optional[list[ChatTool]] = None
     stream: Optional[bool] = False
     max_tokens: Optional[int] = None
-
     model_config = dict(extra="allow")
 
 
@@ -169,8 +166,8 @@ class FastAPIAI:
             content = msg.content
             tool_calls = msg.tool_calls
             if role == "assistant":
-                msg_dict = dict(role="assistant")
-                if isinstance(content, str):
+                msg_dict: dict[str, Any] = dict(role="assistant")
+                if content is not None:
                     msg_dict["content"] = content
                 if isinstance(tool_calls, list):
                     msg_dict["tool_calls"] = tool_calls

--- a/test/integration/test_plugins.py
+++ b/test/integration/test_plugins.py
@@ -6,6 +6,7 @@ from unittest.mock import (
 )
 
 import pytest
+from openai import APIError
 
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
@@ -158,15 +159,19 @@ class TestAiApi(IntegrationTestCase):
 
     @patch("galaxy.webapps.galaxy.api.plugins.AsyncOpenAI")
     def test_provider_error_body_forwarded(self, mock_client):
-        class MockOpenAIError(Exception):
+        class MockOpenAIError(APIError):
             def __init__(self):
+                super().__init__(
+                    message="original error message",
+                    request=object(),
+                    body={
+                        "message": "original error message",
+                        "type": "api_error",
+                        "param": None,
+                        "code": None,
+                    },
+                )
                 self.status_code = 404
-                self.body = {
-                    "message": "original error message",
-                    "type": "api_error",
-                    "param": None,
-                    "code": None,
-                }
 
         mock_instance = MagicMock()
         mock_instance.chat.completions.create = AsyncMock(side_effect=MockOpenAIError())

--- a/test/integration/test_plugins.py
+++ b/test/integration/test_plugins.py
@@ -1,4 +1,8 @@
 import os
+from typing import (
+    Any,
+    cast,
+)
 from unittest.mock import (
     AsyncMock,
     MagicMock,
@@ -163,7 +167,7 @@ class TestAiApi(IntegrationTestCase):
             def __init__(self):
                 super().__init__(
                     message="original error message",
-                    request=object(),
+                    request=cast(Any, object()),
                     body={
                         "message": "original error message",
                         "type": "api_error",


### PR DESCRIPTION
Newer models can return assistant messages with both content and tool_calls. The plugin chat adapter now forwards both fields so tool-based workflows keep working.

The PR also improves error handling for JupyterLite by showing the actual provider error message instead of a generic one.

**Before:**
<img width="243" height="237" alt="image" src="https://github.com/user-attachments/assets/7865f19a-a68c-4266-bde1-fe669f463396" />

**Now:**
<img width="243" height="237" alt="image" src="https://github.com/user-attachments/assets/975f61d1-1209-4fcb-9c8b-a28076bda2fa" />

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
