### PR TITLE
Use ``fail-on-cache-miss`` when restoring the client cache

### DIFF
--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Restore client cache
         uses: actions/cache@v5
         with:
+          fail-on-cache-miss: true
           key: galaxy-static-${{ needs.build-client.outputs.commit-id }}
           path: 'galaxy root/static'
       - name: Install tox

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -71,6 +71,7 @@ jobs:
       - name: Restore client cache
         uses: actions/cache@v5
         with:
+          fail-on-cache-miss: true
           key: galaxy-static-${{ needs.build-client.outputs.commit-id }}
           path: 'galaxy root/static'
       - name: Run tests

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Restore client cache
         uses: actions/cache@v5
         with:
+          fail-on-cache-miss: true
           key: galaxy-static-${{ needs.build-client.outputs.commit-id }}
           path: 'galaxy root/static'
       - name: Install uv

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -78,6 +78,7 @@ jobs:
       - name: Restore client cache
         uses: actions/cache@v5
         with:
+          fail-on-cache-miss: true
           key: galaxy-static-${{ needs.build-client.outputs.commit-id }}
           path: 'galaxy root/static'
       - name: Run tests

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -71,6 +71,7 @@ jobs:
       - name: Restore client cache
         uses: actions/cache@v5
         with:
+          fail-on-cache-miss: true
           key: galaxy-static-${{ needs.build-client.outputs.commit-id }}
           path: 'galaxy root/static'
       - name: Run tests


### PR DESCRIPTION
built by the `build_client.yaml` GitHub workflow.

Galaxy would fail anyway at startup when trying to build the cache due to missing `node`, but the reason for the error would be less clear.
I've noticed this a few days ago when there was some issue with the `cache` action and the restore wasn't working.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
