### PR TITLE
[25.1] Fix help forum integration

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -13900,7 +13900,7 @@ export interface components {
              * Tags
              * @description The tags of the topic.
              */
-            tags: string[];
+            tags: components["schemas"]["HelpForumTag"][];
             /**
              * Tags Descriptions
              * @description The descriptions of the tags of the topic.

--- a/lib/galaxy/schema/help.py
+++ b/lib/galaxy/schema/help.py
@@ -22,6 +22,12 @@ class HelpTempBaseModel(Model):
     model_config = ConfigDict(extra="allow")
 
 
+class HelpForumTag(HelpTempBaseModel):
+    """Model for a tag in the help forum."""
+
+    pass
+
+
 class HelpForumPost(HelpTempBaseModel):
     """Model for a post in the help forum."""
 
@@ -59,7 +65,7 @@ class HelpForumTopic(Model):
     archived: Annotated[bool, Field(description="Whether the topic is archived.")]
     bookmarked: Annotated[Optional[bool], Field(default=None, description="Whether the topic is bookmarked.")]
     liked: Annotated[Optional[bool], Field(default=None, description="Whether the topic is liked.")]
-    tags: Annotated[list[str], Field(description="The tags of the topic.")]
+    tags: Annotated[list[HelpForumTag], Field(description="The tags of the topic.")]
     tags_descriptions: Annotated[
         Optional[Any], Field(default=None, description="The descriptions of the tags of the topic.")
     ]
@@ -75,12 +81,6 @@ class HelpForumUser(HelpTempBaseModel):
 
 class HelpForumCategory(HelpTempBaseModel):
     """Model for a category in the help forum."""
-
-    pass
-
-
-class HelpForumTag(HelpTempBaseModel):
-    """Model for a tag in the help forum."""
 
     pass
 


### PR DESCRIPTION
Fixes #21770

There was a recent API change in Discourse that turned topic tags models from simple strings to objects https://github.com/discourse/discourse_api_docs/pull/191/changes#diff-5016bdc926b6c0f649f363739d09159a1db664aae19a08fa6b38b03406f040dc

<img width="822" height="314" alt="image" src="https://github.com/user-attachments/assets/de32b665-5783-4b16-baa2-f8e4b07917e1" />


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Deploy and open the tool form of any tool that has a help topic associated.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
