### PR TITLE
Add Viz Guidance to ChatGXY

### DIFF
--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -293,11 +293,25 @@ class BaseGalaxyAgent(ABC):
         """Prepare the full prompt including context."""
         prompt_parts = [query]
 
-        # Add context if available
         if context:
+            # Work with a copy to avoid mutating the caller's context
+            context = context.copy()
+
+            # Handle visualizations specially
+            visualizations = context.pop("visualizations", None)
+
+            # Add remaining context
             context_str = "\n".join([f"{k}: {v}" for k, v in context.items() if v])
             if context_str:
                 prompt_parts.insert(0, f"Context:\n{context_str}\n")
+
+            # Add visualization context
+            if visualizations:
+                from galaxy.agents.visualization_context import format_visualization_context
+
+                viz_context = format_visualization_context(visualizations)
+                if viz_context:
+                    prompt_parts.insert(0, viz_context)
 
         return "\n".join(prompt_parts)
 

--- a/lib/galaxy/agents/prompts/orchestrator.md
+++ b/lib/galaxy/agents/prompts/orchestrator.md
@@ -27,3 +27,16 @@ You coordinate multiple Galaxy agents for complex queries. Determine which agent
 - **Sequential**: When later agents need results from earlier ones
 - **Parallel**: When agents work on independent aspects of the query
 - **Hybrid**: Mix of sequential and parallel when appropriate
+
+## Visualization Suggestions
+
+When users ask about visualizing data, viewing results, or creating charts/plots,
+suggest relevant plugins from the Available Visualizations section in the context.
+
+Format visualization links as: `[Plugin Title](/visualizations/create/plugin_name)`
+
+Examples:
+- "How can I view my BAM file?" → Suggest IGV or similar genome browsers
+- "I want to make a scatter plot" → Suggest Plotly or Charts
+- "Show me my phylogenetic tree" → Suggest Phylocanvas
+- "Visualize my multiple sequence alignment" → Suggest MSA viewer

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -9,7 +9,8 @@ Focus on the user's **intent**.
 ## Routing Rules
 
 - For errors, failures, or debugging, route to: **error_analysis**.
-- For creating new tools or tool wrappers, route to: **custom_tool**.
+- For creating new Galaxy tools or tool wrappers (XML/YAML tool definitions), route to: **custom_tool**.
+- For visualization questions (viewing data, charts, plots, graphs, genome browsers), route to: **orchestrator**.
 - For complex, multi-part queries (e.g., "fix my error AND create a tool"), route to: **orchestrator**.
 - For general questions or tasks that don't fit the above categories, route to: **orchestrator**.
 

--- a/lib/galaxy/agents/visualization_context.py
+++ b/lib/galaxy/agents/visualization_context.py
@@ -1,0 +1,131 @@
+"""
+Helper functions for providing visualization plugin context to AI agents.
+"""
+
+from typing import (
+    Any,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    from galaxy.managers.context import ProvidesUserContext
+
+# Shared keywords for identifying visualization-related queries
+VISUALIZATION_KEYWORDS = [
+    "visualiz",
+    "chart",
+    "plot",
+    "graph",
+    "view",
+    "display",
+    "genome browser",
+    "igv",
+    "phylo",
+    "tree",
+    "heatmap",
+    "scatter",
+    "histogram",
+]
+
+
+def is_visualization_query(query: str, visualizations: list[dict[str, Any]] | None = None) -> bool:
+    """
+    Check if a query is about visualization.
+
+    Args:
+        query: User query string
+        visualizations: Optional list of available visualization plugins
+
+    Returns:
+        True if query appears to be visualization-related
+    """
+    query_lower = query.lower()
+
+    # Check for general visualization keywords
+    if any(keyword in query_lower for keyword in VISUALIZATION_KEYWORDS):
+        return True
+
+    # Check if query mentions any known visualization plugin by name or title
+    if visualizations:
+        for viz in visualizations:
+            plugin_name = viz.get("name", "").lower()
+            plugin_title = viz.get("title", "").lower()
+            if plugin_name and plugin_name in query_lower:
+                return True
+            if plugin_title and plugin_title in query_lower:
+                return True
+
+    return False
+
+
+def get_visualization_summaries(trans: "ProvidesUserContext") -> list[dict[str, Any]]:
+    """
+    Get condensed visualization plugin info for AI agent context.
+
+    Returns a list of dictionaries containing:
+    - name: Plugin identifier
+    - title: Display name
+    - description: Plugin description
+    - keywords: Tags/keywords for the plugin
+    - url: URL path to create visualization
+
+    Args:
+        trans: Galaxy transaction context
+
+    Returns:
+        List of visualization plugin summaries, sorted by title
+    """
+    summaries = []
+
+    if not hasattr(trans, "app") or not hasattr(trans.app, "visualizations_registry"):
+        return summaries
+
+    registry = trans.app.visualizations_registry
+    if not hasattr(registry, "plugins"):
+        return summaries
+
+    for name, plugin in registry.plugins.items():
+        if plugin.config.get("hidden"):
+            continue
+        summaries.append({
+            "name": name,
+            "title": plugin.config.get("name") or name,
+            "description": plugin.config.get("description") or "",
+            "keywords": plugin.config.get("tags") or [],
+            "url": f"/visualizations/create/{name}",
+        })
+
+    return sorted(summaries, key=lambda x: x["title"])
+
+
+def format_visualization_context(summaries: list[dict[str, Any]]) -> str:
+    """
+    Format visualization summaries for inclusion in LLM prompts.
+
+    Args:
+        summaries: List of visualization plugin summaries
+
+    Returns:
+        Formatted string for prompt injection
+    """
+    if not summaries:
+        return ""
+
+    lines = ["## Available Visualizations", ""]
+
+    for viz in summaries:
+        title = viz.get("title", viz.get("name", "Unknown"))
+        name = viz.get("name", "")
+        description = viz.get("description", "")
+        keywords = viz.get("keywords", [])
+
+        line = f"- **{title}** (`{name}`)"
+        if description:
+            line += f": {description}"
+        if keywords:
+            line += f" [Keywords: {', '.join(keywords)}]"
+
+        lines.append(line)
+
+    lines.append("")
+    return "\n".join(lines)

--- a/lib/galaxy/managers/agents.py
+++ b/lib/galaxy/managers/agents.py
@@ -122,6 +122,12 @@ class AgentService:
         if context is None:
             context = {}
 
+        # Inject visualization context if not already present
+        if "visualizations" not in context:
+            from galaxy.agents.visualization_context import get_visualization_summaries
+
+            context["visualizations"] = get_visualization_summaries(trans)
+
         # Route to appropriate agent
         actual_agent_type = agent_type
         routing_reasoning = None

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -29,6 +29,7 @@ class ActionType(str, Enum):
     DOCUMENTATION = "documentation"
     CONTACT_SUPPORT = "contact_support"
     VIEW_EXTERNAL = "view_external"
+    VIEW_VISUALIZATION = "view_visualization"
     SAVE_TOOL = "save_tool"
     REFINE_QUERY = "refine_query"
 


### PR DESCRIPTION
xref: #21609. Explores an early visualization guidance addition for ChatGXY, focused on clarifying visualization related intent and language at the UI level. This is an initial, lightweight attempt intended as a concrete starting point for iteration.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
