### PR TITLE
Sort data managers using case-insensitive order for display in admin UI

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/data_manager.py
+++ b/lib/galaxy/webapps/galaxy/controllers/data_manager.py
@@ -30,7 +30,7 @@ class DataManager(BaseUIController):
         status = kwd.get("status", "info")
         data_managers = []
         for data_manager_id, data_manager in sorted(
-            trans.app.data_managers.data_managers.items(), key=lambda dm: dm[1].name
+            trans.app.data_managers.data_managers.items(), key=lambda dm: dm[1].name.lower()
         ):
             data_managers.append(
                 {


### PR DESCRIPTION
Data managers are displayed in the admin UI ordered by name. Most DM names start with an uppercase letter, but not all. Default ordering is "ABCDabcd", which makes locating DMs like dada2 rather difficult (see below). I think a case-insensitive ordering would be easier to use: "AaBbCcDd".

<img width="350" height="618" alt="image" src="https://github.com/user-attachments/assets/e374b0bc-2553-4542-8f60-e1b00bb39e22" />

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
