### PR TITLE
[25.1] Pin setuptools<82 for galaxy-files package - Backport #21824

### DIFF
--- a/packages/files/setup.cfg
+++ b/packages/files/setup.cfg
@@ -34,6 +34,7 @@ include_package_data = True
 install_requires =
     galaxy-util[config-template,template]
     fs
+    setuptools<82  # TODO: remove once pyfilesystem2 drops pkg_resources (https://github.com/PyFilesystem/pyfilesystem2/issues/597)
     pydantic>=2.7.4
     typing-extensions
     fsspec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,7 @@ keep-runtime-typing = true
 [tool.uv]
 constraint-dependencies = [
     "limits>=2.5.0",  # prefer not downgrading this to upgrading packaging
+    "setuptools<82",  # https://github.com/PyFilesystem/pyfilesystem2/issues/597
     "scipy>=1.14.1; python_version>='3.10'",  # Python 3.13 support
 ]
 default-groups = []


### PR DESCRIPTION
See #21823.

Also:
- Pin `setuptools<82` in uv `constraint-dependencies`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
