### PR TITLE
Better error message for unencoded/unresolvable filesource uri

### DIFF
--- a/test/unit/files/test_http.py
+++ b/test/unit/files/test_http.py
@@ -134,3 +134,14 @@ def test_file_source_http_without_stock_specific():
         assert file_source_pair.file_source.id == "test1"
 
         assert_realizes_as(file_sources, test_url, "hello specific world 2", user_context=user_context)
+
+
+def test_file_source_http_with_spaces_in_url_error():
+    """Test that URLs with unencoded spaces give a helpful error (issue #21221)."""
+    test_url = "https://example.com/Markers File.csv"
+    user_context = user_context_fixture()
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+
+    with pytest.raises(ValueError, match="URL contains unencoded characters"):
+        file_source_pair = file_sources.get_file_source_path(test_url)
+        file_source_pair.file_source.realize_to(file_source_pair.path, "/tmp/test", user_context=user_context)


### PR DESCRIPTION
~Fixes an issue where URLs with spaces in filenames (like "Markers File.csv") would fail to materialize because urllib rejects unencoded control characters. Now we properly encode the path component before making the request.~

Better error message for unencoded filesource uris

Fixes #21221 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
