### PR TITLE
Pin setuptools<82 for galaxy-files package

### DIFF
--- a/packages/files/setup.cfg
+++ b/packages/files/setup.cfg
@@ -34,6 +34,7 @@ include_package_data = True
 install_requires =
     galaxy-util[config-template,template]
     fs
+    setuptools<82  # TODO: remove once pyfilesystem2 drops pkg_resources (https://github.com/PyFilesystem/pyfilesystem2/issues/597)
     pydantic>=2.7.4
     typing-extensions
     fsspec


### PR DESCRIPTION
pyfilesystem has a runtime dependency on this package and it was dropped from the latest setuptools. https://github.com/galaxyproject/galaxy/issues/21823

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. See if the package tests pass in CI I guess?

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
