### PR TITLE
[25.1] Harden Dataverse integration

### DIFF
--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -23,13 +23,13 @@ log = logging.getLogger(__name__)
 
 
 class RDMFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
-    token: Union[str, TemplateExpansion]
-    public_name: Union[str, TemplateExpansion]
+    token: Optional[Union[str, TemplateExpansion]] = None
+    public_name: Optional[Union[str, TemplateExpansion]] = None
 
 
 class RDMFileSourceConfiguration(BaseFileSourceConfiguration):
-    token: str
-    public_name: str
+    token: Optional[str] = None
+    public_name: Optional[str] = None
 
 
 class ContainerAndFileIdentifier(NamedTuple):

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -51,7 +51,7 @@ class RDMRepositoryInteractor:
     """
 
     def __init__(self, repository_url: str, plugin: "RDMFilesSource"):
-        self._repository_url = repository_url
+        self._repository_url = self._strip_last_slash(repository_url)
         self._plugin = plugin
 
     @property
@@ -137,6 +137,12 @@ class RDMRepositoryInteractor:
         The file will be downloaded to the file system at the given file_path.
         """
         raise NotImplementedError()
+
+    def _strip_last_slash(self, url: str) -> str:
+        """Utility method to strip the last slash from a URL if present."""
+        if url.endswith("/"):
+            return url[:-1]
+        return url
 
 
 class RDMFilesSource(BaseFilesSource[RDMFileSourceTemplateConfiguration, RDMFileSourceConfiguration]):

--- a/lib/galaxy/files/sources/dataverse.py
+++ b/lib/galaxy/files/sources/dataverse.py
@@ -106,6 +106,7 @@ class DataverseRDMFilesSource(RDMFilesSource):
         - doi:10.70122/FK2/AVNCLL (persistent ID)
         - doi:10.70122/FK2/DIG2DG/AVNCLL (persistent ID)
         - doi:10.70122/FK2/DIG2DG/id:12345 (database ID)
+        - doi:10.5072/FK2/doi:10.70122/AVNCLL (persistent ID)
         - perma:BSC/3ST00L/id:9056 (database ID)
         """
         if not source_path.startswith("/"):
@@ -126,8 +127,7 @@ class DataverseRDMFilesSource(RDMFilesSource):
                 f"Invalid source path: '{source_path}'. Expected format: '/<dataset_id>/<file_identifier>'."
             )
 
-        file_id_part = parts[-1]
-        dataset_id = "/".join(parts[:-1])
+        dataset_id, file_id_part = self._split_dataset_and_file_pid(parts)
 
         # The file identifier can be either:
         # - A persistent ID suffix (e.g., 'AVNCLL' -> full ID is 'doi:10.70122/FK2/DIG2DG/AVNCLL')
@@ -135,10 +135,45 @@ class DataverseRDMFilesSource(RDMFilesSource):
         if file_id_part.startswith("id:"):
             # Database ID format - keep the 'id:' prefix as the file identifier
             file_id = file_id_part
+        elif re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:.*", file_id_part):
+            # Full persistent identifier (e.g. doi:, hdl:, ark:, or custom PID providers).
+            # Files in Dataverse may have their own independent persistent IDs that are
+            # not hierarchically related to the dataset persistent ID.
+            file_id = file_id_part
         else:
-            # Persistent ID format - construct full persistent ID
+            # Dataset-scoped persistent ID suffix - construct full persistent ID
             file_id = f"{dataset_id}/{file_id_part}"
         return ContainerAndFileIdentifier(container_id=dataset_id, file_identifier=file_id)
+
+    @staticmethod
+    def _split_dataset_and_file_pid(parts: list[str]) -> tuple[str, str]:
+        """
+        Split a Dataverse source path into dataset ID and file identifier parts.
+
+        Dataverse file-level persistent IDs may themselves contain slashes and are not
+        necessarily hierarchically related to the dataset persistent ID. For example:
+
+            /doi:10.57745/I8EUTL/doi:10.57745/L7SOAJ
+
+        In this case:
+            dataset_id = doi:10.57745/I8EUTL
+            file_id     = doi:10.57745/L7SOAJ
+
+        This helper detects such cases by recognizing URI-scheme prefixes in path segments
+        and grouping them accordingly.
+        """
+        # Default: last segment is the file identifier
+        file_id_part = parts[-1]
+        dataset_id = "/".join(parts[:-1])
+
+        # Heuristic: if the penultimate segment starts a URI scheme (e.g. doi:, hdl:, ark:),
+        # then the file persistent ID spans the last two segments.
+        pid_scheme_re = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+        if len(parts) >= 3 and pid_scheme_re.match(parts[-2]):
+            file_id_part = f"{parts[-2]}/{parts[-1]}"
+            dataset_id = "/".join(parts[:-2])
+
+        return dataset_id, file_id_part
 
     def get_container_id_from_path(self, source_path: str) -> str:
         return self.parse_path(source_path, container_id_only=True).container_id


### PR DESCRIPTION
Follow-up to #21569

Fixes some new edge cases discovered by users and reported by @yvanlebras (thanks!)
- Make `token` and `public_name` optional in configuration for consistency with the code. The code already handles optional values, but they were forced in the config, unnecessarily forcing the addition of empty values for public instances in the configuration.
- Gracefully handling of trailing slashes in repository URLs
- Expose Dataverse error messages to the user. Errors like "permission required to download file" were not exposed to the user, causing confusion in some cases.
- Fixes more edge cases with PID handling to reference files for download.

See individual commit messages for more details.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Add these file sources to your `config/file_sources_conf.yml` and play around with them:
    ```yaml
    - type: dataverse
      id: recherchedatagouv
      doc: "Recherche Data Gouv French Dataverse instance"
      label: "Recherche Data Gouv"
      url: https://entrepot.recherche.data.gouv.fr
    
    - type: dataverse
      id: indorese
      doc: "IndoRES Dataverse instance"
      label: "IndoRES"
      url: https://data.indores.fr
    
    - type: dataverse
      id: cirad
      doc: "CIRAD Dataverse instance"
      label: "CIRAD"
      url: https://dataverse.cirad.fr/
    
    - type: dataverse
      id: ird
      doc: "IRD Dataverse instance"
      label: "IRD"
      url: https://dataverse.ird.fr/
    ```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
