### PR TITLE
[26.0] Handle TPV floating point memory values

### DIFF
--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -496,13 +496,13 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
 
         # Check for Galaxy job resource parameter 'mem' (in GB, convert to MiB)
         if resource_params.get("mem"):
-            mem_gb = int(resource_params["mem"])
-            return mem_gb * 1024  # Convert GB to MiB
+            mem_gb = float(resource_params["mem"])
+            return int(mem_gb * 1024)  # Convert GB to MiB
 
         # Check for TPV-style 'mem' in destination params (in GB)
         if "mem" in job_destination.params:
-            mem_gb = int(job_destination.params["mem"])
-            return mem_gb * 1024  # Convert GB to MiB
+            mem_gb = float(job_destination.params["mem"])
+            return int(mem_gb * 1024)  # Convert GB to MiB
 
         # Fall back to configured default
         return int(params.get("memory_mib", DEFAULT_MEMORY_MIB))


### PR DESCRIPTION
Floating point values in the TPV memory configuration could cause errors as Google Batch only allows integer values.  This PR ensures all floating point values are converted to the appropriate int value before passing them to Batch.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
