### PR TITLE
Add Claude Code slash commands for GitHub issue triage

### DIFF
--- a/.claude/commands/triage-bug.md
+++ b/.claude/commands/triage-bug.md
@@ -1,0 +1,49 @@
+Persona: You are a senior engineer responsible for maintaining the Galaxy project.
+
+Arguments:
+- $ARGUMENTS - Github issue number and optional work level (low/medium/high, default: medium)
+  Examples: "21536", "21536 low", "21536 high"
+
+Parse the issue number and work level from $ARGUMENTS. Work levels control triage depth:
+- **low**: Research and understand only, skip fix planning
+- **medium**: Research + single plan for most probable cause
+- **high**: Research + plans for all theories + plan assessment
+
+You will be supplied a Github issue number to triage. A Galaxy developer will be assigned the issue but your job is to structure the conversation around the issue.
+
+Fetch the issue "gh view issue" and write the issue contents to ``ISSUE_<#>.md``.
+
+Galaxy versions look like 24.1, 26.2, etc.. and these correspond to branches such as release_24.1, release_26.2, etc.. Be sure you're on the target branch before continuing.
+
+In serial launch subagents to perform actions to help in the triage process. As the agent responsible for the triage process - please read the artifacts generated from subagents and direct the process as it makes sense. Your job is direct the process though - do not try to fix the issue or do research yourself.
+
+When to launch subagents and what they should do are as follows:
+
+- When: Always (all levels)
+  What: Launch a subagent to research the issue. This subagent should create a document called ``ISSUE_<#>_CODE_RESEARCH.md`` where ``<#>`` is the issue number. The subagent should attempt to find the source issue, summarize the code relevant issue, file paths, and develop (roughly 1-3) theories about the possible true cause of the issue.
+- When: The issue is complex and if the issue seems like a regression (all levels)
+  What: Launch a subagent to read in the "code research" document and develop theories about when the issue was introduced. Create a document called ``ISSUE_<#>_HISTORY.md`` where ``<#>`` is the issue number. This document should include links to pull requests that are relevant, authors that have touched the code, etc...
+- When: Work level is **medium** - create ONE plan for the most probable cause
+  What: Launch a subagent to come up with a detailed plan to fix the issue with the most probable root cause identified in the code research. Create a document called ``ISSUE_<#>_PLAN.md``.
+- When: Work level is **high** - create a plan for EACH cause identified
+  What: Launch a subagent for each true cause identified to come up with a detailed plan to fix the issue with the assumed root cause. Create a document called ``ISSUE_<#>_PLAN_<cause>.md`` where cause is a short description of the cause of issue distinguishing it from the other root causes.
+- When: Work level is **high** only
+  What: Launch a subagent to read the code research and the relevant plans to address the issue. This subagent should evaluate the quality of the plans and assess the probability of each to solve the problem. This subagent should create a document called ``ISSUE_<#>_PLAN_ASSESSMENT.md``.
+- When: Always (all levels)
+  What: Launch a subagent to assess bug importance. Create a document called ``ISSUE_<#>_IMPORTANCE.md``. Assess:
+  - Severity (critical/high/medium/low): data loss/security > crash/hang > functional breakage > cosmetic/minor
+  - Blast radius: all users, specific configurations, edge cases only
+  - Workaround existence: none / painful / acceptable
+  - Regression status: new regression (which version) vs long-standing
+  - User impact signals: issue reactions, duplicate reports, support requests
+  - Recommendation: hotfix / next release / backlog / wontfix with rationale
+
+Once all of the subagents are done - please write a new document called ``ISSUE_<#>_SUMMARY.md``.
+
+This document should contain:
+- A concise one paragraph top-line summary about the issue that we will use to guide the discussion about the issue. Including the most probable fix and most probable true cause (with source of the regression if you've collected an issue history document).
+- Importance assessment summary: severity, blast radius, regression status, and overall priority recommendation.
+- Any relevant questions about the context around the issue that would be helpful in debugging and guiding the discussion as a large group.
+- An estimate on the effort required to fix the issue, an assessment on how difficult it is to recreate and test the issue.
+
+Publish all the relevant documents to a gist and print a comment to the user that they can post to the Github issue to aid with the triage process and offer to copy that comment to the clipboard. The comment should be concise but should include all relevant data and questions from the summary document.

--- a/.claude/commands/triage-feature.md
+++ b/.claude/commands/triage-feature.md
@@ -1,0 +1,46 @@
+Persona: You are a senior engineer responsible for maintaining the Galaxy project.
+
+Arguments:
+- $ARGUMENTS - Github issue number and optional work level (low/medium/high, default: medium)
+  Examples: "21474", "21474 low", "21474 high"
+
+Parse the issue number and work level from $ARGUMENTS. Work levels control triage depth:
+- **low**: Research and understand only, skip implementation planning
+- **medium**: Research + single recommended approach with focused plan
+- **high**: Research + multiple approaches + comprehensive plan
+
+You will be supplied a Github issue number for a feature request to triage. A Galaxy developer will be assigned the issue but your job is to structure the conversation around the feature.
+
+Fetch the issue "gh view issue" and write the issue contents to ``FEATURE_<#>.md``.
+
+In serial launch subagents to perform actions to help in the triage process. As the agent responsible for the triage process - please read the artifacts generated from subagents and direct the process as it makes sense. Your job is direct the process though - do not try to implement the feature or do research yourself.
+
+When to launch subagents and what they should do are as follows:
+
+- When: Always (all levels)
+  What: Launch a subagent to research user demand signals. This subagent should create a document called ``FEATURE_<#>_DEMAND.md``. The subagent should analyze: issue reactions/thumbs up, linked/duplicate issues, comment frequency and sentiment, any related discussion threads. Quantify demand where possible.
+- When: Always (all levels)
+  What: Launch a subagent to research the codebase for related functionality. This subagent should create a document called ``FEATURE_<#>_CODE_RESEARCH.md``. The subagent should find: existing similar features, relevant extension points, architectural patterns to follow, and files/modules that would need modification.
+- When: Work level is **high** and the feature has multiple possible implementation approaches
+  What: Launch a subagent to develop alternative implementation approaches. Create a document called ``FEATURE_<#>_APPROACHES.md``. This document should outline 2-4 approaches with tradeoffs (complexity, breaking changes, performance, maintainability).
+- When: Always (all levels)
+  What: Launch a subagent to assess importance. Create a document called ``FEATURE_<#>_IMPORTANCE.md``. Assess:
+  - User demand (high/medium/low) based on reactions, comments, linked issues
+  - Strategic value (high/medium/low) - does it align with project direction, enable other features, improve UX significantly
+  - Effort estimate (small/medium/large/xlarge) based on code research
+  - Risk assessment (breaking changes, migration needs, security considerations)
+  - Recommendation: prioritize now / backlog / defer / decline with rationale
+- When: Work level is **medium** - create a focused implementation plan
+  What: Launch a subagent to read the research documents and create an implementation plan for the single recommended approach. Create a document called ``FEATURE_<#>_PLAN.md``. Include: recommended approach, affected files, testing strategy, migration considerations if any.
+- When: Work level is **high** - create a comprehensive implementation plan
+  What: Launch a subagent to read all research documents (including approaches) and create a detailed implementation plan. Create a document called ``FEATURE_<#>_PLAN.md``. Include: recommended approach with rationale for choosing it over alternatives, affected files, testing strategy, migration considerations if any.
+
+Once all of the subagents are done - please write a new document called ``FEATURE_<#>_SUMMARY.md``.
+
+This document should contain:
+- A concise one paragraph top-line summary about the feature request and recommended approach.
+- Importance assessment summary: demand level, strategic value, effort, and overall priority recommendation.
+- Key questions for the group discussion that would help refine requirements or approach.
+- Any concerns about scope creep, breaking changes, or long-term maintenance burden.
+
+Publish all the relevant documents to a gist and print a comment to the user that they can post to the Github issue to aid with the triage process.

--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -1,0 +1,25 @@
+Persona: You are a senior engineer responsible for maintaining the Galaxy project.
+
+Arguments:
+- $ARGUMENTS - Github issue number and optional work level (low/medium/high, default: medium)
+  Examples: "21536", "21536 low", "21536 high"
+
+Parse the issue number and work level from $ARGUMENTS.
+
+Fetch the issue using "gh issue view <number>" and analyze its content to determine if it is:
+- **Bug**: A report of something broken, not working as expected, an error, regression, or malfunction
+- **Feature**: A request for new functionality, enhancement, improvement, or capability that doesn't exist
+
+Classification signals:
+- Bug indicators: "error", "crash", "broken", "doesn't work", "regression", "fails", "exception", stack traces, reproduction steps describing unexpected behavior
+- Feature indicators: "would be nice", "please add", "feature request", "enhancement", "suggestion", "support for", "ability to", describing desired new behavior
+
+Once classified, inform the user of your classification and reasoning in one sentence.
+
+Then read the appropriate command file and execute its instructions:
+- For bugs: Read `.claude/commands/bug-triage.md` and follow those instructions
+- For features: Read `.claude/commands/feature-triage.md` and follow those instructions
+
+Pass through the original issue number and work level to the triage workflow.
+
+If the classification is ambiguous, ask the user which triage path to follow before proceeding.


### PR DESCRIPTION
Three commands for structured issue analysis:

/triage-issue <number> [level]
  Auto-classifies issue as bug or feature, then delegates to
  the appropriate specialized triage command.

/triage-bug <number> [level]
  Bug report analysis: code research, regression history,
  fix planning, severity/impact assessment.

/triage-feature <number> [level]
  Feature request analysis: demand signals, code research,
  implementation approaches, effort/priority assessment.

Work levels control depth (default: medium):
- low: research only, no planning
- medium: research + single recommended plan
- high: research + multiple plans + comparative assessment

All commands produce markdown artifacts (ISSUE_*.md or FEATURE_*.md), publish to a GitHub gist, and generate a comment for the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Address #21572.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Triage some issues and see whatcha think, in order to be pretty automatic these consume a lot tokens so make so be careful and have a big plan.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
