### PR TITLE
[25.1] Allow workflow download with missing file source references

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2740,6 +2740,11 @@ class DirectoryUriToolParameter(SimpleTextToolParameter):
         super().validate(value, trans=trans)
         if not value:
             return  # value is not set yet, do not validate
+        # Skip file source validation in workflow building mode to allow workflows
+        # referencing removed file sources to be exported/viewed. Users can then
+        # download and edit them. Validation still occurs during tool execution.
+        if trans.workflow_building_mode:
+            return
         file_source_path = trans.app.file_sources.get_file_source_path(value)
         file_source = file_source_path.file_source
         if file_source is None:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -388,6 +388,45 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
         response.raise_for_status()
         assert response.json()["name"] == "test_preview"
 
+    @skip_without_tool("export_remote")
+    def test_download_workflow_with_missing_file_source(self):
+        """Test that workflows referencing non-existent file sources can be downloaded.
+
+        Regression test for https://github.com/galaxyproject/galaxy/issues/21732.
+        When a file source referenced in a workflow is removed from the server configuration,
+        users should still be able to download the workflow for viewing and editing.
+        """
+        # Create a workflow with export_remote tool referencing a non-existent file source
+        workflow_id = self._upload_yaml_workflow(
+            """
+class: GalaxyWorkflow
+inputs:
+  input1: data
+steps:
+  export:
+    tool_id: export_remote
+    in:
+      export_type|infiles: input1
+    state:
+      export_type:
+        export_type_selector: datasets_auto
+      d_uri: "gxfiles://nonexistent_file_source/some/path"
+"""
+        )
+
+        # Download should succeed even though the file source doesn't exist
+        downloaded = self._download_workflow(workflow_id)
+        assert downloaded["a_galaxy_workflow"] == "true"
+        # Verify the tool state with the non-existent file source is preserved
+        export_step = None
+        for step in downloaded["steps"].values():
+            if step.get("tool_id") == "export_remote":
+                export_step = step
+                break
+        assert export_step is not None, "export_remote step should be in downloaded workflow"
+        tool_state = json.loads(export_step["tool_state"])
+        assert "gxfiles://nonexistent_file_source" in tool_state.get("d_uri", "")
+
     def test_delete(self):
         workflow_id = self.workflow_populator.simple_workflow("test_delete")
         workflow_name = "test_delete"


### PR DESCRIPTION
Fixes #21732. Previously, workflows containing steps that reference a file source (like export_remote with a directory_uri parameter) that has been removed from the server configuration would become inaccessible. The validation during workflow export/download would throw an error when the file source could not be found.

This change modifies DirectoryUriToolParameter.validate() to skip validation when in workflow building mode (which includes workflow export/editor operations). This allows users to:
- View workflows with references to removed file sources
- Download workflow JSON files for editing
- Access and modify workflows that were created before file source configuration changes

The file source validation still occurs during actual tool execution, ensuring that workflows cannot be run with invalid file sources.

Includes an API test that creates a workflow with export_remote tool referencing a non-existent file source and verifies that the workflow can be uploaded and downloaded successfully.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
