### PR TITLE
[25.1] Fix loading of credentials when associated tools are missing

### DIFF
--- a/client/src/components/User/Credentials/ServiceCredentialsGroupsList.vue
+++ b/client/src/components/User/Credentials/ServiceCredentialsGroupsList.vue
@@ -96,11 +96,24 @@ const cardTitle = computed(() => (group: ServiceCredentialsGroupDetails) => {
 });
 
 /**
+ * Checks if the source tool for a credential group is missing/deleted.
+ * @param {ServiceCredentialsGroupDetails} group - The credential group to check.
+ * @returns {boolean} True if the tool is no longer available.
+ */
+const isToolMissing = computed(() => (group: ServiceCredentialsGroupDetails) => {
+    return !getToolForId(group.sourceId);
+});
+
+/**
  * Checks if a credential group is currently in use by any tool.
  * @param {ServiceCredentialsGroupDetails} group - The credential group to check.
  * @returns {boolean} True if the group is in use.
  */
 const isGroupInUse = computed(() => (group: ServiceCredentialsGroupDetails) => {
+    if (isToolMissing.value(group)) {
+        return false;
+    }
+
     const userToolKey = userToolsServiceCredentialsStore.getUserToolKey(group.sourceId, group.sourceVersion);
     const userToolService = userToolsServicesCurrentGroupIds.value[userToolKey];
     for (const groupId of Object.values(userToolService || {})) {
@@ -109,15 +122,6 @@ const isGroupInUse = computed(() => (group: ServiceCredentialsGroupDetails) => {
         }
     }
     return false;
-});
-
-/**
- * Checks if the source tool for a credential group is missing/deleted.
- * @param {ServiceCredentialsGroupDetails} group - The credential group to check.
- * @returns {boolean} True if the tool is no longer available.
- */
-const isToolMissing = computed(() => (group: ServiceCredentialsGroupDetails) => {
-    return !getToolForId(group.sourceId);
 });
 
 /**

--- a/lib/galaxy/webapps/galaxy/services/credentials.py
+++ b/lib/galaxy/webapps/galaxy/services/credentials.py
@@ -289,7 +289,7 @@ class CredentialsService:
                     definition = CredentialsRequirement(
                         name=user_credentials.name,
                         version=user_credentials.version,
-                        description="[Tool definition not available]",
+                        description="",
                         label="",
                         optional=False,
                         variables=[],

--- a/lib/galaxy/webapps/galaxy/services/credentials.py
+++ b/lib/galaxy/webapps/galaxy/services/credentials.py
@@ -272,14 +272,30 @@ class CredentialsService:
 
         for user_credentials, credentials_group, credential in existing_user_credentials:
             cred_id = user_credentials.id
-            definition = self._get_credentials_definition(
-                user,
-                cast(SOURCE_TYPE, user_credentials.source_type),
-                user_credentials.source_id,
-                user_credentials.source_version,
-                user_credentials.name,
-                user_credentials.version,
-            )
+            definition = None
+            try:
+                definition = self._get_credentials_definition(
+                    user,
+                    cast(SOURCE_TYPE, user_credentials.source_type),
+                    user_credentials.source_id,
+                    user_credentials.source_version,
+                    user_credentials.name,
+                    user_credentials.version,
+                )
+            except ObjectNotFound:
+                # Tool was removed or is no longer available - create a minimal fallback definition
+                # using the stored credential data so the UI can still display the credentials
+                if include_definition:
+                    definition = CredentialsRequirement(
+                        name=user_credentials.name,
+                        version=user_credentials.version,
+                        description="[Tool definition not available]",
+                        label="",
+                        optional=False,
+                        variables=[],
+                        secrets=[],
+                    )
+
             user_credentials_dict.setdefault(
                 cred_id,
                 {
@@ -295,7 +311,7 @@ class CredentialsService:
                 },
             )
 
-            if include_definition:
+            if include_definition and definition:
                 user_credentials_dict[cred_id]["definition"] = {
                     "name": definition.name,
                     "version": definition.version,

--- a/test/integration/test_credentials.py
+++ b/test/integration/test_credentials.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from unittest.mock import patch
 
 from galaxy.model.db.user import get_user_by_email
 from galaxy.security.vault import UserVaultWrapper
@@ -469,11 +470,8 @@ class TestCredentialsApi(integration_util.IntegrationTestCase, integration_util.
         assert len(credentials_list) == 1
         user_credentials_id = credentials_list[0]["id"]
 
-        # Remove the tool from the toolbox to simulate it being unavailable
-        toolbox = self._app.toolbox
-        original_tool = toolbox._tools_by_id.pop(CREDENTIALS_TEST_TOOL)
-
-        try:
+        # Mock the toolbox.get_tool method to simulate the tool being unavailable
+        with patch.object(self._app.toolbox, "get_tool", return_value=None):
             # Test 1: List credentials with include_definition=True
             response = self._get("/api/users/current/credentials?include_definition=true")
             self._assert_status_code_is(response, 200)
@@ -513,8 +511,6 @@ class TestCredentialsApi(integration_util.IntegrationTestCase, integration_util.
             assert "definition" not in credential_no_def
             assert credential_no_def["id"] == user_credentials_id
             assert len(credential_no_def["groups"]) > 0
-        finally:
-            toolbox._tools_by_id[CREDENTIALS_TEST_TOOL] = original_tool
 
     def _provide_user_credentials(self, payload=None, status_code=200):
         payload = payload or self._build_credentials_payload()

--- a/test/integration/test_credentials.py
+++ b/test/integration/test_credentials.py
@@ -492,7 +492,7 @@ class TestCredentialsApi(integration_util.IntegrationTestCase, integration_util.
             definition = credential["definition"]
             assert definition["name"] == payload["service_credential"]["name"]
             assert definition["version"] == payload["service_credential"]["version"]
-            assert definition["description"] == "[Tool definition not available]"
+            assert definition["description"] == ""
             assert definition["label"] == ""
             assert definition["optional"] is False
             assert definition["variables"] == []

--- a/test/integration/test_credentials.py
+++ b/test/integration/test_credentials.py
@@ -458,6 +458,64 @@ class TestCredentialsApi(integration_util.IntegrationTestCase, integration_util.
                 vault_ref = self._get_vault_ref(payload, group["id"], secret["name"])
                 self._check_vault_entry_exists(test_user_email, vault_ref, should_exist=False)
 
+    @skip_without_tool(CREDENTIALS_TEST_TOOL)
+    def test_list_credentials_with_missing_tool(self):
+        # Create credentials for the test tool
+        payload = self._build_credentials_payload()
+        self._provide_user_credentials(payload)
+
+        # Verify credentials exist normally
+        credentials_list = self._check_credentials_exist()
+        assert len(credentials_list) == 1
+        user_credentials_id = credentials_list[0]["id"]
+
+        # Remove the tool from the toolbox to simulate it being unavailable
+        toolbox = self._app.toolbox
+        original_tool = toolbox._tools_by_id.pop(CREDENTIALS_TEST_TOOL)
+
+        try:
+            # Test 1: List credentials with include_definition=True
+            response = self._get("/api/users/current/credentials?include_definition=true")
+            self._assert_status_code_is(response, 200)
+            credentials_with_definition = response.json()
+
+            assert len(credentials_with_definition) == 1
+            credential = credentials_with_definition[0]
+
+            # Check that the credential still has basic information
+            assert credential["id"] == user_credentials_id
+            assert credential["source_id"] == CREDENTIALS_TEST_TOOL
+            assert credential["source_type"] == "tool"
+
+            # Check that the fallback definition was provided
+            assert "definition" in credential
+            definition = credential["definition"]
+            assert definition["name"] == payload["service_credential"]["name"]
+            assert definition["version"] == payload["service_credential"]["version"]
+            assert definition["description"] == "[Tool definition not available]"
+            assert definition["label"] == ""
+            assert definition["optional"] is False
+            assert definition["variables"] == []
+            assert definition["secrets"] == []
+
+            # Verify that groups are still present and accessible
+            assert len(credential["groups"]) > 0
+
+            # Test 2: List credentials without include_definition
+            response = self._get("/api/users/current/credentials")
+            self._assert_status_code_is(response, 200)
+            credentials_without_definition = response.json()
+
+            assert len(credentials_without_definition) == 1
+            credential_no_def = credentials_without_definition[0]
+
+            # Should not have definition field when not requested
+            assert "definition" not in credential_no_def
+            assert credential_no_def["id"] == user_credentials_id
+            assert len(credential_no_def["groups"]) > 0
+        finally:
+            toolbox._tools_by_id[CREDENTIALS_TEST_TOOL] = original_tool
+
     def _provide_user_credentials(self, payload=None, status_code=200):
         payload = payload or self._build_credentials_payload()
         response = self._post("/api/users/current/credentials", data=payload, json=True)


### PR DESCRIPTION
Ensure we can still display user credentials even when the associated tools are unavailable. This change includes a fallback definition for credentials in such cases and adds a test to verify the functionality. 
closes https://github.com/galaxyproject/galaxy/issues/21548

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
