### PR TITLE
[25.1] Make galaxy-web-apps package compatible with latest FastAPI

### DIFF
--- a/lib/galaxy/webapps/openapi/_compat/__init__.py
+++ b/lib/galaxy/webapps/openapi/_compat/__init__.py
@@ -1,0 +1,5 @@
+from .v2 import get_definitions as get_definitions
+
+__all__ = [
+    "get_definitions",
+]

--- a/lib/galaxy/webapps/openapi/_compat/v2.py
+++ b/lib/galaxy/webapps/openapi/_compat/v2.py
@@ -1,0 +1,33 @@
+from typing import (
+    Any,
+    cast,
+    Union,
+)
+
+from fastapi._compat import ModelField
+from fastapi.types import ModelNameMap
+from pydantic.json_schema import (
+    GenerateJsonSchema as GenerateJsonSchema,
+    JsonSchemaValue as JsonSchemaValue,
+)
+from typing_extensions import Literal
+
+
+def get_definitions(
+    *,
+    fields: list[ModelField],
+    schema_generator: GenerateJsonSchema,
+    model_name_map: ModelNameMap,
+    separate_input_output_schemas: bool = True,
+) -> tuple[
+    dict[tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue],
+    dict[str, dict[str, Any]],
+]:
+    override_mode: Union[Literal["validation"], None] = None if separate_input_output_schemas else "validation"
+    inputs = [(field, override_mode or field.mode, field._type_adapter.core_schema) for field in fields]
+    field_mapping, definitions = schema_generator.generate_definitions(inputs=inputs)
+    for item_def in cast(dict[str, dict[str, Any]], definitions).values():
+        if "description" in item_def:
+            item_description = cast(str, item_def["description"]).split("\f")[0]
+            item_def["description"] = item_description
+    return field_mapping, definitions  # type: ignore[return-value]


### PR DESCRIPTION
This will fix the ephemeris tests once released as v25.1.2 package:

https://github.com/galaxyproject/ephemeris/actions/runs/21643717594/job/62390097823

When merged forward, these changes should be discarded in favour of the code in the release_26.0 branch.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
