### PR TITLE
[25.1] Fix condor typo

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -213,7 +213,7 @@ class CondorJobRunner(AsynchronousJobRunner):
                 cjs.failed = True
                 self.work_queue.put((self.fail_job, cjs))
                 continue
-            cjs.runnning = job_running
+            cjs.running = job_running
             new_watched.append(cjs)
         # Replace the watch list with the updated version
         self.watched = new_watched


### PR DESCRIPTION
This was a small typo found in condor runner while I was analyzing the code (: 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
