### PR TITLE
[26.0] Replaced deprecated actions with modern equivalents

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -105,33 +105,46 @@ jobs:
         run: |
           version=$(python3 -c "import lib.galaxy.version; print(lib.galaxy.version.VERSION)")
           echo "version=$version" >> $GITHUB_OUTPUT
-      - name: Build container image
-        run: docker build . --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg IMAGE_TAG=${{ steps.branch.outputs.name }} -t galaxy/galaxy-min:${{ steps.branch.outputs.name }} -t quay.io/galaxyproject/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
-      - name: Create auto-expiring one for per-commit auto repository
-        run: echo "FROM galaxy/galaxy-min:${{ steps.branch.outputs.name }}" | docker build --label "quay.expires-after"="90d" -t "quay.io/galaxyproject/galaxy-k8s-auto:${{ steps.commit.outputs.sha_short }}" -
+      - name: Build args
+        id: buildargs
+        run: |
+          echo "gitcommit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "builddate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to quay.io
-        uses: actions-hub/docker/login@master
-        env:
-          DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          DOCKER_REGISTRY_URL: quay.io
-      - name: Push to quay.io with branch name
-        uses: actions-hub/docker@master
+        uses: docker/login-action@v3
         with:
-          args: push quay.io/galaxyproject/galaxy-min:${{ steps.branch.outputs.name }}
-      - name: Push to quay.io with commit hash
-        uses: actions-hub/docker@master
-        with:
-          args: push quay.io/galaxyproject/galaxy-k8s-auto:${{ steps.commit.outputs.sha_short }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Login to DockerHub
-        uses: actions-hub/docker/login@master
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Push to DockerHub with branch name
-        uses: actions-hub/docker@master
+        uses: docker/login-action@v3
         with:
-          args: push galaxy/galaxy-min:${{ steps.branch.outputs.name }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push galaxy-min image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .k8s_ci.Dockerfile
+          push: true
+          build-args: |
+            GIT_COMMIT=${{ steps.buildargs.outputs.gitcommit }}
+            BUILD_DATE=${{ steps.buildargs.outputs.builddate }}
+            IMAGE_TAG=${{ steps.branch.outputs.name }}
+          tags: |
+            galaxy/galaxy-min:${{ steps.branch.outputs.name }}
+            quay.io/galaxyproject/galaxy-min:${{ steps.branch.outputs.name }}
+      - name: Create Dockerfile for auto-expiring image
+        run: echo "FROM galaxy/galaxy-min:${{ steps.branch.outputs.name }}" > /tmp/Dockerfile.auto
+      - name: Build and push auto-expiring per-commit image
+        uses: docker/build-push-action@v6
+        with:
+          file: /tmp/Dockerfile.auto
+          push: true
+          tags: quay.io/galaxyproject/galaxy-k8s-auto:${{ steps.commit.outputs.sha_short }}
+          labels: quay.expires-after=90d
 
   smoke-test:
     name: Try installing the new image


### PR DESCRIPTION
Replaces deprecated actions in the build job:

1. `actions-hub/docker/login@master` (quay.io + DockerHub logins) replaced with `docker/login-action@v3` - the same action already used by the ghcrbuild job
2. Manual docker build + `actions-hub/docker@master push` replaced with `docker/build-push-action@v6` - builds and pushes in one step
3. Added `docker/setup-buildx-action@v3` - required by build-push-action

What changed functionally:

- The main `galaxy-min` image is now built and pushed to both DockerHub and quay.io in a single `build-push-action` step (instead of separate build + 2 push commands)
- The auto-expiring `galaxy-k8s-auto` per-commit image writes a temp Dockerfile and uses `build-push-action` to build and push it with the `quay.expires-after=90d` label
- All the same images are pushed to the same registries with the same tags

  The ghcrbuild job was already using these modern actions, so no changes were needed there.
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
