### PR TITLE
[26.0] Fix upload local file drop zone when listing

### DIFF
--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -67,6 +67,8 @@ const bulk = useBulkUploadOperations(selectedFiles, effectiveExtensions);
 
 const { isReadyToUpload } = useUploadReadyState(hasFiles, collectionState);
 
+const showDragOverlay = computed(() => hasFiles.value && isFileOverDropZone.value);
+
 const tableFields = [
     {
         key: "name",
@@ -114,7 +116,7 @@ function onDrop(evt: DragEvent) {
     }
 }
 
-const { isFileOverDropZone } = useFileDrop(dropZoneElement, onDrop, () => {}, false);
+const { isFileOverDropZone } = useFileDrop(dropZoneElement, onDrop, () => {}, false, 10000, true);
 
 function addFiles(files: FileList | File[] | null) {
     if (!files) {
@@ -313,6 +315,14 @@ defineExpose<UploadMethodComponent>({ startUpload });
                 </div>
             </div>
 
+            <!-- Drag-over overlay -->
+            <div v-show="showDragOverlay" class="drag-overlay">
+                <div class="drag-overlay-content">
+                    <FontAwesomeIcon :icon="faCloudUploadAlt" class="drag-overlay-icon" />
+                    <p class="drag-overlay-text">Drop files to add them to the list</p>
+                </div>
+            </div>
+
             <!-- Hidden file input -->
             <label for="local-file-input" class="sr-only">Select files to upload</label>
             <input
@@ -348,6 +358,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
     justify-content: center;
     overflow: hidden;
     min-height: 0;
+    position: relative;
 
     &.drop-zone-active {
         border-color: $brand-primary;
@@ -421,5 +432,46 @@ defineExpose<UploadMethodComponent>({ startUpload });
 
 .file-list-actions {
     @include upload-list-actions;
+}
+
+.drag-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 101;
+    pointer-events: none;
+    background-color: rgba($brand-primary, 0.15);
+    border: 2px solid $brand-primary;
+    border-radius: $border-radius-large;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 1;
+    transition: opacity 0.2s ease;
+
+    &.v-leave-active {
+        transition: opacity 0.1s ease;
+    }
+}
+
+.drag-overlay-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    user-select: none;
+}
+
+.drag-overlay-icon {
+    font-size: 3rem;
+    color: $brand-primary;
+    margin-bottom: 0.75rem;
+    display: block;
+}
+
+.drag-overlay-text {
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: $brand-primary;
+    margin: 0;
 }
 </style>

--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -116,7 +116,14 @@ function onDrop(evt: DragEvent) {
     }
 }
 
-const { isFileOverDropZone } = useFileDrop(dropZoneElement, onDrop, () => {}, false, 10000, true);
+const { isFileOverDropZone } = useFileDrop({
+    dropZone: dropZoneElement,
+    onDrop,
+    onDropCancel: () => {},
+    solo: false,
+    idleTime: 10000,
+    ignoreChildrenOnLeave: true,
+});
 
 function addFiles(files: FileList | File[] | null) {
     if (!files) {

--- a/client/src/components/Upload/DragAndDropModal.vue
+++ b/client/src/components/Upload/DragAndDropModal.vue
@@ -12,7 +12,12 @@ import { useGlobalUploadModal } from "@/composables/globalUploadModal";
 import { useToast } from "@/composables/toast";
 
 const modalContentElement = ref(null);
-const { isFileOverDocument, isFileOverDropZone } = useFileDrop(modalContentElement, onDrop, onDropCancel, true);
+const { isFileOverDocument, isFileOverDropZone } = useFileDrop({
+    dropZone: modalContentElement,
+    onDrop,
+    onDropCancel,
+    solo: true,
+});
 
 const modalClass = computed(() => {
     if (isFileOverDropZone.value) {

--- a/client/src/composables/fileDrop.ts
+++ b/client/src/composables/fileDrop.ts
@@ -85,7 +85,10 @@ export function useFileDrop({
             switch (event.type) {
                 case "dragover":
                     event.preventDefault();
-                    idleTimer = setTimeout(() => (currentState.value = "idle"), idleTime);
+                    idleTimer = setTimeout(() => {
+                        currentState.value = "idle";
+                        isFileOverDropZone.value = false;
+                    }, idleTime);
                     break;
                 case "drop":
                     event.preventDefault();

--- a/client/src/composables/fileDrop.ts
+++ b/client/src/composables/fileDrop.ts
@@ -3,23 +3,33 @@ import { computed, type Ref, ref, unref } from "vue";
 
 export type FileDropHandler = (event: DragEvent) => void;
 
+export interface FileDropOptions {
+    /** Element which files should be dropped on. */
+    dropZone: MaybeRefOrGetter<EventTarget | null | undefined>;
+    /** Callback function called when drop occurs. */
+    onDrop: Ref<FileDropHandler> | FileDropHandler;
+    /** Callback function called when drop cancelled. */
+    onDropCancel: Ref<FileDropHandler> | FileDropHandler;
+    /** When true, only reacts if no modal is open. */
+    solo: MaybeRefOrGetter<boolean>;
+    /** How long to wait until state resets (ms). By default, 800ms. */
+    idleTime?: number;
+    /** When true, dragging over child elements keeps isFileOverDropZone true. Default is false. */
+    ignoreChildrenOnLeave?: boolean;
+}
+
 /**
  * Custom File-Drop composable
- * @param dropZone Element which files should be dropped on
- * @param onDrop callback function called when drop occurs
- * @param onDropCancel callback function called when drop cancelled
- * @param solo when true, only reacts if no modal is open
- * @param idleTime how long to wait until state resets
- * @param ignoreChildrenOnLeave when true, dragging over child elements keeps isFileOverDropZone true
+ * @param options configuration for file-drop handling
  */
-export function useFileDrop(
-    dropZone: MaybeRefOrGetter<EventTarget | null | undefined>,
-    onDrop: Ref<FileDropHandler> | FileDropHandler,
-    onDropCancel: Ref<FileDropHandler> | FileDropHandler,
-    solo: MaybeRefOrGetter<boolean>,
+export function useFileDrop({
+    dropZone,
+    onDrop,
+    onDropCancel,
+    solo,
     idleTime = 800,
     ignoreChildrenOnLeave = false,
-) {
+}: FileDropOptions) {
     /** returns true if any other more specific file drop target is on the screen and should
      *  supersede the global file drop or if an existing modal is present and should likewise
      *  take precedent.


### PR DESCRIPTION
xref #21750

Fixes:
> Drag and drop is not triggered sometimes

Includes some improvements and refactorings for the `useFileDrop` composable:
- Refactor the parameters to accept a configuration object to increase readability for callers.
- New parameter `ignoreChildrenOnLeave` that lets the `isFileOverDropZone` be true when we drag over child elements of the drop zone (we are technically still over the drop zone). This is disabled by default to keep the existing behavior.


https://github.com/user-attachments/assets/415a9bc1-236e-488c-8dc0-cc20b4b8d916



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Drag some more files when there are already some files in the upload list

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
