### PR TITLE
[26.0] Revert startup probe timeout

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -169,9 +169,6 @@ jobs:
           --set persistence.accessMode="ReadWriteOnce" \
           --set resources.requests.memory=0Mi,resources.requests.cpu=0m \
           --set image.tag=${{ needs.build.outputs.tag }} \
-          --set webHandlers.startupProbe.initialDelaySeconds=120 \
-          --set webHandlers.startupProbe.periodSeconds=15 \
-          --set webHandlers.startupProbe.failureThreshold=72 \
           --wait \
           --timeout=1200s
       - name: Debug deployment on failure


### PR DESCRIPTION
The web handler startup probe timeout was increased due to #21262, but now that #21637 has been merged we can revert to the default timeout values specified in the Galaxy Helm chart.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
