### PR TITLE
Fix loading spinner positioning in admin grid

### DIFF
--- a/client/src/components/Grid/GridList.test.js
+++ b/client/src/components/Grid/GridList.test.js
@@ -107,7 +107,7 @@ describe("GridList", () => {
         });
         const findInput = wrapper.find("[data-description='filter text input']");
         expect(findInput.attributes().placeholder).toBe("search tests");
-        expect(wrapper.find(".loading-message").text()).toBe("Loading...");
+        expect(wrapper.find(".grid-initial-loading .text-muted").text()).toBe("Loading...");
         const findAction = wrapper.find("[data-description='grid action test']");
         expect(findAction.text()).toBe("test");
         await findAction.trigger("click");


### PR DESCRIPTION
Replace BOverlay with custom loading overlay that properly centers the spinner within the grid viewport. Uses GalaxyLoader for both initial load and search/filter states for consistent branding.

The BOverlay component's spinner was appearing off-screen for long scrollable tables because it centered within the full table height rather than the visible viewport.

<img width="1245" height="439" alt="image" src="https://github.com/user-attachments/assets/d2d255f8-e745-40a9-ad69-9ff3ecd9bc5a" />


Fixes #21438 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
