### PR TITLE
Use explicit aliases in job search deleted outputs filter

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -727,21 +727,26 @@ class JobSearch:
         outer_select_columns = [subquery_alias.c[col.name] for col in stmt.selected_columns]
         outer_stmt = select(*outer_select_columns).select_from(subquery_alias)
         job_id_from_subquery = subquery_alias.c.job_id
+
+        # Use explicit aliases to avoid potential conflicts with tables used in the main query
+        job_output_collection_assoc = aliased(model.JobToOutputDatasetCollectionAssociation)
+        output_hdca = aliased(model.HistoryDatasetCollectionAssociation)
         deleted_collection_exists = exists().where(
             and_(
-                model.JobToOutputDatasetCollectionAssociation.job_id == job_id_from_subquery,
-                model.JobToOutputDatasetCollectionAssociation.dataset_collection_id
-                == model.HistoryDatasetCollectionAssociation.id,
-                model.HistoryDatasetCollectionAssociation.deleted == true(),
+                job_output_collection_assoc.job_id == job_id_from_subquery,
+                job_output_collection_assoc.dataset_collection_id == output_hdca.id,
+                output_hdca.deleted == true(),
             )
         )
 
         # Subquery for deleted output datasets
+        job_output_dataset_assoc = aliased(model.JobToOutputDatasetAssociation)
+        output_hda = aliased(model.HistoryDatasetAssociation)
         deleted_dataset_exists = exists().where(
             and_(
-                model.JobToOutputDatasetAssociation.job_id == job_id_from_subquery,
-                model.JobToOutputDatasetAssociation.dataset_id == model.HistoryDatasetAssociation.id,
-                model.HistoryDatasetAssociation.deleted == true(),
+                job_output_dataset_assoc.job_id == job_id_from_subquery,
+                job_output_dataset_assoc.dataset_id == output_hda.id,
+                output_hda.deleted == true(),
             )
         )
 

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -316,7 +316,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 3
 
-            self._create_history_then_publish_and_archive_it(f"Public Archived history_{uuid4()}")
+            self._create_history_then_publish_and_archive_it(f"Public Archived history_{unique_id}")
             data = dict(search=name_contains, show_published=False)
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 3
@@ -327,28 +327,29 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
             assert len(index_response) == 0
 
             # Archived public histories should be included when filtering by show_published and show_archived
-            data = dict(search="is:published", show_archived=True)
+            # Use unique_id to filter only histories created by this test
+            data = dict(search=f"{unique_id} is:published", show_archived=True)
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 2
 
             # Searching all published histories will NOT include the archived if show_archived is not set
-            data = dict(search="is:published")
+            data = dict(search=f"{unique_id} is:published")
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 1
 
             # Searching all published histories will include our own archived when show_own is false
             # as long as they are published
-            data = dict(search="is:published", show_own=False)
+            data = dict(search=f"{unique_id} is:published", show_own=False)
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 2
 
             # Publish a history and archive it by a different user
             with self._different_user(f"other_user_{uuid4()}@bx.psu.edu"):
-                self._create_history_then_publish_and_archive_it(f"Public Archived history_{uuid4()}")
+                self._create_history_then_publish_and_archive_it(f"Public Archived history_other_{unique_id}")
 
             # Searching all published histories will include archived from other users and our own
             # as long as they are published
-            data = dict(search="is:published", show_own=False)
+            data = dict(search=f"{unique_id} is:published", show_own=False)
             index_response = self._get("histories", data=data).json()
             assert len(index_response) == 3
 


### PR DESCRIPTION
The _exclude_jobs_with_deleted_outputs function was using unaliased model classes (e.g., model.HistoryDatasetAssociation) in its exists() subqueries, while the main query from _build_stmt_for_hdca uses aliased versions of these same tables (e.g., candidate_hda).

While exists() subqueries should create independent table references, using the same model class without aliasing in both the main query and the exists() subquery could potentially cause ambiguity in PostgreSQL's query planner, leading to non-deterministic query behavior.

This fix adds explicit aliases (job_output_collection_assoc, output_hdca, job_output_dataset_assoc, output_hda) to ensure the tables in the exists() subqueries are clearly distinct from any tables in the outer query.

This (maybe) addresses the flaky test_search_delete_hdca_output issue tracked in GitHub issue #21230.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
