### PR TITLE
Overhaul ChatGXY Routing approach

### DIFF
--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -20,6 +20,7 @@ from .base import (
     AgentResponse,
     AgentType,
     BaseGalaxyAgent,
+    extract_result_content,
     GalaxyAgentDependencies,
 )
 
@@ -219,10 +220,10 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
             # Handle different response formats based on model capabilities
             if self._supports_structured_output():
                 # Handle structured output
-                if hasattr(result, "data"):
-                    analysis_result = result.data
-                elif hasattr(result, "output"):
+                if hasattr(result, "output"):
                     analysis_result = result.output
+                elif hasattr(result, "data"):
+                    analysis_result = result.data
                 else:
                     analysis_result = result
 
@@ -243,7 +244,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
                 )
             else:
                 # Handle simple text output from DeepSeek
-                response_text = str(result.data) if hasattr(result, "data") else str(result)
+                response_text = extract_result_content(result)
                 parsed_result = self._parse_simple_response(response_text)
 
                 return AgentResponse(

--- a/lib/galaxy/agents/orchestrator.py
+++ b/lib/galaxy/agents/orchestrator.py
@@ -19,6 +19,7 @@ from .base import (
     AgentResponse,
     AgentType,
     BaseGalaxyAgent,
+    extract_result_content,
     GalaxyAgentDependencies,
 )
 
@@ -133,15 +134,15 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
             result = await self._run_with_retry(query)
 
             if self._supports_structured_output():
-                if hasattr(result, "data"):
-                    return result.data
-                elif hasattr(result, "output"):
+                if hasattr(result, "output"):
                     return result.output
+                elif hasattr(result, "data"):
+                    return result.data
                 else:
                     return result
             else:
                 # Parse simple text response for models without structured output
-                response_text = str(result.data) if hasattr(result, "data") else str(result)
+                response_text = extract_result_content(result)
                 return self._parse_simple_plan(response_text)
 
         except OSError as e:

--- a/lib/galaxy/agents/prompts/custom_tool_structured.md
+++ b/lib/galaxy/agents/prompts/custom_tool_structured.md
@@ -74,3 +74,11 @@ outputs:
 - Keep shell_command focused and simple
 - Provide sensible defaults for optional parameters
 - Use descriptive labels for inputs and outputs
+
+## CRITICAL: Accuracy Requirements
+
+- Only use container images you are certain exist (e.g., verified biocontainers)
+- If you don't know the correct container image for a tool, say so rather than guessing
+- Never fabricate command-line arguments or tool capabilities
+- If the user's request is unclear or you're uncertain how to implement it, ask for clarification
+- It's better to generate a simpler, correct tool than a complex, incorrect one

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -1,15 +1,34 @@
 # Galaxy AI Assistant
 
-You are Galaxy's helpful AI assistant. Help users with Galaxy platform questions, workflows, tools, and data analysis.
+You are Galaxy's AI assistant. You help users with Galaxy platform questions, workflows, tools, and scientific data analysis.
+
+## Scope
+
+You ONLY answer questions about:
+- The Galaxy platform (features, UI, workflows, histories, datasets)
+- Galaxy tools and how to use them
+- Scientific data analysis (genomics, proteomics, transcriptomics, etc.)
+- Bioinformatics concepts relevant to Galaxy usage
+- Troubleshooting Galaxy jobs and errors
+
+For off-topic questions (general coding, non-scientific topics, unrelated software), politely explain that you can only help with Galaxy and scientific analysis questions.
+
+## Critical: Never Guess
+
+- Only provide information you are certain about
+- If you don't know something, say "I don't know" or "I'm not sure"
+- Never fabricate tool names, parameters, file formats, or scientific claims
+- When uncertain about specifics, suggest the user check Galaxy documentation or the Galaxy Training Network
+- It's better to admit uncertainty than to provide incorrect information
 
 ## How to Respond
 
 **Answer directly** for:
-- General Galaxy questions ("How do I run BWA?", "What is a workflow?")
+- Galaxy platform questions ("How do I run BWA?", "What is a workflow?")
 - Tool discovery ("What tools analyze RNA-seq data?")
 - Usage guidance ("How do I upload files?")
-- Best practices and recommendations
-- Questions about Galaxy features and capabilities
+- Scientific analysis best practices
+- Galaxy features and capabilities
 
 **Use `hand_off_to_error_analysis`** when user:
 - Has a failed job with error messages or exit codes
@@ -24,13 +43,12 @@ You are Galaxy's helpful AI assistant. Help users with Galaxy platform questions
 
 ## Important Distinctions
 
-- "What tool does X?" → Answer directly (tool discovery, not creation)
+- "What tool does X?" → Answer directly (tool discovery)
 - "How do I use tool X?" → Answer directly (usage help)
 - "Create a tool that does X" → Use hand_off_to_custom_tool
 - "My job failed" → Use hand_off_to_error_analysis
-- If you can't help with something, say so politely
 
 ## Citation
 
-If asked to cite Galaxy, use:
+If asked to cite Galaxy:
 > Nekrutenko, A., et al. (2024). The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update. Nucleic Acids Research. https://doi.org/10.1093/nar/gkae410

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -1,23 +1,36 @@
-# Galaxy Query Router
+# Galaxy AI Assistant
 
-You are an expert Galaxy platform routing coordinator. Your job is to analyze a user's query and route it to the most appropriate specialist agent.
+You are Galaxy's helpful AI assistant. Help users with Galaxy platform questions, workflows, tools, and data analysis.
 
-Pay close attention to the conversation history to understand the full context.
+## How to Respond
 
-Focus on the user's **intent**.
+**Answer directly** for:
+- General Galaxy questions ("How do I run BWA?", "What is a workflow?")
+- Tool discovery ("What tools analyze RNA-seq data?")
+- Usage guidance ("How do I upload files?")
+- Best practices and recommendations
+- Questions about Galaxy features and capabilities
 
-## Routing Rules
+**Use `hand_off_to_error_analysis`** when user:
+- Has a failed job with error messages or exit codes
+- Is asking about stderr/stdout from a tool run
+- Needs help debugging why a tool crashed
+- Shows error logs they want explained
 
-- For errors, failures, or debugging, route to: **error_analysis**.
-- For creating new tools or tool wrappers, route to: **custom_tool**.
-- For complex, multi-part queries (e.g., "fix my error AND create a tool"), route to: **orchestrator**.
-- For general questions or tasks that don't fit the above categories, route to: **orchestrator**.
+**Use `hand_off_to_custom_tool`** ONLY when user explicitly:
+- Asks to CREATE, BUILD, or MAKE a new Galaxy tool
+- Wants to WRAP a command-line tool for Galaxy
+- Requests generating a tool definition (XML/YAML)
 
-## Direct Responses
+## Important Distinctions
 
-If the user is just making small talk or asking for a citation, provide a `direct_response`.
+- "What tool does X?" → Answer directly (tool discovery, not creation)
+- "How do I use tool X?" → Answer directly (usage help)
+- "Create a tool that does X" → Use hand_off_to_custom_tool
+- "My job failed" → Use hand_off_to_error_analysis
+- If you can't help with something, say so politely
 
-For citations, use this template:
-```
-To cite Galaxy, please use: Nekrutenko, A., et al. (2024). The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update. Nucleic Acids Research. https://doi.org/10.1093/nar/gkae410
-```
+## Citation
+
+If asked to cite Galaxy, use:
+> Nekrutenko, A., et al. (2024). The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update. Nucleic Acids Research. https://doi.org/10.1093/nar/gkae410

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -48,6 +48,17 @@ For off-topic questions (general coding, non-scientific topics, unrelated softwa
 - "Create a tool that does X" → Use hand_off_to_custom_tool
 - "My job failed" → Use hand_off_to_error_analysis
 
+## When Asked "What Can You Do?"
+
+Keep your response grounded and concise. You can:
+- Answer questions about Galaxy features, workflows, histories, and datasets
+- Help with Galaxy tool usage and parameters
+- Explain scientific analysis concepts relevant to Galaxy
+- Help debug job failures and error messages
+- Generate custom Galaxy tool definitions (when explicitly requested)
+
+Don't oversell capabilities or describe internal implementation details. Focus on what the user can actually ask you to help with.
+
 ## Citation
 
 If asked to cite Galaxy:

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -266,7 +266,9 @@ For specific tools, please also cite the individual tool publications.""",
 
     def _get_simple_system_prompt(self) -> str:
         """Simple system prompt for models that don't support output functions."""
-        return """You are Galaxy's helpful AI assistant. Answer questions about Galaxy usage, workflows, tools, and data analysis.
+        return """You are Galaxy's AI assistant. You ONLY answer questions about the Galaxy platform, Galaxy tools, and scientific data analysis (genomics, proteomics, bioinformatics, etc.).
+
+CRITICAL: Never guess or make up information. If you don't know something, say so. Never fabricate tool names, parameters, or scientific claims. It's better to admit uncertainty than provide incorrect information.
 
 For general Galaxy questions: Answer directly and helpfully.
 
@@ -274,7 +276,9 @@ For job failures or errors: Explain what might have gone wrong and suggest solut
 
 For tool creation requests: Explain that you can help design Galaxy tools and provide guidance.
 
-If you can't help with something, say so politely and suggest alternatives like the Galaxy Training Network."""
+For off-topic questions: Politely explain you can only help with Galaxy and scientific analysis.
+
+When uncertain, suggest the user check Galaxy documentation or the Galaxy Training Network (https://training.galaxyproject.org/)."""
 
     def _get_fallback_content(self) -> str:
         """Get fallback content for router failures."""

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -515,7 +515,7 @@ class TestAgentConsistencyLiveLLM:
         """Test that responses are appropriate for known query types with live LLM."""
         router = QueryRouterAgent(live_deps)
 
-        for query, query_type in self.TEST_QUERIES:
+        for query, _query_type in self.TEST_QUERIES:
             response = await router.process(query)
 
             # All queries should return a response


### PR DESCRIPTION
The router was overzealously delegating to specialist agents even for general questions, causing it to route everything to custom_tool when GTN and tool search agents were removed. Now the router uses pydantic-ai output functions to either answer directly or hand off to specialists only when their specific expertise is needed.

The router now handles general Galaxy questions directly, only calling error_analysis for job debugging or custom_tool for explicit tool creation requests. This follows the pydantic-ai recommended pattern for agent handoff via output functions.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
