### PR TITLE
Fix transient failure in test_delete_dataset_from_storage_view

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -364,7 +364,7 @@ history_storage:
     top_datasets_by_size: "[data-description='chart history top datasets by size']"
     dataset_by_size: "[data-description='chart history top datasets by size'] rect[data-label='${name}']"
     dataset_by_size_delete: '#g-card-action-delete-selected-item-actions-dataset'
-    confirm_delete: '.confirm-delete-dataset-dialog .btn-danger'
+    confirm_delete: '.modal.show .confirm-delete-dataset-dialog .btn-danger'
 
 storage_dashboard:
   selectors:


### PR DESCRIPTION
I've been seeing this exception:

```
=================================== FAILURES ===================================
___________ TestHistoryStorage.test_delete_dataset_from_storage_view ___________

self = <galaxy_test.selenium.test_history_storage.TestHistoryStorage object at 0x7fccb2db8580>

    @selenium_only("Not yet migrated to support Playwright backend")
    @selenium_test
    @managed_history
    def test_delete_dataset_from_storage_view(self):
        """Test deleting a dataset from the history storage overview."""
        # Upload test data with different sizes
        self.perform_upload_of_pasted_content(UPLOAD_DATA_3)
        self.wait_for_history()
    
        # Navigate to history storage overview
        self.home()
        self.components.history_panel.storage_overview.wait_for_and_click()
        self.components.history_storage._.wait_for_visible()
        self.components.history_storage.top_datasets_by_size.wait_for_visible()
    
        # Click on the largest dataset
        self.components.history_storage.dataset_by_size(name="big").wait_for_and_click()
        self.screenshot("history_storage_active_dataset")
    
        # Delete the dataset
        self.components.history_storage.dataset_by_size_delete.wait_for_and_click()
        self.screenshot("history_storage_confirm_delete")
        self.components.history_storage.confirm_delete.wait_for_and_click()
    
        # Verify dataset is removed from storage view
>       self.components.history_storage.dataset_by_size(name="big").wait_for_absent()

self       = <galaxy_test.selenium.test_history_storage.TestHistoryStorage object at 0x7fccb2db8580>

lib/galaxy_test/selenium/test_history_storage.py:85: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/galaxy/selenium/smart_components.py:105: in wait_for_absent
    self._has_driver.wait_for_absent(self._target, **kwds)
        kwds       = {}
        self       = <galaxy.selenium.smart_components.SmartTarget object at 0x7fcc3884dfc0>
lib/galaxy/selenium/has_driver_proxy.py:200: in wait_for_absent
    return self._driver_impl.wait_for_absent(selector_template, **kwds)
        kwds       = {}
        selector_template = <galaxy.navigation.components.SelectorTemplate object at 0x7fcc3c871b40>
        self       = <galaxy_test.selenium.test_history_storage.TestHistoryStorage object at 0x7fccb2db8580>
lib/galaxy/selenium/wait_methods_mixin.py:83: in wait_for_absent
    return self._wait_on_condition_absent(
        kwds       = {}
        selector_template = <galaxy.navigation.components.SelectorTemplate object at 0x7fcc3c871b40>
        self       = <galaxy.selenium.driver_factory._SeleniumDriverImpl object at 0x7fcc30e3aa70>
lib/galaxy/selenium/has_driver.py:309: in _wait_on_condition_absent
    return self._wait_on_selenium_condition(
        kwds       = {}
        locator_tuple = ('css selector',
 "[data-description='chart history top datasets by size'] "
 "rect[data-label='big']")
        message    = ("CSS selector [[data-description='chart history top datasets by size'] "
 "rect[data-label='big']] to become absent")
        self       = <galaxy.selenium.driver_factory._SeleniumDriverImpl object at 0x7fcc30e3aa70>
lib/galaxy/selenium/has_driver.py:332: in _wait_on_selenium_condition
    return wait.until(condition, self._timeout_message(on_str))
        condition  = <function HasDriver._wait_on_condition_absent.<locals>.<lambda> at 0x7fcc3bc8f640>
        kwds       = {}
        on_str     = ("CSS selector [[data-description='chart history top datasets by size'] "
 "rect[data-label='big']] to become absent")
        self       = <galaxy.selenium.driver_factory._SeleniumDriverImpl object at 0x7fcc30e3aa70>
        wait       = <selenium.webdriver.support.wait.WebDriverWait (session="3d39540f529094b92a8415ebbe7e64b1")>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <selenium.webdriver.support.wait.WebDriverWait (session="3d39540f529094b92a8415ebbe7e64b1")>
method = <function HasDriver._wait_on_condition_absent.<locals>.<lambda> at 0x7fcc3bc8f640>
message = "Timeout waiting on CSS selector [[data-description='chart history top datasets by size'] rect[data-label='big']] to become absent."

    def until(self, method: Callable[[D], Literal[False] | T], message: str = "") -> T:
        """Wait until the method returns a value that is not False.
    
        Calls the method provided with the driver as an argument until the
        return value does not evaluate to ``False``.
    
        Args:
            method: A callable object that takes a WebDriver instance as an
                argument.
            message: Optional message for TimeoutException.
    
        Returns:
            The result of the last call to `method`.
    
        Raises:
            TimeoutException: If 'method' does not return a truthy value within
                the WebDriverWait object's timeout.
    
        Example:
            >>> from selenium.webdriver.common.by import By
            >>> from selenium.webdriver.support.ui import WebDriverWait
            >>> from selenium.webdriver.support import expected_conditions as EC
            >>>
            >>> # Wait until an element is visible on the page
            >>> wait = WebDriverWait(driver, 10)
            >>> element = wait.until(EC.visibility_of_element_located((By.ID, "exampleId")))
            >>> print(element.text)
        """
        screen = None
        stacktrace = None
    
        end_time = time.monotonic() + self._timeout
        while True:
            try:
                value = method(self._driver)
                if value:
                    return value
            except self._ignored_exceptions as exc:
                screen = getattr(exc, "screen", None)
                stacktrace = getattr(exc, "stacktrace", None)
            if time.monotonic() > end_time:
                break
            time.sleep(self._poll)
>       raise TimeoutException(message, screen, stacktrace)
E       selenium.common.exceptions.TimeoutException: Message: Timeout waiting on CSS selector [[data-description='chart history top datasets by size'] rect[data-label='big']] to become absent.

end_time   = 1206.48114165
message    = ("Timeout waiting on CSS selector [[data-description='chart history top "
 "datasets by size'] rect[data-label='big']] to become absent.")
method     = <function HasDriver._wait_on_condition_absent.<locals>.<lambda> at 0x7fcc3bc8f640>
screen     = None
self       = <selenium.webdriver.support.wait.WebDriverWait (session="3d39540f529094b92a8415ebbe7e64b1")>
stacktrace = None
value      = False
```


Claude thinks the problem is https://github.com/galaxyproject/galaxy/pull/21746 and has a justification for this fix of:

The confirm dialog uses Bootstrap Vue's msgBoxConfirm with fade animation (~300ms). Selenium's element_to_be_clickable considers the .btn-danger clickable before the fade completes - the button exists in DOM and appears visible/enabled, but clicking mid-animation silently fails or gets intercepted by the transitioning backdrop.

Add .modal.show to the confirm_delete navigation selector so wait_for_and_click blocks until the fade-in transition ends. Bootstrap Vue only applies .show after the CSS transition completes.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
