### PR TITLE
[25.0] Filter out data_manager_json files in deleted histories

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -936,6 +936,7 @@ class User(Base, Dictifiable, RepresentById):
                 HistoryDatasetAssociation.deleted == false(),
                 HistoryDatasetAssociation.extension == "data_manager_json",
                 History.user_id == self.id,
+                History.deleted == false(),
                 Dataset.state == "ok",
                 # excludes data manager runs that actually populated tables.
                 # maybe track this formally by creating a different datatype for bundles ?


### PR DESCRIPTION
I've had a report of slow tool form building for tools that use tool data tables, and that correlated with the number of histories a user has. This seems like a nice pre-filter, you surely wouldn't want to consider inputs from a deleted history.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
