### PR TITLE
[25.0] Fix data manager .loc file selection logic

### DIFF
--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -211,7 +211,7 @@ class ToolDataTable(Dictifiable):
         persist: bool = False,
         entry_source: EntrySource = None,
         tool_data_file_path: Optional[str] = None,
-        use_first_file_path: bool = False,
+        bundle_mode: bool = False,
         **kwd,
     ) -> None:
         raise NotImplementedError("Abstract method")
@@ -223,7 +223,7 @@ class ToolDataTable(Dictifiable):
         persist: bool = False,
         entry_source: EntrySource = None,
         tool_data_file_path: Optional[str] = None,
-        use_first_file_path: bool = False,
+        bundle_mode: bool = False,
         **kwd,
     ) -> int:
         self._add_entry(
@@ -232,7 +232,7 @@ class ToolDataTable(Dictifiable):
             persist=persist,
             entry_source=entry_source,
             tool_data_file_path=tool_data_file_path,
-            use_first_file_path=use_first_file_path,
+            bundle_mode=bundle_mode,
             **kwd,
         )
         return self._update_version()
@@ -670,7 +670,7 @@ class TabularToolDataTable(ToolDataTable):
         persist: bool = False,
         entry_source: EntrySource = None,
         tool_data_file_path: Optional[str] = None,
-        use_first_file_path: bool = False,
+        bundle_mode: bool = False,
         **kwd,
     ) -> None:
         # accepts dict or list of columns
@@ -703,19 +703,9 @@ class TabularToolDataTable(ToolDataTable):
             raise MessageException(
                 f"Attempted to add fields ({fields}) to data table '{self.name}', but there were not enough fields specified ( {len(fields)} < {self.largest_index + 1} )."
             )
-        filename = None
 
         if persist:
-            if tool_data_file_path is not None:
-                filename = tool_data_file_path
-                if os.path.realpath(filename) not in [os.path.realpath(n) for n in self.filenames]:
-                    raise MessageException(f"Path '{tool_data_file_path}' is not a known data table file path.")
-            elif not use_first_file_path:
-                filename = self.get_filename_for_source(entry_source)
-            else:
-                for name in self.filenames:
-                    filename = name
-                    break
+            filename = self._locate_filename(tool_data_file_path, entry_source, bundle_mode)
             if filename is None:
                 # If we reach this point, there is no data table with a corresponding .loc file.
                 raise MessageException(
@@ -741,6 +731,20 @@ class TabularToolDataTable(ToolDataTable):
                         raise
                 fields_collapsed = f"{self.separator.join(fields)}\n"
                 data_table_fh.write(fields_collapsed.encode("utf-8"))
+
+    def _locate_filename(self, tool_data_file_path, entry_source, bundle_mode):
+        if tool_data_file_path is not None:
+            filename = tool_data_file_path
+            if os.path.realpath(filename) not in [os.path.realpath(n) for n in self.filenames]:
+                raise MessageException(f"Path '{tool_data_file_path}' is not a known data table file path.")
+        else:
+            filename = self.get_filename_for_source(entry_source)
+            # If no filename was found, and we are in bundle mode, select the first filename from self.filenames
+            if filename is None and bundle_mode:
+                for name in self.filenames:
+                    filename = name
+                    break
+        return filename
 
     def _remove_entry(self, values):
         # update every file
@@ -1183,7 +1187,7 @@ class ToolDataTableManager(Dictifiable):
         bundle = DataTableBundle(**index)
         assert bundle.output_name
         out_data = {bundle.output_name: DirectoryAsExtraFiles(target_directory)}
-        return _process_bundle(out_data, bundle, options, self)
+        return _process_bundle(out_data, bundle, options, self, bundle_mode=True)
 
     def write_bundle(
         self,
@@ -1255,6 +1259,7 @@ def _process_bundle(
     bundle: DataTableBundle,
     options: BundleProcessingOptions,
     tool_data_tables: ToolDataTableManager,
+    bundle_mode: bool = False,
 ):
     updated_data_tables = []
     data_tables_dict = bundle.data_tables
@@ -1319,7 +1324,7 @@ def _process_bundle(
                 persist=True,
                 entry_source=bundle.repo_info,
                 tool_data_file_path=options.tool_data_file_path,
-                use_first_file_path=True,
+                bundle_mode=bundle_mode,
             )
         # Removes data table entries
         for data_table_row in data_table_remove_values:
@@ -1344,7 +1349,12 @@ def _process_bundle(
                 for name, value in data_table_row.items():
                     if name in path_column_names:
                         data_table_value[name] = os.path.abspath(os.path.join(options.data_manager_path, value))
-                data_table.add_entry(data_table_value, persist=True, entry_source=bundle.repo_info)
+                data_table.add_entry(
+                    data_table_value,
+                    persist=True,
+                    entry_source=bundle.repo_info,
+                    bundle_mode=bundle_mode,
+                )
             updated_data_tables.append(data_table_name)
     else:
         for data_table_name, data_table_values in data_tables_dict.items():

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -737,13 +737,12 @@ class TabularToolDataTable(ToolDataTable):
             filename = tool_data_file_path
             if os.path.realpath(filename) not in [os.path.realpath(n) for n in self.filenames]:
                 raise MessageException(f"Path '{tool_data_file_path}' is not a known data table file path.")
-        else:
+        elif not bundle_mode:
             filename = self.get_filename_for_source(entry_source)
-            # If no filename was found, and we are in bundle mode, select the first filename from self.filenames
-            if filename is None and bundle_mode:
-                for name in self.filenames:
-                    filename = name
-                    break
+        else:
+            for name in self.filenames:
+                filename = name
+                break
         return filename
 
     def _remove_entry(self, values):


### PR DESCRIPTION
This is a partial fix to the issues discussed in #20151:
- when a data manager is executed, the new entry will be added to the corresponding `.loc` file (which fixes the key issue described in #20151)
- when a data bundle is imported:
 UPDATE [edit based on code review]: ~~- if the exact same version of the data manager used to create the bundle is present on the target galaxy instance, the corresponding `.loc` file is selected;~~
the first available `.loc` file is selected from the tool data table config file (which happens now for all cases). The file is selected based on the order in which data table config filenames were inserterted into `tool_util.data.ToolDataTable.filenames` (dictionaries iterated in item insertion order starting with Python 3.6+). 
 
This may or may not be the optimal behavior when importing a tool data bundle, but, unless I'm misunderstanding the intended behavior, this does fix the immediate issue of data managers writing to the wrong `.loc` file (unless the correct file happened to be inserted first). 

I've renamed the `use_first_file_path` to `bundle_mode` to decouple the variable name from how we handle data bundle import.

I've tested this locally in both data manager and data bundle modes in the context of several different DM/tool data configurations.







## How to test the changes?
Instructions for manual testing are as follows:
  1. Install tool: crossmap_wig
  2. Install data manager: data_manager_fetch_genome_dbkeys_all_fasta
  3. Verify that in your `shed_tool_data_table_conf.xml`, the entries for the tool preceed the entries for the data manager
  4. Run the data manager to fetch some data ([example](https://training.galaxyproject.org/training-material/topics/admin/tutorials/reference-genomes/tutorial.html#download-and-install-a-reference-genome-sequence))
  5. Prior to this fix, the `.loc` file for crossmap_wig would have been updated (which is incorrect). With this fix, the data manager .loc file is updated.
 
Testing bundles is more involved. I've tested importing bundles with and without the fix for the following cases:
- data manager not installed
- data manager installed, but the version is not the same as the version used to created the bundle
- data manager of the correct version installed


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
