### PR TITLE
Move BootstrapSize type to shared module

### DIFF
--- a/client/src/components/Common/GCard.types.ts
+++ b/client/src/components/Common/GCard.types.ts
@@ -7,7 +7,7 @@ import type { BootstrapSize, BootstrapVariant } from "@/components/Common";
 export type CardBadgeType = "pill" | "badge";
 
 /** Title sizes for heading components */
-export type TitleSize = "xl" | "lg" | "md" | "sm" | "text";
+export type TitleSize = BootstrapSize | "text";
 
 /** Base properties for all card elements */
 interface BaseCardElement {

--- a/client/src/components/Common/GCard.types.ts
+++ b/client/src/components/Common/GCard.types.ts
@@ -1,13 +1,10 @@
 import type { SizeProp } from "@fortawesome/fontawesome-svg-core";
 import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 
-import type { BootstrapVariant } from "@/components/Common";
+import type { BootstrapSize, BootstrapVariant } from "@/components/Common";
 
 /** Card badge display styles */
 export type CardBadgeType = "pill" | "badge";
-
-/** Bootstrap component sizes */
-export type BootstrapSize = "xs" | "sm" | "md" | "lg" | "xl";
 
 /** Title sizes for heading components */
 export type TitleSize = "xl" | "lg" | "md" | "sm" | "text";

--- a/client/src/components/Common/GTable.types.ts
+++ b/client/src/components/Common/GTable.types.ts
@@ -1,10 +1,7 @@
 import type { SizeProp } from "@fortawesome/fontawesome-svg-core";
 import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 
-import type { BootstrapVariant } from "@/components/Common";
-
-/** Bootstrap component sizes */
-export type BootstrapSize = "xs" | "sm" | "md" | "lg" | "xl";
+import type { BootstrapSize, BootstrapVariant } from "@/components/Common";
 
 /** Table field sorting order */
 export type SortOrder = "asc" | "desc";

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -17,7 +17,8 @@ interface Props {
     bold?: boolean;
     separator?: boolean;
     inline?: boolean;
-    size?: "xl" | "lg" | "md" | "sm" | "text";
+    // TODO: Redo in Vue 3 to use BootstrapSize for prop typing.
+    size?: "xs" | "sm" | "md" | "lg" | "xl" | "text";
     icon?: IconLike;
     truncate?: boolean;
     collapse?: "open" | "closed" | "none";

--- a/client/src/components/Common/index.ts
+++ b/client/src/components/Common/index.ts
@@ -24,6 +24,9 @@ export type BootstrapVariant =
     | "outline-link"
     | "outline-dark";
 
+/** Bootstrap component sizes */
+export type BootstrapSize = "xs" | "sm" | "md" | "lg" | "xl";
+
 /**
  * Represents a breadcrumb item in the BreadcrumbHeading component.
  * Each item can have a title, an optional URL to navigate to, and optional additional text

--- a/client/src/composables/confirmDialog.ts
+++ b/client/src/composables/confirmDialog.ts
@@ -1,6 +1,6 @@
 import { type Ref, ref } from "vue";
 
-import type { BootstrapVariant } from "@/components/Common";
+import type { BootstrapSize, BootstrapVariant } from "@/components/Common";
 
 /**
  * Bootstrap Vue modal message box options interface.
@@ -25,7 +25,7 @@ export interface ConfirmDialogOptions {
      * Modal size: 'sm', 'lg', 'xl'
      * @default undefined (medium)
      */
-    size?: "sm" | "lg" | "xl";
+    size?: BootstrapSize;
     /**
      * Center modal vertically
      * @default true
@@ -60,7 +60,7 @@ export interface ConfirmDialogOptions {
      * Footer button size: 'sm', 'lg'
      * @default undefined (normal)
      */
-    buttonSize?: "sm" | "lg";
+    buttonSize?: BootstrapSize;
     /**
      * Hide header close button
      * @default false


### PR DESCRIPTION
Follow-up to https://github.com/galaxyproject/galaxy/pull/21635#discussion_r2742216579

Unifies the definition of the BootstrapSize type by relocating it to a central module for easier reuse and improved type consistency across components.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
