### PR TITLE
[25.0] Fix race condition in workflow collection populated state check

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6892,6 +6892,12 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
 
     def expire_populated_state(self):
         required_object_session(self).expire(self, ("populated_state",))
+        # Clear the cached populated_optimized value so it will be recomputed
+        # on the next access with fresh database state. This prevents a race
+        # condition where the cached value becomes stale while nested
+        # collections are being populated.
+        if hasattr(self, "_populated_optimized"):
+            delattr(self, "_populated_optimized")
 
     @property
     def allow_implicit_mapping(self):


### PR DESCRIPTION
The `expire_populated_state()` method was only expiring the SQLAlchemy `populated_state` attribute but not clearing the cached `_populated_optimized` value. This caused a race condition during workflow scheduling:

1. `populated_optimized` was called and cached False (nested collection NEW)
2. Job thread marked the nested collection as OK
3. `waiting_for_elements` saw the new state (OK) and returned False
4. `expire_populated_state()` was called but didn't clear the cache
5. Second `populated` check returned the stale cached False
6. Workflow incorrectly failed with collection_failed

The fix ensures the cached value is cleared so the second populated check gets fresh database state, preventing spurious collection_failed errors for collections that are actively being populated.

Fixes flaky test: test_workflow_list_list_multi_data_map_over, follow up to https://github.com/galaxyproject/galaxy/pull/20909

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
