### PR TITLE
[25.1] Fix private dataset sharing error handling

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4502,7 +4502,7 @@ class Dataset(Base, StorableObject, Serializable):
 
     def ensure_shareable(self):
         if not self.shareable:
-            raise Exception(CANNOT_SHARE_PRIVATE_DATASET_MESSAGE)
+            raise galaxy.exceptions.MessageException(CANNOT_SHARE_PRIVATE_DATASET_MESSAGE)
 
     def get_file_name(self, sync_cache: bool = True) -> str:
         if self.purged:
@@ -5906,7 +5906,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         Copy this HDA to a library optionally replacing an existing LDDA.
         """
         if not self.dataset.shareable:
-            raise Exception("Attempting to share a non-shareable dataset.")
+            raise Exception(CANNOT_SHARE_PRIVATE_DATASET_MESSAGE)
 
         if replace_dataset:
             # The replace_dataset param ( when not None ) refers to a LibraryDataset that


### PR DESCRIPTION
Fixes #21684

We still should consider how to communicate this case to the user and offer a viable solution.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #21684
  - You should see the correct error message instead of "500".

<img width="769" height="495" alt="Screenshot from 2026-01-29 11-32-26" src="https://github.com/user-attachments/assets/4c04638f-fce5-432b-8231-4eed4ae81451" />


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
