### PR TITLE
[26.0] Fix selenium test test_rename_history

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -741,6 +741,8 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
             target_card.find_element(By.CSS_SELECTOR, '[id^="g-card-extra-actions-history-"]').click()
 
         action_selector = target_card.find_element(By.CSS_SELECTOR, action_selector)
+        # Hover over parent card first to activate hover state in headless mode
+        self.action_chains().move_to_element(target_card).perform()
         self.move_to_and_click(action_selector)
 
     def edit_dataset_dbkey(self, dbkey_text):


### PR DESCRIPTION
The rename button in GCard is hidden and shown only on hover, which prevents Selenium interaction in headless mode when directly targeting child elements. Hovering the parent card first makes the button visible and interactable before clicking.

Fixes:
```
FAILED lib/galaxy_test/selenium/test_histories_list.py::TestSavedHistories::test_rename_history - selenium.common.exceptions.TimeoutException: Message: Timeout waiting on CSS selector [.ui-form-element input.ui-input] to become present.
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
