### PR TITLE
[26.0] Send a Slack notification if the Docker image build or smoke test fails

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -276,3 +276,73 @@ jobs:
           branch: update-galaxy-${{ needs.build.outputs.version }}
           delete-branch: true
           labels: patch
+
+  notify-failure:
+    name: Notify Slack on failure
+    runs-on: ubuntu-latest
+    needs: [build, smoke-test]
+    if: ${{ always() && (needs.build.result == 'failure' || needs.smoke-test.result == 'failure') }}
+    steps:
+      - name: Determine which job failed
+        id: failure-info
+        run: |
+          if [[ "${{ needs.build.result }}" == "failure" ]]; then
+            echo "failed_job=Docker image build" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.smoke-test.result }}" == "failure" ]]; then
+            echo "failed_job=Smoke test" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.K8S_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: *Build Container Image Failed*",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":x: Build Container Image Failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n${{ github.repository }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch/Tag:*\n${{ github.ref_name }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Failed Job:*\n${{ steps.failure-info.outputs.failed_job }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Run",
+                        "emoji": true
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
Sends a notification to the `galaxy-k8s-sig` Slack channel when the Docker image build or smoke test fails, as discussed with @nuwang and @afgane during our last K8S sig call.  The `K8S_SLACK_WEBHOOK_URL` should be a `galaxyproject` organization level secret that was created by @dannon.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Wait for the Docker build and/or smoke test to fail
  2. Check Slack
  3. 🤷‍♂️ 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
