### PR TITLE
Clean up stale yarn references after pnpm migration

### DIFF
--- a/client/vite-plugin-galaxy-dev-server.js
+++ b/client/vite-plugin-galaxy-dev-server.js
@@ -13,7 +13,7 @@ import { gunzipSync } from "node:zlib";
  * 2. Replace production bundle URLs with Vite dev server entry points
  * 3. Remove production CSS (Vite injects CSS via JS in dev mode)
  *
- * This allows `GALAXY_URL=https://usegalaxy.org yarn develop` to work with
+ * This allows `GALAXY_URL=https://usegalaxy.org pnpm develop` to work with
  * full HMR support without any server-side changes.
  */
 

--- a/doc/source/dev/run_tests_help.txt
+++ b/doc/source/dev/run_tests_help.txt
@@ -21,7 +21,7 @@
 This wrapper script largely serves as a point documentation and convenience for
 running Galaxy's Python tests. All Python tests shipped with Galaxy can be run with
 pytest directly. Galaxy's client unit tests can be run with make client-test
-or yarn directly as documented in detail in client/README.md.
+or pnpm directly as documented in detail in client/README.md.
 
 The main test types are as follows:
 

--- a/lib/tool_shed/webapp/fast_app.py
+++ b/lib/tool_shed/webapp/fast_app.py
@@ -59,7 +59,7 @@ api_tags_metadata = [
 
 # Set this if asset handling should be sent to vite.
 # Run vite with:
-#   yarn dev
+#   pnpm dev
 # Start tool shed with:
 #   TOOL_SHED_VITE_PORT=4040 TOOL_SHED_API_VERSION=v2 ./run_tool_shed.sh
 TOOL_SHED_VITE_PORT: Optional[str] = os.environ.get("TOOL_SHED_VITE_PORT", None)

--- a/packages/web_client/Makefile
+++ b/packages/web_client/Makefile
@@ -54,14 +54,9 @@ setup-venv:
 test:
 	$(IN_VENV) pytest $(TESTS)
 
-dist: clean $(VENV)/bin/yarn galaxy/web_client/client_build_hash.txt
+dist: clean setup-venv galaxy/web_client/client_build_hash.txt
 	$(IN_VENV) python -m build
 	ls -l dist
-
-$(VENV)/bin/yarn: setup-venv
-	$(IN_VENV) pip install build nodeenv
-	$(IN_VENV) nodeenv -n $(shell cat ../../client/.node_version) -p
-	$(IN_VENV) npm install --global yarn
 
 galaxy/web_client/client_build_hash.txt:
 	$(IN_VENV) cd ../..; make client-production


### PR DESCRIPTION
Remove the yarn install target from `packages/web_client/Makefile` — `make client-production` already handles node/pnpm setup via corepack. Also fix leftover yarn mentions in comments and docs.

Closes #21791