### PR TITLE
[25.1] Fix Pulsar with ``default_file_action: none``

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -148,7 +148,7 @@ proto-plus==1.26.1
 protobuf==6.32.1
 prov==1.5.1
 psutil==7.1.0
-pulsar-galaxy-lib==0.15.11
+pulsar-galaxy-lib==0.15.14
 pyasn1==0.6.1
 pyasn1-modules==0.4.2
 pycparser==2.23 ; (implementation_name != 'PyPy' and platform_python_implementation != 'PyPy') or (implementation_name == 'pypy' and platform_python_implementation == 'PyPy')

--- a/test/integration/embedded_pulsar_none_job_conf.yml
+++ b/test/integration/embedded_pulsar_none_job_conf.yml
@@ -1,0 +1,23 @@
+runners:
+  local:
+    load: galaxy.jobs.runners.local:LocalJobRunner
+  pulsar_embed:
+    load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
+    pulsar_app_config:
+      tool_dependency_dir: none
+      conda_auto_init: false
+      conda_auto_install: false
+
+execution:
+  default: pulsar_embed
+  environments:
+    local:
+      runner: local
+    pulsar_embed:
+      runner: pulsar_embed
+      remote_metadata: true
+      default_file_action: none
+
+tools:
+- class: local
+  environment: local

--- a/test/integration/test_pulsar_embedded_none.py
+++ b/test/integration/test_pulsar_embedded_none.py
@@ -1,0 +1,36 @@
+"""Integration tests for the Pulsar embedded runner with default_file_action: none.
+
+This tests the configuration where Pulsar and Galaxy share a filesystem and
+no file staging is needed (default_file_action: none).
+
+See https://github.com/galaxyproject/galaxy/issues/21566
+"""
+
+import os
+
+from galaxy_test.driver import integration_util
+
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+EMBEDDED_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_none_job_conf.yml")
+
+
+class EmbeddedNonePulsarIntegrationInstance(integration_util.IntegrationInstance):
+    """Describe a Galaxy test instance with embedded pulsar configured with default_file_action: none."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
+        config["object_store_store_by"] = "uuid"
+        config["retry_metadata_internally"] = False
+
+
+instance = integration_util.integration_module_instance(EmbeddedNonePulsarIntegrationInstance)
+
+test_tools = integration_util.integration_tool_runner(
+    [
+        "simple_constructs",
+        "job_properties",
+    ]
+)


### PR DESCRIPTION
When using `default_file_action: none` on a shared filesystem, jobs would fail with:
  AttributeError: 'NoneAction' object has no attribute 'write_from_path'

This occurred because NoneAction in pulsar-galaxy-lib was missing the write_from_path method that is called during result collection. The pulsar-side fix is to add a no-op write_from_path method to NoneAction (since files are already in place on shared filesystems).

Fixes https://github.com/galaxyproject/galaxy/issues/21566

Depends on https://github.com/galaxyproject/pulsar/pull/435

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
