### PR TITLE
Add discarded_data option to model store import API

### DIFF
--- a/client/src/api/histories.export.ts
+++ b/client/src/api/histories.export.ts
@@ -80,6 +80,7 @@ export async function reimportHistoryFromRecord(record: ExportRecord) {
         body: {
             store_content_uri: record.importUri,
             model_store_format: record.modelStoreFormat,
+            discarded_data: "forbid",
         },
     });
 

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8671,6 +8671,12 @@ export interface components {
         };
         /** CreateHistoryContentFromStore */
         CreateHistoryContentFromStore: {
+            /**
+             * Discarded Data
+             * @description How to handle datasets with unavailable data. 'forbid': mark as deleted, 'allow': import as discarded but not deleted, 'force': import all datasets as discarded regardless of whether file data is available (useful for importing metadata only).
+             * @default allow
+             */
+            discarded_data: components["schemas"]["DiscardedDataType"];
             model_store_format?: components["schemas"]["ModelStoreFormat"] | null;
             /** Store Content Uri */
             store_content_uri?: string | null;
@@ -8772,6 +8778,12 @@ export interface components {
         };
         /** CreateHistoryFromStore */
         CreateHistoryFromStore: {
+            /**
+             * Discarded Data
+             * @description How to handle datasets with unavailable data. 'forbid': mark as deleted, 'allow': import as discarded but not deleted, 'force': import all datasets as discarded regardless of whether file data is available (useful for importing metadata only).
+             * @default allow
+             */
+            discarded_data: components["schemas"]["DiscardedDataType"];
             model_store_format?: components["schemas"]["ModelStoreFormat"] | null;
             /** Store Content Uri */
             store_content_uri?: string | null;
@@ -8803,6 +8815,12 @@ export interface components {
         };
         /** CreateInvocationsFromStorePayload */
         CreateInvocationsFromStorePayload: {
+            /**
+             * Discarded Data
+             * @description How to handle datasets with unavailable data. 'forbid': mark as deleted, 'allow': import as discarded but not deleted, 'force': import all datasets as discarded regardless of whether file data is available (useful for importing metadata only).
+             * @default allow
+             */
+            discarded_data: components["schemas"]["DiscardedDataType"];
             /**
              * History ID
              * @description The ID of the history associated with the invocations.
@@ -8841,6 +8859,12 @@ export interface components {
         };
         /** CreateLibrariesFromStore */
         CreateLibrariesFromStore: {
+            /**
+             * Discarded Data
+             * @description How to handle datasets with unavailable data. 'forbid': mark as deleted, 'allow': import as discarded but not deleted, 'force': import all datasets as discarded regardless of whether file data is available (useful for importing metadata only).
+             * @default allow
+             */
+            discarded_data: components["schemas"]["DiscardedDataType"];
             model_store_format?: components["schemas"]["ModelStoreFormat"] | null;
             /** Store Content Uri */
             store_content_uri?: string | null;
@@ -11114,6 +11138,12 @@ export interface components {
                 | components["schemas"]["EmptyFieldParameterValidatorModel"]
             )[];
         };
+        /**
+         * DiscardedDataType
+         * @description Options for handling discarded datasets on import.
+         * @enum {string}
+         */
+        DiscardedDataType: "forbid" | "allow" | "force";
         /** DisconnectAction */
         DisconnectAction: {
             /**

--- a/client/src/components/History/useHistoryCardActions.ts
+++ b/client/src/components/History/useHistoryCardActions.ts
@@ -130,6 +130,7 @@ export function useHistoryCardActions(
             body: {
                 model_store_format: hti.export_record_data?.model_store_format,
                 store_content_uri: hti.export_record_data?.target_uri,
+                discarded_data: "forbid",
             },
         });
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1861,10 +1861,28 @@ class ModelStoreFormat(str, Enum):
         return value in [cls.BAG_DOT_TAR, cls.BAG_DOT_TGZ, cls.BAG_DOT_ZIP]
 
 
+class DiscardedDataType(str, Enum):
+    """Options for handling discarded datasets on import."""
+
+    # Don't allow discarded 'okay' datasets on import, datasets will be marked deleted.
+    FORBID = "forbid"
+    # Allow datasets to be imported as DISCARDED datasets that are not deleted if file data is unavailable.
+    ALLOW = "allow"
+    # Import all datasets as discarded regardless of whether file data is available in the store.
+    FORCE = "force"
+
+
 class StoreContentSource(Model):
     store_content_uri: Optional[str] = None
     store_dict: Optional[dict[str, Any]] = None
     model_store_format: Optional["ModelStoreFormat"] = None
+    discarded_data: DiscardedDataType = Field(
+        default=DiscardedDataType.ALLOW,
+        title="Discarded Data",
+        description="How to handle datasets with unavailable data. 'forbid': mark as deleted, "
+        "'allow': import as discarded but not deleted, 'force': import all datasets as discarded "
+        "regardless of whether file data is available (useful for importing metadata only).",
+    )
 
 
 class CreateHistoryFromStore(StoreContentSource):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -681,13 +681,19 @@ class BaseDatasetPopulator(BasePopulator):
         return create_response
 
     def create_contents_from_store(
-        self, history_id: str, store_dict: Optional[dict[str, Any]] = None, store_path: Optional[str] = None
+        self,
+        history_id: str,
+        store_dict: Optional[dict[str, Any]] = None,
+        store_path: Optional[str] = None,
+        discarded_data: Optional[str] = None,
     ) -> list[dict[str, Any]]:
         if store_dict is not None:
             assert isinstance(store_dict, dict)
         if store_path is not None:
             assert isinstance(store_path, str)
         payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        if discarded_data is not None:
+            payload["discarded_data"] = discarded_data
         create_response = self.create_contents_from_store_raw(history_id, payload)
         create_response.raise_for_status()
         return create_response.json()
@@ -2253,7 +2259,7 @@ class BaseWorkflowPopulator(BasePopulator):
         store_dict: Optional[dict[str, Any]] = None,
         store_path: Optional[str] = None,
         model_store_format: Optional[str] = None,
-    ) -> Response:
+    ) -> list[dict[str, Any]]:
         create_response = self.create_invocation_from_store_raw(
             history_id, store_dict=store_dict, store_path=store_path, model_store_format=model_store_format
         )

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -62,6 +62,7 @@ class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
         self.dataset_populator.create_contents_from_store(
             history_id,
             store_dict=one_hda_model_store_dict(include_source=False),
+            discarded_data="force",
         )
         # regression after 3/24/2022 - explicit refresh now required.
         self.home()


### PR DESCRIPTION
and change default from `FORCE` to `ALLOW`.

When importing an invocation via POST /api/invocations/from_store with
a model store that includes files (include_files=True), the datasets
would end up in 'discarded' state with size 0 instead of having their
actual content imported.

The root cause was that create_objects_from_store() used
ImportDiscardedDataType.FORCE which forces all datasets to be discarded
regardless of whether file data is available in the store. This was
originally added for the DEFERRED dataset feature but import_model_store
was later updated to use the default FORBID mode. This change aligns
create_objects_from_store with import_model_store behavior.

You can now choose from these options:

- ALLOW: datasets without data → discarded but not deleted (new default,
  mirrors source structure)
- FORBID: datasets without data → discarded AND deleted
- FORCE: all datasets → discarded regardless of data availability
  (useful if only metadata is needed)

Add test to verify reimported invocation datasets have 'ok' state.

@jmchilton I hope I've captured the intent of the different options correctly here.

This is a prerequisite for invocation round trip tests (https://github.com/galaxyproject/galaxy/pull/21512)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
