### PR TITLE
Disable corepack integrity check to fix Docker build

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -95,6 +95,10 @@ RUN find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 FROM stage1 AS client_build
 ARG SERVER_DIR
 
+# Workaround for corepack signature verification failure due to pnpm key rotation
+# See: https://github.com/nodejs/corepack/issues/612
+ENV COREPACK_INTEGRITY_KEYS=0
+
 RUN ansible-playbook -i localhost, playbook.yml -v --tags "galaxy_build_client" -e galaxy_virtualenv_command=virtualenv
 
 WORKDIR $SERVER_DIR


### PR DESCRIPTION
# Fix Docker build failure due to corepack signature verification

## Summary
- Fix corepack signature verification failure during Docker image build by disabling integrity checks

## Description

Docker builds of the Galaxy container image are failing during the client build stage with a corepack signature verification error. This is caused by pnpm's recent key rotation (see https://github.com/nodejs/corepack/issues/612), where the signing keys used for pnpm packages were changed, but older versions of corepack still have the old public keys embedded.

Node.js 22.13.0 (specified in `client/.node_version`) ships with a corepack version that has outdated pnpm public keys, causing `corepack enable pnpm` to fail when it tries to download and verify pnpm.

This PR adds `ENV COREPACK_INTEGRITY_KEYS=0` to the client build stage of `.k8s_ci.Dockerfile` to disable signature verification as a workaround until a proper fix is ready; likely to the `ansible-galaxy` playbook.

## Additional Consideration

 There's also a recent change (January 15, 2026) to the ansible-galaxy role (PR #241) that skips nodeenv installation for Galaxy >= 25.1, expecting system Node.js to be available. This could cause issues for Docker builds that use the python:3.12-slim base image (which has no  Node.js). However, this appears to be separate from the immediate corepack signature issue.

## Test plan
- [x] Verify Docker image builds successfully with `docker build -f .k8s_ci.Dockerfile .`
- [ ] Verify the built image starts correctly and serves the Galaxy API

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
