### PR TITLE
Adds Vintent visualization plugin

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -120,6 +120,9 @@ unipept:
 venn:
     package: "@galaxyproject/venn"
     version: 0.0.8
+vintent:
+    package: "@galaxyproject/vintent"
+    version: 0.0.0
 vitessce:
     package: "@galaxyproject/vitessce"
     version: 0.0.5


### PR DESCRIPTION
Vintent is a Vega Lite schema builder.


https://github.com/user-attachments/assets/ae7c05f7-a031-4f56-91ab-459f675a1e06


See: https://github.com/galaxyproject/galaxy-visualizations/pull/140

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
