### PR TITLE
Remove dummy header from JupyterLite requests

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -47,7 +47,7 @@ igv:
     version: 0.0.25
 jupyterlite:
     package: "@galaxyproject/jupyterlite"
-    version: 0.0.28
+    version: 0.0.30
 kepler:
     package: "@galaxyproject/kepler"
     version: 0.0.3


### PR DESCRIPTION
Removes an unnecessary dummy header from JupyterLite requests that could interfere with backend handling in some deployments.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
