### PR TITLE
Improve history multiview UX with load more option

### DIFF
--- a/client/src/components/History/Multiple/MultipleView.test.js
+++ b/client/src/components/History/Multiple/MultipleView.test.js
@@ -98,4 +98,47 @@ describe("MultipleView", () => {
         // Test: current (first) history should be shown because only 4 latest are shown by default, and count = 3
         expect(wrapper.find("button[title='Current History']").exists()).toBeTruthy();
     });
+
+    it("load more button is shown when histories exceed the display limit", async () => {
+        const wrapper = await setUpWrapper(8, FIRST_HISTORY_ID);
+        expect(wrapper.find(".load-more-picker").exists()).toBeTruthy();
+    });
+
+    it("load more button is hidden when all histories fit within the display limit", async () => {
+        const wrapper = await setUpWrapper(3, FIRST_HISTORY_ID);
+        expect(wrapper.find(".load-more-picker").exists()).toBeFalsy();
+    });
+
+    it("clicking load more expands displayed histories and hides the button when all are shown", async () => {
+        const wrapper = await setUpWrapper(8, FIRST_HISTORY_ID);
+
+        // Initially 4 of 8 shown; load more is visible
+        expect(wrapper.find(".load-more-picker").exists()).toBeTruthy();
+        expect(wrapper.find("div[title='Currently showing 4 most recently updated histories']").exists()).toBeTruthy();
+
+        await wrapper.find(".load-more-picker").trigger("click");
+        await flushPromises();
+
+        // All 8 now shown; load more is gone and title reflects new count
+        expect(wrapper.find(".load-more-picker").exists()).toBeFalsy();
+        expect(wrapper.find("div[title='Currently showing 8 most recently updated histories']").exists()).toBeTruthy();
+    });
+
+    it("clicking load more multiple times progressively shows more histories", async () => {
+        const wrapper = await setUpWrapper(12, FIRST_HISTORY_ID);
+
+        expect(wrapper.find("div[title='Currently showing 4 most recently updated histories']").exists()).toBeTruthy();
+
+        // First click: 4 → 8; load more still present since 12 > 8
+        await wrapper.find(".load-more-picker").trigger("click");
+        await flushPromises();
+        expect(wrapper.find(".load-more-picker").exists()).toBeTruthy();
+        expect(wrapper.find("div[title='Currently showing 8 most recently updated histories']").exists()).toBeTruthy();
+
+        // Second click: 8 → 12; load more gone since 12 === 12
+        await wrapper.find(".load-more-picker").trigger("click");
+        await flushPromises();
+        expect(wrapper.find(".load-more-picker").exists()).toBeFalsy();
+        expect(wrapper.find("div[title='Currently showing 12 most recently updated histories']").exists()).toBeTruthy();
+    });
 });

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -24,7 +24,8 @@ const filter = ref("");
 const showAdvanced = ref(false);
 const showSelectModal = ref(false);
 const initialLoaded = ref(false);
-const displayCount = ref(4);
+const DISPLAY_INCREMENT = 4;
+const displayCount = ref(DISPLAY_INCREMENT);
 
 const { currentUser } = storeToRefs(useUserStore());
 const { histories, currentHistory, historiesLoading } = storeToRefs(useHistoryStore());
@@ -63,7 +64,7 @@ const canLoadMore = computed(() => {
 });
 
 function loadMore() {
-    displayCount.value += 4;
+    displayCount.value += DISPLAY_INCREMENT;
 }
 
 // On mounted, wait for history store to load, then set `initialLoaded` to true
@@ -113,8 +114,8 @@ const showRecentTitle = computed(() => {
     }
 });
 
-/** Reset to _default_ state; showing 4 latest updated histories */
 function showRecent() {
+    displayCount.value = DISPLAY_INCREMENT;
     historyStore.clearPinnedHistories();
     Toast.info(
         `Showing the ${displayCount.value} most recently updated histories. Pin histories to this view by clicking on Select Histories.`,

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -107,9 +107,9 @@ function addHistoriesToList(incomingHistories: PinnedHistory[]) {
 
 const showRecentTitle = computed(() => {
     if (hasPinnedHistories.value) {
-        return localize("Show 4 most recently updated histories instead");
+        return localize(`Show ${displayCount.value} most recently updated histories instead`);
     } else {
-        return localize("Currently showing 4 most recently updated histories");
+        return localize(`Currently showing ${displayCount.value} most recently updated histories`);
     }
 });
 
@@ -117,7 +117,7 @@ const showRecentTitle = computed(() => {
 function showRecent() {
     historyStore.clearPinnedHistories();
     Toast.info(
-        "Showing the 4 most recently updated histories. Pin histories to this view by clicking on Select Histories.",
+        `Showing the ${displayCount.value} most recently updated histories. Pin histories to this view by clicking on Select Histories.`,
         "History Multiview",
     );
 }

--- a/client/src/components/History/Multiple/MultipleViewList.vue
+++ b/client/src/components/History/Multiple/MultipleViewList.vue
@@ -80,7 +80,7 @@ async function onKeyDown(evt: KeyboardEvent) {
         <div ref="scrollContainer" class="d-flex h-100 w-auto overflow-auto">
             <VirtualList
                 v-if="props.selectedHistories.length"
-                :estimate-size="props.selectedHistories.length"
+                :estimate-size="240"
                 :data-key="'id'"
                 :data-component="MultipleViewItem"
                 :data-sources="props.selectedHistories"

--- a/client/src/components/Panels/MultiviewPanel.vue
+++ b/client/src/components/Panels/MultiviewPanel.vue
@@ -35,9 +35,9 @@ const pinnedHistoryCount = computed(() => {
 
 const pinRecentTitle = computed(() => {
     if (pinnedHistoryCount.value > 0) {
-        return localize("Reset selection to show 4 most recently updated histories instead");
+        return localize("Reset selection to show most recently updated histories instead");
     } else {
-        return localize("Currently showing 4 most recently updated histories in Multiview");
+        return localize("Currently showing most recently updated histories in Multiview");
     }
 });
 
@@ -70,11 +70,11 @@ async function createAndPin() {
     }
 }
 
-/** Reset to _default_ state; showing 4 latest updated histories */
+/** Reset to _default_ state; showing latest updated histories */
 function pinRecent() {
     historyStore.clearPinnedHistories();
     Toast.info(
-        "Showing the 4 most recently updated histories in Multiview. Pin histories to History Multiview by selecting them in the panel.",
+        "Showing the most recently updated histories in Multiview. Pin histories to History Multiview by selecting them in the panel.",
         "History Multiview",
     );
 }

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -53,7 +53,7 @@ class TestHistoryMultiView(SeleniumTestCase):
         self.prepare_multi_history_view(method)
         # The multi-history view is incredibly hard to navigate around (in UI and testing)
         # We just create a new history with the dropped element here.
-        drop_target = self.find_element_by_selector("div.history-picker-box.bottom-picker")
+        drop_target = self.find_element_by_selector("div.history-picker-box.select-picker")
         dataset_element = self.history_panel_wait_for_hid_state(list_of_list_source_hid, None).wait_for_visible()
         ac = self.action_chains()
         ac = ac.move_to_element(dataset_element).click_and_hold()


### PR DESCRIPTION
One minor bug, one enhancement (or ux bugfix?).  I can retarget 26.0 if we want.  Reported by @natefoo in https://matrix.to/#/!XciPHtOkuKNqKoVeKD:gitter.im/$Pt3Z1-L_HNdh6-pFXr6vPpPuqj_IXy8ldv5FXZ-7GBc?via=gitter.im&via=matrix.org&via=matrix.midnightmechanism.xyz

## Summary
- Fix virtual scroll estimate-size bug that could cause layout issues
- Add "Load more" button so users can easily see more than the default 4 histories without opening the full selection modal

## Context
Users were confused by the side-by-side history view only showing 4 histories by default, with blank scrollable space where they expected more. The limit is intentional (performance), but the UX didn't make it obvious how to see more.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
