### PR TITLE
Fix delete dataset storage overview

### DIFF
--- a/client/src/api/datasets.ts
+++ b/client/src/api/datasets.ts
@@ -100,8 +100,8 @@ export async function undeleteDataset(datasetId: string) {
     return data;
 }
 
-export async function deleteDataset(datasetId: string, purge: boolean = false) {
-    const { data, error } = await GalaxyApi().DELETE("/api/datasets/{dataset_id}", {
+export async function deleteDataset(datasetId: string, purge: boolean = false): Promise<void> {
+    const { error } = await GalaxyApi().DELETE("/api/datasets/{dataset_id}", {
         params: {
             path: { dataset_id: datasetId },
             query: { purge },
@@ -110,10 +110,9 @@ export async function deleteDataset(datasetId: string, purge: boolean = false) {
     if (error) {
         rethrowSimple(error);
     }
-    return data;
 }
 
-export async function purgeDataset(datasetId: string) {
+export async function purgeDataset(datasetId: string): Promise<void> {
     return deleteDataset(datasetId, true);
 }
 

--- a/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/Charts/BarChart.vue
@@ -65,6 +65,7 @@ watch(
         props.valueFormatter,
     ],
     () => {
+        clearStaleSelection();
         // make sure v-if to conditionally display the div we're rendering this in
         // is available in the DOM before actually doing the rendering. Without
         // nextTick you cannot go from empty data -> chart when tweaking filtering
@@ -75,6 +76,16 @@ watch(
         });
     },
 );
+
+function clearStaleSelection() {
+    if (selectedDataPoint.value) {
+        const stillExists = props.data.some((d) => d.id === selectedDataPoint.value?.id);
+        if (!stillExists) {
+            selectedDataPoint.value = undefined;
+            emit("selection-changed", undefined);
+        }
+    }
+}
 
 function renderBarChart() {
     chartBars.value = drawChart();

--- a/client/src/components/User/DiskUsage/Visualizations/service.ts
+++ b/client/src/components/User/DiskUsage/Visualizations/service.ts
@@ -139,7 +139,6 @@ export async function undeleteDatasetById(datasetId: string): Promise<ItemSizeSu
     return data as unknown as ItemSizeSummary;
 }
 
-export async function purgeDatasetById(datasetId: string): Promise<PurgeableItemSizeSummary> {
-    const data = await purgeDataset(datasetId);
-    return data as unknown as PurgeableItemSizeSummary;
+export async function purgeDatasetById(datasetId: string): Promise<void> {
+    await purgeDataset(datasetId);
 }

--- a/client/src/components/User/DiskUsage/Visualizations/util.ts
+++ b/client/src/components/User/DiskUsage/Visualizations/util.ts
@@ -65,9 +65,9 @@ export function useDatasetsToDisplay() {
             return;
         }
         try {
-            const result = await purgeDatasetById(datasetId);
+            await purgeDatasetById(datasetId);
             const dataset = datasetsSizeSummaryMap.get(datasetId);
-            if (dataset && result) {
+            if (dataset) {
                 datasetsSizeSummaryMap.delete(datasetId);
                 successToast(localize("Dataset permanently deleted successfully."));
                 reloadData();


### PR DESCRIPTION
Fixes #21743

- We no longer need to expect results returned by deleting or purging datasets since #18732
- Clears the chart selection if the selected element is removed from the chart.


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
