### PR TITLE
Always use context managers in py2filesystem file sources

### DIFF
--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -113,15 +113,16 @@ class PyFilesystem2FilesSource(BaseFilesSource[TTemplateConfig, TResolvedConfig]
 
     def _realize_to(self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[TResolvedConfig]):
         with open(native_path, "wb") as write_file:
-            self._open_fs(context).download(source_path, write_file)
+            with self._open_fs(context) as openfs:
+                openfs.download(source_path, write_file)
 
     def _write_from(self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[TResolvedConfig]):
         with open(native_path, "rb") as read_file:
-            openfs = self._open_fs(context)
-            dirname = fs.path.dirname(target_path)
-            if not openfs.isdir(dirname):
-                openfs.makedirs(dirname)
-            openfs.upload(target_path, read_file)
+            with self._open_fs(context) as openfs:
+                dirname = fs.path.dirname(target_path)
+                if not openfs.isdir(dirname):
+                    openfs.makedirs(dirname)
+                openfs.upload(target_path, read_file)
 
     def _resource_info_to_dict(self, dir_path, resource_info) -> AnyRemoteEntry:
         name = str(resource_info.name)

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -117,12 +117,14 @@ class PyFilesystem2FilesSource(BaseFilesSource[TTemplateConfig, TResolvedConfig]
                 openfs.download(source_path, write_file)
 
     def _write_from(self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[TResolvedConfig]):
-        with open(native_path, "rb") as read_file:
-            with self._open_fs(context) as openfs:
-                dirname = fs.path.dirname(target_path)
-                if not openfs.isdir(dirname):
-                    openfs.makedirs(dirname)
-                openfs.upload(target_path, read_file)
+        with (
+            open(native_path, "rb") as read_file,
+            self._open_fs(context) as openfs,
+        ):
+            dirname = fs.path.dirname(target_path)
+            if not openfs.isdir(dirname):
+                openfs.makedirs(dirname)
+            openfs.upload(target_path, read_file)
 
     def _resource_info_to_dict(self, dir_path, resource_info) -> AnyRemoteEntry:
         name = str(resource_info.name)


### PR DESCRIPTION
as already done in `_list`.

I guess _realize_to and _write_from will be called from jobs and celery jobs, i.e. the impact will be marginal, but its cleaner anyway..,

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
