### PR TITLE
[26.0] Fixes navigation back to added URLs in upload panel

### DIFF
--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -114,6 +114,10 @@ function showUrlInput() {
     showInputArea.value = true;
 }
 
+function showUrlList() {
+    showInputArea.value = false;
+}
+
 function scrollToBottom() {
     nextTick(() => {
         if (tableContainerRef.value) {
@@ -199,15 +203,21 @@ defineExpose<UploadMethodComponent>({ startUpload });
     <div class="paste-links-upload">
         <!-- URL Input Area -->
         <div v-if="showInputArea" class="url-input-area">
-            <label for="paste-links-textarea" class="font-weight-bold mb-2">Paste URLs</label>
+            <label for="paste-links-textarea" class="font-weight-bold mb-0">
+                Paste URLs
+                <small class="text-muted ml-2">One URL per line</small>
+                <GButton v-if="hasItems" size="small" inline class="ui-link p-0 ml-2" @click="showUrlList">
+                    {{ urlItems.length }} URL(s) added
+                </GButton>
+            </label>
             <textarea
                 id="paste-links-textarea"
                 v-model="urlText"
                 class="form-control mb-2 url-textarea"
                 rows="8"
                 :placeholder="placeholder"></textarea>
-            <div class="d-flex justify-content-between align-items-center">
-                <span class="text-muted small">One URL per line</span>
+            <div class="d-flex justify-content-end align-items-center">
+                <GButton v-if="hasItems" class="mr-2" @click="showUrlList">View Added URLs</GButton>
                 <GButton color="blue" :disabled="!urlText.trim()" @click="addUrlsFromText">
                     <FontAwesomeIcon :icon="faLink" class="mr-1" />
                     Add URLs


### PR DESCRIPTION
xref

Fixes:
> So, here, if you add a URL, but then you click Add More URLs, then... how do you go back to that list of currently added (but not uploaded yet) URLs?

Adds UI controls to switch between URL input and the list of added URLs, making it possible to review and manage previously added links.

<img width="782" height="761" alt="Screenshot from 2026-02-09 15-29-12" src="https://github.com/user-attachments/assets/b4818b53-1a3f-46d0-bcde-d54310ffc562" />


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Add some links
  - Click "Add More URLs"
  - Now you have a way to go back to the added URLs view 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
