### PR TITLE
Add tests for oidc usernames

### DIFF
--- a/test/integration/oidc/galaxy-realm-export.json
+++ b/test/integration/oidc/galaxy-realm-export.json
@@ -484,6 +484,40 @@
       "groups": []
     },
     {
+      "id": "f5e8b2c4-9a1d-4e3f-8c6a-7b2d5e4f3c1a",
+      "createdTimestamp": 1694376671733,
+      "username": "rincewind_test",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": true,
+      "firstName": "Rincewind",
+      "lastName": "Ankh-Morpork",
+      "email": "rincewind@galaxy.org",
+      "attributes": {
+        "preferred_username": [
+          "Rincewind (Ankh-Morpork)"
+        ]
+      },
+      "credentials": [
+        {
+          "id": "e5d4c3b2-a1f0-9e8d-7c6b-5a4f3e2d1c0b",
+          "type": "password",
+          "userLabel": "My password",
+          "createdDate": 1694376754826,
+          "secretData": "{\"value\":\"uNBI+UnpCLpXWHhm/tPSnnhuINiNw2MNt1XeDmImJaQ=\",\"salt\":\"fHS/FpnORylnSIco16UHwA==\",\"additionalParameters\":{}}",
+          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "galaxy-access-role",
+        "default-roles-gxyrealm"
+      ],
+      "notBefore": 0,
+      "groups": []
+    },
+    {
       "id": "24ffa3ff-d351-4d5e-b10b-8d615082ec9d",
       "createdTimestamp": 1694376671733,
       "username": "gxyuser_logged_in_once",

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -9,7 +9,6 @@ from typing import Dict
 import pytest
 
 from galaxy import util
-from galaxy.security.validate_user_input import validate_publicname_str
 from galaxy.util.json import safe_loads
 
 SECTION_XML = """<?xml version="1.0" ?>
@@ -203,21 +202,3 @@ def test_validate_doi_fail_too_long():
 def test_ready_name_for_url(input_name, expected_output):
     """Test that ready_name_for_url correctly sanitizes names for URL use."""
     assert util.ready_name_for_url(input_name) == expected_output
-
-
-@pytest.mark.parametrize(
-    "input_name",
-    [
-        "johndoe",
-        "John Doe",
-        "Rincewind (Ankh-Morpork)",
-        "user@example.com",
-        "Hello\u20a9\u25ce\u0491\u029f\u217e",
-        "   spaced   ",
-    ],
-)
-def test_ready_name_for_url_produces_valid_usernames(input_name):
-    """Test that ready_name_for_url().lower() produces valid Galaxy usernames."""
-    sanitized = util.ready_name_for_url(input_name).lower()
-    error = validate_publicname_str(sanitized)
-    assert error == "", f"'{input_name}' -> '{sanitized}' failed validation: {error}"


### PR DESCRIPTION
Adds more tests to ensure that oidc usernames conform to galaxy requirements.

Fixed in: https://github.com/galaxyproject/galaxy/pull/21234
closes: https://github.com/galaxyproject/galaxy/issues/20767

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
