### PR TITLE
Add Selenium tests for workflow extraction UI

### DIFF
--- a/client/src/components/History/HistoryOptions.vue
+++ b/client/src/components/History/HistoryOptions.vue
@@ -210,6 +210,7 @@ function onDelete() {
             <BDropdownItem
                 v-if="historyStore.currentHistoryId === history.id"
                 :disabled="isAnonymous"
+                data-description="extract workflow"
                 :title="userTitle('Convert History to Workflow')"
                 @click="iframeRedirect(`/workflow/build_from_current_history?history_id=${history.id}`)">
                 <FontAwesomeIcon fixed-width :icon="faFileExport" />

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -337,6 +337,7 @@ history_panel:
       type: sizzle
       selector: '.history-options-button-menu > a:contains("${option_label}")'
     options_show_export_history_to_file: 'a[data-description="export to file"]'
+    options_extract_workflow: '[data-description="extract workflow"]'
 
     collection_menu_button: '.collection-menu'
     collection_menu_edit_attributes: '.edit-btn'
@@ -1033,6 +1034,26 @@ workflow_show:
     _: '.published-workflow'
     title: '[data-description="workflow name"]'
     import_link: '[data-description="workflow import"]'
+
+workflow_extract:
+  selectors:
+    _: 'body.full-content'
+    workflow_name_input: 'input[name="workflow_name"]'
+    create_button: 'input[type="submit"].btn-primary'
+    job_checkbox: 'input[name="job_ids"][value="${job_id}"]'
+    job_checkbox_any: 'input[name="job_ids"]'
+    dataset_checkbox: 'input[name="dataset_ids"][value="${hid}"]'
+    dataset_collection_checkbox: 'input[name="dataset_collection_ids"][value="${hid}"]'
+    as_input_checkbox: '#as-input-${encoded_id}'
+    as_named_input: '#as-named-input-${encoded_id}'
+    tool_form: '.toolForm'
+    tool_form_disabled: '.toolFormDisabled'
+    tool_form_title: '.toolFormTitle'
+    warning_message: '.warningmark'
+    info_message: '.alert-info'
+    success_message: '.alert-success'
+    history_item: '#dataset-${encoded_id}'
+    history_item_title: '#dataset-${encoded_id} .title'
 
 invocations:
   selectors:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -2151,6 +2151,16 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
     def click_history_option_sharing(self):
         self.use_bootstrap_dropdown(option="share and manage access", menu="history options")
 
+    def click_history_option_extract_workflow(self):
+        self.use_bootstrap_dropdown(option="extract workflow", menu="history options")
+
+    def navigate_to_workflow_extraction(self):
+        """Navigate to workflow extraction UI via history options menu."""
+        self.click_history_option_extract_workflow()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.switch_to_main_panel()
+        self.components.workflow_extract._.wait_for_visible()
+
     def click_history_option(self, option_label_or_component):
         # Open menu
         self.click_history_options()

--- a/lib/galaxy/selenium/playwright_element.py
+++ b/lib/galaxy/selenium/playwright_element.py
@@ -127,6 +127,14 @@ class PlaywrightElement:
         """
         return self._element.is_enabled()
 
+    def is_selected(self) -> bool:
+        """
+        Check if element is selected (for checkboxes, radio buttons, options).
+
+        Maps to Playwright's is_checked() method.
+        """
+        return self._element.is_checked()
+
     def submit(self) -> None:
         """
         Submit a form element.

--- a/lib/galaxy/selenium/web_element_protocol.py
+++ b/lib/galaxy/selenium/web_element_protocol.py
@@ -62,6 +62,10 @@ class WebElementProtocol(Protocol):
         """Check if the element is enabled (not disabled)."""
         ...
 
+    def is_selected(self) -> bool:
+        """Check if element is selected (for checkboxes, radio buttons, options)."""
+        ...
+
     def submit(self) -> None:
         """Submit a form element."""
         ...

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -200,15 +200,17 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         if not user:
             trans.response.status = 403
             return trans.show_error_message("Must be logged in to create workflows")
-        if (job_ids is None and dataset_ids is None) or workflow_name is None:
+        if workflow_name is None:
+            # Initial page load - render the extraction form
             jobs, warnings = summarize(trans, history)
-            # Render
             return trans.fill_template("build_from_current_history.mako", jobs=jobs, warnings=warnings, history=history)
         else:
             # If there is just one dataset name selected or one dataset collection, these
             # come through as string types instead of lists. xref #3247.
             dataset_names = util.listify(dataset_names)
             dataset_collection_names = util.listify(dataset_collection_names)
+            # Decode encoded job IDs from form submission
+            job_ids = [self.decode_id(job_id) for job_id in util.listify(job_ids)]
             stored_workflow = extract_workflow(
                 trans,
                 user=user,

--- a/lib/galaxy_test/base/workflow_assertions.py
+++ b/lib/galaxy_test/base/workflow_assertions.py
@@ -1,0 +1,113 @@
+"""Shared workflow structure verification methods.
+
+Mixin providing workflow structure assertions shared between API and Selenium tests.
+"""
+
+import operator
+from json import loads
+from typing import (
+    Optional,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class WorkflowStructureAssertions:
+    """Mixin providing workflow structure verification methods."""
+
+    def assert_steps_of_type(
+        self, workflow: "dict[str, Any]", step_type: str, expected_len: Optional[int] = None
+    ) -> "list[dict[str, Any]]":
+        """Get steps of given type from workflow, optionally asserting count."""
+        steps = [s for s in workflow["steps"].values() if s["type"] == step_type]
+        if expected_len is not None:
+            n = len(steps)
+            assert n == expected_len, f"Expected {expected_len} steps of type {step_type}, found {n}"
+        return sorted(steps, key=operator.itemgetter("id"))
+
+    def assert_workflow_connected(self, workflow: "dict[str, Any]") -> None:
+        """Assert all tool steps have input connections."""
+        disconnected = []
+        for step in workflow["steps"].values():
+            if step["type"] == "tool" and not step.get("input_connections"):
+                disconnected.append(step)
+        if disconnected:
+            template = "%d steps disconnected in extracted workflow - disconnected steps are %s - workflow is %s"
+            message = template % (len(disconnected), disconnected, workflow)
+            raise AssertionError(message)
+
+    def assert_input_step_collection_type(self, workflow: "dict[str, Any]", expected_type: str) -> None:
+        """Assert first collection input step has expected collection type."""
+        collection_steps = self.assert_steps_of_type(workflow, "data_collection_input", 1)
+        state = loads(collection_steps[0]["tool_state"])
+        assert state["collection_type"] == expected_type
+
+    def assert_cat1_workflow_structure(self, workflow: "dict[str, Any]") -> None:
+        """Assert workflow matches expected cat1 example structure."""
+        assert len(workflow["steps"]) == 3
+        input_steps = self.assert_steps_of_type(workflow, "data_input", 2)
+        tool_step = self.assert_steps_of_type(workflow, "tool", 1)[0]
+
+        input1 = tool_step["input_connections"]["input1"]
+        input2 = tool_step["input_connections"]["queries_0|input2"]
+        assert input_steps[0]["id"] == input1["id"]
+        assert input_steps[1]["id"] == input2["id"]
+
+    def assert_first_step_is_paired_input(self, workflow: "dict[str, Any]") -> int:
+        """Assert first collection input step is paired type and return its id."""
+        collection_steps = self.assert_steps_of_type(workflow, "data_collection_input", 1)
+        collection_step = collection_steps[0]
+        collection_step_state = loads(collection_step["tool_state"])
+        assert collection_step_state["collection_type"] == "paired"
+        return collection_step["id"]
+
+    def assert_randomlines_mapping_workflow_structure(self, workflow: "dict[str, Any]") -> int:
+        """Assert workflow looks like random_lines mapped workflow. Returns collection step id."""
+        assert len(workflow["steps"]) == 3
+        collection_steps = self.assert_steps_of_type(workflow, "data_collection_input", 1)
+        collection_step = collection_steps[0]
+        collection_step_state = loads(collection_step["tool_state"])
+        assert collection_step_state["collection_type"] == "paired"
+        collect_step_idx = collection_step["id"]
+
+        tool_steps = self.assert_steps_of_type(workflow, "tool", 2)
+        tool_step_idxs = []
+        tool_input_step_idxs = []
+        for tool_step in tool_steps:
+            assert "input" in tool_step["input_connections"], tool_step
+            input_step_idx = tool_step["input_connections"]["input"]["id"]
+            tool_step_idxs.append(tool_step["id"])
+            tool_input_step_idxs.append(input_step_idx)
+
+        assert collect_step_idx not in tool_step_idxs
+        assert tool_input_step_idxs[0] == collect_step_idx
+        assert tool_input_step_idxs[1] == tool_step_idxs[0]
+        return collect_step_idx
+
+    def check_workflow(
+        self,
+        workflow: "dict[str, Any]",
+        step_count: Optional[int] = None,
+        verify_connected: bool = False,
+        data_input_count: Optional[int] = None,
+        data_collection_input_count: Optional[int] = None,
+        tool_ids: "Optional[list[str]]" = None,
+    ) -> None:
+        """Check workflow against expected structure."""
+        steps = workflow["steps"]
+
+        if step_count is not None:
+            assert len(steps) == step_count
+        if verify_connected:
+            self.assert_workflow_connected(workflow)
+        if tool_ids is not None:
+            tool_steps = self.assert_steps_of_type(workflow, "tool")
+            found_steps = set(map(operator.itemgetter("tool_id"), tool_steps))
+            expected_steps = set(tool_ids)
+            assert found_steps == expected_steps
+        if data_input_count is not None:
+            self.assert_steps_of_type(workflow, "data_input", expected_len=data_input_count)
+        if data_collection_input_count is not None:
+            self.assert_steps_of_type(workflow, "data_collection_input", expected_len=data_collection_input_count)

--- a/lib/galaxy_test/selenium/test_workflow_extraction.py
+++ b/lib/galaxy_test/selenium/test_workflow_extraction.py
@@ -1,0 +1,466 @@
+"""Selenium tests for workflow extraction UI.
+
+Tests the user-facing workflow extraction UI (Mako-based build_from_current_history page)
+while reusing test setup infrastructure from API tests.
+
+TODO: Add test for disabled/non-workflow tools shown as disabled (toolFormDisabled class).
+"""
+
+from typing import (
+    cast,
+    Optional,
+)
+
+from galaxy_test.base.populators import skip_without_tool
+from galaxy_test.base.workflow_assertions import WorkflowStructureAssertions
+from galaxy_test.base.workflow_fixtures import WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION
+from .framework import (
+    managed_history,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestWorkflowExtractionSelenium(SeleniumTestCase, WorkflowStructureAssertions):
+    """Selenium tests for workflow extraction from history."""
+
+    ensure_registered = True
+
+    # --- Test Setup Helpers ---
+
+    def setup_cat1_history(self, history_id: str) -> str:
+        """Run cat1 workflow and return the cat1 job_id."""
+        workflow = self.workflow_populator.load_workflow(name="test_for_extract")
+        workflow_request, _, workflow_id = self.workflow_populator.setup_workflow_run(workflow, history_id=history_id)
+        self.workflow_populator.invoke_workflow_and_wait(workflow_id, request=workflow_request, history_id=history_id)
+        # Get cat1 job
+        jobs = self.dataset_populator.history_jobs(history_id)
+        cat1_jobs = [j for j in jobs if j["tool_id"] == "cat1"]
+        assert cat1_jobs, "Expected cat1 job to be present"
+        return cat1_jobs[0]["id"]
+
+    def setup_mapped_collection_history(self, history_id: str) -> tuple:
+        """Create paired collection and run random_lines mapped over it.
+
+        Returns: (hdca, job_id1, job_id2)
+        """
+        hdca = self.dataset_collection_populator.create_pair_in_history(
+            history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
+        ).json()["outputs"][0]
+        hdca_id = hdca["id"]
+
+        inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]}, "num_lines": 2}
+        run1 = self.dataset_populator.run_tool("random_lines1", inputs1, history_id)
+        implicit_hdca1 = run1["implicit_collections"][0]
+        job_id1 = run1["jobs"][0]["id"]
+
+        inputs2 = {"input": {"batch": True, "values": [{"src": "hdca", "id": implicit_hdca1["id"]}]}, "num_lines": 1}
+        run2 = self.dataset_populator.run_tool("random_lines1", inputs2, history_id)
+        job_id2 = run2["jobs"][0]["id"]
+
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        return hdca, job_id1, job_id2
+
+    def setup_copied_cat1_history(self, history_id: str) -> Optional[str]:
+        """Run cat1 in one history, copy outputs to given history.
+
+        Returns: cat1 job_id associated with the copied datasets.
+        """
+        old_history_id = self.dataset_populator.new_history()
+        self.setup_cat1_history(old_history_id)
+
+        old_contents = self.dataset_populator._get(f"histories/{old_history_id}/contents").json()
+
+        for content in old_contents:
+            payload = {"source": "hda", "content": content["id"]}
+            self.dataset_populator._post(f"histories/{history_id}/contents/datasets", data=payload, json=True)
+
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+
+        # Get jobs associated with this history (from copied datasets)
+        jobs = self.dataset_populator.history_jobs(history_id)
+        cat1_jobs = [j for j in jobs if j["tool_id"] == "cat1"]
+        if not cat1_jobs:
+            return None
+        else:
+            return cast(str, cat1_jobs[0]["id"])
+
+    def setup_reduction_history(self, history_id: str) -> tuple:
+        """Create history with collection -> map -> reduce pattern.
+
+        Returns: (hdca, map_job_id, reduce_job_id)
+        """
+        hdca = self.dataset_collection_populator.create_pair_in_history(
+            history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
+        ).json()["outputs"][0]
+
+        # Map random_lines over collection
+        inputs1 = {
+            "input": {"batch": True, "values": [{"src": "hdca", "id": hdca["id"]}]},
+            "num_lines": 2,
+        }
+        run1 = self.dataset_populator.run_tool("random_lines1", inputs1, history_id)
+        implicit_hdca = run1["implicit_collections"][0]
+        map_job_id = run1["jobs"][0]["id"]
+
+        # Reduce with multi_data_param
+        inputs2 = {
+            "f1": {"src": "hdca", "id": implicit_hdca["id"]},
+            "f2": {"src": "hdca", "id": implicit_hdca["id"]},
+        }
+        run2 = self.dataset_populator.run_tool("multi_data_param", inputs2, history_id)
+        reduce_job_id = run2["jobs"][0]["id"]
+
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        return hdca, map_job_id, reduce_job_id
+
+    def setup_output_collection_history(self, history_id: str) -> list:
+        """Create history where tool produces collection output.
+
+        Returns: list of job_ids [cat1_id, split_id, cat_list_id]
+        """
+        self.workflow_populator.run_workflow(WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION, history_id=history_id)
+        jobs = self.dataset_populator.history_jobs(history_id)
+        return [j["id"] for j in jobs if j["tool_id"] in ["cat1", "collection_split_on_column", "cat_list"]]
+
+    def setup_nested_collection_history(self, history_id: str) -> tuple:
+        """Create history with list:paired collection workflow.
+
+        Returns: (hdca_hid, job_ids_list)
+        """
+        self.workflow_populator.run_workflow(
+            """
+class: GalaxyWorkflow
+steps:
+  - label: text_input1
+    type: input_collection
+  - label: noop
+    tool_id: cat1
+    state:
+      input1:
+        $link: text_input1
+test_data:
+  text_input1:
+    collection_type: "list:paired"
+""",
+            history_id=history_id,
+        )
+        jobs = self.dataset_populator.history_jobs(history_id)
+        job_ids = [j["id"] for j in jobs if j["tool_id"] == "cat1"]
+        # Find the list:paired input collection HID
+        contents = self.dataset_populator._get(f"histories/{history_id}/contents?type=dataset_collection").json()
+        hdca_hid = contents[0]["hid"]
+        return hdca_hid, job_ids
+
+    # --- UI Extraction Helpers ---
+
+    def extract_workflow_set_name(self, name: str):
+        """Set the workflow name in extraction form."""
+        name_input = self.components.workflow_extract.workflow_name_input.wait_for_visible()
+        name_input.clear()
+        name_input.send_keys(name)
+
+    def extract_workflow_submit(self):
+        """Submit the extraction form."""
+        self.components.workflow_extract.create_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+    def extract_workflow_toggle_job(self, job_id: str):
+        """Toggle a specific job checkbox by job_id."""
+        checkbox = self.components.workflow_extract.job_checkbox(job_id=job_id)
+        checkbox.wait_for_and_click()
+
+    def find_workflow_by_name(self, name: str) -> str:
+        """Find workflow ID by name via API. Returns most recently created if multiple match."""
+        response = self.workflow_populator._get("workflows")
+        response.raise_for_status()
+        workflows = response.json()
+        matching = [w for w in workflows if w["name"] == name]
+        assert len(matching) >= 1, f"Expected at least 1 workflow '{name}', found 0: {[w['name'] for w in workflows]}"
+        # Return most recently created workflow if multiple match
+        matching.sort(key=lambda w: w["create_time"], reverse=True)
+        return matching[0]["id"]
+
+    def get_workflow_by_name(self, name: str) -> dict:
+        """Find and download workflow by name."""
+        workflow_id = self.find_workflow_by_name(name)
+        return self.workflow_populator.download_workflow(workflow_id)
+
+    def extract_workflow_and_download(self, name: str, screenshot_name: Optional[str] = None) -> dict:
+        """Navigate to extraction, submit form, return downloaded workflow."""
+        self.navigate_to_workflow_extraction()
+        if screenshot_name:
+            self.screenshot(screenshot_name)
+        self.extract_workflow_set_name(name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+        return self.get_workflow_by_name(name)
+
+    def count_job_checkboxes(self) -> int:
+        """Count the number of job checkboxes visible."""
+        checkboxes = self.find_elements_by_selector('input[name="job_ids"]')
+        return len(checkboxes)
+
+    def count_checked_job_checkboxes(self) -> int:
+        """Count number of checked job checkboxes."""
+        return len(self.find_elements_by_selector('input[name="job_ids"]:checked'))
+
+    # --- Tier 1: Basic Functionality Tests ---
+
+    @selenium_test
+    @managed_history
+    def test_extract_form_loads(self):
+        """Verify extraction form displays for empty history."""
+        self.navigate_to_workflow_extraction()
+
+        # Form should be visible
+        self.components.workflow_extract.workflow_name_input.wait_for_visible()
+        self.components.workflow_extract.create_button.wait_for_visible()
+
+        # No jobs should be listed for empty history
+        job_count = self.count_job_checkboxes()
+        assert job_count == 0, f"Expected 0 job checkboxes for empty history, found {job_count}"
+
+        self.screenshot("workflow_extract_empty_history")
+
+        # Switch back to default content
+        self.switch_to_default_content()
+
+    @skip_without_tool("random_lines1")
+    @selenium_test
+    @managed_history
+    def test_extract_form_validation(self):
+        """Test form validation: empty name, no jobs selected."""
+        history_id = self.current_history_id()
+        hdca, job_id1, job_id2 = self.setup_mapped_collection_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+
+        # Verify initial state
+        assert self.count_job_checkboxes() >= 2, "Expected at least 2 job checkboxes"
+        initial_checked = self.count_checked_job_checkboxes()
+        assert initial_checked >= 2, f"Expected at least 2 checked, got {initial_checked}"
+
+        # Test: uncheck all jobs
+        self.extract_workflow_toggle_job(job_id1)
+        self.extract_workflow_toggle_job(job_id2)
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        unchecked_count = self.count_checked_job_checkboxes()
+        assert unchecked_count == initial_checked - 2, f"Expected 2 fewer checked, got {unchecked_count}"
+
+        self.screenshot("workflow_extract_no_jobs_selected")
+
+        # Submit with no jobs - should still work (creates empty workflow)
+        workflow_name = "Selenium Empty Selection"
+        self.extract_workflow_set_name(workflow_name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+
+        # Verify workflow was created (may be empty or have just inputs)
+        workflow = self.get_workflow_by_name(workflow_name)
+        assert workflow is not None, "Expected workflow to be created even with no jobs selected"
+
+    @skip_without_tool("cat1")
+    @selenium_test
+    @managed_history
+    def test_extract_cat1_workflow(self):
+        """Test extraction UI with cat1: job listing, checkbox toggle, and extraction."""
+        history_id = self.current_history_id()
+        cat1_job_id = self.setup_cat1_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+
+        # Verify jobs are listed
+        job_count = self.count_job_checkboxes()
+        assert job_count >= 1, f"Expected at least 1 job checkbox, found {job_count}"
+        self.screenshot("workflow_extract_with_jobs")
+
+        # Verify checkboxes start checked
+        initial_checked = self.find_elements_by_selector('input[name="job_ids"]:checked')
+        assert len(initial_checked) >= 1, "Expected at least 1 checked job checkbox"
+
+        # Toggle checkbox off
+        self.extract_workflow_toggle_job(cat1_job_id)
+        self.sleep_for(self.wait_types.UX_RENDER)
+        cat1_checkbox = self.find_element_by_selector(f'input[name="job_ids"][value="{cat1_job_id}"]')
+        assert not cat1_checkbox.is_selected(), "Expected checkbox unchecked after toggle"
+
+        # Toggle back on
+        self.extract_workflow_toggle_job(cat1_job_id)
+        self.sleep_for(self.wait_types.UX_RENDER)
+        cat1_checkbox = self.find_element_by_selector(f'input[name="job_ids"][value="{cat1_job_id}"]')
+        assert cat1_checkbox.is_selected(), "Expected checkbox checked after second toggle"
+        self.screenshot("workflow_extract_toggle_checkbox")
+
+        # Extract workflow and verify structure
+        workflow_name = "Selenium Extracted Cat1"
+        self.extract_workflow_set_name(workflow_name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        self.assert_cat1_workflow_structure(workflow)
+
+    @skip_without_tool("random_lines1")
+    @selenium_test
+    @managed_history
+    def test_extract_toggle_job_subset(self):
+        """Toggle some jobs off, verify only selected jobs create workflow steps."""
+        history_id = self.current_history_id()
+        hdca, job_id1, job_id2 = self.setup_mapped_collection_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+
+        # Verify both jobs checked initially
+        assert self.count_checked_job_checkboxes() >= 2, "Expected at least 2 checked jobs"
+        self.screenshot("workflow_extract_job_subset_initial")
+
+        # Toggle off first job
+        self.extract_workflow_toggle_job(job_id1)
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # Verify first job unchecked, second still checked
+        job1_checkbox = self.find_element_by_selector(f'input[name="job_ids"][value="{job_id1}"]')
+        job2_checkbox = self.find_element_by_selector(f'input[name="job_ids"][value="{job_id2}"]')
+        assert not job1_checkbox.is_selected(), "Expected job1 unchecked"
+        assert job2_checkbox.is_selected(), "Expected job2 still checked"
+
+        self.screenshot("workflow_extract_job_subset_toggled")
+
+        # Submit extraction
+        workflow_name = "Selenium Job Subset"
+        self.extract_workflow_set_name(workflow_name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+
+        # Verify extracted workflow has 2 steps (1 input + 1 tool), not 3
+        workflow = self.get_workflow_by_name(workflow_name)
+        assert len(workflow["steps"]) == 2, f"Expected 2 steps (1 input + 1 tool), got {len(workflow['steps'])}"
+
+    @skip_without_tool("cat1")
+    @selenium_test
+    @managed_history
+    def test_extract_with_copied_inputs(self):
+        """Verify extraction form displays correctly for copied datasets."""
+        history_id = self.current_history_id()
+        self.setup_copied_cat1_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+
+        # Verify at least 1 job checkbox visible
+        job_count = self.count_job_checkboxes()
+        assert job_count >= 1, f"Expected at least 1 job checkbox, found {job_count}"
+        self.screenshot("workflow_extract_copied_inputs")
+
+        # Verify job checkbox exists and is checked
+        initial_checked = self.count_checked_job_checkboxes()
+        assert initial_checked >= 1, "Expected at least 1 checked job checkbox"
+
+        # Extract and verify structure
+        workflow_name = "Selenium Copied Inputs"
+        self.extract_workflow_set_name(workflow_name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        self.assert_cat1_workflow_structure(workflow)
+
+    # --- Tier 3: Collection Tests ---
+
+    @skip_without_tool("random_lines1")
+    @selenium_test
+    @managed_history
+    def test_extract_with_collection_input(self):
+        """Extract workflow with collection mapped over."""
+        history_id = self.current_history_id()
+        hdca, job_id1, job_id2 = self.setup_mapped_collection_history(history_id)
+
+        workflow = self.extract_workflow_and_download(
+            "Selenium Collection Workflow", "workflow_extract_with_collection"
+        )
+
+        # Should have 3 steps (input + 2 tool steps)
+        assert len(workflow["steps"]) == 3
+        self.assert_input_step_collection_type(workflow, "paired")
+
+    @skip_without_tool("random_lines1")
+    @skip_without_tool("multi_data_param")
+    @selenium_test
+    @managed_history
+    def test_extract_reduce_collection_ui(self):
+        """Extract workflow with map -> reduce pattern."""
+        history_id = self.current_history_id()
+        hdca, map_job_id, reduce_job_id = self.setup_reduction_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+
+        # Verify 2 tool jobs visible
+        job_count = self.count_job_checkboxes()
+        assert job_count >= 2, f"Expected at least 2 job checkboxes, found {job_count}"
+        self.screenshot("workflow_extract_reduce_collection")
+
+        workflow_name = "Selenium Reduce Collection"
+        self.extract_workflow_set_name(workflow_name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        # Should have 3 steps (1 collection input + 2 tools)
+        assert len(workflow["steps"]) == 3, f"Expected 3 steps, got {len(workflow['steps'])}"
+
+        tool_ids = {step.get("tool_id") for step in workflow["steps"].values() if step.get("tool_id")}
+        assert tool_ids == {"random_lines1", "multi_data_param"}, f"Unexpected tool_ids: {tool_ids}"
+
+    @skip_without_tool("cat1")
+    @skip_without_tool("collection_split_on_column")
+    @skip_without_tool("cat_list")
+    @selenium_test
+    @managed_history
+    def test_extract_output_collections_ui(self):
+        """Extract workflow where tools produce collection outputs."""
+        history_id = self.current_history_id()
+        self.setup_output_collection_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+
+        # Verify 3+ tool jobs visible
+        job_count = self.count_job_checkboxes()
+        assert job_count >= 3, f"Expected at least 3 job checkboxes, found {job_count}"
+        self.screenshot("workflow_extract_output_collections")
+
+        workflow_name = "Selenium Output Collections"
+        self.extract_workflow_set_name(workflow_name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        # Should have 5 steps (2 data inputs + 3 tools)
+        assert len(workflow["steps"]) == 5, f"Expected 5 steps, got {len(workflow['steps'])}"
+
+    @skip_without_tool("cat1")
+    @selenium_test
+    @managed_history
+    def test_extract_nested_collection_ui(self):
+        """Extract workflow with nested collections (list:paired)."""
+        history_id = self.current_history_id()
+        hdca_hid, job_ids = self.setup_nested_collection_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+
+        # Verify 1+ tool jobs visible
+        job_count = self.count_job_checkboxes()
+        assert job_count >= 1, f"Expected at least 1 job checkbox, found {job_count}"
+        self.screenshot("workflow_extract_nested_collection")
+
+        workflow_name = "Selenium Nested Collection"
+        self.extract_workflow_set_name(workflow_name)
+        self.extract_workflow_submit()
+        self.switch_to_default_content()
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        # Should have 2 steps (1 collection input + 1 tool)
+        assert len(workflow["steps"]) == 2, f"Expected 2 steps, got {len(workflow['steps'])}"
+
+        # Verify collection input is list:paired
+        self.assert_input_step_collection_type(workflow, "list:paired")

--- a/lib/galaxy_test/selenium/test_workflow_extraction.py
+++ b/lib/galaxy_test/selenium/test_workflow_extraction.py
@@ -42,8 +42,8 @@ class TestWorkflowExtractionSelenium(SeleniumTestCase, WorkflowStructureAssertio
     def setup_mapped_collection_history(self, history_id: str) -> tuple:
         """Create paired collection and run random_lines mapped over it twice.
 
-        Returns: (hdca, all_job_ids) where all_job_ids is list of 4 job IDs
-        (2 jobs per batch run over paired collection with 2 elements).
+        Returns: (hdca, all_job_ids) where all_job_ids is list of 2 job IDs
+        (1 job per batch run - batch creates single job processing entire collection).
         """
         hdca = self.dataset_collection_populator.create_pair_in_history(
             history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
@@ -235,9 +235,9 @@ test_data:
 
         self.navigate_to_workflow_extraction()
 
-        # Verify initial state: 4 jobs (2 per batch run over paired collection)
-        assert self.count_job_checkboxes() == 4, "Expected exactly 4 job checkboxes"
-        assert self.count_checked_job_checkboxes() == 4, "Expected all 4 jobs checked initially"
+        # Verify initial state: 2 jobs (1 per batch run over collection)
+        assert self.count_job_checkboxes() == 2, "Expected exactly 2 job checkboxes"
+        assert self.count_checked_job_checkboxes() == 2, "Expected both jobs checked initially"
 
         # Uncheck ALL jobs
         for job_id in all_job_ids:
@@ -312,24 +312,21 @@ test_data:
 
         self.navigate_to_workflow_extraction()
 
-        # Verify all 4 jobs checked initially
-        assert self.count_checked_job_checkboxes() == 4, "Expected 4 checked jobs"
+        # Verify both jobs checked initially
+        assert self.count_checked_job_checkboxes() == 2, "Expected 2 checked jobs"
         self.screenshot("workflow_extract_job_subset_initial")
 
-        # Toggle off jobs from first tool run (first 2 job IDs)
-        jobs_from_run1 = all_job_ids[:2]
-        for job_id in jobs_from_run1:
-            self.extract_workflow_toggle_job(job_id)
+        # Toggle off first job (from first tool run)
+        job_id_run1 = all_job_ids[0]
+        self.extract_workflow_toggle_job(job_id_run1)
         self.sleep_for(self.wait_types.UX_RENDER)
 
-        # Verify first run's jobs unchecked, second run's jobs still checked
-        for job_id in jobs_from_run1:
-            checkbox = self.find_element_by_selector(f'input[name="job_ids"][value="{job_id}"]')
-            assert not checkbox.is_selected(), f"Expected job {job_id} unchecked"
-        jobs_from_run2 = all_job_ids[2:]
-        for job_id in jobs_from_run2:
-            checkbox = self.find_element_by_selector(f'input[name="job_ids"][value="{job_id}"]')
-            assert checkbox.is_selected(), f"Expected job {job_id} still checked"
+        # Verify first run's job unchecked, second run's job still checked
+        job_id_run2 = all_job_ids[1]
+        checkbox1 = self.find_element_by_selector(f'input[name="job_ids"][value="{job_id_run1}"]')
+        checkbox2 = self.find_element_by_selector(f'input[name="job_ids"][value="{job_id_run2}"]')
+        assert not checkbox1.is_selected(), f"Expected job {job_id_run1} unchecked"
+        assert checkbox2.is_selected(), f"Expected job {job_id_run2} still checked"
 
         self.screenshot("workflow_extract_job_subset_toggled")
 
@@ -401,9 +398,9 @@ test_data:
 
         self.navigate_to_workflow_extraction()
 
-        # Verify 3 jobs: 2 from random_lines1 mapped over paired + 1 from multi_data_param reduce
+        # Verify 2 jobs: 1 from random_lines1 mapped over paired + 1 from multi_data_param reduce
         job_count = self.count_job_checkboxes()
-        assert job_count == 3, f"Expected exactly 3 job checkboxes, found {job_count}"
+        assert job_count == 2, f"Expected exactly 2 job checkboxes, found {job_count}"
         self.screenshot("workflow_extract_reduce_collection")
 
         workflow_name = "Selenium Reduce Collection"

--- a/templates/build_from_current_history.mako
+++ b/templates/build_from_current_history.mako
@@ -75,20 +75,6 @@
             }
         </style>
 
-        <script type="text/javascript">
-            $(function() {
-                $("#checkall").click( function() {
-                    $("input[type=checkbox]").attr( 'checked', true );
-                    $(".as-named-input").prop( 'disabled', false );
-                    return false;
-                }).show();
-                $("#uncheckall").click( function() {
-                    $("input[type=checkbox]").attr( 'checked', false );
-                    $(".as-named-input").prop( 'disabled', true );
-                    return false;
-                }).show();
-            });
-        </script>
     </head>
 
 <body scroll="no" class="full-content">
@@ -111,8 +97,6 @@ into a workflow will be shown in gray.</p>
 </div>
 <p>
     <input type="submit" class="btn btn-primary" value="Create Workflow" />
-    <button id="checkall" style="display: none;">Check all</button>
-    <button id="uncheckall" style="display: none;">Uncheck all</button>
 </p>
 
 <table border="0" cellspacing="0">
@@ -156,10 +140,13 @@ into a workflow will be shown in gray.</p>
 
                 <div class="toolFormTitle">${tool_name}</div>
                 <div class="toolFormBody">
+                    <%
+                        encoded_job_id = trans.app.security.encode_id(job.id)
+                    %>
                     %if disabled:
                         <div style="font-style: italic; color: gray">${disabled_why}</div>
                     %else:
-                        <div><input type="checkbox" name="job_ids" value="${job.id}" ${checked_job} />Include "${tool_name}" in workflow</div>
+                        <div><input type="checkbox" name="job_ids" value="${encoded_job_id}" ${checked_job} />Include "${tool_name}" in workflow</div>
                         %if not checked_job:
                             ${ render_msg( "All job outputs have been deleted", status="info" ) }
                         %endif


### PR DESCRIPTION
## Summary
- Add 9 Selenium tests for the Mako-based workflow extraction page (`build_from_current_history`)
- Create shared `WorkflowStructureAssertions` mixin to deduplicate verification logic between API and Selenium tests
- Fix bugs in extraction flow discovered by tests: encoded job IDs in form, empty job selection handling

## Bug fixes
- **Encode job IDs in Mako template**: Checkbox values now use `encode_id(job.id)` so they match API-returned IDs; controller decodes before passing to `extract_workflow()`
- **Allow empty job selection**: Controller previously re-rendered the form when no jobs were selected; now uses `workflow_name is None` as the form-submission indicator
- **Remove dead JS**: Removed unused jQuery check/uncheck-all script and buttons from Mako template

## Test coverage
| Test | What it covers |
|------|---------------|
| `test_extract_form_loads` | Form renders for empty history, 0 job checkboxes |
| `test_extract_form_validation` | Uncheck all jobs, submit creates workflow with only inputs |
| `test_extract_cat1_workflow` | Checkbox toggle on/off, extract and verify structure |
| `test_extract_toggle_job_subset` | Deselect one job, verify extracted workflow has fewer steps |
| `test_extract_with_copied_inputs` | Extraction works for datasets copied from another history |
| `test_extract_with_collection_input` | Paired collection mapped over two tool steps |
| `test_extract_reduce_collection_ui` | Map + reduce pattern (random_lines1 + multi_data_param) |
| `test_extract_output_collections_ui` | Tools producing collection outputs |
| `test_extract_nested_collection_ui` | Nested list:paired collection input |

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
