### PR TITLE
Migrate Toolshed Components from Bootstrap Components to GComponents and add Local Filter to GTable

### DIFF
--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -74,6 +74,12 @@ interface Props {
     hover?: boolean;
 
     /**
+     * Whether to hide the table header
+     * @default false
+     */
+    hideHeader?: boolean;
+
+    /**
      * Table data items
      * @default []
      */
@@ -181,6 +187,7 @@ const props = withDefaults(defineProps<Props>(), {
     fields: () => [],
     filter: "",
     hover: true,
+    hideHeader: false,
     items: () => [],
     loading: false,
     loadingMessage: "Loading...",
@@ -473,7 +480,7 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
 </script>
 
 <template>
-    <div :id="`g-table-container-${props.id}`" class="w-100" :class="containerClass">
+    <div :id="`g-table-container-${props.id}`" :class="containerClass">
         <!-- Table wrapper -->
         <BOverlay :show="overlayLoading" rounded="sm" class="position-relative w-100">
             <div :id="`g-table-wrapper-${props.id}`" class="position-relative w-100">
@@ -486,7 +493,7 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                         { 'table-bordered': bordered },
                         tableClass,
                     ]">
-                    <thead>
+                    <thead v-if="!props.hideHeader">
                         <tr>
                             <th v-if="selectable" class="g-table-select-column">
                                 <slot name="head-select">

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -216,6 +216,7 @@ const emit = defineEmits<{
 
 const sortBy = ref<string>(props.sortBy || "update_time");
 const sortDesc = ref<boolean>(props.sortDesc || true);
+const expandedRows = ref<Set<number>>(new Set());
 
 const localItems = computed(() => {
     const items = props.items || [];
@@ -339,6 +340,26 @@ function onSelectAll(selected: boolean) {
 function onRowSelect(item: T, index: number) {
     const isSelected = props.selectedItems.includes(index);
     emit("row-select", { item, index, selected: !isSelected });
+}
+
+/**
+ * Check if row details are expanded
+ */
+function isRowExpanded(index: number) {
+    return expandedRows.value.has(index);
+}
+
+/**
+ * Toggle row details expansion
+ */
+function toggleRowDetails(index: number) {
+    if (isRowExpanded(index)) {
+        expandedRows.value.delete(index);
+    } else {
+        expandedRows.value.add(index);
+    }
+    // Trigger reactivity
+    expandedRows.value = new Set(expandedRows.value);
 }
 
 /**
@@ -479,87 +500,106 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                     </thead>
 
                     <tbody v-if="localItems.length > 0">
-                        <tr
-                            v-for="(item, index) in localItems"
-                            :id="getRowId(props.id, index)"
-                            :key="index"
-                            :class="{
-                                'g-table-row-clickable': clickableRows,
-                                'g-table-row-selected': isRowSelected(index),
-                            }"
-                            @click="onRowClick(item, index, $event)">
-                            <!-- Selection checkbox column -->
-                            <td v-if="selectable" class="g-table-select-column">
-                                <BFormCheckbox
-                                    :id="`${getRowId(props.id, index)}-select`"
-                                    v-b-tooltip.hover.noninteractive
-                                    :checked="isRowSelected(index)"
-                                    title="Select for bulk actions"
-                                    @click.stop
-                                    @change="onRowSelect(item, index)" />
-                            </td>
+                        <template v-for="(item, index) in localItems">
+                            <template>
+                                <tr
+                                    :id="getRowId(props.id, index)"
+                                    :key="`tr` + index"
+                                    :class="{
+                                        'g-table-row-clickable': clickableRows,
+                                        'g-table-row-selected': isRowSelected(index),
+                                    }"
+                                    @click="onRowClick(item, index, $event)">
+                                    <!-- Selection checkbox column -->
+                                    <td v-if="selectable" class="g-table-select-column">
+                                        <BFormCheckbox
+                                            :id="`${getRowId(props.id, index)}-select`"
+                                            v-b-tooltip.hover.noninteractive
+                                            :checked="isRowSelected(index)"
+                                            title="Select for bulk actions"
+                                            @click.stop
+                                            @change="onRowSelect(item, index)" />
+                                    </td>
 
-                            <!-- Data columns -->
-                            <td
-                                v-for="(field, fieldIndex) in props.fields"
-                                :id="getCellId(props.id, field.key, index)"
-                                :key="field.key"
-                                :class="[
-                                    field.cellClass,
-                                    field.class,
-                                    getAlignmentClass(field.align),
-                                    { 'hide-on-small': field.hideOnSmall },
-                                ]">
-                                <template v-if="fieldIndex === 0 && getStatusIcon(item, index)">
-                                    <FontAwesomeIcon
-                                        v-if="getStatusIcon(item, index)"
-                                        v-b-tooltip.hover.noninteractive
-                                        v-bind="getIconProps(item, index)"
-                                        fixed-width />
-                                </template>
-
-                                <slot :name="`cell(${field.key})`" :value="item[field.key]" :item="item" :index="index">
-                                    <span>{{ getCellValue(item, field) }}</span>
-                                </slot>
-                            </td>
-
-                            <!-- Actions column -->
-                            <td v-if="props.actions" class="g-table-actions-column">
-                                <slot name="actions" :item="item" :index="index">
-                                    <BDropdown
-                                        v-b-tooltip.hover.noninteractive
-                                        no-caret
-                                        right
-                                        title="More actions"
-                                        variant="link"
-                                        size="lg"
-                                        toggle-class="text-decoration-none p-0"
-                                        @click.stop>
-                                        <template v-slot:button-content>
-                                            <FontAwesomeIcon :icon="faEllipsisV" fixed-width />
+                                    <!-- Data columns -->
+                                    <td
+                                        v-for="(field, fieldIndex) in props.fields"
+                                        :id="getCellId(props.id, field.key, index)"
+                                        :key="field.key"
+                                        :class="[
+                                            field.cellClass,
+                                            field.class,
+                                            getAlignmentClass(field.align),
+                                            { 'hide-on-small': field.hideOnSmall },
+                                        ]">
+                                        <template v-if="fieldIndex === 0 && getStatusIcon(item, index)">
+                                            <FontAwesomeIcon
+                                                v-if="getStatusIcon(item, index)"
+                                                v-b-tooltip.hover.noninteractive
+                                                v-bind="getIconProps(item, index)"
+                                                fixed-width />
                                         </template>
 
-                                        <template v-for="ac in props.actions">
-                                            <BDropdownItem
-                                                v-if="ac.visible ?? true"
-                                                :id="ac.id"
-                                                :key="ac.id"
-                                                :disabled="ac.disabled"
-                                                :size="ac.size || 'sm'"
-                                                :variant="ac.variant || 'link'"
-                                                :to="ac.to"
-                                                :title="ac.title"
-                                                :href="ac.href"
-                                                :target="ac.externalLink ? '_blank' : undefined"
-                                                @click.stop="ac.handler && ac.handler(item, index)">
-                                                <FontAwesomeIcon v-if="ac.icon" :icon="ac.icon" fixed-width />
-                                                {{ ac.label }}
-                                            </BDropdownItem>
-                                        </template>
-                                    </BDropdown>
-                                </slot>
-                            </td>
-                        </tr>
+                                        <slot
+                                            :name="`cell(${field.key})`"
+                                            :value="item[field.key]"
+                                            :item="item"
+                                            :index="index"
+                                            :toggle-details="() => toggleRowDetails(index)">
+                                            <span>{{ getCellValue(item, field) }}</span>
+                                        </slot>
+                                    </td>
+
+                                    <!-- Actions column -->
+                                    <td v-if="props.actions" class="g-table-actions-column">
+                                        <slot name="actions" :item="item" :index="index">
+                                            <BDropdown
+                                                v-b-tooltip.hover.noninteractive
+                                                no-caret
+                                                right
+                                                title="More actions"
+                                                variant="link"
+                                                size="lg"
+                                                toggle-class="text-decoration-none p-0"
+                                                @click.stop>
+                                                <template v-slot:button-content>
+                                                    <FontAwesomeIcon :icon="faEllipsisV" fixed-width />
+                                                </template>
+
+                                                <template v-for="ac in props.actions">
+                                                    <BDropdownItem
+                                                        v-if="ac.visible ?? true"
+                                                        :id="ac.id"
+                                                        :key="ac.id"
+                                                        :disabled="ac.disabled"
+                                                        :size="ac.size || 'sm'"
+                                                        :variant="ac.variant || 'link'"
+                                                        :to="ac.to"
+                                                        :title="ac.title"
+                                                        :href="ac.href"
+                                                        :target="ac.externalLink ? '_blank' : undefined"
+                                                        @click.stop="ac.handler && ac.handler(item, index)">
+                                                        <FontAwesomeIcon v-if="ac.icon" :icon="ac.icon" fixed-width />
+                                                        {{ ac.label }}
+                                                    </BDropdownItem>
+                                                </template>
+                                            </BDropdown>
+                                        </slot>
+                                    </td>
+                                </tr>
+                            </template>
+
+                            <!-- Row details expansion -->
+                            <tr v-if="isRowExpanded(index)" :key="`details-${index}`" class="g-table-details-row">
+                                <td :colspan="props.fields.length + (selectable ? 1 : 0) + (props.actions ? 1 : 0)">
+                                    <slot
+                                        name="row-details"
+                                        :item="item"
+                                        :index="index"
+                                        :toggle-details="() => toggleRowDetails(index)" />
+                                </td>
+                            </tr>
+                        </template>
                     </tbody>
                 </table>
 
@@ -615,6 +655,10 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
 
             &.g-table-row-selected {
                 background-color: $brand-light;
+            }
+
+            &.g-table-details-row {
+                background-color: lighten($brand-light, 0.3);
             }
         }
 

--- a/client/src/components/Toolshed/InstalledList/Index.test.js
+++ b/client/src/components/Toolshed/InstalledList/Index.test.js
@@ -3,6 +3,7 @@ import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 import Index from "./Index.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
 
 vi.mock("app");
 vi.mock("onload/loadConfig", () => ({
@@ -42,20 +43,22 @@ describe("InstalledList", () => {
             },
             stubs: {
                 RepositoryDetails: true,
+                GLink,
+                LoadingSpan: true,
             },
             localVue,
         });
-        expect(wrapper.find(".loading-message").text()).toBe("Loading installed repositories...");
+        expect(wrapper.find("loadingspan-stub").attributes("message")).toBe("Loading installed repositories");
         await wrapper.vm.$nextTick();
         expect(wrapper.find(".installed-message").text()).toBe("2 repositories installed on this instance.");
         const names = wrapper.findAll(".name");
         expect(names.length).toBe(2);
         expect(names.at(0).text()).toBe("name_0");
         expect(names.at(1).text()).toBe("name_1");
-        const links = wrapper.findAll("a");
+        const links = wrapper.findAllComponents(GLink);
         expect(links.length).toBe(3);
         const badge = links.at(1).find(".badge");
         expect(badge.text()).toBe("Newer version available!");
-        expect(wrapper.find('th[role="columnheader"][aria-colindex="3"] > div').text()).toBe("Tool Shed");
+        expect(wrapper.vm.fields.some((field) => field.key === "tool_shed")).toBe(true);
     });
 });

--- a/client/src/components/Toolshed/InstalledList/Index.vue
+++ b/client/src/components/Toolshed/InstalledList/Index.vue
@@ -20,28 +20,29 @@
                         </span>
                     </b-link>
                 </div>
+
                 <Monitor v-if="showMonitor" @onQuery="onQuery" />
-                <b-table
+
+                <GTable
                     id="repository-table"
-                    striped
                     :fields="fields"
-                    :sort-by="sortBy"
                     :items="repositories"
                     :filter="filter"
                     @filtered="filtered">
-                    <template v-slot:cell(name)="row">
-                        <b-link href="#" role="button" class="font-weight-bold" @click="row.toggleDetails">
-                            <div v-if="!isLatest(row.item)">
+                    <template v-slot:cell(name)="{ item, toggleDetails }">
+                        <b-link href="#" role="button" class="font-weight-bold" @click.prevent="toggleDetails">
+                            <div v-if="!isLatest(item)">
                                 <b-badge variant="danger" class="mb-2"> Newer version available! </b-badge>
                             </div>
-                            <div class="name">{{ row.item.name }}</div>
+                            <div class="name">{{ item.name }}</div>
                         </b-link>
-                        <div>{{ row.item.description }}</div>
+                        <div>{{ item.description }}</div>
                     </template>
-                    <template v-slot:row-details="row">
-                        <RepositoryDetails :repo="row.item" />
+                    <template v-slot:row-details="{ item }">
+                        <RepositoryDetails :repo="item" />
                     </template>
-                </b-table>
+                </GTable>
+
                 <div v-if="showNotFound">
                     No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
                     >.
@@ -51,6 +52,7 @@
         </div>
     </div>
 </template>
+
 <script>
 import BootstrapVue from "bootstrap-vue";
 import Vue from "vue";
@@ -61,12 +63,14 @@ import { Services } from "../services";
 
 import RepositoryDetails from "./Details.vue";
 import Monitor from "./Monitor.vue";
+import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 Vue.use(BootstrapVue);
 
 export default {
     components: {
+        GTable,
         LoadingSpan,
         Monitor,
         RepositoryDetails,
@@ -86,7 +90,6 @@ export default {
             nRepositories: 0,
             repositories: [],
             showMonitor: false,
-            sortBy: "name",
         };
     },
     computed: {
@@ -110,13 +113,12 @@ export default {
             const fields = [
                 {
                     key: "name",
+                    label: "Name",
                     sortable: true,
-                    sortByFormatted: (value, key, item) => {
-                        return `${this.isLatest(item)}_${value}`;
-                    },
                 },
                 {
                     key: "owner",
+                    label: "Owner",
                     sortable: true,
                 },
             ];

--- a/client/src/components/Toolshed/InstalledList/Index.vue
+++ b/client/src/components/Toolshed/InstalledList/Index.vue
@@ -4,21 +4,23 @@
         <div v-else>
             <LoadingSpan v-if="loading" message="Loading installed repositories" />
             <div v-else>
-                <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+                <BAlert :variant="messageVariant" :show="showMessage">{{ message }}</BAlert>
+
                 <div class="m-1">
                     <span class="installed-message text-muted">
                         {{ repositories.length }} repositories installed on this instance.
                     </span>
-                    <b-link class="font-weight-bold" @click="toggleMonitor">
+
+                    <GLink class="font-weight-bold" @click="toggleMonitor">
                         <span v-if="showMonitor">
-                            <span class="fa fa-angle-double-up" />
+                            <FontAwesomeIcon :icon="faAngleDoubleUp" />
                             <span>Hide installation progress.</span>
                         </span>
                         <span v-else>
-                            <span class="fa fa-angle-double-down" />
+                            <FontAwesomeIcon :icon="faAngleDoubleDown" />
                             <span>Show installation progress.</span>
                         </span>
-                    </b-link>
+                    </GLink>
                 </div>
 
                 <Monitor v-if="showMonitor" @onQuery="onQuery" />
@@ -30,14 +32,17 @@
                     :filter="filter"
                     @filtered="filtered">
                     <template v-slot:cell(name)="{ item, toggleDetails }">
-                        <b-link href="#" role="button" class="font-weight-bold" @click.prevent="toggleDetails">
+                        <GLink class="font-weight-bold" @click.prevent="toggleDetails">
                             <div v-if="!isLatest(item)">
-                                <b-badge variant="danger" class="mb-2"> Newer version available! </b-badge>
+                                <BBadge variant="danger" class="mb-2"> Newer version available! </BBadge>
                             </div>
+
                             <div class="name">{{ item.name }}</div>
-                        </b-link>
+                        </GLink>
+
                         <div>{{ item.description }}</div>
                     </template>
+
                     <template v-slot:row-details="{ item }">
                         <RepositoryDetails :repo="item" />
                     </template>
@@ -54,8 +59,9 @@
 </template>
 
 <script>
-import BootstrapVue from "bootstrap-vue";
-import Vue from "vue";
+import { faAngleDoubleDown, faAngleDoubleUp } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert, BBadge } from "bootstrap-vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
 
@@ -63,13 +69,16 @@ import { Services } from "../services";
 
 import RepositoryDetails from "./Details.vue";
 import Monitor from "./Monitor.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
-Vue.use(BootstrapVue);
-
 export default {
     components: {
+        BAlert,
+        BBadge,
+        FontAwesomeIcon,
+        GLink,
         GTable,
         LoadingSpan,
         Monitor,
@@ -83,6 +92,8 @@ export default {
     },
     data() {
         return {
+            faAngleDoubleDown,
+            faAngleDoubleUp,
             error: null,
             loading: true,
             message: null,

--- a/client/src/components/Toolshed/InstalledList/Monitor.test.js
+++ b/client/src/components/Toolshed/InstalledList/Monitor.test.js
@@ -33,17 +33,18 @@ describe("Monitor", () => {
     it("test monitor", async () => {
         const localVue = getLocalVue();
         const wrapper = mount(Monitor, { localVue });
+
         await localVue.nextTick();
-        const headers = wrapper.findAll("th");
-        expect(headers.length).toBe(3);
-        expect(headers.at(0).text()).toBe("Name");
-        expect(headers.at(1).text()).toBe("Status");
+
+        expect(wrapper.vm.fields.length).toBe(3);
+        expect(wrapper.vm.fields[0].label).toBe("Name");
+        expect(wrapper.vm.fields[1].label).toBe("Status");
 
         const cells = wrapper.findAll("td");
         expect(cells.length).toBe(6);
-        expect(cells.at(0).text()).toBe("name_0 (owner_0)");
+        expect(cells.at(0).text()).toContain("name_0 (owner_0)");
         expect(cells.at(1).text()).toContain("status_0_0");
-        expect(cells.at(3).text()).toBe("name_1 (owner_1)");
+        expect(cells.at(3).text()).toContain("name_1 (owner_1)");
         expect(cells.at(4).text()).toContain("status_1");
     });
 });

--- a/client/src/components/Toolshed/InstalledList/Monitor.test.js
+++ b/client/src/components/Toolshed/InstalledList/Monitor.test.js
@@ -1,5 +1,5 @@
-import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
 import { describe, expect, it, vi } from "vitest";
 
 import Monitor from "./Monitor.vue";
@@ -31,14 +31,12 @@ vi.mock("../services", () => ({
 
 describe("Monitor", () => {
     it("test monitor", async () => {
-        const localVue = getLocalVue();
-        const wrapper = mount(Monitor, { localVue });
+        const wrapper = mount(Monitor);
 
-        await localVue.nextTick();
+        await flushPromises();
 
-        expect(wrapper.vm.fields.length).toBe(3);
-        expect(wrapper.vm.fields[0].label).toBe("Name");
-        expect(wrapper.vm.fields[1].label).toBe("Status");
+        const headers = wrapper.findAll("th");
+        expect(headers.length).toBe(0);
 
         const cells = wrapper.findAll("td");
         expect(cells.length).toBe(6);

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <b-alert v-if="error" variant="danger" show>
+        <BAlert v-if="error" variant="danger" show>
             {{ error }}
-        </b-alert>
+        </BAlert>
 
         <GCard v-if="showItems" class="my-2">
             <h2 class="m-3 h-text">Currently installing...</h2>
@@ -27,13 +27,12 @@
             </GTable>
         </GCard>
 
-        <b-alert v-if="showEmpty" variant="info" show> Currently there are no installing repositories. </b-alert>
+        <BAlert v-if="showEmpty" variant="info" show> Currently there are no installing repositories. </BAlert>
     </div>
 </template>
 
 <script>
-import BootstrapVue from "bootstrap-vue";
-import Vue from "vue";
+import { BAlert } from "bootstrap-vue";
 
 import { Services } from "../services";
 
@@ -42,10 +41,9 @@ import GLink from "@/components/BaseComponents/GLink.vue";
 import GCard from "@/components/Common/GCard.vue";
 import GTable from "@/components/Common/GTable.vue";
 
-Vue.use(BootstrapVue);
-
 export default {
     components: {
+        BAlert,
         GCard,
         GLink,
         GTable,

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -9,11 +9,13 @@
 
             <GTable :items="items" :fields="fields" hide-header class="m-2">
                 <template v-slot:cell(name)="row">
-                    <b-link @click="onQuery(row.item.name)"> {{ row.item.name }} ({{ row.item.owner }}) </b-link>
+                    <GLink @click="onQuery(row.item.name)"> {{ row.item.name }} ({{ row.item.owner }}) </GLink>
                 </template>
+
                 <template v-slot:cell(status)="row">
                     <b>Status: </b><span>{{ row.item.status }}</span>
                 </template>
+
                 <template v-slot:cell(actions)="row">
                     <InstallationActions
                         class="float-right"
@@ -34,6 +36,7 @@ import Vue from "vue";
 import { Services } from "../services";
 
 import InstallationActions from "../RepositoryDetails/InstallationActions.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GCard from "@/components/Common/GCard.vue";
 import GTable from "@/components/Common/GTable.vue";
 
@@ -42,6 +45,7 @@ Vue.use(BootstrapVue);
 export default {
     components: {
         GCard,
+        GLink,
         GTable,
         InstallationActions,
     },

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -9,7 +9,9 @@
 
             <GTable :items="items" :fields="fields" hide-header class="m-2">
                 <template v-slot:cell(name)="row">
-                    <GLink @click="onQuery(row.item.name)"> {{ row.item.name }} ({{ row.item.owner }}) </GLink>
+                    <GLink tooltip title="Show all repositories with this name" @click="onQuery(row.item.name)">
+                        {{ row.item.name }} ({{ row.item.owner }})
+                    </GLink>
                 </template>
 
                 <template v-slot:cell(status)="row">

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -5,12 +5,8 @@
         </b-alert>
         <b-card v-if="showItems" no-body class="my-2">
             <h2 class="m-3 h-text">Currently installing...</h2>
-            <b-table
-                class="mx-3 mb-0"
-                sticky-header
-                thead-class="installation-monitor-header"
-                :items="items"
-                :fields="fields">
+
+            <GTable :items="items" :fields="fields" hide-header class="m-2">
                 <template v-slot:cell(name)="row">
                     <b-link @click="onQuery(row.item.name)"> {{ row.item.name }} ({{ row.item.owner }}) </b-link>
                 </template>
@@ -23,11 +19,13 @@
                         :status="row.item.status"
                         @onUninstall="uninstallRepository(row.item)" />
                 </template>
-            </b-table>
+            </GTable>
         </b-card>
+
         <b-alert v-if="showEmpty" variant="info" show> Currently there are no installing repositories. </b-alert>
     </div>
 </template>
+
 <script>
 import BootstrapVue from "bootstrap-vue";
 import Vue from "vue";
@@ -35,11 +33,13 @@ import Vue from "vue";
 import { Services } from "../services";
 
 import InstallationActions from "../RepositoryDetails/InstallationActions.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 Vue.use(BootstrapVue);
 
 export default {
     components: {
+        GTable,
         InstallationActions,
     },
     data() {
@@ -48,7 +48,20 @@ export default {
             loading: true,
             error: null,
             items: [],
-            fields: ["name", "status", "actions"],
+            fields: [
+                {
+                    key: "name",
+                    label: "Name",
+                },
+                {
+                    key: "status",
+                    label: "Status",
+                },
+                {
+                    key: "actions",
+                    label: "Actions",
+                },
+            ],
         };
     },
     computed: {
@@ -103,8 +116,3 @@ export default {
     },
 };
 </script>
-<style>
-.installation-monitor-header {
-    display: none;
-}
-</style>

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -3,7 +3,8 @@
         <b-alert v-if="error" variant="danger" show>
             {{ error }}
         </b-alert>
-        <b-card v-if="showItems" no-body class="my-2">
+
+        <GCard v-if="showItems" class="my-2">
             <h2 class="m-3 h-text">Currently installing...</h2>
 
             <GTable :items="items" :fields="fields" hide-header class="m-2">
@@ -20,7 +21,7 @@
                         @onUninstall="uninstallRepository(row.item)" />
                 </template>
             </GTable>
-        </b-card>
+        </GCard>
 
         <b-alert v-if="showEmpty" variant="info" show> Currently there are no installing repositories. </b-alert>
     </div>
@@ -33,12 +34,14 @@ import Vue from "vue";
 import { Services } from "../services";
 
 import InstallationActions from "../RepositoryDetails/InstallationActions.vue";
+import GCard from "@/components/Common/GCard.vue";
 import GTable from "@/components/Common/GTable.vue";
 
 Vue.use(BootstrapVue);
 
 export default {
     components: {
+        GCard,
         GTable,
         InstallationActions,
     },

--- a/client/src/components/Toolshed/RepositoryDetails/Index.test.ts
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.test.ts
@@ -34,7 +34,7 @@ describe("RepositoryDetails", () => {
 
         const localVue = getLocalVue();
         const pinia = createPinia();
-        const wrapper = shallowMount(Index, {
+        const wrapper = shallowMount(Index as object, {
             propsData: {
                 repo: {
                     id: "id",
@@ -47,7 +47,7 @@ describe("RepositoryDetails", () => {
             localVue,
             pinia,
         });
-        expect(wrapper.find(".loading-message").text()).toBe("Loading repository details...");
+        expect(wrapper.find("loadingspan-stub").attributes("message")).toBe("Loading repository details");
         await flushPromises();
         expect(wrapper.findAll(".alert").length).toBe(0);
     });

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import { useResourceWatcher } from "@/composables/resourceWatcher";
@@ -11,6 +13,7 @@ import InstallationActions from "./InstallationActions.vue";
 import InstallationSettings from "./InstallationSettings.vue";
 import RepositoryTools from "./RepositoryTools.vue";
 import GTable from "@/components/Common/GTable.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const props = defineProps({
     repo: {
@@ -32,8 +35,6 @@ const repositoryWatcher = useResourceWatcher(loadInstalledRepositories, {
     enableBackgroundPolling: false,
 });
 
-const repoChecked = "fa fa-check text-success";
-const repoUnchecked = "fa fa-times text-danger";
 const repoFields = [
     { key: "numeric_revision", label: "Revision" },
     { key: "tools", label: "Tools and Versions" },
@@ -220,10 +221,7 @@ function stopWatchingRepository() {
             <b-link :href="repo.repository_url" target="_blank">Show additional details and dependencies.</b-link>
         </div>
         <div>
-            <span v-if="loading">
-                <span class="fa fa-spinner fa-spin" />
-                <span class="loading-message">Loading repository details...</span>
-            </span>
+            <LoadingSpan v-if="loading" message="Loading repository details" />
             <div v-else>
                 <b-alert v-if="error" variant="danger" show>
                     {{ error }}
@@ -240,12 +238,12 @@ function stopWatchingRepository() {
                             {{ row.value ? `+${row.value}` : "-" }}
                         </template>
                         <template v-slot:cell(missing_test_components)="row">
-                            <span v-if="!row.value" :class="repoChecked" />
-                            <span v-else :class="repoUnchecked" />
+                            <FontAwesomeIcon v-if="!row.value" :icon="faCheck" class="text-success" />
+                            <FontAwesomeIcon v-else :icon="faTimes" class="text-danger" />
                         </template>
                         <template v-slot:cell(status)="row">
                             <template v-if="row.item.status">
-                                <span v-if="!isFinalState(row.item.status)" class="fa fa-spinner fa-spin" />
+                                <LoadingSpan v-if="!isFinalState(row.item.status)" />
                                 {{ row.item.status }}
                             </template>
                             <template v-else> - </template>

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -243,8 +243,7 @@ function stopWatchingRepository() {
                         </template>
                         <template v-slot:cell(status)="row">
                             <template v-if="row.item.status">
-                                <LoadingSpan v-if="!isFinalState(row.item.status)" />
-                                {{ row.item.status }}
+                                <LoadingSpan v-if="!isFinalState(row.item.status)" :message="row.item.status" />
                             </template>
                             <template v-else> - </template>
                         </template>

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -10,6 +10,7 @@ import { Services } from "../services";
 import InstallationActions from "./InstallationActions.vue";
 import InstallationSettings from "./InstallationSettings.vue";
 import RepositoryTools from "./RepositoryTools.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 const props = defineProps({
     repo: {
@@ -228,26 +229,26 @@ function stopWatchingRepository() {
                     {{ error }}
                 </b-alert>
                 <div v-else class="border rounded">
-                    <b-table borderless :items="repoTable" :fields="repoFields" class="text-center m-0">
-                        <template v-slot:cell(numeric_revision)="data">
-                            <span class="font-weight-bold">{{ data.value }}</span>
+                    <GTable borderless :items="repoTable" :fields="repoFields" class="text-center m-0">
+                        <template v-slot:cell(numeric_revision)="row">
+                            <span class="font-weight-bold">{{ row.value }}</span>
                         </template>
-                        <template v-slot:cell(tools)="data">
-                            <RepositoryTools :tools="data.value" />
+                        <template v-slot:cell(tools)="row">
+                            <RepositoryTools :tools="row.value" />
                         </template>
-                        <template v-slot:cell(profile)="data">
-                            {{ data.value ? `+${data.value}` : "-" }}
+                        <template v-slot:cell(profile)="row">
+                            {{ row.value ? `+${row.value}` : "-" }}
                         </template>
-                        <template v-slot:cell(missing_test_components)="data">
-                            <span v-if="!data.value" :class="repoChecked" />
+                        <template v-slot:cell(missing_test_components)="row">
+                            <span v-if="!row.value" :class="repoChecked" />
                             <span v-else :class="repoUnchecked" />
                         </template>
                         <template v-slot:cell(status)="row">
-                            <span v-if="row.item.status">
+                            <template v-if="row.item.status">
                                 <span v-if="!isFinalState(row.item.status)" class="fa fa-spinner fa-spin" />
                                 {{ row.item.status }}
-                            </span>
-                            <span v-else> - </span>
+                            </template>
+                            <template v-else> - </template>
                         </template>
                         <template v-slot:cell(actions)="row">
                             <InstallationActions
@@ -257,7 +258,8 @@ function stopWatchingRepository() {
                                 @onUninstall="uninstallRepository(row.item)"
                                 @onReset="resetRepository(row.item)" />
                         </template>
-                    </b-table>
+                    </GTable>
+
                     <InstallationSettings
                         v-if="showSettings && selectedChangeset"
                         :repo="repo"

--- a/client/src/components/Toolshed/SearchList/Categories.test.js
+++ b/client/src/components/Toolshed/SearchList/Categories.test.js
@@ -2,6 +2,7 @@ import { createLocalVue, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import Categories from "./Categories.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
 
 vi.mock("../services", () => ({
     Services: class Services {
@@ -35,8 +36,11 @@ describe("Categories", () => {
                 toolshedUrl: "toolshedUrl",
             },
             localVue,
+            stubs: {
+                LoadingSpan: true,
+            },
         });
-        expect(wrapper.find(".loading-message").text()).toBe("Loading categories...");
+        expect(wrapper.find("loadingspan-stub").attributes("message")).toBe("Loading categories");
     });
 
     it("test categories table", async () => {
@@ -46,12 +50,17 @@ describe("Categories", () => {
                 toolshedUrl: "toolshedUrl",
             },
             localVue,
+            stubs: {
+                GLink,
+            },
         });
         await localVue.nextTick();
-        const links = wrapper.findAll("a");
+        const links = wrapper.findAllComponents(GLink);
         expect(links.length).toBe(2);
-        expect(links.at(0).text()).toBe("name_0");
-        expect(links.at(1).text()).toBe("name_1");
+
+        expect(links.at(0).text()).toContain("name_0");
+        expect(links.at(1).text()).toContain("name_1");
+
         const rows = wrapper.findAll("tr");
         expect(rows.length).toBe(3);
         const cells = rows.at(1).findAll("td");

--- a/client/src/components/Toolshed/SearchList/Categories.vue
+++ b/client/src/components/Toolshed/SearchList/Categories.vue
@@ -1,31 +1,35 @@
 <template>
     <div>
         <LoadingSpan v-if="loading" message="Loading categories" />
-        <b-table v-else striped no-sort-reset :items="categories" :fields="fields">
-            <template v-slot:cell(name)="data">
-                <b-link
-                    href="javascript:void(0)"
-                    role="button"
-                    class="font-weight-bold"
-                    @click="onCategory(data.value)">
-                    {{ data.value }}
-                </b-link>
-            </template>
-        </b-table>
+        <div v-else>
+            <GTable :items="categories" :fields="fields">
+                <template v-slot:cell(name)="data">
+                    <GLink
+                        href="#"
+                        tooltip
+                        title="View repositories in this category"
+                        @click.prevent="onCategory(data.item.name)">
+                        {{ data.item.name }}
+                    </GLink>
+                </template>
+            </GTable>
+        </div>
     </div>
 </template>
+
 <script>
-import BootstrapVue from "bootstrap-vue";
-import Vue from "vue";
+import { Services } from "@/components/Toolshed/services";
 
-import { Services } from "../services";
-
+import GLink from "@/components/BaseComponents/GLink.vue";
+import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
-Vue.use(BootstrapVue);
-
 export default {
-    components: { LoadingSpan },
+    components: {
+        GLink,
+        GTable,
+        LoadingSpan,
+    },
     props: {
         toolshedUrl: {
             type: String,
@@ -41,8 +45,8 @@ export default {
             categories: [],
             fields: [
                 { key: "name", label: "Category", sortable: true },
-                { key: "description", sortable: false },
-                { key: "repositories", sortable: true },
+                { key: "description", label: "Description", sortable: false },
+                { key: "repositories", label: "Repositories", sortable: true },
             ],
         };
     },

--- a/client/src/components/Toolshed/SearchList/Repositories.vue
+++ b/client/src/components/Toolshed/SearchList/Repositories.vue
@@ -1,30 +1,27 @@
 <template>
     <div>
-        <b-table id="shed-search-results" striped :items="repositories" :fields="fields">
-            <template v-slot:cell(name)="row">
-                <b-link href="javascript:void(0)" role="button" class="font-weight-bold" @click="row.toggleDetails">
-                    {{ row.item.name }}
-                </b-link>
-                <div>{{ row.item.description }}</div>
-            </template>
-            <template v-slot:row-details="row">
-                <RepositoryDetails :repo="row.item" :toolshed-url="toolshedUrl" />
-            </template>
-        </b-table>
         <div v-if="noResultsFound" class="unavailable-message">No matching repositories found.</div>
+
         <LoadingSpan v-if="pageLoading" message="Loading repositories" />
+        <GTable v-else id="shed-search-results" :items="repositories" :fields="fields">
+            <template v-slot:cell(name)="{ item, toggleDetails }">
+                <GLink href="#" @click.prevent="toggleDetails">{{ item.name }}</GLink>
+                <div>{{ item.description }}</div>
+            </template>
+            <template v-slot:row-details="{ item }">
+                <RepositoryDetails :repo="item" :toolshed-url="toolshedUrl" />
+            </template>
+        </GTable>
     </div>
 </template>
-<script>
-import BootstrapVue from "bootstrap-vue";
-import Vue from "vue";
 
+<script>
 import { Services } from "../services";
 
-import RepositoryDetails from "../RepositoryDetails/Index.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
+import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
-
-Vue.use(BootstrapVue);
+import RepositoryDetails from "@/components/Toolshed/RepositoryDetails/Index.vue";
 
 const READY = 0;
 const LOADING = 1;
@@ -32,6 +29,8 @@ const COMPLETE = 2;
 export default {
     components: {
         LoadingSpan,
+        GLink,
+        GTable,
         RepositoryDetails,
     },
     props: {
@@ -52,10 +51,10 @@ export default {
         return {
             repositories: [],
             fields: [
-                { key: "name" },
-                { key: "owner", label: "Owner" },
-                { key: "times_downloaded", label: "Downloaded" },
-                { key: "last_updated", label: "Updated" },
+                { key: "name", label: "Name", sortable: true },
+                { key: "owner", label: "Owner", sortable: true },
+                { key: "times_downloaded", label: "Downloaded", sortable: true },
+                { key: "last_updated", label: "Updated", sortable: true },
             ],
             page: 1,
             pageSize: 50,


### PR DESCRIPTION
This PR migrates some ToolShed components (`SearchList/Categories.vue`, `SearchList/Repositories.vue`, `InstalledList/Monitor.vue`, `InstalledList/Index.vue`, `RepositoryDetails/Index.vue`) from Bootstrap-Vue's components to our `GComponents` as part of the ongoing effort tracked in #21703, and also adds local filtering and hideHeader prop to `GTable`.

|Before|After|
|----|----|
|<img width="1476" height="1041" alt="image" src="https://github.com/user-attachments/assets/045a65bd-084b-4e4f-bb86-a314779fac81" />|<img width="1476" height="1041" alt="image" src="https://github.com/user-attachments/assets/1a3b2f1c-54b7-4399-b7ac-41511eb2df4a" />|
|<img width="1476" height="1041" alt="image" src="https://github.com/user-attachments/assets/804b0106-4d48-4cac-bc2f-a9c184d5635d" />|<img width="1476" height="1041" alt="image" src="https://github.com/user-attachments/assets/20ffd338-7a04-486b-bf4d-0a73d1fe9660" />|
|<img width="1476" height="1041" alt="image" src="https://github.com/user-attachments/assets/cfa21152-c951-4dd5-8674-5c0d2b8683f2" />|<img width="1476" height="1041" alt="2026-02-05_19-10-05" src="https://github.com/user-attachments/assets/6624f2a6-2330-44a6-afd7-8f8a3ecd4e82" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open `Admin -> Tool Management -> Install and Uninstall `

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
