### PR TITLE
Restore visual hierarchy for ReStructuredText headers in tool form's help section

### DIFF
--- a/client/src/components/Tool/ToolHelpRst.vue
+++ b/client/src/components/Tool/ToolHelpRst.vue
@@ -25,20 +25,13 @@ const { formattedContent } = useFormattedToolHelp(props.content);
     }
 
     &:deep(h4) {
-        font-size: $h4-font-size;
-        font-weight: normal;
-        text-decoration: underline;
-    }
-
-    &:deep(h5) {
         font-size: $h5-font-size;
         font-weight: bold;
     }
 
-    &:deep(h6) {
-        font-size: $h5-font-size;
-        font-weight: normal;
-        text-decoration: underline;
+    &:deep(h5), &:deep(h6) {
+        font-size: $h6-font-size;
+        font-weight: bold;
     }
 }
 </style>

--- a/client/src/components/Tool/ToolHelpRst.vue
+++ b/client/src/components/Tool/ToolHelpRst.vue
@@ -25,17 +25,19 @@ const { formattedContent } = useFormattedToolHelp(props.content);
     }
 
     &:deep(h4) {
+        font-size: $h4-font-size;
+        font-weight: normal;
+        text-decoration: underline;
+    }
+
+    &:deep(h5) {
         font-size: $h5-font-size;
         font-weight: bold;
     }
 
-    &:deep(h5) {
-        font-size: $h6-font-size;
-        font-weight: bold;
-    }
-
     &:deep(h6) {
-        font-size: $h6-font-size;
+        font-size: $h5-font-size;
+        font-weight: normal;
         text-decoration: underline;
     }
 }

--- a/client/src/components/Tool/ToolHelpRst.vue
+++ b/client/src/components/Tool/ToolHelpRst.vue
@@ -29,7 +29,8 @@ const { formattedContent } = useFormattedToolHelp(props.content);
         font-weight: bold;
     }
 
-    &:deep(h5), &:deep(h6) {
+    &:deep(h5),
+    &:deep(h6) {
         font-size: $h6-font-size;
         font-weight: bold;
     }


### PR DESCRIPTION
_Addresses:_ #21679 

_Changes:_
- Improves visual differentiation of ReStructuredText headers in tool help.
- RST headers are assigned via docutils outside Galaxy and offset relative to W3C h1–h6, which combined with Galaxy’s small h6 font size collapses header hierarchy. Apply underline styling scoped to RST content as a low-impact workaround.

_before:_
<img width="296" height="162" alt="before" src="https://github.com/user-attachments/assets/d3687285-0825-4e37-9d5f-83db10aae3fa" />

_after:_
<img width="264" height="170" alt="after" src="https://github.com/user-attachments/assets/4dcd81fe-6650-4b12-ba33-984ba819f04b" />

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Place following ReStructured Text inside of a Tool Form's custom tool Help section (ie. <help>):

```
***************
h3
***************

h4
=============

h5
-----------------------------

h6
^^^^^^^^^^^^^^^^

Normal Text
```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
