### PR TITLE
[25.1] Fix workflow rename modal is not reactive to prop changes

### DIFF
--- a/client/src/components/Workflow/List/WorkflowCardList.vue
+++ b/client/src/components/Workflow/List/WorkflowCardList.vue
@@ -123,8 +123,8 @@ const workflowPublished = ref<InstanceType<typeof WorkflowPublished>>();
             @on-workflow-card-click="(...args) => emit('on-workflow-card-click', ...args)" />
 
         <WorkflowRename
+            v-if="showRename"
             :id="modalOptions.rename.id"
-            :show="showRename"
             :name="modalOptions.rename.name"
             @close="onRenameClose" />
 

--- a/client/src/components/Workflow/List/WorkflowRename.vue
+++ b/client/src/components/Workflow/List/WorkflowRename.vue
@@ -22,11 +22,11 @@ const emit = defineEmits<{
 
 const nameModel = ref(props.name);
 
-const nameRemainsSame = computed(() => nameModel.value === props.name);
+const nameRemainsSame = computed(() => nameModel.value.trim() === props.name.trim());
 
 async function onRename(newName: string) {
     try {
-        await updateWorkflow(props.id, { name: newName });
+        await updateWorkflow(props.id, { name: newName.trim() });
         Toast.success("Workflow renamed");
     } catch (e) {
         Toast.error("Failed to rename workflow");

--- a/client/src/components/Workflow/List/WorkflowRename.vue
+++ b/client/src/components/Workflow/List/WorkflowRename.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { BForm, BFormInput, BModal } from "bootstrap-vue";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import { updateWorkflow } from "@/components/Workflow/workflows.services";
 import { Toast } from "@/composables/toast";
@@ -11,7 +11,6 @@ import Heading from "@/components/Common/Heading.vue";
 interface Props {
     id: string;
     name: string;
-    show: boolean;
 }
 
 const props = defineProps<Props>();
@@ -22,7 +21,8 @@ const emit = defineEmits<{
 }>();
 
 const nameModel = ref(props.name);
-const workflowNameInput = ref<HTMLInputElement | null>(null);
+
+const nameRemainsSame = computed(() => nameModel.value === props.name);
 
 async function onRename(newName: string) {
     try {
@@ -34,15 +34,19 @@ async function onRename(newName: string) {
         emit("close");
     }
 }
+
+function onClose() {
+    emit("close");
+}
 </script>
 
 <template>
     <BModal
-        :visible="show"
-        :ok-disabled="!nameModel"
+        visible
         :ok-title="localize('Rename')"
+        :ok-disabled="nameRemainsSame"
         @ok="onRename(nameModel)"
-        @hide="$emit('close')">
+        @hide="onClose">
         <template v-slot:modal-title>
             <Heading h2 inline size="sm"> Rename workflow: {{ localize(name) }}</Heading>
         </template>


### PR DESCRIPTION
The workflow rename modal now resets to whatever workflow it is being opened for.

Fixes https://github.com/galaxyproject/galaxy/issues/21298

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Try renaming a workflow in the workflow list
  2. The rename input field is prepopulated with whatever workflow it is opened for

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
