### PR TITLE
Return redirection instead of a JSON with the redirect URI

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -88,7 +88,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
 
     # Authentication endpoints.
     if app.config.enable_oidc:
-        webapp.add_route("/authnz/", controller="authnz", action="index", provider=None)
+        webapp.add_route("/authnz/", controller="authnz", action="index", provider=None, redirect=None)
         webapp.add_route("/authnz/{provider}/login", controller="authnz", action="login", provider=None)
         webapp.add_route("/authnz/{provider}/callback", controller="authnz", action="callback", provider=None)
         webapp.add_route(

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -78,7 +78,7 @@ class OIDC(BaseUIController):
 
     @web.json
     @web.expose
-    def login(self, trans, provider, idphint=None, next=None, **kwargs):
+    def login(self, trans, provider, idphint=None, next=None, redirect=None):
         if not trans.app.config.enable_oidc:
             msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance."
             log.debug(msg)
@@ -90,7 +90,7 @@ class OIDC(BaseUIController):
             trans.set_cookie(value="/", name=LOGIN_NEXT_COOKIE_NAME)
         success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans, idphint)
         if success:
-            if kwargs.get("redirect", None) == "true":
+            if redirect and redirect.lower() == "true":
                 return trans.response.send_redirect(redirect_uri)
             else:
                 return {"redirect_uri": redirect_uri}

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -78,7 +78,7 @@ class OIDC(BaseUIController):
 
     @web.json
     @web.expose
-    def login(self, trans, provider, idphint=None, next=None):
+    def login(self, trans, provider, idphint=None, next=None, **kwargs):
         if not trans.app.config.enable_oidc:
             msg = "Login to Galaxy using third-party identities is not enabled on this Galaxy instance."
             log.debug(msg)
@@ -90,7 +90,10 @@ class OIDC(BaseUIController):
             trans.set_cookie(value="/", name=LOGIN_NEXT_COOKIE_NAME)
         success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans, idphint)
         if success:
-            return {"redirect_uri": redirect_uri}
+            if kwargs.get("redirect", None) == "true":
+                return trans.response.send_redirect(redirect_uri)
+            else:
+                return {"redirect_uri": redirect_uri}
         else:
             raise exceptions.AuthenticationFailed(message)
 


### PR DESCRIPTION
Return redirection instead of a JSON with the redirect URI.

In order to keep all existing functionality, adds a new param `redirect` that if set to `true` it will return a HTTP redirect 302 with the expected URI to start the authentication process. This is useful to get users authenticated directly without the need to go through clicking the button.

Deals with #21129 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
