### PR TITLE
[25.1] Exclude node_modules at all depths in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 .k8s_ci.Dockerfile
 .venv
 database
-node_modules
+**/node_modules


### PR DESCRIPTION
The pattern `node_modules` only matches at the root level in .dockerignore (unlike .gitignore). Use `**/node_modules` to exclude client/node_modules and avoid copying 22GB to the build context.

Taken from @dannon's https://github.com/galaxyproject/galaxy/pull/21593

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
