### PR TITLE
[25.1] Make database heartbeat more robust (backport)

### DIFF
--- a/lib/galaxy/model/base.py
+++ b/lib/galaxy/model/base.py
@@ -61,7 +61,7 @@ def check_database_connection(session):
     if isinstance(session, scoped_session):
         session = session()
     trans = session.get_transaction()
-    if (trans and not trans.is_active) or session.connection().invalidated:
+    if trans and (not trans.is_active or session.connection().invalidated):
         session.rollback()
         log.error("Database transaction rolled back due to inactive session transaction or invalid connection state.")
 

--- a/lib/galaxy/model/database_heartbeat.py
+++ b/lib/galaxy/model/database_heartbeat.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
 )
 
 from galaxy.model import WorkerProcess
+from galaxy.model.base import check_database_connection
 from galaxy.model.orm.now import now
 
 log = logging.getLogger(__name__)
@@ -106,7 +107,11 @@ class DatabaseHeartbeat:
     def send_database_heartbeat(self):
         if self.active:
             while not self.exit.is_set():
-                self.update_watcher_designation()
+                check_database_connection(self.sa_session)
+                try:
+                    self.update_watcher_designation()
+                except Exception:
+                    log.exception("Error sending database heartbeat for server '%s'", self.server_name)
                 self.exit.wait(self.heartbeat_interval)
 
     def _delete_worker_process(self):


### PR DESCRIPTION
#21734 was meant to go to 25.1

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
