### PR TITLE
[25.1] Strip inline comments in conditional requirements

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -3,6 +3,7 @@ Determine what optional dependencies are needed.
 """
 
 import os
+import re
 import sys
 from os.path import (
     dirname,
@@ -337,6 +338,12 @@ class ConditionalDependencies:
         return "huggingface" in self.file_sources
 
 
+def strip_comment(line):
+    # lifted from https://github.com/tox-dev/tox/commit/3c6b4f204e89852c4b7536b246a66d20be6d39ec
+    # xref https://github.com/pyupio/dparse/issues/34
+    return re.sub(r"\s+#.*", "", line).strip()
+
+
 def optional(config_file=None):
     if not config_file:
         config_file = find_config_file(["galaxy", "universe_wsgi"], include_samples=True)
@@ -347,5 +354,5 @@ def optional(config_file=None):
     conditional = ConditionalDependencies(config_file)
     for dependency in conditional.conditional_reqs:
         if conditional.check(dependency.name):
-            rval.append(dependency.line)
+            rval.append(strip_comment(dependency.line))
     return rval


### PR DESCRIPTION
Alternative to https://github.com/galaxyproject/ansible-galaxy/pull/243 and 18c0b8c7ed416cffc52c13f547aa63d93f2086b4. Seems cleaner to strip it at the source.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
