### PR TITLE
[25.1] Fix collection job state not preserved during history export/import

### DIFF
--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -729,6 +729,18 @@ class ImportExportTests(BaseHistories):
             history_id=imported_history_id, hid=1, assert_ok=False, hda_checker=check_failed, job_checker=check_failed
         )
 
+        # Also check collection state is preserved - regression test for issue #20450
+        imported_collection = self.dataset_populator.get_history_collection_details(
+            history_id=imported_history_id,
+            history_content_type="dataset_collection",
+            assert_ok=False,
+        )
+        assert "job_state_summary" in imported_collection, imported_collection
+        assert imported_collection["job_state_summary"].get("error", 0) == 1, (
+            f"Expected error count of 1 after import, got {imported_collection['job_state_summary']}. "
+            "Collection job state was not preserved during history export/import (issue #20450)."
+        )
+
     def test_import_metadata_regeneration(self):
         if self.task_based:
             raise SkipTest("skipping test_import_metadata_regeneration for task based...")


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/20450

Two issues were causing collection job_state_summary to be lost:

1. Export filtering: Collections with state != "ok" were skipped during export
   due to using `break` instead of `continue`. This prevented error-state
   collections from being exported entirely.

2. Job association: During import, when restoring jobs with output collections,
   the HDCA's job reference was not being set. The job_state_summary property
   relies on this relationship to aggregate job states.

Changes:
- Remove state filter that skipped non-ok collections during export
- Set HDCA.job during job import to restore the job state link

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
