### PR TITLE
[25.0] Fix option propagation for workflow inputs connected to multiple subworkflows

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1487,10 +1487,15 @@ class InputParameterModule(WorkflowModule):
                     subworkflow_input_name = connection.input_name
                     for step in module.subworkflow.input_steps:
                         if step.input_type == "parameter" and step.label == subworkflow_input_name:
+                            # static_options are raw tuples, convert to ParameterOption namedtuples
+                            # to match ToolModule path and support intersection logic
                             static_options.append(
-                                step.module.get_runtime_inputs(step, connections=step.output_connections)[
-                                    "input"
-                                ].static_options
+                                [
+                                    ParameterOption(*o)
+                                    for o in step.module.get_runtime_inputs(step, connections=step.output_connections)[
+                                        "input"
+                                    ].static_options
+                                ]
                             )
 
             options: Optional[List[OptionDict]] = None


### PR DESCRIPTION
When a workflow input with `restrictOnConnections: true` connects to multiple subworkflows, the options were silently disappearing. The root cause was a type mismatch in the `restrict_options()` method:

- ToolModule path returns ParameterOption namedtuples (supports .value/.name)
- SubWorkflowModule path was returning raw tuples (only supports index access)

The intersection logic at lines 1524-1528 uses attribute access (.value, .name) which only works with ParameterOption namedtuples. Single connections worked because that code path uses index access, but multiple connections failed.

The fix converts raw tuples to ParameterOption namedtuples in the SubWorkflowModule branch to maintain type consistency.

Fixes https://github.com/galaxyproject/galaxy/issues/21602

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
