### PR TITLE
[25.0] Add missing filter_failed_collection_1.1.0.xml tool

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -43,6 +43,7 @@
     <tool file="${model_tools_path}/merge_collection.xml" />
     <tool file="${model_tools_path}/relabel_from_file.xml" />
     <tool file="${model_tools_path}/filter_from_file.xml" />
+    <tool file="${model_tools_path}/filter_from_file_1.1.0.xml" />
     <tool file="${model_tools_path}/sort_collection_list.xml" />
     <tool file="${model_tools_path}/harmonize_two_collections_list.xml" />
     <tool file="${model_tools_path}/cross_product_flat.xml" />

--- a/lib/galaxy/tools/filter_failed_collection_1.1.0.xml
+++ b/lib/galaxy/tools/filter_failed_collection_1.1.0.xml
@@ -1,0 +1,66 @@
+<tool id="__FILTER_FAILED_DATASETS__"
+      name="Filter failed datasets"
+      version="1.1.0"
+      tool_type="filter_failed_datasets_collection">
+    <description></description>
+    <type class="FilterFailedDatasetsTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <edam_operations>
+        <edam_operation>operation_3695</edam_operation>
+    </edam_operations>
+    <inputs>
+        <param type="data_collection" collection_type="list,list:paired" name="input" label="Input Collection" />
+        <param type="data" name="replacement" optional="true" label="Replace failed elements with this dataset" help="If provided, failed elements will be replaced with this dataset"/>
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type_source="input" label="${on_string} (filtered failed datasets)" >
+        </collection>
+    </outputs>
+    <tests>
+        <!-- Test framework has no way of creating a collection with
+             failed elements, so best we can do is verify identity on
+             an okay collection. API tests verify this tool works
+             though.
+        -->
+        <test>
+            <param name="input">
+                <collection type="list">
+                    <element name="e1" value="simple_line.txt" />
+                </collection>
+            </param>
+            <output_collection name="output" type="list">
+                <element name="e1">
+                  <assert_contents>
+                      <has_text_matching expression="^This is a line of text.\n$" />
+                  </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+========
+Synopsis
+========
+
+Removes datasets in error (red) from a collection.
+
+===========
+Description
+===========
+
+This tool takes a dataset collection and filters out (removes) datasets in the failed (red) state. This is useful for continuing a multi-sample analysis when one or more of the samples fails at some point.
+
+.. image:: ${static_path}/images/tools/collection_ops/filter_error.svg
+  :width: 500
+  :alt: Filter failed datasets
+
+-----
+
+.. class:: infomark
+
+This tool will create new history datasets from your collection but your quota usage will not increase.
+
+      ]]></help>
+</tool>


### PR DESCRIPTION
Fixes #21389

The tool_conf.xml.sample references filter_failed_collection_1.1.0.xml which did not exist. The filter_failed_collection.xml (version 1.0.0) incorrectly had the "replacement" parameter which should only be present in the 1.1.0 version. I chose to keep it so that we don't cause issues with existing workflows and reruns.

This change:
- Creates filter_failed_collection_1.1.0.xml with the replacement parameter, following the pattern of other 1.1.0 tools like filter_empty_collection_1.1.0.xml

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
