### PR TITLE
[25.1] Add database operation tool to convert sample sheets to list collections

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -53,6 +53,7 @@
     <tool file="${model_tools_path}/build_list.xml" />
     <tool file="${model_tools_path}/build_list_1.2.0.xml" />
     <tool file="${model_tools_path}/sample_sheet_to_tabular.xml" />
+    <tool file="${model_tools_path}/convert_sample_sheet.xml" />
     <tool file="${model_tools_path}/extract_dataset.xml" />
     <tool file="${model_tools_path}/duplicate_file_to_collection.xml" />
   </section>

--- a/lib/galaxy/model/dataset_collections/types/sample_sheet_workbook.py
+++ b/lib/galaxy/model/dataset_collections/types/sample_sheet_workbook.py
@@ -618,5 +618,24 @@ def _list_to_sample_sheet_collection_type(input_collection_type: str) -> SampleS
         )
 
 
+def _sample_sheet_to_list_collection_type(input_collection_type: str) -> str:
+    """Convert sample_sheet collection types to corresponding list collection types.
+
+    Converts sample_sheet types to list types (e.g., sample_sheet:paired -> list:paired).
+    """
+    if input_collection_type == "sample_sheet":
+        return "list"
+    elif input_collection_type == "sample_sheet:paired":
+        return "list:paired"
+    elif input_collection_type == "sample_sheet:paired_or_unpaired":
+        return "list:paired_or_unpaired"
+    elif input_collection_type == "sample_sheet:record":
+        return "list:record"
+    else:
+        raise RequestParameterInvalidException(
+            f"Invalid collection type for sample sheet conversion: {input_collection_type}"
+        )
+
+
 def _prefix_column_to_column_target(column_header: FetchPrefixColumn) -> ColumnTarget:
     return target_model_by_type(column_header.type)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -57,6 +57,7 @@ from galaxy.model import (
     StoredWorkflow,
 )
 from galaxy.model.dataset_collections.matching import MatchingCollections
+from galaxy.model.dataset_collections.types.sample_sheet_workbook import _sample_sheet_to_list_collection_type
 from galaxy.schema.credentials import CredentialsContext
 from galaxy.tool_shed.util.repository_util import get_installed_repository
 from galaxy.tool_shed.util.shed_util_common import set_image_paths
@@ -4671,6 +4672,66 @@ class DuplicateFileToCollectionTool(DatabaseOperationTool):
         )
 
 
+class ConvertSampleSheetTool(DatabaseOperationTool):
+    """Convert a sample sheet collection back to its corresponding non-sample-sheet type.
+
+    This tool strips the sample sheet metadata (column_definitions and row columns)
+    and converts the collection type from sample_sheet variants to list variants.
+    """
+
+    tool_type = "convert_sample_sheet"
+    require_terminal_states = False
+    require_dataset_ok = False
+
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
+        has_collection = incoming["input"]
+        if hasattr(has_collection, "element_type"):
+            # It is a DCE
+            collection = has_collection.element_object
+        else:
+            # It is an HDCA
+            collection = has_collection.collection
+
+        input_collection_type = collection.collection_type
+        output_collection_type = _sample_sheet_to_list_collection_type(input_collection_type)
+
+        new_elements: dict[str, Any] = {}
+        copied_datasets = []
+
+        def copy_elements(source_collection, target_dict):
+            for dce in source_collection.elements:
+                element_identifier = dce.element_identifier
+                dce_object = dce.element_object
+                if dce.is_collection:
+                    # Handle nested collections (e.g., paired within sample_sheet:paired)
+                    sub_collection: dict[str, Any] = {}
+                    sub_collection["src"] = "new_collection"
+                    sub_collection["collection_type"] = dce_object.collection_type
+                    sub_elements = {}
+                    for sub_dce in dce_object.elements:
+                        sub_element_identifier = sub_dce.element_identifier
+                        sub_dce_object = sub_dce.element_object
+                        copied_dataset = sub_dce_object.copy(copy_tags=sub_dce_object.tags, flush=False)
+                        sub_elements[sub_element_identifier] = copied_dataset
+                        copied_datasets.append(copied_dataset)
+                    sub_collection["elements"] = sub_elements
+                    target_dict[element_identifier] = sub_collection
+                else:
+                    copied_dataset = dce_object.copy(copy_tags=dce_object.tags, flush=False)
+                    target_dict[element_identifier] = copied_dataset
+                    copied_datasets.append(copied_dataset)
+
+        copy_elements(collection, new_elements)
+        self._add_datasets_to_history(history, copied_datasets)
+        output_collections.create_collection(
+            next(iter(self.outputs.values())),
+            "output",
+            collection_type=output_collection_type,
+            elements=new_elements,
+            propagate_hda_tags=False,
+        )
+
+
 # Populate tool_type to ToolClass mappings
 TOOL_CLASSES: list[type[Tool]] = [
     Tool,
@@ -4690,6 +4751,7 @@ TOOL_CLASSES: list[type[Tool]] = [
     BuildListCollectionTool,
     ExtractDatasetCollectionTool,
     DataDestinationTool,
+    ConvertSampleSheetTool,
 ]
 tool_types = {tool_class.tool_type: tool_class for tool_class in TOOL_CLASSES}
 

--- a/lib/galaxy/tools/convert_sample_sheet.xml
+++ b/lib/galaxy/tools/convert_sample_sheet.xml
@@ -1,0 +1,52 @@
+<tool id="__CONVERT_SAMPLE_SHEET__"
+      name="Convert sample sheet"
+      version="1.0.0"
+      tool_type="convert_sample_sheet">
+    <description>to list collection</description>
+    <type class="ConvertSampleSheetTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <edam_operations>
+        <edam_operation>operation_2409</edam_operation>
+    </edam_operations>
+    <macros>
+        <import>model_operation_macros.xml</import>
+    </macros>
+    <inputs>
+        <param type="data_collection" collection_type="sample_sheet,sample_sheet:paired,sample_sheet:paired_or_unpaired,sample_sheet" name="input" label="Sample sheet to convert" />
+    </inputs>
+    <outputs>
+        <!-- type_source is a lie, we don't have a way to encode the transform that is actually happening -->
+        <collection name="output" format_source="input" type_source="input" label="${on_string} (converted)" >
+        </collection>
+    </outputs>
+    <help><![CDATA[
+
+========
+Synopsis
+========
+
+Converts a sample sheet collection back to its corresponding list collection type.
+
+===========
+Description
+===========
+
+This tool takes a sample sheet collection and produces a regular list collection, removing all sample sheet metadata (column definitions and row values).
+
+The conversion follows this mapping:
+
+- ``sample_sheet`` becomes ``list``
+- ``sample_sheet:paired`` becomes ``list:paired``
+- ``sample_sheet:paired_or_unpaired`` becomes ``list:paired_or_unpaired``
+
+Use this tool when you need to pass a sample sheet to a tool that expects a regular list collection, or when you want to discard the sample sheet metadata.
+
+----
+
+.. class:: infomark
+
+@QUOTA_USAGE_NOTE@
+
+     ]]></help>
+</tool>

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -751,6 +751,89 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert run_response.status_code == 400
             assert run_response.json()["err_msg"] == "Dataset collection has no element_index with key 100."
 
+    @skip_without_tool("__CONVERT_SAMPLE_SHEET__")
+    def test_convert_sample_sheet_to_list(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            # Create sample_sheet collection with column_definitions and rows
+            create_response = self.dataset_collection_populator.create_sample_sheet(
+                history_id,
+                contents=[("sample1", "content1"), ("sample2", "content2")],
+                column_definitions=[
+                    {"type": "int", "name": "replicate", "optional": False},
+                    {"type": "string", "name": "treatment", "optional": False},
+                ],
+                rows={"sample1": [1, "control"], "sample2": [2, "treatment"]},
+            )
+            self._assert_status_code_is(create_response, 200)
+            sample_sheet_hdca = create_response.json()
+            assert sample_sheet_hdca["collection_type"] == "sample_sheet"
+            assert sample_sheet_hdca["column_definitions"] is not None
+
+            # Run convert sample sheet tool
+            inputs = {"input": {"src": "hdca", "id": sample_sheet_hdca["id"]}}
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            response = self._run("__CONVERT_SAMPLE_SHEET__", history_id, inputs, assert_ok=True)
+
+            # Verify output is a list collection without sample sheet metadata
+            output_collections = response["output_collections"]
+            assert len(output_collections) == 1
+            self.dataset_populator.wait_for_job(response["jobs"][0]["id"], assert_ok=True)
+            converted_hdca = self.dataset_populator.get_history_collection_details(
+                history_id, hid=output_collections[0]["hid"]
+            )
+            assert converted_hdca["collection_type"] == "list"
+            assert converted_hdca.get("column_definitions") is None
+            assert len(converted_hdca["elements"]) == 2
+            element_identifiers = [e["element_identifier"] for e in converted_hdca["elements"]]
+            assert "sample1" in element_identifiers
+            assert "sample2" in element_identifiers
+
+    @skip_without_tool("__CONVERT_SAMPLE_SHEET__")
+    def test_convert_sample_sheet_paired_to_list_paired(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            # Create sample_sheet:paired collection
+            pair_identifiers = self.dataset_collection_populator.pair_identifiers(history_id, ["forward", "reverse"])
+            element_identifiers = [
+                {
+                    "name": "sample1",
+                    "collection_type": "paired",
+                    "src": "new_collection",
+                    "element_identifiers": pair_identifiers,
+                }
+            ]
+            create_response = self.dataset_collection_populator.create_sample_sheet(
+                history_id,
+                contents=element_identifiers,
+                column_definitions=[{"type": "int", "name": "replicate", "default_value": 0, "optional": False}],
+                rows={"sample1": [42]},
+                collection_type="sample_sheet:paired",
+            )
+            self._assert_status_code_is(create_response, 200)
+            sample_sheet_hdca = create_response.json()
+            assert sample_sheet_hdca["collection_type"] == "sample_sheet:paired"
+            assert sample_sheet_hdca["column_definitions"] is not None
+
+            # Run convert sample sheet tool
+            inputs = {"input": {"src": "hdca", "id": sample_sheet_hdca["id"]}}
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            response = self._run("__CONVERT_SAMPLE_SHEET__", history_id, inputs, assert_ok=True)
+
+            # Verify output is a list:paired collection without sample sheet metadata
+            output_collections = response["output_collections"]
+            assert len(output_collections) == 1
+            self.dataset_populator.wait_for_job(response["jobs"][0]["id"], assert_ok=True)
+            converted_hdca = self.dataset_populator.get_history_collection_details(
+                history_id, hid=output_collections[0]["hid"]
+            )
+            assert converted_hdca["collection_type"] == "list:paired"
+            assert converted_hdca.get("column_definitions") is None
+            assert len(converted_hdca["elements"]) == 1
+            # Verify nested paired structure is preserved
+            element = converted_hdca["elements"][0]
+            assert element["element_type"] == "dataset_collection"
+            assert element["object"]["collection_type"] == "paired"
+            assert len(element["object"]["elements"]) == 2
+
     @skip_without_tool("__FILTER_FAILED_DATASETS__")
     def test_filter_failed_list(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -3555,6 +3555,47 @@ class BaseDatasetCollectionPopulator:
         element_identifiers = [hda_to_identifier(i, hda) for (i, hda) in enumerate(hdas)]
         return element_identifiers
 
+    def create_sample_sheet(
+        self,
+        history_id: str,
+        contents: list,
+        column_definitions: list,
+        rows: dict,
+        name: str = "test sample sheet",
+        collection_type: str = "sample_sheet",
+    ):
+        """Create a sample_sheet collection with metadata.
+
+        Args:
+            history_id: The history ID to create the collection in.
+            contents: A list of 2-tuples of form (name, dataset_content) for flat sample sheets,
+                      or a list of element identifiers dicts for nested collections.
+            column_definitions: List of column definition dicts.
+            rows: Dict mapping element identifiers to row values.
+            name: Name for the collection.
+            collection_type: The collection type (sample_sheet, sample_sheet:paired, etc).
+
+        Returns:
+            Response from creating the collection.
+        """
+        # For flat sample sheets, create element identifiers from contents
+        if contents and isinstance(contents[0], tuple):
+            element_identifiers = self.list_identifiers(history_id, contents)
+        else:
+            # Assume contents is already element_identifiers for nested collections
+            element_identifiers = contents
+
+        payload = dict(
+            name=name,
+            instance_type="history",
+            history_id=history_id,
+            element_identifiers=element_identifiers,
+            collection_type=collection_type,
+            column_definitions=column_definitions,
+            rows=rows,
+        )
+        return self._create_collection(payload)
+
     def __create(self, payload, wait=False):
         # Create a collection - either from existing datasets using collection creation API
         # or from direct uploads with the fetch API. Dispatch on "targets" keyword in payload

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -338,6 +338,7 @@
   <tool file="${model_tools_path}/build_list.xml" />
   <tool file="${model_tools_path}/build_list_1.2.0.xml" />
   <tool file="${model_tools_path}/sample_sheet_to_tabular.xml" />
+  <tool file="${model_tools_path}/convert_sample_sheet.xml" />
   <tool file="${model_tools_path}/extract_dataset.xml" />
   <tool file="${model_tools_path}/duplicate_file_to_collection.xml" />
   <tool file="${model_tools_path}/split_paired_and_unpaired.xml" />


### PR DESCRIPTION
This tool converts sample sheet collections back to their corresponding non-sample-sheet types by stripping the column_definitions and row column metadata:

- sample_sheet -> list
- sample_sheet:paired -> list:paired
- sample_sheet:paired_or_unpaired -> list:paired_or_unpaired

Useful when a sample sheet needs to be passed to a tool that expects a regular list collection, or when discarding sample sheet metadata.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
