### PR TITLE
Migrate OrganizationViewer and PersonViewer from BTable to GTable

### DIFF
--- a/client/src/components/SchemaOrg/OrganizationViewer.vue
+++ b/client/src/components/SchemaOrg/OrganizationViewer.vue
@@ -1,57 +1,61 @@
 <template>
     <span itemprop="creator" itemscope itemtype="https://schema.org/Organization">
         <FontAwesomeIcon ref="button" :icon="faBuilding" />
-        <b-popover
-            triggers="click blur"
-            :placement="hoverPlacement"
-            :target="$refs['button'] || 'works-lazily'"
-            title="Organization">
+
+        <BPopover triggers="click blur" :target="$refs['button'] || 'works-lazily'" title="Organization">
             <GTable :items="items" :fields="fields" />
-        </b-popover>
+        </BPopover>
+
         <span v-if="name">
             <span itemprop="name">{{ name }}</span>
             <span v-if="email">
-                (<span itemprop="email" :content="organization.email">{{ email }}</span
-                >)
+                (
+                <span itemprop="email" :content="organization.email">
+                    {{ email }}
+                </span>
+                )
             </span>
         </span>
         <span v-else-if="email" itemprop="email" :content="organization.email">
             {{ email }}
         </span>
-        <a v-if="url" v-b-tooltip.hover title="Organization URL" :href="url" target="_blank">
+
+        <GLink v-if="url" v-b-tooltip.hover title="Organization URL" :href="url" target="_blank">
             <link itemprop="url" :href="url" />
             <FontAwesomeIcon :icon="faExternalLinkAlt" />
-        </a>
+        </GLink>
+
         <meta
             v-for="attribute in explicitMetaAttributes"
             :key="attribute.attribute"
             :itemprop="attribute.attribute"
             :content="attribute.value" />
-        <slot name="buttons"></slot>
+
+        <slot name="buttons" />
     </span>
 </template>
 
 <script>
 import { faBuilding, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BPopover } from "bootstrap-vue";
 
 import ThingViewerMixin from "./ThingViewerMixin";
 
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
+        BPopover,
         FontAwesomeIcon,
+        GLink,
         GTable,
     },
     mixins: [ThingViewerMixin],
     props: {
         organization: {
             type: Object,
-        },
-        hoverPlacement: {
-            type: String,
-            default: "left",
         },
     },
     data() {

--- a/client/src/components/SchemaOrg/OrganizationViewer.vue
+++ b/client/src/components/SchemaOrg/OrganizationViewer.vue
@@ -6,7 +6,7 @@
             :placement="hoverPlacement"
             :target="$refs['button'] || 'works-lazily'"
             title="Organization">
-            <b-table striped :items="items"> </b-table>
+            <GTable :items="items" :fields="fields" />
         </b-popover>
         <span v-if="name">
             <span itemprop="name">{{ name }}</span>
@@ -37,9 +37,12 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 import ThingViewerMixin from "./ThingViewerMixin";
 
+import GTable from "@/components/Common/GTable.vue";
+
 export default {
     components: {
         FontAwesomeIcon,
+        GTable,
     },
     mixins: [ThingViewerMixin],
     props: {
@@ -57,6 +60,10 @@ export default {
             faExternalLinkAlt,
             implicitMicrodataProperties: ["name", "email", "url", "identifier"],
             thing: this.organization,
+            fields: [
+                { key: "attribute", label: "Attribute" },
+                { key: "value", label: "Value" },
+            ],
         };
     },
     computed: {

--- a/client/src/components/SchemaOrg/OrganizationViewer.vue
+++ b/client/src/components/SchemaOrg/OrganizationViewer.vue
@@ -10,9 +10,7 @@
             <span itemprop="name">{{ name }}</span>
             <span v-if="email">
                 (
-                <span itemprop="email" :content="organization.email">
-                    {{ email }}
-                </span>
+                <span itemprop="email" :content="organization.email">{{ email }}</span>
                 )
             </span>
         </span>
@@ -20,7 +18,7 @@
             {{ email }}
         </span>
 
-        <GLink v-if="url" v-b-tooltip.hover title="Organization URL" :href="url" target="_blank">
+        <GLink v-if="url" v-b-tooltip.hover tooltip title="Organization URL" :href="url" target="_blank">
             <link itemprop="url" :href="url" />
             <FontAwesomeIcon :icon="faExternalLinkAlt" />
         </GLink>

--- a/client/src/components/SchemaOrg/PersonViewer.vue
+++ b/client/src/components/SchemaOrg/PersonViewer.vue
@@ -6,7 +6,7 @@
             :placement="hoverPlacement"
             :target="$refs['button'] || 'works-lazily'"
             title="Person">
-            <b-table striped :items="items"> </b-table>
+            <GTable :items="items" :fields="fields" />
         </b-popover>
         <span v-if="name">
             <meta v-if="person.name" itemprop="name" :content="person.name" />
@@ -45,9 +45,12 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 import ThingViewerMixin from "./ThingViewerMixin";
 
+import GTable from "@/components/Common/GTable.vue";
+
 export default {
     components: {
         FontAwesomeIcon,
+        GTable,
     },
     mixins: [ThingViewerMixin],
     props: {
@@ -66,6 +69,10 @@ export default {
             faExternalLinkAlt,
             implicitMicrodataProperties: ["name", "givenName", "email", "familyName", "url", "identifier"],
             thing: this.person,
+            fields: [
+                { key: "attribute", label: "Attribute" },
+                { key: "value", label: "Value" },
+            ],
         };
     },
     computed: {

--- a/client/src/components/SchemaOrg/PersonViewer.vue
+++ b/client/src/components/SchemaOrg/PersonViewer.vue
@@ -1,40 +1,48 @@
 <template>
     <span itemprop="creator" itemscope itemtype="https://schema.org/Person">
         <FontAwesomeIcon ref="button" :icon="faUser" />
-        <b-popover
-            triggers="click blur"
-            :placement="hoverPlacement"
-            :target="$refs['button'] || 'works-lazily'"
-            title="Person">
+
+        <BPopover triggers="click blur" :target="$refs['button'] || 'works-lazily'" title="Person">
             <GTable :items="items" :fields="fields" />
-        </b-popover>
+        </BPopover>
+
         <span v-if="name">
             <meta v-if="person.name" itemprop="name" :content="person.name" />
             <meta v-if="person.givenName" itemprop="givenName" :content="person.givenName" />
             <meta v-if="person.familyName" itemprop="familyName" :content="person.familyName" />
             {{ name }}
             <span v-if="email">
-                (<span itemprop="email" :content="person.email">{{ email }}</span
-                >)
+                (
+                <span itemprop="email" :content="person.email">{{ email }}</span>
+                )
             </span>
         </span>
         <span v-else itemprop="email" :content="person.email">
             {{ email }}
         </span>
-        <a v-if="orcidLink" v-b-tooltip.hover title="View orcid.org profile" :href="orcidLink" target="_blank">
+
+        <GLink
+            v-if="orcidLink"
+            v-b-tooltip.hover
+            tooltip
+            title="View orcid.org profile"
+            :href="orcidLink"
+            target="_blank">
             <link itemprop="identifier" :href="orcidLink" />
             <FontAwesomeIcon :icon="faOrcid" />
-        </a>
-        <a v-if="url" v-b-tooltip.hover title="URL" :href="url" target="_blank">
+        </GLink>
+        <GLink v-if="url" v-b-tooltip.hover tooltip title="URL" :href="url" target="_blank">
             <link itemprop="url" :href="url" />
             <FontAwesomeIcon :icon="faExternalLinkAlt" />
-        </a>
+        </GLink>
+
         <meta
             v-for="attribute in explicitMetaAttributes"
             :key="attribute.attribute"
             :itemprop="attribute.attribute"
             :content="attribute.value" />
-        <slot name="buttons"></slot>
+
+        <slot name="buttons" />
     </span>
 </template>
 
@@ -42,24 +50,24 @@
 import { faOrcid } from "@fortawesome/free-brands-svg-icons";
 import { faExternalLinkAlt, faUser } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BPopover } from "bootstrap-vue";
 
 import ThingViewerMixin from "./ThingViewerMixin";
 
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
+        BPopover,
         FontAwesomeIcon,
+        GLink,
         GTable,
     },
     mixins: [ThingViewerMixin],
     props: {
         person: {
             type: Object,
-        },
-        hoverPlacement: {
-            type: String,
-            default: "left",
         },
     },
     data() {


### PR DESCRIPTION
This PR fixes #21757 and migrates `OrganizationViewer.vue` and `PersonViewer.vue` from Bootstrap-Vue's `BTable` to our custom `GTable` component, as part of the ongoing effort tracked in #21703.

|Before|After|
|----|----|
|<img width="1238" height="746" alt="image" src="https://github.com/user-attachments/assets/9575bc50-c8ea-4317-b51b-040e5a385fe2" />|<img width="1238" height="746" alt="image" src="https://github.com/user-attachments/assets/7dc3a70d-ecb1-489e-a6a3-05a631064209" />|
|<img width="916" height="746" alt="image" src="https://github.com/user-attachments/assets/8abfda27-4f35-48cf-8c0b-5a37a64e0a85" />|<img width="916" height="746" alt="image" src="https://github.com/user-attachments/assets/be2b1370-26c9-4dd5-8356-dccd4bd1d7f1" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to workflow editor
  2. Add a creator and save
  3. Click on the creators' icons

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
