### PR TITLE
Add missing types to visualization model

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -24897,6 +24897,15 @@ export interface components {
         /** VisualizationPluginResponse */
         VisualizationPluginResponse: {
             /**
+             * Data Sources
+             * @description The data sources of the plugin.
+             */
+            data_sources?:
+                | {
+                      [key: string]: unknown;
+                  }[]
+                | null;
+            /**
              * Description
              * @description The description of the plugin.
              */
@@ -24913,6 +24922,11 @@ export interface components {
             entry_point: {
                 [key: string]: unknown;
             };
+            /**
+             * Help
+             * @description The help text of the plugin.
+             */
+            help?: string | null;
             /**
              * Href
              * @description The href of the plugin.
@@ -24934,6 +24948,13 @@ export interface components {
              */
             name: string;
             /**
+             * Params
+             * @description The parameters of the plugin.
+             */
+            params?: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Settings
              * @description The settings of the plugin.
              */
@@ -24949,6 +24970,20 @@ export interface components {
             specs?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * Tags
+             * @description The tags of the plugin.
+             */
+            tags?: string[] | null;
+            /**
+             * Tests
+             * @description The tests of the plugin.
+             */
+            tests?:
+                | {
+                      [key: string]: unknown;
+                  }[]
+                | null;
             /**
              * Title
              * @description The title of the plugin.

--- a/lib/galaxy/schema/visualization.py
+++ b/lib/galaxy/schema/visualization.py
@@ -188,6 +188,31 @@ class VisualizationPluginResponse(Model):
         title="Specs",
         description="The specs of the plugin.",
     )
+    params: Optional[dict] = Field(
+        None,
+        title="Params",
+        description="The parameters of the plugin.",
+    )
+    data_sources: Optional[list[dict]] = Field(
+        None,
+        title="Data Sources",
+        description="The data sources of the plugin.",
+    )
+    help: Optional[str] = Field(
+        None,
+        title="Help",
+        description="The help text of the plugin.",
+    )
+    tags: Optional[list[str]] = Field(
+        None,
+        title="Tags",
+        description="The tags of the plugin.",
+    )
+    tests: Optional[list[dict]] = Field(
+        None,
+        title="Tests",
+        description="The tests of the plugin.",
+    )
     href: str = Field(
         ...,
         title="Href",

--- a/test/integration/test_plugins.py
+++ b/test/integration/test_plugins.py
@@ -56,10 +56,6 @@ class TestVisualizationPluginsApi(IntegrationTestCase):
         assert "dataset_id" in params
         assert params["dataset_id"]["required"] is True
         assert params["dataset_id"]["type"] == "str"
-        assert "limit" in params
-        assert params["limit"]["required"] is False
-        assert params["limit"]["type"] == "int"
-        assert params["limit"]["default"] == "10"
 
         # Verify data_sources are returned
         assert "data_sources" in plugin

--- a/test/integration/test_visualization_plugins/jupyterlite/static/jupyterlite.xml
+++ b/test/integration/test_visualization_plugins/jupyterlite/static/jupyterlite.xml
@@ -8,7 +8,6 @@
     </data_sources>
     <params>
         <param required="true">dataset_id</param>
-        <param type="int" required="false" default="10">limit</param>
     </params>
     <entry_point entry_point_type="script" src="script.js" />
     <specs>

--- a/test/integration/test_visualization_plugins/jupyterlite/static/jupyterlite.xml
+++ b/test/integration/test_visualization_plugins/jupyterlite/static/jupyterlite.xml
@@ -1,13 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <visualization name="JupyterLite Test" hidden="true">
-    <description>Test fixture for AI chat integration tests</description>
+    <description>Test fixture for visualization plugin integration tests</description>
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>
         </data_source>
     </data_sources>
+    <params>
+        <param required="true">dataset_id</param>
+        <param type="int" required="false" default="10">limit</param>
+    </params>
     <entry_point entry_point_type="script" src="script.js" />
     <specs>
         <ai_prompt>test prompt</ai_prompt>
+        <custom_setting>test_value</custom_setting>
     </specs>
+    <tags>
+        <tag>Test</tag>
+        <tag>Integration</tag>
+    </tags>
+    <help>This is test help text for the JupyterLite test plugin.</help>
+    <tests>
+        <test>
+            <param name="dataset_id" value="test.tabular" />
+        </test>
+    </tests>
 </visualization>


### PR DESCRIPTION
Add missing typing to the visualization model and tests to ensure all required attributes are serialized.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Navigate to a visualization
  2. Notice the missing help content

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
