### PR TITLE
[25.1] Fix npm trusted publishing in 25.1 release workflow

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat client/.node_version)" >> $GITHUB_OUTPUT
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ steps.node-version.outputs.version }}
           cache: 'yarn'
@@ -46,6 +46,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: build client
         run: yarn && yarn build-production
+        working-directory: 'client'
+      # Ensure npm 11.5.1 or later for trusted publishing
+      - run: npm install -g npm@latest
         working-directory: 'client'
       - name: publish client
         if: "!github.event.release.prerelease"


### PR DESCRIPTION
The 25.1.1 release [failed to publish to npm](https://github.com/galaxyproject/galaxy/actions/runs/21633429303/job/62352048620#step:6:452) because the bundled npm (10.9.2) is too old to handle OIDC token exchange for trusted publishing (requires >= 11.5.1).

- Bump `actions/setup-node` to v6 and add `npm install -g npm@latest` step before publish, matching what's already in the dev/26.0 workflow.

We'll need to re-release 25.1.1 (or create a new patch release) and verify the npm publish step succeeds.