### PR TITLE
[26.0] Various fixes to file source template's validation system

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -22845,8 +22845,10 @@ export interface components {
         TaskState: "PENDING" | "STARTED" | "RETRY" | "FAILURE" | "SUCCESS";
         /** TemplateSecret */
         TemplateSecret: {
+            /** Default */
+            default?: string | null;
             /** Help */
-            help: string | null;
+            help?: string | null;
             /** Label */
             label?: string | null;
             /** Name */
@@ -22854,13 +22856,10 @@ export interface components {
         };
         /** TemplateVariableBoolean */
         TemplateVariableBoolean: {
-            /**
-             * Default
-             * @default false
-             */
-            default: boolean;
+            /** Default */
+            default?: boolean | null;
             /** Help */
-            help: string | null;
+            help?: string | null;
             /** Label */
             label?: string | null;
             /** Name */
@@ -22881,13 +22880,10 @@ export interface components {
         };
         /** TemplateVariableInteger */
         TemplateVariableInteger: {
-            /**
-             * Default
-             * @default 0
-             */
-            default: number;
+            /** Default */
+            default?: number | null;
             /** Help */
-            help: string | null;
+            help?: string | null;
             /** Label */
             label?: string | null;
             /** Name */
@@ -22911,7 +22907,7 @@ export interface components {
             /** Default */
             default?: string | null;
             /** Help */
-            help: string | null;
+            help?: string | null;
             /** Label */
             label?: string | null;
             /** Name */
@@ -22932,13 +22928,10 @@ export interface components {
         };
         /** TemplateVariableString */
         TemplateVariableString: {
-            /**
-             * Default
-             * @default
-             */
-            default: string;
+            /** Default */
+            default?: string | null;
             /** Help */
-            help: string | null;
+            help?: string | null;
             /** Label */
             label?: string | null;
             /** Name */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -22845,8 +22845,6 @@ export interface components {
         TaskState: "PENDING" | "STARTED" | "RETRY" | "FAILURE" | "SUCCESS";
         /** TemplateSecret */
         TemplateSecret: {
-            /** Default */
-            default?: string | null;
             /** Help */
             help?: string | null;
             /** Label */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -22853,6 +22853,8 @@ export interface components {
             label?: string | null;
             /** Name */
             name: string;
+            /** Optional */
+            optional?: boolean | null;
         };
         /** TemplateVariableBoolean */
         TemplateVariableBoolean: {
@@ -22864,6 +22866,8 @@ export interface components {
             label?: string | null;
             /** Name */
             name: string;
+            /** Optional */
+            optional?: boolean | null;
             /**
              * Type
              * @constant
@@ -22888,6 +22892,8 @@ export interface components {
             label?: string | null;
             /** Name */
             name: string;
+            /** Optional */
+            optional?: boolean | null;
             /**
              * Type
              * @constant
@@ -22912,6 +22918,8 @@ export interface components {
             label?: string | null;
             /** Name */
             name: string;
+            /** Optional */
+            optional?: boolean | null;
             /**
              * Type
              * @constant
@@ -22936,6 +22944,8 @@ export interface components {
             label?: string | null;
             /** Name */
             name: string;
+            /** Optional */
+            optional?: boolean | null;
             /**
              * Type
              * @constant

--- a/client/src/components/ConfigTemplates/InstanceForm.vue
+++ b/client/src/components/ConfigTemplates/InstanceForm.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { ref } from "vue";
+
+import { isDefined } from "@/utils/validation";
+
 import type { FormEntry } from "./formUtil";
 
 import ForceActionButton from "./ForceActionButton.vue";
@@ -27,9 +31,14 @@ const emit = defineEmits<{
 }>();
 
 let formData: any;
+const hasValidationErrors = ref(false);
 
 function onChange(incoming: any) {
     formData = incoming;
+}
+
+function onValidation(validation: any) {
+    hasValidationErrors.value = isDefined(validation);
 }
 
 async function handleSubmit() {
@@ -46,11 +55,17 @@ async function handleForceSubmit() {
         <div v-else>
             <FormCard :title="title">
                 <template v-slot:body>
-                    <FormDisplay :inputs="inputs" @onChange="onChange" />
+                    <FormDisplay :inputs="inputs" @onChange="onChange" @onValidation="onValidation" />
                 </template>
             </FormCard>
             <div class="mt-3">
-                <GButton id="submit" color="blue" class="mr-1" :disabled="busy" @click="handleSubmit">
+                <GButton
+                    id="submit"
+                    color="blue"
+                    class="mr-1"
+                    :disabled="busy || hasValidationErrors"
+                    disabled-title="Please fix validation errors before submitting"
+                    @click="handleSubmit">
                     {{ submitTitle }}
                 </GButton>
                 <ForceActionButton v-show="showForceActionButton" :action="submitTitle" @click="handleForceSubmit">

--- a/client/src/components/ConfigTemplates/InstanceForm.vue
+++ b/client/src/components/ConfigTemplates/InstanceForm.vue
@@ -62,7 +62,7 @@ async function handleForceSubmit() {
                 <GButton
                     id="submit"
                     color="blue"
-                    class="mr-1"
+                    class="mr-1 mb-3"
                     :disabled="busy || hasValidationErrors"
                     disabled-title="Please fix validation errors before submitting"
                     @click="handleSubmit">

--- a/client/src/components/ConfigTemplates/InstanceForm.vue
+++ b/client/src/components/ConfigTemplates/InstanceForm.vue
@@ -55,7 +55,11 @@ async function handleForceSubmit() {
         <div v-else>
             <FormCard :title="title">
                 <template v-slot:body>
-                    <FormDisplay :inputs="inputs" @onChange="onChange" @onValidation="onValidation" />
+                    <FormDisplay
+                        :inputs="inputs"
+                        :allow-empty-value-on-required-input="true"
+                        @onChange="onChange"
+                        @onValidation="onValidation" />
                 </template>
             </FormCard>
             <div class="mt-3">

--- a/client/src/components/ConfigTemplates/formUtil.test.ts
+++ b/client/src/components/ConfigTemplates/formUtil.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import type { TemplateVariable } from "@/api/configTemplates";
+import type { TemplateSecret, TemplateVariable } from "@/api/configTemplates";
 
-import { createTemplateForm, templateVariableFormEntry, upgradeForm } from "./formUtil";
+import { createTemplateForm, templateSecretFormEntry, templateVariableFormEntry, upgradeForm } from "./formUtil";
 import {
     GENERIC_FTP_FILE_SOURCE_TEMPLATE,
     OBJECT_STORE_INSTANCE,
@@ -97,6 +97,88 @@ describe("formUtils", () => {
             const hostVariable = FTP_VARIABLES[0] as TemplateVariable;
             const formEntry = templateVariableFormEntry(hostVariable, "mycoolhost.org");
             expect(formEntry.value).toBe("mycoolhost.org");
+        });
+    });
+
+    describe("templateVariableFormEntry optional field", () => {
+        it("should mark variable as optional when it has a default", () => {
+            const varWithDefault: TemplateVariable = {
+                name: "test_var",
+                type: "string",
+                default: "default_value",
+            };
+            const formEntry = templateVariableFormEntry(varWithDefault, undefined);
+            expect(formEntry.optional).toBe(true);
+        });
+
+        it("should mark variable as required when it has no default", () => {
+            const varWithoutDefault: TemplateVariable = {
+                name: "test_var",
+                type: "string",
+            };
+            const formEntry = templateVariableFormEntry(varWithoutDefault, undefined);
+            expect(formEntry.optional).toBe(false);
+        });
+
+        it("should mark integer variable as optional when default is zero", () => {
+            const varWithZeroDefault: TemplateVariable = {
+                name: "test_var",
+                type: "integer",
+                default: 0,
+            };
+            const formEntry = templateVariableFormEntry(varWithZeroDefault, undefined);
+            expect(formEntry.optional).toBe(true);
+        });
+
+        it("should mark boolean variable as optional when default is false", () => {
+            const varWithFalseDefault: TemplateVariable = {
+                name: "test_var",
+                type: "boolean",
+                default: false,
+            };
+            const formEntry = templateVariableFormEntry(varWithFalseDefault, undefined);
+            expect(formEntry.optional).toBe(true);
+        });
+
+        it("should mark string variable as optional when default is empty string", () => {
+            const varWithEmptyDefault: TemplateVariable = {
+                name: "test_var",
+                type: "string",
+                default: "",
+            };
+            const formEntry = templateVariableFormEntry(varWithEmptyDefault, undefined);
+            expect(formEntry.optional).toBe(true);
+        });
+    });
+
+    describe("templateSecretFormEntry optional field", () => {
+        it("should mark secret as optional when it has a default", () => {
+            const secretWithDefault: TemplateSecret = {
+                name: "mysecret",
+                help: "Help text",
+                default: "default_value",
+            };
+            const formEntry = templateSecretFormEntry(secretWithDefault);
+            expect(formEntry.optional).toBe(true);
+        });
+
+        it("should mark secret as required when it has no default", () => {
+            const secretWithoutDefault: TemplateSecret = {
+                name: "mysecret",
+                help: "Help text",
+            };
+            const formEntry = templateSecretFormEntry(secretWithoutDefault);
+            expect(formEntry.optional).toBe(false);
+        });
+
+        it("should mark secret as optional when default is empty string", () => {
+            const secretWithEmptyDefault: TemplateSecret = {
+                name: "mysecret",
+                help: "Help text",
+                default: "",
+            };
+            const formEntry = templateSecretFormEntry(secretWithEmptyDefault);
+            expect(formEntry.optional).toBe(true);
         });
     });
 });

--- a/client/src/components/ConfigTemplates/formUtil.test.ts
+++ b/client/src/components/ConfigTemplates/formUtil.test.ts
@@ -101,84 +101,64 @@ describe("formUtils", () => {
     });
 
     describe("templateVariableFormEntry optional field", () => {
-        it("should mark variable as optional when it has a default", () => {
-            const varWithDefault: TemplateVariable = {
+        it("should mark variable as optional when template specifies optional=true", () => {
+            const optionalVar: TemplateVariable = {
                 name: "test_var",
                 type: "string",
-                default: "default_value",
+                optional: true,
             };
-            const formEntry = templateVariableFormEntry(varWithDefault, undefined);
+            const formEntry = templateVariableFormEntry(optionalVar, undefined);
             expect(formEntry.optional).toBe(true);
         });
 
-        it("should mark variable as required when it has no default", () => {
-            const varWithoutDefault: TemplateVariable = {
+        it("should mark variable as required when template specifies optional=false", () => {
+            const requiredVar: TemplateVariable = {
                 name: "test_var",
                 type: "string",
+                optional: false,
             };
-            const formEntry = templateVariableFormEntry(varWithoutDefault, undefined);
+            const formEntry = templateVariableFormEntry(requiredVar, undefined);
             expect(formEntry.optional).toBe(false);
         });
 
-        it("should mark integer variable as optional when default is zero", () => {
-            const varWithZeroDefault: TemplateVariable = {
-                name: "test_var",
-                type: "integer",
-                default: 0,
-            };
-            const formEntry = templateVariableFormEntry(varWithZeroDefault, undefined);
-            expect(formEntry.optional).toBe(true);
-        });
-
-        it("should mark boolean variable as optional when default is false", () => {
-            const varWithFalseDefault: TemplateVariable = {
-                name: "test_var",
-                type: "boolean",
-                default: false,
-            };
-            const formEntry = templateVariableFormEntry(varWithFalseDefault, undefined);
-            expect(formEntry.optional).toBe(true);
-        });
-
-        it("should mark string variable as optional when default is empty string", () => {
-            const varWithEmptyDefault: TemplateVariable = {
+        it("should mark variable as required when template does not specify optional", () => {
+            const varWithoutOptional: TemplateVariable = {
                 name: "test_var",
                 type: "string",
-                default: "",
             };
-            const formEntry = templateVariableFormEntry(varWithEmptyDefault, undefined);
-            expect(formEntry.optional).toBe(true);
+            const formEntry = templateVariableFormEntry(varWithoutOptional, undefined);
+            expect(formEntry.optional).toBe(false);
         });
     });
 
     describe("templateSecretFormEntry optional field", () => {
-        it("should mark secret as optional when it has a default", () => {
-            const secretWithDefault: TemplateSecret = {
+        it("should mark secret as optional when template specifies optional=true", () => {
+            const optionalSecret: TemplateSecret = {
                 name: "mysecret",
                 help: "Help text",
-                default: "default_value",
+                optional: true,
             };
-            const formEntry = templateSecretFormEntry(secretWithDefault);
+            const formEntry = templateSecretFormEntry(optionalSecret);
             expect(formEntry.optional).toBe(true);
         });
 
-        it("should mark secret as required when it has no default", () => {
-            const secretWithoutDefault: TemplateSecret = {
+        it("should mark secret as required when template specifies optional=false", () => {
+            const requiredSecret: TemplateSecret = {
                 name: "mysecret",
                 help: "Help text",
+                optional: false,
             };
-            const formEntry = templateSecretFormEntry(secretWithoutDefault);
+            const formEntry = templateSecretFormEntry(requiredSecret);
             expect(formEntry.optional).toBe(false);
         });
 
-        it("should mark secret as optional when default is empty string", () => {
-            const secretWithEmptyDefault: TemplateSecret = {
+        it("should mark secret as required when template does not specify optional", () => {
+            const secretWithoutOptional: TemplateSecret = {
                 name: "mysecret",
                 help: "Help text",
-                default: "",
             };
-            const formEntry = templateSecretFormEntry(secretWithEmptyDefault);
-            expect(formEntry.optional).toBe(true);
+            const formEntry = templateSecretFormEntry(secretWithoutOptional);
+            expect(formEntry.optional).toBe(false);
         });
     });
 });

--- a/client/src/components/ConfigTemplates/formUtil.ts
+++ b/client/src/components/ConfigTemplates/formUtil.ts
@@ -11,6 +11,7 @@ import type {
     VariableValueType,
 } from "@/api/configTemplates";
 import { markup } from "@/components/ObjectStore/configurationMarkdown";
+import { isDefined } from "@/utils/validation";
 
 export interface FormEntry {
     name: string;
@@ -48,6 +49,7 @@ export function templateVariableFormEntry(variable: TemplateVariable, variableVa
         label: variable.label ?? variable.name,
         help: markup(variable.help || "", true),
         validators: variable.validators ?? [],
+        optional: isDefined(variable.default),
     };
     if (variable.type == "string") {
         const defaultValue = variable.default ?? "";

--- a/client/src/components/ConfigTemplates/formUtil.ts
+++ b/client/src/components/ConfigTemplates/formUtil.ts
@@ -11,7 +11,6 @@ import type {
     VariableValueType,
 } from "@/api/configTemplates";
 import { markup } from "@/components/ObjectStore/configurationMarkdown";
-import { isDefined } from "@/utils/validation";
 
 export interface FormEntry {
     name: string;
@@ -49,7 +48,7 @@ export function templateVariableFormEntry(variable: TemplateVariable, variableVa
         label: variable.label ?? variable.name,
         help: markup(variable.help || "", true),
         validators: variable.validators ?? [],
-        optional: isDefined(variable.default),
+        optional: variable.optional || false,
     };
     if (variable.type == "string") {
         const defaultValue = variable.default ?? "";
@@ -91,7 +90,7 @@ export function templateSecretFormEntry(secret: TemplateSecret): FormEntry {
         type: "password",
         help: markup(secret.help || "", true),
         value: "",
-        optional: isDefined(secret.default),
+        optional: secret.optional || false,
     };
 }
 

--- a/client/src/components/ConfigTemplates/formUtil.ts
+++ b/client/src/components/ConfigTemplates/formUtil.ts
@@ -91,6 +91,7 @@ export function templateSecretFormEntry(secret: TemplateSecret): FormEntry {
         type: "password",
         help: markup(secret.help || "", true),
         value: "",
+        optional: isDefined(secret.default),
     };
 }
 

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -1,5 +1,7 @@
 import _ from "underscore";
 
+import { isValidNumber } from "@/utils/validation";
+
 /** Visits tool inputs.
  * @param{dict}   inputs    - Nested dictionary of input elements
  * @param{dict}   callback  - Called with the mapped dictionary object and corresponding model node
@@ -131,10 +133,10 @@ function validateLength(validator, value) {
     const valueLength = String(value).length;
     let isValid = true;
 
-    if (validator.min !== undefined && valueLength < validator.min) {
+    if (isValidNumber(validator.min) && valueLength < validator.min) {
         isValid = false;
     }
-    if (validator.max !== undefined && valueLength > validator.max) {
+    if (isValidNumber(validator.max) && valueLength > validator.max) {
         isValid = false;
     }
     if (validator.negate) {
@@ -164,10 +166,10 @@ function validateInRange(validator, value) {
 
     let isValid = true;
 
-    if (validator.min !== undefined && numericValue < validator.min) {
+    if (isValidNumber(validator.min) && numericValue < validator.min) {
         isValid = false;
     }
-    if (validator.max !== undefined && numericValue > validator.max) {
+    if (isValidNumber(validator.max) && numericValue > validator.max) {
         isValid = false;
     }
     if (validator.negate) {

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -210,11 +210,11 @@ function runValidator(validator, value) {
 export function validateInputs(index, values, allowEmptyValueOnRequiredInput = false) {
     let batchN = -1;
     let batchSrc = null;
-    for (const inputId in values) {
+    for (const inputId in index) {
+        const inputDef = index[inputId];
         const inputValue = values[inputId];
         const isEmpty = !isDefined(inputValue) || inputValue === "";
         const hasValue = !isEmpty;
-        const inputDef = index[inputId];
         const isRequired = !inputDef.optional;
         if (!inputDef || inputDef.step_linked) {
             continue;

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -227,7 +227,7 @@ export function validateInputs(index, values, allowEmptyValueOnRequiredInput = f
         if (inputDef.wp_linked && inputDef.text_value == inputValue) {
             return [inputId, "Please provide a value for this workflow parameter."];
         }
-        if (inputValue && Array.isArray(inputValue.values) && inputValue.values.length == 0 && !isRequired) {
+        if (inputValue && Array.isArray(inputValue.values) && inputValue.values.length == 0 && isRequired) {
             return [inputId, "Please provide data for this input."];
         }
         if (inputValue) {

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -213,11 +213,13 @@ export function validateInputs(index, values, allowEmptyValueOnRequiredInput = f
     for (const inputId in values) {
         const inputValue = values[inputId];
         const isEmpty = !isDefined(inputValue) || inputValue === "";
+        const hasValue = !isEmpty;
         const inputDef = index[inputId];
+        const isRequired = !inputDef.optional;
         if (!inputDef || inputDef.step_linked) {
             continue;
         }
-        if (!inputDef.optional && inputDef.type != "hidden") {
+        if (isRequired && inputDef.type != "hidden") {
             if (isEmpty && !allowEmptyValueOnRequiredInput) {
                 return [inputId, "Please provide a value for this option."];
             }
@@ -225,7 +227,7 @@ export function validateInputs(index, values, allowEmptyValueOnRequiredInput = f
         if (inputDef.wp_linked && inputDef.text_value == inputValue) {
             return [inputId, "Please provide a value for this workflow parameter."];
         }
-        if (inputValue && Array.isArray(inputValue.values) && inputValue.values.length == 0 && !inputDef.optional) {
+        if (inputValue && Array.isArray(inputValue.values) && inputValue.values.length == 0 && !isRequired) {
             return [inputId, "Please provide data for this input."];
         }
         if (inputValue) {
@@ -263,8 +265,8 @@ export function validateInputs(index, values, allowEmptyValueOnRequiredInput = f
             }
         }
 
-        // Run custom validators if present
-        if (inputDef.validators && inputValue != null && inputValue !== "") {
+        // Run custom validators if field is required or has a value
+        if (inputDef.validators && (isRequired || hasValue)) {
             for (const validator of inputDef.validators) {
                 const validationResult = runValidator(validator, inputValue);
                 if (!validationResult.isValid) {

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -220,7 +220,7 @@ export function validateInputs(index, values, allowEmptyValueOnRequiredInput = f
             continue;
         }
         if (isRequired && inputDef.type != "hidden") {
-            if (isEmpty && !allowEmptyValueOnRequiredInput) {
+            if (!isDefined(inputValue) || (allowEmptyValueOnRequiredInput && inputValue === "")) {
                 return [inputId, "Please provide a value for this option."];
             }
         }

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { isValidNumber } from "@/utils/validation";
+import { isDefined, isValidNumber } from "@/utils/validation";
 
 /** Visits tool inputs.
  * @param{dict}   inputs    - Nested dictionary of input elements
@@ -212,12 +212,13 @@ export function validateInputs(index, values, allowEmptyValueOnRequiredInput = f
     let batchSrc = null;
     for (const inputId in values) {
         const inputValue = values[inputId];
+        const isEmpty = !isDefined(inputValue) || inputValue === "";
         const inputDef = index[inputId];
         if (!inputDef || inputDef.step_linked) {
             continue;
         }
         if (!inputDef.optional && inputDef.type != "hidden") {
-            if (inputValue == null || (allowEmptyValueOnRequiredInput && inputValue === "")) {
+            if (isEmpty && !allowEmptyValueOnRequiredInput) {
                 return [inputId, "Please provide a value for this option."];
             }
         }

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -402,10 +402,11 @@ describe("form component utilities", () => {
             },
         };
 
-        // Empty string should fail for required field
+        // Empty string should PASS for required field (default behavior - allowEmptyValueOnRequiredInput=false)
+        // Note: allowEmptyValueOnRequiredInput is misnamed - it should be rejectEmptyRequiredInputs
         let values = { required_field: "" };
         let result = validateInputs(index, values);
-        expect(result).toEqual(["required_field", "Please provide a value for this option."]);
+        expect(result).toEqual(null);
 
         // undefined should fail for required field
         values = { required_field: undefined };
@@ -421,5 +422,11 @@ describe("form component utilities", () => {
         values = { required_field: "value" };
         result = validateInputs(index, values);
         expect(result).toEqual(null);
+
+        // When allowEmptyValueOnRequiredInput=true (misnamed, really means reject empty strings too),
+        // empty string should also fail
+        values = { required_field: "" };
+        result = validateInputs(index, values, true);
+        expect(result).toEqual(["required_field", "Please provide a value for this option."]);
     });
 });

--- a/client/src/components/ObjectStore/Instances/CreateForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/CreateForm.test.ts
@@ -120,6 +120,10 @@ describe("CreateForm", () => {
 
         const nameForElement = wrapper.find("#form-element-_meta_name");
         await nameForElement.find("input").setValue("My New Name");
+
+        const passwordElement = wrapper.find("#form-element-mysecret");
+        await passwordElement.find("input").setValue("mysecretvalue");
+
         const submitElement = wrapper.find("#submit");
         await submitElement.trigger("click");
         await flushPromises();
@@ -147,14 +151,42 @@ describe("CreateForm", () => {
         await flushPromises();
         const nameForElement = wrapper.find("#form-element-_meta_name");
         nameForElement.find("input").setValue("My New Name");
-        const submitElement = wrapper.find("#submit");
+
+        const passwordElement = wrapper.find("#form-element-mysecret");
+        await passwordElement.find("input").setValue("mysecretvalue");
+
         expect(wrapper.find("[data-description='object-store-creation-error']").exists()).toBe(false);
-        submitElement.trigger("click");
+
+        const submitElement = wrapper.find("#submit");
+        await submitElement.trigger("click");
         await flushPromises();
         const emitted = wrapper.emitted("created") || [];
         expect(emitted).toHaveLength(0);
         const errorEl = wrapper.find("[data-description='object-store-creation-error']");
         expect(errorEl.exists()).toBe(true);
         expect(errorEl.html()).toContain("Error creating this");
+    });
+
+    it("should disable submit when there are validation errors", async () => {
+        const wrapper = mount(CreateForm as object, {
+            propsData: {
+                template: SIMPLE_TEMPLATE,
+            },
+            localVue,
+        });
+
+        const nameForElement = wrapper.find("#form-element-_meta_name");
+        await nameForElement.find("input").setValue("My New Name");
+
+        // Leave secret empty to trigger validation error
+
+        const submitElement = wrapper.find("#submit");
+        expect(submitElement.classes().includes("g-disabled")).toBe(true);
+
+        // Try to click when submit is disabled will not emit created event
+        await submitElement.trigger("click");
+        await flushPromises();
+        const emitted = wrapper.emitted("created") || [];
+        expect(emitted).toHaveLength(0);
     });
 });

--- a/client/src/components/ObjectStore/Instances/CreateForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/CreateForm.test.ts
@@ -130,7 +130,6 @@ const OPTIONAL_VAR_WITH_VALIDATION_TEMPLATE: ObjectStoreTemplateSummary = {
         {
             name: "mysecret",
             help: "mysecret help",
-            default: "default_secret",
             optional: true,
         },
     ],

--- a/client/src/components/ObjectStore/Instances/CreateForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/CreateForm.test.ts
@@ -95,7 +95,7 @@ const OPTIONAL_SECRET_TEMPLATE: ObjectStoreTemplateSummary = {
         {
             name: "optional_secret",
             help: "An optional secret",
-            default: "default_value",
+            optional: true,
         },
     ],
     id: "moo",
@@ -114,6 +114,7 @@ const OPTIONAL_VAR_WITH_VALIDATION_TEMPLATE: ObjectStoreTemplateSummary = {
             type: "string",
             help: "optional var help",
             default: "",
+            optional: true,
             validators: [
                 {
                     type: "length",
@@ -130,6 +131,7 @@ const OPTIONAL_VAR_WITH_VALIDATION_TEMPLATE: ObjectStoreTemplateSummary = {
             name: "mysecret",
             help: "mysecret help",
             default: "default_secret",
+            optional: true,
         },
     ],
     id: "moo",

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
@@ -42,6 +42,7 @@ const STANDARD_TEMPLATE: ObjectStoreTemplateSummary = {
         {
             name: "newsecret",
             help: "new secret help",
+            default: "", // New secret with default value making it effectively optional, so no need to fill in value
         },
     ],
     id: "moo",

--- a/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
+++ b/client/src/components/ObjectStore/Instances/UpgradeForm.test.ts
@@ -26,12 +26,14 @@ const STANDARD_TEMPLATE: ObjectStoreTemplateSummary = {
             type: "string",
             help: "old var help",
             default: "old default",
+            optional: true,
         },
         {
             name: "newvar",
             type: "string",
             help: "new var help",
             default: "",
+            optional: true,
         },
     ],
     secrets: [
@@ -42,7 +44,7 @@ const STANDARD_TEMPLATE: ObjectStoreTemplateSummary = {
         {
             name: "newsecret",
             help: "new secret help",
-            default: "", // New secret with default value making it effectively optional, so no need to fill in value
+            optional: true, // New secret is optional
         },
     ],
     id: "moo",

--- a/doc/source/admin/data.md
+++ b/doc/source/admin/data.md
@@ -439,12 +439,12 @@ Example configuration for EBI SRA downloads:
   id: ebi_aspera
   label: "EBI Aspera Downloads"
   doc: "High-speed downloads from EBI SRA using Aspera FASP protocol"
-  ascp_path: "ascp"  # Path to ascp binary
+  ascp_path: "ascp" # Path to ascp binary
   user: "era-fasp"
   host: "fasp.sra.ebi.ac.uk"
   port: 33001
-  rate_limit: "300m"  # Transfer rate limit (e.g., "300m" for 300 Mbps)
-  disable_encryption: true  # Disable encryption for maximum speed
+  rate_limit: "300m" # Transfer rate limit (e.g., "300m" for 300 Mbps)
+  disable_encryption: true # Disable encryption for maximum speed
   # Retry and resume configuration (optional)
   max_retries: 3
   retry_base_delay: 2.0
@@ -459,11 +459,11 @@ Example configuration for EBI SRA downloads:
   ssh_key_passphrase: sample_passphrase
 ```
 
-The plugin is **download-only** and supports automatic retry with exponential backoff for transient 
+The plugin is **download-only** and supports automatic retry with exponential backoff for transient
 network errors and can resume interrupted transfers. Both `ascp://` and `fasp://` URL schemes are supported.
 
-**SSH Key Configuration Note:** The plugin requires SSH key content (not file paths) because Galaxy jobs often 
-run on clusters that don't mount Galaxy's root or configuration directories. The configuration block is copied 
+**SSH Key Configuration Note:** The plugin requires SSH key content (not file paths) because Galaxy jobs often
+run on clusters that don't mount Galaxy's root or configuration directories. The configuration block is copied
 to the job's directory, but referenced key paths wouldn't be accessible.
 
 **Note:** The plugin does not support browsing directories or uploading files (`writable: false`, `browsable: false`).

--- a/doc/source/admin/data.md
+++ b/doc/source/admin/data.md
@@ -763,6 +763,19 @@ on the simple minio example.
 
 Template variables can include optional validators to enforce constraints on user input. Validators ensure that users provide valid values when configuring file sources or object stores, providing clear error messages when validation fails.
 
+### Required vs optional template variables and secrets
+
+When defining `variables` and `secrets` in file source (and object store) templates, Galaxy follows **explicit rules**:
+
+- Variables and secrets are **required by default**.
+- A variable or secret is optional **only if** `optional: true` is explicitly set.
+- Defining a `default` value **does not** make a field optional.
+- Default values are applied **only** for variables or secrets marked as `optional: true`.
+- Validators are evaluated **only when a value is provided**; omitted optional fields are not validated.
+- Default values **are validated** when they are applied (i.e. for `optional: true` fields with a default).
+
+This explicit model avoids implicit behavior and makes template intent clear and predictable.
+
 ### Validator Types
 
 Galaxy supports three types of validators that can be applied to template variables:

--- a/lib/galaxy/files/templates/examples/omero_server.yml
+++ b/lib/galaxy/files/templates/examples/omero_server.yml
@@ -16,11 +16,13 @@
           label: Server Host
           type: string
           help: Host of the OMERO Server to connect to. For example, to connect to the IDR use idr.openmicroscopy.org.
+          optional: true
           default: idr.openmicroscopy.org
       port:
           label: Port
           type: integer
           help: Port used to connect to the OMERO server.
+          optional: true
           default: 4064
       username:
           label: Username

--- a/lib/galaxy/files/templates/examples/onedata.yml
+++ b/lib/galaxy/files/templates/examples/onedata.yml
@@ -18,6 +18,7 @@
       help: |
         Allows connection to Onedata servers that do not present trusted SSL certificates.
         SHOULD NOT be used unless you really know what you are doing.
+      optional: true
       default: False
     writable:
       label: Writable?
@@ -25,6 +26,7 @@
       help: |
         Allow Galaxy to write data to this Onedata repository.
         Requires an access token with write data access.
+      optional: true
       default: False
   secrets:
     access_token:

--- a/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml
+++ b/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml
@@ -23,6 +23,7 @@
     writable:
       label: Writable?
       type: boolean
+      optional: true
       default: false
       help: Is this a bucket you have permission to write to?
   secrets:

--- a/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml
+++ b/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml
@@ -17,12 +17,14 @@
     bucket:
       label: Bucket
       type: string
+      default: ""
       help: |
         The [Amazon Web Services Bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html) to
         access. This should be a bucket the user described by the Access Key ID has access to.
     writable:
       label: Writable?
       type: boolean
+      default: false
       help: Is this a bucket you have permission to write to?
   secrets:
     secret_key:

--- a/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml
+++ b/lib/galaxy/files/templates/examples/production_aws_private_bucket.yml
@@ -17,7 +17,6 @@
     bucket:
       label: Bucket
       type: string
-      default: ""
       help: |
         The [Amazon Web Services Bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html) to
         access. This should be a bucket the user described by the Access Key ID has access to.

--- a/lib/galaxy/files/templates/examples/production_azure.yml
+++ b/lib/galaxy/files/templates/examples/production_azure.yml
@@ -26,6 +26,7 @@
     hierarchical:
       label: Hierarchical?
       type: boolean
+      optional: true
       default: true
       help: |
         Is this storage hierarchical (e.g. does it use a Azure Data Lake Storage Gen2 hierarchical namespace)?
@@ -34,6 +35,7 @@
     writable:
       label: Writable?
       type: boolean
+      optional: true
       default: true
       help: Allow Galaxy to write data to this Azure Blob Storage container.
   secrets:

--- a/lib/galaxy/files/templates/examples/production_azureflat.yml
+++ b/lib/galaxy/files/templates/examples/production_azureflat.yml
@@ -25,6 +25,7 @@
     writable:
       label: Writable?
       type: boolean
+      optional: true
       default: false
       help: Allow Galaxy to write data to this Azure Blob Storage container.
   secrets:

--- a/lib/galaxy/files/templates/examples/production_dataverse.yml
+++ b/lib/galaxy/files/templates/examples/production_dataverse.yml
@@ -2,8 +2,8 @@
   version: 0
   name: Dataverse
   description: |
-      [The Dataverse Project](https://dataverse.org) is an open-source web application for sharing, preserving, citing, exploring, and analyzing research data. 
-      It enables institutions and researchers to host and manage datasets with rich metadata and persistent identifiers. 
+      [The Dataverse Project](https://dataverse.org) is an open-source web application for sharing, preserving, citing, exploring, and analyzing research data.
+      It enables institutions and researchers to host and manage datasets with rich metadata and persistent identifiers.
       This configuration allows you to connect Galaxy to a Dataverse instance of your choice.
 
       **Note:** Your **registered email address** will be used to create datasets in Dataverse.
@@ -17,6 +17,7 @@
       writable:
           label: Allow Galaxy to export data to Dataverse?
           type: boolean
+          optional: true
           default: true
           help: |
               Allow Galaxy to write data to this Dataverse instance. Set it to "Yes" if you want to export data from Galaxy to

--- a/lib/galaxy/files/templates/examples/production_elabftw.yml
+++ b/lib/galaxy/files/templates/examples/production_elabftw.yml
@@ -15,6 +15,7 @@
     writable:
       label: Allow Galaxy to export data to eLabFTW?
       type: boolean
+      optional: true
       default: true
       help: |
         Allow Galaxy to write data to this eLabFTW instance. Set it to "Yes" if you want to export data from Galaxy to

--- a/lib/galaxy/files/templates/examples/production_ftp.yml
+++ b/lib/galaxy/files/templates/examples/production_ftp.yml
@@ -25,12 +25,14 @@
     writable:
       label: Writable?
       type: boolean
+      optional: true
       default: false
       help: Is this an FTP server you have permission to write to?
     port:
       label: FTP Port
       type: integer
       help: Port used to connect to the FTP server.
+      optional: true
       default: 21
   secrets:
     password:

--- a/lib/galaxy/files/templates/examples/production_ftp.yml
+++ b/lib/galaxy/files/templates/examples/production_ftp.yml
@@ -18,12 +18,14 @@
     user:
       label: FTP User
       type: string
+      default: ""
       help: |
         Username to connect with. Leave this blank to connect to the server
         anonymously (if allowed by target server).
     writable:
       label: Writable?
       type: boolean
+      default: false
       help: Is this an FTP server you have permission to write to?
     port:
       label: FTP Port
@@ -33,6 +35,7 @@
   secrets:
     password:
       label: FTP Password
+      default: ""
       help: |
         Password to connect to FTP server with. Leave this blank to connect
         to the server anonymously (if allowed by target server).

--- a/lib/galaxy/files/templates/examples/production_ftp.yml
+++ b/lib/galaxy/files/templates/examples/production_ftp.yml
@@ -18,7 +18,7 @@
     user:
       label: FTP User
       type: string
-      default: ""
+      optional: true
       help: |
         Username to connect with. Leave this blank to connect to the server
         anonymously (if allowed by target server).
@@ -35,7 +35,7 @@
   secrets:
     password:
       label: FTP Password
-      default: ""
+      optional: true
       help: |
         Password to connect to FTP server with. Leave this blank to connect
         to the server anonymously (if allowed by target server).

--- a/lib/galaxy/files/templates/examples/production_huggingface.yml
+++ b/lib/galaxy/files/templates/examples/production_huggingface.yml
@@ -15,7 +15,7 @@
   secrets:
       token:
           label: Hugging Face Access Token
-          default: ""
+          optional: true
           help: |
               The personal access token to use to connect to the Hugging Face Hub. You can generate a new token in your Hugging Face account settings.
               This will allow Galaxy to access private models if you have the necessary permissions.

--- a/lib/galaxy/files/templates/examples/production_huggingface.yml
+++ b/lib/galaxy/files/templates/examples/production_huggingface.yml
@@ -15,6 +15,7 @@
   secrets:
       token:
           label: Hugging Face Access Token
+          default: ""
           help: |
               The personal access token to use to connect to the Hugging Face Hub. You can generate a new token in your Hugging Face account settings.
               This will allow Galaxy to access private models if you have the necessary permissions.

--- a/lib/galaxy/files/templates/examples/production_huggingface.yml
+++ b/lib/galaxy/files/templates/examples/production_huggingface.yml
@@ -8,6 +8,7 @@
       endpoint:
           label: Hugging Face Hub Endpoint
           type: string
+          optional: true
           help: |
               Custom endpoint of the Hugging Face Hub you are connecting to. This should be the full URL including the protocol (http or https) and the domain name.
               You can leave this blank to use the default Hugging Face Hub endpoint (https://huggingface.co).

--- a/lib/galaxy/files/templates/examples/production_invenio.yml
+++ b/lib/galaxy/files/templates/examples/production_invenio.yml
@@ -14,6 +14,7 @@
       writable:
           label: Allow Galaxy to export data to InvenioRDM?
           type: boolean
+          optional: true
           default: true
           help: |
               Allow Galaxy to write data to this InvenioRDM instance. Set it to "Yes" if you want to export data from Galaxy to

--- a/lib/galaxy/files/templates/examples/production_s3fs.yml
+++ b/lib/galaxy/files/templates/examples/production_s3fs.yml
@@ -102,6 +102,7 @@
     writable:
       label: Writable?
       type: boolean
+      optional: true
       default: false
       help: Is this a bucket you have permission to write to?
   secrets:

--- a/lib/galaxy/files/templates/examples/production_s3fs.yml
+++ b/lib/galaxy/files/templates/examples/production_s3fs.yml
@@ -102,6 +102,7 @@
     writable:
       label: Writable?
       type: boolean
+      default: false
       help: Is this a bucket you have permission to write to?
   secrets:
     secret_key:

--- a/lib/galaxy/files/templates/examples/production_webdav.yml
+++ b/lib/galaxy/files/templates/examples/production_webdav.yml
@@ -24,6 +24,7 @@
     writable:
       label: Writable?
       type: boolean
+      optional: true
       default: false
       help: Allow Galaxy to write data to this WebDAV server.
   secrets:

--- a/lib/galaxy/files/templates/examples/production_zenodo.yml
+++ b/lib/galaxy/files/templates/examples/production_zenodo.yml
@@ -11,6 +11,7 @@
       writable:
           label: Allow Galaxy to export data to Zenodo?
           type: boolean
+          optional: true
           default: true
           help: |
               Set it to "Yes" if you want to export data from Galaxy to Zenodo, set it to "No" if you only need to import

--- a/lib/galaxy/files/templates/examples/s3fs_by_host_and_port.yml
+++ b/lib/galaxy/files/templates/examples/s3fs_by_host_and_port.yml
@@ -43,6 +43,7 @@
     port:
       label: Connection Port
       type: integer
+      optional: true
       default: 443
       help: |
         The [port](https://en.wikipedia.org/wiki/Port_(computer_networking)) used to connect
@@ -59,6 +60,7 @@
     connection_path:
       label: Connection Path
       type: string
+      optional: true
       default: ""
       help: |
         This is an advanced configuration option and it is very likely best to just keep this empty
@@ -67,6 +69,7 @@
     secure:
       label: Use HTTPS?
       type: boolean
+      optional: true
       default: true
       help: |
         This is an advanced configuration option and if this option is not checked, you should not assume

--- a/lib/galaxy/objectstore/templates/examples/irods.yml
+++ b/lib/galaxy/objectstore/templates/examples/irods.yml
@@ -13,6 +13,7 @@
     port:
       label: iRODS host port
       type: integer
+      optional: true
       help: Host port to connect to.
       default: 1247
     username:
@@ -23,27 +24,31 @@
     timeout:
       label: Connection timeout
       type: integer
+      optional: true
       help: Connection timeout in seconds.
       default: 30
     refresh_time:
       label: Refresh time
       type: integer
+      optional: true
       help: Connection refresh time in seconds.
       default: 300
     connection_pool_monitor_interval:
       label: Connection pool monitor interval
       type: integer
+      optional: true
       help: Interval for monitoring the connection pool in seconds.
       default: 3600
     zone:
       label: iRODS zone
       type: string
       help: |
-        An iRODS Zone is an independent iRODS system consisting of a Catalog Service 
+        An iRODS Zone is an independent iRODS system consisting of a Catalog Service
         Provider
     resource:
       label: Resource
       type: string
+      optional: true
       help: |
         The iRODS resource to use
       default: "default"
@@ -67,4 +72,3 @@
       timeout: '{{ variables.timeout }}'
       refresh_time: '{{ variables.refresh_time }}'
       connection_pool_monitor_interval: '{{ variables.connection_pool_monitor_interval }}'
-

--- a/lib/galaxy/objectstore/templates/examples/irods_ssl.yml
+++ b/lib/galaxy/objectstore/templates/examples/irods_ssl.yml
@@ -13,6 +13,7 @@
     port:
       label: iRODS host port
       type: integer
+      optional: true
       help: Host port to connect to.
       default: 1247
     username:
@@ -23,91 +24,104 @@
     logical_path:
       label: Logical path
       type: string
+      optional: true
       help: |
-        All Data Objects stored in an iRODS system are stored in some Collection, 
+        All Data Objects stored in an iRODS system are stored in some Collection,
         which is a logical name for that set of Data Objects.
         All Galaxy output will be stored in this collection
       default: ""
     timeout:
       label: Connection timeout
       type: integer
+      optional: true
       help: Connection timeout in seconds.
       default: 30
     refresh_time:
       label: Refresh time
       type: integer
+      optional: true
       help: Connection refresh time in seconds.
       default: 300
     connection_pool_monitor_interval:
       label: Connection pool monitor interval
       type: integer
+      optional: true
       help: Interval for monitoring the connection pool in seconds.
       default: 3600
     zone:
       label: iRODS zone
       type: string
       help: |
-        An iRODS Zone is an independent iRODS system consisting of a Catalog Service 
+        An iRODS Zone is an independent iRODS system consisting of a Catalog Service
         Provider
     resource:
       label: Resource
       type: string
+      optional: true
       help: |
         The iRODS resource to use
       default: "default"
     client_server_negotiation:
       label: Server negotiation
       type: string
+      optional: true
       help: |
         Server negotiation
       default: "request_server_negotiation"
     client_server_policy:
       label: Server policy
       type: string
+      optional: true
       help: |
         Server policy
       default: "CS_NEG_REQUIRE"
     encryption_algorithm:
       label: Encryption algorithm
       type: string
+      optional: true
       help: |
         EVP-supplied encryption algorithm for parallel transfer encryption
       default: "AES-256-CBC"
     encryption_key_size:
       label: Encryption key size
       type: integer
+      optional: true
       help: |
         Key size for parallel transfer encryption
       default: 32
     encryption_num_hash_rounds:
       label: Number of hash rounds for encryption
       type: integer
+      optional: true
       help: |
         Number of hash rounds for parallel transfer encryption
       default: 16
     encryption_salt_size:
       label: Salt size
       type: integer
+      optional: true
       help: |
         Salt size for parallel transfer encryption
       default: 8
     ssl_verify_server:
       label: Ssl verify server
       type: string
+      optional: true
       help: |
-        What level of server certificate based authentication to perform. 
-        'none' means not to perform any authentication at all. 
-        'cert' means to verify the certificate validity (i.e. that it was signed by a trusted CA). 
-        'hostname' means to validate the certificate and to verify that the irods_host's 
-        FQDN matches either the common name or one of the subjectAltNames of the certificate. 
+        What level of server certificate based authentication to perform.
+        'none' means not to perform any authentication at all.
+        'cert' means to verify the certificate validity (i.e. that it was signed by a trusted CA).
+        'hostname' means to validate the certificate and to verify that the irods_host's
+        FQDN matches either the common name or one of the subjectAltNames of the certificate.
         'hostname' is the default setting.
       default: "hostname"
     ssl_ca_certificate_file:
       label: Ssl ca certificate file path
       type: string
+      optional: true
       help: |
-        Location of a file of trusted CA certificates in PEM format. 
-        Note that the certificates in this file are used in conjunction with the system default 
+        Location of a file of trusted CA certificates in PEM format.
+        Note that the certificates in this file are used in conjunction with the system default
         trusted certificates
       default: "/etc/irods/ssl/irods.crt"
   secrets:
@@ -141,4 +155,3 @@
       ssl_ca_certificate_file: '{{ variables.ssl_ca_certificate_file }}'
     logical:
       path: '{{ variables.logical_path }}'
-

--- a/lib/galaxy/objectstore/templates/examples/onedata.yml
+++ b/lib/galaxy/objectstore/templates/examples/onedata.yml
@@ -16,6 +16,7 @@
     disable_tls_certificate_validation:
       label: Disable tls certificate validation?
       type: boolean
+      optional: true
       help: |
         Allows connection to Onedata servers that do not present trusted SSL certificates.
         SHOULD NOT be used unless you really know what you are doing.
@@ -31,6 +32,7 @@
     galaxy_root_dir:
       label: Galaxy root directory
       type: string
+      optional: true
       help: |
         The relative directory path in the space at which the Galaxy data
         will be stored. If empty, the data will be stored in the space's

--- a/lib/galaxy/objectstore/templates/examples/production_generic_s3_legacy.yml
+++ b/lib/galaxy/objectstore/templates/examples/production_generic_s3_legacy.yml
@@ -44,6 +44,7 @@
     port:
       label: Connection Port
       type: integer
+      optional: true
       default: 443
       help: |
         The [port](https://en.wikipedia.org/wiki/Port_(computer_networking)) used to connect
@@ -60,6 +61,7 @@
     connection_path:
       label: Connection Path
       type: string
+      optional: true
       default: ""
       help: |
         This is an advanced configuration option and it is very likely best to just keep this empty
@@ -68,6 +70,7 @@
     secure:
       label: Use HTTPS?
       type: boolean
+      optional: true
       default: true
       help: |
         This is an advanced configuration option and if this option is not checked, you should not assume

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -79,18 +79,18 @@ class StrictModel(BaseModel):
 class BaseTemplateVariable(StrictModel):
     name: str
     label: Optional[str] = None
-    help: Optional[MarkdownContent]
+    help: Optional[MarkdownContent] = None
     validators: Optional[Sequence[AnySafeValidatorModel]] = None
 
 
 class TemplateVariableString(BaseTemplateVariable):
     type: Literal["string"]
-    default: str = ""
+    default: Optional[str] = None
 
 
 class TemplateVariableInteger(BaseTemplateVariable):
     type: Literal["integer"]
-    default: int = 0
+    default: Optional[int] = None
     # add min/max
 
 
@@ -101,7 +101,7 @@ class TemplateVariablePathComponent(BaseTemplateVariable):
 
 class TemplateVariableBoolean(BaseTemplateVariable):
     type: Literal["boolean"]
-    default: bool = False
+    default: Optional[bool] = None
 
 
 TemplateVariable = Union[

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -112,7 +112,8 @@ TemplateVariable = Union[
 class TemplateSecret(StrictModel):
     name: str
     label: Optional[str] = None
-    help: Optional[MarkdownContent]
+    help: Optional[MarkdownContent] = None
+    default: Optional[str] = None  # If set, secret is optional
 
 
 class TemplateEnvironmentSecret(StrictModel):
@@ -362,7 +363,8 @@ def validate_defines_all_required_secrets(instance: InstanceDefinition, template
     secrets = instance.secrets
     for template_secret in template.secrets or []:
         name = template_secret.name
-        if name not in secrets:
+        has_default = template_secret.default is not None
+        if name not in secrets and not has_default:
             raise RequestParameterMissingException(f"Must define secret '{name}'")
 
 

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -80,6 +80,7 @@ class BaseTemplateVariable(StrictModel):
     name: str
     label: Optional[str] = None
     help: Optional[MarkdownContent] = None
+    optional: Optional[bool] = None
     validators: Optional[Sequence[AnySafeValidatorModel]] = None
 
 
@@ -113,6 +114,7 @@ class TemplateSecret(StrictModel):
     name: str
     label: Optional[str] = None
     help: Optional[MarkdownContent] = None
+    optional: Optional[bool] = None
     default: Optional[str] = None  # If set, secret is optional
 
 

--- a/test/unit/files/test_template_models.py
+++ b/test/unit/files/test_template_models.py
@@ -217,6 +217,7 @@ LIBRARY_FTP_WITH_DEFAULT_SFTP_PORT = """
     port:
       type: integer
       help: Port used to connect to the SFTP server.
+      optional: true
       default: 22
   secrets:
     password:

--- a/test/unit/files/test_template_models.py
+++ b/test/unit/files/test_template_models.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from yaml import safe_load
 
 from galaxy.files.templates.examples import get_example
@@ -291,19 +293,10 @@ def test_production_aws_public_bucket():
 
 
 def test_examples_parse():
-    _assert_example_parses("production_ftp.yml")
-    _assert_example_parses("production_azure.yml")
-    _assert_example_parses("production_aws_private_bucket.yml")
-    _assert_example_parses("production_aws_public_bucket.yml")
-    _assert_example_parses("production_s3fs.yml")
-    _assert_example_parses("production_dropbox.yml")
-    _assert_example_parses("s3fs_by_host_and_port.yml")
-    _assert_example_parses("templating_override.yml")
-    _assert_example_parses("admin_secrets.yml")
-    _assert_example_parses("admin_secrets_with_defaults.yml")
-    _assert_example_parses("testing_multi_version_with_secrets.yml")
-    _assert_example_parses("dropbox_client_secrets_in_vault.yml")
-    _assert_example_parses("dropbox_client_secrets_explicit.yml")
+    # Ensure every YAML example in `lib/galaxy/files/templates/examples/` parses without error
+    examples_dir = Path(__file__).resolve().parents[3] / "lib" / "galaxy" / "files" / "templates" / "examples"
+    for example_file in examples_dir.glob("*.yml"):
+        _assert_example_parses(example_file.name)
 
 
 def _assert_example_parses(filename: str):


### PR DESCRIPTION
Fixes #21668

While investigating #21668 I discovered several issues with file source templates validation and **form validation in general**.
- In templates, there was no way to tell if a variable or secret was required or optional. I'm not sure if this was intentional, but all template variable models (`TemplateVariableString`, `TemplateVariableInteger`, `TemplateVariableBoolean`) had a hardcoded default that made them allways optional by definition. Also, the `optional` field was not set in the UI for any of these fields, so the form couldn't tell if they were actually optional or not, which made it confusing for the user.
  | Before | After |
  |--------|-------|
  |  <img width="212" height="68" alt="image" src="https://github.com/user-attachments/assets/882d1e6c-833b-486a-8287-0b179436cd96" />  | <img width="212" height="68" alt="image" src="https://github.com/user-attachments/assets/d3989f74-92f7-4931-9265-8cfeccd490be" /> |
  | <img width="212" height="68" alt="image" src="https://github.com/user-attachments/assets/eef0f51d-0121-43de-97f4-4558cd227aeb" />   | <img width="212" height="68" alt="image" src="https://github.com/user-attachments/assets/6fbde63f-23e2-45e5-84e2-b9a1ed35ded2" />  |

- <del>There were also a couple of conditions in form validation in general that seem wrong. For example, in https://github.com/galaxyproject/galaxy/pull/21704/changes/2fad152fcebb401087087457facf4d4325dae377, having `(allowEmptyValueOnRequiredInput && inputValue === "")` resulted in a validation error, which, according to the name of `allowEmptyValueOnRequiredInput`, should be completely the opposite. Also in https://github.com/galaxyproject/galaxy/pull/21704/changes/49b3cab74f4079229027e922f1c18cbd7cf4dd57, the `!isRequired` condition seemed to be wrong.</del> The logic was correct, but the `allowEmptyValueOnRequiredInput` flag really means `rejectEmptyRequiredInputs` and will be renamed in dev here https://github.com/galaxyproject/galaxy/pull/21775
- Another issue was that `validateInputs` was only validating some inputs and not all of them. For example, if we provide the required name of file source, and then clear the field, the validation will pass because we were checking only "provided" values for validation and not all input definitions. See https://github.com/galaxyproject/galaxy/pull/21704/changes/3fa5bd0dab67df31858cdb68acc06c3019ed78c4.
- The "create" button was always enabled, even when validation issues were still present.

  | Before | After |
  |--------|-------|
  | <img width="78" height="40" alt="image" src="https://github.com/user-attachments/assets/a837e8fb-84ad-4a5d-b011-f4363a2f6be3" />   | <img width="70" height="36" alt="image" src="https://github.com/user-attachments/assets/072bbf51-430d-4c39-a9c5-3a9173e2fa17" />  |


I've updated the templates to include optional values when appropriate, and I increased the test coverage to account for possible optional values.

## How Validation Works now in templates according to "optionality"

- Variables and secrets are **required by default**.
- A variable or secret is optional **only if** `optional: true` is explicitly set.
- Defining a `default` value **does not** make a field optional.
- Default values are applied **only** for variables or secrets marked as `optional: true`.
- Validators are evaluated **only when a value is provided**; omitted optional fields are not validated.
- Default values **are validated** when they are applied (i.e. for `optional: true` fields with a default).


**Frontend Behavior:**
- Iterates over field definitions (not just provided values) to catch missing required fields
- The first validation issue found stops the iteration and displays the error, and as soon as it is fixed, the next validation error is shown. This was the same before, but the additional field validation was skipped due to all fields being considered optional.
- Real-time validation feedback with error messages
- Submit button is disabled when validation errors exist

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Enable any of the file source templates in `config/file_source_templates.yml`
  - Play around with the `optional`, `default`, and `validators` fields in the templates
  - Restart Galaxy to pick up the template changes
  - Go to your User settings and try to create any of the file sources with those tweaks
  - Check that the validation and optionality work as expected

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
