### PR TITLE
Add Polaris Dataset Lineage Visualization

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -104,7 +104,7 @@ plyr:
     version: 0.0.4
 polaris:
     package: "@galaxyproject/polaris"
-    version: 0.0.3
+    version: 0.0.5
 rerunio:
     package: "@galaxyproject/rerunio"
     version: 0.0.0

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -104,7 +104,7 @@ plyr:
     version: 0.0.4
 polaris:
     package: "@galaxyproject/polaris"
-    version: 0.0.5
+    version: 0.0.6
 rerunio:
     package: "@galaxyproject/rerunio"
     version: 0.0.0

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -104,7 +104,7 @@ plyr:
     version: 0.0.4
 polaris:
     package: "@galaxyproject/polaris"
-    version: 0.0.2
+    version: 0.0.3
 rerunio:
     package: "@galaxyproject/rerunio"
     version: 0.0.0

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -102,6 +102,9 @@ plotly_surface:
 plyr:
     package: "@galaxyproject/plyr"
     version: 0.0.4
+polaris:
+    package: "@galaxyproject/polaris"
+    version: 0.0.2
 rerunio:
     package: "@galaxyproject/rerunio"
     version: 0.0.0


### PR DESCRIPTION
Adds Polaris, a Galaxy visualization for exploring dataset lineage.

Polaris renders a focused, read only view of a selected dataset and recursively traverses its inputs and outputs up to a limited depth. It helps users understand how a dataset was produced, how it is connected within a history, and which jobs and intermediate datasets contribute to it.

https://github.com/user-attachments/assets/13c75fa0-6768-4a65-8de2-85a78c569cfd

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
