### PR TITLE
[25.1] Fix tool credentials on containerized (Singularity/Docker) destinations

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1472,6 +1472,17 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
         self.javascript_requirements = javasscript_requirements
         self.credentials = credentials
 
+        # Add credential inject_as_env names to docker_env_pass_through
+        # so they are passed into containerized environments (Docker -e, Singularity SINGULARITYENV_)
+        if self.credentials:
+            if not self.docker_env_pass_through:
+                self.docker_env_pass_through = []
+            for credential in self.credentials:
+                for secret in credential.secrets:
+                    self.docker_env_pass_through.append(secret.inject_as_env)
+                for variable in credential.variables:
+                    self.docker_env_pass_through.append(variable.inject_as_env)
+
         required_files = tool_source.parse_required_files()
         if required_files is None:
             old_id = self.old_id

--- a/test/functional/tools/secret_tool.xml
+++ b/test/functional/tools/secret_tool.xml
@@ -1,5 +1,6 @@
 <tool id="secret_tool" name="secret_tool" version="test" profile="23.0">
     <requirements>
+        <container type="docker">busybox:1.36.1-glibc</container>
         <credentials name="service1" version="v1" label="Your credentials set" description="Optional description of the service using credentials">
             <variable name="server" inject_as_env="service1_url" optional="false" label="Your Service1 server" description="You can set the server..."/>
             <secret name="username" inject_as_env="service1_user" optional="false" label="Your Service1 username" description="Your username is your email"/>

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -102,7 +102,7 @@ def skip_if_container_type_unavailable(cls) -> None:
         raise unittest.SkipTest(f"Executable '{cls.container_type}' not found on PATH")
 
 
-class TestDockerizedJobsIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+class TestDockerizedJobsIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases, ConfiguresDatabaseVault):
     dataset_populator: DatasetPopulator
     jobs_directory: str
     job_config_file = DOCKERIZED_JOB_CONFIG_FILE
@@ -116,6 +116,7 @@ class TestDockerizedJobsIntegration(BaseJobEnvironmentIntegrationTestCase, Mulle
         config["jobs_directory"] = cls.jobs_directory
         config["job_config_file"] = cls.job_config_file
         disable_dependency_resolution(config)
+        cls._configure_database_vault(config)
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -3,13 +3,17 @@
 import json
 import os
 import unittest
-from typing import (
-    Any,
-)
+from typing import Any
 
 from galaxy.util.commands import which
-from galaxy_test.base.populators import DatasetPopulator
-from galaxy_test.driver.integration_util import IntegrationTestCase
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    skip_without_tool,
+)
+from galaxy_test.driver.integration_util import (
+    ConfiguresDatabaseVault,
+    IntegrationTestCase,
+)
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))

--- a/test/unit/tool_util/test_singularity_util.py
+++ b/test/unit/tool_util/test_singularity_util.py
@@ -18,3 +18,19 @@ def test_build_singularity_run_command_no_cleanenv_ipc_pid():
         ipc=False,
     )
     assert cmd == "singularity -s exec --contain --no-mount tmp busybox echo hi"
+
+
+def test_build_singularity_run_command_with_env_passthrough():
+    """Test that environment variables are properly prefixed with SINGULARITYENV_"""
+    cmd = build_singularity_run_command(
+        container_command="echo hi",
+        image="busybox",
+        env=[
+            ("MY_SECRET", "secret_value"),
+            ("MY_VAR", "var_value"),
+        ],
+    )
+    # Verify that all env vars are prefixed with SINGULARITYENV_
+    assert 'SINGULARITYENV_MY_SECRET="secret_value"' in cmd
+    assert 'SINGULARITYENV_MY_VAR="var_value"' in cmd
+    assert cmd.endswith("busybox echo hi")

--- a/test/unit/tool_util/test_singularity_util.py
+++ b/test/unit/tool_util/test_singularity_util.py
@@ -18,19 +18,3 @@ def test_build_singularity_run_command_no_cleanenv_ipc_pid():
         ipc=False,
     )
     assert cmd == "singularity -s exec --contain --no-mount tmp busybox echo hi"
-
-
-def test_build_singularity_run_command_with_env_passthrough():
-    """Test that environment variables are properly prefixed with SINGULARITYENV_"""
-    cmd = build_singularity_run_command(
-        container_command="echo hi",
-        image="busybox",
-        env=[
-            ("MY_SECRET", "secret_value"),
-            ("MY_VAR", "var_value"),
-        ],
-    )
-    # Verify that all env vars are prefixed with SINGULARITYENV_
-    assert 'SINGULARITYENV_MY_SECRET="secret_value"' in cmd
-    assert 'SINGULARITYENV_MY_VAR="var_value"' in cmd
-    assert cmd.endswith("busybox echo hi")


### PR DESCRIPTION
Fixes #21715
Fixes #21884

Tool credentials (secrets/variables from `<credentials>` in tool XML) were not being passed to Singularity/Docker containers. Credential env vars were exported in job scripts but never added to container passthrough lists.

Add credential `inject_as_env` names to `docker_env_pass_through` at tool parse time. This list already feeds both Docker (`-e` flags) and Singularity (`SINGULARITYENV_` prefix) container builders.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
