### PR TITLE
[25.1] Fix route to workflow editor with version does not load expected version

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1205,6 +1205,11 @@ export default {
             await Vue.nextTick();
             this.hasChanges = has_changes;
         },
+        /**
+         * Fetches and loads the workflow data for the given id and version into the editor.
+         * @param {string} id - The workflow ID
+         * @param {number|undefined} version - The workflow version number
+         */
         async _loadCurrent(id, version) {
             if (!this.isNewTempWorkflow) {
                 await this.resetStores();

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -44,7 +44,7 @@ export default {
                 this.skipNextReload = false;
             }
 
-            this.version = Query.get("version");
+            this.version = parseInt(Query.get("version"), 10);
             this.storedWorkflowId = Query.get("id");
             this.workflowId = Query.get("workflow_id");
             const workflowId = this.workflowId || this.storedWorkflowId;


### PR DESCRIPTION
Routing to edit a workflow for a specific version was broken simply because in the `Index.vue` component, we were passing the version as a string as opposed to a number. 

_TODO: Once this gets merged forward we should add a vitest for this._

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a workflow and save multiple version with changes in each version (or use an existing one with easily differentiable multiple versions; for e.g.: have it as 2 steps in the first version, then 3 in the second)
  2. Now try routing to the editor with `workflows/edit?id={workflow_id}&version=0` (i.e.: the first version)
  3. Note that we land on the expected first version, and not the second one

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
