### PR TITLE
[25.1] Add split paired or unpaired tool to sample tool conf

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -56,6 +56,7 @@
     <tool file="${model_tools_path}/convert_sample_sheet.xml" />
     <tool file="${model_tools_path}/extract_dataset.xml" />
     <tool file="${model_tools_path}/duplicate_file_to_collection.xml" />
+    <tool file="${model_tools_path}/split_paired_and_unpaired.xml" />
   </section>
   <section id="expression_tools" name="Expression Tools">
     <tool file="expression_tools/parse_values_from_file.xml"/>


### PR DESCRIPTION
tool is currently not available on usegalaxy.*

Follow up on https://github.com/galaxyproject/galaxy/pull/19377/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
