### PR TITLE
[26.0] Fix storing origin for workflow landing requests

### DIFF
--- a/lib/galaxy/managers/landing.py
+++ b/lib/galaxy/managers/landing.py
@@ -156,6 +156,7 @@ class LandingRequestManager:
         model.client_secret = payload.client_secret
         model.request_state = self.validate_workflow_request_state(payload.request_state)
         model.public = payload.public
+        model.origin = str(payload.origin) if payload.origin else None
         self._save(model)
         return self._workflow_response(model)
 

--- a/lib/galaxy_test/api/test_landing.py
+++ b/lib/galaxy_test/api/test_landing.py
@@ -67,6 +67,25 @@ class TestLandingApi(ApiTestCase):
         assert_error_code_is(response, 400008)
         assert "Input should be a valid integer" in response.text
 
+    @skip_without_tool("cat1")
+    def test_workflow_landing_origin(self):
+        request = _get_simple_landing_payload(self.workflow_populator, public=True)
+        request = CreateWorkflowLandingRequestPayload(
+            workflow_id=request.workflow_id,
+            workflow_target_type=request.workflow_target_type,
+            request_state=request.request_state,
+            public=request.public,
+            origin=HttpUrl("http://example.localhost/"),
+        )
+        response = self.dataset_populator.create_workflow_landing(request)
+        assert response.workflow_id == request.workflow_id
+        assert response.state == "unclaimed"
+        assert str(response.origin) == "http://example.localhost/"
+        response = self.dataset_populator.claim_workflow_landing(response.uuid)
+        assert response.workflow_id == request.workflow_id
+        assert response.state == "claimed"
+        assert str(response.origin) == "http://example.localhost/"
+
     def test_data_landing(self):
         data_landing_request_state = DataLandingRequestState(
             targets=[


### PR DESCRIPTION
The origin field was being accepted in the payload but not stored to the model in create_workflow_landing_request(). This was inconsistent with create_tool_landing_request() which correctly stores the origin. Added a test to verify the origin is preserved through create and claim operations.

https://claude.ai/code/session_01Nk9FaZ1BsPghEvrdJbNQJQ

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
