### PR TITLE
Allow admin to override `$GALAXY_MEMORY_MB`

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
@@ -1,10 +1,8 @@
-if [ -z "$GALAXY_MEMORY_MB" ]; then
-    if [ -n "$SLURM_JOB_ID" ]; then
-        GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>$metadata_directory/memory_statement.log
-    fi
-    if [ -n "$SGE_HGR_h_vmem" ]; then
-        GALAXY_MEMORY_MB_PER_SLOT=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>$metadata_directory/memory_statement.log
-    fi
+if [ -z "$GALAXY_MEMORY_MB" -a -n "$SLURM_JOB_ID" ]; then
+    GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>$metadata_directory/memory_statement.log
+fi
+if [ -n "$SGE_HGR_h_vmem" ]; then
+    GALAXY_MEMORY_MB_PER_SLOT=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>$metadata_directory/memory_statement.log
 fi
 
 if [ -z "$GALAXY_MEMORY_MB_PER_SLOT" -a -n "$GALAXY_MEMORY_MB" ]; then

--- a/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT_TEMPLATE.sh
@@ -1,8 +1,10 @@
-if [ -n "$SLURM_JOB_ID" ]; then
-    GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>$metadata_directory/memory_statement.log
-fi
-if [ -n "$SGE_HGR_h_vmem" ]; then
-    GALAXY_MEMORY_MB_PER_SLOT=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>$metadata_directory/memory_statement.log
+if [ -z "$GALAXY_MEMORY_MB" ]; then
+    if [ -n "$SLURM_JOB_ID" ]; then
+        GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>$metadata_directory/memory_statement.log
+    fi
+    if [ -n "$SGE_HGR_h_vmem" ]; then
+        GALAXY_MEMORY_MB_PER_SLOT=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>$metadata_directory/memory_statement.log
+    fi
 fi
 
 if [ -z "$GALAXY_MEMORY_MB_PER_SLOT" -a -n "$GALAXY_MEMORY_MB" ]; then


### PR DESCRIPTION
Otherwise, `$GALAXY_MEMORY_MB` is unconditionally overridden.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
