### PR TITLE
Migrate DatasetIndex from BTable to GTable and Add Local Sorting to GTable

### DIFF
--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -104,10 +104,10 @@ interface Props {
     overlayLoading?: boolean;
 
     /**
-     * Whether to disable local sorting (will only emit sort-changed event)
-     * @default false
+     * Whether to use local sorting (client-side) or rely on external sorting (server-side)
+     * @default true
      */
-    noLocalSorting?: boolean;
+    localSorting?: boolean;
 
     /**
      * Whether to show striped rows
@@ -173,7 +173,7 @@ const props = withDefaults(defineProps<Props>(), {
     loadingMessage: "Loading...",
     loadMoreLoading: false,
     loadMoreMessage: "Loading more...",
-    noLocalSorting: false,
+    localSorting: true,
     overlayLoading: false,
     selectable: false,
     selectedItems: () => [],
@@ -221,7 +221,7 @@ const localItems = computed(() => {
     const items = props.items || [];
 
     // If local sorting is disabled, return items as-is
-    if (props.noLocalSorting) {
+    if (!props.localSorting) {
         return items;
     }
 

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -110,8 +110,6 @@ describe("DatasetIndex", () => {
         });
 
         await flushPromises();
-        await wrapper.vm.$nextTick();
-        await flushPromises();
 
         expect(wrapper.text()).toContain("nonexistent.txt");
         expect(wrapper.text()).toContain("is not found!");

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -182,8 +182,6 @@ describe("DatasetIndex", () => {
         });
 
         await flushPromises();
-        await wrapper.vm.$nextTick();
-        await flushPromises();
 
         const gTable = wrapper.find("gtable-stub");
         const errorDiv = wrapper.find("div");

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -86,8 +86,6 @@ describe("DatasetIndex", () => {
         });
 
         await flushPromises();
-        await wrapper.vm.$nextTick();
-        await flushPromises();
 
         expect(wrapper.text()).toContain("is not a directory!");
         const gTable = wrapper.find("gtable-stub");

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -136,9 +136,6 @@ describe("DatasetIndex", () => {
         });
 
         await flushPromises();
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        await wrapper.vm.$nextTick();
-        await flushPromises();
 
         const html = wrapper.html();
         expect(html).toContain("fields");

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -164,9 +164,6 @@ describe("DatasetIndex", () => {
         });
 
         await flushPromises();
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        await wrapper.vm.$nextTick();
-        await flushPromises();
 
         // Check that table renders (shallowMount converts GTable to anonymous-stub)
         expect(wrapper.html()).toContain("fields");

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -44,9 +44,6 @@ describe("DatasetIndex", () => {
 
         // Wait for async computedAsync to resolve
         await flushPromises();
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        await wrapper.vm.$nextTick();
-        await flushPromises();
 
         // Table renders (shallowMount converts it to anonymous-stub)
         const gTable = wrapper.find("#g-table-0");

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -62,8 +62,6 @@ describe("DatasetIndex", () => {
         });
 
         await flushPromises();
-        await wrapper.vm.$nextTick();
-        await flushPromises();
 
         expect(wrapper.text()).toContain("Dataset is not composite!");
         const gTable = wrapper.find("gtable-stub");

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.test.ts
@@ -1,0 +1,210 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { shallowMount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { computed } from "vue";
+
+import type { PathDestination } from "@/composables/datasetPathDestination";
+import * as datasetPathDestinationModule from "@/composables/datasetPathDestination";
+
+import DatasetIndex from "./DatasetIndex.vue";
+
+const localVue = getLocalVue();
+
+vi.mock("@/composables/datasetPathDestination");
+
+describe("DatasetIndex", () => {
+    let mockDatasetPathDestination: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        // Reset mock before each test
+        mockDatasetPathDestination = vi.fn();
+        vi.mocked(datasetPathDestinationModule.useDatasetPathDestination).mockReturnValue({
+            datasetPathDestination: computed(() => mockDatasetPathDestination) as any,
+        });
+    });
+
+    it("renders GTable when dataset has valid content", async () => {
+        const mockPathDestination: PathDestination = {
+            datasetContent: [
+                { path: "file1.txt", class: "File" },
+                { path: "file2.csv", class: "File" },
+            ],
+            isDirectory: false,
+        };
+
+        mockDatasetPathDestination.mockResolvedValue(mockPathDestination);
+
+        const wrapper = shallowMount(DatasetIndex as object, {
+            propsData: {
+                historyDatasetId: "test-dataset-123",
+            },
+            localVue,
+        });
+
+        // Wait for async computedAsync to resolve
+        await flushPromises();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        // Table renders (shallowMount converts it to anonymous-stub)
+        const gTable = wrapper.find("#g-table-0");
+        expect(gTable.exists()).toBe(true);
+        expect(gTable.attributes("fields")).toBeDefined();
+    });
+
+    it("displays error message when dataset is not composite", async () => {
+        mockDatasetPathDestination.mockResolvedValue(null);
+
+        const wrapper = shallowMount(DatasetIndex as object, {
+            propsData: {
+                historyDatasetId: "test-dataset-123",
+            },
+            localVue,
+        });
+
+        await flushPromises();
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        expect(wrapper.text()).toContain("Dataset is not composite!");
+        const gTable = wrapper.find("gtable-stub");
+        expect(gTable.exists()).toBe(false);
+    });
+
+    it("displays error message when path points to a file", async () => {
+        const mockPathDestination: PathDestination = {
+            datasetContent: [{ path: "file1.txt", class: "File" }],
+            isDirectory: false,
+            fileLink: "/api/datasets/123/file1.txt",
+        };
+
+        mockDatasetPathDestination.mockResolvedValue(mockPathDestination);
+
+        const wrapper = shallowMount(DatasetIndex as object, {
+            propsData: {
+                historyDatasetId: "test-dataset-123",
+                path: "file1.txt",
+            },
+            localVue,
+        });
+
+        await flushPromises();
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        expect(wrapper.text()).toContain("is not a directory!");
+        const gTable = wrapper.find("gtable-stub");
+        expect(gTable.exists()).toBe(false);
+    });
+
+    it("displays error message when path is not found", async () => {
+        const mockPathDestination: PathDestination = {
+            datasetContent: [{ path: "other.txt", class: "File" }],
+            isDirectory: false,
+            filepath: "nonexistent.txt",
+        };
+
+        mockDatasetPathDestination.mockResolvedValue(mockPathDestination);
+
+        const wrapper = shallowMount(DatasetIndex as object, {
+            propsData: {
+                historyDatasetId: "test-dataset-123",
+                path: "nonexistent.txt",
+            },
+            localVue,
+        });
+
+        await flushPromises();
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        expect(wrapper.text()).toContain("nonexistent.txt");
+        expect(wrapper.text()).toContain("is not found!");
+        const gTable = wrapper.find("gtable-stub");
+        expect(gTable.exists()).toBe(false);
+    });
+
+    it("renders GTable with correct fields configuration", async () => {
+        const mockPathDestination: PathDestination = {
+            datasetContent: [
+                { path: "test.txt", class: "File" },
+                { path: "data.csv", class: "File" },
+            ],
+            isDirectory: false,
+        };
+
+        mockDatasetPathDestination.mockResolvedValue(mockPathDestination);
+
+        const wrapper = shallowMount(DatasetIndex as object, {
+            propsData: {
+                historyDatasetId: "test-dataset-123",
+            },
+            localVue,
+        });
+
+        await flushPromises();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        const html = wrapper.html();
+        expect(html).toContain("fields");
+        expect(html).toContain("items");
+        expect(html).toContain("[object Object]");
+    });
+
+    it("filters directory content when viewing a subdirectory", async () => {
+        const mockPathDestination: PathDestination = {
+            datasetContent: [
+                { path: "subfolder/nested.txt", class: "File" },
+                { path: "subfolder/another.csv", class: "File" },
+            ],
+            isDirectory: true,
+            filepath: "subfolder",
+        };
+
+        mockDatasetPathDestination.mockResolvedValue(mockPathDestination);
+
+        const wrapper = shallowMount(DatasetIndex as object, {
+            propsData: {
+                historyDatasetId: "test-dataset-123",
+                path: "subfolder",
+            },
+            localVue,
+        });
+
+        await flushPromises();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        // Check that table renders (shallowMount converts GTable to anonymous-stub)
+        expect(wrapper.html()).toContain("fields");
+        expect(wrapper.html()).not.toContain("is not found");
+        expect(wrapper.html()).not.toContain("is not a directory");
+    });
+
+    it("does not render GTable when error message is displayed", async () => {
+        mockDatasetPathDestination.mockResolvedValue(null);
+
+        const wrapper = shallowMount(DatasetIndex as object, {
+            propsData: {
+                historyDatasetId: "test-dataset-123",
+            },
+            localVue,
+        });
+
+        await flushPromises();
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        const gTable = wrapper.find("gtable-stub");
+        const errorDiv = wrapper.find("div");
+
+        expect(gTable.exists()).toBe(false);
+        expect(errorDiv.exists()).toBe(true);
+        expect(errorDiv.text()).toContain("Dataset is not composite!");
+    });
+});

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
@@ -81,9 +81,9 @@ const fields: TableField[] = [
 
 <template>
     <div>
-        <GTable v-if="directoryContent && !errorMessage" :fields="fields" :items="directoryContent" />
         <div v-if="errorMessage">
             <b v-if="path">{{ path }}</b> {{ errorMessage }}
         </div>
+        <GTable v-else-if="directoryContent" :fields="fields" :items="directoryContent" />
     </div>
 </template>

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
@@ -3,7 +3,10 @@ import { computedAsync } from "@vueuse/core";
 import { computed } from "vue";
 
 import type { DatasetExtraFiles } from "@/api/datasets";
+import type { TableField } from "@/components/Common/GTable.types";
 import { type PathDestination, useDatasetPathDestination } from "@/composables/datasetPathDestination";
+
+import GTable from "@/components/Common/GTable.vue";
 
 interface Props {
     historyDatasetId: string;
@@ -62,9 +65,10 @@ function removeParentDirectory(datasetContent: DatasetExtraFiles, filepath?: str
     });
 }
 
-const fields = [
+const fields: TableField[] = [
     {
         key: "path",
+        label: "Path",
         sortable: true,
     },
     {
@@ -77,14 +81,7 @@ const fields = [
 
 <template>
     <div>
-        <b-table
-            v-if="directoryContent && !errorMessage"
-            thead-class="hidden_header"
-            striped
-            hover
-            :fields="fields"
-            :items="directoryContent">
-        </b-table>
+        <GTable v-if="directoryContent && !errorMessage" :fields="fields" :items="directoryContent" />
         <div v-if="errorMessage">
             <b v-if="path">{{ path }}</b> {{ errorMessage }}
         </div>

--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -296,7 +296,7 @@ onMounted(() => {
                 selectable
                 show-select-all
                 no-sort-reset
-                no-local-sorting
+                :local-sorting="false"
                 :fields="fields"
                 :items="rows"
                 :sort-by="sortBy"


### PR DESCRIPTION
This PR migrates `DatasetIndex.vue` from Bootstrap-Vue's `BTable` to our custom `GTable` component, as part of the ongoing effort tracked in #21703.

required #21727

|Before|After|
|----|----|
|<img width="1426" height="483" alt="image" src="https://github.com/user-attachments/assets/11c5ef05-e1dd-40dc-861f-d862dadf9343" />|<img width="1426" height="483" alt="image" src="https://github.com/user-attachments/assets/c5e986dd-0d64-44f9-84d3-3aca9ad1f971" />|

## Summary

- Migrate `DatasetIndex` to use `GTable`.
- Add local sorting to `GTable` with new `noLocalSorting` prop (default false) so sortable columns work out of the box.
- Add a simple unit test for `DatasetIndex`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upload a composite dataset
  2. Create/edit a page
  3. Click on `Insert Markdown Objects` -> `History` -> `Dataset Index` and select the composite dataset
  4. Save and view the page

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
