### PR TITLE
Fix and tweak the weekly triage command (follow-up to #21579)

### DIFF
--- a/.claude/commands/triage-bug.md
+++ b/.claude/commands/triage-bug.md
@@ -13,9 +13,11 @@ You will be supplied a Github issue number to triage. A Galaxy developer will be
 
 Fetch the issue using "gh issue view <number>" and write the issue contents to ``ISSUE_<#>.md``.
 
+Write all triage artifacts to the current working directory.
+
 Galaxy versions look like 24.1, 26.2, etc.. and these correspond to branches such as release_24.1, release_26.2, etc.. Be sure you're on the target branch before continuing.
 
-In serial launch subagents to perform actions to help in the triage process. As the agent responsible for the triage process - please read the artifacts generated from subagents and direct the process as it makes sense. Your job is direct the process though - do not try to fix the issue or do research yourself.
+Launch subagents to perform actions to help in the triage process. Run independent tasks in parallel where possible (e.g., code research and importance assessment can run concurrently since they only need the original issue), but tasks that depend on artifacts from earlier subagents must wait (e.g., history research and planning need to read the code research document first). As the agent responsible for the triage process - please read the artifacts generated from subagents and direct the process as it makes sense. Your job is to direct the process though - do not try to fix the issue or do research yourself.
 
 When to launch subagents and what they should do are as follows:
 

--- a/.claude/commands/triage-bug.md
+++ b/.claude/commands/triage-bug.md
@@ -11,7 +11,7 @@ Parse the issue number and work level from $ARGUMENTS. Work levels control triag
 
 You will be supplied a Github issue number to triage. A Galaxy developer will be assigned the issue but your job is to structure the conversation around the issue.
 
-Fetch the issue "gh view issue" and write the issue contents to ``ISSUE_<#>.md``.
+Fetch the issue using "gh issue view <number>" and write the issue contents to ``ISSUE_<#>.md``.
 
 Galaxy versions look like 24.1, 26.2, etc.. and these correspond to branches such as release_24.1, release_26.2, etc.. Be sure you're on the target branch before continuing.
 

--- a/.claude/commands/triage-feature.md
+++ b/.claude/commands/triage-feature.md
@@ -11,7 +11,7 @@ Parse the issue number and work level from $ARGUMENTS. Work levels control triag
 
 You will be supplied a Github issue number for a feature request to triage. A Galaxy developer will be assigned the issue but your job is to structure the conversation around the feature.
 
-Fetch the issue "gh view issue" and write the issue contents to ``FEATURE_<#>.md``.
+Fetch the issue using "gh issue view <number>" and write the issue contents to ``FEATURE_<#>.md``.
 
 In serial launch subagents to perform actions to help in the triage process. As the agent responsible for the triage process - please read the artifacts generated from subagents and direct the process as it makes sense. Your job is direct the process though - do not try to implement the feature or do research yourself.
 

--- a/.claude/commands/triage-feature.md
+++ b/.claude/commands/triage-feature.md
@@ -13,7 +13,9 @@ You will be supplied a Github issue number for a feature request to triage. A Ga
 
 Fetch the issue using "gh issue view <number>" and write the issue contents to ``FEATURE_<#>.md``.
 
-In serial launch subagents to perform actions to help in the triage process. As the agent responsible for the triage process - please read the artifacts generated from subagents and direct the process as it makes sense. Your job is direct the process though - do not try to implement the feature or do research yourself.
+Write all triage artifacts to the current working directory.
+
+Launch subagents to perform actions to help in the triage process. Run independent tasks in parallel where possible (e.g., demand research and code research can run concurrently since they only need the original issue), but tasks that depend on artifacts from earlier subagents must wait (e.g., implementation planning needs to read the research documents first). As the agent responsible for the triage process - please read the artifacts generated from subagents and direct the process as it makes sense. Your job is to direct the process though - do not try to implement the feature or do research yourself.
 
 When to launch subagents and what they should do are as follows:
 

--- a/.claude/commands/triage-issue.md
+++ b/.claude/commands/triage-issue.md
@@ -17,8 +17,8 @@ Classification signals:
 Once classified, inform the user of your classification and reasoning in one sentence.
 
 Then read the appropriate command file and execute its instructions:
-- For bugs: Read `.claude/commands/bug-triage.md` and follow those instructions
-- For features: Read `.claude/commands/feature-triage.md` and follow those instructions
+- For bugs: Read `.claude/commands/triage-bug.md` and follow those instructions
+- For features: Read `.claude/commands/triage-feature.md` and follow those instructions
 
 Pass through the original issue number and work level to the triage workflow.
 


### PR DESCRIPTION
Follow-up to #21579 with a few fixes and improvements.                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                              
## Fixes                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                              
- **File path references**: `triage-issue.md` was pointing to `bug-triage.md` and `feature-triage.md` but the actual files are named `triage-bug.md` and `triage-feature.md`                                                                                                                                                
- **gh CLI syntax**: Both specialized commands had `"gh view issue"` instead of `"gh issue view <number>"`                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                              
## Improvements                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                              
- **Output directory**: Added explicit instruction that artifacts are written to the current working directory                                                                                                                                                                                                              
- **Parallel execution**: Clarified that independent subagent tasks can run in parallel since subagents communicate through artifact files, not shared context. Tasks that only need the original issue (e.g., code research + importance assessment) can run concurrently, while tasks that depend on earlier artifacts (e.g., planning needs code research) must wait.   


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
