### PR TITLE
Migrate CleanupResultDialog from BTable to GTable

### DIFF
--- a/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import localize from "@/utils/localization";
 
 import type { CleanupResult } from "./model";
 
 import Alert from "@/components/Alert.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 interface CleanupResultDialogProps {
     result?: CleanupResult;
@@ -33,7 +35,7 @@ const title = computed<string>(() => {
     return message;
 });
 
-const errorFields = [
+const errorFields: TableField[] = [
     { key: "name", label: localize("Name") },
     { key: "reason", label: localize("Reason") },
 ];
@@ -54,7 +56,7 @@ defineExpose({
                 variant="info"
                 message="After the operation, the storage space that will be freed up will only be for the unique items. This means that some items may not free up any storage space because they are duplicates of other items." />
             <b-spinner v-if="isLoading" class="mx-auto" data-test-id="loading-spinner" />
-            <div v-else>
+            <div v-else-if="result">
                 <b-alert v-if="result.hasFailed" show variant="danger" data-test-id="error-alert">
                     {{ result.errorMessage }}
                 </b-alert>
@@ -72,11 +74,10 @@ defineExpose({
                         </h3>
                     </b-alert>
                 </div>
-                <b-table-lite
+                <GTable
                     v-if="result.hasSomeErrors"
                     :fields="errorFields"
                     :items="result.errors"
-                    small
                     data-test-id="errors-table" />
             </div>
         </div>

--- a/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BAlert, BModal, BSpinner } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
 import type { TableField } from "@/components/Common/GTable.types";
@@ -50,16 +51,17 @@ defineExpose({
 </script>
 
 <template>
-    <b-modal id="cleanup-result-modal" v-model="showModal" :title="title" title-tag="h2" hide-footer static>
+    <BModal id="cleanup-result-modal" v-model="showModal" :title="title" title-tag="h2" hide-footer static>
         <div class="text-center">
             <Alert
                 variant="info"
                 message="After the operation, the storage space that will be freed up will only be for the unique items. This means that some items may not free up any storage space because they are duplicates of other items." />
-            <b-spinner v-if="isLoading" class="mx-auto" data-test-id="loading-spinner" />
+
+            <BSpinner v-if="isLoading" class="mx-auto" data-test-id="loading-spinner" />
             <div v-else-if="result">
-                <b-alert v-if="result.hasFailed" show variant="danger" data-test-id="error-alert">
+                <BAlert v-if="result.hasFailed" show variant="danger" data-test-id="error-alert">
                     {{ result.errorMessage }}
-                </b-alert>
+                </BAlert>
                 <h3 v-else-if="result.success" data-test-id="success-info">
                     You've cleared <b>{{ result.niceTotalFreeBytes }}</b>
                 </h3>
@@ -68,12 +70,13 @@ defineExpose({
                         You've successfully cleared <b>{{ result.totalCleaned }}</b> items for a total of
                         <b>{{ result.niceTotalFreeBytes }}</b> but...
                     </h3>
-                    <b-alert v-if="result.hasSomeErrors" show variant="warning">
+                    <BAlert v-if="result.hasSomeErrors" show variant="warning">
                         <h3 class="mb-0">
                             <b>{{ result.errors.length }}</b> items couldn't be cleared
                         </h3>
-                    </b-alert>
+                    </BAlert>
                 </div>
+
                 <GTable
                     v-if="result.hasSomeErrors"
                     :fields="errorFields"
@@ -81,5 +84,5 @@ defineExpose({
                     data-test-id="errors-table" />
             </div>
         </div>
-    </b-modal>
+    </BModal>
 </template>


### PR DESCRIPTION
This PR migrates `CleanupResultDialog.vue` from Bootstrap-Vue's `BTable` to our custom `GTable` component, as part of the ongoing effort tracked in #21703.

required #21728

|Before|After|
|----|----|
|<img width="727" height="214" alt="image" src="https://github.com/user-attachments/assets/74cfc948-6086-47e5-a777-416357c50141" />|<img width="727" height="214" alt="image" src="https://github.com/user-attachments/assets/58855ddb-5de4-4fea-a063-7ffef65a0ae6" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
