### PR TITLE
[26.0] Removes unnecessary overflow restriction in upload method panel

### DIFF
--- a/client/src/components/Panels/Upload/UploadMethodList.vue
+++ b/client/src/components/Panels/Upload/UploadMethodList.vue
@@ -76,7 +76,7 @@ function updateQuery(newQuery: string) {
                 @change="updateQuery" />
         </Teleport>
 
-        <div class="flex-grow-1 overflow-hidden">
+        <div class="flex-grow-1">
             <ScrollList
                 :item-key="(method) => method.id"
                 :in-panel="inPanel"


### PR DESCRIPTION
xref #21750

Fixes:
> The scroll list used here does not overflow well/show the last card(s) fully

| Before | After |
|--------|-------|
| <img width="528" height="535" alt="Screenshot from 2026-02-06 14-04-48" src="https://github.com/user-attachments/assets/2f8539da-c18d-4291-ae66-e4691c1c1b5f" />   | <img width="528" height="535" alt="Screenshot from 2026-02-06 14-04-31" src="https://github.com/user-attachments/assets/d36efe0f-a552-49b2-9dfa-c2b8083f2daa" />  |


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to http://localhost:5173/upload
  - Ensure your screen is tiny so there is not enough vertical space
  - Scroll to the end and see the end of the list
  

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
