### PR TITLE
Break dereference_input into HDA and HDCA variants

### DIFF
--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -355,21 +355,28 @@ class HDAManager(
                 raise exceptions.RequestParameterInvalidException(error)
 
 
-def dereference_input(
+def dereference_input_to_hda(
     trans: ProvidesHistoryContext,
-    data_request: Union[DataRequestUri, FileRequestUri, DataRequestCollectionUri],
+    data_request: Union[DataRequestUri, FileRequestUri],
     history: model.History,
-) -> Union[HistoryDatasetAssociation, HistoryDatasetCollectionAssociation]:
+) -> HistoryDatasetAssociation:
     permissions = trans.app.security_agent.history_get_default_permissions(history)
-    if isinstance(data_request, DataRequestCollectionUri):
-        hdca = derefence_collection_to_model(trans.sa_session, trans.user, history, data_request)
-        for hda in hdca.dataset_instances:
-            trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions, new=True, flush=False)
-        return hdca
     hda = dereference_to_model(trans.sa_session, trans.user, history, data_request)
     trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions, new=True, flush=False)
     trans.sa_session.commit()
     return hda
+
+
+def dereference_input_to_hdca(
+    trans: ProvidesHistoryContext,
+    data_request: DataRequestCollectionUri,
+    history: model.History,
+) -> HistoryDatasetCollectionAssociation:
+    permissions = trans.app.security_agent.history_get_default_permissions(history)
+    hdca = derefence_collection_to_model(trans.sa_session, trans.user, history, data_request)
+    for hda in hdca.dataset_instances:
+        trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions, new=True, flush=False)
+    return hdca
 
 
 class HDAStorageCleanerManager(base.StorageCleanerManager):

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -51,7 +51,8 @@ from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import (
-    dereference_input,
+    dereference_input_to_hda,
+    dereference_input_to_hdca,
     HDAManager,
 )
 from galaxy.managers.histories import HistoryManager
@@ -2103,12 +2104,11 @@ class JobSubmitter:
             if not history:
                 raise InconsistentDatabase("Tool request has no history associated")
 
-            hdca = dereference_input(trans, data_request, history)
-            assert isinstance(hdca, model.HistoryDatasetCollectionAssociation)
+            hdca = dereference_input_to_hdca(trans, data_request, history)
 
             # we need the HDCA to have an ID - so we force a commit here - for
-            # consistency it would be great if this happened in the dereference_input
-            # since the HDA is committed in the other branch.
+            # consistency it would be great if this happened in dereference_input_to_hdca
+            # since the HDA is committed in dereference_input_to_hda.
             history.add_pending_items()
             trans.sa_session.commit()
 
@@ -2132,8 +2132,7 @@ class JobSubmitter:
             if not history:
                 raise InconsistentDatabase("Tool request has no history associated")
 
-            hda = dereference_input(trans, data_request, history)
-            assert isinstance(hda, model.HistoryDatasetAssociation)
+            hda = dereference_input_to_hda(trans, data_request, history)
             new_hdas.append(DereferencedDatasetPair(hda, data_request))
             return DataRequestInternalHda(id=hda.id, src="hda")
 

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -12,7 +12,10 @@ from pydantic import ValidationError
 
 from galaxy import exceptions
 from galaxy.exceptions.utils import validation_error_to_message_exception
-from galaxy.managers.hdas import dereference_input
+from galaxy.managers.hdas import (
+    dereference_input_to_hda,
+    dereference_input_to_hdca,
+)
 from galaxy.model import (
     EffectiveOutput,
     History,
@@ -26,7 +29,12 @@ from galaxy.model import (
     WorkflowRequestStepState,
 )
 from galaxy.model.base import ensure_object_added_to_session
-from galaxy.tool_util_models.parameters import DataOrCollectionRequestAdapter
+from galaxy.tool_util_models.parameters import (
+    DataOrCollectionRequestAdapter,
+    DataRequestCollectionUri,
+    DataRequestUri,
+    FileRequestUri,
+)
 from galaxy.tools.parameters.basic import ParameterValueError
 from galaxy.tools.parameters.meta import expand_workflow_inputs
 from galaxy.tools.parameters.workflow_utils import NO_REPLACEMENT
@@ -419,11 +427,20 @@ def build_workflow_run_configs(
                     content = app.dataset_collection_manager.get_dataset_collection_instance(
                         trans, "history", data_request.id
                     )
-                elif data_request.src == "url" or data_request.class_ == "File" or data_request.class_ == "Collection":
-                    request_input = dereference_input(trans, data_request, history)
+                elif isinstance(data_request, DataRequestCollectionUri):
+                    hdca_input = dereference_input_to_hdca(trans, data_request, history)
                     added_to_history = True
                     content = InputWithRequest(
-                        input=request_input,
+                        input=hdca_input,
+                        request=data_request.model_dump(mode="json"),
+                    )
+                    if not data_request.deferred:
+                        requires_materialization = True
+                elif isinstance(data_request, (DataRequestUri, FileRequestUri)):
+                    hda_input = dereference_input_to_hda(trans, data_request, history)
+                    added_to_history = True
+                    content = InputWithRequest(
+                        input=hda_input,
                         request=data_request.model_dump(mode="json"),
                     )
                     if not data_request.deferred:


### PR DESCRIPTION
Split the dereference_input function into two specialized methods:
- dereference_input_to_hda: Returns HistoryDatasetAssociation
- dereference_input_to_hdca: Returns HistoryDatasetCollectionAssociation

This improves type safety by having each function return a specific type rather than a union, eliminating the need for runtime isinstance checks and assertions at call sites.

Fixes #20160

https://claude.ai/code/session_01QWGeMjFzqh1JECMNdUo6mQ

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
