### PR TITLE
Migrate admin components from BTable to GTable and Add stacked Style to GTable

### DIFF
--- a/client/src/components/Common/GTable.types.ts
+++ b/client/src/components/Common/GTable.types.ts
@@ -42,17 +42,19 @@ export interface SortChangeEvent {
 }
 
 /** Row click event payload */
-export interface RowClickEvent<T = any> {
+export interface RowClickEvent<T> {
     /** The row item data */
     item: T;
     /** The row index */
     index: number;
     /** The original mouse/keyboard event */
     event: MouseEvent | KeyboardEvent;
+    /** Toggle row details expansion */
+    toggleDetails: () => void;
 }
 
 /** Row selection event payload */
-export interface RowSelectEvent<T = any> {
+export interface RowSelectEvent<T> {
     /** The selected row item */
     item: T;
     /** The row index */

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -457,7 +457,7 @@ function onRowClick(item: T, index: number, event: MouseEvent | KeyboardEvent) {
         return;
     }
 
-    emit("row-click", { item, index, event });
+    emit("row-click", { item, index, event, toggleDetails: () => toggleRowDetails(index) });
 }
 
 function onSelectAll(selected: boolean) {
@@ -483,7 +483,7 @@ function isRowExpanded(index: number) {
  * Toggle row details expansion
  */
 function toggleRowDetails(index: number) {
-    if (isRowExpanded(index)) {
+    if (expandedRows.value.has(index)) {
         expandedRows.value.delete(index);
     } else {
         expandedRows.value.add(index);

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -38,6 +38,12 @@ interface Props {
     bordered?: boolean;
 
     /**
+     * Whether to place table caption at the top (above the table)
+     * @default false
+     */
+    captionTop?: boolean;
+
+    /**
      * Whether rows are clickable
      * @default false
      */
@@ -211,6 +217,7 @@ const props = withDefaults(defineProps<Props>(), {
     id: () => useUid("g-table-").value,
     actions: undefined,
     bordered: false,
+    captionTop: false,
     clickableRows: false,
     compact: false,
     containerClass: "",
@@ -557,8 +564,13 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                         { 'table-bordered': bordered },
                         { 'g-table-compact': compact },
                         { 'g-table-fixed': fixed },
+                        { 'caption-top': captionTop },
                         tableClass,
                     ]">
+                    <caption v-if="$slots['table-caption']" :class="{ 'caption-top': captionTop }">
+                        <slot name="table-caption" />
+                    </caption>
+
                     <thead v-if="!props.hideHeader">
                         <tr>
                             <th v-if="selectable" class="g-table-select-column">
@@ -828,5 +840,11 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
 
 .g-table-load-more {
     border-top: 1px solid $brand-secondary;
+}
+
+.g-table.caption-top {
+    caption {
+        caption-side: top;
+    }
 }
 </style>

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts" generic="T extends Record<string, any>">
 import { faEllipsisV, faSort, faSortDown, faSortUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BDropdown, BDropdownItem, BFormCheckbox, BOverlay } from "bootstrap-vue";
+import { BAlert, BDropdown, BDropdownItem, BFormCheckbox, BOverlay } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
 import type { BootstrapSize } from "@/components/Common";
@@ -652,7 +652,17 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                         </tr>
                     </thead>
 
-                    <tbody v-if="paginatedLocalItems.length > 0">
+                    <tbody>
+                        <tr v-if="!props.items.length">
+                            <td :colspan="(selectable ? 1 : 0) + props.fields.length + (props.actions ? 1 : 0)">
+                                <slot name="empty">
+                                    <BAlert v-if="!loading" variant="info" show class="w-100 m-0">
+                                        {{ props.emptyState?.message ?? "No data available" }}
+                                    </BAlert>
+                                </slot>
+                            </td>
+                        </tr>
+
                         <template v-for="(item, paginatedIndex) in paginatedLocalItems">
                             <template>
                                 <tr

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -526,6 +526,18 @@ function getAlignmentClass(align?: FieldAlignment) {
 }
 
 /**
+ * Get cell variant class for Bootstrap color variants (e.g., "success", "danger", "info")
+ * Supports the _cellVariants convention from b-table for backward compatibility
+ */
+function getCellVariantClass(item: T, field: TableField) {
+    const cellVariants = item._cellVariants as Record<string, string> | undefined;
+    if (!cellVariants || !cellVariants[field.key]) {
+        return undefined;
+    }
+    return `table-${cellVariants[field.key]}`;
+}
+
+/**
  * Check if row is selected
  */
 function isRowSelected(index: number) {
@@ -672,6 +684,7 @@ const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table
                                             field.cellClass,
                                             field.class,
                                             getAlignmentClass(field.align),
+                                            getCellVariantClass(item, field),
                                             { 'hide-on-small': field.hideOnSmall },
                                         ]">
                                         <template

--- a/client/src/components/admin/BaseList.test.js
+++ b/client/src/components/admin/BaseList.test.js
@@ -24,6 +24,7 @@ describe("Categories", () => {
     const setter = async () => {
         return {};
     };
+
     test("test categories loading", async () => {
         const wrapper = mount(BaseList, {
             propsData: {
@@ -31,7 +32,11 @@ describe("Categories", () => {
                 tooltip: "tooltip",
                 plural: "plural",
                 success: "success",
-                fields: ["execute", "col_0", "col_1"],
+                fields: [
+                    { key: "execute", label: "Execute" },
+                    { key: "col_0", label: "Col 0" },
+                    { key: "col_1", label: "Col 1" },
+                ],
                 getter: getter,
                 setter: setter,
             },

--- a/client/src/components/admin/BaseList.vue
+++ b/client/src/components/admin/BaseList.vue
@@ -1,6 +1,7 @@
 <template>
     <div>
-        <b-alert :show="messageVisible" :variant="messageVariant"> {{ messageText }} </b-alert>
+        <BAlert :show="messageVisible" :variant="messageVariant"> {{ messageText }} </BAlert>
+
         <div v-if="itemsVisible" class="card-header">
             There are {{ itemsLength }}
             <GButton
@@ -38,11 +39,14 @@
 </template>
 
 <script>
+import { BAlert } from "bootstrap-vue";
+
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
+        BAlert,
         GButton,
         GTable,
     },

--- a/client/src/components/admin/BaseList.vue
+++ b/client/src/components/admin/BaseList.vue
@@ -14,7 +14,8 @@
             </GButton>
             {{ plural }} available.
         </div>
-        <b-table v-if="itemsVisible" striped no-sort-reset :fields="fields" :items="items">
+
+        <GTable v-if="itemsVisible" striped no-sort-reset :fields="fields" :items="items">
             <template v-slot:cell(execute)="data">
                 <GButton
                     size="small"
@@ -26,25 +27,25 @@
                     <span :class="icon" />
                 </GButton>
             </template>
+
             <template v-slot:cell(links)="data">
                 <li v-for="link in data.item.links" :key="link.name">
                     {{ link.name }}
                 </li>
             </template>
-        </b-table>
+        </GTable>
     </div>
 </template>
 
 <script>
-import BootstrapVue from "bootstrap-vue";
-import Vue from "vue";
-
 import GButton from "@/components/BaseComponents/GButton.vue";
-
-Vue.use(BootstrapVue);
+import GTable from "@/components/Common/GTable.vue";
 
 export default {
-    components: { GButton },
+    components: {
+        GButton,
+        GTable,
+    },
     props: {
         icon: {
             type: String,

--- a/client/src/components/admin/DataManager/DataManagerJob.vue
+++ b/client/src/components/admin/DataManager/DataManagerJob.vue
@@ -1,54 +1,60 @@
 <template>
     <div>
-        <b-breadcrumb v-if="dataManager && jobId && !loading" id="breadcrumb" :items="breadcrumbItems" />
+        <BBreadcrumb v-if="dataManager && jobId && !loading" id="breadcrumb" :items="breadcrumbItems" />
+
         <Alert :message="message" :variant="status" />
+
         <Alert v-for="(error, index) in errorMessages" :key="index" :message="error" variant="error" />
+
         <Alert v-if="viewOnly" message="Not implemented" variant="dark" />
         <Alert v-else-if="loading" message="Waiting for data" variant="info" />
-        <b-container v-else-if="dataManager">
-            <b-row>
-                <b-col>
-                    <b-card
+        <BContainer v-else-if="dataManager">
+            <BRow>
+                <BCol>
+                    <BCard
                         id="data-manager-card"
                         header-bg-variant="primary"
                         header-text-variant="white"
                         border-variant="primary"
                         class="mb-3">
                         <template v-slot:header>
-                            <b-container>
-                                <b-row align-v="center">
-                                    <b-col cols="auto">
+                            <BContainer>
+                                <BRow align-v="center">
+                                    <BCol cols="auto">
                                         <GButton tooltip title="Rerun" :href="runUrl">
-                                            <span class="fa fa-redo" />
+                                            <!-- <span class="fa fa-redo" /> -->
+                                            <FontAwesomeIcon :icon="faRedo" />
                                         </GButton>
-                                    </b-col>
-                                    <b-col>
+                                    </BCol>
+
+                                    <BCol>
                                         <b>{{ dataManager["name"] }}</b> <i>{{ dataManager["description"] }}</i>
-                                    </b-col>
-                                </b-row>
-                            </b-container>
+                                    </BCol>
+                                </BRow>
+                            </BContainer>
                         </template>
-                        <b-card v-for="(hda, i) in hdaInfo" :id="'data-card-' + i" :key="i" class="mb-4">
+
+                        <BCard v-for="(hda, i) in hdaInfo" :id="'data-card-' + i" :key="i" class="mb-4">
                             <template v-slot:header>
                                 <GTable :fields="fields" :items="[hda]" caption-top compact stacked>
                                     <template v-slot:table-caption>
-                                        <b-container>
-                                            <b-row align-v="center">
-                                                <b-col cols="auto">
+                                        <BContainer>
+                                            <BRow align-v="center">
+                                                <BCol cols="auto">
                                                     <GButton
                                                         tooltip
                                                         title="View complete info"
                                                         :href="hdaInfo[i]['infoUrl']"
                                                         target="galaxy_main">
-                                                        <span class="fa fa-info-circle" />
+                                                        <FontAwesomeIcon :icon="faInfoCircle" />
                                                     </GButton>
-                                                </b-col>
+                                                </BCol>
 
-                                                <b-col>
+                                                <BCol>
                                                     <b>{{ hda["name"] }}</b>
-                                                </b-col>
-                                            </b-row>
-                                        </b-container>
+                                                </BCol>
+                                            </BRow>
+                                        </BContainer>
                                     </template>
                                 </GTable>
                             </template>
@@ -66,16 +72,19 @@
                                     Data Table: <b>{{ output[0] }}</b>
                                 </template>
                             </GTable>
-                        </b-card>
-                    </b-card>
-                </b-col>
-            </b-row>
-        </b-container>
+                        </BCard>
+                    </BCard>
+                </BCol>
+            </BRow>
+        </BContainer>
     </div>
 </template>
 
 <script>
+import { faInfoCircle, faRedo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
+import { BBreadcrumb, BCard, BCol, BContainer, BRow } from "bootstrap-vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
 
@@ -86,6 +95,12 @@ import GTable from "@/components/Common/GTable.vue";
 export default {
     components: {
         Alert,
+        BBreadcrumb,
+        BCard,
+        BCol,
+        BContainer,
+        BRow,
+        FontAwesomeIcon,
         GButton,
         GTable,
     },
@@ -97,6 +112,8 @@ export default {
     },
     data() {
         return {
+            faInfoCircle,
+            faRedo,
             jobId: Number,
             exitCode: Number,
             runUrl: "#",

--- a/client/src/components/admin/DataManager/DataManagerJob.vue
+++ b/client/src/components/admin/DataManager/DataManagerJob.vue
@@ -30,7 +30,7 @@
                         </template>
                         <b-card v-for="(hda, i) in hdaInfo" :id="'data-card-' + i" :key="i" class="mb-4">
                             <template v-slot:header>
-                                <b-table :fields="fields" :items="[hda]" caption-top small stacked>
+                                <GTable :fields="fields" :items="[hda]" caption-top compact stacked>
                                     <template v-slot:table-caption>
                                         <b-container>
                                             <b-row align-v="center">
@@ -43,15 +43,17 @@
                                                         <span class="fa fa-info-circle" />
                                                     </GButton>
                                                 </b-col>
+
                                                 <b-col>
                                                     <b>{{ hda["name"] }}</b>
                                                 </b-col>
                                             </b-row>
                                         </b-container>
                                     </template>
-                                </b-table>
+                                </GTable>
                             </template>
-                            <b-table
+
+                            <GTable
                                 v-for="(output, j) in dataManagerOutput[i]"
                                 :key="j"
                                 :fields="outputFields(output[1][0])"
@@ -63,7 +65,7 @@
                                 <template v-slot:table-caption>
                                     Data Table: <b>{{ output[0] }}</b>
                                 </template>
-                            </b-table>
+                            </GTable>
                         </b-card>
                     </b-card>
                 </b-col>
@@ -79,11 +81,13 @@ import { getAppRoot } from "@/onload/loadConfig";
 
 import Alert from "@/components/Alert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
         Alert,
         GButton,
+        GTable,
     },
     props: {
         id: {

--- a/client/src/components/admin/DataManager/DataManagerJobs.vue
+++ b/client/src/components/admin/DataManager/DataManagerJobs.vue
@@ -1,41 +1,45 @@
 <template>
     <div>
-        <b-breadcrumb v-if="dataManager && !loading" id="breadcrumb" :items="breadcrumbItems" />
+        <BBreadcrumb v-if="dataManager && !loading" id="breadcrumb" :items="breadcrumbItems" />
+
         <Alert :message="message" :variant="status" />
+
         <Alert v-if="viewOnly" message="Not implemented" variant="dark" />
         <Alert v-else-if="loading" message="Waiting for data" variant="info" />
         <Alert v-else-if="jobs && !jobs.length" message="There are no jobs for this data manager." variant="primary" />
         <div v-else-if="jobs">
-            <b-container fluid class="mb-3">
-                <b-row>
-                    <b-col md="6">
-                        <b-form-group description="Search for strings or regular expressions">
-                            <b-input-group>
-                                <b-form-input
+            <BContainer fluid class="mb-3">
+                <BRow>
+                    <BCol md="6">
+                        <BFormGroup description="Search for strings or regular expressions">
+                            <BInputGroup>
+                                <BFormInput
                                     v-model="filter"
                                     placeholder="Type to Search"
                                     @keyup.esc.native="filter = ''" />
-                                <b-input-group-append>
-                                    <b-btn :disabled="!filter" @click="filter = ''">Clear (esc)</b-btn>
-                                </b-input-group-append>
-                            </b-input-group>
-                        </b-form-group>
-                    </b-col>
-                </b-row>
-                <b-row>
-                    <b-col>
+
+                                <BInputGroupAppend>
+                                    <BButton :disabled="!filter" @click="filter = ''">Clear (esc)</BButton>
+                                </BInputGroupAppend>
+                            </BInputGroup>
+                        </BFormGroup>
+                    </BCol>
+                </BRow>
+
+                <BRow>
+                    <BCol>
                         <GButton :pressed.sync="showCommandLine" outline>
                             {{ showCommandLine ? "Hide" : "Show" }} Command Line
                         </GButton>
-                    </b-col>
-                </b-row>
-            </b-container>
+                    </BCol>
+                </BRow>
+            </BContainer>
 
             <GTable hover striped :fields="tableFields" :items="tableItems" :filter="filter">
                 <template v-slot:cell(actions)="row">
                     <GButtonGroup>
                         <GButton tooltip title="Rerun" target="_top" :href="jobs[row.index]['runUrl']">
-                            <span class="fa fa-redo" />
+                            <FontAwesomeIcon :icon="faRedo" />
                         </GButton>
 
                         <GButton
@@ -43,7 +47,7 @@
                             tooltip
                             title="View Info"
                             :to="{ name: 'DataManagerJob', params: { id: jobs[row.index]['encId'] } }">
-                            <span class="fa fa-info-circle" />
+                            <FontAwesomeIcon :icon="faInfoCircle" />
                         </GButton>
 
                         <GButton
@@ -57,7 +61,7 @@
                 </template>
 
                 <template v-slot:row-details="row">
-                    <b-card>
+                    <BCard>
                         <h2 class="h-text">Command Line</h2>
 
                         <pre class="code"><code class="command-line">{{ row.item.commandLine }}</code></pre>
@@ -65,7 +69,7 @@
                         <template v-slot:footer>
                             <GButton class="mt-3" @click="row.toggleDetails"> Hide Info </GButton>
                         </template>
-                    </b-card>
+                    </BCard>
                 </template>
             </GTable>
         </div>
@@ -73,7 +77,21 @@
 </template>
 
 <script>
+import { faInfoCircle, faRedo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
+import {
+    BBreadcrumb,
+    BButton,
+    BCard,
+    BCol,
+    BContainer,
+    BFormGroup,
+    BFormInput,
+    BInputGroup,
+    BInputGroupAppend,
+    BRow,
+} from "bootstrap-vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
 
@@ -85,6 +103,17 @@ import GTable from "@/components/Common/GTable.vue";
 export default {
     components: {
         Alert,
+        BBreadcrumb,
+        BButton,
+        BCard,
+        BCol,
+        BContainer,
+        BFormGroup,
+        BFormInput,
+        BInputGroup,
+        BInputGroupAppend,
+        BRow,
+        FontAwesomeIcon,
         GButton,
         GButtonGroup,
         GTable,
@@ -97,6 +126,8 @@ export default {
     },
     data() {
         return {
+            faInfoCircle,
+            faRedo,
             dataManager: [],
             jobs: [],
             fields: [

--- a/client/src/components/admin/DataManager/DataManagerJobs.vue
+++ b/client/src/components/admin/DataManager/DataManagerJobs.vue
@@ -30,19 +30,14 @@
                     </b-col>
                 </b-row>
             </b-container>
-            <b-table
-                id="jobs-table"
-                :fields="tableFields"
-                :items="tableItems"
-                :filter="filter"
-                hover
-                responsive
-                striped>
+
+            <GTable hover striped :fields="tableFields" :items="tableItems" :filter="filter">
                 <template v-slot:cell(actions)="row">
                     <GButtonGroup>
                         <GButton tooltip title="Rerun" target="_top" :href="jobs[row.index]['runUrl']">
                             <span class="fa fa-redo" />
                         </GButton>
+
                         <GButton
                             :id="'job-' + jobs[row.index]['encId']"
                             tooltip
@@ -50,6 +45,7 @@
                             :to="{ name: 'DataManagerJob', params: { id: jobs[row.index]['encId'] } }">
                             <span class="fa fa-info-circle" />
                         </GButton>
+
                         <GButton
                             v-if="!showCommandLine"
                             outline
@@ -59,16 +55,19 @@
                         </GButton>
                     </GButtonGroup>
                 </template>
+
                 <template v-slot:row-details="row">
                     <b-card>
                         <h2 class="h-text">Command Line</h2>
+
                         <pre class="code"><code class="command-line">{{ row.item.commandLine }}</code></pre>
+
                         <template v-slot:footer>
                             <GButton class="mt-3" @click="row.toggleDetails"> Hide Info </GButton>
                         </template>
                     </b-card>
                 </template>
-            </b-table>
+            </GTable>
         </div>
     </div>
 </template>
@@ -81,12 +80,14 @@ import { getAppRoot } from "@/onload/loadConfig";
 import Alert from "@/components/Alert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
         Alert,
         GButton,
         GButtonGroup,
+        GTable,
     },
     props: {
         id: {

--- a/client/src/components/admin/DataManager/DataManagerJobs.vue
+++ b/client/src/components/admin/DataManager/DataManagerJobs.vue
@@ -35,7 +35,7 @@
                 </BRow>
             </BContainer>
 
-            <GTable hover striped :fields="tableFields" :items="tableItems" :filter="filter">
+            <GTable id="jobs-table" hover striped :fields="tableFields" :items="tableItems" :filter="filter">
                 <template v-slot:cell(actions)="row">
                     <GButtonGroup>
                         <GButton tooltip title="Rerun" target="_top" :href="jobs[row.index]['runUrl']">

--- a/client/src/components/admin/DataManager/DataManagerTable.vue
+++ b/client/src/components/admin/DataManager/DataManagerTable.vue
@@ -1,30 +1,33 @@
 <template>
     <div>
-        <b-breadcrumb v-if="dataTable && !loading" id="breadcrumb" :items="breadcrumbItems" />
+        <BBreadcrumb v-if="dataTable && !loading" id="breadcrumb" :items="breadcrumbItems" />
+
         <Alert :message="message" :variant="status" />
+
         <Alert v-if="viewOnly" message="Not implemented" variant="dark" />
         <Alert v-else-if="loading" message="Waiting for data" status="info" />
         <Alert
             v-else-if="dataTable && !dataTable['data'].length"
             message="There are currently no entries in this tool data table."
             variant="primary" />
-        <b-container v-else-if="dataTable">
-            <b-row>
-                <b-col>
-                    <b-card id="data-table-card" flush>
+        <BContainer v-else-if="dataTable">
+            <BRow>
+                <BCol>
+                    <BCard id="data-table-card" flush>
                         <template v-slot:header>
-                            <b-container>
-                                <b-row align-v="center">
-                                    <b-col cols="auto">
+                            <BContainer>
+                                <BRow align-v="center">
+                                    <BCol cols="auto">
                                         <GButton tooltip :title="buttonLabel" @click="reload()">
-                                            <span class="fa fa-sync" />
+                                            <FontAwesomeIcon :icon="faSync" />
                                         </GButton>
-                                    </b-col>
-                                    <b-col>
+                                    </BCol>
+
+                                    <BCol>
                                         <b>{{ dataTableName }}</b>
-                                    </b-col>
-                                </b-row>
-                            </b-container>
+                                    </BCol>
+                                </BRow>
+                            </BContainer>
                         </template>
 
                         <GTable
@@ -33,15 +36,18 @@
                             striped
                             :fields="fields(dataTable['columns'])"
                             :items="dataTable['data']" />
-                    </b-card>
-                </b-col>
-            </b-row>
-        </b-container>
+                    </BCard>
+                </BCol>
+            </BRow>
+        </BContainer>
     </div>
 </template>
 
 <script>
+import { faSync } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
+import { BBreadcrumb, BCard, BCol, BContainer, BRow } from "bootstrap-vue";
 
 import { getAppRoot } from "@/onload/loadConfig";
 
@@ -52,6 +58,12 @@ import GTable from "@/components/Common/GTable.vue";
 export default {
     components: {
         Alert,
+        BBreadcrumb,
+        BCard,
+        BCol,
+        BContainer,
+        BRow,
+        FontAwesomeIcon,
         GButton,
         GTable,
     },
@@ -63,6 +75,7 @@ export default {
     },
     data() {
         return {
+            faSync,
             dataTable: {},
             viewOnly: false,
             message: "",

--- a/client/src/components/admin/DataManager/DataManagerTable.vue
+++ b/client/src/components/admin/DataManager/DataManagerTable.vue
@@ -26,12 +26,13 @@
                                 </b-row>
                             </b-container>
                         </template>
-                        <b-table
-                            :fields="fields(dataTable['columns'])"
-                            :items="dataTable['data']"
-                            small
+
+                        <GTable
+                            compact
                             hover
-                            striped />
+                            striped
+                            :fields="fields(dataTable['columns'])"
+                            :items="dataTable['data']" />
                     </b-card>
                 </b-col>
             </b-row>
@@ -46,11 +47,13 @@ import { getAppRoot } from "@/onload/loadConfig";
 
 import Alert from "@/components/Alert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
         Alert,
         GButton,
+        GTable,
     },
     props: {
         name: {

--- a/client/src/components/admin/Dependencies/ContainerIndex.vue
+++ b/client/src/components/admin/Dependencies/ContainerIndex.vue
@@ -63,37 +63,43 @@
                 </GButton>
             </b-row>
         </template>
+
         <template v-slot:body>
-            <b-table id="containers-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
+            <GTable id="containers-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
                 <template v-slot:cell(selected)="data">
                     <b-form-checkbox v-model="data.item.selected"></b-form-checkbox>
                 </template>
+
                 <template v-slot:cell(requirement)="row">
                     <requirements :requirements="row.item.requirements" />
                 </template>
+
                 <template v-slot:cell(resolution)="row">
                     <status-display :status="row.item.status" />
                 </template>
+
                 <template v-slot:cell(container)="row">
                     <container-description :container-description="row.item.status.container_description" />
                 </template>
+
                 <template v-slot:cell(resolver)="row">
                     <container-resolver :container-resolver="row.item.status.container_resolver" />
                 </template>
+
                 <template v-slot:cell(tool)="row">
                     <tool-display :tool-id="row.item.tool_id" />
                 </template>
+
                 <template v-slot:row-details="row">
                     <ContainerResolutionDetails :resolution="row.item" />
                 </template>
-            </b-table>
+            </GTable>
         </template>
     </dependency-index-wrapper>
 </template>
+
 <script>
-import BootstrapVue from "bootstrap-vue";
 import _ from "underscore";
-import Vue from "vue";
 
 import { getContainerResolutionToolbox, resolveContainersWithInstall } from "../AdminServices";
 import DependencyIndexMixin from "./DependencyIndexMixin";
@@ -101,14 +107,17 @@ import DependencyIndexMixin from "./DependencyIndexMixin";
 import ContainerResolutionDetails from "./ContainerResolutionDetails.vue";
 import { DESCRIPTION } from "./ContainerResolver.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
-
-Vue.use(BootstrapVue);
+import GTable from "@/components/Common/GTable.vue";
 
 const RESOLVER_TYPE_OPTIONS = _.keys(DESCRIPTION).map((resolverType) => ({ value: resolverType, text: resolverType }));
 RESOLVER_TYPE_OPTIONS.splice(0, 0, { value: null, text: "*any*" });
 
 export default {
-    components: { ContainerResolutionDetails, GButton },
+    components: {
+        ContainerResolutionDetails,
+        GButton,
+        GTable,
+    },
     mixins: [DependencyIndexMixin],
     data() {
         return {

--- a/client/src/components/admin/Dependencies/ContainerIndex.vue
+++ b/client/src/components/admin/Dependencies/ContainerIndex.vue
@@ -1,93 +1,98 @@
 <template>
-    <dependency-index-wrapper
+    <DependencyIndexWrapper
         :error="error"
         :loading="loading"
         loading-message="Loading container resolution information">
         <template v-slot:header>
-            <b-row class="m-1">
-                <b-form inline>
+            <BRow class="m-1">
+                <BForm inline>
                     <b>Resolution:</b>
                     <label class="mr-sm-2" for="manage-container-type">Resolve containers of type</label>
-                    <b-form-select
+
+                    <BFormSelect
                         id="manage-container-type"
                         v-model="containerType"
                         class="mb-2 mr-sm-2 mb-sm-0"
-                        :options="containerTypeOptions"></b-form-select>
+                        :options="containerTypeOptions" />
                     <label class="mr-sm-2" for="manage-resolver-type">using resolvers of type</label>
-                    <b-form-select
+
+                    <BFormSelect
                         id="manage-resolver-type"
                         v-model="resolverType"
                         class="mb-2 mr-sm-2 mb-sm-0"
-                        :options="resolverTypeOptions"></b-form-select>
-                </b-form>
-            </b-row>
-            <b-row class="m-1">
-                <b-form inline>
+                        :options="resolverTypeOptions" />
+                </BForm>
+            </BRow>
+
+            <BRow class="m-1">
+                <BForm inline>
                     <b>Filter:</b>
+
                     <label class="mr-sm-2" for="manage-filter-resolution">Resolution</label>
-                    <b-form-select
-                        id="manage-filter-resolution"
-                        v-model="filterResolution"
-                        class="mb-2 mr-sm-2 mb-sm-0">
+
+                    <BFormSelect id="manage-filter-resolution" v-model="filterResolution" class="mb-2 mr-sm-2 mb-sm-0">
                         <option :value="null">*any*</option>
                         <option value="unresolved">Unresolved</option>
                         <option value="resolved">Resolved</option>
-                    </b-form-select>
-                    <label v-if="filterResolution != 'unresolved'" class="mr-sm-2" for="manage-filter-container-type"
-                        >Containers of type</label
-                    >
-                    <b-form-select
+                    </BFormSelect>
+
+                    <label v-if="filterResolution != 'unresolved'" class="mr-sm-2" for="manage-filter-container-type">
+                        Containers of type
+                    </label>
+
+                    <BFormSelect
                         v-if="filterResolution != 'unresolved'"
                         id="manage-filter-container-type"
                         v-model="filterContainerType"
                         class="mb-2 mr-sm-2 mb-sm-0"
-                        :options="containerTypeOptions"></b-form-select>
-                    <label v-if="filterResolution != 'unresolved'" class="mr-sm-2" for="manage-filter-resolver-type"
-                        >Resolvers of type</label
-                    >
-                    <b-form-select
+                        :options="containerTypeOptions" />
+
+                    <label v-if="filterResolution != 'unresolved'" class="mr-sm-2" for="manage-filter-resolver-type">
+                        Resolvers of type
+                    </label>
+
+                    <BFormSelect
                         v-if="filterResolution != 'unresolved'"
                         id="manage-filter-resolver-type"
                         v-model="filterResolverType"
                         class="mb-2 mr-sm-2 mb-sm-0"
-                        :options="resolverTypeOptions"></b-form-select>
-                </b-form>
-            </b-row>
+                        :options="resolverTypeOptions" />
+                </BForm>
+            </BRow>
         </template>
         <template v-slot:actions>
-            <b-row class="m-1">
+            <BRow class="m-1">
                 <GButton class="mb-2 mr-sm-2 mb-sm-0" @click="installSelected">
-                    <!-- v-bind:disabled="!hasSelection"  -->
-                    <span class="fa fa-plus" />
+                    <FontAwesomeIcon :icon="faPlus" />
                     Attempt Build
                 </GButton>
-            </b-row>
+            </BRow>
         </template>
 
         <template v-slot:body>
             <GTable id="containers-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
                 <template v-slot:cell(selected)="data">
-                    <b-form-checkbox v-model="data.item.selected"></b-form-checkbox>
+                    <BFormCheckbox v-model="data.item.selected" />
                 </template>
 
                 <template v-slot:cell(requirement)="row">
-                    <requirements :requirements="row.item.requirements" />
+                    <Requirements :requirements="row.item.requirements" />
                 </template>
 
                 <template v-slot:cell(resolution)="row">
-                    <status-display :status="row.item.status" />
+                    <StatusDisplay :status="row.item.status" />
                 </template>
 
                 <template v-slot:cell(container)="row">
-                    <container-description :container-description="row.item.status.container_description" />
+                    <ContainerDescription :container-description="row.item.status.container_description" />
                 </template>
 
                 <template v-slot:cell(resolver)="row">
-                    <container-resolver :container-resolver="row.item.status.container_resolver" />
+                    <ContainerResolver :container-resolver="row.item.status.container_resolver" />
                 </template>
 
                 <template v-slot:cell(tool)="row">
-                    <tool-display :tool-id="row.item.tool_id" />
+                    <ToolDisplay :tool-id="row.item.tool_id" />
                 </template>
 
                 <template v-slot:row-details="row">
@@ -95,17 +100,25 @@
                 </template>
             </GTable>
         </template>
-    </dependency-index-wrapper>
+    </DependencyIndexWrapper>
 </template>
 
 <script>
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BForm, BFormCheckbox, BFormSelect, BRow } from "bootstrap-vue";
 import _ from "underscore";
 
 import { getContainerResolutionToolbox, resolveContainersWithInstall } from "../AdminServices";
 import DependencyIndexMixin from "./DependencyIndexMixin";
 
-import ContainerResolutionDetails from "./ContainerResolutionDetails.vue";
-import { DESCRIPTION } from "./ContainerResolver.vue";
+import ContainerDescription from "@/components/admin/Dependencies/ContainerDescription.vue";
+import ContainerResolutionDetails from "@/components/admin/Dependencies/ContainerResolutionDetails.vue";
+import ContainerResolver, { DESCRIPTION } from "@/components/admin/Dependencies/ContainerResolver.vue";
+import DependencyIndexWrapper from "@/components/admin/Dependencies/DependencyIndexWrapper.vue";
+import Requirements from "@/components/admin/Dependencies/Requirements.vue";
+import StatusDisplay from "@/components/admin/Dependencies/StatusDisplay.vue";
+import ToolDisplay from "@/components/admin/Dependencies/ToolDisplay.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GTable from "@/components/Common/GTable.vue";
 
@@ -114,13 +127,25 @@ RESOLVER_TYPE_OPTIONS.splice(0, 0, { value: null, text: "*any*" });
 
 export default {
     components: {
+        BForm,
+        BFormCheckbox,
+        BFormSelect,
+        BRow,
+        ContainerDescription,
         ContainerResolutionDetails,
+        ContainerResolver,
+        DependencyIndexWrapper,
+        FontAwesomeIcon,
         GButton,
         GTable,
+        Requirements,
+        StatusDisplay,
+        ToolDisplay,
     },
     mixins: [DependencyIndexMixin],
     data() {
         return {
+            faPlus,
             error: null,
             loading: true,
             fields: [

--- a/client/src/components/admin/Dependencies/ContainerIndex.vue
+++ b/client/src/components/admin/Dependencies/ContainerIndex.vue
@@ -8,14 +8,13 @@
                 <BForm inline>
                     <b>Resolution:</b>
                     <label class="mr-sm-2" for="manage-container-type">Resolve containers of type</label>
-
                     <BFormSelect
                         id="manage-container-type"
                         v-model="containerType"
                         class="mb-2 mr-sm-2 mb-sm-0"
                         :options="containerTypeOptions" />
-                    <label class="mr-sm-2" for="manage-resolver-type">using resolvers of type</label>
 
+                    <label class="mr-sm-2" for="manage-resolver-type">using resolvers of type</label>
                     <BFormSelect
                         id="manage-resolver-type"
                         v-model="resolverType"
@@ -27,9 +26,7 @@
             <BRow class="m-1">
                 <BForm inline>
                     <b>Filter:</b>
-
                     <label class="mr-sm-2" for="manage-filter-resolution">Resolution</label>
-
                     <BFormSelect id="manage-filter-resolution" v-model="filterResolution" class="mb-2 mr-sm-2 mb-sm-0">
                         <option :value="null">*any*</option>
                         <option value="unresolved">Unresolved</option>
@@ -39,7 +36,6 @@
                     <label v-if="filterResolution != 'unresolved'" class="mr-sm-2" for="manage-filter-container-type">
                         Containers of type
                     </label>
-
                     <BFormSelect
                         v-if="filterResolution != 'unresolved'"
                         id="manage-filter-container-type"
@@ -50,7 +46,6 @@
                     <label v-if="filterResolution != 'unresolved'" class="mr-sm-2" for="manage-filter-resolver-type">
                         Resolvers of type
                     </label>
-
                     <BFormSelect
                         v-if="filterResolution != 'unresolved'"
                         id="manage-filter-resolver-type"
@@ -60,6 +55,7 @@
                 </BForm>
             </BRow>
         </template>
+
         <template v-slot:actions>
             <BRow class="m-1">
                 <GButton class="mb-2 mr-sm-2 mb-sm-0" @click="installSelected">
@@ -150,11 +146,11 @@ export default {
             loading: true,
             fields: [
                 { key: "selected", label: "" },
-                { key: "tool" },
+                { key: "tool", label: "Tool" },
                 { key: "requirement", label: "Requirements" },
-                { key: "resolution" },
-                { key: "resolver" },
-                { key: "container" },
+                { key: "resolution", label: "Resolution" },
+                { key: "resolver", label: "Resolver" },
+                { key: "container", label: "Container" },
             ],
             containerType: null,
             containerTypeOptions: [

--- a/client/src/components/admin/Dependencies/ContainerIndex.vue
+++ b/client/src/components/admin/Dependencies/ContainerIndex.vue
@@ -66,7 +66,13 @@
         </template>
 
         <template v-slot:body>
-            <GTable id="containers-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
+            <GTable
+                id="containers-table"
+                striped
+                clickable-rows
+                :fields="fields"
+                :items="items"
+                @row-click="showRowDetails($event)">
                 <template v-slot:cell(selected)="data">
                     <BFormCheckbox v-model="data.item.selected" />
                 </template>

--- a/client/src/components/admin/Dependencies/DependencyIndexMixin.js
+++ b/client/src/components/admin/Dependencies/DependencyIndexMixin.js
@@ -38,10 +38,8 @@ export default {
         },
     },
     methods: {
-        showRowDetails(row, index, e) {
-            if (e.target.nodeName != "A") {
-                row._showDetails = !row._showDetails;
-            }
+        showRowDetails({ toggleDetails }) {
+            toggleDetails();
         },
         handleError(e) {
             this.error = e;

--- a/client/src/components/admin/Dependencies/ResolutionIndex.vue
+++ b/client/src/components/admin/Dependencies/ResolutionIndex.vue
@@ -1,62 +1,58 @@
 <template>
-    <dependency-index-wrapper
+    <DependencyIndexWrapper
         :error="error"
         :loading="loading"
         loading-message="Loading tool requirement resolution information">
         <template v-slot:header>
-            <b-row class="m-1">
-                <b-form inline>
+            <BRow class="m-1">
+                <BForm inline>
                     <b>Resolution:</b>
                     <label class="mr-sm-2" for="manage-resolver-type">Using resolvers of type</label>
-                    <b-form-select
+                    <BFormSelect
                         id="manage-resolver-type"
                         v-model="resolverType"
                         class="mb-2 mr-sm-2 mb-sm-0"
-                        :options="resolverTypeOptions"></b-form-select>
-                </b-form>
-            </b-row>
-            <b-row class="m-1">
-                <b-form inline>
+                        :options="resolverTypeOptions" />
+                </BForm>
+            </BRow>
+
+            <BRow class="m-1">
+                <BForm inline>
                     <b>Filter:</b>
                     <label class="mr-sm-2" for="manage-filter-resolution">Resolution</label>
-                    <b-form-select
-                        id="manage-filter-resolution"
-                        v-model="filterResolution"
-                        class="mb-2 mr-sm-2 mb-sm-0">
+                    <BFormSelect id="manage-filter-resolution" v-model="filterResolution" class="mb-2 mr-sm-2 mb-sm-0">
                         <option :value="null">*any*</option>
                         <option value="unresolved">Unresolved</option>
                         <option value="resolved">Resolved</option>
-                    </b-form-select>
-                </b-form>
-            </b-row>
+                    </BFormSelect>
+                </BForm>
+            </BRow>
         </template>
 
         <template v-slot:body>
             <GTable id="requirements-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
                 <template v-slot:cell(selected)="data">
-                    <b-form-checkbox
-                        v-model="data.item.selected"
-                        @change="changeToggleCheckboxState($event)"></b-form-checkbox>
+                    <BFormCheckbox v-model="data.item.selected" @change="changeToggleCheckboxState($event)" />
                 </template>
 
                 <template v-slot:head(selected)="">
-                    <b-form-checkbox v-model="toggleState" @change="toggleSelectAll"></b-form-checkbox>
+                    <BFormCheckbox v-model="toggleState" @change="toggleSelectAll" />
                 </template>
 
                 <template v-slot:cell(requirement)="row">
-                    <requirements :requirements="row.item.requirements" />
+                    <Requirements :requirements="row.item.requirements" />
                 </template>
 
                 <template v-slot:cell(resolution)="row">
-                    <statuses :statuses="row.item.status" />
+                    <Statuses :statuses="row.item.status" />
                 </template>
 
                 <template v-slot:cell(tools)="row">
-                    <tools :tool-ids="row.item.tool_ids" />
+                    <Tools :tool-ids="row.item.tool_ids" />
                 </template>
 
                 <template v-slot:cell(tool)="row">
-                    <tool-display :tool-id="row.item.tool" />
+                    <ToolDisplay :tool-id="row.item.tool" />
                 </template>
 
                 <template v-slot:row-details="row">
@@ -66,37 +62,46 @@
         </template>
 
         <template v-slot:actions>
-            <b-row class="m-1">
+            <BRow class="m-1">
                 <GButton class="m-1" @click="installSelected">
-                    <span class="fa fa-plus" />
-                    <!-- v-bind:disabled="!hasSelection"  -->
+                    <FontAwesomeIcon :icon="faPlus" />
                     Install
                 </GButton>
+
                 <GButton class="m-1" @click="uninstallSelected">
-                    <span class="fa fa-minus" />
-                    <!-- v-bind:disabled="!hasSelection"  -->
+                    <FontAwesomeIcon :icon="faMinus" />
                     Uninstall
                 </GButton>
+
                 <GButton v-if="!expandToolIds" class="m-1" @click="setExpandToolIds(true)">
-                    <span class="fa fa-chevron-down" />
+                    <FontAwesomeIcon :icon="faChevronDown" />
                     Expand Tools
                 </GButton>
+
                 <GButton v-if="expandToolIds" class="m-1" @click="setExpandToolIds(false)">
-                    <span class="fa fa-chevron-up" />
+                    <FontAwesomeIcon :icon="faChevronUp" />
                     Group by Requirements
                 </GButton>
-            </b-row>
+            </BRow>
         </template>
-    </dependency-index-wrapper>
+    </DependencyIndexWrapper>
 </template>
 
 <script>
+import { faChevronDown, faChevronUp, faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BForm, BFormCheckbox, BFormSelect, BRow } from "bootstrap-vue";
 import _ from "underscore";
 
 import { getToolboxDependencies, installDependencies, uninstallDependencies } from "../AdminServices";
 import DependencyIndexMixin from "./DependencyIndexMixin";
 
 import ResolutionDetails from "./ResolutionDetails.vue";
+import DependencyIndexWrapper from "@/components/admin/Dependencies/DependencyIndexWrapper.vue";
+import Requirements from "@/components/admin/Dependencies/Requirements.vue";
+import Statuses from "@/components/admin/Dependencies/Statuses.vue";
+import ToolDisplay from "@/components/admin/Dependencies/ToolDisplay.vue";
+import Tools from "@/components/admin/Dependencies/Tools.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GTable from "@/components/Common/GTable.vue";
 
@@ -115,13 +120,27 @@ RESOLVER_TYPE_OPTIONS.splice(0, 0, { value: null, text: "*any*" });
 
 export default {
     components: {
-        ResolutionDetails,
+        BForm,
+        BFormCheckbox,
+        BFormSelect,
+        BRow,
+        FontAwesomeIcon,
+        DependencyIndexWrapper,
         GButton,
         GTable,
+        ResolutionDetails,
+        Requirements,
+        Statuses,
+        ToolDisplay,
+        Tools,
     },
     mixins: [DependencyIndexMixin],
     data() {
         return {
+            faChevronDown,
+            faChevronUp,
+            faMinus,
+            faPlus,
             toggleState: false,
             expandToolIds: false,
             error: null,

--- a/client/src/components/admin/Dependencies/ResolutionIndex.vue
+++ b/client/src/components/admin/Dependencies/ResolutionIndex.vue
@@ -30,7 +30,13 @@
         </template>
 
         <template v-slot:body>
-            <GTable id="requirements-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
+            <GTable
+                id="requirements-table"
+                striped
+                clickable-rows
+                :fields="fields"
+                :items="items"
+                @row-click="showRowDetails($event)">
                 <template v-slot:cell(selected)="data">
                     <BFormCheckbox v-model="data.item.selected" @change="changeToggleCheckboxState($event)" />
                 </template>

--- a/client/src/components/admin/Dependencies/ResolutionIndex.vue
+++ b/client/src/components/admin/Dependencies/ResolutionIndex.vue
@@ -147,7 +147,11 @@ export default {
             loading: true,
             resolverType: null,
             resolverTypeOptions: RESOLVER_TYPE_OPTIONS,
-            baseFields: [{ key: "selected", label: "" }, { key: "requirement" }, { key: "resolution" }],
+            baseFields: [
+                { key: "selected", label: "" },
+                { key: "requirement", label: "Requirement" },
+                { key: "resolution", label: "Resolution" },
+            ],
             filterResolution: null,
             requirements: [],
         };

--- a/client/src/components/admin/Dependencies/ResolutionIndex.vue
+++ b/client/src/components/admin/Dependencies/ResolutionIndex.vue
@@ -30,33 +30,41 @@
                 </b-form>
             </b-row>
         </template>
+
         <template v-slot:body>
-            <b-table id="requirements-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
+            <GTable id="requirements-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
                 <template v-slot:cell(selected)="data">
                     <b-form-checkbox
                         v-model="data.item.selected"
                         @change="changeToggleCheckboxState($event)"></b-form-checkbox>
                 </template>
+
                 <template v-slot:head(selected)="">
                     <b-form-checkbox v-model="toggleState" @change="toggleSelectAll"></b-form-checkbox>
                 </template>
+
                 <template v-slot:cell(requirement)="row">
                     <requirements :requirements="row.item.requirements" />
                 </template>
+
                 <template v-slot:cell(resolution)="row">
                     <statuses :statuses="row.item.status" />
                 </template>
+
                 <template v-slot:cell(tools)="row">
                     <tools :tool-ids="row.item.tool_ids" />
                 </template>
+
                 <template v-slot:cell(tool)="row">
                     <tool-display :tool-id="row.item.tool" />
                 </template>
+
                 <template v-slot:row-details="row">
                     <ResolutionDetails :resolution="row.item" />
                 </template>
-            </b-table>
+            </GTable>
         </template>
+
         <template v-slot:actions>
             <b-row class="m-1">
                 <GButton class="m-1" @click="installSelected">
@@ -83,17 +91,14 @@
 </template>
 
 <script>
-import BootstrapVue from "bootstrap-vue";
 import _ from "underscore";
-import Vue from "vue";
 
 import { getToolboxDependencies, installDependencies, uninstallDependencies } from "../AdminServices";
 import DependencyIndexMixin from "./DependencyIndexMixin";
 
 import ResolutionDetails from "./ResolutionDetails.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
-
-Vue.use(BootstrapVue);
+import GTable from "@/components/Common/GTable.vue";
 
 export const RESOLVER_DESCRIPTIONS = {
     conda: "",
@@ -109,7 +114,11 @@ const RESOLVER_TYPE_OPTIONS = _.keys(RESOLVER_DESCRIPTIONS).map((resolverType) =
 RESOLVER_TYPE_OPTIONS.splice(0, 0, { value: null, text: "*any*" });
 
 export default {
-    components: { ResolutionDetails, GButton },
+    components: {
+        ResolutionDetails,
+        GButton,
+        GTable,
+    },
     mixins: [DependencyIndexMixin],
     data() {
         return {

--- a/client/src/components/admin/Dependencies/UnusedIndex.vue
+++ b/client/src/components/admin/Dependencies/UnusedIndex.vue
@@ -4,7 +4,7 @@
         :error="error"
         loading-message="Loading tool dependency resolver information">
         <template v-slot:body>
-            <GTable id="unused-paths-table" striped :fields="fields" :items="items">
+            <GTable id="unused-paths-table" striped :fields="fields" :items="items" class="mb-3">
                 <template v-slot:cell(selected)="data">
                     <BFormCheckbox v-model="data.item.selected" />
                 </template>

--- a/client/src/components/admin/Dependencies/UnusedIndex.vue
+++ b/client/src/components/admin/Dependencies/UnusedIndex.vue
@@ -39,7 +39,10 @@ export default {
         return {
             error: null,
             loading: true,
-            fields: [{ key: "selected", label: "" }, { key: "path" }],
+            fields: [
+                { key: "selected", label: "" },
+                { key: "path", label: "Path" },
+            ],
             paths: [],
         };
     },

--- a/client/src/components/admin/Dependencies/UnusedIndex.vue
+++ b/client/src/components/admin/Dependencies/UnusedIndex.vue
@@ -6,7 +6,7 @@
         <template v-slot:body>
             <GTable id="unused-paths-table" striped :fields="fields" :items="items">
                 <template v-slot:cell(selected)="data">
-                    <b-form-checkbox v-model="data.item.selected"></b-form-checkbox>
+                    <BFormCheckbox v-model="data.item.selected" />
                 </template>
             </GTable>
         </template>
@@ -20,6 +20,8 @@
 </template>
 
 <script>
+import { BFormCheckbox } from "bootstrap-vue";
+
 import { deletedUnusedPaths, getDependencyUnusedPaths } from "../AdminServices";
 
 import DependencyIndexWrapper from "./DependencyIndexWrapper.vue";
@@ -28,6 +30,7 @@ import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
+        BFormCheckbox,
         DependencyIndexWrapper,
         GButton,
         GTable,

--- a/client/src/components/admin/Dependencies/UnusedIndex.vue
+++ b/client/src/components/admin/Dependencies/UnusedIndex.vue
@@ -4,12 +4,13 @@
         :error="error"
         loading-message="Loading tool dependency resolver information">
         <template v-slot:body>
-            <b-table id="unused-paths-table" striped :fields="fields" :items="items">
+            <GTable id="unused-paths-table" striped :fields="fields" :items="items">
                 <template v-slot:cell(selected)="data">
                     <b-form-checkbox v-model="data.item.selected"></b-form-checkbox>
                 </template>
-            </b-table>
+            </GTable>
         </template>
+
         <template v-slot:actions>
             <div>
                 <GButton @click="deleteSelected"> Delete Selected Environments </GButton>
@@ -17,14 +18,20 @@
         </template>
     </DependencyIndexWrapper>
 </template>
+
 <script>
 import { deletedUnusedPaths, getDependencyUnusedPaths } from "../AdminServices";
 
 import DependencyIndexWrapper from "./DependencyIndexWrapper.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 export default {
-    components: { DependencyIndexWrapper, GButton },
+    components: {
+        DependencyIndexWrapper,
+        GButton,
+        GTable,
+    },
     data() {
         return {
             error: null,

--- a/client/src/components/admin/DisplayApplications.vue
+++ b/client/src/components/admin/DisplayApplications.vue
@@ -11,10 +11,11 @@
             :setter="setter" />
     </div>
 </template>
+
 <script>
 import { getDisplayApplications, reloadDisplayApplications } from "./AdminServices";
 
-import BaseList from "./BaseList.vue";
+import BaseList from "@/components/admin/BaseList.vue";
 
 export default {
     components: {
@@ -24,10 +25,10 @@ export default {
         return {
             fields: [
                 { key: "execute", label: "Refresh" },
-                { key: "name", sortable: true },
-                { key: "id", sortable: true },
-                { key: "version" },
-                { key: "links" },
+                { key: "name", label: "Name", sortable: true },
+                { key: "id", label: "ID", sortable: true },
+                { key: "version", label: "Version" },
+                { key: "links", label: "Links" },
             ],
             getter: getDisplayApplications,
             setter: reloadDisplayApplications,

--- a/client/src/components/admin/ErrorStack.vue
+++ b/client/src/components/admin/ErrorStack.vue
@@ -2,13 +2,20 @@
     <div>
         <b-alert :show="messageVisible" variant="danger"> {{ messageText }} </b-alert>
         <b-alert :show="infoVisible" variant="info"> No errors available. </b-alert>
-        <b-table v-if="errorStackVisible" striped :fields="errorStackAttributes" :items="errorStack" />
+
+        <GTable v-if="errorStackVisible" striped :fields="errorStackAttributes" :items="errorStack" />
     </div>
 </template>
+
 <script>
 import { getErrorStack } from "./AdminServices";
 
+import GTable from "@/components/Common/GTable.vue";
+
 export default {
+    components: {
+        GTable,
+    },
     data() {
         return {
             errorStack: [],

--- a/client/src/components/admin/ErrorStack.vue
+++ b/client/src/components/admin/ErrorStack.vue
@@ -1,19 +1,23 @@
 <template>
     <div>
-        <b-alert :show="messageVisible" variant="danger"> {{ messageText }} </b-alert>
-        <b-alert :show="infoVisible" variant="info"> No errors available. </b-alert>
+        <BAlert :show="messageVisible" variant="danger"> {{ messageText }} </BAlert>
+
+        <BAlert :show="infoVisible" variant="info"> No errors available. </BAlert>
 
         <GTable v-if="errorStackVisible" striped :fields="errorStackAttributes" :items="errorStack" />
     </div>
 </template>
 
 <script>
+import { BAlert } from "bootstrap-vue";
+
 import { getErrorStack } from "./AdminServices";
 
 import GTable from "@/components/Common/GTable.vue";
 
 export default {
     components: {
+        BAlert,
         GTable,
     },
     data() {

--- a/client/src/components/admin/JobFields.js
+++ b/client/src/components/admin/JobFields.js
@@ -1,10 +1,10 @@
 export const commonJobFields = [
     { key: "id", label: "Encoded Job ID", sortable: true },
     { key: "decoded_job_id", label: "Decoded Job ID", sortable: true },
-    { key: "user_email" },
+    { key: "user_email", label: "User Email", sortable: true },
     { key: "tool_id", label: "Tool", tdClass: ["break-word"] },
-    { key: "state" },
-    { key: "handler" },
-    { key: "job_runner_name", label: "Job Runner" },
+    { key: "state", label: "State", sortable: true },
+    { key: "handler", label: "Handler", sortable: true },
+    { key: "job_runner_name", label: "Job Runner", sortable: true },
     { key: "external_id", label: "PID/Cluster ID", sortable: true },
 ];

--- a/client/src/components/admin/JobsTable.vue
+++ b/client/src/components/admin/JobsTable.vue
@@ -10,16 +10,17 @@
             striped
             caption-top
             :busy="busy"
+            clickable-rows
             class="jobs-table"
             show-empty
-            @row-clicked="toggleDetails">
+            @row-click="onRowClick($event)">
             <template v-slot:table-caption>
                 {{ tableCaption }}
             </template>
 
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading jobs" />
-                <BAlert v-else class="no-jobs" variant="info" show>
+                <BAlert v-else-if="!items || items.length === 0" class="no-jobs" variant="info" show>
                     {{ noItemsMessage }}
                 </BAlert>
             </template>
@@ -144,8 +145,8 @@ export default {
                 item._cellVariants = { state: this.translateState(item.state) };
             });
         },
-        toggleDetails(item) {
-            this.$set(item, "_showDetails", !item._showDetails);
+        onRowClick({ toggleDetails }) {
+            toggleDetails();
         },
         translateState(state) {
             const translateDict = {

--- a/client/src/components/admin/JobsTable.vue
+++ b/client/src/components/admin/JobsTable.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="jobs-table-wrapper">
-        <b-table
+        <GTable
             v-model="innerValue"
             :fields="fields"
             :items="items"
@@ -16,66 +16,81 @@
             <template v-slot:table-caption>
                 {{ tableCaption }}
             </template>
+
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading jobs" />
                 <b-alert v-else class="no-jobs" variant="info" show>
                     {{ noItemsMessage }}
                 </b-alert>
             </template>
+
             <template v-slot:cell(update_time)="data">
                 <UtcDate :date="data.value" mode="elapsed" />
             </template>
+
             <template v-slot:row-details="row">
                 <b-card>
                     <JobDetails :job="row.item" />
                 </b-card>
             </template>
+
             <template v-slot:cell(user_email)="data">
-                <a class="job-filter-link-user" :data-user="data.value" @click="$emit('user-clicked', data.value)">{{
-                    data.value
-                }}</a>
+                <a class="job-filter-link-user" :data-user="data.value" @click="$emit('user-clicked', data.value)">
+                    {{ data.value }}
+                </a>
             </template>
+
             <template v-slot:cell(tool_id)="data">
                 <a
                     class="job-filter-link-tool-id"
                     :data-tool-id="data.value"
-                    @click="$emit('tool-clicked', data.value)"
-                    >{{ data.value }}</a
-                >
+                    @click="$emit('tool-clicked', data.value)">
+                    {{ data.value }}
+                </a>
             </template>
+
             <template v-slot:cell(job_runner_name)="data">
                 <a
                     class="job-filter-link-runner"
                     :data-runner="data.value"
-                    @click="$emit('runner-clicked', data.value)"
-                    >{{ data.value }}</a
-                >
+                    @click="$emit('runner-clicked', data.value)">
+                    {{ data.value }}
+                </a>
             </template>
+
             <template v-slot:cell(handler)="data">
                 <a
                     class="job-filter-link-handler"
                     :data-handler="data.handler"
-                    @click="$emit('handler-clicked', data.value)"
-                    >{{ data.value }}</a
-                >
+                    @click="$emit('handler-clicked', data.value)">
+                    {{ data.value }}
+                </a>
             </template>
+
             <template v-for="(index, name) in $slots" v-slot:[name]>
                 <slot :name="name" />
             </template>
+
             <template v-for="(index, name) in $scopedSlots" v-slot:[name]="data">
                 <slot :name="name" v-bind="data"></slot>
             </template>
-        </b-table>
+        </GTable>
     </div>
 </template>
 
 <script>
+import GTable from "@/components/Common/GTable.vue";
 import JobDetails from "@/components/JobInformation/JobDetails.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
 export default {
-    components: { UtcDate, JobDetails, LoadingSpan },
+    components: {
+        UtcDate,
+        JobDetails,
+        LoadingSpan,
+        GTable,
+    },
     props: {
         tableCaption: {
             type: String,

--- a/client/src/components/admin/JobsTable.vue
+++ b/client/src/components/admin/JobsTable.vue
@@ -19,9 +19,9 @@
 
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading jobs" />
-                <b-alert v-else class="no-jobs" variant="info" show>
+                <BAlert v-else class="no-jobs" variant="info" show>
                     {{ noItemsMessage }}
-                </b-alert>
+                </BAlert>
             </template>
 
             <template v-slot:cell(update_time)="data">
@@ -29,42 +29,42 @@
             </template>
 
             <template v-slot:row-details="row">
-                <b-card>
+                <BCard>
                     <JobDetails :job="row.item" />
-                </b-card>
+                </BCard>
             </template>
 
             <template v-slot:cell(user_email)="data">
-                <a class="job-filter-link-user" :data-user="data.value" @click="$emit('user-clicked', data.value)">
+                <GLink class="job-filter-link-user" :data-user="data.value" @click="$emit('user-clicked', data.value)">
                     {{ data.value }}
-                </a>
+                </GLink>
             </template>
 
             <template v-slot:cell(tool_id)="data">
-                <a
+                <GLink
                     class="job-filter-link-tool-id"
                     :data-tool-id="data.value"
                     @click="$emit('tool-clicked', data.value)">
                     {{ data.value }}
-                </a>
-            </template>
-
-            <template v-slot:cell(job_runner_name)="data">
-                <a
-                    class="job-filter-link-runner"
-                    :data-runner="data.value"
-                    @click="$emit('runner-clicked', data.value)">
-                    {{ data.value }}
-                </a>
+                </GLink>
             </template>
 
             <template v-slot:cell(handler)="data">
-                <a
+                <GLink
                     class="job-filter-link-handler"
                     :data-handler="data.handler"
                     @click="$emit('handler-clicked', data.value)">
                     {{ data.value }}
-                </a>
+                </GLink>
+            </template>
+
+            <template v-slot:cell(job_runner_name)="data">
+                <GLink
+                    class="job-filter-link-runner"
+                    :data-runner="data.value"
+                    @click="$emit('runner-clicked', data.value)">
+                    {{ data.value }}
+                </GLink>
             </template>
 
             <template v-for="(index, name) in $slots" v-slot:[name]>
@@ -79,6 +79,9 @@
 </template>
 
 <script>
+import { BAlert, BCard } from "bootstrap-vue";
+
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import JobDetails from "@/components/JobInformation/JobDetails.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
@@ -86,10 +89,13 @@ import UtcDate from "@/components/UtcDate.vue";
 
 export default {
     components: {
-        UtcDate,
+        BAlert,
+        BCard,
+        GLink,
+        GTable,
         JobDetails,
         LoadingSpan,
-        GTable,
+        UtcDate,
     },
     props: {
         tableCaption: {

--- a/client/src/components/admin/ResetMetadata.vue
+++ b/client/src/components/admin/ResetMetadata.vue
@@ -8,10 +8,11 @@
         :getter="getter"
         :setter="setter" />
 </template>
+
 <script>
 import { getInstalledRepositories, resetRepositoryMetadata } from "./AdminServices";
 
-import BaseList from "./BaseList.vue";
+import BaseList from "@/components/admin/BaseList.vue";
 
 export default {
     components: {
@@ -22,7 +23,7 @@ export default {
             fields: [
                 { key: "execute", label: "Reset" },
                 { key: "name", label: "Metadata", sortable: true },
-                { key: "owner", sortable: true },
+                { key: "owner", label: "Owner", sortable: true },
                 { key: "ctx_rev", label: "Revision" },
             ],
             getter: getInstalledRepositories,

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1137,7 +1137,7 @@ admin:
       unused: 'a[contains(text(), "Unused")]'
       resolver_type: '#manage-resolver-type'
       container_type: '#manage-container-type'
-      unused_paths: '#unused-paths-table'
+      unused_paths: '#g-table-container-unused-paths-table'
 
   manage_jobs:
     selectors:
@@ -1203,7 +1203,7 @@ admin:
     dm_data_managers_card: '#data-managers-card'
     dm_jobs_button: '#${data_manager}-jobs'
     dm_jobs_breadcrumb: '#breadcrumb'
-    dm_jobs_table: '#jobs-table'
+    dm_jobs_table: '#g-table-container-jobs-table'
     dm_job: '#job-${job_id}'
     dm_job_breadcrumb: '#breadcrumb'
     dm_job_data_manager_card: '#data-manager-card'


### PR DESCRIPTION
This PR migrates Admin components (`admin/JobsTable.vue`, `admin/Dependencies/ResolutionIndex.vue`, `admin/Dependencies/UnusedIndex.vue`, `admin/Dependencies/ContainerIndex.vue`, `admin/DataManager/DataManagerTable.vue`, `admin/DataManager/DataManagerJob.vue`, `admin/DataManager/DataManagerJobs.vue`, `admin/BaseList.vue`, and `admin/ErrorStack.vue`) from Bootstrap-Vue's components to our `GComponents` as part of the ongoing effort tracked in #21703, and also adds stacked layout support for responsive design and added captionTop prop for optional table caption positioning to `GTable`, and improve its.
|Before|After|
|---|---|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/d2182fe6-56fe-4a61-a61e-15a9400d86d1" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/985c6c42-bef6-4ebb-8e1e-499f935eb0c8" />|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/b961c424-26b5-4f67-b9b5-4fbdf098b662" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/bb1305c7-0c30-4b33-9adb-1677e87b94d9" />|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/ec1c6608-9c22-4e7d-a499-6247f92df434" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/81276590-74b2-471b-b4f2-f6d4fdd72514" />|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/a9106f1d-9bb3-4672-9774-bd3195e270fa" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/42107b6f-f12a-4dd0-b9c2-57d0182d09a5" />|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/b3e93384-23a8-41a5-ba11-b6d8f3652528" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/a32fded6-37ec-499a-bb24-59a7bf67137d" />|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/187cc537-23f8-4ddc-8987-b1e62cbaf6de" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/171ac60e-dbc6-4f1e-9413-3ed18ef33bee" />|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/9a1ed7b3-ad5d-4212-b02d-f2653b7a9542" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/b6dd56fc-d0eb-4955-9498-e03c6f156f58" />|
|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/f68f4747-fb24-4f0c-9f8d-6ee75b865434" />|<img width="1800" height="1040" alt="image" src="https://github.com/user-attachments/assets/64b875ad-f676-4b96-b622-bdf9f590d05c" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
