### PR TITLE
Fix slow startup regression

### DIFF
--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -72,15 +72,16 @@ def parse_tool_test_descriptions(
     for i, raw_test_dict in enumerate(raw_tests_dict.get("tests", [])):
         validation_exception: Optional[Exception] = None
         request_and_schema: Optional[TestRequestAndSchema] = None
-        try:
-            tool_parameter_bundle = input_models_for_tool_source(tool_source)
-            validated_test_case = case_state(raw_test_dict, tool_parameter_bundle.parameters, profile, validate=True)
-            request_and_schema = TestRequestAndSchema(
-                validated_test_case.tool_state,
-                tool_parameter_bundle,
-            )
-        except Exception as e:
-            validation_exception = e
+        if validate_on_load:
+            try:
+                tool_parameter_bundle = input_models_for_tool_source(tool_source)
+                validated_test_case = case_state(raw_test_dict, tool_parameter_bundle.parameters, profile, validate=True)
+                request_and_schema = TestRequestAndSchema(
+                    validated_test_case.tool_state,
+                    tool_parameter_bundle,
+                )
+            except Exception as e:
+                validation_exception = e
 
         if validation_exception and validate_on_load:
             tool_id, tool_version = _tool_id_and_version(tool_source, tool_guid)

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -75,7 +75,9 @@ def parse_tool_test_descriptions(
         if validate_on_load:
             try:
                 tool_parameter_bundle = input_models_for_tool_source(tool_source)
-                validated_test_case = case_state(raw_test_dict, tool_parameter_bundle.parameters, profile, validate=True)
+                validated_test_case = case_state(
+                    raw_test_dict, tool_parameter_bundle.parameters, profile, validate=True
+                )
                 request_and_schema = TestRequestAndSchema(
                     validated_test_case.tool_state,
                     tool_parameter_bundle,
@@ -83,7 +85,7 @@ def parse_tool_test_descriptions(
             except Exception as e:
                 validation_exception = e
 
-        if validation_exception and validate_on_load:
+        if validation_exception:
             tool_id, tool_version = _tool_id_and_version(tool_source, tool_guid)
             test = ToolTestDescription.from_tool_source_dict(
                 InvalidToolTestDict(


### PR DESCRIPTION
# Fix slow startup regression caused by unconditional tool test validation

Closes #21262

## Summary
- Restore the `if validate_on_load:` conditional guard in `parse_tool_test_descriptions()` to fix startup time regression

## Description

After PR #20935 (Tool Request API) was merged, Galaxy startup time approximately doubled from ~6 minutes to ~12 minutes. This was reported in issue #21262.

### Root Cause

Commit `2e4a50a38c` removed the `if validate_on_load:` guard in `lib/galaxy/tool_util/verify/parse.py`, causing `input_models_for_tool_source()` to be called unconditionally for every test case in every tool during startup.

Previously, this expensive validation only ran for tools with profile >= 24.2 (where `validate_on_load` is true). With approximately 1,670 tools being loaded, calling this function unconditionally added significant overhead to startup time when tools were being loaded from a (slow) network or CVMFS.

### Fix

This PR restores the `if validate_on_load:` conditional guard around the expensive validation code block in `parse_tool_test_descriptions()`, ensuring that `input_models_for_tool_source()` is only called when validation is actually needed (i.e., for tools with profile >= 24.2).

### Discussion Notes

Why are all the tools tests being loaded (and validated) for **all** tools on startup on production instances of Galaxy?  Are these really needed?  Can the tools tests be loaded lazily as they are needed rather than all at once during startup?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
