### PR TITLE
[25.1] Fix database migration error from 25.0 > 25.1

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/c0959ad462b2_add_tool_id_and_tool_version_to_tool_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/c0959ad462b2_add_tool_id_and_tool_version_to_tool_.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
 
 from galaxy.model.migrations.util import (
     add_column,
+    column_exists,
     drop_column,
     transaction,
 )
@@ -31,8 +32,10 @@ tool_version_column = "tool_version"
 
 def upgrade():
     with transaction():
-        add_column(table_name, Column(tool_id_column, String(255), nullable=False))
-        add_column(table_name, Column(tool_version_column, String(255), nullable=True))
+        if not column_exists(table_name, tool_id_column, False):
+            add_column(table_name, Column(tool_id_column, String(255), nullable=False))
+        if not column_exists(table_name, tool_version_column, False):
+            add_column(table_name, Column(tool_version_column, String(255), nullable=True))
 
 
 def downgrade():


### PR DESCRIPTION
Fix #21699.

This is needed because the migration adding these fields was added to 25.1, fixing a bug in 24.2. So if a new galaxy db was created under versions 24.2 or 25.0, these fields were added from the model during startup. Thus, in that case, there was no path to safely migrate to 25.1, as the fields that were being added in the migration were already in the database - hense, the migration error.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
