### PR TITLE
Stop uv from using the system Python to create the venv

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -118,7 +118,8 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
                 conda_activate
             fi
             if command -v uv >/dev/null; then
-                uv venv "$GALAXY_VIRTUAL_ENV"
+                # Ensure uv uses the active conda python to avoid picking a different interpreter on PATH.
+                uv venv --python "${CONDA_PREFIX}/bin/python" "$GALAXY_VIRTUAL_ENV"
             else
                 python3 -m venv "$GALAXY_VIRTUAL_ENV"
             fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -118,7 +118,7 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
                 conda_activate
             fi
             if command -v uv >/dev/null; then
-                # Ensure uv uses the active conda python to avoid picking a different interpreter on PATH.
+                # Ensure uv uses the active conda python to avoid picking a different uv-managed interpreter.
                 uv venv --python "${CONDA_PREFIX}/bin/python" "$GALAXY_VIRTUAL_ENV"
             else
                 python3 -m venv "$GALAXY_VIRTUAL_ENV"


### PR DESCRIPTION
This change addresses https://github.com/astral-sh/uv/issues/7829 in galaxy, where under certain conditions (despite using a conda environment) .venv is created using system python leading to Segmentation fault if system python and conda python are of different versions. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. install system python@3.13
  2. install system uv
  3. use system uv for a while
  4. remove .venv , database/*
  5. ./run.sh 

Expected behaviour: Galaxy starts normally 
Before this patch: Galaxy's process get's a SIGSEGV

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
