### PR TITLE
Fix Auto Layout crash with conditional (when) step inputs

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -173,7 +173,12 @@ import type { GraphStep } from "@/composables/useInvocationGraph";
 import { useWorkflowStores } from "@/composables/workflowStores";
 import type { TerminalPosition, XYPosition } from "@/stores/workflowEditorStateStore";
 import { useWorkflowNodeInspectorStore } from "@/stores/workflowNodeInspectorStore";
-import type { InputTerminalSource, OutputTerminalSource, Step } from "@/stores/workflowStepStore";
+import {
+    getCombinedStepInputs,
+    type InputTerminalSource,
+    type OutputTerminalSource,
+    type Step,
+} from "@/stores/workflowStepStore";
 import { composedPartialPath, isClickable } from "@/utils/dom";
 
 import { isWorkflowInput } from "../constants";
@@ -290,8 +295,9 @@ const headerClass = computed(() => {
 
 const inputs = computed(() => {
     const connections = connectionStore.getConnectionsForStep(props.id);
-    const extraStepInputs = stepStore.getStepExtraInputs(props.id);
-    const stepInputs = [...extraStepInputs, ...(props.step.inputs || [])];
+    // Use getCombinedStepInputs for Step objects, fall back to direct access for GraphStep
+    const step = stepStore.getStep(props.id);
+    const stepInputs = step ? getCombinedStepInputs(step, stepStore) : [...(props.step.inputs || [])];
     const unknownInputs: string[] = [];
     connections.forEach((connection) => {
         if (connection.input.stepId == props.id && !stepInputs.find((input) => input.name === connection.input.name)) {

--- a/client/src/components/Workflow/Editor/modules/layout.test.ts
+++ b/client/src/components/Workflow/Editor/modules/layout.test.ts
@@ -1,0 +1,227 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import { type InputTerminalSource, type NewStep, useWorkflowStepStore } from "@/stores/workflowStepStore";
+
+import { autoLayout } from "./layout";
+
+// Helper to create a minimal step with position
+function createStep(
+    id: number,
+    options: {
+        inputs?: InputTerminalSource[];
+        when?: string;
+        inputConnections?: NewStep["input_connections"];
+    } = {},
+): NewStep {
+    return {
+        id,
+        name: `Step ${id}`,
+        type: "tool",
+        inputs: options.inputs ?? [],
+        outputs: [
+            {
+                name: "output",
+                extensions: ["txt"],
+                optional: false,
+            },
+        ],
+        input_connections: options.inputConnections ?? {},
+        position: { left: id * 200, top: 100 },
+        post_job_actions: {},
+        tool_state: {},
+        workflow_outputs: [],
+        when: options.when,
+    };
+}
+
+describe("layout.ts", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    describe("autoLayout with conditional steps", () => {
+        it("handles steps with 'when' conditional inputs without crashing", async () => {
+            const workflowId = "test-workflow";
+            const stepStore = useWorkflowStepStore(workflowId);
+            const stateStore = useWorkflowStateStore(workflowId);
+
+            // Create a boolean parameter step (source)
+            const paramStep = stepStore.addStep(
+                createStep(0, {
+                    outputs: [
+                        {
+                            name: "output",
+                            extensions: [],
+                            optional: false,
+                            type: "boolean",
+                            parameter: true,
+                            multiple: false,
+                        },
+                    ],
+                }),
+            );
+
+            // Create a tool step with conditional execution
+            const conditionalStep = stepStore.addStep(
+                createStep(1, {
+                    inputs: [
+                        {
+                            name: "input_file",
+                            label: "Input File",
+                            multiple: false,
+                            optional: false,
+                            extensions: ["txt"],
+                            input_type: "dataset",
+                        },
+                    ],
+                    when: "${check_value}",
+                    inputConnections: {
+                        check_value: { output_name: "output", id: 0 },
+                    },
+                }),
+            );
+
+            // Set up step positions in state store
+            stateStore.stepPosition[paramStep.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[conditionalStep.id] = { width: 180, height: 80 };
+
+            const steps = {
+                [paramStep.id]: paramStep,
+                [conditionalStep.id]: conditionalStep,
+            };
+
+            // This should not throw "Referenced shape does not exist" error
+            const result = await autoLayout(workflowId, steps, []);
+
+            expect(result).toBeDefined();
+            expect(result?.steps).toHaveLength(2);
+        });
+
+        it("handles multiple conditional steps", async () => {
+            const workflowId = "test-workflow-multi";
+            const stepStore = useWorkflowStepStore(workflowId);
+            const stateStore = useWorkflowStateStore(workflowId);
+
+            // Source step
+            const sourceStep = stepStore.addStep(createStep(0));
+
+            // First conditional step
+            const cond1 = stepStore.addStep(
+                createStep(1, {
+                    when: "${flag1}",
+                    inputConnections: { flag1: { output_name: "output", id: 0 } },
+                }),
+            );
+
+            // Second conditional step
+            const cond2 = stepStore.addStep(
+                createStep(2, {
+                    when: "${flag2}",
+                    inputConnections: { flag2: { output_name: "output", id: 0 } },
+                }),
+            );
+
+            stateStore.stepPosition[sourceStep.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[cond1.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[cond2.id] = { width: 180, height: 50 };
+
+            const steps = {
+                [sourceStep.id]: sourceStep,
+                [cond1.id]: cond1,
+                [cond2.id]: cond2,
+            };
+
+            const result = await autoLayout(workflowId, steps, []);
+
+            expect(result).toBeDefined();
+            expect(result?.steps).toHaveLength(3);
+        });
+    });
+
+    describe("edge validation", () => {
+        it("filters out edges with orphaned connections", async () => {
+            const workflowId = "test-workflow-orphan";
+            const stepStore = useWorkflowStepStore(workflowId);
+            const stateStore = useWorkflowStateStore(workflowId);
+
+            // Create a step with an input that doesn't exist on the step
+            // This simulates an orphaned connection from workflow import
+            const step0 = stepStore.addStep(createStep(0));
+            const step1 = stepStore.addStep(
+                createStep(1, {
+                    // Input connections reference a non-existent input
+                    inputConnections: {
+                        nonexistent_input: { output_name: "output", id: 0 },
+                    },
+                }),
+            );
+
+            stateStore.stepPosition[step0.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[step1.id] = { width: 180, height: 50 };
+
+            const steps = {
+                [step0.id]: step0,
+                [step1.id]: step1,
+            };
+
+            // Spy on console.warn to verify warning is logged
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+            const result = await autoLayout(workflowId, steps, []);
+
+            // Should complete without error
+            expect(result).toBeDefined();
+            expect(result?.steps).toHaveLength(2);
+
+            // Should have logged a warning about the orphaned edge
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Auto Layout: skipping edge"));
+
+            warnSpy.mockRestore();
+        });
+
+        it("does not filter valid edges", async () => {
+            const workflowId = "test-workflow-valid";
+            const stepStore = useWorkflowStepStore(workflowId);
+            const stateStore = useWorkflowStateStore(workflowId);
+
+            const step0 = stepStore.addStep(createStep(0));
+            const step1 = stepStore.addStep(
+                createStep(1, {
+                    inputs: [
+                        {
+                            name: "input_file",
+                            label: "Input",
+                            multiple: false,
+                            optional: false,
+                            extensions: ["txt"],
+                            input_type: "dataset",
+                        },
+                    ],
+                    inputConnections: {
+                        input_file: { output_name: "output", id: 0 },
+                    },
+                }),
+            );
+
+            stateStore.stepPosition[step0.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[step1.id] = { width: 180, height: 50 };
+
+            const steps = {
+                [step0.id]: step0,
+                [step1.id]: step1,
+            };
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+            const result = await autoLayout(workflowId, steps, []);
+
+            expect(result).toBeDefined();
+            // No warning should be logged for valid edges
+            expect(warnSpy).not.toHaveBeenCalled();
+
+            warnSpy.mockRestore();
+        });
+    });
+});

--- a/client/src/components/Workflow/Editor/modules/layout.test.ts
+++ b/client/src/components/Workflow/Editor/modules/layout.test.ts
@@ -1,44 +1,19 @@
 import { createPinia, setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
-import { type InputTerminalSource, type NewStep, useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 
-import { autoLayout } from "./layout";
-
-// Helper to create a minimal step with position
-function createStep(
-    id: number,
-    options: {
-        inputs?: InputTerminalSource[];
-        when?: string;
-        inputConnections?: NewStep["input_connections"];
-    } = {},
-): NewStep {
-    return {
-        id,
-        name: `Step ${id}`,
-        type: "tool",
-        inputs: options.inputs ?? [],
-        outputs: [
-            {
-                name: "output",
-                extensions: ["txt"],
-                optional: false,
-            },
-        ],
-        input_connections: options.inputConnections ?? {},
-        position: { left: id * 200, top: 100 },
-        post_job_actions: {},
-        tool_state: {},
-        workflow_outputs: [],
-        when: options.when,
-    };
-}
+import { createMockStepPosition, createTestStep } from "../test_fixtures";
+import { AUTO_LAYOUT_ORPHAN_EDGE_WARNING_PREFIX, autoLayout } from "./layout";
 
 describe("layout.ts", () => {
     beforeEach(() => {
         setActivePinia(createPinia());
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     describe("autoLayout with conditional steps", () => {
@@ -49,11 +24,10 @@ describe("layout.ts", () => {
 
             // Create a boolean parameter step (source)
             const paramStep = stepStore.addStep(
-                createStep(0, {
+                createTestStep(0, {
                     outputs: [
                         {
                             name: "output",
-                            extensions: [],
                             optional: false,
                             type: "boolean",
                             parameter: true,
@@ -65,7 +39,7 @@ describe("layout.ts", () => {
 
             // Create a tool step with conditional execution
             const conditionalStep = stepStore.addStep(
-                createStep(1, {
+                createTestStep(1, {
                     inputs: [
                         {
                             name: "input_file",
@@ -84,8 +58,8 @@ describe("layout.ts", () => {
             );
 
             // Set up step positions in state store
-            stateStore.stepPosition[paramStep.id] = { width: 180, height: 50 };
-            stateStore.stepPosition[conditionalStep.id] = { width: 180, height: 80 };
+            stateStore.stepPosition[paramStep.id] = createMockStepPosition(180, 50);
+            stateStore.stepPosition[conditionalStep.id] = createMockStepPosition(180, 80);
 
             const steps = {
                 [paramStep.id]: paramStep,
@@ -105,11 +79,11 @@ describe("layout.ts", () => {
             const stateStore = useWorkflowStateStore(workflowId);
 
             // Source step
-            const sourceStep = stepStore.addStep(createStep(0));
+            const sourceStep = stepStore.addStep(createTestStep(0));
 
             // First conditional step
             const cond1 = stepStore.addStep(
-                createStep(1, {
+                createTestStep(1, {
                     when: "${flag1}",
                     inputConnections: { flag1: { output_name: "output", id: 0 } },
                 }),
@@ -117,15 +91,15 @@ describe("layout.ts", () => {
 
             // Second conditional step
             const cond2 = stepStore.addStep(
-                createStep(2, {
+                createTestStep(2, {
                     when: "${flag2}",
                     inputConnections: { flag2: { output_name: "output", id: 0 } },
                 }),
             );
 
-            stateStore.stepPosition[sourceStep.id] = { width: 180, height: 50 };
-            stateStore.stepPosition[cond1.id] = { width: 180, height: 50 };
-            stateStore.stepPosition[cond2.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[sourceStep.id] = createMockStepPosition(180, 50);
+            stateStore.stepPosition[cond1.id] = createMockStepPosition(180, 50);
+            stateStore.stepPosition[cond2.id] = createMockStepPosition(180, 50);
 
             const steps = {
                 [sourceStep.id]: sourceStep,
@@ -148,9 +122,9 @@ describe("layout.ts", () => {
 
             // Create a step with an input that doesn't exist on the step
             // This simulates an orphaned connection from workflow import
-            const step0 = stepStore.addStep(createStep(0));
+            const step0 = stepStore.addStep(createTestStep(0));
             const step1 = stepStore.addStep(
-                createStep(1, {
+                createTestStep(1, {
                     // Input connections reference a non-existent input
                     inputConnections: {
                         nonexistent_input: { output_name: "output", id: 0 },
@@ -158,8 +132,8 @@ describe("layout.ts", () => {
                 }),
             );
 
-            stateStore.stepPosition[step0.id] = { width: 180, height: 50 };
-            stateStore.stepPosition[step1.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[step0.id] = createMockStepPosition(180, 50);
+            stateStore.stepPosition[step1.id] = createMockStepPosition(180, 50);
 
             const steps = {
                 [step0.id]: step0,
@@ -176,9 +150,7 @@ describe("layout.ts", () => {
             expect(result?.steps).toHaveLength(2);
 
             // Should have logged a warning about the orphaned edge
-            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Auto Layout: skipping edge"));
-
-            warnSpy.mockRestore();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(AUTO_LAYOUT_ORPHAN_EDGE_WARNING_PREFIX));
         });
 
         it("does not filter valid edges", async () => {
@@ -186,9 +158,9 @@ describe("layout.ts", () => {
             const stepStore = useWorkflowStepStore(workflowId);
             const stateStore = useWorkflowStateStore(workflowId);
 
-            const step0 = stepStore.addStep(createStep(0));
+            const step0 = stepStore.addStep(createTestStep(0));
             const step1 = stepStore.addStep(
-                createStep(1, {
+                createTestStep(1, {
                     inputs: [
                         {
                             name: "input_file",
@@ -205,8 +177,8 @@ describe("layout.ts", () => {
                 }),
             );
 
-            stateStore.stepPosition[step0.id] = { width: 180, height: 50 };
-            stateStore.stepPosition[step1.id] = { width: 180, height: 50 };
+            stateStore.stepPosition[step0.id] = createMockStepPosition(180, 50);
+            stateStore.stepPosition[step1.id] = createMockStepPosition(180, 50);
 
             const steps = {
                 [step0.id]: step0,
@@ -220,8 +192,6 @@ describe("layout.ts", () => {
             expect(result).toBeDefined();
             // No warning should be logged for valid edges
             expect(warnSpy).not.toHaveBeenCalled();
-
-            warnSpy.mockRestore();
         });
     });
 });

--- a/client/src/components/Workflow/Editor/modules/layout.ts
+++ b/client/src/components/Workflow/Editor/modules/layout.ts
@@ -16,6 +16,8 @@ import { AxisAlignedBoundingBox, type Rectangle, rectDistance } from "./geometry
 
 const elk = new ELK();
 
+export const AUTO_LAYOUT_ORPHAN_EDGE_WARNING_PREFIX = "Auto Layout: skipping edge";
+
 interface OptionObject {
     [key: string]: OptionValue | OptionObject;
 }
@@ -152,7 +154,7 @@ export async function autoLayout(id: string, steps: { [index: string]: Step }, c
 
         if (!sourceExists || !targetExists) {
             console.warn(
-                `Auto Layout: skipping edge with non-existent port(s): source=${sourcePortId} (${sourceExists}), target=${targetPortId} (${targetExists})`,
+                `${AUTO_LAYOUT_ORPHAN_EDGE_WARNING_PREFIX} with non-existent port(s): source=${sourcePortId} (${sourceExists}), target=${targetPortId} (${targetExists})`,
             );
             return false;
         }

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -3,14 +3,15 @@ import EventEmitter from "events";
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import type { useWorkflowStores } from "@/composables/workflowStores";
 import { getConnectionId } from "@/stores/workflowConnectionStore";
-import type {
-    CollectionOutput,
-    DataCollectionStepInput,
-    DataOutput,
-    DataStepInput,
-    ParameterOutput,
-    ParameterStepInput,
-    TerminalSource,
+import {
+    type CollectionOutput,
+    type DataCollectionStepInput,
+    type DataOutput,
+    type DataStepInput,
+    getCombinedStepInputs,
+    type ParameterOutput,
+    type ParameterStepInput,
+    type TerminalSource,
 } from "@/stores/workflowStepStore";
 import type { Connection, ConnectionId } from "@/stores/workflowStoreTypes";
 import { assertDefined } from "@/utils/assertions";
@@ -695,10 +696,8 @@ class BaseOutputTerminal extends Terminal {
             const inputStep = this.stores.stepStore.getStep(connection.input.stepId);
             assertDefined(inputStep, `Invalid step. Could not find step with id ${connection.input.stepId} in store.`);
 
-            const extraStepInput = this.stores.stepStore.getStepExtraInputs(inputStep.id);
-            const terminalSource = [...extraStepInput, ...inputStep.inputs].find(
-                (input) => input.name === connection.input.name,
-            );
+            const allInputs = getCombinedStepInputs(inputStep, this.stores.stepStore);
+            const terminalSource = allInputs.find((input) => input.name === connection.input.name);
             if (!terminalSource) {
                 return new InvalidInputTerminal({
                     valid: false,

--- a/client/src/components/Workflow/Editor/test_fixtures.ts
+++ b/client/src/components/Workflow/Editor/test_fixtures.ts
@@ -1,7 +1,7 @@
 import type { UseElementBoundingReturn } from "@vueuse/core";
 import { reactive, toRefs } from "vue";
 
-import type { Steps } from "@/stores/workflowStepStore";
+import type { InputTerminalSource, NewStep, Steps } from "@/stores/workflowStepStore";
 
 import _advancedSteps from "./test-data/parameter_steps.json";
 import _simpleSteps from "./test-data/simple_steps.json";
@@ -12,3 +12,49 @@ export const mockOffset: UseElementBoundingReturn = { ..._mockOffset, update: ()
 
 export const simpleSteps = _simpleSteps as Steps;
 export const advancedSteps = _advancedSteps as Steps;
+
+/** Creates a mock step position for testing (satisfies UseElementBoundingReturn shape) */
+export function createMockStepPosition(width: number, height: number) {
+    return {
+        width,
+        height,
+        top: 0,
+        left: 0,
+        bottom: height,
+        right: width,
+        x: 0,
+        y: 0,
+        update: () => {},
+    };
+}
+
+/** Creates a minimal workflow step for testing */
+export function createTestStep(
+    id: number,
+    options: {
+        inputs?: InputTerminalSource[];
+        outputs?: NewStep["outputs"];
+        when?: string;
+        inputConnections?: NewStep["input_connections"];
+    } = {},
+): NewStep {
+    return {
+        id,
+        name: `Step ${id}`,
+        type: "tool",
+        inputs: options.inputs ?? [],
+        outputs: options.outputs ?? [
+            {
+                name: "output",
+                extensions: ["txt"],
+                optional: false,
+            },
+        ],
+        input_connections: options.inputConnections ?? {},
+        position: { left: id * 200, top: 100 },
+        post_job_actions: {},
+        tool_state: {},
+        workflow_outputs: [],
+        when: options.when,
+    };
+}

--- a/client/src/stores/workflowStepStore.test.ts
+++ b/client/src/stores/workflowStepStore.test.ts
@@ -1,7 +1,13 @@
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { type NewStep, type StepInputConnection, useWorkflowStepStore } from "@/stores/workflowStepStore";
+import {
+    getCombinedStepInputs,
+    type InputTerminalSource,
+    type NewStep,
+    type StepInputConnection,
+    useWorkflowStepStore,
+} from "@/stores/workflowStepStore";
 
 import { useConnectionStore } from "./workflowConnectionStore";
 
@@ -60,5 +66,85 @@ describe("Connection Store", () => {
         expect(connectionStore.connections.length).toBe(1);
         stepStore.removeStep(stepOne.id);
         expect(connectionStore.connections.length).toBe(0);
+    });
+});
+
+describe("getCombinedStepInputs", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    const regularInput: InputTerminalSource = {
+        name: "input_dataset",
+        label: "Input Dataset",
+        multiple: false,
+        optional: false,
+        extensions: ["txt"],
+        input_type: "dataset",
+    };
+
+    const stepWithRegularInputs: NewStep = {
+        id: 0,
+        input_connections: {},
+        inputs: [regularInput],
+        name: "tool step",
+        outputs: [],
+        post_job_actions: {},
+        tool_state: {},
+        type: "tool",
+        workflow_outputs: [],
+    };
+
+    const stepWithWhen: NewStep = {
+        ...stepWithRegularInputs,
+        id: 1,
+        when: "${check_value}",
+        input_connections: {
+            check_value: { output_name: "output", id: 0 },
+        },
+    };
+
+    it("returns only regular inputs when step has no extra inputs", () => {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const step = stepStore.addStep(stepWithRegularInputs);
+
+        const combinedInputs = getCombinedStepInputs(step, stepStore);
+
+        expect(combinedInputs).toHaveLength(1);
+        expect(combinedInputs[0]?.name).toBe("input_dataset");
+    });
+
+    it("includes extra inputs when step has conditional parameters", () => {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        stepStore.addStep(workflowStepZero); // Add step 0 as output source
+        const step = stepStore.addStep(stepWithWhen);
+
+        const combinedInputs = getCombinedStepInputs(step, stepStore);
+
+        expect(combinedInputs.length).toBeGreaterThan(1);
+        const inputNames = combinedInputs.map((i) => i.name);
+        expect(inputNames).toContain("check_value");
+        expect(inputNames).toContain("input_dataset");
+    });
+
+    it("places extra inputs before regular inputs", () => {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        stepStore.addStep(workflowStepZero);
+        const step = stepStore.addStep(stepWithWhen);
+
+        const combinedInputs = getCombinedStepInputs(step, stepStore);
+
+        // Extra inputs should come first
+        expect(combinedInputs[0]?.name).toBe("check_value");
+        expect(combinedInputs[1]?.name).toBe("input_dataset");
+    });
+
+    it("handles step with no inputs gracefully", () => {
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const step = stepStore.addStep(workflowStepZero); // Step with empty inputs
+
+        const combinedInputs = getCombinedStepInputs(step, stepStore);
+
+        expect(combinedInputs).toHaveLength(0);
     });
 });

--- a/client/src/stores/workflowStepStore.test.ts
+++ b/client/src/stores/workflowStepStore.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createTestStep } from "@/components/Workflow/Editor/test_fixtures";
 import {
     getCombinedStepInputs,
     type InputTerminalSource,
@@ -35,6 +36,10 @@ const workflowStepOne: NewStep = { ...workflowStepZero, input_connections: stepI
 describe("Connection Store", () => {
     beforeEach(() => {
         setActivePinia(createPinia());
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it("adds step", () => {
@@ -74,6 +79,10 @@ describe("getCombinedStepInputs", () => {
         setActivePinia(createPinia());
     });
 
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     const regularInput: InputTerminalSource = {
         name: "input_dataset",
         label: "Input Dataset",
@@ -83,26 +92,19 @@ describe("getCombinedStepInputs", () => {
         input_type: "dataset",
     };
 
-    const stepWithRegularInputs: NewStep = {
-        id: 0,
-        input_connections: {},
+    const stepWithRegularInputs = createTestStep(0, {
         inputs: [regularInput],
-        name: "tool step",
         outputs: [],
-        post_job_actions: {},
-        tool_state: {},
-        type: "tool",
-        workflow_outputs: [],
-    };
+    });
 
-    const stepWithWhen: NewStep = {
-        ...stepWithRegularInputs,
-        id: 1,
+    const stepWithWhen = createTestStep(1, {
+        inputs: [regularInput],
+        outputs: [],
         when: "${check_value}",
-        input_connections: {
+        inputConnections: {
             check_value: { output_name: "output", id: 0 },
         },
-    };
+    });
 
     it("returns only regular inputs when step has no extra inputs", () => {
         const stepStore = useWorkflowStepStore("mock-workflow");

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -150,6 +150,15 @@ interface StepInputMapOver {
 
 export type WorkflowStepStore = ReturnType<typeof useWorkflowStepStore>;
 
+/**
+ * Returns combined step inputs: extra inputs (e.g., "when" conditionals) followed by regular inputs.
+ * This is the single source of truth for all step inputs.
+ */
+export function getCombinedStepInputs(step: Step, stepStore: WorkflowStepStore): InputTerminalSource[] {
+    const extraInputs = stepStore.getStepExtraInputs(step.id);
+    return [...extraInputs, ...step.inputs];
+}
+
 export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (workflowId) => {
     const steps = ref<Steps>({});
     const stepMapOver = ref<{ [index: number]: CollectionTypeDescriptor }>({});


### PR DESCRIPTION
Include extra inputs (e.g., "when" conditionals) in ELK graph by
adding getCombinedStepInputs() helper and using it in layout.ts.

Also add defensive edge validation to handle orphaned connections
from imported workflows.

Fixes https://github.com/galaxyproject/galaxy/issues/21603, https://github.com/galaxyproject/galaxy/issues/21601, https://github.com/galaxyproject/galaxy/issues/19806

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
