### PR TITLE
Add tool_source endpoint to tool shed API

### DIFF
--- a/lib/tool_shed/test/functional/test_shed_tools.py
+++ b/lib/tool_shed/test/functional/test_shed_tools.py
@@ -76,3 +76,17 @@ class TestShedToolsApi(ShedApiTestCase):
         url = f"tools/{encoded_tool_id}/versions/1.1.0/parameter_request_schema"
         tool_response = self.api_interactor.get(url)
         tool_response.raise_for_status()
+
+    @skip_if_api_v1
+    def test_tool_source(self):
+        populator = self.populator
+        repository = populator.setup_column_maker_repo(prefix="toolsource")
+        tool_id = populator.tool_guid(self, repository, "Add_a_column1")
+        tool_shed_base, encoded_tool_id = encode_identifier(tool_id)
+        url = f"tools/{encoded_tool_id}/versions/1.1.0/tool_source"
+        tool_response = self.api_interactor.get(url)
+        tool_response.raise_for_status()
+        assert tool_response.headers["language"] == "xml"
+        content = tool_response.text
+        assert "Add_a_column1" in content
+        assert "<tool " in content

--- a/lib/tool_shed/webapp/api2/tools.py
+++ b/lib/tool_shed/webapp/api2/tools.py
@@ -16,6 +16,7 @@ from tool_shed.context import SessionRequestContext
 from tool_shed.managers.tools import (
     parsed_tool_model_cached_for,
     search,
+    tool_source_for,
 )
 from tool_shed.managers.trs import (
     get_tool,
@@ -196,3 +197,20 @@ class FastAPITools:
     ) -> Response:
         parsed_tool = parsed_tool_model_cached_for(trans, tool_id, tool_version)
         return json_schema_response_for_tool_state_model(TestCaseToolState, parsed_tool.inputs)
+
+    @router.get(
+        "/api/tools/{tool_id}/versions/{tool_version}/tool_source",
+        operation_id="tools__tool_source",
+        summary="Return the expanded tool document as a string.",
+    )
+    def tool_source(
+        self,
+        trans: SessionRequestContext = DependsOnTrans,
+        tool_id: str = TOOL_ID_PATH_PARAM,
+        tool_version: str = TOOL_VERSION_PATH_PARAM,
+    ) -> Response:
+        source, _ = tool_source_for(trans, tool_id, tool_version)
+        return Response(
+            content=source.to_string(),
+            headers={"language": source.language},
+        )

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -606,6 +606,23 @@ export interface paths {
         patch?: never
         trace?: never
     }
+    "/api/tools/{tool_id}/versions/{tool_version}/tool_source": {
+        parameters: {
+            query?: never
+            header?: never
+            path?: never
+            cookie?: never
+        }
+        /** Return the expanded tool document as a string. */
+        get: operations["tools__tool_source"]
+        put?: never
+        post?: never
+        delete?: never
+        options?: never
+        head?: never
+        patch?: never
+        trace?: never
+    }
     "/api/users": {
         parameters: {
             query?: never
@@ -5118,6 +5135,49 @@ export interface operations {
         }
     }
     tools__parameter_test_case_xml_schema: {
+        parameters: {
+            query?: never
+            header?: never
+            path: {
+                /** @description See also https://ga4gh.github.io/tool-registry-service-schemas/DataModel/#trs-tool-and-trs-tool-version-ids */
+                tool_id: string
+                /** @description The full version string defined on the Galaxy tool wrapper. */
+                tool_version: string
+            }
+            cookie?: never
+        }
+        requestBody?: never
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown
+                }
+                content: {
+                    "application/json": unknown
+                }
+            }
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown
+                }
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"]
+                }
+            }
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown
+                }
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"]
+                }
+            }
+        }
+    }
+    tools__tool_source: {
         parameters: {
             query?: never
             header?: never


### PR DESCRIPTION
Add `/api/tools/{tool_id}/versions/{tool_version}/tool_source` endpoint that returns the expanded tool document string with the source language in the response header. Reuses the existing tool_source_for() manager function, consistent with other versioned tool endpoints.

Planning to use this in planemo to determine if the tool source for a given tool has changed since the last tool shed release and therefore requires a version bump, but other applications of this are also thinkable.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
