### PR TITLE
Escape `$` in galaxy.xsd to fix output filter docs rendering

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6562,7 +6562,7 @@ block to be executed to test whether to include this output in the outputs the
 tool ultimately creates. If the code of each of these filters, when executed, returns ``True``,
 the output dataset is retained, i.e. the output is excluded if at least one evaluates to ``False``.
 In these code blocks the tool parameters appear
-as Python variables and are thus referred to without the $ used for the Cheetah
+as Python variables and are thus referred to without the ``$`` used for the Cheetah
 template (used in the ``<command>`` tag). Variables that are part of
 conditionals are accessed using a dictionary named after the conditional. Boolean
 parameters appear as booleans, not the value of their ``truevalue`` and


### PR DESCRIPTION
Add Escape `` to $ char in 6565 line. This change will fix visualisation issue in the the guide at https://docs.galaxyproject.org/en/latest/dev/schema.html#tool-outputs-data-filter

Fix https://github.com/galaxyproject/galaxy/issues/21418 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
