### PR TITLE
Migrate remaining vitest tests from `axios-mock-adapter` to `useServerMock`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -183,7 +183,6 @@
     "@vue/test-utils": "^1.3.6",
     "@vue/tsconfig": "^0.4.0",
     "autoprefixer": "10.4.16",
-    "axios-mock-adapter": "^1.22.0",
     "buffer": "^6.0.3",
     "cpy-cli": "^5.0.0",
     "eslint": "^8.52.0",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -410,9 +410,6 @@ importers:
       autoprefixer:
         specifier: 10.4.16
         version: 10.4.16(postcss@8.5.6)
-      axios-mock-adapter:
-        specifier: ^1.22.0
-        version: 1.22.0(axios@1.12.0)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1743,11 +1740,6 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
 
-  axios-mock-adapter@1.22.0:
-    resolution: {integrity: sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==}
-    peerDependencies:
-      axios: '>= 0.17.0'
-
   axios@1.12.0:
     resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
 
@@ -2856,10 +2848,6 @@ packages:
 
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-
-  is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
-    engines: {node: '>=4'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -5951,12 +5939,6 @@ snapshots:
 
   available-typed-arrays@1.0.5: {}
 
-  axios-mock-adapter@1.22.0(axios@1.12.0):
-    dependencies:
-      axios: 1.12.0
-      fast-deep-equal: 3.1.3
-      is-buffer: 2.0.5
-
   axios@1.12.0:
     dependencies:
       follow-redirects: 1.15.6
@@ -7243,8 +7225,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-buffer@1.1.6: {}
-
-  is-buffer@2.0.5: {}
 
   is-callable@1.2.7: {}
 

--- a/client/src/components/Citation/services.test.ts
+++ b/client/src/components/Citation/services.test.ts
@@ -1,10 +1,12 @@
 // Vitest test for Citation component
 
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 
 import { getCitations } from "./services";
+
+const { server, http } = useServerMock();
 
 const mockCitationResponseJson = [
     {
@@ -15,19 +17,13 @@ const mockCitationResponseJson = [
 ];
 
 describe("Citation", () => {
-    let axiosMock: MockAdapter;
-
-    beforeEach(() => {
-        axiosMock = new MockAdapter(axios);
-    });
-
-    afterEach(() => {
-        axiosMock.restore();
-    });
-
     describe("services", () => {
         it("Should fetch and create a citation object", async () => {
-            axiosMock.onGet(`/api/tools/random_lines1/citations`).reply(200, mockCitationResponseJson);
+            server.use(
+                http.untyped.get("/api/tools/random_lines1/citations", () => {
+                    return HttpResponse.json(mockCitationResponseJson);
+                }),
+            );
             const citations = await getCitations("tools", "random_lines1");
             const formattedCitation = citations?.[0]?.cite.format("bibliography", {
                 format: "html",

--- a/client/src/components/DatasetInformation/DatasetInformation.test.ts
+++ b/client/src/components/DatasetInformation/DatasetInformation.test.ts
@@ -1,11 +1,11 @@
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue, injectTestRouter } from "@tests/vitest/helpers";
 import { mount, type Wrapper } from "@vue/test-utils";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import { format, parseISO } from "date-fns";
 import flushPromises from "flush-promises";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 
 import DatasetInformation from "./DatasetInformation.vue";
 
@@ -13,6 +13,7 @@ const HDA_ID = "FOO_HDA_ID";
 
 const localVue = getLocalVue();
 const router = injectTestRouter(localVue);
+const { server, http } = useServerMock();
 
 interface DatasetResponse {
     id: string;
@@ -45,16 +46,14 @@ const datasetResponse: DatasetResponse = {
 
 describe("DatasetInformation/DatasetInformation", () => {
     let wrapper: Wrapper<Vue>;
-    let axiosMock: MockAdapter;
     let datasetInfoTable: Wrapper<Vue>;
 
-    afterEach(() => {
-        axiosMock.restore();
-    });
-
     beforeEach(async () => {
-        axiosMock = new MockAdapter(axios);
-        axiosMock.onGet(new RegExp(`api/configuration/decode/*`)).reply(200, { decoded_id: 123 });
+        server.use(
+            http.untyped.get(/api\/configuration\/decode\/.*/, () => {
+                return HttpResponse.json({ decoded_id: 123 });
+            }),
+        );
 
         const pinia = createTestingPinia({ createSpy: vi.fn });
 

--- a/client/src/components/JobParameters/JobParameters.test.ts
+++ b/client/src/components/JobParameters/JobParameters.test.ts
@@ -1,10 +1,9 @@
 import { mount, type Wrapper } from "@vue/test-utils";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { createPinia } from "pinia";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import raw from "@/components/providers/test/json/Dataset.json";
 
 import paramResponse from "./parameters-response.json";
@@ -21,21 +20,20 @@ const DatasetProvider: any = {
     },
 };
 const pinia = createPinia();
+const { server, http } = useServerMock();
 
 describe("JobParameters/JobParameters.vue", () => {
     const linkParam = paramResponse.parameters.find((element) => Array.isArray(element.value)) ?? {
         text: "Test Parameter not found",
         value: "NOT FOUND",
     };
-    let axiosMock: MockAdapter;
 
     beforeEach(() => {
-        axiosMock = new MockAdapter(axios);
-        axiosMock.onGet(`/api/jobs/${JOB_ID}/parameters_display`).reply(200, paramResponse);
-    });
-
-    afterEach(() => {
-        axiosMock.restore();
+        server.use(
+            http.untyped.get(`/api/jobs/${JOB_ID}/parameters_display`, () => {
+                return HttpResponse.json(paramResponse);
+            }),
+        );
     });
 
     it("should render job parameters", async () => {

--- a/client/src/components/Login/ChangePassword.test.ts
+++ b/client/src/components/Login/ChangePassword.test.ts
@@ -26,7 +26,7 @@ let postRequests: PostRequest[] = [];
 describe("ChangePassword", () => {
     let wrapper: Wrapper<Vue>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         postRequests = [];
         server.use(
             http.untyped.post(/.*/, async ({ request }) => {
@@ -35,6 +35,9 @@ describe("ChangePassword", () => {
                 return HttpResponse.json({});
             }),
         );
+        // Navigate to a different route to avoid NavigationDuplicated error
+        // when the component calls router.push("/") on successful submit
+        await router.push("/change-password").catch(() => {});
         wrapper = mount(MountTarget as object, {
             propsData: {
                 messageText: "message_text",

--- a/client/src/components/Login/ChangePassword.test.ts
+++ b/client/src/components/Login/ChangePassword.test.ts
@@ -1,4 +1,4 @@
-import { getLocalVue } from "@tests/vitest/helpers";
+import { getLocalVue, injectTestRouter } from "@tests/vitest/helpers";
 import { mount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +13,7 @@ vi.mock("utils/redirect", () => ({
 }));
 
 const localVue = getLocalVue(true);
+const router = injectTestRouter(localVue);
 const { server, http } = useServerMock();
 
 interface PostRequest {
@@ -40,6 +41,7 @@ describe("ChangePassword", () => {
                 messageVariant: "message_variant",
             },
             localVue,
+            router,
         });
     });
 

--- a/client/src/components/Login/LoginForm.test.ts
+++ b/client/src/components/Login/LoginForm.test.ts
@@ -1,13 +1,10 @@
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue, injectTestRouter } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useServerMock } from "@/api/client/__mocks__";
-import { HttpResponse } from "@/api/client/__mocks__/index";
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 
 import MountTarget from "./LoginForm.vue";
 
@@ -21,6 +18,13 @@ const SELECTORS = {
     REGISTER_TOGGLE: "[id=register-toggle]",
     REGISTRATION_DISABLED: "[data-description='registration disabled message']",
 };
+
+interface PostRequest {
+    url: string;
+    data: Record<string, unknown>;
+}
+
+let postRequests: PostRequest[] = [];
 
 async function mountLoginForm() {
     const wrapper = mount(MountTarget as object, {
@@ -39,19 +43,19 @@ async function mountLoginForm() {
 }
 
 describe("LoginForm", () => {
-    let axiosMock: MockAdapter;
-
     beforeEach(() => {
-        axiosMock = new MockAdapter(axios);
+        postRequests = [];
         server.use(
             http.get("/api/configuration", ({ response }) => {
                 return response.untyped(HttpResponse.json({ oidc: { cilogon: false } }));
             }),
+            http.untyped.post("/user/login", async ({ request }) => {
+                const url = request.url;
+                const data = (await request.json()) as Record<string, unknown>;
+                postRequests.push({ url, data });
+                return HttpResponse.json({});
+            }),
         );
-    });
-
-    afterEach(() => {
-        axiosMock.reset();
     });
 
     it("basics", async () => {
@@ -75,10 +79,11 @@ describe("LoginForm", () => {
 
         const submitButton = wrapper.find("button[type='submit']");
         await submitButton.trigger("submit");
+        await flushPromises();
 
-        const postedData = JSON.parse(axiosMock.history.post?.[0]?.data);
-        expect(postedData.login).toBe("test_user");
-        expect(postedData.password).toBe("test_pwd");
+        expect(postRequests.length).toBe(1);
+        expect(postRequests[0]?.data.login).toBe("test_user");
+        expect(postRequests[0]?.data.password).toBe("test_pwd");
     });
 
     it("props", async () => {
@@ -145,14 +150,12 @@ describe("LoginForm", () => {
         const submitButton = wrapper.find("button[type='submit']");
 
         await submitButton.trigger("submit");
-
-        const postedData = JSON.parse(axiosMock.history.post?.[0]?.data);
-        expect(postedData.login).toBe(external_email);
-        expect(postedData.password).toBe("test_pwd");
-
-        const postedURL = axiosMock.history.post?.[0]?.url;
-        expect(postedURL).toBe("/user/login");
         await flushPromises();
+
+        expect(postRequests.length).toBe(1);
+        expect(postRequests[0]?.data.login).toBe(external_email);
+        expect(postRequests[0]?.data.password).toBe("test_pwd");
+        expect(postRequests[0]?.url).toContain("/user/login");
 
         locationSpy.mockRestore();
     });

--- a/client/src/components/Login/NewUserConfirmation.test.ts
+++ b/client/src/components/Login/NewUserConfirmation.test.ts
@@ -21,8 +21,12 @@ let originalSearch: string;
 describe("NewUserConfirmation", () => {
     let wrapper: Wrapper<Vue>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         postRequests = [];
+
+        // Navigate to a different route to avoid NavigationDuplicated error
+        // when the component calls router.push("/") on successful submit
+        await router.push("/new-user-confirmation").catch(() => {});
 
         // Mock window.location.search
         originalSearch = window.location.search;

--- a/client/src/components/Login/NewUserConfirmation.test.ts
+++ b/client/src/components/Login/NewUserConfirmation.test.ts
@@ -1,4 +1,4 @@
-import { getLocalVue } from "@tests/vitest/helpers";
+import { getLocalVue, injectTestRouter } from "@tests/vitest/helpers";
 import { mount, type Wrapper } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -8,28 +8,28 @@ import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import MountTarget from "./NewUserConfirmation.vue";
 
 const localVue = getLocalVue(true);
+const router = injectTestRouter(localVue);
 const { server, http } = useServerMock();
-
-const originalLocation = window.location;
 
 interface PostRequest {
     url: string;
 }
 
 let postRequests: PostRequest[] = [];
+let originalSearch: string;
 
 describe("NewUserConfirmation", () => {
     let wrapper: Wrapper<Vue>;
 
     beforeEach(() => {
         postRequests = [];
+
         // Mock window.location.search
-        Object.defineProperty(window, "location", {
+        originalSearch = window.location.search;
+        Object.defineProperty(window.location, "search", {
             configurable: true,
-            value: {
-                ...originalLocation,
-                search: "?provider=test_provider&provider_token=sample_token",
-            },
+            writable: true,
+            value: "?provider=test_provider&provider_token=sample_token",
         });
 
         server.use(
@@ -42,14 +42,16 @@ describe("NewUserConfirmation", () => {
         wrapper = mount(MountTarget as object, {
             propsData: {},
             localVue,
+            router,
         });
     });
 
     afterEach(() => {
-        // Restore original location
-        Object.defineProperty(window, "location", {
+        // Restore original search
+        Object.defineProperty(window.location, "search", {
             configurable: true,
-            value: originalLocation,
+            writable: true,
+            value: originalSearch,
         });
     });
 

--- a/client/src/components/Panels/ToolBox.test.js
+++ b/client/src/components/Panels/ToolBox.test.js
@@ -1,7 +1,6 @@
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import toolsList from "@/components/ToolsView/testData/toolsList";
 import toolsListInPanel from "@/components/ToolsView/testData/toolsListInPanel";
 import { setMockConfig } from "@/composables/__mocks__/config";
@@ -14,6 +13,8 @@ setMockConfig({
     toolbox_auto_sort: true,
 });
 
+const { server, http } = useServerMock();
+
 describe("ToolBox", () => {
     const toolsMock = toolsList.reduce((acc, item) => {
         acc[item.id] = item;
@@ -21,20 +22,20 @@ describe("ToolBox", () => {
     }, {});
     const toolPanelMock = toolsListInPanel;
     const resultsMock = ["liftOver1", "__FILTER_EMPTY_DATASETS__", "__UNZIP_COLLECTION__"];
-    let axiosMock;
-
-    beforeEach(async () => {
-        axiosMock = new MockAdapter(axios);
-    });
 
     it("test filter functions correctly matching: (1) Tools store array-of-objects with (2) Results array", async () => {
-        axiosMock
-            .onGet(`/api/tool_panels/default`)
-            .replyOnce(200, toolsListInPanel)
-            .onGet(`/api/tools?in_panel=False`)
-            .replyOnce(200, toolsMock)
-            .onGet(/api\/tools?.*/)
-            .replyOnce(200, resultsMock);
+        server.use(
+            http.untyped.get("/api/tool_panels/default", () => {
+                return HttpResponse.json(toolsListInPanel);
+            }),
+            http.untyped.get("/api/tools", ({ request }) => {
+                const url = new URL(request.url);
+                if (url.searchParams.get("in_panel") === "False") {
+                    return HttpResponse.json(toolsMock);
+                }
+                return HttpResponse.json(resultsMock);
+            }),
+        );
         const toolsResults = filterTools(toolsMock, resultsMock);
         const resultIds = Object.keys(toolsResults);
         expect(resultIds.length).toBe(3);

--- a/client/src/components/Tool/ToolCard.test.js
+++ b/client/src/components/Tool/ToolCard.test.js
@@ -1,13 +1,11 @@
 import { expectConfigurationRequest, getLocalVue } from "@tests/vitest/helpers";
 import { setupMockConfig } from "@tests/vitest/mockConfig";
 import { mount } from "@vue/test-utils";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { createPinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useServerMock } from "@/api/client/__mocks__";
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import { useUserStore } from "@/stores/userStore";
 
 import ToolCard from "./ToolCard.vue";
@@ -23,16 +21,18 @@ const localVue = getLocalVue();
 
 describe("ToolCard", () => {
     let wrapper;
-    let axiosMock;
     let userStore;
 
     beforeEach(async () => {
         // some child component must be bypassing useConfig - so we need to explicitly
         // stup the API endpoint also. If you can drop this without request problems in log,
         // this hack can be removed.
-        server.use(expectConfigurationRequest(http, {}));
-        axiosMock = new MockAdapter(axios);
-        axiosMock.onGet(`/api/webhooks`).reply(200, []);
+        server.use(
+            expectConfigurationRequest(http, {}),
+            http.untyped.get("/api/webhooks", () => {
+                return HttpResponse.json([]);
+            }),
+        );
 
         const pinia = createPinia();
 

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -1,12 +1,10 @@
 import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useServerMock } from "@/api/client/__mocks__";
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 
 import FormTool from "./FormTool.vue";
 
@@ -24,13 +22,13 @@ const localVue = getLocalVue();
 const { server, http } = useServerMock();
 
 describe("FormTool", () => {
-    const axiosMock = new MockAdapter(axios);
-    axiosMock.onGet(`/api/webhooks`).reply(200, []);
-
     beforeEach(() => {
         server.use(
             http.get("/api/configuration", ({ response }) => {
                 return response(200).json({});
+            }),
+            http.untyped.get("/api/webhooks", () => {
+                return HttpResponse.json([]);
             }),
         );
     });

--- a/client/src/components/Workflow/WorkflowExport.test.js
+++ b/client/src/components/Workflow/WorkflowExport.test.js
@@ -1,25 +1,32 @@
 import { getLocalVue } from "@tests/vitest/helpers";
 import { shallowMount } from "@vue/test-utils";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { beforeEach, describe, expect, it } from "vitest";
 import { nextTick } from "vue";
 
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
+
 import WorkflowExport from "./WorkflowExport.vue";
 
 const localVue = getLocalVue();
-const axiosMock = new MockAdapter(axios);
-axiosMock.onGet("/api/workflows/0").reply(200, {
-    id: "0",
-    name: "workflow",
-});
-axiosMock.onGet("/api/workflows/1").reply(200, {
-    id: "1",
-    owner: "owner",
-    slug: "slug",
-    importable: true,
-});
+const { server, http } = useServerMock();
+
+server.use(
+    http.untyped.get("/api/workflows/0", () => {
+        return HttpResponse.json({
+            id: "0",
+            name: "workflow",
+        });
+    }),
+    http.untyped.get("/api/workflows/1", () => {
+        return HttpResponse.json({
+            id: "1",
+            owner: "owner",
+            slug: "slug",
+            importable: true,
+        });
+    }),
+);
 
 function getHref(item) {
     return item.attributes("href");

--- a/client/src/components/providers/PageProvider.test.js
+++ b/client/src/components/providers/PageProvider.test.js
@@ -1,27 +1,29 @@
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 
 import { pagesProvider } from "./PageProvider";
 
+const { server, http } = useServerMock();
+
 describe("PageProvider", () => {
-    let axiosMock;
-
-    beforeEach(async () => {
-        axiosMock = new MockAdapter(axios);
-    });
-
-    afterEach(() => {
-        axiosMock.restore();
-    });
-
     describe("fetching pages without an error", () => {
         it("should make an API call and fire callback", async () => {
-            axiosMock
-                .onGet("/prefix/api/pages", {
-                    params: { limit: 50, offset: 0, search: "rna tutorial" },
-                })
-                .reply(200, [{ model_class: "Page" }], { total_matches: "1" });
+            server.use(
+                http.untyped.get("/prefix/api/pages", ({ request }) => {
+                    const url = new URL(request.url);
+                    if (
+                        url.searchParams.get("limit") === "50" &&
+                        url.searchParams.get("offset") === "0" &&
+                        url.searchParams.get("search") === "rna tutorial"
+                    ) {
+                        return HttpResponse.json([{ model_class: "Page" }], {
+                            headers: { total_matches: "1" },
+                        });
+                    }
+                    return HttpResponse.json([]);
+                }),
+            );
 
             const ctx = {
                 root: "/prefix/",

--- a/client/src/watch/watchHistory.test.js
+++ b/client/src/watch/watchHistory.test.js
@@ -1,16 +1,16 @@
 import { suppressDebugConsole } from "@tests/vitest/helpers";
 import { createLocalVue, mount } from "@vue/test-utils";
-import axios from "axios";
-import MockAdapter from "axios-mock-adapter";
 import { createPinia, mapState } from "pinia";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
 import { useHistoryStore } from "@/stores/historyStore";
 
 import { watchHistoryOnce } from "./watchHistory";
 
 const pinia = createPinia();
+const { server, http } = useServerMock();
 
 const testApp = {
     template: `<div/>`,
@@ -21,7 +21,6 @@ const testApp = {
 };
 
 describe("watchHistory", () => {
-    let axiosMock;
     let wrapper;
     const historyData = {
         id: "history-id",
@@ -49,7 +48,6 @@ describe("watchHistory", () => {
     ];
 
     beforeEach(() => {
-        axiosMock = new MockAdapter(axios);
         const localVue = createLocalVue();
         useHistoryItemsStore(pinia);
 
@@ -63,16 +61,15 @@ describe("watchHistory", () => {
         historyStore.setCurrentHistoryId("history-id");
     });
 
-    afterEach(() => {
-        axiosMock.reset();
-    });
-
     it("sets up the history and history item stores", async () => {
-        axiosMock
-            .onGet(`/history/current_history_json`)
-            .replyOnce(200, historyData)
-            .onGet(/api\/histories\/history-id\/contents?.*/)
-            .replyOnce(200, historyItems);
+        server.use(
+            http.untyped.get("/history/current_history_json", () => {
+                return HttpResponse.json(historyData);
+            }),
+            http.untyped.get(/api\/histories\/history-id\/contents?.*/, () => {
+                return HttpResponse.json(historyItems);
+            }),
+        );
         await watchHistoryOnce();
         expect(wrapper.vm.getHistoryItems("history-id", "").length).toBe(2);
         expect(wrapper.vm.getHistoryItems("history-id", "second")[0].hid).toBe(2);
@@ -82,41 +79,55 @@ describe("watchHistory", () => {
     it("survives a failing request", async () => {
         suppressDebugConsole(); // we log that 500, totally expected, do not include it in test output
 
-        // Setup a failing request, then update history content
-        axiosMock
-            .onGet(`/history/current_history_json`)
-            .replyOnce(200, historyData)
-            .onGet(/api\/histories\/history-id\/contents?.*/)
-            .replyOnce(200, historyItems)
-            .onGet(`/history/current_history_json`)
-            .replyOnce(500);
+        // Stage 1: Initial successful load
+        server.use(
+            http.untyped.get("/history/current_history_json", () => {
+                return HttpResponse.json(historyData);
+            }),
+            http.untyped.get(/api\/histories\/history-id\/contents?.*/, () => {
+                return HttpResponse.json(historyItems);
+            }),
+        );
 
         await watchHistoryOnce();
         expect(wrapper.vm.currentHistoryId).toBe("history-id");
         expect(wrapper.vm.getHistoryItems("history-id", "").length).toBe(2);
+
+        // Stage 2: Failing request
+        server.resetHandlers();
+        server.use(
+            http.untyped.get("/history/current_history_json", () => {
+                return new HttpResponse(null, { status: 500 });
+            }),
+        );
+
         try {
             await watchHistoryOnce();
         } catch (error) {
             expect(error.message).toContain("500");
         }
-        // Need to reset axios mock here. Smells like a bug,
-        // maybe in axios-mock-adapter, maybe on our side
-        axiosMock.reset();
-        axiosMock
-            .onGet(`/history/current_history_json`)
-            .replyOnce(200, { ...historyData, update_time: "1" })
-            .onGet(/api\/histories\/history-id\/contents?.*/)
-            .replyOnce(200, [
-                {
-                    id: "id-3",
-                    hid: 3,
-                    name: "third",
-                    state: "ok",
-                    deleted: false,
-                    visible: true,
-                    history_id: "history-id",
-                },
-            ]);
+
+        // Stage 3: Recovery with updated data
+        server.resetHandlers();
+        server.use(
+            http.untyped.get("/history/current_history_json", () => {
+                return HttpResponse.json({ ...historyData, update_time: "1" });
+            }),
+            http.untyped.get(/api\/histories\/history-id\/contents?.*/, () => {
+                return HttpResponse.json([
+                    {
+                        id: "id-3",
+                        hid: 3,
+                        name: "third",
+                        state: "ok",
+                        deleted: false,
+                        visible: true,
+                        history_id: "history-id",
+                    },
+                ]);
+            }),
+        );
+
         await watchHistoryOnce();
         // We should have received the update and have 3 items in the history
         expect(wrapper.vm.getHistoryItems("history-id", "").length).toBe(3);


### PR DESCRIPTION
Switches all the remaining test files from `axios-mock-adapter` to `useServerMock` and removes the axios-mock-adapter package.  Suggested by @davelopez in the Vue 3 branch PR - started working on it there but splitting it out here so it can land independently, then we'll rebase that.

30 test files migrated, axios-mock-adapter removed from devDependencies. All tests pass.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
