### PR TITLE
Migrate tool execution request from api/tools to api/jobs

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -17614,6 +17614,12 @@ export interface components {
         };
         /** JobRequest */
         JobRequest: {
+            /** Credentials Context */
+            credentials_context?:
+                | {
+                      [key: string]: unknown;
+                  }[]
+                | null;
             /** Data Manager Mode */
             data_manager_mode?: string | null;
             /**
@@ -23506,7 +23512,7 @@ export interface components {
             };
             state: components["schemas"]["ToolRequestState"];
             /** State Message */
-            state_message: string | null;
+            state_message?: unknown | null;
         };
         /** ToolRequestImplicitCollectionReference */
         ToolRequestImplicitCollectionReference: {
@@ -23550,7 +23556,7 @@ export interface components {
             };
             state: components["schemas"]["ToolRequestState"];
             /** State Message */
-            state_message: string | null;
+            state_message?: unknown | null;
         };
         /**
          * ToolRequestState

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -23511,8 +23511,7 @@ export interface components {
                 [key: string]: unknown;
             };
             state: components["schemas"]["ToolRequestState"];
-            /** State Message */
-            state_message?: unknown | null;
+            state_message?: components["schemas"]["ToolRequestStateMessage"] | null;
         };
         /** ToolRequestImplicitCollectionReference */
         ToolRequestImplicitCollectionReference: {
@@ -23555,14 +23554,22 @@ export interface components {
                 [key: string]: unknown;
             };
             state: components["schemas"]["ToolRequestState"];
-            /** State Message */
-            state_message?: unknown | null;
+            state_message?: components["schemas"]["ToolRequestStateMessage"] | null;
         };
         /**
          * ToolRequestState
          * @enum {string}
          */
         ToolRequestState: "new" | "submitted" | "failed";
+        /** ToolRequestStateMessage */
+        ToolRequestStateMessage: {
+            /** Err Data */
+            err_data?: {
+                [key: string]: unknown;
+            } | null;
+            /** Err Msg */
+            err_msg: string;
+        };
         /** ToolStep */
         ToolStep: {
             /**

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -17614,6 +17614,8 @@ export interface components {
         };
         /** JobRequest */
         JobRequest: {
+            /** Data Manager Mode */
+            data_manager_mode?: string | null;
             /**
              * history_id
              * @description TODO
@@ -17626,6 +17628,8 @@ export interface components {
             inputs?: {
                 [key: string]: unknown;
             } | null;
+            /** Preferred Object Store ID */
+            preferred_object_store_id?: string | null;
             /**
              * rerun_remap_job_id
              * @description TODO
@@ -17643,6 +17647,8 @@ export interface components {
              * @default true
              */
             strict: boolean;
+            /** Tags */
+            tags?: string[] | null;
             /**
              * tool_id
              * @description TODO

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -227,14 +227,21 @@ function _convertDataValue(value) {
     if (value.batch) {
         return {
             __class__: "Batch",
-            values: value.values.map((v) => ({ src: v.src, id: v.id })),
+            values: value.values.map((v) => _convertDataEntry(v)),
         };
     }
     if (value.values.length === 1) {
-        const v = value.values[0];
-        return { src: v.src, id: v.id };
+        return _convertDataEntry(value.values[0]);
     }
-    return value.values.map((v) => ({ src: v.src, id: v.id }));
+    return value.values.map((v) => _convertDataEntry(v));
+}
+
+function _convertDataEntry(v) {
+    const entry = { src: v.src, id: v.id };
+    if (v.map_over_type) {
+        entry.map_over_type = v.map_over_type;
+    }
+    return entry;
 }
 
 /** Validate value against a regular expression pattern

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -188,7 +188,7 @@ function _buildLevel(inputs, formData, prefix) {
 
 function _convertValue(node, value) {
     if (node.type === "data" || node.type === "data_collection") {
-        return _convertDataValue(value);
+        return _convertDataValue(value, node.multiple);
     }
     if (node.type === "data_column") {
         if (value === null || value === undefined || value === "") {
@@ -220,7 +220,7 @@ function _convertValue(node, value) {
     return value;
 }
 
-function _convertDataValue(value) {
+function _convertDataValue(value, multiple = false) {
     if (!value || !value.values || value.values.length === 0) {
         return null;
     }
@@ -230,7 +230,7 @@ function _convertDataValue(value) {
             values: value.values.map((v) => _convertDataEntry(v)),
         };
     }
-    if (value.values.length === 1) {
+    if (value.values.length === 1 && !multiple) {
         return _convertDataEntry(value.values[0]);
     }
     return value.values.map((v) => _convertDataEntry(v));

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -217,6 +217,15 @@ function _convertValue(node, value) {
         }
         return value;
     }
+    if (node.type === "select" && node.multiple) {
+        if (value === null || value === undefined) {
+            return value;
+        }
+        if (!Array.isArray(value)) {
+            return [value];
+        }
+        return value;
+    }
     return value;
 }
 

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -692,6 +692,16 @@ describe("form component utilities", () => {
             });
         });
 
+        it("should wrap single dataset value as array when multiple is true", () => {
+            const inputs = [{ name: "input1", type: "data", multiple: true }];
+            const formData = {
+                input1: { batch: false, product: false, values: [{ id: "abc123", src: "hda", map_over_type: null }] },
+            };
+            expect(buildNestedState(inputs, formData)).toEqual({
+                input1: [{ src: "hda", id: "abc123" }],
+            });
+        });
+
         it("should return null for empty dataset values", () => {
             const inputs = [{ name: "input1", type: "data" }];
             const formData = { input1: { batch: false, values: [] } };

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -773,6 +773,21 @@ describe("form component utilities", () => {
             expect(buildNestedState(inputs, { val: 2.718 })).toEqual({ val: 2.718 });
         });
 
+        it("should wrap multiple select string value as array", () => {
+            const inputs = [{ name: "sel", type: "select", multiple: true }];
+            expect(buildNestedState(inputs, { sel: "a_check" })).toEqual({ sel: ["a_check"] });
+        });
+
+        it("should preserve multiple select array value", () => {
+            const inputs = [{ name: "sel", type: "select", multiple: true }];
+            expect(buildNestedState(inputs, { sel: ["a", "b"] })).toEqual({ sel: ["a", "b"] });
+        });
+
+        it("should preserve multiple select null value", () => {
+            const inputs = [{ name: "sel", type: "select", multiple: true }];
+            expect(buildNestedState(inputs, { sel: null })).toEqual({ sel: null });
+        });
+
         it("should handle the full tool model from test data", () => {
             // Build formData from the tool model (mimics what visitInputs collects)
             const formData = {};

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -87,7 +87,7 @@ function onVisualize() {
 }
 
 function onRerun() {
-    router.push(`/root?job_id=${props.item.creating_job}`);
+    router.push(`/?job_id=${props.item.creating_job}`);
 }
 </script>
 

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -113,6 +113,7 @@
 import { mapActions, mapState, storeToRefs } from "pinia";
 
 import { canMutateHistory } from "@/api";
+import { buildNestedState } from "@/components/Form/utilities";
 import { useUserToolCredentials } from "@/composables/userToolCredentials";
 import { useConfigStore } from "@/stores/configurationStore";
 import { useHistoryItemsStore } from "@/stores/historyItemsStore";
@@ -122,7 +123,13 @@ import { useTourStore } from "@/stores/tourStore";
 import { useUserStore } from "@/stores/userStore";
 import { useUserToolsServiceCredentialsStore } from "@/stores/userToolsServiceCredentialsStore";
 
-import { getToolFormData, submitJob, updateToolFormData } from "./services";
+import {
+    buildJobResponse,
+    getToolFormData,
+    submitJobRequest,
+    updateToolFormData,
+    waitForToolRequest,
+} from "./services";
 
 import ToolRecommendation from "../ToolRecommendation.vue";
 import ToolCard from "./ToolCard.vue";
@@ -379,7 +386,7 @@ export default {
         onUpdatePreferredObjectStoreId(preferredObjectStoreId) {
             this.preferredObjectStoreId = preferredObjectStoreId;
         },
-        onExecute(config, historyId) {
+        async onExecute(config, historyId) {
             // If a tour is active that was generated for this tool, end it.
             if (this.currentTour?.id.startsWith(`tool-generated-${this.formConfig.id}`)) {
                 this.setTour(undefined);
@@ -391,107 +398,89 @@ export default {
             }
             this.showExecuting = true;
             this.addRecentTool(this.formConfig?.id);
+
+            const nestedInputs = buildNestedState(this.formConfig.inputs, this.formData);
             const jobDef = {
-                history_id: historyId,
                 tool_id: this.formConfig.id,
                 tool_version: this.formConfig.version,
-                tool_uuid: this.toolUuid,
-                __tags: this.tags,
-                inputs: {
-                    ...this.formData,
-                },
+                history_id: historyId,
+                inputs: nestedInputs,
+                use_cached_jobs: this.useCachedJobs || false,
+                send_email_notification: this.useEmail || false,
             };
-            if (this.useEmail) {
-                jobDef.inputs["send_email_notification"] = true;
-            }
             if (this.useJobRemapping) {
-                jobDef.inputs["rerun_remap_job_id"] = this.job_id;
-            }
-            if (this.useCachedJobs) {
-                jobDef.inputs["use_cached_job"] = true;
+                jobDef.rerun_remap_job_id = this.job_id;
             }
             if (this.preferredObjectStoreId) {
                 jobDef.preferred_object_store_id = this.preferredObjectStoreId;
             }
+            if (this.tags?.length) {
+                jobDef.tags = this.tags;
+            }
             if (this.dataManagerMode === "bundle") {
                 jobDef.data_manager_mode = this.dataManagerMode;
             }
-            if (this.formConfig.credentials?.length) {
-                jobDef.credentials_context = this.getCredentialsExecutionContextForTool(
-                    this.formConfig.id,
-                    this.formConfig.version,
-                );
-            }
+
             console.debug("toolForm::onExecute()", jobDef);
             const prevRoute = this.$route.fullPath;
-            submitJob(jobDef).then(
-                (jobResponse) => {
-                    this.submissionRequestFailed = false;
-                    this.showExecuting = false;
-                    let changeRoute = false;
-                    this.startWatchingHistory();
-                    if (jobResponse.produces_entry_points) {
-                        this.showEntryPoints = true;
-                        this.entryPoints = jobResponse.jobs;
+
+            try {
+                const submitResponse = await submitJobRequest(jobDef);
+                const toolRequestId = submitResponse.tool_request_id;
+                const toolRequestDetail = await waitForToolRequest(toolRequestId);
+                const jobResponse = await buildJobResponse(toolRequestDetail);
+
+                this.submissionRequestFailed = false;
+                this.showExecuting = false;
+                this.startWatchingHistory();
+
+                if (jobResponse.produces_entry_points) {
+                    this.showEntryPoints = true;
+                    this.entryPoints = jobResponse.jobs;
+                }
+
+                const nJobs = jobResponse.jobs ? jobResponse.jobs.length : 0;
+                if (nJobs > 0) {
+                    this.showForm = false;
+                    this.saveLatestResponse({
+                        jobDef,
+                        jobResponse,
+                        toolName: this.toolName,
+                    });
+                }
+
+                if (prevRoute === this.$route.fullPath) {
+                    this.$router.push(`/jobs/submission/success`);
+                } else {
+                    if ([true, "true"].includes(config.enable_tool_recommendations)) {
+                        this.showRecommendation = true;
                     }
-                    const nJobs = jobResponse && jobResponse.jobs ? jobResponse.jobs.length : 0;
-                    if (nJobs > 0 && !jobResponse.errors?.length) {
-                        this.showForm = false;
-                        const toolName = this.toolName;
-                        this.saveLatestResponse({
-                            jobDef,
-                            jobResponse,
-                            toolName,
-                        });
-                        changeRoute = prevRoute === this.$route.fullPath;
-                    } else {
-                        const defaultErrorTitle = "Job submission rejected.";
-                        this.showError = true;
-                        this.showForm = true;
-                        if (jobResponse?.errors) {
-                            const nErrors = jobResponse.errors.length;
-                            if (nJobs > 0) {
-                                this.errorTitle = `Job submission for ${nErrors} out of ${
-                                    nJobs + nErrors
-                                } jobs failed.`;
-                            } else {
-                                this.errorTitle = defaultErrorTitle;
-                            }
-                            this.errorContent = jobResponse.errors;
-                        } else {
-                            this.errorTitle = defaultErrorTitle;
-                            this.errorContent = jobResponse;
-                        }
+                    document.querySelector("#center").scrollTop = 0;
+                }
+            } catch (e) {
+                this.showExecuting = false;
+
+                const errorData = e?.response?.data?.err_data;
+                if (errorData) {
+                    const errorEntries = Object.entries(errorData);
+                    if (errorEntries.length > 0) {
+                        this.errorMessage = e?.response?.data?.err_msg;
+                        this.submissionRequestFailed = true;
+                        this.validationScrollTo = errorEntries[0];
+                        return;
                     }
-                    if (changeRoute) {
-                        this.$router.push(`/jobs/submission/success`);
-                    } else {
-                        if ([true, "true"].includes(config.enable_tool_recommendations)) {
-                            this.showRecommendation = true;
-                        }
-                        document.querySelector("#center").scrollTop = 0;
-                    }
-                },
-                (e) => {
-                    this.errorMessage = e?.response?.data?.err_msg;
+                }
+
+                if (e?.response?.data?.err_msg) {
+                    this.errorMessage = e.response.data.err_msg;
                     this.submissionRequestFailed = true;
-                    this.showExecuting = false;
-                    let genericError = true;
-                    const errorData = e && e.response && e.response.data && e.response.data.err_data;
-                    if (errorData) {
-                        const errorEntries = Object.entries(errorData);
-                        if (errorEntries.length > 0) {
-                            this.validationScrollTo = errorEntries[0];
-                            genericError = false;
-                        }
-                    }
-                    if (genericError) {
-                        this.showError = true;
-                        this.errorTitle = "Job submission failed.";
-                        this.errorContent = jobDef;
-                    }
-                },
-            );
+                    return;
+                }
+
+                this.showError = true;
+                this.errorTitle = "Job submission failed.";
+                this.errorContent = e?.message || jobDef;
+            }
         },
     },
 };

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -122,6 +122,7 @@ import { useJobStore } from "@/stores/jobStore";
 import { useTourStore } from "@/stores/tourStore";
 import { useUserStore } from "@/stores/userStore";
 import { useUserToolsServiceCredentialsStore } from "@/stores/userToolsServiceCredentialsStore";
+import { parseBool } from "@/utils/parseBool";
 
 import {
     buildJobResponse,
@@ -460,7 +461,7 @@ export default {
                 if (prevRoute === this.$route.fullPath) {
                     this.$router.push(`/jobs/submission/success`);
                 } else {
-                    if ([true, "true"].includes(config.enable_tool_recommendations)) {
+                    if (parseBool(config.enable_tool_recommendations)) {
                         this.showRecommendation = true;
                     }
                     document.querySelector("#center").scrollTop = 0;

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -420,6 +420,12 @@ export default {
             if (this.dataManagerMode === "bundle") {
                 jobDef.data_manager_mode = this.dataManagerMode;
             }
+            if (this.formConfig.credentials?.length) {
+                jobDef.credentials_context = this.getCredentialsExecutionContextForTool(
+                    this.formConfig.id,
+                    this.formConfig.version,
+                );
+            }
 
             console.debug("toolForm::onExecute()", jobDef);
             const prevRoute = this.$route.fullPath;
@@ -429,6 +435,7 @@ export default {
                 const toolRequestId = submitResponse.tool_request_id;
                 const toolRequestDetail = await waitForToolRequest(toolRequestId);
                 const jobResponse = await buildJobResponse(toolRequestDetail);
+                jobResponse.produces_entry_points = this.formConfig.model_class === "InteractiveTool";
 
                 this.submissionRequestFailed = false;
                 this.showExecuting = false;
@@ -460,19 +467,21 @@ export default {
             } catch (e) {
                 this.showExecuting = false;
 
-                const errorData = e?.response?.data?.err_data;
+                // Check for structured error data from both axios responses and tool request failures
+                const errorData = e?.response?.data?.err_data || e?.err_data;
                 if (errorData) {
                     const errorEntries = Object.entries(errorData);
                     if (errorEntries.length > 0) {
-                        this.errorMessage = e?.response?.data?.err_msg;
+                        this.errorMessage = e?.response?.data?.err_msg || e?.err_msg;
                         this.submissionRequestFailed = true;
                         this.validationScrollTo = errorEntries[0];
                         return;
                     }
                 }
 
-                if (e?.response?.data?.err_msg) {
-                    this.errorMessage = e.response.data.err_msg;
+                const errorMsg = e?.response?.data?.err_msg || e?.err_msg;
+                if (errorMsg) {
+                    this.errorMessage = errorMsg;
                     this.submissionRequestFailed = true;
                     return;
                 }

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -402,6 +402,7 @@ export default {
             const nestedInputs = buildNestedState(this.formConfig.inputs, this.formData);
             const jobDef = {
                 tool_id: this.formConfig.id,
+                tool_uuid: this.toolUuid,
                 tool_version: this.formConfig.version,
                 history_id: historyId,
                 inputs: nestedInputs,

--- a/client/src/components/Tool/services.js
+++ b/client/src/components/Tool/services.js
@@ -56,8 +56,90 @@ export async function getToolFormData(tool_id, tool_version, job_id, history_id)
     }
 }
 
-export async function submitJob(jobDetails) {
-    const url = `${getAppRoot()}api/tools`;
-    const { data } = await axios.post(url, jobDetails);
+/** Submit a job via the async POST /api/jobs endpoint.
+ * Returns { tool_request_id, task_result }.
+ */
+export async function submitJobRequest(jobRequest) {
+    const url = `${getAppRoot()}api/jobs`;
+    const { data } = await axios.post(url, jobRequest);
     return data;
+}
+
+/** Poll GET /api/tool_requests/{id}/state until terminal state.
+ * Returns the ToolRequestDetailedModel on success.
+ * Throws on failure with the state_message from the server.
+ */
+export async function waitForToolRequest(toolRequestId, { pollInterval = 1000, maxAttempts = 600 } = {}) {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const stateUrl = `${getAppRoot()}api/tool_requests/${toolRequestId}/state`;
+        const { data: state } = await axios.get(stateUrl);
+        if (state === "submitted") {
+            const detailUrl = `${getAppRoot()}api/tool_requests/${toolRequestId}`;
+            const { data: detail } = await axios.get(detailUrl);
+            return detail;
+        }
+        if (state === "failed") {
+            const detailUrl = `${getAppRoot()}api/tool_requests/${toolRequestId}`;
+            const { data: detail } = await axios.get(detailUrl);
+            throw new Error(detail.state_message || "Tool request failed");
+        }
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+    throw new Error("Tool request timed out waiting for completion");
+}
+
+/** Fetch output datasets and collections for a completed job.
+ * Returns an array of JobOutputAssociation | JobOutputCollectionAssociation.
+ */
+export async function fetchJobOutputs(jobId) {
+    const url = `${getAppRoot()}api/jobs/${jobId}/outputs`;
+    const { data } = await axios.get(url);
+    return data;
+}
+
+/** Build a JobResponse-compatible object from a completed ToolRequestDetailedModel.
+ * Fetches job outputs and resolves dataset details for the success page.
+ * @param {Object} toolRequestDetail - The ToolRequestDetailedModel from polling
+ * @returns {Object} Compatible with JobResponse { produces_entry_points, jobs, outputs, output_collections }
+ */
+export async function buildJobResponse(toolRequestDetail) {
+    const jobs = toolRequestDetail.jobs.map((j) => ({ id: j.id }));
+
+    // Fetch outputs for all jobs in parallel
+    const allJobOutputs = await Promise.all(jobs.map((j) => fetchJobOutputs(j.id)));
+
+    // Collect dataset and collection IDs from job outputs
+    const datasetFetches = [];
+    const collectionFetches = [];
+
+    for (const jobOutputs of allJobOutputs) {
+        for (const out of jobOutputs) {
+            if (out.dataset) {
+                datasetFetches.push(
+                    axios
+                        .get(`${getAppRoot()}api/datasets/${out.dataset.id}`)
+                        .then((r) => ({ hid: r.data.hid, name: r.data.name })),
+                );
+            }
+            if (out.dataset_collection_instance) {
+                collectionFetches.push(
+                    axios
+                        .get(`${getAppRoot()}api/dataset_collections/${out.dataset_collection_instance.id}`)
+                        .then((r) => ({ hid: r.data.hid, name: r.data.name })),
+                );
+            }
+        }
+    }
+
+    const [outputs, output_collections] = await Promise.all([
+        Promise.all(datasetFetches),
+        Promise.all(collectionFetches),
+    ]);
+
+    return {
+        produces_entry_points: false,
+        jobs,
+        outputs,
+        output_collections,
+    };
 }

--- a/client/src/components/Tool/services.js
+++ b/client/src/components/Tool/services.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+import { GalaxyApi } from "@/api";
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
@@ -60,8 +61,12 @@ export async function getToolFormData(tool_id, tool_version, job_id, history_id)
  * Returns { tool_request_id, task_result }.
  */
 export async function submitJobRequest(jobRequest) {
-    const url = `${getAppRoot()}api/jobs`;
-    const { data } = await axios.post(url, jobRequest);
+    const { data, error } = await GalaxyApi().POST("/api/jobs", {
+        body: jobRequest,
+    });
+    if (error) {
+        rethrowSimple(error);
+    }
     return data;
 }
 
@@ -71,16 +76,28 @@ export async function submitJobRequest(jobRequest) {
  */
 export async function waitForToolRequest(toolRequestId, { pollInterval = 1000, maxAttempts = 600 } = {}) {
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        const stateUrl = `${getAppRoot()}api/tool_requests/${toolRequestId}/state`;
-        const { data: state } = await axios.get(stateUrl);
+        const { data: state, error: stateError } = await GalaxyApi().GET("/api/tool_requests/{id}/state", {
+            params: { path: { id: toolRequestId } },
+        });
+        if (stateError) {
+            rethrowSimple(stateError);
+        }
         if (state === "submitted") {
-            const detailUrl = `${getAppRoot()}api/tool_requests/${toolRequestId}`;
-            const { data: detail } = await axios.get(detailUrl);
+            const { data: detail, error: detailError } = await GalaxyApi().GET("/api/tool_requests/{id}", {
+                params: { path: { id: toolRequestId } },
+            });
+            if (detailError) {
+                rethrowSimple(detailError);
+            }
             return detail;
         }
         if (state === "failed") {
-            const detailUrl = `${getAppRoot()}api/tool_requests/${toolRequestId}`;
-            const { data: detail } = await axios.get(detailUrl);
+            const { data: detail, error: detailError } = await GalaxyApi().GET("/api/tool_requests/{id}", {
+                params: { path: { id: toolRequestId } },
+            });
+            if (detailError) {
+                rethrowSimple(detailError);
+            }
             const stateMessage = detail.state_message;
             const error = new Error(
                 typeof stateMessage === "object" ? stateMessage?.err_msg : stateMessage || "Tool request failed",
@@ -100,8 +117,12 @@ export async function waitForToolRequest(toolRequestId, { pollInterval = 1000, m
  * Returns an array of JobOutputAssociation | JobOutputCollectionAssociation.
  */
 export async function fetchJobOutputs(jobId) {
-    const url = `${getAppRoot()}api/jobs/${jobId}/outputs`;
-    const { data } = await axios.get(url);
+    const { data, error } = await GalaxyApi().GET("/api/jobs/{job_id}/outputs", {
+        params: { path: { job_id: jobId } },
+    });
+    if (error) {
+        rethrowSimple(error);
+    }
     return data;
 }
 
@@ -124,16 +145,20 @@ export async function buildJobResponse(toolRequestDetail) {
         for (const out of jobOutputs) {
             if (out.dataset) {
                 datasetFetches.push(
-                    axios
-                        .get(`${getAppRoot()}api/datasets/${out.dataset.id}`)
-                        .then((r) => ({ hid: r.data.hid, name: r.data.name })),
+                    GalaxyApi()
+                        .GET("/api/datasets/{dataset_id}", {
+                            params: { path: { dataset_id: out.dataset.id } },
+                        })
+                        .then(({ data }) => ({ hid: data.hid, name: data.name })),
                 );
             }
             if (out.dataset_collection_instance) {
                 collectionFetches.push(
-                    axios
-                        .get(`${getAppRoot()}api/dataset_collections/${out.dataset_collection_instance.id}`)
-                        .then((r) => ({ hid: r.data.hid, name: r.data.name })),
+                    GalaxyApi()
+                        .GET("/api/dataset_collections/{hdca_id}", {
+                            params: { path: { hdca_id: out.dataset_collection_instance.id } },
+                        })
+                        .then(({ data }) => ({ hid: data.hid, name: data.name })),
                 );
             }
         }

--- a/client/src/components/Tool/services.js
+++ b/client/src/components/Tool/services.js
@@ -100,13 +100,9 @@ export async function waitForToolRequest(toolRequestId, { pollInterval = 1000, t
 
     if (terminalState === "failed") {
         const stateMessage = detail.state_message;
-        const error = new Error(
-            typeof stateMessage === "object" ? stateMessage?.err_msg : stateMessage || "Tool request failed",
-        );
-        if (typeof stateMessage === "object") {
-            error.err_data = stateMessage?.err_data;
-            error.err_msg = stateMessage?.err_msg;
-        }
+        const error = new Error(stateMessage?.err_msg || "Tool request failed");
+        error.err_data = stateMessage?.err_data;
+        error.err_msg = stateMessage?.err_msg;
         throw error;
     }
 

--- a/client/src/components/Tool/services.js
+++ b/client/src/components/Tool/services.js
@@ -86,7 +86,7 @@ export async function waitForToolRequest(toolRequestId, { pollInterval = 1000, t
             }
             return data;
         },
-        condition: (state) => state === "submitted" || state === "failed",
+        condition: (state) => state !== "new",
         interval: pollInterval,
         timeout,
     });

--- a/client/src/components/Tool/services.js
+++ b/client/src/components/Tool/services.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
 import { GalaxyApi } from "@/api";
+import { pollUntil } from "@/composables/pollUntil";
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
@@ -74,43 +75,42 @@ export async function submitJobRequest(jobRequest) {
  * Returns the ToolRequestDetailedModel on success.
  * Throws on failure with the state_message from the server.
  */
-export async function waitForToolRequest(toolRequestId, { pollInterval = 1000, maxAttempts = 600 } = {}) {
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        const { data: state, error: stateError } = await GalaxyApi().GET("/api/tool_requests/{id}/state", {
-            params: { path: { id: toolRequestId } },
-        });
-        if (stateError) {
-            rethrowSimple(stateError);
-        }
-        if (state === "submitted") {
-            const { data: detail, error: detailError } = await GalaxyApi().GET("/api/tool_requests/{id}", {
+export async function waitForToolRequest(toolRequestId, { pollInterval = 1000, timeout = 600000 } = {}) {
+    const terminalState = await pollUntil({
+        fn: async () => {
+            const { data, error } = await GalaxyApi().GET("/api/tool_requests/{id}/state", {
                 params: { path: { id: toolRequestId } },
             });
-            if (detailError) {
-                rethrowSimple(detailError);
+            if (error) {
+                rethrowSimple(error);
             }
-            return detail;
-        }
-        if (state === "failed") {
-            const { data: detail, error: detailError } = await GalaxyApi().GET("/api/tool_requests/{id}", {
-                params: { path: { id: toolRequestId } },
-            });
-            if (detailError) {
-                rethrowSimple(detailError);
-            }
-            const stateMessage = detail.state_message;
-            const error = new Error(
-                typeof stateMessage === "object" ? stateMessage?.err_msg : stateMessage || "Tool request failed",
-            );
-            if (typeof stateMessage === "object") {
-                error.err_data = stateMessage?.err_data;
-                error.err_msg = stateMessage?.err_msg;
-            }
-            throw error;
-        }
-        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+            return data;
+        },
+        condition: (state) => state === "submitted" || state === "failed",
+        interval: pollInterval,
+        timeout,
+    });
+
+    const { data: detail, error: detailError } = await GalaxyApi().GET("/api/tool_requests/{id}", {
+        params: { path: { id: toolRequestId } },
+    });
+    if (detailError) {
+        rethrowSimple(detailError);
     }
-    throw new Error("Tool request timed out waiting for completion");
+
+    if (terminalState === "failed") {
+        const stateMessage = detail.state_message;
+        const error = new Error(
+            typeof stateMessage === "object" ? stateMessage?.err_msg : stateMessage || "Tool request failed",
+        );
+        if (typeof stateMessage === "object") {
+            error.err_data = stateMessage?.err_data;
+            error.err_msg = stateMessage?.err_msg;
+        }
+        throw error;
+    }
+
+    return detail;
 }
 
 /** Fetch output datasets and collections for a completed job.

--- a/client/src/components/User/Credentials/ServiceCredentialsGroupsList.vue
+++ b/client/src/components/User/Credentials/ServiceCredentialsGroupsList.vue
@@ -268,7 +268,7 @@ function getBadgesFor(group: ServiceCredentialsGroupDetails): CardBadge[] {
             ? "This tool is no longer available."
             : "This tool is using this credentials group. Click to view.",
         label: getToolDisplayName.value(group),
-        to: toolMissing ? undefined : `/root?tool_id=${group.sourceId}&tool_version=${group.sourceVersion}`,
+        to: toolMissing ? undefined : `/?tool_id=${group.sourceId}&tool_version=${group.sourceVersion}`,
     });
 
     if (!toolMissing) {

--- a/client/src/composables/pollUntil.test.ts
+++ b/client/src/composables/pollUntil.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { pollUntil } from "./pollUntil";
+
+describe("pollUntil", () => {
+    it("should return immediately when condition is met on first call", async () => {
+        const fn = vi.fn().mockResolvedValue("done");
+        const result = await pollUntil({
+            fn,
+            condition: (v) => v === "done",
+        });
+        expect(result).toBe("done");
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("should poll until condition is met", async () => {
+        let callCount = 0;
+        const fn = vi.fn().mockImplementation(async () => {
+            callCount++;
+            return callCount >= 3 ? "ready" : "pending";
+        });
+        const result = await pollUntil({
+            fn,
+            condition: (v) => v === "ready",
+            interval: 10,
+        });
+        expect(result).toBe("ready");
+        expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it("should throw on timeout", async () => {
+        const fn = vi.fn().mockResolvedValue("pending");
+        await expect(
+            pollUntil({
+                fn,
+                condition: (v) => v === "done",
+                interval: 10,
+                timeout: 50,
+            }),
+        ).rejects.toThrow("Polling timed out");
+    });
+
+    it("should propagate errors from fn", async () => {
+        const fn = vi.fn().mockRejectedValue(new Error("network error"));
+        await expect(
+            pollUntil({
+                fn,
+                condition: () => true,
+            }),
+        ).rejects.toThrow("network error");
+    });
+
+    it("should wait the specified interval between polls", async () => {
+        let callCount = 0;
+        const fn = vi.fn().mockImplementation(async () => {
+            callCount++;
+            return callCount >= 2 ? "done" : "pending";
+        });
+        const start = Date.now();
+        await pollUntil({
+            fn,
+            condition: (v) => v === "done",
+            interval: 100,
+        });
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeGreaterThanOrEqual(80);
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("should work with complex result types", async () => {
+        const fn = vi.fn().mockResolvedValue({ status: "complete", value: 42 });
+        const result = await pollUntil({
+            fn,
+            condition: (r) => r.status === "complete",
+        });
+        expect(result).toEqual({ status: "complete", value: 42 });
+    });
+});

--- a/client/src/composables/pollUntil.test.ts
+++ b/client/src/composables/pollUntil.test.ts
@@ -71,7 +71,7 @@ describe("pollUntil", () => {
         const fn = vi.fn().mockResolvedValue({ status: "complete", value: 42 });
         const result = await pollUntil({
             fn,
-            condition: (r) => r.status === "complete",
+            condition: (r: { status: string; value: number }) => r.status === "complete",
         });
         expect(result).toEqual({ status: "complete", value: 42 });
     });

--- a/client/src/composables/pollUntil.ts
+++ b/client/src/composables/pollUntil.ts
@@ -1,0 +1,30 @@
+/**
+ * Polls an async function until a condition is met or timeout is reached.
+ * Returns the final result that satisfied the condition.
+ *
+ * @param fn - Async function to call on each poll iteration.
+ * @param condition - Predicate that determines when polling should stop.
+ * @param interval - Milliseconds between poll attempts (default: 1000).
+ * @param timeout - Maximum milliseconds before throwing a timeout error (default: 600000).
+ */
+export async function pollUntil<T>({
+    fn,
+    condition,
+    interval = 1000,
+    timeout = 600000,
+}: {
+    fn: () => Promise<T>;
+    condition: (result: T) => boolean;
+    interval?: number;
+    timeout?: number;
+}): Promise<T> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        const result = await fn();
+        if (condition(result)) {
+            return result;
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+    throw new Error("Polling timed out");
+}

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -231,7 +231,6 @@ export function getRouter(Galaxy) {
                     ...StorageRoutes,
                     {
                         path: "",
-                        alias: "root",
                         component: Home,
                         props: (route) => ({ config: Galaxy.config, query: route.query }),
                     },

--- a/client/src/utils/parseBool.test.ts
+++ b/client/src/utils/parseBool.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { parseBool } from "./parseBool";
+
+describe("parseBool", () => {
+    it("should return true for boolean true", () => {
+        expect(parseBool(true)).toBe(true);
+    });
+
+    it("should return false for boolean false", () => {
+        expect(parseBool(false)).toBe(false);
+    });
+
+    it("should return true for string 'true'", () => {
+        expect(parseBool("true")).toBe(true);
+    });
+
+    it("should return true for string 'True' (case-insensitive)", () => {
+        expect(parseBool("True")).toBe(true);
+        expect(parseBool("TRUE")).toBe(true);
+    });
+
+    it("should return false for string 'false'", () => {
+        expect(parseBool("false")).toBe(false);
+    });
+
+    it("should return false for other strings", () => {
+        expect(parseBool("yes")).toBe(false);
+        expect(parseBool("1")).toBe(false);
+        expect(parseBool("")).toBe(false);
+    });
+
+    it("should return false for non-boolean non-string values", () => {
+        expect(parseBool(null)).toBe(false);
+        expect(parseBool(undefined)).toBe(false);
+        expect(parseBool(0)).toBe(false);
+        expect(parseBool(1)).toBe(false);
+    });
+});

--- a/client/src/utils/parseBool.ts
+++ b/client/src/utils/parseBool.ts
@@ -1,0 +1,14 @@
+/**
+ * Parses a value to a boolean.
+ * Returns true for boolean `true` or the string `"true"` (case-insensitive).
+ * Returns false for everything else.
+ */
+export function parseBool(value: unknown): boolean {
+    if (typeof value === "boolean") {
+        return value;
+    }
+    if (typeof value === "string") {
+        return value.toLowerCase() === "true";
+    }
+    return false;
+}

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -361,9 +361,7 @@ export function mergeObjectListsById<T extends { id: string; [key: string]: any 
     return mergedList;
 }
 
-export function parseBool(value: string): boolean {
-    return value.toLowerCase() === "true";
-}
+export { parseBool } from "./parseBool";
 
 type MatchObject<T extends string | number | symbol, R> = {
     [_Case in T]: () => R;

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -85,7 +85,7 @@ def cached_create_tool_from_representation(
     app: MinimalManagerApp,
     raw_tool_source: str,
     tool_source_class: TOOL_SOURCE_CLASS,
-    tool_dir: str = "",
+    tool_dir: Optional[str] = None,
 ):
     return create_tool_from_representation(
         app=app, raw_tool_source=raw_tool_source, tool_dir=tool_dir, tool_source_class=tool_source_class
@@ -418,7 +418,7 @@ def queue_jobs(request: QueueJobs, app: MinimalManagerApp, job_submitter: JobSub
     tool = cached_create_tool_from_representation(
         app=app,
         raw_tool_source=raw_tool_source,
-        tool_dir=request.tool_source.tool_dir or "",
+        tool_dir=request.tool_source.tool_dir,
         tool_source_class=tool_source_class,
     )
 

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -418,7 +418,7 @@ def queue_jobs(request: QueueJobs, app: MinimalManagerApp, job_submitter: JobSub
     tool = cached_create_tool_from_representation(
         app=app,
         raw_tool_source=raw_tool_source,
-        tool_dir=request.tool_source.tool_dir,
+        tool_dir=request.tool_source.tool_dir or "",
         tool_source_class=tool_source_class,
     )
 

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -48,10 +48,7 @@ from typing import (
 
 from sqlalchemy import select
 
-from galaxy.exceptions import (
-    AuthenticationRequired,
-    UserActivationRequiredException,
-)
+from galaxy.exceptions import UserActivationRequiredException
 from galaxy.model import (
     Dataset,
     Event,
@@ -220,9 +217,10 @@ class ProvidesUserContext(ProvidesAppContext):
 
     @property
     def async_request_user(self) -> RequestUser:
+        galaxy_session_id = self.galaxy_session.id if self.galaxy_session else None
         if self.user is None:
-            raise AuthenticationRequired("The async task requires user authentication.")
-        return RequestUser(user_id=self.user.id)
+            return RequestUser(galaxy_session_id=galaxy_session_id)
+        return RequestUser(user_id=self.user.id, galaxy_session_id=galaxy_session_id)
 
     @property
     @abc.abstractmethod

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -182,6 +182,7 @@ class HDAManager(
             file_sources=self.app.file_sources,
             sa_session=session,
         )
+        assert request_user.user_id
         user = self.user_manager.by_id(request_user.user_id)
         if request.source == DatasetSourceType.hda:
             dataset_instance: Union[HistoryDatasetAssociation, LibraryDatasetDatasetAssociation] = self.get_accessible(

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -67,7 +67,6 @@ from galaxy.model import (
     Job,
     JobMetricNumeric,
     JobParameter,
-    PostJobAction,
     ToolRequest,
     User,
     Workflow,
@@ -2216,20 +2215,9 @@ class JobSubmitter:
                 credentials_context=credentials_context,
             )
             if request.tags:
-                tag_handler = request_context.tag_handler
-                for _, hda in execution_tracker.output_datasets:
-                    tag_handler.apply_item_tags(
-                        user=request_context.user, item=hda, tags_str=",".join(request.tags), flush=False
-                    )
-                for _, hdca in execution_tracker.output_collections:
-                    tag_handler.apply_item_tags(
-                        user=request_context.user, item=hdca, tags_str=",".join(request.tags), flush=False
-                    )
+                execution_tracker.apply_tags(request_context.tag_handler, request_context.user, request.tags)
             if request.send_email_notification:
-                if request_context.user is None:
-                    raise Exception("Anonymously run jobs cannot send an email notification.")
-                for job in execution_tracker.successful_jobs:
-                    job.add_post_job_action(PostJobAction("EmailAction"))
+                execution_tracker.apply_email_action(request_context.user)
             tool_request.state = ToolRequest.states.SUBMITTED
             sa_session.add(tool_request)
             sa_session.commit()

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -89,6 +89,7 @@ from galaxy.schema.schema import (
 from galaxy.schema.tasks import (
     MaterializeDatasetInstanceTaskRequest,
     QueueJobs,
+    RequestUser,
 )
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import (
@@ -2122,8 +2123,10 @@ class JobSubmitter:
     def materialize_request_for(
         self, trans: WorkRequestContext, hda: model.HistoryDatasetAssociation
     ) -> MaterializeDatasetInstanceTaskRequest:
+        if trans.user is None:
+            raise RequestParameterInvalidException("Materialization of URL-sourced inputs requires an authenticated user")
         return MaterializeDatasetInstanceTaskRequest(
-            user=trans.async_request_user,
+            user=RequestUser(user_id=trans.user.id),
             history_id=trans.history.id,
             source="hda",
             content=hda.id,

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -40,6 +40,7 @@ from galaxy.exceptions import (
     ConfigDoesNotAllowException,
     InconsistentDatabase,
     ItemAccessibilityException,
+    MessageException,
     ObjectNotFound,
     RequestParameterInvalidException,
     RequestParameterMissingException,
@@ -80,6 +81,7 @@ from galaxy.model.index_filter_util import (
     text_column_filter,
 )
 from galaxy.model.scoped_session import galaxy_scoped_session
+from galaxy.schema.credentials import CredentialsContext
 from galaxy.schema.schema import (
     JobIndexQueryPayload,
     JobIndexSortByEnum,
@@ -2195,6 +2197,11 @@ class JobSubmitter:
                 # here we just created the datasets - lets just materialize them in place
                 # and avoid extra and confusing input copies
                 self.hda_manager.materialize(materialize_request, sa_session(), in_place=True)
+            if request.data_manager_mode:
+                tool_request.request["__data_manager_mode"] = request.data_manager_mode
+            credentials_context = (
+                CredentialsContext(root=cast(Any, request.credentials_context)) if request.credentials_context else None
+            )
             execution_tracker = tool.handle_input_async(
                 request_context,
                 tool_request,
@@ -2203,6 +2210,7 @@ class JobSubmitter:
                 use_cached_job=use_cached_jobs,
                 rerun_remap_job_id=rerun_remap_job_id,
                 preferred_object_store_id=request.preferred_object_store_id,
+                credentials_context=credentials_context,
             )
             if request.tags:
                 tag_handler = request_context.tag_handler
@@ -2225,7 +2233,11 @@ class JobSubmitter:
         except Exception as e:
             log.exception("Problem validating tool state after request created")
             tool_request.state = ToolRequest.states.FAILED
-            tool_request.state_message = str(e)
+            state_message: dict = {"err_msg": str(e)}
+            if isinstance(e, MessageException) and e.extra_error_info:
+                if "err_data" in e.extra_error_info:
+                    state_message["err_data"] = e.extra_error_info["err_data"]
+            tool_request.state_message = cast(Any, state_message)
             sa_session.add(tool_request)
             sa_session.commit()
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -2124,7 +2124,9 @@ class JobSubmitter:
         self, trans: WorkRequestContext, hda: model.HistoryDatasetAssociation
     ) -> MaterializeDatasetInstanceTaskRequest:
         if trans.user is None:
-            raise RequestParameterInvalidException("Materialization of URL-sourced inputs requires an authenticated user")
+            raise RequestParameterInvalidException(
+                "Materialization of URL-sourced inputs requires an authenticated user"
+            )
         return MaterializeDatasetInstanceTaskRequest(
             user=RequestUser(user_id=trans.user.id),
             history_id=trans.history.id,

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -61,6 +61,7 @@ from galaxy.managers.histories import HistoryManager
 from galaxy.managers.lddas import LDDAManager
 from galaxy.managers.users import UserManager
 from galaxy.model import (
+    DynamicTool,
     ImplicitCollectionJobs,
     ImplicitCollectionJobsJobAssociation,
     Job,
@@ -2184,6 +2185,8 @@ class JobSubmitter:
     def queue_jobs(self, tool: Tool, request: QueueJobs) -> None:
         tool_request: ToolRequest = self._tool_request(request.tool_request_id)
         sa_session = self.app.model.context
+        if request.dynamic_tool_id:
+            tool.dynamic_tool = sa_session.get(DynamicTool, request.dynamic_tool_id)
         try:
             request_context = self._context(tool_request, request)
             target_history = request_context.history

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -2230,12 +2230,16 @@ class JobSubmitter:
             sa_session.commit()
 
     def _context(self, tool_request: ToolRequest, request: QueueJobs) -> WorkRequestContext:
-        user = self.user_manager.by_id(request.user.user_id)
+        user = self.user_manager.by_id(request.user.user_id) if request.user.user_id else None
         target_history = tool_request.history
+        galaxy_session = None
+        if request.user.galaxy_session_id:
+            galaxy_session = self.app.model.context.get(model.GalaxySession, request.user.galaxy_session_id)
         trans = WorkRequestContext(
             self.app,
             user,
             history=target_history,
+            galaxy_session=galaxy_session,
         )
         return trans
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -65,6 +65,7 @@ from galaxy.model import (
     Job,
     JobMetricNumeric,
     JobParameter,
+    PostJobAction,
     ToolRequest,
     User,
     Workflow,
@@ -2194,14 +2195,30 @@ class JobSubmitter:
                 # here we just created the datasets - lets just materialize them in place
                 # and avoid extra and confusing input copies
                 self.hda_manager.materialize(materialize_request, sa_session(), in_place=True)
-            tool.handle_input_async(
+            execution_tracker = tool.handle_input_async(
                 request_context,
                 tool_request,
                 tool_state,
                 history=target_history,
                 use_cached_job=use_cached_jobs,
                 rerun_remap_job_id=rerun_remap_job_id,
+                preferred_object_store_id=request.preferred_object_store_id,
             )
+            if request.tags:
+                tag_handler = request_context.tag_handler
+                for _, hda in execution_tracker.output_datasets:
+                    tag_handler.apply_item_tags(
+                        user=request_context.user, item=hda, tags_str=",".join(request.tags), flush=False
+                    )
+                for _, hdca in execution_tracker.output_collections:
+                    tag_handler.apply_item_tags(
+                        user=request_context.user, item=hdca, tags_str=",".join(request.tags), flush=False
+                    )
+            if request.send_email_notification:
+                if request_context.user is None:
+                    raise Exception("Anonymously run jobs cannot send an email notification.")
+                for job in execution_tracker.successful_jobs:
+                    job.add_post_job_action(PostJobAction("EmailAction"))
             tool_request.state = ToolRequest.states.SUBMITTED
             sa_session.add(tool_request)
             sa_session.commit()

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -191,6 +191,7 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
+        assert request.user.user_id
         user_context = self._build_user_context(request.user.user_id)
         export_metadata = self.set_invocation_export_request_metadata(request)
 
@@ -239,6 +240,7 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
+        assert request.user.user_id
         user_context = self._build_user_context(request.user.user_id)
         with model.store.get_export_store_factory(
             self._app, model_store_format, export_files=export_files, user_context=user_context
@@ -257,6 +259,7 @@ class ModelStoreManager:
     def write_history_to(self, request: WriteHistoryTo):
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
+        assert request.user.user_id
         user_context = self._build_user_context(request.user.user_id)
         export_metadata = self.set_history_export_request_metadata(request)
 
@@ -360,6 +363,7 @@ class ModelStoreManager:
             history = self._sa_session.get(model.History, history_id)
         else:
             history = None
+        assert request.user.user_id
         user_context = self._build_user_context(request.user.user_id)
         model_import_store = source_to_import_store(
             request.source_uri,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -4020,7 +4020,7 @@ class ToolRequestModel(Model):
     id: EncodedDatabaseIdField = ToolRequestIdField
     request: dict[str, Any]
     state: ToolRequestState
-    state_message: Optional[str]
+    state_message: Optional[Any] = None
 
 
 class ToolRequestJobReference(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -4016,11 +4016,16 @@ class ToolRequestState(str, Enum):
     FAILED = "failed"
 
 
+class ToolRequestStateMessage(Model):
+    err_msg: str
+    err_data: Optional[dict[str, Any]] = None
+
+
 class ToolRequestModel(Model):
     id: EncodedDatabaseIdField = ToolRequestIdField
     request: dict[str, Any]
     state: ToolRequestState
-    state_message: Optional[Any] = None
+    state_message: Optional[ToolRequestStateMessage] = None
 
 
 class ToolRequestJobReference(Model):

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -43,9 +43,8 @@ class GeneratePdfDownload(Model):
 
 # serialize user info for tasks
 class RequestUser(Model):
-    user_id: int
-    # TODO: allow make the above optional and allow a session_id for anonymous users...
-    # session_id: Optional[str]
+    user_id: Optional[int] = None
+    galaxy_session_id: Optional[int] = None
 
 
 class GenerateHistoryDownload(ShortTermStoreExportPayload):

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -190,3 +190,7 @@ class QueueJobs(Model):
     user: RequestUser  # TODO: test anonymous users through this submission path
     use_cached_jobs: bool
     rerun_remap_job_id: Optional[int]  # link to a job to rerun & remap
+    preferred_object_store_id: Optional[str] = None
+    tags: Optional[list[str]] = None
+    data_manager_mode: Optional[str] = None
+    send_email_notification: bool = False

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -193,3 +193,4 @@ class QueueJobs(Model):
     tags: Optional[list[str]] = None
     data_manager_mode: Optional[str] = None
     send_email_notification: bool = False
+    credentials_context: Optional[list[dict]] = None

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -179,7 +179,7 @@ TOOL_SOURCE_CLASS = Literal["XmlToolSource", "YamlToolSource", "CwlToolSource"]
 
 class ToolSource(Model):
     raw_tool_source: str
-    tool_dir: str
+    tool_dir: Optional[str] = None
     tool_source_class: TOOL_SOURCE_CLASS = "XmlToolSource"
 
 
@@ -194,3 +194,4 @@ class QueueJobs(Model):
     data_manager_mode: Optional[str] = None
     send_email_notification: bool = False
     credentials_context: Optional[list[dict]] = None
+    dynamic_tool_id: Optional[int] = None  # link to DynamicTool for custom/user tools

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -428,7 +428,7 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
 
 
 DataSrcT = Literal["hda", "ldda"]
-MultiDataSrcT = Literal["hda", "ldda", "hdca"]
+MultiDataSrcT = Literal["hda", "ldda", "hdca", "dce"]
 # @jmchilton you meant CollectionSrcT - fix that at some point please.
 CollectionStrT = Literal["hdca"]
 # Internal collection source type - includes dce for subcollection mapping
@@ -462,6 +462,11 @@ class DataRequestLd(LegacyRequestModelAttributes):
 
 class DataRequestHdca(LegacyRequestModelAttributes):
     src: Literal["hdca"] = "hdca"
+    id: StrictStr
+
+
+class DataRequestDce(LegacyRequestModelAttributes):
+    src: Literal["dce"] = "dce"
     id: StrictStr
 
 
@@ -621,6 +626,8 @@ def multi_data_discriminator(v: Any) -> str:
             return "data_request_ldda"
         elif src == "hdca":
             return "data_request_hdca"
+        elif src == "dce":
+            return "data_request_dce"
         elif src == "url":
             return "data_request_uri"
     return ""
@@ -639,6 +646,7 @@ MultiDataInstance: Type = cast(
                 tag(DataRequestHda, "data_request_hda"),
                 tag(DataRequestLdda, "data_request_ldda"),
                 tag(DataRequestHdca, "data_request_hdca"),
+                tag(DataRequestDce, "data_request_dce"),
                 tag(DataRequestUri, "data_request_uri"),
                 tag(DataRequestCollectionUri, "data_request_collection_uri"),
             ]
@@ -661,6 +669,11 @@ class DataRequestInternalLdda(StrictModel):
 
 class DataRequestInternalHdca(StrictModel):
     src: Literal["hdca"]
+    id: StrictInt
+
+
+class DataRequestInternalDce(StrictModel):
+    src: Literal["dce"]
     id: StrictInt
 
 
@@ -941,6 +954,7 @@ DataRequestInternal: Type = cast(
                 tag(DataRequestInternalHda, "data_request_hda"),
                 tag(DataRequestInternalLdda, "data_request_ldda"),
                 tag(DataRequestInternalHdca, "data_request_hdca"),
+                tag(DataRequestInternalDce, "data_request_dce"),
                 tag(DataRequestUri, "data_request_uri"),
                 tag(DataRequestCollectionUri, "data_request_collection_uri"),
             ]
@@ -958,6 +972,7 @@ DataRequestInternalDereferenced: Type = cast(
 class DatasetCollectionElementReference(StrictModel):
     src: Literal["dce"]
     id: StrictInt
+    map_over_type: Optional[str] = None
 
 
 DataJobInternalT = Union[DataRequestInternalHda, DataRequestInternalLdda, DatasetCollectionElementReference]
@@ -996,14 +1011,21 @@ BatchDataInstanceInternal: Type = cast(
 MultiDataInstanceInternal: Type = cast(
     Type,
     Annotated[
-        Union[DataRequestInternalHda, DataRequestInternalLdda, DataRequestInternalHdca, DataRequestUri],
+        Union[
+            DataRequestInternalHda,
+            DataRequestInternalLdda,
+            DataRequestInternalHdca,
+            DataRequestInternalDce,
+            DataRequestUri,
+        ],
         Field(discriminator="src"),
     ],
 )
 MultiDataInstanceInternalDereferenced: Type = cast(
     Type,
     Annotated[
-        Union[DataRequestInternalHda, DataRequestInternalLdda, DataRequestInternalHdca], Field(discriminator="src")
+        Union[DataRequestInternalHda, DataRequestInternalLdda, DataRequestInternalHdca, DataRequestInternalDce],
+        Field(discriminator="src"),
     ],
 )
 
@@ -1518,7 +1540,7 @@ class RulesMapping(StrictModel):
 
 class RulesModel(StrictModel):
     rules: List[Dict[str, Any]]
-    mappings: List[RulesMapping]
+    mapping: List[RulesMapping]
 
 
 class RulesParameterModel(BaseGalaxyToolParameterModelDefinition):

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -963,11 +963,6 @@ DataRequestInternal: Type = cast(
         Field(discriminator=MultiDataInstanceDiscriminator),
     ],
 )
-DataRequestInternalDereferencedT = Union[DataRequestInternalHda, DataRequestInternalLdda]
-DataRequestInternalDereferenced: Type = cast(
-    Type,
-    Annotated[DataRequestInternalDereferencedT, Field(discriminator="src")],
-)
 
 
 class DatasetCollectionElementReference(StrictModel):
@@ -975,6 +970,14 @@ class DatasetCollectionElementReference(StrictModel):
     id: StrictInt
     map_over_type: Optional[str] = None
 
+
+DataRequestInternalDereferencedT = Union[
+    DataRequestInternalHda, DataRequestInternalLdda, DatasetCollectionElementReference
+]
+DataRequestInternalDereferenced: Type = cast(
+    Type,
+    Annotated[DataRequestInternalDereferencedT, Field(discriminator="src")],
+)
 
 DataJobInternalT = Union[DataRequestInternalHda, DataRequestInternalLdda, DatasetCollectionElementReference]
 DataJobInternal: Type = cast(

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -572,7 +572,7 @@ class DataRequestCollectionUri(StrictModel):
 
 
 _DataRequest = Annotated[
-    Union[DataRequestHda, DataRequestLdda, DataRequestLd, DataRequestUri], Field(discriminator="src")
+    Union[DataRequestHda, DataRequestLdda, DataRequestLd, DataRequestDce, DataRequestUri], Field(discriminator="src")
 ]
 DataRequest: Type = cast(Type, _DataRequest)
 
@@ -582,6 +582,7 @@ FileOrCollectionRequest = Annotated[Union[FileRequestUri, DataRequestCollectionU
 DataRequestHda.model_rebuild()
 DataRequestLd.model_rebuild()
 DataRequestLdda.model_rebuild()
+DataRequestDce.model_rebuild()
 DataRequestUri.model_rebuild()
 DataRequestHdca.model_rebuild()
 DataRequestCollectionUri.model_rebuild()

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1321,6 +1321,13 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         """
         if self.require_login and user is None:
             return False
+        if self.dynamic_tool and not self.dynamic_tool.public:
+            if user is None:
+                return False
+            try:
+                self.app.dynamic_tool_manager.ensure_can_use_unprivileged_tool(user)
+            except Exception:
+                return False
         return True
 
     def parse(self, tool_source: ToolSource, guid: Optional[str] = None, dynamic: bool = False) -> None:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1321,13 +1321,19 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         """
         if self.require_login and user is None:
             return False
-        if self.dynamic_tool and not self.dynamic_tool.public:
-            if user is None:
-                return False
+        if self.dynamic_tool:
             try:
-                self.app.dynamic_tool_manager.ensure_can_use_unprivileged_tool(user)
+                is_public = self.dynamic_tool.public
             except Exception:
-                return False
+                # DynamicTool not bound to session, access was validated at load time
+                is_public = True
+            if not is_public:
+                if user is None:
+                    return False
+                try:
+                    self.app.dynamic_tool_manager.ensure_can_use_unprivileged_tool(user)
+                except Exception:
+                    return False
         return True
 
     def parse(self, tool_source: ToolSource, guid: Optional[str] = None, dynamic: bool = False) -> None:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2370,7 +2370,7 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         completed_jobs: dict[int, Optional[model.Job]] = self.completed_jobs(
             request_context, use_cached_job, all_params
         )
-        execute_async(
+        return execute_async(
             request_context,
             self,
             mapping_params,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2393,6 +2393,7 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         credentials_context: Optional[CredentialsContext] = None,
         input_format: InputFormatT = "legacy",
         tags: Optional[list[str]] = None,
+        send_email_notification: bool = False,
     ):
         """
         Process incoming parameters for this tool from the dict `incoming`,
@@ -2424,15 +2425,11 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
             completed_jobs=completed_jobs,
         )
 
-        # Reserved global tags parameter. Applies to all tool outputs.
-        # This may change in the future if per-output tags are introduced.
         if tags:
-            tag_handler = trans.tag_handler
-            for _, hda in execution_tracker.output_datasets:
-                tag_handler.apply_item_tags(user=trans.user, item=hda, tags_str=",".join(tags), flush=False)
-
-            for _, hdca in execution_tracker.output_collections:
-                tag_handler.apply_item_tags(user=trans.user, item=hdca, tags_str=",".join(tags), flush=False)
+            execution_tracker.apply_tags(trans.tag_handler, trans.user, tags)
+            trans.sa_session.commit()
+        if send_email_notification:
+            execution_tracker.apply_email_action(trans.user)
             trans.sa_session.commit()
 
         # Raise an exception if there were jobs to execute and none of them were submitted,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1727,7 +1727,7 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
             parameters = input_models_for_pages(pages, self.profile)
             self.parameters = parameters
         except Exception:
-            pass
+            log.warning("Failed to generate parameter models for tool '%s'", self.id, exc_info=True)
         if pages.inputs_defined:
             if hasattr(pages, "input_elem"):
                 input_elem = pages.input_elem

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -25,7 +25,10 @@ from packaging.version import Version
 
 from galaxy import model
 from galaxy.exceptions import ToolInputsNotOKException
-from galaxy.model import ToolRequest
+from galaxy.model import (
+    PostJobAction,
+    ToolRequest,
+)
 from galaxy.model.dataset_collections.matching import MatchingCollections
 from galaxy.model.dataset_collections.structure import (
     get_structure,
@@ -447,6 +450,19 @@ class ExecutionTracker:
         message = "There was a failure executing a job for tool [%s] - %s"
         log.warning(message, self.tool.id, error)
         self.execution_errors.append(error)
+
+    def apply_tags(self, tag_handler, user, tags: list[str]) -> None:
+        tags_str = ",".join(tags)
+        for _, hda in self.output_datasets:
+            tag_handler.apply_item_tags(user=user, item=hda, tags_str=tags_str, flush=False)
+        for _, hdca in self.output_collections:
+            tag_handler.apply_item_tags(user=user, item=hdca, tags_str=tags_str, flush=False)
+
+    def apply_email_action(self, user) -> None:
+        if user is None:
+            raise Exception("Anonymously run jobs cannot send an email notification.")
+        for job in self.successful_jobs:
+            job.add_post_job_action(PostJobAction("EmailAction"))
 
     @staticmethod
     def _collection_info_to_collection_hids_element_ids(

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -300,7 +300,7 @@ class FetchTools:
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> ToolRequestDetailedModel:
         tool_request = self._get_tool_request_or_raise_not_found(trans, id)
-        return tool_request_detailed_to_model(tool_request)
+        return tool_request_detailed_to_model(tool_request, trans.security)
 
     @router.get(
         "/api/tool_requests/{id}/state",

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -37,16 +37,16 @@ from galaxy.schema.schema import (
     ToolRequestModel,
 )
 from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.short_term_storage import (
+    ShortTermStorageAllocator,
+    ShortTermStorageTarget,
+)
 from galaxy.tool_util.parameters import (
     encode as encode_request,
     input_models_for_tool_source,
 )
 from galaxy.tool_util.parameters.state import RequestInternalToolState
 from galaxy.tool_util.parser import get_tool_source
-from galaxy.short_term_storage import (
-    ShortTermStorageAllocator,
-    ShortTermStorageTarget,
-)
 from galaxy.util import ready_name_for_url
 
 

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -37,6 +37,12 @@ from galaxy.schema.schema import (
     ToolRequestModel,
 )
 from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.tool_util.parameters import (
+    encode as encode_request,
+    input_models_for_tool_source,
+)
+from galaxy.tool_util.parameters.state import RequestInternalToolState
+from galaxy.tool_util.parser import get_tool_source
 from galaxy.short_term_storage import (
     ShortTermStorageAllocator,
     ShortTermStorageTarget,
@@ -201,28 +207,22 @@ def async_task_summary(async_result: AsyncResult) -> AsyncTaskResultSummary:
     )
 
 
-def _encode_request_ids(request: dict[str, Any], security: IdEncodingHelper) -> dict[str, Any]:
-    """Walk the request dict and encode dataset IDs (raw ints → encoded strings).
-
-    Looks for dicts with ``{"id": <int>, "src": "hda"|"hdca"|...}`` and encodes the ``id``.
-    """
-    import copy
-
-    def _walk(obj):
-        if isinstance(obj, dict):
-            if "src" in obj and "id" in obj and isinstance(obj["id"], int):
-                obj = dict(obj)
-                obj["id"] = security.encode_id(obj["id"])
-            return {k: _walk(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
-            return [_walk(item) for item in obj]
-        return obj
-
-    return _walk(copy.deepcopy(request))
+def _encode_tool_request(tool_request: ToolRequest, security: IdEncodingHelper) -> dict[str, Any]:
+    """Encode request IDs using strongly-typed parameter walking."""
+    tool_source_model = tool_request.tool_source
+    raw_tool_source = cast(str, tool_source_model.source)
+    parsed_tool_source = get_tool_source(
+        tool_source_class=tool_source_model.source_class,
+        raw_tool_source=raw_tool_source,
+    )
+    parameter_bundle = input_models_for_tool_source(parsed_tool_source)
+    internal_state = RequestInternalToolState(tool_request.request)
+    encoded_state = encode_request(internal_state, parameter_bundle, security.encode_id)
+    return encoded_state.input_state
 
 
 def tool_request_to_model(tool_request: ToolRequest, security: IdEncodingHelper) -> ToolRequestModel:
-    encoded_request = _encode_request_ids(tool_request.request, security)
+    encoded_request = _encode_tool_request(tool_request, security)
     as_dict = {
         "id": tool_request.id,
         "request": encoded_request,
@@ -233,7 +233,7 @@ def tool_request_to_model(tool_request: ToolRequest, security: IdEncodingHelper)
 
 
 def tool_request_detailed_to_model(tool_request: ToolRequest, security: IdEncodingHelper) -> ToolRequestDetailedModel:
-    encoded_request = _encode_request_ids(tool_request.request, security)
+    encoded_request = _encode_tool_request(tool_request, security)
     jobs = [{"src": "job", "id": job.id} for job in tool_request.jobs]
     implicit_collections = [
         {"src": "hdca", "id": assoc.dataset_collection.id, "output_name": assoc.output_name}

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -547,7 +547,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
     ) -> list[ToolRequestModel]:
         history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
         tool_requests = history.tool_requests
-        return [tool_request_to_model(tr) for tr in tool_requests]
+        return [tool_request_to_model(tr, trans.security) for tr in tool_requests]
 
     def citations(self, trans: ProvidesHistoryContext, history_id: DecodedDatabaseIdField):
         """

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -93,6 +93,7 @@ class JobRequest(BaseModel):
     preferred_object_store_id: Optional[str] = Field(default=None, title="Preferred Object Store ID")
     tags: Optional[list[str]] = Field(default=None, title="Tags")
     data_manager_mode: Optional[str] = Field(default=None, title="Data Manager Mode")
+    credentials_context: Optional[list[dict[str, Any]]] = Field(default=None, title="Credentials Context")
 
 
 class JobCreateResponse(BaseModel):
@@ -293,6 +294,7 @@ class JobsService(ServiceBase):
             tags=job_request.tags,
             data_manager_mode=job_request.data_manager_mode,
             send_email_notification=job_request.send_email_notification,
+            credentials_context=job_request.credentials_context,
         )
         result = queue_jobs.delay(request=task_request)
         return JobCreateResponse(

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -295,6 +295,7 @@ class JobsService(ServiceBase):
             data_manager_mode=job_request.data_manager_mode,
             send_email_notification=job_request.send_email_notification,
             credentials_context=job_request.credentials_context,
+            dynamic_tool_id=tool.dynamic_tool.id if tool.dynamic_tool else None,
         )
         result = queue_jobs.delay(request=task_request)
         return JobCreateResponse(

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -90,6 +90,9 @@ class JobRequest(BaseModel):
         default=None, title="rerun_remap_job_id", description="TODO"
     )
     send_email_notification: bool = Field(default=False, title="Send Email Notification", description="TODO")
+    preferred_object_store_id: Optional[str] = Field(default=None, title="Preferred Object Store ID")
+    tags: Optional[list[str]] = Field(default=None, title="Tags")
+    data_manager_mode: Optional[str] = Field(default=None, title="Data Manager Mode")
 
 
 class JobCreateResponse(BaseModel):
@@ -286,6 +289,10 @@ class JobsService(ServiceBase):
             tool_request_id=tool_request_id,
             use_cached_jobs=job_request.use_cached_jobs or False,
             rerun_remap_job_id=job_request.rerun_remap_job_id,
+            preferred_object_store_id=job_request.preferred_object_store_id,
+            tags=job_request.tags,
+            data_manager_mode=job_request.data_manager_mode,
+            send_email_notification=job_request.send_email_notification,
         )
         result = queue_jobs.delay(request=task_request)
         return JobCreateResponse(

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -32,7 +32,6 @@ from galaxy.managers.tools import (
 )
 from galaxy.model import (
     LibraryDatasetDatasetAssociation,
-    PostJobAction,
     User,
 )
 from galaxy.schema.credentials import CredentialsContext
@@ -369,23 +368,8 @@ class ToolsService(ServiceBase):
             preferred_object_store_id=preferred_object_store_id,
             credentials_context=CredentialsContext(root=credentials_context) if credentials_context else None,
             tags=tags,
+            send_email_notification=inputs.get("send_email_notification", False),
         )
-
-        new_pja_flush = False
-        for job in vars.get("jobs", []):
-            if inputs.get("send_email_notification", False):
-                # Unless an anonymous user is invoking this via the API it
-                # should never be an option, but check and enforce that here
-                if trans.user is None:
-                    raise exceptions.ToolExecutionError("Anonymously run jobs cannot send an email notification.")
-                else:
-                    job_email_action = PostJobAction("EmailAction")
-                    job.add_post_job_action(job_email_action)
-                    new_pja_flush = True
-
-        if new_pja_flush:
-            trans.sa_session.commit()
-
         return self._handle_inputs_output_to_api_response(trans, tool, target_history, vars)
 
     def _handle_inputs_output_to_api_response(self, trans, tool, target_history, vars) -> JobCreateResponse:

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -73,6 +73,9 @@ class WorkRequestContext(ProvidesHistoryContext):
             self.__user_current_roles = super().get_current_user_roles()
         return self.__user_current_roles
 
+    def get_galaxy_session(self):
+        return self.galaxy_session
+
     def set_user(self, user):
         """Set the current user."""
         raise NotImplementedError("Cannot change users from a work request context.")

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -478,6 +478,25 @@ def test_map_over_collection(
 
 
 @requires_tool_id("cat|cat1")
+def test_dce_as_input(target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    """Test using a dataset collection element (dce) as a direct input to a tool.
+
+    This corresponds to drag-and-dropping an individual element from a collection
+    onto a tool input, which sends {"src": "dce", "id": "<dce_id>"} as the input value.
+    """
+    hdca = target_history.with_pair(["123", "456"])
+    collection_details = target_history._dataset_populator.get_history_collection_details(
+        target_history.id, content_id=hdca.id
+    )
+    forward_element = collection_details["elements"][0]
+    assert forward_element["element_identifier"] == "forward"
+    dce_src_dict = {"src": "dce", "id": forward_element["id"]}
+    inputs = tool_input_format.when.any({"input1": dce_src_dict})
+    execute = required_tool.execute().with_inputs(inputs)
+    execute.assert_has_single_job.with_single_output.with_contents_stripped("123")
+
+
+@requires_tool_id("cat|cat1")
 def test_map_over_data_with_paired_or_unpaired_unpaired(target_history: TargetHistory, required_tool: RequiredTool):
     hdca = target_history.with_unpaired()
     execute = required_tool.execute().with_inputs({"input1": {"batch": True, "values": [hdca.src_dict]}})

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -478,7 +478,9 @@ def test_map_over_collection(
 
 
 @requires_tool_id("cat|cat1")
-def test_dce_as_input(target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+def test_dce_as_input(
+    target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
     """Test using a dataset collection element (dce) as a direct input to a tool.
 
     This corresponds to drag-and-dropping an individual element from a collection

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -4442,8 +4442,13 @@ class DescribeFailure:
         if message not in (actual_text := self._response.text):
             if self._tool_request:
                 state_message = self._tool_request["state_message"]
-                if message not in state_message:
-                    raise AssertionError(f"'{message}' not found in '{state_message}'")
+                error_text = (
+                    state_message.get("err_msg", str(state_message))
+                    if isinstance(state_message, dict)
+                    else state_message
+                )
+                if message not in error_text:
+                    raise AssertionError(f"'{message}' not found in '{error_text}'")
             else:
                 raise AssertionError(f"'{message}' not found in '{actual_text}'")
         return self

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -1,11 +1,13 @@
 import logging
 import time
+from unittest.mock import MagicMock
 
 import pytest
 import routes
 
 from galaxy import model
 from galaxy.app_unittest_utils.toolbox_support import BaseToolBoxTestCase
+from galaxy.exceptions import InsufficientPermissionsException
 from galaxy.tool_util.unittest_utils import mock_trans
 from galaxy.tool_util.unittest_utils.sample_data import (
     SIMPLE_MACRO,
@@ -155,6 +157,44 @@ class TestToolBox(BaseToolBoxTestCase):
         self.toolbox.get_tool("test_tool").allow_user_access = allow_user_access
         as_dict = self.toolbox.to_dict(mock_trans(), in_panel=False)
         assert len(as_dict) == 0, as_dict
+
+    def test_allow_user_access_non_public_dynamic_tool(self):
+        self._init_tool()
+        self._add_config("""<toolbox><tool file="tool.xml" /></toolbox>""")
+        tool = self.toolbox.get_tool("test_tool")
+
+        # Regular tool allows access without a user
+        assert tool.allow_user_access(None) is True
+
+        # Simulate a non-public dynamic tool
+        dynamic_tool = MagicMock()
+        dynamic_tool.public = False
+        tool.dynamic_tool = dynamic_tool
+
+        # Mock the dynamic tool manager to reject the user
+        mock_manager = MagicMock()
+        mock_manager.ensure_can_use_unprivileged_tool.side_effect = InsufficientPermissionsException(
+            "User is not allowed to run unprivileged tools"
+        )
+        tool.app.dynamic_tool_manager = mock_manager
+
+        # Non-public dynamic tool denies access without a user
+        assert tool.allow_user_access(None) is False
+
+        # Non-public dynamic tool denies access for user without execute role
+        mock_user = MagicMock()
+        assert tool.allow_user_access(mock_user) is False
+        mock_manager.ensure_can_use_unprivileged_tool.assert_called_with(mock_user)
+
+        # Non-public dynamic tool allows access for user with execute role
+        mock_manager.ensure_can_use_unprivileged_tool.side_effect = None
+        assert tool.allow_user_access(mock_user) is True
+
+        # Detached dynamic tool allows access (validated at load time)
+        detached_dynamic_tool = MagicMock()
+        type(detached_dynamic_tool).public = property(lambda self: (_ for _ in ()).throw(Exception("not bound")))
+        tool.dynamic_tool = detached_dynamic_tool
+        assert tool.allow_user_access(None) is True
 
     def _find_section(self, as_dict, section_id):
         for elem in as_dict:

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1287,6 +1287,7 @@ gx_data:
    - parameter: {__class__: "Batch", values: [{src: dce, id: 5, map_over_type: paired}]}
    - parameter: {src: hda, id: 5}
    - parameter: {src: hda, id: 0}
+   - parameter: {src: dce, id: 5}
   request_internal_dereferenced_invalid:
    # the difference between request internal and request internal dereferenced is that these have been converted
    # to datasets.

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1247,11 +1247,11 @@ gx_data:
    - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd}]}
    - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd, map_over_type: paired}]}
    - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd, map_over_type: null}]}
+   - parameter: {src: dce, id: abcdabcd}
   request_invalid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    # map_over_type only valid on hdca/dce, not hda/ldda
    - parameter: {__class__: "Batch", values: [{src: hda, id: abcdabcd, map_over_type: paired}]}
-   - parameter: {src: dce, id: abcdabcd}
    - parameter: {src: hda, id: 7}
    - parameter: {src: hdca, id: abcdabcd}
    - parameter: null


### PR DESCRIPTION
This PR switches tool execution to the canonical POST `/api/jobs` endpoint and removes the legacy `/api/tools` fallback from the frontend.

Before submission, the form state is transformed from the existing flat, pipe-separated structure into a nested RequestToolState that mirrors the backend model. All required type coercion is handled client-side so the request leaves the browser in a normalized, strictly typed form.

The backend remains strictly typed (strict: true by default) and required only small adjustments for feature parity, including support for tags, email notifications, object store preferences, and ID encoding.

After submission, the client polls `/api/tool_requests/{id}/state` until the request reaches a terminal state and then retrieves the outputs to render the success view.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
