### PR TITLE
[26.0] Standardize agent API schemas and response metadata

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7243,6 +7243,8 @@ export interface components {
         /**
          * AgentQueryRequest
          * @description Request to query an AI agent.
+         *
+         *     DEPRECATED: Use /api/chat instead for new integrations.
          */
         AgentQueryRequest: {
             /**
@@ -7263,16 +7265,12 @@ export interface components {
              * @description The user's question or request
              */
             query: string;
-            /**
-             * Stream
-             * @description Whether to stream the response
-             * @default false
-             */
-            stream: boolean;
         };
         /**
          * AgentQueryResponse
          * @description Response from an AI agent query.
+         *
+         *     DEPRECATED: Use /api/chat instead for new integrations.
          */
         AgentQueryResponse: {
             /**
@@ -7282,13 +7280,6 @@ export interface components {
             processing_time?: number | null;
             /** @description The agent's response */
             response: components["schemas"]["AgentResponse"];
-            /**
-             * Routing Info
-             * @description Information about how the query was routed
-             */
-            routing_info?: {
-                [key: string]: unknown;
-            } | null;
         };
         /**
          * AgentResponse
@@ -7775,6 +7766,12 @@ export interface components {
              * @description Description of the error or problem
              */
             query: string;
+            /**
+             * Save Exchange
+             * @description Save exchange for feedback tracking
+             * @default false
+             */
+            save_exchange: boolean;
         };
         /** Body_create_api_histories_post */
         Body_create_api_histories_post: {
@@ -7811,6 +7808,12 @@ export interface components {
              * @description Description of the tool to create
              */
             query: string;
+            /**
+             * Save Exchange
+             * @description Save exchange for feedback tracking
+             * @default false
+             */
+            save_exchange: boolean;
         };
         /** Body_create_form_api_libraries__library_id__contents_post */
         Body_create_form_api_libraries__library_id__contents_post: {
@@ -8232,16 +8235,20 @@ export interface components {
              * @description The query to be sent to the chatbot.
              */
             query: string;
+            /**
+             * Regenerate
+             * @description Force fresh analysis even if a cached response exists (for job-based queries).
+             * @default false
+             */
+            regenerate: boolean;
         };
         /** ChatResponse */
         ChatResponse: {
             /**
              * Agent Response
-             * @description Full agent response with metadata and suggestions.
+             * @description Full structured agent response with metadata and suggestions.
              */
-            agent_response?: {
-                [key: string]: unknown;
-            } | null;
+            agent_response?: components["schemas"]["AgentResponse"] | null;
             /**
              * Error Code
              * @description The error code, if any, for the chat query.
@@ -8257,6 +8264,11 @@ export interface components {
              * @description The ID of the chat exchange for continuing conversations.
              */
             exchange_id?: number | null;
+            /**
+             * Processing Time
+             * @description Time taken to process the query in seconds.
+             */
+            processing_time?: number | null;
             /**
              * Response
              * @description The response to the chat query.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7307,6 +7307,8 @@ export interface components {
              * @description Main response content
              */
             content: string;
+            /** @description Handoff information if response was delegated */
+            handoff?: components["schemas"]["HandoffInfo"] | null;
             /**
              * Metadata
              * @description Additional metadata
@@ -8234,6 +8236,13 @@ export interface components {
         /** ChatResponse */
         ChatResponse: {
             /**
+             * Agent Response
+             * @description Full agent response with metadata and suggestions.
+             */
+            agent_response?: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Error Code
              * @description The error code, if any, for the chat query.
              */
@@ -8243,6 +8252,11 @@ export interface components {
              * @description The error message, if any, for the chat query.
              */
             error_message: string | null;
+            /**
+             * Exchange ID
+             * @description The ID of the chat exchange for continuing conversations.
+             */
+            exchange_id?: number | null;
             /**
              * Response
              * @description The response to the chat query.
@@ -14785,6 +14799,27 @@ export interface components {
              * @default 0
              */
             waiting: number;
+        };
+        /**
+         * HandoffInfo
+         * @description Information about agent-to-agent handoffs.
+         */
+        HandoffInfo: {
+            /**
+             * Reason
+             * @description Reason for the handoff
+             */
+            reason?: string | null;
+            /**
+             * Source Agent
+             * @description Agent that initiated the handoff
+             */
+            source_agent: string;
+            /**
+             * Target Agent
+             * @description Agent that received the handoff
+             */
+            target_agent: string;
         };
         /**
          * HashFunctionNameEnum

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7099,7 +7099,7 @@ export interface components {
          * @description Types of actions agents can suggest.
          * @enum {string}
          */
-        ActionType: "tool_run" | "documentation" | "contact_support" | "view_external" | "save_tool" | "refine_query";
+        ActionType: "tool_run" | "save_tool" | "contact_support" | "view_external" | "documentation";
         /** AddInputAction */
         AddInputAction: {
             /**
@@ -7298,8 +7298,6 @@ export interface components {
              * @description Main response content
              */
             content: string;
-            /** @description Handoff information if response was delegated */
-            handoff?: components["schemas"]["HandoffInfo"] | null;
             /**
              * Metadata
              * @description Additional metadata
@@ -14808,27 +14806,6 @@ export interface components {
              * @default 0
              */
             waiting: number;
-        };
-        /**
-         * HandoffInfo
-         * @description Information about agent-to-agent handoffs.
-         */
-        HandoffInfo: {
-            /**
-             * Reason
-             * @description Reason for the handoff
-             */
-            reason?: string | null;
-            /**
-             * Source Agent
-             * @description Agent that initiated the handoff
-             */
-            source_agent: string;
-            /**
-             * Target Agent
-             * @description Agent that received the handoff
-             */
-            target_agent: string;
         };
         /**
          * HashFunctionNameEnum

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7768,10 +7768,9 @@ export interface components {
             query: string;
             /**
              * Save Exchange
-             * @description Save exchange for feedback tracking
-             * @default false
+             * @description Save exchange for feedback tracking. Defaults to false.
              */
-            save_exchange: boolean;
+            save_exchange?: boolean | null;
         };
         /** Body_create_api_histories_post */
         Body_create_api_histories_post: {
@@ -7810,10 +7809,9 @@ export interface components {
             query: string;
             /**
              * Save Exchange
-             * @description Save exchange for feedback tracking
-             * @default false
+             * @description Save exchange for feedback tracking. Defaults to false.
              */
-            save_exchange: boolean;
+            save_exchange?: boolean | null;
         };
         /** Body_create_form_api_libraries__library_id__contents_post */
         Body_create_form_api_libraries__library_id__contents_post: {
@@ -8237,10 +8235,9 @@ export interface components {
             query: string;
             /**
              * Regenerate
-             * @description Force fresh analysis even if a cached response exists (for job-based queries).
-             * @default false
+             * @description Force fresh analysis even if a cached response exists (for job-based queries). Defaults to false if not provided.
              */
-            regenerate: boolean;
+            regenerate?: boolean | null;
         };
         /** ChatResponse */
         ChatResponse: {

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -310,7 +310,7 @@ class BaseGalaxyAgent(ABC):
         if validation_error:
             return AgentResponse(
                 content=validation_error,
-                confidence="low",
+                confidence=ConfidenceLevel.LOW,
                 agent_type=self.agent_type,
                 suggestions=[],
                 metadata={"validation_error": True},

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -511,7 +511,7 @@ class BaseGalaxyAgent(ABC):
     def _build_response(
         self,
         content: str,
-        confidence: Union[str, ConfidenceLevel],
+        confidence: ConfidenceLevel,
         method: str,
         result: Any = None,
         query: Optional[str] = None,

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -519,6 +519,7 @@ class BaseGalaxyAgent(ABC):
         agent_data: Optional[dict[str, Any]] = None,
         fallback: bool = False,
         error: Optional[str] = None,
+        reasoning: Optional[str] = None,
     ) -> AgentResponse:
         """
         Build an AgentResponse with metadata filled in.
@@ -531,6 +532,7 @@ class BaseGalaxyAgent(ABC):
             agent_type=self.agent_type,
             suggestions=suggestions or [],
             metadata=self._build_metadata(method, result, query, agent_data, fallback, error),
+            reasoning=reasoning,
         )
 
     def _supports_structured_output(self) -> bool:

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -821,26 +821,11 @@ class SimpleGalaxyAgent(BaseGalaxyAgent):
             return ConfidenceLevel.MEDIUM
 
     def _extract_suggestions(self, content: str) -> list[ActionSuggestion]:
-        """Extract action suggestions from response content."""
-        suggestions = []
+        """Extract action suggestions from response content.
 
-        # Simple heuristics to extract suggestions
-        if "try" in content.lower() or "recommend" in content.lower():
-            suggestions.append(
-                ActionSuggestion(
-                    action_type=ActionType.TOOL_RUN,
-                    description="Follow the suggested approach",
-                    confidence=ConfidenceLevel.MEDIUM,
-                )
-            )
-
-        if "documentation" in content.lower() or "manual" in content.lower():
-            suggestions.append(
-                ActionSuggestion(
-                    action_type=ActionType.DOCUMENTATION,
-                    description="Check the relevant documentation",
-                    confidence=ConfidenceLevel.MEDIUM,
-                )
-            )
-
-        return suggestions
+        Returns empty list by default - subclasses should override to provide
+        meaningful, actionable suggestions with proper parameters.
+        """
+        # Don't create vague suggestions from keyword matching.
+        # Suggestions should be concrete, executable Galaxy actions.
+        return []

--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -17,7 +17,6 @@ from pydantic_ai import Agent
 from galaxy.schema.agents import ConfidenceLevel
 from .base import (
     ActionSuggestion,
-    ActionType,
     AgentResponse,
     AgentType,
     BaseGalaxyAgent,
@@ -383,14 +382,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
             "content": "\n\n".join(content_parts),
             "confidence": confidence_level,
             "error_category": error_type.group(1).strip() if error_type else "unknown",
-            "suggestions": [
-                ActionSuggestion(
-                    action_type=ActionType.CONTACT_SUPPORT,
-                    description="Get additional help if this doesn't resolve the issue",
-                    confidence=ConfidenceLevel.MEDIUM,
-                    priority=2,
-                )
-            ],
+            "suggestions": [],
         }
 
     def _get_fallback_content(self) -> str:

--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -322,23 +322,23 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
         """Create action suggestions from analysis result."""
         suggestions = []
 
-        # Primary solution
+        # Primary solution - use REFINE_QUERY since this is guidance, not a specific tool
         if analysis.solution_steps:
             suggestions.append(
                 ActionSuggestion(
-                    action_type=ActionType.TOOL_RUN,
-                    description=f"Follow the {len(analysis.solution_steps)}-step solution",
+                    action_type=ActionType.REFINE_QUERY,
+                    description=f"Follow the {len(analysis.solution_steps)}-step solution above",
                     confidence=analysis.confidence,
                     priority=1,
                 )
             )
 
-        # Alternative approaches
+        # Alternative approaches - also guidance
         for approach in analysis.alternative_approaches[:2]:  # Limit to 2 alternatives
             suggestions.append(
                 ActionSuggestion(
-                    action_type=ActionType.TOOL_RUN,
-                    description=f"Try alternative: {approach[:100]}...",
+                    action_type=ActionType.REFINE_QUERY,
+                    description=f"Try alternative: {approach[:100]}",
                     confidence="medium",
                     priority=2,
                 )

--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -323,34 +323,12 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
 
         Only creates suggestions for concrete, executable Galaxy actions.
         General guidance (solution steps, alternatives) is in the response content.
+
+        Currently returns empty - future work could add:
+        - CONTACT_SUPPORT with pre-filled context when requires_admin=True
+        - TOOL_RUN with specific tool_id if we can suggest rerunning with different params
         """
-        suggestions = []
-
-        # Admin contact if needed - this is an actionable suggestion
-        if analysis.requires_admin:
-            # Build context message for support request
-            message_parts = [
-                f"Error Type: {analysis.error_category}",
-                f"Severity: {analysis.error_severity}",
-                f"Likely Cause: {analysis.likely_cause}",
-            ]
-            if analysis.solution_steps:
-                message_parts.append(f"Attempted Solutions: {'; '.join(analysis.solution_steps)}")
-
-            suggestions.append(
-                ActionSuggestion(
-                    action_type=ActionType.CONTACT_SUPPORT,
-                    description="Contact Galaxy administrator",
-                    parameters={"message": "\n".join(message_parts)},
-                    confidence="high",
-                    priority=1,
-                )
-            )
-
-        # Future: could add TOOL_RUN suggestions with specific tool_id
-        # if we have job context and can suggest rerunning with different params
-
-        return suggestions
+        return []
 
     def _get_simple_system_prompt(self) -> str:
         """Simple system prompt for models without structured output."""

--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -17,6 +17,7 @@ from pydantic_ai import Agent
 from galaxy.schema.agents import ConfidenceLevel
 from .base import (
     ActionSuggestion,
+    ActionType,
     AgentResponse,
     AgentType,
     BaseGalaxyAgent,
@@ -322,12 +323,20 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
 
         Only creates suggestions for concrete, executable Galaxy actions.
         General guidance (solution steps, alternatives) is in the response content.
-
-        Currently returns empty - future work could add:
-        - CONTACT_SUPPORT with pre-filled context when requires_admin=True
-        - TOOL_RUN with specific tool_id if we can suggest rerunning with different params
         """
-        return []
+        suggestions = []
+
+        if analysis.requires_admin:
+            suggestions.append(
+                ActionSuggestion(
+                    action_type=ActionType.CONTACT_SUPPORT,
+                    description="Contact Galaxy administrator for assistance",
+                    confidence=ConfidenceLevel.HIGH,
+                    priority=1,
+                )
+            )
+
+        return suggestions
 
     def _get_simple_system_prompt(self) -> str:
         """Simple system prompt for models without structured output."""

--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -241,7 +241,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
 
                 return self._build_response(
                     content=content,
-                    confidence=analysis_result.confidence,
+                    confidence=ConfidenceLevel(analysis_result.confidence),
                     method="structured",
                     result=result,
                     query=query,
@@ -376,15 +376,18 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
         if not content_parts:
             content_parts = [normalized_text]  # Fallback to full response
 
+        conf_str = confidence.group(1).lower() if confidence else "medium"
+        confidence_level = ConfidenceLevel(conf_str)
+
         return {
             "content": "\n\n".join(content_parts),
-            "confidence": confidence.group(1).lower() if confidence else "medium",
+            "confidence": confidence_level,
             "error_category": error_type.group(1).strip() if error_type else "unknown",
             "suggestions": [
                 ActionSuggestion(
                     action_type=ActionType.CONTACT_SUPPORT,
                     description="Get additional help if this doesn't resolve the issue",
-                    confidence="medium",
+                    confidence=ConfidenceLevel.MEDIUM,
                     priority=2,
                 )
             ],

--- a/lib/galaxy/agents/orchestrator.py
+++ b/lib/galaxy/agents/orchestrator.py
@@ -106,12 +106,12 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
             # Combine responses
             combined_content = self._combine_responses(responses, plan.reasoning)
 
-            return AgentResponse(
+            return self._build_response(
                 content=combined_content,
                 confidence=ConfidenceLevel.HIGH,
-                agent_type=self.agent_type,
-                suggestions=[],
-                metadata={
+                method="orchestrated",
+                query=query,
+                agent_data={
                     "agents_used": plan.agents,
                     "execution_type": "sequential" if plan.sequential else "parallel",
                     "reasoning": plan.reasoning,

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -8,6 +8,7 @@ Uses pydantic-ai output functions to either:
 - Hand off to tool_recommendation for tool discovery
 """
 
+import json
 import logging
 from pathlib import Path
 from typing import (
@@ -78,6 +79,30 @@ class QueryRouterAgent(BaseGalaxyAgent):
         prompt_path = Path(__file__).parent / "prompts" / "router.md"
         return prompt_path.read_text()
 
+    def _serialize_handoff(self, response: AgentResponse, target_agent: str) -> str:
+        """
+        Wrap a delegated agent's response in JSON so we can pass it back through
+        the router's output function while keeping all the metadata intact.
+        """
+        return json.dumps(
+            {
+                "__handoff__": True,
+                "content": response.content,
+                "agent_type": response.agent_type,
+                "confidence": (
+                    response.confidence.value if hasattr(response.confidence, "value") else response.confidence
+                ),
+                "metadata": response.metadata,
+                "suggestions": [
+                    s.model_dump() if hasattr(s, "model_dump") else s for s in (response.suggestions or [])
+                ],
+                "handoff_info": {
+                    "source_agent": self.agent_type,
+                    "target_agent": target_agent,
+                },
+            }
+        )
+
     def _create_error_analysis_handoff(self):
         """Create output function for error analysis handoff."""
 
@@ -102,18 +127,8 @@ class QueryRouterAgent(BaseGalaxyAgent):
 
             try:
                 agent = ErrorAnalysisAgent(ctx.deps)
-
-                # Pass conversation history if available
-                message_history = ctx.messages[:-1] if hasattr(ctx, "messages") and ctx.messages else None
-
-                result = await agent.agent.run(
-                    task,
-                    deps=ctx.deps,
-                    usage=ctx.usage,
-                    message_history=message_history,
-                )
-
-                return extract_result_content(result)
+                response = await agent.process(task)
+                return self._serialize_handoff(response, "error_analysis")
             except Exception as e:
                 log.error(f"Error analysis handoff failed: {e}")
                 return (
@@ -149,18 +164,8 @@ class QueryRouterAgent(BaseGalaxyAgent):
 
             try:
                 agent = CustomToolAgent(ctx.deps)
-
-                # Pass conversation history if available
-                message_history = ctx.messages[:-1] if hasattr(ctx, "messages") and ctx.messages else None
-
-                result = await agent.agent.run(
-                    request,
-                    deps=ctx.deps,
-                    usage=ctx.usage,
-                    message_history=message_history,
-                )
-
-                return extract_result_content(result)
+                response = await agent.process(request)
+                return self._serialize_handoff(response, "custom_tool")
             except Exception as e:
                 log.error(f"Custom tool handoff failed: {e}")
                 return (
@@ -198,8 +203,8 @@ class QueryRouterAgent(BaseGalaxyAgent):
 
             try:
                 agent = ToolRecommendationAgent(ctx.deps)
-                result = await agent.process(query)
-                return result.content
+                response = await agent.process(query)
+                return self._serialize_handoff(response, "tool_recommendation")
             except Exception as e:
                 log.error(f"Tool recommendation handoff failed: {e}")
                 return f"I encountered an issue while searching for tools. Please try again or browse the tool panel directly. Error: {e}"
@@ -221,15 +226,32 @@ class QueryRouterAgent(BaseGalaxyAgent):
             result = await self._run_with_retry(full_query)
             content = extract_result_content(result)
 
-            return AgentResponse(
+            # Check if this is a handoff response (JSON-encoded with agent info)
+            try:
+                handoff_data = json.loads(content)
+                if handoff_data.get("__handoff__"):
+                    # This was a handoff - use the delegated agent's response
+                    # Preserve handoff_info in metadata if present
+                    metadata = handoff_data.get("metadata", {})
+                    if handoff_data.get("handoff_info"):
+                        metadata["handoff_info"] = handoff_data["handoff_info"]
+                    return AgentResponse(
+                        content=handoff_data["content"],
+                        confidence=handoff_data.get("confidence", ConfidenceLevel.MEDIUM),
+                        agent_type=handoff_data.get("agent_type", self.agent_type),
+                        suggestions=handoff_data.get("suggestions", []),
+                        metadata=metadata,
+                    )
+            except (json.JSONDecodeError, TypeError, KeyError):
+                pass  # Not a handoff response, continue with normal processing
+
+            # Direct response from router - use helper for consistent metadata
+            return self._build_response(
                 content=content,
                 confidence=ConfidenceLevel.HIGH,
-                agent_type=self.agent_type,
-                suggestions=[],
-                metadata={
-                    "method": "output_function",
-                    "query_length": len(query),
-                },
+                method="output_function",
+                result=result,
+                query=query,
             )
 
         except OSError as e:
@@ -263,45 +285,112 @@ class QueryRouterAgent(BaseGalaxyAgent):
 
         # Check for citation requests
         if any(phrase in query_lower for phrase in ["cite galaxy", "citation", "reference"]):
-            return AgentResponse(
+            return self._build_response(
                 content="""To cite Galaxy, please use: Nekrutenko, A., et al. (2024). The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update. Nucleic Acids Research. https://doi.org/10.1093/nar/gkae410
 
 For specific tools, please also cite the individual tool publications.""",
                 confidence=ConfidenceLevel.HIGH,
-                agent_type=self.agent_type,
-                suggestions=[],
-                metadata={"fallback": True, "reason": "citation_request"},
+                method="fallback",
+                query=query,
+                fallback=True,
+                agent_data={"reason": "citation_request"},
             )
 
         # Check for error-related keywords
-        error_keywords = ["error", "fail", "crash", "not work", "broken", "stderr", "exit code", "died", "killed"]
+        error_keywords = [
+            "error",
+            "fail",
+            "crash",
+            "not work",
+            "broken",
+            "stderr",
+            "exit code",
+            "died",
+            "killed",
+        ]
         if any(kw in query_lower for kw in error_keywords):
-            return AgentResponse(
+            return self._build_response(
                 content="I noticed you're asking about an error or failure. Unfortunately, I'm having trouble connecting to the AI service right now. Please try again in a moment, or check the job details panel for error information.",
                 confidence=ConfidenceLevel.LOW,
-                agent_type=self.agent_type,
-                suggestions=[],
-                metadata={"fallback": True, "reason": "error_query_service_unavailable", "error": error_msg},
+                method="fallback",
+                query=query,
+                fallback=True,
+                error=error_msg,
+                agent_data={"reason": "error_query_service_unavailable"},
             )
 
         # Check for explicit tool creation keywords
-        tool_keywords = ["create a tool", "build a tool", "make a tool", "wrap a tool", "tool wrapper"]
+        tool_keywords = [
+            "create a tool",
+            "build a tool",
+            "make a tool",
+            "wrap a tool",
+            "tool wrapper",
+        ]
         if any(kw in query_lower for kw in tool_keywords):
-            return AgentResponse(
+            return self._build_response(
                 content="I noticed you want to create a Galaxy tool. Unfortunately, I'm having trouble connecting to the AI service right now. Please try again in a moment.",
                 confidence=ConfidenceLevel.LOW,
-                agent_type=self.agent_type,
-                suggestions=[],
-                metadata={"fallback": True, "reason": "tool_creation_service_unavailable", "error": error_msg},
+                method="fallback",
+                query=query,
+                fallback=True,
+                error=error_msg,
+                agent_data={"reason": "tool_creation_service_unavailable"},
+            )
+
+        # Check for tool discovery keywords
+        tool_discovery_keywords = [
+            "what tool",
+            "which tool",
+            "find a tool",
+            "is there a tool",
+            "tool for",
+            "tool to",
+        ]
+        if any(kw in query_lower for kw in tool_discovery_keywords):
+            return self._build_response(
+                content="I noticed you're looking for a Galaxy tool. Unfortunately, I'm having trouble connecting to the AI service right now. You can browse available tools in the tool panel on the left, or search using the tool search box.",
+                confidence=ConfidenceLevel.LOW,
+                method="fallback",
+                query=query,
+                fallback=True,
+                error=error_msg,
+                agent_data={"reason": "tool_discovery_service_unavailable"},
+            )
+
+        # Check for training/tutorial keywords
+        training_keywords = [
+            "tutorial",
+            "training",
+            "learn",
+            "how do i analyze",
+            "how to analyze",
+            "rna-seq",
+            "chip-seq",
+            "variant calling",
+            "best practice",
+            "workflow for",
+        ]
+        if any(kw in query_lower for kw in training_keywords):
+            return self._build_response(
+                content="I noticed you're looking for training materials or guidance on analysis. Unfortunately, I'm having trouble connecting to the AI service right now. You can browse tutorials directly at the Galaxy Training Network: https://training.galaxyproject.org/training-material/",
+                confidence=ConfidenceLevel.LOW,
+                method="fallback",
+                query=query,
+                fallback=True,
+                error=error_msg,
+                agent_data={"reason": "training_service_unavailable"},
             )
 
         # General fallback
-        return AgentResponse(
+        return self._build_response(
             content="I'm having trouble connecting to the AI service right now. Please try again in a moment. If you have a question about Galaxy, you can also check the Galaxy Training Network (https://training.galaxyproject.org/) for tutorials and documentation.",
             confidence=ConfidenceLevel.LOW,
-            agent_type=self.agent_type,
-            suggestions=[],
-            metadata={"fallback": True, "reason": "service_unavailable", "error": error_msg},
+            method="fallback",
+            query=query,
+            fallback=True,
+            error=error_msg,
+            agent_data={"reason": "service_unavailable"},
         )
 
     def _get_simple_system_prompt(self) -> str:

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -237,7 +237,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
                         metadata["handoff_info"] = handoff_data["handoff_info"]
                     return AgentResponse(
                         content=handoff_data["content"],
-                        confidence=handoff_data.get("confidence", ConfidenceLevel.MEDIUM),
+                        confidence=ConfidenceLevel(handoff_data.get("confidence", "medium")),
                         agent_type=handoff_data.get("agent_type", self.agent_type),
                         suggestions=handoff_data.get("suggestions", []),
                         metadata=metadata,

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -16,6 +16,7 @@ from typing import (
     Optional,
 )
 
+from pydantic import ValidationError
 from pydantic_ai import (
     Agent,
     RunContext,
@@ -242,8 +243,8 @@ class QueryRouterAgent(BaseGalaxyAgent):
                         suggestions=handoff_data.get("suggestions", []),
                         metadata=metadata,
                     )
-            except (json.JSONDecodeError, TypeError, KeyError):
-                pass  # Not a handoff response, continue with normal processing
+            except (json.JSONDecodeError, TypeError, KeyError, ValidationError):
+                pass  # Not a handoff response or malformed suggestions, continue normally
 
             # Direct response from router - use helper for consistent metadata
             return self._build_response(

--- a/lib/galaxy/agents/tools.py
+++ b/lib/galaxy/agents/tools.py
@@ -325,14 +325,9 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
                 content = self._format_recommendation_response(recommendation)
                 suggestions = self._create_suggestions(recommendation)
 
-                # Convert string confidence to enum
-                conf_str = recommendation.confidence.lower() if recommendation.confidence else "medium"
-                if conf_str == "high":
-                    confidence = ConfidenceLevel.HIGH
-                elif conf_str == "low":
-                    confidence = ConfidenceLevel.LOW
-                else:
-                    confidence = ConfidenceLevel.MEDIUM
+                confidence = ConfidenceLevel(
+                    recommendation.confidence.lower() if recommendation.confidence else "medium"
+                )
 
                 return AgentResponse(
                     content=content,
@@ -436,13 +431,7 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
 
             # Only add suggestions if we have a valid tool_id AND the tool exists
             if tool_id and self._verify_tool_exists(tool_id):
-                conf_value = recommendation.confidence.lower()
-                if conf_value == "high":
-                    action_confidence = ConfidenceLevel.HIGH
-                elif conf_value == "low":
-                    action_confidence = ConfidenceLevel.LOW
-                else:
-                    action_confidence = ConfidenceLevel.MEDIUM
+                action_confidence = ConfidenceLevel(recommendation.confidence.lower())
                 suggestions.append(
                     ActionSuggestion(
                         action_type=ActionType.TOOL_RUN,

--- a/lib/galaxy/agents/tools.py
+++ b/lib/galaxy/agents/tools.py
@@ -533,20 +533,23 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
         if not content_parts:
             content_parts = [normalized_text]  # Fallback to full response
 
-        # Create suggestions
+        # Create suggestions - only if tool actually exists in toolbox
         suggestions = []
         if tool and tool.group(1).strip():
             tool_name = tool.group(1).strip()
             tool_id_value = tool_id.group(1).strip() if tool_id else tool_name.lower().replace(" ", "_")
-            suggestions.append(
-                ActionSuggestion(
-                    action_type=ActionType.TOOL_RUN,
-                    description=f"Run {tool_name}",
-                    parameters={"tool_id": tool_id_value, "tool_name": tool_name},
-                    confidence=confidence_level,
-                    priority=1,
+            if self._verify_tool_exists(tool_id_value):
+                suggestions.append(
+                    ActionSuggestion(
+                        action_type=ActionType.TOOL_RUN,
+                        description=f"Run {tool_name}",
+                        parameters={"tool_id": tool_id_value, "tool_name": tool_name},
+                        confidence=confidence_level,
+                        priority=1,
+                    )
                 )
-            )
+            else:
+                log.warning(f"Tool '{tool_id_value}' from simple response not found in toolbox - skipping suggestion")
 
         return {
             "content": "\n\n".join(content_parts),

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -72,21 +72,23 @@ class AgentResponse(BaseModel):
 
 
 class AgentQueryRequest(BaseModel):
-    """Request to query an AI agent."""
+    """Request to query an AI agent.
+
+    DEPRECATED: Use /api/chat instead for new integrations.
+    """
 
     query: str = Field(description="The user's question or request")
     agent_type: str = Field(default="auto", description="Preferred agent type ('auto' for routing)")
     context: dict[str, Any] = Field(default_factory=dict, description="Additional context for the query")
-    stream: bool = Field(default=False, description="Whether to stream the response")
 
 
 class AgentQueryResponse(BaseModel):
-    """Response from an AI agent query."""
+    """Response from an AI agent query.
+
+    DEPRECATED: Use /api/chat instead for new integrations.
+    """
 
     response: AgentResponse = Field(description="The agent's response")
-    routing_info: Optional[dict[str, Any]] = Field(
-        default=None, description="Information about how the query was routed"
-    )
     processing_time: Optional[float] = Field(default=None, description="Time taken to process the query in seconds")
 
 

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -23,14 +23,6 @@ class TokenUsage(BaseModel):
     total_tokens: int = Field(default=0, description="Total tokens used")
 
 
-class HandoffInfo(BaseModel):
-    """Information about agent-to-agent handoffs."""
-
-    source_agent: str = Field(description="Agent that initiated the handoff")
-    target_agent: str = Field(description="Agent that received the handoff")
-    reason: Optional[str] = Field(default=None, description="Reason for the handoff")
-
-
 class ConfidenceLevel(str, Enum):
     """Confidence levels for agent responses."""
 
@@ -82,7 +74,6 @@ class AgentResponse(BaseModel):
     suggestions: list[ActionSuggestion] = Field(default_factory=list, description="Actionable suggestions")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     reasoning: Optional[str] = Field(default=None, description="Explanation of the agent's reasoning")
-    handoff: Optional[HandoffInfo] = Field(default=None, description="Handoff information if response was delegated")
 
 
 class AgentQueryRequest(BaseModel):

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -14,6 +14,22 @@ from pydantic import (
 )
 
 
+class TokenUsage(BaseModel):
+    """Token usage information from LLM calls."""
+
+    input_tokens: int = Field(default=0, description="Number of input tokens")
+    output_tokens: int = Field(default=0, description="Number of output tokens")
+    total_tokens: int = Field(default=0, description="Total tokens used")
+
+
+class HandoffInfo(BaseModel):
+    """Information about agent-to-agent handoffs."""
+
+    source_agent: str = Field(description="Agent that initiated the handoff")
+    target_agent: str = Field(description="Agent that received the handoff")
+    reason: Optional[str] = Field(default=None, description="Reason for the handoff")
+
+
 class ConfidenceLevel(str, Enum):
     """Confidence levels for agent responses."""
 
@@ -52,6 +68,7 @@ class AgentResponse(BaseModel):
     suggestions: list[ActionSuggestion] = Field(default_factory=list, description="Actionable suggestions")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     reasoning: Optional[str] = Field(default=None, description="Explanation of the agent's reasoning")
+    handoff: Optional[HandoffInfo] = Field(default=None, description="Handoff information if response was delegated")
 
 
 class AgentQueryRequest(BaseModel):

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -15,14 +15,6 @@ from pydantic import (
 )
 
 
-class TokenUsage(BaseModel):
-    """Token usage information from LLM calls."""
-
-    input_tokens: int = Field(default=0, description="Number of input tokens")
-    output_tokens: int = Field(default=0, description="Number of output tokens")
-    total_tokens: int = Field(default=0, description="Total tokens used")
-
-
 class ConfidenceLevel(str, Enum):
     """Confidence levels for agent responses."""
 

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -43,11 +43,10 @@ class ActionType(str, Enum):
     """Types of actions agents can suggest."""
 
     TOOL_RUN = "tool_run"
-    DOCUMENTATION = "documentation"
+    SAVE_TOOL = "save_tool"
     CONTACT_SUPPORT = "contact_support"
     VIEW_EXTERNAL = "view_external"
-    SAVE_TOOL = "save_tool"
-    REFINE_QUERY = "refine_query"
+    DOCUMENTATION = "documentation"
 
 
 class ActionSuggestion(BaseModel):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3905,6 +3905,16 @@ class ChatResponse(BaseModel):
         title="Error Message",
         description="The error message, if any, for the chat query.",
     )
+    agent_response: Optional[dict[str, Any]] = Field(
+        default=None,
+        title="Agent Response",
+        description="Full agent response with metadata and suggestions.",
+    )
+    exchange_id: Optional[int] = Field(
+        default=None,
+        title="Exchange ID",
+        description="The ID of the chat exchange for continuing conversations.",
+    )
 
 
 class GenerateTourResponse(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3888,10 +3888,10 @@ class ChatPayload(Model):
         title="Exchange ID",
         description="The ID of an existing chat exchange to continue.",
     )
-    regenerate: bool = Field(
-        default=False,
+    regenerate: Optional[bool] = Field(
+        default=None,
         title="Regenerate",
-        description="Force fresh analysis even if a cached response exists (for job-based queries).",
+        description="Force fresh analysis even if a cached response exists (for job-based queries). Defaults to false if not provided.",
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -35,6 +35,7 @@ from typing_extensions import (
     TypedDict,
 )
 
+from galaxy.schema.agents import AgentResponse
 from galaxy.schema.bco import XrefItem
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
@@ -3887,6 +3888,11 @@ class ChatPayload(Model):
         title="Exchange ID",
         description="The ID of an existing chat exchange to continue.",
     )
+    regenerate: bool = Field(
+        default=False,
+        title="Regenerate",
+        description="Force fresh analysis even if a cached response exists (for job-based queries).",
+    )
 
 
 class ChatResponse(BaseModel):
@@ -3905,15 +3911,20 @@ class ChatResponse(BaseModel):
         title="Error Message",
         description="The error message, if any, for the chat query.",
     )
-    agent_response: Optional[dict[str, Any]] = Field(
+    agent_response: Optional[AgentResponse] = Field(
         default=None,
         title="Agent Response",
-        description="Full agent response with metadata and suggestions.",
+        description="Full structured agent response with metadata and suggestions.",
     )
     exchange_id: Optional[int] = Field(
         default=None,
         title="Exchange ID",
         description="The ID of the chat exchange for continuing conversations.",
+    )
+    processing_time: Optional[float] = Field(
+        default=None,
+        title="Processing Time",
+        description="Time taken to process the query in seconds.",
     )
 
 

--- a/lib/galaxy/webapps/galaxy/api/agents.py
+++ b/lib/galaxy/webapps/galaxy/api/agents.py
@@ -133,7 +133,9 @@ class AgentAPI:
         query: str = Body(..., description="Description of the error or problem"),
         job_id: Optional[DecodedDatabaseIdField] = Body(None, description="Job ID for context"),
         error_details: Optional[dict[str, Any]] = Body(None, description="Additional error details"),
-        save_exchange: bool = Body(False, description="Save exchange for feedback tracking"),
+        save_exchange: Optional[bool] = Body(
+            None, description="Save exchange for feedback tracking. Defaults to false."
+        ),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
     ) -> AgentResponse:
@@ -156,7 +158,7 @@ class AgentAPI:
             )
 
             # Save chat exchange for feedback tracking if requested or if job_id provided
-            if save_exchange or job_id:
+            if bool(save_exchange) or job_id:
                 if job_id:
                     job = self.job_manager.get_accessible_job(trans, job_id)
                     if job:
@@ -181,7 +183,9 @@ class AgentAPI:
         self,
         query: str = Body(..., description="Description of the tool to create"),
         context: Optional[dict[str, Any]] = Body(None, description="Additional context for tool creation"),
-        save_exchange: bool = Body(False, description="Save exchange for feedback tracking"),
+        save_exchange: Optional[bool] = Body(
+            None, description="Save exchange for feedback tracking. Defaults to false."
+        ),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
     ) -> AgentResponse:
@@ -200,7 +204,7 @@ class AgentAPI:
             )
 
             # Save chat exchange for feedback tracking if requested
-            if save_exchange and trans.user:
+            if bool(save_exchange) and trans.user:
                 result = {"response": response.content, "agent_response": response.model_dump()}
                 exchange = self.chat_manager.create_general_chat(trans, query, result, "custom_tool")
                 response.metadata["exchange_id"] = exchange.id

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -217,7 +217,13 @@ class ChatAPI:
                     result["exchange_id"] = exchange_id
                 else:
                     # Create new exchange for first message
-                    exchange = self.chat_manager.create_general_chat(trans, query_text, result, agent_type)
+                    # Serialize agent_response for JSON storage
+                    agent_resp = result.get("agent_response")
+                    storable_result = {
+                        "response": result.get("response", ""),
+                        "agent_response": agent_resp.model_dump() if agent_resp else None,
+                    }
+                    exchange = self.chat_manager.create_general_chat(trans, query_text, storable_result, agent_type)
                     result["exchange_id"] = exchange.id
 
             result["processing_time"] = time.time() - start_time

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -135,7 +135,7 @@ class ChatAPI:
             # Context from payload is a string (e.g., "tool_error"), convert to dict for agent system
             context_str = payload.context if hasattr(payload, "context") else None
             query_context = {"context_type": context_str} if context_str else {}
-            regenerate = payload.regenerate if hasattr(payload, "regenerate") else False
+            regenerate = bool(payload.regenerate) if hasattr(payload, "regenerate") else False
         elif query:
             # New format: query parameters (context not supported in this path)
             query_text = query

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -34,6 +34,11 @@ from unittest.mock import (
     patch,
 )
 
+from galaxy.agents import (
+    agent_registry,
+    GalaxyAgentDependencies,
+)
+from galaxy.agents.error_analysis import ErrorAnalysisResult
 from galaxy.tool_util_models import UserToolSource
 from galaxy.util.unittest_utils import pytestmark_live_llm
 from galaxy_test.base.populators import (
@@ -69,11 +74,6 @@ class AgentIntegrationTestCase(IntegrationTestCase):
 
 def _create_deps_with_mock_model(self, trans, user):
     """Replacement for AgentService.create_dependencies that injects a mock model_factory."""
-    from galaxy.agents import (
-        agent_registry,
-        GalaxyAgentDependencies,
-    )
-
     toolbox = trans.app.toolbox if hasattr(trans, "app") and hasattr(trans.app, "toolbox") else None
     return GalaxyAgentDependencies(
         trans=trans,
@@ -216,8 +216,6 @@ class TestAgentsApiMocked(AgentIntegrationTestCase):
 
         # Mock error analysis
         async def mock_run(*args, **kwargs):
-            from galaxy.agents.error_analysis import ErrorAnalysisResult
-
             result = MagicMock()
             mock_analysis = ErrorAnalysisResult(
                 error_category="tool_configuration",

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -254,10 +254,9 @@ class TestAgentsApiMocked(AgentIntegrationTestCase):
         content = data["response"]["content"].lower()
         assert "command" in content or "samtools" in content or "not found" in content
 
-        # Verify suggestions are present and valid
+        # Suggestions are optional - only returned for actionable items like CONTACT_SUPPORT
+        # In this mock, requires_admin=False, so no suggestions expected
         suggestions = data["response"].get("suggestions", [])
-        assert len(suggestions) >= 1, "Error analysis should return at least one suggestion"
-        # All suggestions should have valid action types
         for suggestion in suggestions:
             assert "action_type" in suggestion
             assert "description" in suggestion

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -195,14 +195,10 @@ class TestAgentUnitMocked:
         assert suggestions == []
 
     def test_error_analysis_suggestions_with_admin_required(self):
-        """Test error analysis creates CONTACT_SUPPORT suggestion when admin required."""
+        """Test error analysis doesn't create suggestions yet (future work)."""
         from galaxy.agents.error_analysis import (
             ErrorAnalysisAgent,
             ErrorAnalysisResult,
-        )
-        from galaxy.schema.agents import (
-            ActionSuggestion,
-            ActionType,
         )
 
         analysis = ErrorAnalysisResult(
@@ -217,18 +213,8 @@ class TestAgentUnitMocked:
         agent = ErrorAnalysisAgent(self.deps)
         suggestions = agent._create_suggestions(analysis)
 
-        # Should include exactly one CONTACT_SUPPORT suggestion
-        assert len(suggestions) == 1
-        assert suggestions[0].action_type == ActionType.CONTACT_SUPPORT
-
-        # Should include context message for support request
-        message = suggestions[0].parameters.get("message")
-        assert message is not None
-        assert "system_error" in message
-        assert "Disk quota exceeded" in message
-
-        # Validate through ActionSuggestion to ensure it passes validation
-        ActionSuggestion.model_validate(suggestions[0].model_dump())
+        # Currently returns empty - CONTACT_SUPPORT not wired up yet
+        assert suggestions == []
 
     @pytest.mark.skip(reason="TestModel API changed in pydantic-ai, needs update for new version")
     @pytest.mark.asyncio

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -29,6 +29,7 @@ import pytest
 
 # Skip entire module if pydantic_ai is not installed
 pydantic_ai = pytest.importorskip("pydantic_ai")
+from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
 
 from galaxy.agents import (
@@ -37,6 +38,11 @@ from galaxy.agents import (
     ErrorAnalysisAgent,
     GalaxyAgentDependencies,
     QueryRouterAgent,
+)
+from galaxy.agents.error_analysis import ErrorAnalysisResult
+from galaxy.agents.orchestrator import (
+    AgentPlan,
+    WorkflowOrchestratorAgent,
 )
 from galaxy.schema.agents import ConfidenceLevel
 from galaxy.tool_util_models import UserToolSource
@@ -175,11 +181,6 @@ class TestAgentUnitMocked:
         Solution steps and alternatives are guidance, not executable actions,
         so they shouldn't generate suggestions.
         """
-        from galaxy.agents.error_analysis import (
-            ErrorAnalysisAgent,
-            ErrorAnalysisResult,
-        )
-
         analysis = ErrorAnalysisResult(
             error_category="tool_configuration",
             error_severity="medium",
@@ -197,11 +198,6 @@ class TestAgentUnitMocked:
 
     def test_error_analysis_suggestions_with_admin_required(self):
         """When requires_admin=True, should suggest contacting support."""
-        from galaxy.agents.error_analysis import (
-            ErrorAnalysisAgent,
-            ErrorAnalysisResult,
-        )
-
         analysis = ErrorAnalysisResult(
             error_category="system_error",
             error_severity="high",
@@ -226,8 +222,6 @@ class TestAgentUnitMocked:
         # The router now uses output functions and returns AgentResponse directly
         # rather than RoutingDecision objects
         with patch("galaxy.agents.router.QueryRouterAgent._create_agent") as mock_create:
-            from pydantic_ai import Agent
-
             # Create TestModel with predictable output
             test_model = TestModel()
             # This API no longer exists in newer pydantic-ai versions
@@ -272,11 +266,6 @@ class TestAgentUnitMocked:
     @pytest.mark.asyncio
     async def test_workflow_orchestrator_agent_mocked(self):
         """Test WorkflowOrchestratorAgent with mocked responses."""
-        from galaxy.agents.orchestrator import (
-            AgentPlan,
-            WorkflowOrchestratorAgent,
-        )
-
         agent = WorkflowOrchestratorAgent(self.deps)
 
         # Test 1: Query that should NOT trigger orchestration (single agent)
@@ -307,11 +296,6 @@ class TestAgentUnitMocked:
     @pytest.mark.asyncio
     async def test_workflow_orchestrator_sequential_execution(self):
         """Test orchestrator sequential workflow execution."""
-        from galaxy.agents.orchestrator import (
-            AgentPlan,
-            WorkflowOrchestratorAgent,
-        )
-
         agent = WorkflowOrchestratorAgent(self.deps)
 
         # Mock a complex plan requiring sequential orchestration
@@ -365,11 +349,6 @@ class TestAgentUnitMocked:
     @pytest.mark.asyncio
     async def test_workflow_orchestrator_parallel_execution(self):
         """Test orchestrator parallel workflow execution."""
-        from galaxy.agents.orchestrator import (
-            AgentPlan,
-            WorkflowOrchestratorAgent,
-        )
-
         agent = WorkflowOrchestratorAgent(self.deps)
 
         # Mock parallel plan
@@ -432,8 +411,6 @@ class TestAgentUnitMocked:
 
     def _orchestrator_agent(self):
         """Helper to create a patched orchestrator agent with mocked dependencies."""
-        from galaxy.agents.orchestrator import WorkflowOrchestratorAgent
-
         agent = WorkflowOrchestratorAgent(self.deps)
         return agent
 

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -38,6 +38,7 @@ from galaxy.agents import (
     GalaxyAgentDependencies,
     QueryRouterAgent,
 )
+from galaxy.schema.agents import ConfidenceLevel
 from galaxy.tool_util_models import UserToolSource
 from galaxy.util.unittest_utils import pytestmark_live_llm
 
@@ -195,7 +196,7 @@ class TestAgentUnitMocked:
         assert suggestions == []
 
     def test_error_analysis_suggestions_with_admin_required(self):
-        """Test error analysis doesn't create suggestions yet (future work)."""
+        """When requires_admin=True, should suggest contacting support."""
         from galaxy.agents.error_analysis import (
             ErrorAnalysisAgent,
             ErrorAnalysisResult,
@@ -213,8 +214,9 @@ class TestAgentUnitMocked:
         agent = ErrorAnalysisAgent(self.deps)
         suggestions = agent._create_suggestions(analysis)
 
-        # Currently returns empty - CONTACT_SUPPORT not wired up yet
-        assert suggestions == []
+        assert len(suggestions) == 1
+        assert suggestions[0].action_type.value == "contact_support"
+        assert suggestions[0].confidence == ConfidenceLevel.HIGH
 
     @pytest.mark.skip(reason="TestModel API changed in pydantic-ai, needs update for new version")
     @pytest.mark.asyncio

--- a/test/unit/schema/test_action_suggestion.py
+++ b/test/unit/schema/test_action_suggestion.py
@@ -119,15 +119,6 @@ class TestActionSuggestionValidation:
         )
         assert s.parameters == {}
 
-    def test_refine_query_no_params_required(self):
-        """REFINE_QUERY does not require any parameters."""
-        s = ActionSuggestion(
-            action_type=ActionType.REFINE_QUERY,
-            description="Try rephrasing your question",
-            confidence=ConfidenceLevel.LOW,
-        )
-        assert s.parameters == {}
-
     def test_priority_defaults_to_one(self):
         """Priority defaults to 1 when not specified."""
         s = ActionSuggestion(

--- a/test/unit/schema/test_action_suggestion.py
+++ b/test/unit/schema/test_action_suggestion.py
@@ -1,0 +1,148 @@
+"""Unit tests for ActionSuggestion parameter validation."""
+
+import pytest
+
+from galaxy.schema.agents import (
+    ActionSuggestion,
+    ActionType,
+    ConfidenceLevel,
+)
+
+
+class TestActionSuggestionValidation:
+    """Test ActionSuggestion validates required parameters per action type."""
+
+    def test_tool_run_requires_tool_id(self):
+        """TOOL_RUN action must have a tool_id parameter."""
+        with pytest.raises(ValueError, match="tool_id"):
+            ActionSuggestion(
+                action_type=ActionType.TOOL_RUN,
+                description="Open tool",
+                confidence=ConfidenceLevel.HIGH,
+            )
+
+    def test_tool_run_rejects_empty_tool_id(self):
+        """TOOL_RUN rejects empty string tool_id."""
+        with pytest.raises(ValueError, match="tool_id"):
+            ActionSuggestion(
+                action_type=ActionType.TOOL_RUN,
+                description="Open tool",
+                parameters={"tool_id": ""},
+                confidence=ConfidenceLevel.HIGH,
+            )
+
+    def test_tool_run_accepts_valid_params(self):
+        """TOOL_RUN accepts valid tool_id parameter."""
+        s = ActionSuggestion(
+            action_type=ActionType.TOOL_RUN,
+            description="Open BWA",
+            parameters={"tool_id": "bwa"},
+            confidence=ConfidenceLevel.HIGH,
+        )
+        assert s.parameters["tool_id"] == "bwa"
+
+    def test_save_tool_requires_tool_yaml(self):
+        """SAVE_TOOL action must have a tool_yaml parameter."""
+        with pytest.raises(ValueError, match="tool_yaml"):
+            ActionSuggestion(
+                action_type=ActionType.SAVE_TOOL,
+                description="Save tool",
+                confidence=ConfidenceLevel.HIGH,
+            )
+
+    def test_save_tool_rejects_empty_tool_yaml(self):
+        """SAVE_TOOL rejects empty string tool_yaml."""
+        with pytest.raises(ValueError, match="tool_yaml"):
+            ActionSuggestion(
+                action_type=ActionType.SAVE_TOOL,
+                description="Save tool",
+                parameters={"tool_yaml": ""},
+                confidence=ConfidenceLevel.HIGH,
+            )
+
+    def test_save_tool_accepts_valid_params(self):
+        """SAVE_TOOL accepts valid tool_yaml parameter."""
+        yaml_content = "id: test\nname: Test Tool"
+        s = ActionSuggestion(
+            action_type=ActionType.SAVE_TOOL,
+            description="Save the tool",
+            parameters={"tool_yaml": yaml_content, "tool_id": "test"},
+            confidence=ConfidenceLevel.HIGH,
+        )
+        assert s.parameters["tool_yaml"] == yaml_content
+        assert s.parameters["tool_id"] == "test"
+
+    def test_view_external_requires_url(self):
+        """VIEW_EXTERNAL action must have a url parameter."""
+        with pytest.raises(ValueError, match="url"):
+            ActionSuggestion(
+                action_type=ActionType.VIEW_EXTERNAL,
+                description="View docs",
+                confidence=ConfidenceLevel.HIGH,
+            )
+
+    def test_view_external_rejects_empty_url(self):
+        """VIEW_EXTERNAL rejects empty string url."""
+        with pytest.raises(ValueError, match="url"):
+            ActionSuggestion(
+                action_type=ActionType.VIEW_EXTERNAL,
+                description="View docs",
+                parameters={"url": ""},
+                confidence=ConfidenceLevel.HIGH,
+            )
+
+    def test_view_external_accepts_valid_params(self):
+        """VIEW_EXTERNAL accepts valid url parameter."""
+        s = ActionSuggestion(
+            action_type=ActionType.VIEW_EXTERNAL,
+            description="View Galaxy training",
+            parameters={"url": "https://training.galaxyproject.org"},
+            confidence=ConfidenceLevel.HIGH,
+        )
+        assert s.parameters["url"] == "https://training.galaxyproject.org"
+
+    def test_contact_support_no_params_required(self):
+        """CONTACT_SUPPORT does not require any parameters."""
+        s = ActionSuggestion(
+            action_type=ActionType.CONTACT_SUPPORT,
+            description="Get help",
+            confidence=ConfidenceLevel.HIGH,
+        )
+        assert s.parameters == {}
+
+    def test_documentation_no_params_required(self):
+        """DOCUMENTATION does not require any parameters."""
+        s = ActionSuggestion(
+            action_type=ActionType.DOCUMENTATION,
+            description="Read the docs",
+            confidence=ConfidenceLevel.MEDIUM,
+        )
+        assert s.parameters == {}
+
+    def test_refine_query_no_params_required(self):
+        """REFINE_QUERY does not require any parameters."""
+        s = ActionSuggestion(
+            action_type=ActionType.REFINE_QUERY,
+            description="Try rephrasing your question",
+            confidence=ConfidenceLevel.LOW,
+        )
+        assert s.parameters == {}
+
+    def test_priority_defaults_to_one(self):
+        """Priority defaults to 1 when not specified."""
+        s = ActionSuggestion(
+            action_type=ActionType.CONTACT_SUPPORT,
+            description="Get help",
+            confidence=ConfidenceLevel.HIGH,
+        )
+        assert s.priority == 1
+
+    def test_accepts_custom_priority(self):
+        """Custom priority values are accepted."""
+        s = ActionSuggestion(
+            action_type=ActionType.DOCUMENTATION,
+            description="Low priority docs",
+            confidence=ConfidenceLevel.LOW,
+            priority=3,
+        )
+        assert s.priority == 3


### PR DESCRIPTION
Followup to https://github.com/galaxyproject/galaxy/pull/21580 — final cleanup/standardization pass on the agent system before release.

Goals: make agent responses consistent across all agents, fix schema issues causing data loss, and tighten suggestion validation.

- Fixed metadata (exchange_id, token usage, model name) getting lost when delegated agents pass back through the router
- Added `_build_metadata()` / `_build_response()` helpers so all agents produce consistent responses
- Typed `ChatResponse.agent_response` as `Optional[AgentResponse]` instead of `dict[str, Any]`
- Added `processing_time`, `regenerate`, `save_exchange` fields to relevant schemas
- Deprecated `/api/ai/agents/query` (duplicates `/api/chat`), removed dead `routing_info`/`stream` fields
- Added `model_validator` on `ActionSuggestion` enforcing required params per action type
- TOOL_RUN suggestions validated against toolbox, removed unused REFINE_QUERY action type
- `ConfidenceLevel` enum used consistently everywhere instead of raw strings
- Removed unused `HandoffInfo` schema model and preemptive CONTACT_SUPPORT suggestions

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).