### PR TITLE
Migrate History Markdown Components to GComponents and GTable Enhancements

### DIFF
--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -171,6 +171,12 @@ interface Props {
     statusIcon?: (item: T, index: number) => RowIcon | undefined;
 
     /**
+     * Whether to use sticky header with optional max height (e.g. "300px")
+     * @default false
+     */
+    stickyHeader?: boolean | string;
+
+    /**
      * Additional CSS classes for the table element
      * @default ""
      */
@@ -203,6 +209,7 @@ const props = withDefaults(defineProps<Props>(), {
     sortDesc: false,
     striped: true,
     statusIcon: undefined,
+    stickyHeader: false,
     tableClass: "",
 });
 
@@ -244,6 +251,13 @@ const emit = defineEmits<{
 const sortBy = ref<string>(props.sortBy || "update_time");
 const sortDesc = ref<boolean>(props.sortDesc || true);
 const expandedRows = ref<Set<number>>(new Set());
+
+const stickyHeaderMaxHeight = computed(() => {
+    if (!props.stickyHeader) {
+        return undefined;
+    }
+    return props.stickyHeader === true ? "300px" : props.stickyHeader;
+});
 
 const localItems = computed(() => {
     let items = props.items || [];
@@ -483,7 +497,10 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
     <div :id="`g-table-container-${props.id}`" :class="containerClass">
         <!-- Table wrapper -->
         <BOverlay :show="overlayLoading" rounded="sm" class="position-relative w-100">
-            <div :id="`g-table-wrapper-${props.id}`" class="position-relative w-100">
+            <div
+                :id="`g-table-wrapper-${props.id}`"
+                class="position-relative w-100"
+                :class="{ 'g-table-sticky-header': props.stickyHeader }">
                 <table
                     :id="`g-table-${props.id}`"
                     class="g-table table w-100 mb-0"
@@ -661,6 +678,12 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
 @import "@/style/scss/_breakpoints.scss";
 
 // Essential custom styles that cannot be replaced with utility classes
+
+.g-table-sticky-header {
+    overflow-y: auto;
+    max-height: v-bind(stickyHeaderMaxHeight);
+}
+
 .g-table {
     thead th {
         position: sticky;

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -618,7 +618,7 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                                     <!-- Data columns -->
                                     <td
                                         v-for="(field, fieldIndex) in props.fields"
-                                        :id="getCellId(props.id, field.key, index)"
+                                        :id="getCellId(props.id, field.key, getGlobalIndex(paginatedIndex))"
                                         :key="field.key"
                                         :class="[
                                             field.cellClass,

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetAsTable.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetAsTable.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { BCard, BCardFooter, BCardTitle } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { TableField } from "@/components/Common/GTable.types";
 import { UrlDataProvider } from "@/components/providers/UrlDataProvider.js";
 
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -87,39 +89,39 @@ function getItems(textData: string, metaData: any) {
 </script>
 
 <template>
-    <b-card :no-body="props.compact">
-        <b-card-title v-if="title">
+    <BCard :no-body="props.compact">
+        <BCardTitle v-if="title">
             <b>{{ title }}</b>
-        </b-card-title>
+        </BCardTitle>
+
         <UrlDataProvider v-slot="{ result: itemContent, loading, error }" :url="itemUrl">
             <LoadingSpan v-if="loading" message="Loading Dataset" />
             <div v-else-if="error">{{ error }}</div>
             <div v-else :class="contentClass">
                 <div v-if="itemContent.item_data">
-                    <div>
-                        <UrlDataProvider
-                            v-slot="{ result: metaData, loading: metaLoading, error: metaError }"
-                            :url="metaUrl">
-                            <LoadingSpan v-if="metaLoading" message="Loading Metadata" />
-                            <div v-else-if="metaError">{{ metaError }}</div>
-                            <GTable
-                                v-else
-                                :hide-header="!props.showColumnHeaders"
-                                striped
-                                hover
-                                :fields="getFields(metaData)"
-                                :items="getItems(itemContent.item_data, metaData)" />
-                        </UrlDataProvider>
-                    </div>
+                    <UrlDataProvider
+                        v-slot="{ result: metaData, loading: metaLoading, error: metaError }"
+                        :url="metaUrl">
+                        <LoadingSpan v-if="metaLoading" message="Loading Metadata" />
+                        <div v-else-if="metaError">{{ metaError }}</div>
+                        <GTable
+                            v-else
+                            :hide-header="!props.showColumnHeaders"
+                            striped
+                            hover
+                            :fields="getFields(metaData)"
+                            :items="getItems(itemContent.item_data, metaData)" />
+                    </UrlDataProvider>
                 </div>
                 <div v-else>No content found.</div>
-                <b-link v-if="itemContent.truncated" :href="itemContent.item_url"> Show More... </b-link>
+
+                <GLink v-if="itemContent.truncated" :href="itemContent.item_url"> Show More... </GLink>
             </div>
         </UrlDataProvider>
-        <b-card-footer v-if="footer">
+        <BCardFooter v-if="footer">
             {{ footer }}
-        </b-card-footer>
-    </b-card>
+        </BCardFooter>
+    </BCard>
 </template>
 
 <style scoped>

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetAsTable.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetAsTable.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import { UrlDataProvider } from "@/components/providers/UrlDataProvider.js";
 
+import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface HistoryDatasetAsTableProps {
@@ -44,8 +46,8 @@ const contentClass = computed(() => {
     }
 });
 
-function getFields(metaData: any) {
-    const fields = [];
+function getFields(metaData: any): TableField[] {
+    const fields: TableField[] = [];
     const columnNames = metaData.metadata_column_names || [];
     const columnCount = metaData.metadata_columns;
     for (let i = 0; i < columnCount; i++) {
@@ -58,15 +60,15 @@ function getFields(metaData: any) {
     return fields;
 }
 
-function getItems(textData: any, metaData: any) {
-    const tableData: object[] = [];
+function getItems(textData: string, metaData: any) {
+    const tableData: Record<string, string>[] = [];
     const delimiter: string = metaData.metadata_delimiter || "\t";
     const comments: number = metaData.metadata_comment_lines || 0;
     const lines = textData.split("\n");
     lines.forEach((line: string, i: number) => {
         if (i >= comments) {
             const tabs = line.split(delimiter);
-            const rowData: string[] = [];
+            const rowData: Record<string, string> = {};
             let hasData = false;
             tabs.forEach((cellData: string, j: number) => {
                 const cellDataTrimmed = cellData.trim();
@@ -100,9 +102,9 @@ function getItems(textData: any, metaData: any) {
                             :url="metaUrl">
                             <LoadingSpan v-if="metaLoading" message="Loading Metadata" />
                             <div v-else-if="metaError">{{ metaError }}</div>
-                            <b-table
+                            <GTable
                                 v-else
-                                :thead-class="props.showColumnHeaders ? '' : 'd-none'"
+                                :hide-header="!props.showColumnHeaders"
                                 striped
                                 hover
                                 :fields="getFields(metaData)"

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.test.js
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.test.js
@@ -92,13 +92,13 @@ describe("History Text Dataset Display", () => {
 
     it("should expand dataset", async () => {
         await mountTarget();
-        const expandBTN = wrapper.find('.btn[title="Expand"]');
+        const expandBTN = wrapper.find('button[data-title="Expand"]');
         expect(expandBTN.exists()).toBe(true);
         expect(wrapper.find(".embedded-dataset").exists()).toBe(true);
 
         await expandBTN.trigger("click");
 
-        expect(wrapper.find('.btn[title="Collapse"]').exists()).toBe(true);
+        expect(wrapper.find('button[data-title="Collapse"]').exists()).toBe(true);
         expect(wrapper.find(".embedded-dataset-expanded").exists()).toBe(true);
     });
 });

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
@@ -2,53 +2,50 @@
     <BCard body-class="p-0">
         <BCardHeader v-if="!embedded">
             <span class="float-right">
-                <BButton
-                    v-b-tooltip.hover
+                <GButton
                     :href="downloadUrl"
-                    variant="link"
-                    size="sm"
-                    role="button"
+                    tooltip
+                    transparent
+                    color="blue"
+                    size="small"
                     title="Download Dataset"
-                    type="button"
                     class="py-0 px-1">
-                    <span class="fa fa-download" />
-                </BButton>
+                    <FontAwesomeIcon :icon="faDownload" fixed-width />
+                </GButton>
 
-                <BButton
-                    v-b-tooltip.hover
+                <GButton
                     :href="importUrl"
-                    role="button"
-                    variant="link"
+                    tooltip
+                    transparent
+                    color="blue"
+                    size="small"
                     title="Import Dataset"
-                    type="button"
                     class="py-0 px-1">
-                    <span class="fa fa-file-import" />
-                </BButton>
+                    <FontAwesomeIcon :icon="faFileImport" fixed-width />
+                </GButton>
 
-                <BButton
+                <GButton
                     v-if="expandable && expanded"
-                    v-b-tooltip.hover
-                    href="#"
-                    role="button"
-                    variant="link"
+                    tooltip
+                    transparent
+                    color="blue"
+                    size="small"
                     title="Collapse"
-                    type="button"
                     class="py-0 px-1"
                     @click="onExpand">
-                    <span class="fa fa-angle-double-up" />
-                </BButton>
-                <BButton
+                    <FontAwesomeIcon :icon="faAngleDoubleUp" fixed-width />
+                </GButton>
+                <GButton
                     v-else-if="expandable"
-                    v-b-tooltip.hover
-                    href="#"
-                    role="button"
-                    variant="link"
+                    tooltip
+                    transparent
+                    color="blue"
+                    size="small"
                     title="Expand"
-                    type="button"
                     class="py-0 px-1"
                     @click="onExpand">
-                    <span class="fa fa-angle-double-down" />
-                </BButton>
+                    <FontAwesomeIcon :icon="faAngleDoubleDown" fixed-width />
+                </GButton>
             </span>
 
             <span>
@@ -105,7 +102,9 @@
 </template>
 
 <script setup lang="ts">
-import { BButton, BCard, BCardBody, BCardHeader, BEmbed, BPagination } from "bootstrap-vue";
+import { faAngleDoubleDown, faAngleDoubleUp, faDownload, faFileImport } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BCard, BCardBody, BCardHeader, BEmbed, BPagination } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 
@@ -116,6 +115,7 @@ import { useDatasetTextContentStore } from "@/stores/datasetTextContentStore";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 
 import HistoryDatasetAsImage from "./HistoryDatasetAsImage.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
 import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
@@ -1,8 +1,8 @@
 <template>
-    <b-card body-class="p-0">
-        <b-card-header v-if="!embedded">
+    <BCard body-class="p-0">
+        <BCardHeader v-if="!embedded">
             <span class="float-right">
-                <b-button
+                <BButton
                     v-b-tooltip.hover
                     :href="downloadUrl"
                     variant="link"
@@ -12,8 +12,9 @@
                     type="button"
                     class="py-0 px-1">
                     <span class="fa fa-download" />
-                </b-button>
-                <b-button
+                </BButton>
+
+                <BButton
                     v-b-tooltip.hover
                     :href="importUrl"
                     role="button"
@@ -22,8 +23,9 @@
                     type="button"
                     class="py-0 px-1">
                     <span class="fa fa-file-import" />
-                </b-button>
-                <b-button
+                </BButton>
+
+                <BButton
                     v-if="expandable && expanded"
                     v-b-tooltip.hover
                     href="#"
@@ -34,8 +36,8 @@
                     class="py-0 px-1"
                     @click="onExpand">
                     <span class="fa fa-angle-double-up" />
-                </b-button>
-                <b-button
+                </BButton>
+                <BButton
                     v-else-if="expandable"
                     v-b-tooltip.hover
                     href="#"
@@ -46,14 +48,16 @@
                     class="py-0 px-1"
                     @click="onExpand">
                     <span class="fa fa-angle-double-down" />
-                </b-button>
+                </BButton>
             </span>
+
             <span>
                 <span>Dataset:</span>
                 <span class="font-weight-light">{{ metaContent?.name || "..." }}</span>
             </span>
-        </b-card-header>
-        <b-card-body>
+        </BCardHeader>
+
+        <BCardBody>
             <div v-if="metaError">{{ metaError }}</div>
             <LoadingSpan v-else-if="!metaType" message="Loading Metadata" />
             <LoadingSpan v-else-if="dataLoading" message="Loading Dataset" />
@@ -61,7 +65,7 @@
             <LoadingSpan v-else-if="datatypesLoading" message="Loading Datatypes" />
             <div v-else-if="!datatypesMapper">Datatypes not loaded.</div>
             <div v-else>
-                <b-embed
+                <BEmbed
                     v-if="datatypesMapper.isSubTypeOfAny(metaType, ['pdf', 'html'])"
                     type="iframe"
                     aspect="16by9"
@@ -81,7 +85,7 @@
                             :current-page="currentPage"
                             :fields="getFields(metaContent)"
                             :items="getItems(dataContent.item_data, metaContent)" />
-                        <b-pagination
+                        <BPagination
                             v-model="currentPage"
                             align="center"
                             :total-rows="getItems(dataContent.item_data, metaContent).length"
@@ -93,13 +97,15 @@
                     </pre>
                 </div>
                 <div v-else>No content found.</div>
-                <b-link v-if="dataContent?.truncated" :href="dataContent?.item_url"> Show More... </b-link>
+
+                <GLink v-if="dataContent?.truncated" :href="dataContent?.item_url"> Show More... </GLink>
             </div>
-        </b-card-body>
-    </b-card>
+        </BCardBody>
+    </BCard>
 </template>
 
 <script setup lang="ts">
+import { BButton, BCard, BCardBody, BCardHeader, BEmbed, BPagination } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 
@@ -110,6 +116,7 @@ import { useDatasetTextContentStore } from "@/stores/datasetTextContentStore";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 
 import HistoryDatasetAsImage from "./HistoryDatasetAsImage.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
@@ -114,11 +114,11 @@ import { useDatasetStore } from "@/stores/datasetStore";
 import { useDatasetTextContentStore } from "@/stores/datasetTextContentStore";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 
-import HistoryDatasetAsImage from "./HistoryDatasetAsImage.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
+import HistoryDatasetAsImage from "@/components/Markdown/Sections/Elements/HistoryDatasetAsImage.vue";
 
 interface Dataset {
     name?: string;

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
@@ -71,10 +71,10 @@
                     :dataset-id="datasetId" />
                 <div v-else-if="dataContent?.item_data">
                     <div v-if="datatypesMapper.isSubTypeOfAny(metaType, ['tabular'])">
-                        <b-table
+                        <GTable
                             id="tabular-dataset-table"
+                            class="mb-2"
                             sticky-header
-                            thead-tr-class="sticky-top"
                             striped
                             hover
                             :per-page="perPage"
@@ -103,12 +103,14 @@
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import { getAppRoot } from "@/onload/loadConfig";
 import { useDatasetStore } from "@/stores/datasetStore";
 import { useDatasetTextContentStore } from "@/stores/datasetTextContentStore";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 
 import HistoryDatasetAsImage from "./HistoryDatasetAsImage.vue";
+import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Dataset {
@@ -165,8 +167,8 @@ const metaContent = computed(() => getDataset(props.datasetId) as Dataset);
 const metaError = computed(() => getDatasetError(props.datasetId));
 const metaType = computed(() => metaContent.value?.extension);
 
-const getFields = (metaContent: Dataset) => {
-    const fields = [];
+const getFields = (metaContent: Dataset): TableField[] => {
+    const fields: TableField[] = [];
     const columnNames = metaContent.metadata_column_names || [];
     const columnCount = metaContent.metadata_columns || 0;
     for (let i = 0; i < columnCount; i++) {
@@ -180,7 +182,7 @@ const getFields = (metaContent: Dataset) => {
 };
 
 const getItems = (textData: string, metaData: Dataset) => {
-    const tableData: any[] = [];
+    const tableData: Record<string, string>[] = [];
     const delimiter = metaData.metadata_delimiter || "\t";
     const comments = metaData.metadata_comment_lines || 0;
     const lines = textData.split("\n");

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
@@ -181,7 +181,7 @@ const getFields = (metaContent: Dataset): TableField[] => {
     for (let i = 0; i < columnCount; i++) {
         fields.push({
             key: `${i}`,
-            label: columnNames[i] || i,
+            label: columnNames[i] || String(i),
             sortable: true,
         });
     }


### PR DESCRIPTION
This PR migrates `HistoryDatasetAsTable.vue` and `HistoryDatasetDisplay.vue` from Bootstrap-Vue’s `BTable` to our custom `GTable` component, as part of the ongoing effort tracked in #21703.
It also adds new props to `GTable` (`currentPage`, `perPage`, and `stickyHeader`) used by these components.

|Before|After|
|---|---|
|<img width="1800" height="1039" alt="image" src="https://github.com/user-attachments/assets/f7740c05-cc07-4ee7-8caa-4f1aa23b0453" />|<img width="1800" height="1039" alt="image" src="https://github.com/user-attachments/assets/c012f71d-7fdc-4cb3-8f99-d309b367cdc8" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create/edit a page and add a tabular dataset using `History > Dataset` and  `History > Embedded Dataset as table`.
  2. Save and view the page

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
