### PR TITLE
Fix package test using ``--index-strategy unsafe-best-match`` to match pip behavior 

### DIFF
--- a/packages/test.sh
+++ b/packages/test.sh
@@ -3,7 +3,10 @@
 set -ex
 
 PACKAGE_LIST_FILE=packages_by_dep_dag.txt
-: "${PIP_EXTRA_ARGS:=--index-url https://wheels.galaxyproject.org/simple --extra-index-url https://pypi.python.org/simple}"
+# uv's default index strategy (first-match) won't check other indexes once a package is found,
+# unlike pip which merges all indexes. Use unsafe-best-match to get pip-like behavior and
+# allow wheels.galaxyproject.org wheels to be preferred over PyPI source distributions.
+: "${PIP_EXTRA_ARGS:=--index-strategy unsafe-best-match --extra-index-url https://wheels.galaxyproject.org/simple}"
 FOR_PULSAR=0
 SKIP_PACKAGES=(
     web_client

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -3,6 +3,7 @@
 set -ex
 
 PACKAGE_LIST_FILE=packages_by_dep_dag.txt
+: "${PIP_EXTRA_ARGS:=--index-url https://wheels.galaxyproject.org/simple --extra-index-url https://pypi.python.org/simple}"
 FOR_PULSAR=0
 SKIP_PACKAGES=(
     web_client
@@ -50,7 +51,8 @@ if [ "${PIP_CMD}" = 'python -m pip' ]; then
     ${PIP_CMD} install --upgrade pip setuptools wheel
 fi
 if [ $FOR_PULSAR -eq 0 ]; then
-    ${PIP_CMD} install -r ../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
+    # shellcheck disable=SC2086 - word splitting is intentional for PIP_EXTRA_ARGS
+    ${PIP_CMD} install ${PIP_EXTRA_ARGS} -r ../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
 fi
 
 # Ensure ordered by dependency DAG
@@ -73,14 +75,15 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
     cd "$package_dir"
 
     # Install extras (if needed)
+    # shellcheck disable=SC2086 - word splitting is intentional for PIP_EXTRA_ARGS
     if [ "$package_dir" = "util" ]; then
-        ${PIP_CMD} install '.[image-util,template,jstree,config-template,test]'
+        ${PIP_CMD} install ${PIP_EXTRA_ARGS} '.[image-util,template,jstree,config-template,test]'
     elif [ "$package_dir" = "tool_util" ]; then
-        ${PIP_CMD} install '.[cwl,mulled,edam,extended-assertions,test]'
+        ${PIP_CMD} install ${PIP_EXTRA_ARGS} '.[cwl,mulled,edam,extended-assertions,test]'
     elif grep -q 'test =' setup.cfg 2>/dev/null; then
-        ${PIP_CMD} install '.[test]'
+        ${PIP_CMD} install ${PIP_EXTRA_ARGS} '.[test]'
     else
-        ${PIP_CMD} install .
+        ${PIP_CMD} install ${PIP_EXTRA_ARGS} .
     fi
 
     if [ $FOR_PULSAR -eq 0 ]; then


### PR DESCRIPTION
So pysam wheels on wheels.galaxyproject.org are used. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
