### PR TITLE
Fix width and height assignment for image metadata using Pillow

### DIFF
--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -170,8 +170,8 @@ class Image(data.Data):
                     im_ndim = len(im_shape)
 
                     # Determine the metadata values that are available without loading the image data
-                    dataset.metadata.width = im.size[1]
-                    dataset.metadata.height = im.size[0]
+                    dataset.metadata.width = im.size[0]
+                    dataset.metadata.height = im.size[1]
                     dataset.metadata.depth = 0
                     dataset.metadata.frames = getattr(im, "n_frames", 0)
                     dataset.metadata.dtype = str(np.array((0,), im_typestr).dtype)


### PR DESCRIPTION
In the code for deducing the width and height for the metadata for an image in https://github.com/galaxyproject/galaxy/pull/18951 there was a bug so that width and height were confused when using Pillow for reading the data (the [`Image.size`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.size) tuple is width/height and not height/width like the `.shape` tuple of NumPy arrays). This PR fixes it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
