### PR TITLE
[25.1] Fix Galaxy UI nesting in data manager job info view

### DIFF
--- a/client/src/components/admin/DataManager/DataManagerJob.vue
+++ b/client/src/components/admin/DataManager/DataManagerJob.vue
@@ -38,8 +38,7 @@
                                                     <GButton
                                                         tooltip
                                                         title="View complete info"
-                                                        :href="hdaInfo[i]['infoUrl']"
-                                                        target="galaxy_main">
+                                                        :to="`/datasets/${hdaInfo[i]['encId']}/show_params`">
                                                         <span class="fa fa-info-circle" />
                                                     </GButton>
                                                 </b-col>


### PR DESCRIPTION
Replace legacy `target="galaxy_main"` iframe navigation with Vue Router `:to` navigation for the "View complete info" button in DataManagerJob. The old target caused the entire Galaxy UI to load nested inside its own central panel when clicking the info button.

Fixes https://github.com/galaxyproject/galaxy/issues/21752

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
