### PR TITLE
Fix scratchbook window z-index stacking and improve styling

### DIFF
--- a/client/src/entry/analysis/window-manager.js
+++ b/client/src/entry/analysis/window-manager.js
@@ -12,6 +12,7 @@ export class WindowManager {
         options = options || {};
         this.counter = 0;
         this.active = false;
+        this.zIndexInitialized = false;
     }
 
     /** Return window masthead tab props */
@@ -28,13 +29,12 @@ export class WindowManager {
     }
 
     /** Add and display a new window based on options. */
-    add(options, layout = 10, margin = 20, index = 850) {
+    add(options, layout = 10, margin = 20) {
         const url = this._build_url(withPrefix(options.url), { hide_panels: true, hide_masthead: true });
         const x = this.counter * margin;
         const y = (this.counter % layout) * margin;
         this.counter++;
-        const win = WinBox.new({
-            index: index,
+        const params = {
             title: options.title || "Window",
             url: url,
             x: x,
@@ -42,8 +42,15 @@ export class WindowManager {
             onclose: () => {
                 this.counter--;
             },
-        });
-        win.focus();
+        };
+        // Set z-index floor on the first window only to position above
+        // Galaxy UI (masthead is z-index 900). Subsequent windows omit
+        // index so WinBox auto-increments correctly.
+        if (!this.zIndexInitialized) {
+            params.index = 850;
+            this.zIndexInitialized = true;
+        }
+        WinBox.new(params);
     }
 
     /** Called before closing all windows. */

--- a/client/src/entry/analysis/window-manager.js
+++ b/client/src/entry/analysis/window-manager.js
@@ -33,7 +33,7 @@ export class WindowManager {
         const x = this.counter * margin;
         const y = (this.counter % layout) * margin;
         this.counter++;
-        WinBox.new({
+        const win = WinBox.new({
             index: index,
             title: options.title || "Window",
             url: url,
@@ -43,6 +43,7 @@ export class WindowManager {
                 this.counter--;
             },
         });
+        win.focus();
     }
 
     /** Called before closing all windows. */

--- a/client/src/entry/analysis/window-manager.js
+++ b/client/src/entry/analysis/window-manager.js
@@ -50,7 +50,15 @@ export class WindowManager {
             params.index = 850;
             this.zIndexInitialized = true;
         }
-        WinBox.new(params);
+        const win = WinBox.new(params);
+        // Overlay to capture clicks on unfocused windows, since mousedown
+        // doesn't propagate out of iframes. WinBox toggles the "focus"
+        // class, and CSS sets pointer-events:none on the overlay for the
+        // focused window so the iframe works normally.
+        const overlay = document.createElement("div");
+        overlay.className = "iframe-focus-overlay";
+        overlay.addEventListener("mousedown", () => win.focus());
+        win.body.appendChild(overlay);
     }
 
     /** Called before closing all windows. */

--- a/client/src/style/scss/windows.scss
+++ b/client/src/style/scss/windows.scss
@@ -37,6 +37,19 @@
     background: $body-bg;
 }
 
+.iframe-focus-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+}
+
+.winbox.focus .iframe-focus-overlay {
+    pointer-events: none;
+}
+
 .wb-icon * {
     opacity: 0.65;
 }

--- a/client/src/style/scss/windows.scss
+++ b/client/src/style/scss/windows.scss
@@ -2,11 +2,16 @@
     border-radius: $border-radius-base;
     margin-left: 1px;
     margin-top: calc($masthead-height + 1px);
+    box-shadow: 0 0.5rem 1rem rgba($black, 0.15);
+    border: $border-default;
+    font-family: $font-family-sans-serif;
 }
 
 .winbox.max {
     border-radius: 0;
     margin: 0;
+    box-shadow: none;
+    border: none;
     .wb-header {
         border-radius: 0;
     }
@@ -17,9 +22,19 @@
 }
 
 .wb-header {
-    background: $brand-info;
+    background: $brand-primary;
     border-top-left-radius: $border-radius-base;
     border-top-right-radius: $border-radius-base;
+}
+
+.winbox .wb-title {
+    font-family: $font-family-sans-serif;
+    font-size: $font-size-base;
+    font-weight: bold;
+}
+
+.wb-body {
+    background: $body-bg;
 }
 
 .wb-icon * {


### PR DESCRIPTION
Fix scratchbook window z-index stacking, iframe click-to-front, and improve styling.

- Stop passing `index` to every WinBox.new() call — WinBox's constructor calls focus() which auto-increments z-index, but then the index parameter overwrites it. Pass it only on the first window to set a z-index floor above Galaxy UI.
- Add a transparent click overlay on unfocused windows so clicking iframe content brings the window to front. WinBox's mousedown-based focus can't detect clicks inside iframes. The overlay uses pointer-events:none on the focused window so the iframe works normally.
- Style windows to match Galaxy UI — brand-primary title bar, Bootstrap modal shadow, Galaxy font family, proper body background. Shadow and border removed when maximized.

Addresses feedback from @nekrut

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Enable Window Manager (grid icon in masthead)
  2. Open multiple dataset visualizations — each new window should appear on top
  3. Click inside a background window's content — it should come to front
  4. Verify styling: shadow, Galaxy font, dark blue title bar
  5. Maximize a window — shadow/border should disappear

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).