### PR TITLE
[26.0] When getting tool by uuid, get that exact tool

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -745,7 +745,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             tool_from_uuid = self._get_tool_by_uuid(tool_uuid)
             if tool_from_uuid is None:
                 raise ObjectNotFound(f"Failed to find a tool with uuid [{tool_uuid}]")
-            tool_id = tool_from_uuid.id
+            return tool_from_uuid
         assert tool_id
 
         if tool_version:


### PR DESCRIPTION
and not a potentially conflicting tool with the same tool id

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
