### PR TITLE
Create a history datasets store that caches compact dataset summaries

### DIFF
--- a/client/src/components/Collections/CollectionCreatorIndex.vue
+++ b/client/src/components/Collections/CollectionCreatorIndex.vue
@@ -71,8 +71,8 @@ const {
     historyId: () => props.historyId,
     filterText: () => props.filterText || "",
     enabled: () => localShowToggle.value,
-    immediate: false,
 });
+
 const pairedOrUnpairedSupportedCollectionType = computed<SupportedPairedOrPairedBuilderCollectionTypes | null>(() => {
     if (
         ["list:paired", "list:list", "list:paired_or_unpaired", "list:list:paired"].indexOf(props.collectionType) !== -1
@@ -225,6 +225,7 @@ defineExpose({ redrawCreator });
                 </div>
             </Heading>
         </template>
+
         <BAlert v-if="isFetchingItems && !initialFetch" variant="info" show>
             <LoadingSpan :message="localize('Loading items')" />
         </BAlert>

--- a/client/src/composables/useHistoryDatasets.test.ts
+++ b/client/src/composables/useHistoryDatasets.test.ts
@@ -1,0 +1,505 @@
+import { createTestingPinia } from "@pinia/testing";
+import flushPromises from "flush-promises";
+import { setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "vue";
+
+import type { AnyHistory, HDASummary } from "@/api";
+import { useServerMock } from "@/api/client/__mocks__";
+import { useHistoryStore } from "@/stores/historyStore";
+
+import { useHistoryDatasets } from "./useHistoryDatasets";
+
+const { server, http } = useServerMock();
+
+function buildFakeDataset(id: string, name: string): HDASummary {
+    return {
+        id,
+        name,
+        history_content_type: "dataset",
+        deleted: false,
+        visible: true,
+        state: "ok",
+        extension: "txt",
+        create_time: "2024-01-01T00:00:00",
+        update_time: "2024-01-01T00:00:00",
+        history_id: "history-1",
+        hid: 1,
+        type_id: "dataset",
+        type: "file",
+        tags: [],
+        model_class: "HistoryDatasetAssociation",
+        genome_build: null,
+        purged: false,
+    } as unknown as HDASummary;
+}
+
+function buildFakeHistory(id: string, updateTime: string) {
+    return {
+        id,
+        name: `History ${id}`,
+        update_time: updateTime,
+    };
+}
+
+describe("useHistoryDatasets", () => {
+    const historyId = "history-1";
+    const historyUpdateTime = "2024-01-01T12:00:00";
+
+    beforeEach(() => {
+        const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
+        setActivePinia(pinia);
+
+        // Set up the history store with a mock history
+        const historyStore = useHistoryStore();
+        historyStore.storedHistories[historyId] = buildFakeHistory(historyId, historyUpdateTime) as AnyHistory;
+
+        // Default API response
+        server.use(
+            http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                return response(200).json([]);
+            }),
+        );
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("initial state", () => {
+        it("should have empty datasets initially", () => {
+            const { datasets } = useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            expect(datasets.value).toEqual([]);
+        });
+
+        it("should not be fetching initially when immediate is false", () => {
+            const { isFetching } = useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            expect(isFetching.value).toBe(false);
+        });
+
+        it("should have no error initially", () => {
+            const { error } = useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            expect(error.value).toBeNull();
+        });
+
+        it("should have initialFetchDone as false initially", () => {
+            const { initialFetchDone } = useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            expect(initialFetchDone.value).toBe(false);
+        });
+
+        it("should provide the history from the store", () => {
+            const { history } = useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            expect(history.value?.id).toBe(historyId);
+            expect(history.value?.update_time).toBe(historyUpdateTime);
+        });
+    });
+
+    describe("immediate fetch", () => {
+        it("should fetch immediately when immediate is true (default)", async () => {
+            const expectedDatasets = [buildFakeDataset("dataset-1", "Dataset 1")];
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    return response(200).json(expectedDatasets);
+                }),
+            );
+
+            const { datasets, initialFetchDone } = useHistoryDatasets({
+                historyId,
+            });
+
+            await flushPromises();
+
+            expect(datasets.value).toEqual(expectedDatasets);
+            expect(initialFetchDone.value).toBe(true);
+        });
+
+        it("should not fetch immediately when immediate is false", async () => {
+            const fetchSpy = vi.fn();
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    fetchSpy();
+                    return response(200).json([]);
+                }),
+            );
+
+            useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            await flushPromises();
+
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it("should not fetch immediately when enabled is false", async () => {
+            const fetchSpy = vi.fn();
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    fetchSpy();
+                    return response(200).json([]);
+                }),
+            );
+
+            useHistoryDatasets({
+                historyId,
+                enabled: false,
+                immediate: true,
+            });
+
+            await flushPromises();
+
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("caching behavior", () => {
+        it("should cache datasets for the same scope", async () => {
+            const expectedDatasets = [buildFakeDataset("dataset-1", "Dataset 1")];
+            let fetchCount = 0;
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    fetchCount++;
+                    return response(200).json(expectedDatasets);
+                }),
+            );
+
+            const { datasets, fetchDatasets } = useHistoryDatasets({
+                historyId,
+            });
+
+            await flushPromises();
+            expect(fetchCount).toBe(1);
+            expect(datasets.value).toEqual(expectedDatasets);
+
+            // Fetch again with same scope - should use cache
+            await fetchDatasets();
+            await flushPromises();
+
+            // The store's caching logic should prevent a second API call
+            // when scope hasn't changed
+            expect(datasets.value).toEqual(expectedDatasets);
+        });
+
+        it("should cache datasets per filter text", async () => {
+            const datasetsNoFilter = [buildFakeDataset("dataset-1", "Dataset 1")];
+            const datasetsWithFilter = [buildFakeDataset("dataset-2", "Dataset 2")];
+
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ request, response }) => {
+                    const url = new URL(request.url);
+                    const qParam = url.searchParams.get("q");
+                    if (qParam && qParam.includes("name-contains")) {
+                        return response(200).json(datasetsWithFilter);
+                    }
+                    return response(200).json(datasetsNoFilter);
+                }),
+            );
+
+            const filterText = ref("");
+            const { datasets } = useHistoryDatasets({
+                historyId,
+                filterText: () => filterText.value,
+            });
+
+            await flushPromises();
+            expect(datasets.value).toEqual(datasetsNoFilter);
+
+            // Change filter text
+            filterText.value = "name:Dataset 2";
+            await nextTick();
+            await flushPromises();
+
+            expect(datasets.value).toEqual(datasetsWithFilter);
+        });
+    });
+
+    describe("watching scope changes", () => {
+        it("should refetch when historyId changes", async () => {
+            const historyId2 = "history-2";
+            const historyUpdateTime2 = "2024-01-02T12:00:00";
+
+            // Add second history to the store
+            const historyStore = useHistoryStore();
+            historyStore.storedHistories[historyId2] = buildFakeHistory(historyId2, historyUpdateTime2) as AnyHistory;
+
+            const datasets1 = [buildFakeDataset("dataset-1", "Dataset 1")];
+            const datasets2 = [buildFakeDataset("dataset-2", "Dataset 2")];
+
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ params, response }) => {
+                    if (params.history_id === historyId2) {
+                        return response(200).json(datasets2);
+                    }
+                    return response(200).json(datasets1);
+                }),
+            );
+
+            const currentHistoryId = ref(historyId);
+            const { datasets } = useHistoryDatasets({
+                historyId: () => currentHistoryId.value,
+            });
+
+            await flushPromises();
+            expect(datasets.value).toEqual(datasets1);
+
+            // Change history ID
+            currentHistoryId.value = historyId2;
+            await nextTick();
+            await flushPromises();
+
+            expect(datasets.value).toEqual(datasets2);
+        });
+
+        it("should expose historyUpdateTime from the history store", async () => {
+            // This test verifies the composable correctly derives historyUpdateTime
+            // from the history store, which is used by the watcher
+            const { history } = useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            expect(history.value?.update_time).toBe(historyUpdateTime);
+        });
+
+        it("should use the history update time from the store when fetching", async () => {
+            // This test verifies that the composable passes the correct historyUpdateTime
+            // to the store's fetch function, which is critical for cache invalidation
+            const receivedParams: { historyId?: string; updateTime?: string } = {};
+
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ params, response }) => {
+                    receivedParams.historyId = params.history_id as string;
+                    return response(200).json([]);
+                }),
+            );
+
+            const { history } = useHistoryDatasets({
+                historyId,
+            });
+
+            await flushPromises();
+
+            // Verify the composable has access to the correct update time
+            expect(history.value?.update_time).toBe(historyUpdateTime);
+            expect(receivedParams.historyId).toBe(historyId);
+        });
+
+        it("should refetch when filterText changes", async () => {
+            const allDatasets = [buildFakeDataset("dataset-1", "Alpha"), buildFakeDataset("dataset-2", "Beta")];
+            const filteredDatasets = [buildFakeDataset("dataset-1", "Alpha")];
+
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ request, response }) => {
+                    const url = new URL(request.url);
+                    const qParam = url.searchParams.get("q");
+                    if (qParam && qParam.includes("name-contains")) {
+                        return response(200).json(filteredDatasets);
+                    }
+                    return response(200).json(allDatasets);
+                }),
+            );
+
+            const filterText = ref("");
+            const { datasets } = useHistoryDatasets({
+                historyId,
+                filterText: () => filterText.value,
+            });
+
+            await flushPromises();
+            expect(datasets.value).toEqual(allDatasets);
+
+            // Change filter
+            filterText.value = "name:Alpha";
+            await nextTick();
+            await flushPromises();
+
+            expect(datasets.value).toEqual(filteredDatasets);
+        });
+    });
+
+    describe("enabled option", () => {
+        it("should not fetch when enabled is false", async () => {
+            const fetchSpy = vi.fn();
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    fetchSpy();
+                    return response(200).json([]);
+                }),
+            );
+
+            const enabled = ref(false);
+            useHistoryDatasets({
+                historyId,
+                enabled: () => enabled.value,
+            });
+
+            await flushPromises();
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it("should fetch when enabled becomes true", async () => {
+            const expectedDatasets = [buildFakeDataset("dataset-1", "Dataset 1")];
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    return response(200).json(expectedDatasets);
+                }),
+            );
+
+            const enabled = ref(false);
+            const { datasets, initialFetchDone } = useHistoryDatasets({
+                historyId,
+                enabled: () => enabled.value,
+            });
+
+            await flushPromises();
+            expect(datasets.value).toEqual([]);
+            expect(initialFetchDone.value).toBe(false);
+
+            // Enable fetching
+            enabled.value = true;
+            await nextTick();
+            await flushPromises();
+
+            expect(datasets.value).toEqual(expectedDatasets);
+            expect(initialFetchDone.value).toBe(true);
+        });
+
+        it("should not trigger fetch on scope change when disabled", async () => {
+            const fetchSpy = vi.fn();
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    fetchSpy();
+                    return response(200).json([]);
+                }),
+            );
+
+            const filterText = ref("");
+            useHistoryDatasets({
+                historyId,
+                filterText: () => filterText.value,
+                enabled: false,
+            });
+
+            await flushPromises();
+            expect(fetchSpy).not.toHaveBeenCalled();
+
+            // Change filter while disabled
+            filterText.value = "name:test";
+            await nextTick();
+            await flushPromises();
+
+            expect(fetchSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("error handling", () => {
+        it("should set error when fetch fails", async () => {
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    return response("5XX").json({ err_msg: "Internal server error", err_code: 500 }, { status: 500 });
+                }),
+            );
+
+            const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+            const { error, datasets } = useHistoryDatasets({
+                historyId,
+            });
+
+            await flushPromises();
+
+            expect(error.value).not.toBeNull();
+            expect(datasets.value).toEqual([]);
+
+            consoleErrorSpy.mockRestore();
+        });
+
+        it("should clear error on successful fetch after error", async () => {
+            let shouldFail = true;
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ request, response }) => {
+                    const url = new URL(request.url);
+                    const qParam = url.searchParams.get("q");
+                    // Fail only for initial fetch (no filter), succeed for filtered fetch
+                    if (shouldFail && (!qParam || !qParam.includes("name-contains"))) {
+                        return response("5XX").json(
+                            { err_msg: "Internal server error", err_code: 500 },
+                            { status: 500 },
+                        );
+                    }
+                    return response(200).json([buildFakeDataset("dataset-1", "Dataset 1")]);
+                }),
+            );
+
+            const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+            const filterText = ref("");
+            const { error, datasets } = useHistoryDatasets({
+                historyId,
+                filterText: () => filterText.value,
+            });
+
+            await flushPromises();
+            expect(error.value).not.toBeNull();
+
+            // Now change filter text to trigger a new fetch with different scope
+            // This bypasses the store cache and allows a successful fetch
+            shouldFail = false;
+            filterText.value = "name:test";
+
+            await nextTick();
+            await flushPromises();
+
+            expect(error.value).toBeNull();
+            expect(datasets.value).toHaveLength(1);
+
+            consoleErrorSpy.mockRestore();
+        });
+    });
+
+    describe("manual fetch", () => {
+        it("should allow manual fetch via fetchDatasets", async () => {
+            const expectedDatasets = [buildFakeDataset("dataset-1", "Dataset 1")];
+            server.use(
+                http.get("/api/histories/{history_id}/contents", ({ response }) => {
+                    return response(200).json(expectedDatasets);
+                }),
+            );
+
+            const { datasets, fetchDatasets, initialFetchDone } = useHistoryDatasets({
+                historyId,
+                immediate: false,
+            });
+
+            expect(datasets.value).toEqual([]);
+            expect(initialFetchDone.value).toBe(false);
+
+            await fetchDatasets();
+            await flushPromises();
+
+            expect(datasets.value).toEqual(expectedDatasets);
+            expect(initialFetchDone.value).toBe(true);
+        });
+    });
+});

--- a/client/src/composables/useHistoryDatasets.ts
+++ b/client/src/composables/useHistoryDatasets.ts
@@ -1,0 +1,108 @@
+/**
+ * Composable for fetching and watching history datasets based on filter criteria.
+ * This encapsulates the logic for fetching datasets when history ID, update time,
+ * or filter text changes, making it reusable across components like `CollectionCreatorIndex`
+ * (and in the future `ChatGXY`).
+ */
+import { type MaybeRefOrGetter, toValue } from "@vueuse/shared";
+import { computed, ref, watch } from "vue";
+
+import { useHistoryDatasetsStore } from "@/stores/historyDatasetsStore";
+import { useHistoryStore } from "@/stores/historyStore";
+
+interface UseHistoryDatasetsOptions {
+    /** The history ID to fetch datasets for */
+    historyId: MaybeRefOrGetter<string>;
+    /** Optional filter text to apply when fetching datasets */
+    filterText?: MaybeRefOrGetter<string>;
+    /** Whether fetching is enabled. When false, watchers won't trigger fetches. Defaults to `true`. */
+    enabled?: MaybeRefOrGetter<boolean>;
+    /** Whether to fetch immediately when the composable is initialized. Defaults to `true`. */
+    immediate?: boolean;
+}
+
+export function useHistoryDatasets(options: UseHistoryDatasetsOptions) {
+    const { historyId, filterText = "", enabled = true, immediate = true } = options;
+
+    const historyStore = useHistoryStore();
+    const historyDatasetsStore = useHistoryDatasetsStore();
+
+    // Internal state
+    const error = ref<string | null>(null);
+    const initialFetchDone = ref(false);
+
+    // Computed values from options
+    const historyIdValue = computed(() => toValue(historyId));
+    const filterTextValue = computed(() => toValue(filterText));
+    const isEnabled = computed(() => toValue(enabled));
+
+    // Get history and its update time from the history store
+    const history = computed(() => historyStore.getHistoryById(historyIdValue.value));
+    const historyUpdateTime = computed(() => history.value?.update_time);
+
+    // Computed values from the store
+    const isFetching = computed(() => historyDatasetsStore.isFetching[filterTextValue.value] ?? false);
+    const datasets = computed(() => {
+        if (historyDatasetsStore.cachedDatasetsForFilterText) {
+            return historyDatasetsStore.cachedDatasetsForFilterText[filterTextValue.value] || [];
+        }
+        return [];
+    });
+
+    /**
+     * Fetches history datasets using the current scope values.
+     * Can be called manually or is triggered automatically by watchers.
+     */
+    async function fetchDatasets() {
+        const { error: fetchError } = await historyDatasetsStore.fetchDatasetsForFiltertext(
+            historyIdValue.value,
+            historyUpdateTime.value,
+            filterTextValue.value,
+        );
+
+        if (fetchError) {
+            error.value = fetchError;
+            console.error("Error fetching history datasets:", fetchError);
+        } else {
+            error.value = null;
+        }
+
+        if (!initialFetchDone.value) {
+            initialFetchDone.value = true;
+        }
+    }
+
+    // Watch for changes in scope and refetch when enabled
+    watch([historyIdValue, historyUpdateTime, filterTextValue], async () => {
+        if (isEnabled.value) {
+            await fetchDatasets();
+        }
+    });
+
+    // Watch for enabled state changes
+    watch(isEnabled, async (nowEnabled) => {
+        if (nowEnabled) {
+            await fetchDatasets();
+        }
+    });
+
+    // Initial fetch if immediate is true and enabled
+    if (immediate && toValue(enabled)) {
+        fetchDatasets();
+    }
+
+    return {
+        /** The fetched datasets for the current filter text */
+        datasets,
+        /** Whether datasets are currently being fetched */
+        isFetching,
+        /** Any error that occurred during fetching */
+        error,
+        /** Whether the initial fetch has completed */
+        initialFetchDone,
+        /** The history object from the history store */
+        history,
+        /** Manually trigger a fetch */
+        fetchDatasets,
+    };
+}

--- a/client/src/stores/collectionBuilderItemsStore.ts
+++ b/client/src/stores/collectionBuilderItemsStore.ts
@@ -1,82 +1,8 @@
 import { defineStore } from "pinia";
-import { ref, set } from "vue";
+import { ref } from "vue";
 
-import { GalaxyApi, type HDASummary, type HistoryItemSummary } from "@/api";
+import type { HistoryItemSummary } from "@/api";
 import type { ShowElementExtensionFunction } from "@/components/Collections/common/useExtensionFilter";
-import { HistoryFilters } from "@/components/History/HistoryFilters";
-import { filtersToQueryValues } from "@/components/History/model/queries";
-import { errorMessageAsString } from "@/utils/simple-error";
-
-const DEFAULT_FILTERS: Record<string, any> = { visible: true, deleted: false };
-
-/**
- * Fetches datasets for the Collection Builder modal. It caches the datasets for each filter text.
- */
-export const useCollectionBuilderItemsStore = defineStore("collectionBuilderItemsStore", () => {
-    const cachedDatasetsForFilterText = ref<Record<string, HDASummary[]>>({});
-    const errorMessage = ref<string | null>(null);
-    const isFetching = ref<Record<string, boolean>>({});
-    const lastFetch = ref<{ id: string; time: string; text: string } | null>(null);
-
-    async function fetchDatasetsForFiltertext(historyId: string, historyUpdateTime?: string, filterText = "") {
-        if (isFetching.value[filterText]) {
-            return { data: [], error: null };
-        }
-
-        if (
-            lastFetch.value &&
-            lastFetch.value.id === historyId &&
-            lastFetch.value.time === historyUpdateTime &&
-            lastFetch.value.text === filterText
-        ) {
-            return {
-                data: cachedDatasetsForFilterText.value[filterText] || [],
-                error: errorMessage.value,
-            };
-        }
-
-        set(isFetching.value, filterText, true);
-
-        const filterQuery = getFilterQuery(filterText);
-
-        // Note: Had "/api/histories/{history_id}/contents/datasets" before but it was returning datasets and collections
-        const { data, error: apiError } = await GalaxyApi().GET("/api/histories/{history_id}/contents", {
-            params: {
-                path: { history_id: historyId },
-                query: { ...filterQuery, v: "dev" },
-            },
-        });
-        const returnedData = data as HDASummary[];
-
-        let error = null;
-        if (apiError) {
-            error = errorMessageAsString(apiError);
-            errorMessage.value = error;
-        } else {
-            set(cachedDatasetsForFilterText.value, filterText, returnedData);
-        }
-
-        set(isFetching.value, filterText, false);
-        lastFetch.value = { id: historyId, time: historyUpdateTime || "", text: filterText };
-
-        return { data: returnedData, error };
-    }
-
-    function getFilterQuery(filterText: string) {
-        let filters = filterText ? HistoryFilters.getQueryDict(filterText) : DEFAULT_FILTERS;
-        if (filters.history_content_type) {
-            delete filters.history_content_type;
-        }
-        filters = { ...filters, history_content_type: "dataset" };
-        return filtersToQueryValues(filters);
-    }
-
-    return {
-        cachedDatasetsForFilterText,
-        isFetching,
-        fetchDatasetsForFiltertext,
-    };
-});
 
 /**
  * Stores the history items selected for collection building.

--- a/client/src/stores/historyDatasetsStore.ts
+++ b/client/src/stores/historyDatasetsStore.ts
@@ -1,0 +1,86 @@
+import { defineStore } from "pinia";
+import { ref, set } from "vue";
+
+import { GalaxyApi, type HDASummary } from "@/api";
+import { HistoryFilters } from "@/components/History/HistoryFilters";
+import { filtersToQueryValues } from "@/components/History/model/queries";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+const DEFAULT_FILTERS: Record<string, any> = { visible: true, deleted: false };
+
+/**
+ * Fetches compact dataset summaries. It caches the datasets for each filter text, for the current
+ * history only.
+ *
+ * It is scoped to `historyId`, `historyUpdateTime` and `filterText`.
+ *
+ * **Note:** *This store does not track the current history - it is meant to be used in tandem with
+ * the `useHistoryDatasets` composable*.
+ */
+export const useHistoryDatasetsStore = defineStore("historyDatasetsStore", () => {
+    const cachedDatasetsForFilterText = ref<Record<string, HDASummary[]>>({});
+    const errorMessage = ref<string | null>(null);
+    const isFetching = ref<Record<string, boolean>>({});
+
+    /** The current scope of the cached datasets, defined by history ID, update time, and filter text */
+    const currentScope = ref<{ id: string; time: string; text: string } | null>(null);
+
+    async function fetchDatasetsForFiltertext(historyId: string, historyUpdateTime?: string, filterText = "") {
+        if (isFetching.value[filterText]) {
+            return { data: [], error: null };
+        }
+
+        if (
+            currentScope.value &&
+            currentScope.value.id === historyId &&
+            currentScope.value.time === historyUpdateTime &&
+            currentScope.value.text === filterText
+        ) {
+            return {
+                data: cachedDatasetsForFilterText.value[filterText] || [],
+                error: errorMessage.value,
+            };
+        }
+
+        set(isFetching.value, filterText, true);
+
+        const filterQuery = getFilterQuery(filterText);
+
+        // Note: Had "/api/histories/{history_id}/contents/datasets" before but it was returning datasets and collections
+        const { data, error: apiError } = await GalaxyApi().GET("/api/histories/{history_id}/contents", {
+            params: {
+                path: { history_id: historyId },
+                query: { ...filterQuery, v: "dev" },
+            },
+        });
+        const returnedData = data as HDASummary[];
+
+        let error = null;
+        if (apiError) {
+            error = errorMessageAsString(apiError);
+            errorMessage.value = error;
+        } else {
+            set(cachedDatasetsForFilterText.value, filterText, returnedData);
+        }
+
+        set(isFetching.value, filterText, false);
+        currentScope.value = { id: historyId, time: historyUpdateTime || "", text: filterText };
+
+        return { data: returnedData, error };
+    }
+
+    function getFilterQuery(filterText: string) {
+        let filters = filterText ? HistoryFilters.getQueryDict(filterText) : DEFAULT_FILTERS;
+        if (filters.history_content_type) {
+            delete filters.history_content_type;
+        }
+        filters = { ...filters, history_content_type: "dataset" };
+        return filtersToQueryValues(filters);
+    }
+
+    return {
+        cachedDatasetsForFilterText,
+        isFetching,
+        fetchDatasetsForFiltertext,
+    };
+});


### PR DESCRIPTION
These datasets stored here are scoped to a `historyId`, `filterText` and the last `update_time`. It essentially replaces the existing `useCollectionBuilderItemsStore`.

This is meant to be used in tandem with a newly added `useHistoryDatasets` composable which keeps track of the current history id, text and update time.

**NOTE:** Just wanted to break out some work from PR #21706. This will be used there in `ChatGXY.vue` as well as the existing usage in the collection builder. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
