### PR TITLE
Add badges to upload methods with staged items count

### DIFF
--- a/client/src/components/Panels/Upload/UploadMethodList.vue
+++ b/client/src/components/Panels/Upload/UploadMethodList.vue
@@ -80,6 +80,7 @@ function getStagingBadges(method: UploadMethodConfig): CardBadge[] {
             title: `${count} upload item${count === 1 ? "" : "s"} staged and pending submission`,
             variant: "primary",
             type: "badge",
+            handler: () => selectUploadMethod(method),
         },
     ];
 }

--- a/client/src/components/Panels/Upload/UploadMethodList.vue
+++ b/client/src/components/Panels/Upload/UploadMethodList.vue
@@ -2,7 +2,9 @@
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
+import type { CardBadge } from "@/components/Common/GCard.types";
 import { useConfig } from "@/composables/config";
+import { useUploadStagingCounts } from "@/composables/upload/useUploadStaging";
 
 import type { UploadMethodConfig } from "./types";
 import { useAllUploadMethods } from "./uploadMethodRegistry";
@@ -30,6 +32,7 @@ const query = ref("");
 const searchInputClass = computed(() => (props.searchTeleportTarget ? "my-2" : props.inPanel ? "my-2" : "mb-3"));
 
 const allUploadMethods = useAllUploadMethods();
+const stagedCountsByMode = useUploadStagingCounts();
 
 const availableMethods = computed(() => {
     if (!isConfigLoaded.value) {
@@ -64,6 +67,22 @@ function selectUploadMethod(method: UploadMethodConfig) {
 function updateQuery(newQuery: string) {
     query.value = newQuery;
 }
+
+function getStagingBadges(method: UploadMethodConfig): CardBadge[] {
+    const count = stagedCountsByMode.value[method.id] ?? 0;
+    if (count === 0) {
+        return [];
+    }
+    return [
+        {
+            id: `staged-${method.id}`,
+            label: String(count),
+            title: `${count} upload item${count === 1 ? "" : "s"} staged and pending submission`,
+            variant: "primary",
+            type: "badge",
+        },
+    ];
+}
 </script>
 
 <template>
@@ -95,6 +114,7 @@ function updateQuery(newQuery: string) {
                         :full-description="true"
                         :description="method.description"
                         :title-icon="{ icon: method.icon, class: 'text-primary', size: 'lg' }"
+                        :badges="getStagingBadges(method)"
                         :data-method-id="method.id"
                         @click="selectUploadMethod(method)" />
                 </template>

--- a/client/src/composables/upload/useUploadStaging.ts
+++ b/client/src/composables/upload/useUploadStaging.ts
@@ -2,7 +2,9 @@ import { storeToRefs } from "pinia";
 import { computed, onMounted, type Ref, watch } from "vue";
 
 import type { UploadMethod } from "@/components/Panels/Upload/types";
-import { type StagedUploadItem, useUploadStagingStore } from "@/stores/uploadStagingStore";
+import type { PasteContentItem } from "@/components/Panels/Upload/types/uploadItem";
+import type { StagedUploadItem } from "@/stores/uploadStagingStore";
+import { useUploadStagingStore } from "@/stores/uploadStagingStore";
 
 interface UseUploadStagingReturn {
     clear: () => void;
@@ -54,8 +56,24 @@ export function useUploadStagingCounts() {
     return computed<Partial<Record<UploadMethod, number>>>(() => {
         const counts: Partial<Record<UploadMethod, number>> = {};
         for (const [mode, items] of Object.entries(itemsByMode.value)) {
-            counts[mode as UploadMethod] = items?.length ?? 0;
+            const uploadMode = mode as UploadMethod;
+            counts[uploadMode] = countStagedItems(uploadMode, items ?? []);
         }
         return counts;
     });
+}
+
+function countStagedItems(mode: UploadMethod, items: StagedUploadItem[]): number {
+    if (mode == "paste-content") {
+        return items.filter(isNonEmptyPasteContentItem).length;
+    }
+    return items.length;
+}
+
+function isNonEmptyPasteContentItem(item: StagedUploadItem): item is PasteContentItem {
+    return isPasteContentItem(item) && item.content.trim().length > 0;
+}
+
+export function isPasteContentItem(item: StagedUploadItem): item is PasteContentItem {
+    return "content" in item;
 }

--- a/client/src/composables/upload/useUploadStaging.ts
+++ b/client/src/composables/upload/useUploadStaging.ts
@@ -1,4 +1,5 @@
-import { onMounted, type Ref, watch } from "vue";
+import { storeToRefs } from "pinia";
+import { computed, onMounted, type Ref, watch } from "vue";
 
 import type { UploadMethod } from "@/components/Panels/Upload/types";
 import { type StagedUploadItem, useUploadStagingStore } from "@/stores/uploadStagingStore";
@@ -45,4 +46,16 @@ export function useUploadStaging<T extends StagedUploadItem>(
     return {
         clear,
     };
+}
+
+export function useUploadStagingCounts() {
+    const { itemsByMode } = storeToRefs(useUploadStagingStore());
+
+    return computed<Partial<Record<UploadMethod, number>>>(() => {
+        const counts: Partial<Record<UploadMethod, number>> = {};
+        for (const [mode, items] of Object.entries(itemsByMode.value)) {
+            counts[mode as UploadMethod] = items?.length ?? 0;
+        }
+        return counts;
+    });
 }

--- a/client/src/stores/uploadStagingStore.ts
+++ b/client/src/stores/uploadStagingStore.ts
@@ -27,12 +27,19 @@ export const useUploadStagingStore = defineStore("uploadStagingStore", () => {
     }
 
     function setItems<T extends StagedUploadItem>(mode: UploadMethod, items: T[]) {
-        // always store a new array reference so reactivity triggers
+        // Ensure the key exists (Vue 2 key reactivity) with a one-time object replacement.
+        if (!(mode in itemsByMode.value)) {
+            itemsByMode.value = { ...itemsByMode.value, [mode]: [] };
+        }
+        // Always store a new array reference so reactivity triggers.
         itemsByMode.value[mode] = [...items];
     }
 
     function clearItems(mode: UploadMethod) {
-        delete itemsByMode.value[mode];
+        if (!(mode in itemsByMode.value)) {
+            return;
+        }
+        itemsByMode.value[mode] = [];
     }
 
     return {


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/21750

Enhancement idea from @ahmedhamidawan 
> Maybe having a little counter on the card of each currently populated upload type would be useful (especially to remind users that they haven't lost everything they entered on one view).



<img width="1545" height="937" alt="image" src="https://github.com/user-attachments/assets/ea2541c7-7469-4013-b821-46c38a655cc5" />


https://github.com/user-attachments/assets/396c56f4-20e5-4858-98ea-23d9029d7bd4



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - See video

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
