### PR TITLE
Fix incorrect router tag in plugins API

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -63,7 +63,7 @@ from galaxy.work.context import SessionRequestContext
 
 log = logging.getLogger(__name__)
 
-router = Router(tags=["jobs"])
+router = Router(tags=["plugins"])
 
 GALAXY_PROMPT = """
 You are a Galaxy agent.


### PR DESCRIPTION
The plugins API router was tagged as `jobs`, which is... not what plugins are. Now correctly tagged as `plugins` so these endpoints show up in the right section of the OpenAPI docs.

Introduced in #21612.