### PR TITLE
Migrate Upload Components from BTable to GTable and Enhance Table Styling

### DIFF
--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -80,6 +80,12 @@ interface Props {
     filter?: string;
 
     /**
+     * Whether to use fixed table layout (BootstrapVue `fixed`)
+     * @default false
+     */
+    fixed?: boolean;
+
+    /**
      * Whether to show hover effect on rows
      * @default true
      */
@@ -212,6 +218,7 @@ const props = withDefaults(defineProps<Props>(), {
     emptyState: () => ({ message: "No data available" }),
     fields: () => [],
     filter: "",
+    fixed: false,
     hover: true,
     hideHeader: false,
     items: () => [],
@@ -549,6 +556,7 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                         { 'table-hover': hover },
                         { 'table-bordered': bordered },
                         { 'g-table-compact': compact },
+                        { 'g-table-fixed': fixed },
                         tableClass,
                     ]">
                     <thead v-if="!props.hideHeader">
@@ -735,6 +743,11 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
 }
 
 .g-table {
+    &.g-table-fixed {
+        table-layout: fixed;
+        width: 100%;
+    }
+
     thead th {
         position: sticky;
         top: 0;

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -598,7 +598,7 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                                     <FontAwesomeIcon
                                         v-if="field.sortable && getSortIcon(field)"
                                         :icon="getSortIcon(field)"
-                                        :class="{ 'text-muted': sortBy !== field.key }"
+                                        :class="{ 'g-table-sort-icon': sortBy !== field.key }"
                                         class="ml-1 flex-shrink-0" />
                                 </div>
                             </th>
@@ -768,6 +768,10 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
 
         &.g-table-sorted {
             background-color: $brand-light;
+        }
+
+        .g-table-sort-icon {
+            color: $brand-secondary;
         }
     }
 

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -587,12 +587,12 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                                     { 'g-table-sorted': sortBy === field.key },
                                     { 'hide-on-small': field.hideOnSmall },
                                 ]"
-                                :style="field.width ? { width: field.width } : undefined"
+                                :style="field.width ? { width: field.width, minWidth: field.width } : undefined"
                                 @click="onHeaderClick(field)">
                                 <div class="d-flex align-items-center">
                                     <div class="flex-grow-1" :class="getTextAlignmentClass(field.align)">
                                         <slot :name="`head(${field.key})`" :field="field">
-                                            {{ field.label || field.key }}
+                                            {{ field.label ?? field.key }}
                                         </slot>
                                     </div>
                                     <FontAwesomeIcon

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -44,6 +44,12 @@ interface Props {
     clickableRows?: boolean;
 
     /**
+     * Whether to use compact table spacing (BootstrapVue `small`)
+     * @default false
+     */
+    compact?: boolean;
+
+    /**
      * Additional CSS classes for the table container
      * @default ""
      */
@@ -200,6 +206,7 @@ const props = withDefaults(defineProps<Props>(), {
     actions: undefined,
     bordered: false,
     clickableRows: false,
+    compact: false,
     containerClass: "",
     currentPage: undefined,
     emptyState: () => ({ message: "No data available" }),
@@ -541,6 +548,7 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                         { 'table-striped': striped },
                         { 'table-hover': hover },
                         { 'table-bordered': bordered },
+                        { 'g-table-compact': compact },
                         tableClass,
                     ]">
                     <thead v-if="!props.hideHeader">
@@ -774,6 +782,13 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
         td {
             padding: 0.75rem;
             vertical-align: middle;
+        }
+    }
+
+    &.g-table-compact {
+        thead th,
+        tbody td {
+            padding: 0.3rem;
         }
     }
 

--- a/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
+++ b/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
@@ -778,11 +778,11 @@ defineExpose<UploadMethodComponent>({ startUpload });
 
                     <template v-slot:cell(permission)="{ item }">
                         <span
-                            v-if="getPermissionIcon(item.entry)"
+                            v-if="getPermissionIcon(item.entry as AnyLibraryFolderItem)"
                             v-b-tooltip.hover
                             class="mr-2 text-muted"
-                            :title="getPermissionTitle(item.entry)">
-                            <FontAwesomeIcon :icon="getPermissionIcon(item.entry)" />
+                            :title="getPermissionTitle(item.entry as AnyLibraryFolderItem)">
+                            <FontAwesomeIcon :icon="getPermissionIcon(item.entry as AnyLibraryFolderItem)" />
                         </span>
                     </template>
 
@@ -807,8 +807,8 @@ defineExpose<UploadMethodComponent>({ startUpload });
 
                     <template v-slot:cell(updated)="{ item }">
                         <UtcDate
-                            v-if="item.entry && item.entry.update_time"
-                            :date="item.entry.update_time"
+                            v-if="item.entry && (item.entry as AnyLibraryFolderItem).update_time"
+                            :date="(item.entry as AnyLibraryFolderItem).update_time"
                             mode="pretty" />
                         <span v-else class="text-muted">—</span>
                     </template>

--- a/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
+++ b/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
@@ -678,6 +678,15 @@ function getPermissionTitle(entry: AnyLibraryFolderItem) {
     return undefined;
 }
 
+function getItemFolderEntry(item: SelectionItem): AnyLibraryFolderItem {
+    return item.entry as AnyLibraryFolderItem;
+}
+
+function getItemUpdateTime(item: SelectionItem): string {
+    const entry = item.entry as AnyLibraryFolderItem;
+    return entry?.update_time;
+}
+
 // Initialize: load libraries (only if not showing staged items)
 onMounted(async () => {
     if (showBrowser.value) {
@@ -778,11 +787,11 @@ defineExpose<UploadMethodComponent>({ startUpload });
 
                     <template v-slot:cell(permission)="{ item }">
                         <span
-                            v-if="getPermissionIcon(item.entry as AnyLibraryFolderItem)"
+                            v-if="item.entry && getPermissionIcon(getItemFolderEntry(item))"
                             v-b-tooltip.hover
                             class="mr-2 text-muted"
-                            :title="getPermissionTitle(item.entry as AnyLibraryFolderItem)">
-                            <FontAwesomeIcon :icon="getPermissionIcon(item.entry as AnyLibraryFolderItem)" />
+                            :title="getPermissionTitle(getItemFolderEntry(item))">
+                            <FontAwesomeIcon :icon="getPermissionIcon(getItemFolderEntry(item))" />
                         </span>
                     </template>
 
@@ -806,10 +815,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
                     </template>
 
                     <template v-slot:cell(updated)="{ item }">
-                        <UtcDate
-                            v-if="item.entry && (item.entry as AnyLibraryFolderItem).update_time"
-                            :date="(item.entry as AnyLibraryFolderItem).update_time"
-                            mode="pretty" />
+                        <UtcDate v-if="getItemUpdateTime(item)" :date="getItemUpdateTime(item)" mode="pretty" />
                         <span v-else class="text-muted">—</span>
                     </template>
                 </GTable>

--- a/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
+++ b/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
@@ -504,7 +504,7 @@ const libraryFields: TableField[] = [
         key: "name",
         label: "Name",
         sortable: true,
-        align: "center",
+        align: "left",
     },
     {
         key: "synopsis",

--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { faCloudUploadAlt, faLaptop, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BTable } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import { useFileDrop } from "@/composables/fileDrop";
 import { useBulkUploadOperations } from "@/composables/upload/bulkUploadOperations";
 import { useCollectionCreation } from "@/composables/upload/collectionCreation";
@@ -28,6 +28,7 @@ import UploadTableNameCell from "../shared/UploadTableNameCell.vue";
 import UploadTableOptionsCell from "../shared/UploadTableOptionsCell.vue";
 import UploadTableOptionsHeader from "../shared/UploadTableOptionsHeader.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 interface Props {
     method: UploadMethodConfig;
@@ -69,43 +70,50 @@ const { isReadyToUpload } = useUploadReadyState(hasFiles, collectionState);
 
 const showDragOverlay = computed(() => hasFiles.value && isFileOverDropZone.value);
 
-const tableFields = [
+const tableFields: TableField[] = [
     {
         key: "name",
         label: "Name",
         sortable: true,
-        thStyle: { minWidth: "200px", width: "auto" },
-        tdClass: "file-name-cell align-middle",
+        width: "200px",
+        align: "center",
+        class: "file-name-cell",
     },
     {
         key: "size",
         label: "Size",
         sortable: true,
-        thStyle: { minWidth: "80px", width: "80px" },
-        tdClass: "align-middle",
+        width: "80px",
+        align: "center",
     },
     {
         key: "extension",
         label: "Type",
         sortable: false,
-        thStyle: { minWidth: "100px", width: "180px" },
-        tdClass: "align-middle",
+        width: "180px",
+        align: "center",
     },
     {
         key: "dbKey",
         label: "Reference",
         sortable: false,
-        thStyle: { minWidth: "100px", width: "200px" },
-        tdClass: "align-middle",
+        width: "200px",
+        align: "center",
     },
     {
         key: "options",
         label: "Upload Settings",
         sortable: false,
-        thStyle: { width: "140px" },
-        tdClass: "align-middle",
+        width: "140px",
+        align: "center",
     },
-    { key: "actions", label: "", sortable: false, tdClass: "text-right align-middle", thStyle: { width: "50px" } },
+    {
+        key: "actions",
+        label: "",
+        sortable: false,
+        width: "50px",
+        align: "center",
+    },
 ];
 
 watch(isReadyToUpload, (ready) => emit("ready", ready), { immediate: true });
@@ -205,14 +213,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
                 </div>
 
                 <div class="file-table-container">
-                    <BTable
-                        :items="selectedFiles"
-                        :fields="tableFields"
-                        hover
-                        striped
-                        small
-                        fixed
-                        thead-class="file-table-header">
+                    <GTable hover striped compact fixed :items="selectedFiles" :fields="tableFields" class="file-table">
                         <template v-slot:cell(name)="{ item }">
                             <UploadTableNameCell
                                 :value="item.name"
@@ -291,7 +292,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
                                 <FontAwesomeIcon :icon="faTimes" />
                             </button>
                         </template>
-                    </BTable>
+                    </GTable>
                 </div>
 
                 <!-- Collection Creation Section -->
@@ -428,7 +429,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
 .file-table-container {
     @include upload-table-container;
 
-    :deep(.file-table-header) {
+    :deep(.file-table thead) {
         @include upload-table-header;
     }
 

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { faLink, faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BFormInput, BTable } from "bootstrap-vue";
+import { BFormInput } from "bootstrap-vue";
 import { computed, nextTick, ref, watch } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import { useBulkUploadOperations } from "@/composables/upload/bulkUploadOperations";
 import { useCollectionCreation } from "@/composables/upload/collectionCreation";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
@@ -27,6 +28,7 @@ import UploadTableNameCell from "../shared/UploadTableNameCell.vue";
 import UploadTableOptionsCell from "../shared/UploadTableOptionsCell.vue";
 import UploadTableOptionsHeader from "../shared/UploadTableOptionsHeader.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 interface Props {
     method: UploadMethodConfig;
@@ -127,43 +129,47 @@ function removeItem(id: number) {
     urlItems.value = urlItems.value.filter((item) => item.id !== id);
 }
 
-const tableFields = [
+const tableFields: TableField[] = [
     {
         key: "name",
         label: "Name",
         sortable: true,
-        thStyle: { width: "200px" },
-        tdClass: "url-name-cell align-middle",
+        width: "200px",
+        class: "url-name-cell",
     },
     {
         key: "url",
         label: "URL",
         sortable: false,
-        thStyle: { width: "auto" },
-        tdClass: "align-middle url-column",
+        class: "url-column",
     },
     {
         key: "extension",
         label: "Type",
         sortable: false,
-        thStyle: { minWidth: "180px", width: "180px" },
-        tdClass: "align-middle",
+        width: "180px",
+        align: "center",
     },
     {
         key: "dbKey",
         label: "Reference",
         sortable: false,
-        thStyle: { minWidth: "200px", width: "200px" },
-        tdClass: "align-middle",
+        width: "200px",
+        align: "center",
     },
     {
         key: "options",
         label: "Upload Settings",
         sortable: false,
-        thStyle: { width: "auto" },
-        tdClass: "align-middle",
+        align: "center",
     },
-    { key: "actions", label: "", sortable: false, tdClass: "text-right align-middle", thStyle: { width: "50px" } },
+    {
+        key: "actions",
+        label: "",
+        sortable: false,
+        width: "50px",
+        align: "center",
+    },
 ];
 
 function clearAll() {
@@ -224,14 +230,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
             </div>
 
             <div ref="tableContainerRef" class="url-table-container">
-                <BTable
-                    :items="urlItems"
-                    :fields="tableFields"
-                    hover
-                    striped
-                    small
-                    fixed
-                    thead-class="url-table-header">
+                <GTable hover striped fixed compact :items="urlItems" :fields="tableFields" class="url-table">
                     <!-- Name column -->
                     <template v-slot:cell(name)="{ item }">
                         <UploadTableNameCell
@@ -330,7 +329,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
                             <FontAwesomeIcon :icon="faTimes" />
                         </button>
                     </template>
-                </BTable>
+                </GTable>
             </div>
 
             <!-- Collection Creation Section -->
@@ -405,7 +404,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
 .url-table-container {
     @include upload-table-container;
 
-    :deep(.url-table-header) {
+    :deep(.url-table thead) {
         @include upload-table-header;
     }
 

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -443,7 +443,7 @@ const browserFields: TableField[] = [
         key: "details",
         label: "Details",
         sortable: false,
-        align: "center",
+        align: "left",
     },
 ];
 

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -674,7 +674,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
 
                     <!-- Details column -->
                     <template v-slot:cell(details)="{ item }">
-                        <RemoteEntryMetadata v-if="item.isLeaf && item.entry" :entry="item.entry" />
+                        <RemoteEntryMetadata v-if="item.isLeaf && item.entry" :entry="item.entry as RemoteEntry" />
                         <span v-else-if="urlTracker.isAtRoot && item.details">
                             {{ item.details }}
                         </span>

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { faFolder, faGlobe, faPlus, faTimes, faUser } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BFormCheckbox, BFormInput, BPagination, BTable } from "bootstrap-vue";
+import { BAlert, BFormCheckbox, BFormInput, BPagination } from "bootstrap-vue";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { browseRemoteFiles, fetchFileSources, type RemoteEntry } from "@/api/remoteFiles";
 import type { BreadcrumbItem } from "@/components/Common";
+import type { TableField } from "@/components/Common/GTable.types";
 import { Model } from "@/components/FilesDialog/model";
 import { fileSourcePluginToItem } from "@/components/FilesDialog/utilities";
 import type { SelectionItem } from "@/components/SelectionDialog/selectionTypes";
@@ -39,6 +40,7 @@ import UploadTableOptionsCell from "../shared/UploadTableOptionsCell.vue";
 import UploadTableOptionsHeader from "../shared/UploadTableOptionsHeader.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import BreadcrumbNavigation from "@/components/Common/BreadcrumbNavigation.vue";
+import GTable from "@/components/Common/GTable.vue";
 import DataDialogSearch from "@/components/SelectionDialog/DataDialogSearch.vue";
 
 interface Props {
@@ -330,6 +332,10 @@ function onItemClick(item: SelectionItem) {
     }
 }
 
+function onRowClick(event: { item: SelectionItem }) {
+    onItemClick(event.item);
+}
+
 function open(item: SelectionItem) {
     urlTracker.forward(item);
     currentPage.value = 1;
@@ -413,81 +419,86 @@ function createNewFileSource() {
 }
 
 // Browser table fields
-const browserFields = [
+const browserFields: TableField[] = [
     {
         key: "select",
         label: "",
-        thStyle: { width: "40px" },
-        tdClass: "align-middle",
+        width: "40px",
+        align: "center",
     },
     {
         key: "user",
         label: "",
         sortable: false,
-        thStyle: { width: "35px" },
-        tdClass: "align-middle text-center",
+        width: "35px",
+        align: "center",
     },
     {
         key: "name",
         label: "Name",
         sortable: false,
-        thStyle: { minWidth: "200px" },
-        tdClass: "align-middle",
+        align: "center",
     },
     {
         key: "details",
         label: "Details",
         sortable: false,
-        thStyle: { width: "auto", minWidth: "200px" },
-        tdClass: "align-middle",
+        align: "center",
     },
 ];
 
 // File list table fields
-const tableFields = [
+const tableFields: TableField[] = [
     {
         key: "name",
         label: "Name",
         sortable: true,
-        thStyle: { width: "200px" },
-        tdClass: "file-name-cell align-middle",
+        width: "200px",
+        align: "center",
+        class: "file-name-cell",
     },
     {
         key: "size",
         label: "Size",
         sortable: true,
-        thStyle: { minWidth: "80px", width: "80px" },
-        tdClass: "align-middle",
+        width: "80px",
+        align: "center",
+        class: "size-column",
     },
     {
         key: "url",
         label: "URI",
         sortable: false,
-        thStyle: { width: "auto" },
-        tdClass: "align-middle uri-column",
+        align: "center",
+        class: "uri-column",
     },
     {
         key: "extension",
         label: "Type",
         sortable: false,
-        thStyle: { minWidth: "180px", width: "180px" },
-        tdClass: "align-middle",
+        width: "180px",
+        align: "center",
     },
     {
         key: "dbKey",
         label: "Reference",
         sortable: false,
-        thStyle: { minWidth: "200px", width: "200px" },
-        tdClass: "align-middle",
+        width: "200px",
+        align: "center",
     },
     {
         key: "options",
         label: "Upload Settings",
         sortable: false,
-        thStyle: { width: "auto" },
-        tdClass: "align-middle",
+        align: "center",
     },
-    { key: "actions", label: "", sortable: false, tdClass: "text-right align-middle", thStyle: { width: "50px" } },
+    {
+        key: "actions",
+        label: "",
+        sortable: false,
+        width: "50px",
+        align: "center",
+    },
 ];
 
 function clearAll() {
@@ -602,17 +613,18 @@ defineExpose<UploadMethodComponent>({ startUpload });
 
             <!-- Browser table -->
             <div class="browser-table-container">
-                <BTable
+                <GTable
                     v-if="!errorMessage && (browserItems.length > 0 || isBusy)"
                     :items="browserItems"
                     :fields="browserFields"
-                    :busy="isBusy"
+                    :overlay-loading="isBusy"
                     hover
                     striped
-                    small
+                    clickable-rows
+                    compact
                     fixed
-                    thead-class="browser-table-header"
-                    @row-clicked="onItemClick">
+                    class="browser-table"
+                    @row-click="onRowClick">
                     <!-- Select column header (select all) -->
                     <template v-slot:head(select)>
                         <BFormCheckbox
@@ -669,19 +681,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
                     </template>
 
                     <!-- Loading slot -->
-                    <template v-slot:table-busy>
-                        <div class="text-center my-2">
-                            <b-spinner small class="align-middle"></b-spinner>
-                            <strong class="ml-2">
-                                {{
-                                    supportsServerPagination
-                                        ? "Loading..."
-                                        : "Loading all files (this may take a moment)..."
-                                }}
-                            </strong>
-                        </div>
-                    </template>
-                </BTable>
+                </GTable>
 
                 <!-- Empty state message when no items are available -->
                 <div v-else-if="!errorMessage && !isBusy" class="text-center text-muted my-5">
@@ -733,14 +733,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
             </div>
 
             <div ref="tableContainerRef" class="file-table-container">
-                <BTable
-                    :items="remoteFileItems"
-                    :fields="tableFields"
-                    hover
-                    striped
-                    small
-                    fixed
-                    thead-class="file-table-header">
+                <GTable :items="remoteFileItems" :fields="tableFields" hover striped table-class="table-sm file-table">
                     <!-- Name column -->
                     <template v-slot:cell(name)="{ item }">
                         <UploadTableNameCell
@@ -838,7 +831,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
                             <FontAwesomeIcon :icon="faTimes" />
                         </button>
                     </template>
-                </BTable>
+                </GTable>
             </div>
 
             <!-- Collection Creation Section -->
@@ -904,7 +897,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
     overflow: auto;
     min-height: 0;
 
-    :deep(.browser-table-header) {
+    :deep(.browser-table thead) {
         @include upload-table-header;
     }
 
@@ -941,7 +934,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
 .file-table-container {
     @include upload-table-container;
 
-    :deep(.file-table-header) {
+    :deep(.file-table thead) {
         @include upload-table-header;
     }
 

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -573,6 +573,10 @@ function onErrorRetry() {
     load();
 }
 
+function getItemEntry(item: SelectionItem): RemoteEntry {
+    return item.entry as RemoteEntry;
+}
+
 defineExpose<UploadMethodComponent>({ startUpload });
 </script>
 
@@ -674,7 +678,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
 
                     <!-- Details column -->
                     <template v-slot:cell(details)="{ item }">
-                        <RemoteEntryMetadata v-if="item.isLeaf && item.entry" :entry="item.entry as RemoteEntry" />
+                        <RemoteEntryMetadata v-if="item.isLeaf && getItemEntry(item)" :entry="getItemEntry(item)" />
                         <span v-else-if="urlTracker.isAtRoot && item.details">
                             {{ item.details }}
                         </span>


### PR DESCRIPTION
This PR migrates Upload components (`Panels/Upload/methods/RemoteFilesUpload.vue`, `Panels/Upload/methods/DataLibraryUpload.vue`, `Panels/Upload/methods/LocalFileUpload.vue`, `Panels/Upload/methods/PasteContentUpload.vue` and `Panels/Upload/methods/PasteLinksUpload.vue`) from Bootstrap-Vue's components to our `GComponents` as part of the ongoing effort tracked in #21703, and also adds compact and fixed style to `GTable`, and improve its.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use `Beta Upload Panel` options

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
