### PR TITLE
[25.1] Show "Expires today" instead of "Expires soon" in Expiration Warning

### DIFF
--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -121,8 +121,11 @@ const expirationMessage = computed(() => {
     if (hasExpired.value) {
         return "Expired";
     }
-    if (daysToExpire.value !== null && daysToExpire.value <= 1) {
-        return `Expires soon!`;
+    if (daysToExpire.value !== null && daysToExpire.value < 1) {
+        return `Expires today`;
+    }
+    if (daysToExpire.value === 1) {
+        return `Expires in 1 day`;
     }
     return `Expires in ${daysToExpire.value} days`;
 });
@@ -135,11 +138,11 @@ const expirationTooltip = computed(() => {
     if (hasExpired.value) {
         return `This ${itemType} was stored in ${
             objectStoreName.value
-        } and has expired on ${expirationDate.value.toDateString()}.`;
+        } and has expired on ${expirationDate.value.toLocaleString()}.`;
     }
     return `This ${itemType} is stored in ${
         objectStoreName.value
-    } and expires on ${expirationDate.value.toDateString()}.`;
+    } and expires on ${expirationDate.value.toLocaleString()}.`;
 });
 
 const variant = computed(() => {


### PR DESCRIPTION
- Change "Expires soon!" to "Expires today" when less than 1 day remains
- Add proper singular handling ("Expires in 1 day" instead of "1 days")
- Show full date and time in tooltip using toLocaleString() instead of just the date, so users can see the exact expiration time in their local timezone

Fixes https://github.com/galaxyproject/galaxy/issues/21559

Before:
<img width="431" height="219" alt="Screenshot 2026-01-12 at 16 34 14" src="https://github.com/user-attachments/assets/b108bf1e-044b-406b-9f40-339e3163ea53" />

After:
<img width="414" height="207" alt="Screenshot 2026-01-12 at 16 31 43" src="https://github.com/user-attachments/assets/c2aa1f66-a77d-4d1e-a945-01bbb06d1281" />

Don't have a dataset that will expire today, but in this case it should say today instead of soon.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
