### PR TITLE
Remove sanitization from built-in grep tool

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5663,7 +5663,7 @@ For use with validator ``dataset_metadata_in_file``</xs:documentation>
       <xs:documentation xml:lang="en"><![CDATA[
 
 See
-[/tools/filters/grep.xml](https://github.com/galaxyproject/galaxy/blob/dev/tools/filters/grep.xml)
+[/tools/stats/filtering.xml](https://github.com/galaxyproject/galaxy/blob/dev/tools/stats/filtering.xml)
 for a typical example of how to use this tag set. This tag set is used to
 replace the basic parameter sanitization with custom directives. This tag set is
 contained within the ``<param>`` tag set - it contains a set of ``<valid>`` and

--- a/tools/filters/grep.xml
+++ b/tools/filters/grep.xml
@@ -1,10 +1,10 @@
-<tool id="Grep1" name="Select" version="1.0.4" profile="20.05">
+<tool id="Grep1" name="Select" version="1.0.5" profile="24.2">
   <description>lines that match an expression</description>
   <edam_operations>
     <edam_operation>operation_3695</edam_operation>
   </edam_operations>
   <requirements>
-    <requirement type="package" version="3.4">grep</requirement>
+    <requirement type="package" version="3.11">grep</requirement>
   </requirements>
   <stdio>
     <exit_code range="2:" level="warning" description="Select failed" />
@@ -29,10 +29,7 @@
       <option value="-v">NOT Matching</option>
     </param>
     <param name="pattern" type="text" value="^chr([0-9A-Za-z])+" label="the pattern" help="here you can enter text or regular expression (for syntax check lower part of this frame)">
-      <sanitizer>
-        <valid initial="string.printable">
-        </valid>
-      </sanitizer>
+      <sanitizer sanitize="false"/>
     </param>
     <param name="keep_header" type="boolean" truevalue="true" falsevalue="false" label="Keep header line" help="i.e. the first line is kept independent of the regular expression"/>
   </inputs>
@@ -100,6 +97,26 @@
         <assert_contents>
           <has_text text="chrX"/>
           <not_has_text text="chr1"/>
+        </assert_contents>
+      </output>
+    </test>
+    <!-- tests of non-ASCII character support -->
+    <test>
+      <param name="input" value="asian_chars_1.txt"/>
+      <param name="pattern" value=":制癌性物質"/>
+      <output name="out_file1">
+        <assert_contents>
+          <has_n_lines n="1"/>
+        </assert_contents>
+      </output>
+    </test>
+    <test>
+      <param name="input" value="asian_chars_1.txt"/>
+      <param name="invert" value="-v"/>
+      <param name="pattern" value=":制癌性物質"/>
+      <output name="out_file1">
+        <assert_contents>
+          <has_n_lines n="0"/>
         </assert_contents>
       </output>
     </test>

--- a/tools/filters/grep.xml
+++ b/tools/filters/grep.xml
@@ -1,10 +1,10 @@
-<tool id="Grep1" name="Select" version="1.0.5" profile="24.2">
+<tool id="Grep1" name="Select" version="1.0.4" profile="20.05">
   <description>lines that match an expression</description>
   <edam_operations>
     <edam_operation>operation_3695</edam_operation>
   </edam_operations>
   <requirements>
-    <requirement type="package" version="3.11">grep</requirement>
+    <requirement type="package" version="3.4">grep</requirement>
   </requirements>
   <stdio>
     <exit_code range="2:" level="warning" description="Select failed" />


### PR DESCRIPTION
## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

Since this tool reads the input from a config file, there is no real reason for sanitizing it. With the change users will be able to grep non-ASCII char patterns.