### PR TITLE
[25.1] Fix #21542 - allow workbook bootstrap generation for sample sheet collection types.

### DIFF
--- a/lib/galaxy/model/dataset_collections/types/sample_sheet_workbook.py
+++ b/lib/galaxy/model/dataset_collections/types/sample_sheet_workbook.py
@@ -585,26 +585,37 @@ def _load_row_data(
     return rows
 
 
-def _list_to_sample_sheet_collection_type(input_collection_type: str) -> SampleSheetCollectionType:
-    """Convert simple list collection types to corresponding sample_sheet collection types.
+SAMPLE_SHEET_COLLECTION_TYPES: set[SampleSheetCollectionType] = {
+    "sample_sheet",
+    "sample_sheet:paired",
+    "sample_sheet:paired_or_unpaired",
+    "sample_sheet:record",
+}
 
-    What would the sample_sheet collection type that allows decorating that kind of list. For instance,
-    list:paired becomes sample_sheet:paired.
+
+def _list_to_sample_sheet_collection_type(input_collection_type: str) -> SampleSheetCollectionType:
+    """Convert list collection types to corresponding sample_sheet collection types.
+
+    Converts list types to sample_sheet types (e.g., list:paired -> sample_sheet:paired).
+    Passes through existing sample_sheet types unchanged.
     """
-    sample_sheet_collection_type: Optional[SampleSheetCollectionType] = None
+    # Pass through existing sample_sheet types unchanged
+    if input_collection_type in SAMPLE_SHEET_COLLECTION_TYPES:
+        return cast(SampleSheetCollectionType, input_collection_type)
+
+    # Convert list types to sample_sheet types
     if input_collection_type == "list":
-        sample_sheet_collection_type = "sample_sheet"
+        return "sample_sheet"
     elif input_collection_type == "list:paired":
-        sample_sheet_collection_type = "sample_sheet:paired"
+        return "sample_sheet:paired"
     elif input_collection_type == "list:paired_or_unpaired":
-        sample_sheet_collection_type = "sample_sheet:paired_or_unpaired"
+        return "sample_sheet:paired_or_unpaired"
     elif input_collection_type == "list:record":
-        raise NotImplementedError("Work in progress, this has not bee implemented yet")
+        raise NotImplementedError("Work in progress, this has not been implemented yet")
     else:
         raise RequestParameterInvalidException(
             f"Invalid collection type for sample sheet workbook generation {input_collection_type}"
         )
-    return sample_sheet_collection_type
 
 
 def _prefix_column_to_column_target(column_header: FetchPrefixColumn) -> ColumnTarget:

--- a/test/unit/data/dataset_collections/test_sample_sheet_workbook.py
+++ b/test/unit/data/dataset_collections/test_sample_sheet_workbook.py
@@ -16,8 +16,6 @@ from galaxy.model.dataset_collections.types.sample_sheet_workbook import (
     CreateWorkbook,
     CreateWorkbookRequest,
     CreateWorkbookRequestForCollection,
-    DatasetCollectionElementLike,
-    DatasetCollectionLike,
     DEFAULT_TITLE,
     generate_workbook,
     generate_workbook_from_request,
@@ -30,7 +28,10 @@ from galaxy.model.dataset_collections.types.sample_sheet_workbook import (
 )
 from galaxy.util.resources import resource_path
 
+# Test configuration
 WRITE_TEST_WORKBOOKS = False
+
+# Test data
 TEST_DATA = [
     ["https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz", "DRR000770", 1, "treatment1", False],
     ["https://zenodo.org/records/3263975/files/DRR000771.fastqsanger.gz", "DRR000771", 2, "treatment1", False],
@@ -73,236 +74,255 @@ TEST_COLUMN_DEFINITIONS_1 = [
 ]
 
 
-def test_generate_without_seed_data():
-    create = CreateWorkbook.model_validate(
-        {"collection_type": "sample_sheet", "column_definitions": TEST_COLUMN_DEFINITIONS_1}
-    )
-    workbook = generate_workbook(create)
-    if WRITE_TEST_WORKBOOKS:
-        for index, row in enumerate(TEST_DATA):
-            for col, column in enumerate(row):
-                workbook.active.cell(row=index + 2, column=col + 1, value=column)
-
-        path = "~/test_workbook.xlsx"
-        expanded_path = os.path.expanduser(path)
-        workbook.save(expanded_path)
-
-
-def test_generate_from_request_without_seed_data():
-    column_definition = TEST_COLUMN_DEFINITIONS_1
-    create = CreateWorkbookRequest(collection_type="sample_sheet", column_definitions=column_definition)
-    workbook = generate_workbook_from_request(create)
-    if WRITE_TEST_WORKBOOKS:
-        for index, row in enumerate(TEST_DATA):
-            for col, column in enumerate(row):
-                workbook.active.cell(row=index + 2, column=col + 1, value=column)
-
-        path = "~/test_workbook_from_base64.xlsx"
-        expanded_path = os.path.expanduser(path)
-        workbook.save(expanded_path)
+# Helper functions
+def _make_collection(collection_type: str, element_identifiers: list[str]) -> DatasetCollection:
+    """Create a real DatasetCollection with DatasetCollectionElements."""
+    collection = DatasetCollection(collection_type=collection_type)
+    for i, identifier in enumerate(element_identifiers):
+        DatasetCollectionElement(
+            id=i + 1,
+            collection=collection,
+            element=DatasetCollectionElement.UNINITIALIZED_ELEMENT,
+            element_index=i,
+            element_identifier=identifier,
+        )
+    return collection
 
 
-def test_generate_with_seed_data():
-    create = CreateWorkbook.model_validate(
-        {
-            "collection_type": "sample_sheet",
-            "column_definitions": TEST_COLUMN_DEFINITIONS_1,
-            "prefix_values": [
-                ["https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz", "DRR000770"],
-                ["https://zenodo.org/records/3263975/files/DRR000771.fastqsanger.gz", "DRR000770"],
-            ],
-        }
-    )
-    workbook = generate_workbook(create)
-    if WRITE_TEST_WORKBOOKS:
-        path = "~/test_workbook_seeded.xlsx"
-        expanded_path = os.path.expanduser(path)
-        workbook.save(expanded_path)
-
-
-def test_generate_with_seed_data_paired():
-    create = CreateWorkbook.model_validate(
-        {
-            "collection_type": "sample_sheet:paired",
-            "column_definitions": TEST_COLUMN_DEFINITIONS_1,
-            "prefix_values": [
-                [
-                    "https://zenodo.org/record/3554549/files/SRR1799908_forward.fastq",
-                    "https://zenodo.org/record/3554549/files/SRR1799908_reverse.fastq",
-                    "SRR1799908",
-                ],
-            ],
-        }
-    )
-    workbook = generate_workbook(create)
-    if WRITE_TEST_WORKBOOKS:
-        path = "~/test_workbook_seeded_paired.xlsx"
-        expanded_path = os.path.expanduser(path)
-        workbook.save(expanded_path)
-
-
-class MockDatasetCollectionElement(DatasetCollectionElementLike):
-
-    def __init__(self, id: int, element_identifier: str):
-        self.id = id
-        self.element_identifier = element_identifier
-
-
-class MockDatasetCollection(DatasetCollectionLike):
-    elements: list[DatasetCollectionElementLike]
-    collection_type: str = "list"
-
-    def __init__(self, id: int):
-        self.id = id
-        self.elements = []
-
-
-def test_generate_from_collection():
-    column_definitions = column_definitions_as_models()
-    collection = _mock_collection()
-    create = CreateWorkbookRequestForCollection(
-        title=DEFAULT_TITLE,
-        dataset_collection=collection,
-        column_definitions=column_definitions,
-    )
-    workbook = generate_workbook_from_request_for_collection(create)
-    if WRITE_TEST_WORKBOOKS:
-        path = "~/test_workbook_seeded_from_collection.xlsx"
-        expanded_path = os.path.expanduser(path)
-        workbook.save(expanded_path)
-
-
-def test_parse_base64_workbook():
-    content_base64 = unittest_file_to_base64("filled_in_workbook_1.xlsx")
-    parse_payload = ParseWorkbook(
-        collection_type="sample_sheet",
-        column_definitions=TEST_COLUMN_DEFINITIONS_1,
-        content=content_base64,
-    )
-    result = parse_workbook(parse_payload)
-    rows = result.rows
-    assert rows
-    first_row = result.rows[0]
-    assert first_row["url"] == "https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz"
-    assert first_row["replicate number"] == 1
-    assert first_row["treatment"] == "treatment1"
-    assert first_row["is control?"] is False
-    second_row = result.rows[1]
-    assert second_row["replicate number"] == 2
-    assert second_row["treatment"] == "treatment1"
-
-
-def test_parse_base64_workbook_tsv():
-    content_base64 = unittest_file_to_base64("filled_in_workbook_1.tsv")
-    parse_payload = ParseWorkbook(
-        collection_type="sample_sheet",
-        column_definitions=TEST_COLUMN_DEFINITIONS_1,
-        content=content_base64,
-    )
-    result = parse_workbook(parse_payload)
-    rows = result.rows
-    assert rows
-    first_row = result.rows[0]
-    assert first_row["url"] == "https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz"
-    assert first_row["replicate number"] == 1
-    assert first_row["treatment"] == "treatment1"
-    assert first_row["is control?"] is False
-    second_row = result.rows[1]
-    assert second_row["replicate number"] == 2
-    assert second_row["treatment"] == "treatment1"
-
-
-def test_parse_base64_workbook_with_dbkey_column():
-    content_base64 = unittest_file_to_base64("filled_in_workbook_1_with_dbkey.xlsx")
-    parse_payload = ParseWorkbook(
-        collection_type="sample_sheet",
-        column_definitions=TEST_COLUMN_DEFINITIONS_1,
-        content=content_base64,
-    )
-    result = parse_workbook(parse_payload)
-    rows = result.rows
-    assert rows
-    first_row = result.rows[0]
-    assert first_row["url"] == "https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz"
-    assert first_row["replicate number"] == 1
-    assert first_row["treatment"] == "treatment1"
-    assert first_row["is control?"] is False
-    assert result.extra_columns[0].type == "dbkey"
-    assert first_row["dbkey"] == "hg18"
-
-
-def test_parse_base64_workbook_paired():
-    content_base64 = unittest_file_to_base64("filled_in_workbook_paired.xlsx")
-    parse_payload = ParseWorkbook(
-        collection_type="sample_sheet:paired",
-        column_definitions=TEST_COLUMN_DEFINITIONS_1,
-        content=content_base64,
-    )
-    result = parse_workbook(parse_payload)
-    rows = result.rows
-    assert rows
-    assert result.rows[0]["url"] == "https://zenodo.org/record/3554549/files/SRR1799908_forward.fastq"
-    assert result.rows[0]["url_1"] == "https://zenodo.org/record/3554549/files/SRR1799908_reverse.fastq"
-    assert result.rows[0]["replicate number"] == 1
-    assert result.rows[0]["treatment"] == "treatment1"
-    assert result.rows[0]["is control?"] is False
-
-
-def test_parse_base64_workbook_paired_or_unpaired():
-    content_base64 = unittest_file_to_base64("filled_in_workbook_paired_or_unpaired.xlsx")
-    parse_payload = ParseWorkbook(
-        collection_type="sample_sheet:paired_or_unpaired",
-        column_definitions=TEST_COLUMN_DEFINITIONS_1,
-        content=content_base64,
-    )
-    result = parse_workbook(parse_payload)
-    rows = result.rows
-    assert rows
-    assert result.rows[0]["url"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
-    assert result.rows[0]["url_1"] is None
-    assert result.rows[0]["replicate number"] == 1
-    assert result.rows[0]["treatment"] == "treatment1"
-    assert result.rows[0]["is control?"] is False
-
-    assert result.rows[1]["url"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
-    assert result.rows[1]["url_1"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
-    assert result.rows[1]["replicate number"] == 2
-    assert result.rows[1]["treatment"] == "treatment2"
-    assert result.rows[1]["is control?"] is True
-
-
-def column_definitions_as_models():
+def _column_definitions_as_models():
     return SampleSheetColumnDefinitionsModel.model_validate(TEST_COLUMN_DEFINITIONS_1).root
 
 
-def test_parse_base64_workbook_from_collection():
-    content_base64 = unittest_file_to_base64("filled_in_workbook_from_collection.xlsx")
-    collection = _mock_collection()
-    parse_payload = ParseWorkbookForCollection(
-        column_definitions=column_definitions_as_models(),
-        dataset_collection=collection,
-        content=content_base64,
-    )
-    result = parse_workbook_for_collection(parse_payload)
-    rows = result.rows
-    assert rows
-
-
-def unittest_file_to_base64(filename: str) -> str:
+def _unittest_file_to_base64(filename: str) -> str:
     path = resource_path("galaxy.model.unittest_utils", filename)
     example_as_bytes = path.read_bytes()
     content_base64 = base64.b64encode(example_as_bytes).decode("utf-8")
     return content_base64
 
 
-def _mock_collection() -> MockDatasetCollection:
-    collection = MockDatasetCollection(23)
-    dce = MockDatasetCollectionElement(
-        45,
-        element_identifier="sample1",
-    )
-    collection.elements.append(dce)
-    return collection
+class TestWorkbookGeneration:
+    """Tests for workbook generation functions."""
+
+    def test_generate_without_seed_data(self):
+        create = CreateWorkbook.model_validate(
+            {"collection_type": "sample_sheet", "column_definitions": TEST_COLUMN_DEFINITIONS_1}
+        )
+        workbook = generate_workbook(create)
+        if WRITE_TEST_WORKBOOKS:
+            for index, row in enumerate(TEST_DATA):
+                for col, column in enumerate(row):
+                    workbook.active.cell(row=index + 2, column=col + 1, value=column)
+
+            path = "~/test_workbook.xlsx"
+            expanded_path = os.path.expanduser(path)
+            workbook.save(expanded_path)
+
+    def test_generate_from_request_without_seed_data(self):
+        column_definition = TEST_COLUMN_DEFINITIONS_1
+        create = CreateWorkbookRequest(collection_type="sample_sheet", column_definitions=column_definition)
+        workbook = generate_workbook_from_request(create)
+        if WRITE_TEST_WORKBOOKS:
+            for index, row in enumerate(TEST_DATA):
+                for col, column in enumerate(row):
+                    workbook.active.cell(row=index + 2, column=col + 1, value=column)
+
+            path = "~/test_workbook_from_base64.xlsx"
+            expanded_path = os.path.expanduser(path)
+            workbook.save(expanded_path)
+
+    def test_generate_with_seed_data(self):
+        create = CreateWorkbook.model_validate(
+            {
+                "collection_type": "sample_sheet",
+                "column_definitions": TEST_COLUMN_DEFINITIONS_1,
+                "prefix_values": [
+                    ["https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz", "DRR000770"],
+                    ["https://zenodo.org/records/3263975/files/DRR000771.fastqsanger.gz", "DRR000770"],
+                ],
+            }
+        )
+        workbook = generate_workbook(create)
+        if WRITE_TEST_WORKBOOKS:
+            path = "~/test_workbook_seeded.xlsx"
+            expanded_path = os.path.expanduser(path)
+            workbook.save(expanded_path)
+
+    def test_generate_with_seed_data_paired(self):
+        create = CreateWorkbook.model_validate(
+            {
+                "collection_type": "sample_sheet:paired",
+                "column_definitions": TEST_COLUMN_DEFINITIONS_1,
+                "prefix_values": [
+                    [
+                        "https://zenodo.org/record/3554549/files/SRR1799908_forward.fastq",
+                        "https://zenodo.org/record/3554549/files/SRR1799908_reverse.fastq",
+                        "SRR1799908",
+                    ],
+                ],
+            }
+        )
+        workbook = generate_workbook(create)
+        if WRITE_TEST_WORKBOOKS:
+            path = "~/test_workbook_seeded_paired.xlsx"
+            expanded_path = os.path.expanduser(path)
+            workbook.save(expanded_path)
+
+    def test_generate_from_list_collection(self):
+        column_definitions = _column_definitions_as_models()
+        collection = _make_collection("list", ["sample1"])
+        create = CreateWorkbookRequestForCollection(
+            title=DEFAULT_TITLE,
+            dataset_collection=collection,
+            column_definitions=column_definitions,
+        )
+        workbook = generate_workbook_from_request_for_collection(create)
+        if WRITE_TEST_WORKBOOKS:
+            path = "~/test_workbook_seeded_from_collection.xlsx"
+            expanded_path = os.path.expanduser(path)
+            workbook.save(expanded_path)
+
+    def test_generate_from_sample_sheet_collection(self):
+        """Test generating workbook from existing sample_sheet collection (issue #21542)."""
+        column_definitions = _column_definitions_as_models()
+        collection = _make_collection("sample_sheet", ["sample1", "sample2"])
+        create = CreateWorkbookRequestForCollection(
+            title=DEFAULT_TITLE,
+            dataset_collection=collection,
+            column_definitions=column_definitions,
+        )
+        workbook = generate_workbook_from_request_for_collection(create)
+        sheet = workbook.active
+        assert sheet.title == DEFAULT_TITLE
+        assert sheet["A1"].value == "Element Identifier"
+        assert sheet["A2"].value == "sample1"
+        assert sheet["A3"].value == "sample2"
+        assert sheet["A4"].value is None
+
+    def test_generate_from_sample_sheet_paired_collection(self):
+        """Test generating workbook from existing sample_sheet:paired collection (issue #21542)."""
+        column_definitions = _column_definitions_as_models()
+        collection = _make_collection("sample_sheet:paired", ["paired_sample1"])
+        create = CreateWorkbookRequestForCollection(
+            title=DEFAULT_TITLE,
+            dataset_collection=collection,
+            column_definitions=column_definitions,
+        )
+        workbook = generate_workbook_from_request_for_collection(create)
+        sheet = workbook.active
+        assert sheet.title == DEFAULT_TITLE
+        assert sheet["A1"].value == "Element Identifier"
+        assert sheet["A2"].value == "paired_sample1"
+        assert sheet["A3"].value is None
+
+
+class TestWorkbookParsing:
+    """Tests for workbook parsing functions."""
+
+    def test_parse_xlsx(self):
+        content_base64 = _unittest_file_to_base64("filled_in_workbook_1.xlsx")
+        parse_payload = ParseWorkbook(
+            collection_type="sample_sheet",
+            column_definitions=TEST_COLUMN_DEFINITIONS_1,
+            content=content_base64,
+        )
+        result = parse_workbook(parse_payload)
+        rows = result.rows
+        assert rows
+        first_row = result.rows[0]
+        assert first_row["url"] == "https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz"
+        assert first_row["replicate number"] == 1
+        assert first_row["treatment"] == "treatment1"
+        assert first_row["is control?"] is False
+        second_row = result.rows[1]
+        assert second_row["replicate number"] == 2
+        assert second_row["treatment"] == "treatment1"
+
+    def test_parse_tsv(self):
+        content_base64 = _unittest_file_to_base64("filled_in_workbook_1.tsv")
+        parse_payload = ParseWorkbook(
+            collection_type="sample_sheet",
+            column_definitions=TEST_COLUMN_DEFINITIONS_1,
+            content=content_base64,
+        )
+        result = parse_workbook(parse_payload)
+        rows = result.rows
+        assert rows
+        first_row = result.rows[0]
+        assert first_row["url"] == "https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz"
+        assert first_row["replicate number"] == 1
+        assert first_row["treatment"] == "treatment1"
+        assert first_row["is control?"] is False
+        second_row = result.rows[1]
+        assert second_row["replicate number"] == 2
+        assert second_row["treatment"] == "treatment1"
+
+    def test_parse_with_dbkey_column(self):
+        content_base64 = _unittest_file_to_base64("filled_in_workbook_1_with_dbkey.xlsx")
+        parse_payload = ParseWorkbook(
+            collection_type="sample_sheet",
+            column_definitions=TEST_COLUMN_DEFINITIONS_1,
+            content=content_base64,
+        )
+        result = parse_workbook(parse_payload)
+        rows = result.rows
+        assert rows
+        first_row = result.rows[0]
+        assert first_row["url"] == "https://zenodo.org/records/3263975/files/DRR000770.fastqsanger.gz"
+        assert first_row["replicate number"] == 1
+        assert first_row["treatment"] == "treatment1"
+        assert first_row["is control?"] is False
+        assert result.extra_columns[0].type == "dbkey"
+        assert first_row["dbkey"] == "hg18"
+
+    def test_parse_paired(self):
+        content_base64 = _unittest_file_to_base64("filled_in_workbook_paired.xlsx")
+        parse_payload = ParseWorkbook(
+            collection_type="sample_sheet:paired",
+            column_definitions=TEST_COLUMN_DEFINITIONS_1,
+            content=content_base64,
+        )
+        result = parse_workbook(parse_payload)
+        rows = result.rows
+        assert rows
+        assert result.rows[0]["url"] == "https://zenodo.org/record/3554549/files/SRR1799908_forward.fastq"
+        assert result.rows[0]["url_1"] == "https://zenodo.org/record/3554549/files/SRR1799908_reverse.fastq"
+        assert result.rows[0]["replicate number"] == 1
+        assert result.rows[0]["treatment"] == "treatment1"
+        assert result.rows[0]["is control?"] is False
+
+    def test_parse_paired_or_unpaired(self):
+        content_base64 = _unittest_file_to_base64("filled_in_workbook_paired_or_unpaired.xlsx")
+        parse_payload = ParseWorkbook(
+            collection_type="sample_sheet:paired_or_unpaired",
+            column_definitions=TEST_COLUMN_DEFINITIONS_1,
+            content=content_base64,
+        )
+        result = parse_workbook(parse_payload)
+        rows = result.rows
+        assert rows
+        assert result.rows[0]["url"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
+        assert result.rows[0]["url_1"] is None
+        assert result.rows[0]["replicate number"] == 1
+        assert result.rows[0]["treatment"] == "treatment1"
+        assert result.rows[0]["is control?"] is False
+
+        assert result.rows[1]["url"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
+        assert result.rows[1]["url_1"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
+        assert result.rows[1]["replicate number"] == 2
+        assert result.rows[1]["treatment"] == "treatment2"
+        assert result.rows[1]["is control?"] is True
+
+    def test_parse_from_collection(self):
+        content_base64 = _unittest_file_to_base64("filled_in_workbook_from_collection.xlsx")
+        collection = _make_collection("list", ["sample1"])
+        parse_payload = ParseWorkbookForCollection(
+            column_definitions=_column_definitions_as_models(),
+            dataset_collection=collection,
+            content=content_base64,
+        )
+        result = parse_workbook_for_collection(parse_payload)
+        rows = result.rows
+        assert rows
 
 
 class TestListToSampleSheetCollectionType:
@@ -318,7 +338,10 @@ class TestListToSampleSheetCollectionType:
         """Test that sample_sheet types pass through unchanged (issue #21542 fix)."""
         assert _list_to_sample_sheet_collection_type("sample_sheet") == "sample_sheet"
         assert _list_to_sample_sheet_collection_type("sample_sheet:paired") == "sample_sheet:paired"
-        assert _list_to_sample_sheet_collection_type("sample_sheet:paired_or_unpaired") == "sample_sheet:paired_or_unpaired"
+        assert (
+            _list_to_sample_sheet_collection_type("sample_sheet:paired_or_unpaired")
+            == "sample_sheet:paired_or_unpaired"
+        )
         assert _list_to_sample_sheet_collection_type("sample_sheet:record") == "sample_sheet:record"
 
     def test_all_sample_sheet_types_passthrough(self):
@@ -342,57 +365,3 @@ class TestListToSampleSheetCollectionType:
         """Test that list:record raises NotImplementedError (WIP)."""
         with pytest.raises(NotImplementedError):
             _list_to_sample_sheet_collection_type("list:record")
-
-
-def _make_collection(collection_type: str, element_identifiers: list[str]) -> DatasetCollection:
-    """Create a real DatasetCollection with DatasetCollectionElements."""
-    collection = DatasetCollection(collection_type=collection_type)
-    for i, identifier in enumerate(element_identifiers):
-        DatasetCollectionElement(
-            id=i + 1,  # needs non-None id for ModelObjectPrefixValue
-            collection=collection,
-            element=DatasetCollectionElement.UNINITIALIZED_ELEMENT,
-            element_index=i,
-            element_identifier=identifier,
-        )
-        # element is auto-added to collection.elements via SQLAlchemy relationship
-    return collection
-
-
-def test_generate_from_sample_sheet_collection():
-    """Test generating workbook from existing sample_sheet collection (issue #21542)."""
-    column_definitions = column_definitions_as_models()
-    collection = _make_collection("sample_sheet", ["sample1", "sample2"])
-    create = CreateWorkbookRequestForCollection(
-        title=DEFAULT_TITLE,
-        dataset_collection=collection,
-        column_definitions=column_definitions,
-    )
-    workbook = generate_workbook_from_request_for_collection(create)
-    sheet = workbook.active
-    assert sheet.title == DEFAULT_TITLE
-    # "Element Identifier" prefix column + 3 user columns from TEST_COLUMN_DEFINITIONS_1
-    assert sheet["A1"].value == "Element Identifier"
-    assert sheet["A2"].value == "sample1"
-    assert sheet["A3"].value == "sample2"
-    # No more data rows after sample2
-    assert sheet["A4"].value is None
-
-
-def test_generate_from_sample_sheet_paired_collection():
-    """Test generating workbook from existing sample_sheet:paired collection (issue #21542)."""
-    column_definitions = column_definitions_as_models()
-    collection = _make_collection("sample_sheet:paired", ["paired_sample1"])
-    create = CreateWorkbookRequestForCollection(
-        title=DEFAULT_TITLE,
-        dataset_collection=collection,
-        column_definitions=column_definitions,
-    )
-    workbook = generate_workbook_from_request_for_collection(create)
-    sheet = workbook.active
-    assert sheet.title == DEFAULT_TITLE
-    assert sheet["A1"].value == "Element Identifier"
-    assert sheet["A2"].value == "paired_sample1"
-    # No more data rows after paired_sample1
-    assert sheet["A3"].value is None
-


### PR DESCRIPTION
Rearranged and simplified existing unit tests to make it more harmonious while I was in there.

## How to test the changes?
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
