### PR TITLE
[25.1] Add `builtin_converters` section to integrated tool panel

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -547,12 +547,22 @@ class ToolBox(AbstractToolBox):
         section = ToolSection({"name": "Built-in Converters", "id": id})
         self._tool_panel[id] = section
 
+        # Create a separate section for the integrated tool panel as well
+        # (so panel views that include the section id "builtin_converters" will get this section from the integrated tool panel)
+        integrated_section = ToolSection({"name": "Built-in Converters", "id": id})
+        self._integrated_tool_panel[id] = integrated_section
+
         converters = {
             tool for target in self.app.datatypes_registry.datatype_converters.values() for tool in target.values()
         }
         for tool in converters:
             tool.hidden = False
             section.elems.append_tool(tool)
+            integrated_section.elems.append_tool(tool)
+
+        # Load panel views so built in converter sections are included in panel views that have the id "builtin_converters"
+        if self.app.name == "galaxy":
+            self._load_tool_panel_views()
 
     def can_load_config_file(self, config_filename):
         if config_filename == self.app.config.shed_tool_config_file and not self.app.config.is_set(

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -387,6 +387,13 @@ class TestToolBox(BaseToolBoxTestCase):
             == "github.com/galaxyproject/example/test_tool/0.2"
         )
 
+    def test_builtin_converters_in_integrated_panel(self):
+        self._init_tool()
+        self._add_config("""<toolbox><tool file="tool.xml" /></toolbox>""")
+        toolbox = self.toolbox
+        assert "builtin_converters" in toolbox._tool_panel
+        assert "builtin_converters" in toolbox._integrated_tool_panel
+
     def test_default_lineage(self):
         self.__init_versioned_tools()
         self._add_config("""<toolbox><tool file="tool_v01.xml" /><tool file="tool_v02.xml" /></toolbox>""")


### PR DESCRIPTION
So that any panel views that include this section filter, get this section as well.

Fixes https://github.com/galaxyproject/galaxy/issues/21767

## Should Builtin Converters section always be included in every view?
So, this change only affects those custom panel views that include the `builtin_converters` section filter as follows:
```yml
- type: section
  id: builtin_converters
```

It does not automatically include this section otherwise; which means that of course EDAM views still do not include this section.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
