### PR TITLE
[26.0] Hide interactivetools activity when disabled in config

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -101,14 +101,22 @@ const { activities: storeActivities, isSideBarOpen, sidePanelWidth } = storeToRe
 
 const activities = computed({
     get() {
-        return storeActivities.value.filter(
-            (activity) => activity.id !== "user-defined-tools" || canUseUnprivilegedTools.value,
-        );
+        return storeActivities.value.filter((activity) => {
+            if (activity.id === "user-defined-tools" && !canUseUnprivilegedTools.value) {
+                return false;
+            }
+            if (activity.id === "interactivetools" && !config.value?.interactivetools_enable) {
+                return false;
+            }
+            return true;
+        });
     },
     set(newActivities: Activity[]) {
         // Find any filtered-out activities and add them back
         const filteredOut = storeActivities.value.filter(
-            (activity) => activity.id === "user-defined-tools" && !canUseUnprivilegedTools.value,
+            (activity) =>
+                (activity.id === "user-defined-tools" && !canUseUnprivilegedTools.value) ||
+                (activity.id === "interactivetools" && !config.value?.interactivetools_enable),
         );
         storeActivities.value = [...newActivities, ...filteredOut];
     },


### PR DESCRIPTION
Filter out the interactivetools activity from the activity bar when interactivetools_enable is false. No point showing users an option they can't use.

Fixes #21739