### PR TITLE
[25.1] Fix AWS Batch monitor crash, delete copied monitor method

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -890,7 +890,11 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors):
             finally:
                 self.app.model.unset_request_id(scoped_id)
             # Sleep a bit before the next state check
-            time.sleep(self.app.config.job_runner_monitor_sleep)
+            time.sleep(self.monitor_sleep_time)
+
+    @property
+    def monitor_sleep_time(self):
+        return self.app.config.job_runner_monitor_sleep
 
     def monitor_job(self, job_state: AsynchronousJobState) -> None:
         self.monitor_queue.put(job_state)

--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -6,8 +6,6 @@ import json
 import logging
 import os
 import re
-import time
-from queue import Empty
 from typing import (
     TYPE_CHECKING,
 )
@@ -42,8 +40,6 @@ except ImportError as e:
 
 __all__ = ("AWSBatchJobRunner",)
 log = logging.getLogger(__name__)
-
-STOP_SIGNAL = object()
 
 
 class AWSBatchRunnerException(Exception):
@@ -212,6 +208,10 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
             region_name=self.runner_params.get("region") or None,
         )
         self._batch_client = session.client("batch")
+
+    @property
+    def monitor_sleep_time(self):
+        return max(self.app.config.job_runner_monitor_sleep, self.MIN_QUERY_INTERVAL)
 
     def queue_job(self, job_wrapper):
         log.debug(f"Starting queue_job for job {job_wrapper.get_id_tag()}")
@@ -434,31 +434,6 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
             self._finish_or_resubmit_job(job_state, "", fail_message)
             if job_state.job_wrapper.cleanup_job == "always":
                 job_state.cleanup()
-
-    def monitor(self):
-        """
-        Watches jobs currently in the monitor queue and deals with state
-        changes (queued to running) and job completion.
-        """
-        while True:
-            # Take any new watched jobs and put them on the monitor list
-            try:
-                while True:
-                    async_job_state = self.monitor_queue.get_nowait()
-                    if async_job_state is STOP_SIGNAL:
-                        # TODO: This is where any cleanup would occur
-                        self.handle_stop()
-                        return
-                    self.watched.append(async_job_state)
-            except Empty:
-                pass
-            # Iterate over the list of watched jobs and check state
-            try:
-                self.check_watched_items()
-            except Exception:
-                log.exception("Unhandled exception checking active jobs")
-            # Sleep a bit before the next state check
-            time.sleep(max(self.app.config.job_runner_monitor_sleep, self.MIN_QUERY_INTERVAL))
 
     def check_watched_items(self):
         done: set[str] = set()


### PR DESCRIPTION
The AWS Batch runner defined its own `STOP_SIGNAL = object()` (a local sentinel) while the base class `AsynchronousJobRunner.shutdown()` puts the *base class's* `STOP_SIGNAL` into the monitor_queue. Since these are two different `object()` instances, the `is` identity check in the AWS runner's `monitor()` loop never matches the shutdown signal.

This causes the base class sentinel to be appended to `self.watched` as if it were a job, and when `check_watched_items()` later tries to access `.job_id` on it, the monitor thread crashes with an AttributeError.

Fix by using the base method and overriding the monitor sleep time using a property.

Alternative to https://github.com/galaxyproject/galaxy/pull/21768

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
