### PR TITLE
Beta upload: create dataset collections directly via HdcaDataItemsTarget

### DIFF
--- a/client/src/components/Panels/Upload/CollectionCreationConfig.vue
+++ b/client/src/components/Panels/Upload/CollectionCreationConfig.vue
@@ -117,9 +117,11 @@ defineExpose({ reset });
 <template>
     <div class="collection-section mt-3">
         <div class="d-flex align-items-center justify-content-between">
-            <BFormCheckbox v-model="isCreateCollectionActive" switch>
-                <strong>Create a collection from these files</strong>
-            </BFormCheckbox>
+            <span data-test-id="collection-toggle">
+                <BFormCheckbox v-model="isCreateCollectionActive" switch>
+                    <strong>Create a collection from these files</strong>
+                </BFormCheckbox>
+            </span>
             <a
                 href="https://training.galaxyproject.org/training-material/topics/galaxy-interface/tutorials/collections/tutorial.html"
                 target="_blank"

--- a/client/src/components/Panels/Upload/CollectionCreationConfig.vue
+++ b/client/src/components/Panels/Upload/CollectionCreationConfig.vue
@@ -187,7 +187,7 @@ defineExpose({ reset });
             <!-- Info about source items -->
             <div class="small text-muted mt-2">
                 <FontAwesomeIcon :icon="faInfoCircle" class="mr-1" />
-                Individual uploaded files will be hidden after collection creation
+                Files will be uploaded directly into the collection
             </div>
         </div>
     </div>

--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -112,6 +112,7 @@ function handleReadyStateChange(ready: boolean) {
                     color="blue"
                     :disabled="!canUpload"
                     :title="canUpload ? 'Start uploading to Galaxy' : 'Configure upload options first'"
+                    data-test-id="start-upload"
                     @click="handleStart">
                     <span v-localize>Start</span>
                 </GButton>

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -224,7 +224,7 @@ defineExpose<UploadMethodComponent>({ startUpload });
                 :placeholder="placeholder"></textarea>
             <div class="d-flex justify-content-end align-items-center">
                 <GButton v-if="hasItems" class="mr-2" @click="showUrlList">View Added URLs</GButton>
-                <GButton color="blue" :disabled="!urlText.trim()" @click="addUrlsFromText">
+                <GButton color="blue" :disabled="!urlText.trim()" data-test-id="add-urls" @click="addUrlsFromText">
                     <FontAwesomeIcon :icon="faLink" class="mr-1" />
                     Add URLs
                 </GButton>

--- a/client/src/components/Panels/Upload/uploadState.ts
+++ b/client/src/components/Panels/Upload/uploadState.ts
@@ -54,13 +54,13 @@ export interface CollectionBatchState {
     name: string;
     /** Collection type */
     type: SupportedCollectionType;
-    /** Whether to hide source datasets after collection creation */
+    /** Whether to hide source datasets after collection creation (two-step path only) */
     hideSourceItems: boolean;
     /** Target history ID */
     historyId: string;
     /** Upload item IDs belonging to this batch */
     uploadIds: string[];
-    /** Dataset IDs created from uploads (needed for collection creation) */
+    /** Dataset IDs created from uploads (needed for two-step collection creation) */
     datasetIds: string[];
     /** Batch processing status */
     status: BatchStatus;
@@ -70,6 +70,8 @@ export interface CollectionBatchState {
     error?: string;
     /** Timestamp when batch was created */
     createdAt: number;
+    /** Whether this batch uses direct HDCA creation (no separate collection creation step) */
+    directCreation?: boolean;
 }
 
 function generateId() {
@@ -209,11 +211,13 @@ export function useUploadState() {
      * Creates a new collection batch.
      * @param config - Collection configuration
      * @param uploadIds - Upload IDs belonging to this batch
+     * @param directCreation - Whether to use direct HDCA creation (default: false)
      * @returns Unique batch identifier
      */
     function addBatch(
         config: { name: string; type: SupportedCollectionType; hideSourceItems: boolean; historyId: string },
         uploadIds: string[],
+        directCreation = false,
     ): string {
         const batch: CollectionBatchState = {
             id: generateId(),
@@ -222,6 +226,7 @@ export function useUploadState() {
             datasetIds: [],
             status: "uploading",
             createdAt: Date.now(),
+            directCreation,
         };
 
         batches.value.push(batch);

--- a/client/src/composables/uploadQueue.ts
+++ b/client/src/composables/uploadQueue.ts
@@ -646,12 +646,6 @@ export function useUploadQueue() {
 
             // Direct-creation batches don't have a separate collection creation step
             if (batch.directCreation) {
-                if (batch.status === "uploading") {
-                    uploadState.setBatchError(
-                        batch.id,
-                        "Upload was interrupted. Please re-upload the files to create the collection.",
-                    );
-                }
                 return;
             }
 

--- a/client/src/composables/uploadQueue.ts
+++ b/client/src/composables/uploadQueue.ts
@@ -11,7 +11,12 @@ import type { CollectionElementIdentifiers } from "@/api";
 import { createHistoryDatasetCollectionInstanceFull } from "@/api/datasetCollections";
 import { copyDataset } from "@/api/datasets";
 import type { FetchDataResponse } from "@/api/tools";
-import { COMMON_FILTERS, DEFAULT_FILTER, guessInitialFilterType, guessNameForPair } from "@/components/Collections/pairing";
+import {
+    COMMON_FILTERS,
+    DEFAULT_FILTER,
+    guessInitialFilterType,
+    guessNameForPair,
+} from "@/components/Collections/pairing";
 import { useUploadState } from "@/components/Panels/Upload/uploadState";
 import type { CollectionCreationInput, SupportedCollectionType } from "@/composables/upload/collectionTypes";
 import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
@@ -92,8 +97,7 @@ function buildCollectionElements(
             }
 
             const basePairName =
-                guessNameForPair(item1, item2, forwardFilter, reverseFilter, true) ||
-                `pair_${Math.floor(i / 2) + 1}`;
+                guessNameForPair(item1, item2, forwardFilter, reverseFilter, true) || `pair_${Math.floor(i / 2) + 1}`;
             let pairName = basePairName;
 
             // Ensure unique pair names by adding suffix if needed

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1371,7 +1371,7 @@ beta_upload:
     method_card: '[data-method-id="${method_id}"]'
     paste_textarea: '#paste-links-textarea'
     add_urls_button: '[data-test-id="add-urls"]'
-    collection_section: '.collection-section'
+    collection_section: '[data-test-id="collection-toggle"] label'
     collection_name_input: '#collection-name-input'
     collection_type_select: '#collection-type-select'
     start_button: '[data-test-id="start-upload"]'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1363,6 +1363,19 @@ upload:
     local_button: '#btn-local'
     explore_archive_button: '.btn-explore-archive'
 
+beta_upload:
+  selectors:
+    activity:
+      type: xpath
+      selector: '//button[contains(., "Beta Upload")]'
+    method_card: '[data-method-id="${method_id}"]'
+    paste_textarea: '#paste-links-textarea'
+    add_urls_button: '[data-test-id="add-urls"]'
+    collection_section: '.collection-section'
+    collection_name_input: '#collection-name-input'
+    collection_type_select: '#collection-type-select'
+    start_button: '[data-test-id="start-upload"]'
+
 new_user_welcome:
   selectors:
     _: .new-user-welcome

--- a/client/src/utils/upload.test.ts
+++ b/client/src/utils/upload.test.ts
@@ -14,7 +14,6 @@ import {
     createFileUploadItem,
     createPastedUploadItem,
     createUrlUploadItem,
-    extractPairName,
     fetchDatasets,
     isGalaxyFileName,
     type LegacyUploadItem,
@@ -537,44 +536,6 @@ describe("buildUploadPayload", () => {
         const items: ApiUploadItem[] = [createUrlUploadItem("not-a-valid-url", "historyId")];
 
         expect(() => buildUploadPayload(items)).toThrow("Invalid URL: not-a-valid-url");
-    });
-});
-
-// ============================================================================
-// Pair Name Extraction Tests
-// ============================================================================
-
-describe("extractPairName", () => {
-    test("detects _R1/_R2 suffix", () => {
-        expect(extractPairName("sample_R1.fastq", "sample_R2.fastq")).toBe("sample");
-    });
-
-    test("detects _1/_2 suffix", () => {
-        expect(extractPairName("sample_1.fastq", "sample_2.fastq")).toBe("sample");
-    });
-
-    test("detects .R1/.R2 suffix", () => {
-        expect(extractPairName("sample.R1.fastq", "sample.R2.fastq")).toBe("sample");
-    });
-
-    test("detects _F/_R suffix", () => {
-        expect(extractPairName("sample_F.fastq", "sample_R.fastq")).toBe("sample");
-    });
-
-    test("detects _fwd/_rev suffix", () => {
-        expect(extractPairName("sample_fwd.fastq", "sample_rev.fastq")).toBe("sample");
-    });
-
-    test("detects _forward/_reverse suffix", () => {
-        expect(extractPairName("sample_forward.fastq", "sample_reverse.fastq")).toBe("sample");
-    });
-
-    test("falls back to common prefix", () => {
-        expect(extractPairName("sampleA.fastq", "sampleB.fastq")).toBe("sample");
-    });
-
-    test("returns first file base name when no common pattern", () => {
-        expect(extractPairName("alpha.txt", "beta.txt")).toBe("alpha");
     });
 });
 

--- a/client/src/utils/upload.test.ts
+++ b/client/src/utils/upload.test.ts
@@ -2,17 +2,19 @@ import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
 
 import { useServerMock } from "@/api/client/__mocks__";
-import type { CompositeDataElement, HdasUploadTarget } from "@/api/tools";
+import type { CompositeDataElement, HdasUploadTarget, HdcaUploadTarget, NestedElement } from "@/api/tools";
 
 import { createTusUpload } from "./tusUpload";
 import {
     type ApiUploadItem,
+    buildCollectionUploadPayload,
     buildLegacyPayload,
     buildUploadPayload,
     cleanUrlFilename,
     createFileUploadItem,
     createPastedUploadItem,
     createUrlUploadItem,
+    extractPairName,
     fetchDatasets,
     isGalaxyFileName,
     type LegacyUploadItem,
@@ -539,6 +541,265 @@ describe("buildUploadPayload", () => {
 });
 
 // ============================================================================
+// Pair Name Extraction Tests
+// ============================================================================
+
+describe("extractPairName", () => {
+    test("detects _R1/_R2 suffix", () => {
+        expect(extractPairName("sample_R1.fastq", "sample_R2.fastq")).toBe("sample");
+    });
+
+    test("detects _1/_2 suffix", () => {
+        expect(extractPairName("sample_1.fastq", "sample_2.fastq")).toBe("sample");
+    });
+
+    test("detects .R1/.R2 suffix", () => {
+        expect(extractPairName("sample.R1.fastq", "sample.R2.fastq")).toBe("sample");
+    });
+
+    test("detects _F/_R suffix", () => {
+        expect(extractPairName("sample_F.fastq", "sample_R.fastq")).toBe("sample");
+    });
+
+    test("detects _fwd/_rev suffix", () => {
+        expect(extractPairName("sample_fwd.fastq", "sample_rev.fastq")).toBe("sample");
+    });
+
+    test("detects _forward/_reverse suffix", () => {
+        expect(extractPairName("sample_forward.fastq", "sample_reverse.fastq")).toBe("sample");
+    });
+
+    test("falls back to common prefix", () => {
+        expect(extractPairName("sampleA.fastq", "sampleB.fastq")).toBe("sample");
+    });
+
+    test("returns first file base name when no common pattern", () => {
+        expect(extractPairName("alpha.txt", "beta.txt")).toBe("alpha");
+    });
+});
+
+// ============================================================================
+// Collection Upload Payload Building Tests
+// ============================================================================
+
+describe("buildCollectionUploadPayload", () => {
+    test("throws on empty items", () => {
+        expect(() => buildCollectionUploadPayload([], { collectionName: "test", collectionType: "list" })).toThrow(
+            "No upload items provided.",
+        );
+    });
+
+    test("throws on mixed history IDs", () => {
+        const items: ApiUploadItem[] = [
+            createUrlUploadItem("http://example.com/1.txt", "history1"),
+            createUrlUploadItem("http://example.com/2.txt", "history2"),
+        ];
+
+        expect(() => buildCollectionUploadPayload(items, { collectionName: "test", collectionType: "list" })).toThrow(
+            "All upload items must target the same history.",
+        );
+    });
+
+    test("builds list collection payload with URL items", () => {
+        const items: ApiUploadItem[] = [
+            createUrlUploadItem("http://example.com/1.txt", "historyId"),
+            createUrlUploadItem("http://example.com/2.txt", "historyId"),
+        ];
+
+        const result = buildCollectionUploadPayload(items, {
+            collectionName: "My List",
+            collectionType: "list",
+        });
+
+        expect(result.history_id).toBe("historyId");
+        expect(result.auto_decompress).toBe(true);
+        expect(result.files).toEqual([]);
+        expect(result.targets).toHaveLength(1);
+
+        const target = result.targets[0] as HdcaUploadTarget;
+        expect(target.destination).toEqual({ type: "hdca" });
+        expect(target.collection_type).toBe("list");
+        expect(target.name).toBe("My List");
+        expect(target.elements).toHaveLength(2);
+
+        const elem1 = target.elements[0] as { src: string; url: string };
+        const elem2 = target.elements[1] as { src: string; url: string };
+        expect(elem1.src).toBe("url");
+        expect(elem1.url).toBe("http://example.com/1.txt");
+        expect(elem2.src).toBe("url");
+        expect(elem2.url).toBe("http://example.com/2.txt");
+    });
+
+    test("builds list collection payload with local file items", () => {
+        const file1 = createMockFile("file1.txt");
+        const file2 = createMockFile("file2.txt");
+        const items: ApiUploadItem[] = [
+            createFileUploadItem(file1, "historyId"),
+            createFileUploadItem(file2, "historyId"),
+        ];
+
+        const result = buildCollectionUploadPayload(items, {
+            collectionName: "File List",
+            collectionType: "list",
+        });
+
+        expect(result.files).toHaveLength(2);
+        expect(result.files[0]).toBe(file1);
+        expect(result.files[1]).toBe(file2);
+
+        const target = result.targets[0] as HdcaUploadTarget;
+        expect(target.destination).toEqual({ type: "hdca" });
+        expect(target.collection_type).toBe("list");
+        expect(target.elements).toHaveLength(2);
+
+        const elem1 = target.elements[0] as { src: string };
+        const elem2 = target.elements[1] as { src: string };
+        expect(elem1.src).toBe("files");
+        expect(elem2.src).toBe("files");
+    });
+
+    test("builds list:paired collection payload with nested elements", () => {
+        const items: ApiUploadItem[] = [
+            createUrlUploadItem("http://example.com/sample_R1.fastq", "historyId", { name: "sample_R1.fastq" }),
+            createUrlUploadItem("http://example.com/sample_R2.fastq", "historyId", { name: "sample_R2.fastq" }),
+        ];
+
+        const result = buildCollectionUploadPayload(items, {
+            collectionName: "Paired List",
+            collectionType: "list:paired",
+        });
+
+        const target = result.targets[0] as HdcaUploadTarget;
+        expect(target.destination).toEqual({ type: "hdca" });
+        expect(target.collection_type).toBe("list:paired");
+        expect(target.name).toBe("Paired List");
+        expect(target.elements).toHaveLength(1); // 1 pair
+
+        const pair = target.elements[0] as NestedElement;
+        expect(pair.name).toBe("sample");
+        expect(pair.elements).toHaveLength(2);
+
+        const fwd = pair.elements[0] as { name: string; src: string; url: string };
+        const rev = pair.elements[1] as { name: string; src: string; url: string };
+        expect(fwd.name).toBe("forward");
+        expect(fwd.src).toBe("url");
+        expect(rev.name).toBe("reverse");
+        expect(rev.src).toBe("url");
+    });
+
+    test("builds list:paired with multiple pairs", () => {
+        const items: ApiUploadItem[] = [
+            createUrlUploadItem("http://example.com/s1_R1.fastq", "historyId", { name: "s1_R1.fastq" }),
+            createUrlUploadItem("http://example.com/s1_R2.fastq", "historyId", { name: "s1_R2.fastq" }),
+            createUrlUploadItem("http://example.com/s2_R1.fastq", "historyId", { name: "s2_R1.fastq" }),
+            createUrlUploadItem("http://example.com/s2_R2.fastq", "historyId", { name: "s2_R2.fastq" }),
+        ];
+
+        const result = buildCollectionUploadPayload(items, {
+            collectionName: "Two Pairs",
+            collectionType: "list:paired",
+        });
+
+        const target = result.targets[0] as HdcaUploadTarget;
+        expect(target.elements).toHaveLength(2); // 2 pairs
+
+        const pair1 = target.elements[0] as NestedElement;
+        const pair2 = target.elements[1] as NestedElement;
+        expect(pair1.name).toBe("s1");
+        expect(pair2.name).toBe("s2");
+    });
+
+    test("files array order matches depth-first element traversal for list:paired", () => {
+        const file1 = createMockFile("s1_R1.fastq");
+        const file2 = createMockFile("s1_R2.fastq");
+        const file3 = createMockFile("s2_R1.fastq");
+        const file4 = createMockFile("s2_R2.fastq");
+
+        const items: ApiUploadItem[] = [
+            createFileUploadItem(file1, "historyId", { name: "s1_R1.fastq" }),
+            createFileUploadItem(file2, "historyId", { name: "s1_R2.fastq" }),
+            createFileUploadItem(file3, "historyId", { name: "s2_R1.fastq" }),
+            createFileUploadItem(file4, "historyId", { name: "s2_R2.fastq" }),
+        ];
+
+        const result = buildCollectionUploadPayload(items, {
+            collectionName: "Paired Files",
+            collectionType: "list:paired",
+        });
+
+        // Files must be in order: pair1-fwd, pair1-rev, pair2-fwd, pair2-rev
+        // This matches the backend's depth-first replace_file_srcs iteration
+        expect(result.files).toHaveLength(4);
+        expect(result.files[0]).toBe(file1);
+        expect(result.files[1]).toBe(file2);
+        expect(result.files[2]).toBe(file3);
+        expect(result.files[3]).toBe(file4);
+    });
+
+    test("handles mixed element types (files + URLs)", () => {
+        const file1 = createMockFile("local.txt");
+        const items: ApiUploadItem[] = [
+            createFileUploadItem(file1, "historyId"),
+            createUrlUploadItem("http://example.com/remote.txt", "historyId"),
+        ];
+
+        const result = buildCollectionUploadPayload(items, {
+            collectionName: "Mixed List",
+            collectionType: "list",
+        });
+
+        expect(result.files).toHaveLength(1);
+        expect(result.files[0]).toBe(file1);
+
+        const target = result.targets[0] as HdcaUploadTarget;
+        expect(target.elements).toHaveLength(2);
+
+        const elem1 = target.elements[0] as { src: string };
+        const elem2 = target.elements[1] as { src: string };
+        expect(elem1.src).toBe("files");
+        expect(elem2.src).toBe("url");
+    });
+
+    test("handles pasted content in collection", () => {
+        const items: ApiUploadItem[] = [
+            createPastedUploadItem("content 1", "historyId", { name: "paste1.txt" }),
+            createPastedUploadItem("content 2", "historyId", { name: "paste2.txt" }),
+        ];
+
+        const result = buildCollectionUploadPayload(items, {
+            collectionName: "Pasted List",
+            collectionType: "list",
+        });
+
+        expect(result.files).toEqual([]);
+
+        const target = result.targets[0] as HdcaUploadTarget;
+        expect(target.elements).toHaveLength(2);
+
+        const elem1 = target.elements[0] as { src: string; paste_content: string };
+        expect(elem1.src).toBe("pasted");
+        expect(elem1.paste_content).toBe("content 1");
+    });
+
+    test("validates empty file data", () => {
+        const emptyFile = new File([], "empty.txt");
+        const items: ApiUploadItem[] = [createFileUploadItem(emptyFile, "historyId")];
+
+        expect(() => buildCollectionUploadPayload(items, { collectionName: "test", collectionType: "list" })).toThrow(
+            "File data is empty for upload item: empty.txt",
+        );
+    });
+
+    test("validates invalid URL", () => {
+        const items: ApiUploadItem[] = [createUrlUploadItem("not-a-url", "historyId")];
+
+        expect(() => buildCollectionUploadPayload(items, { collectionName: "test", collectionType: "list" })).toThrow(
+            "Invalid URL: not-a-url",
+        );
+    });
+});
+
+// ============================================================================
 // Upload Submission Tests
 // ============================================================================
 
@@ -904,6 +1165,124 @@ describe("upload submission", () => {
             });
 
             expect(errorCallback).toHaveBeenCalled();
+        });
+
+        it("should directly submit HDCA collection target with URLs (no TUS)", async () => {
+            const successCallback = vi.fn();
+
+            server.use(
+                http.post("/api/tools/fetch", () => {
+                    return HttpResponse.json({ jobs: [{ id: "job_hdca" }] });
+                }),
+            );
+
+            await submitUpload({
+                data: {
+                    history_id: "hist123",
+                    targets: [
+                        {
+                            destination: { type: "hdca" },
+                            collection_type: "list",
+                            name: "My Collection",
+                            auto_decompress: false,
+                            elements: [
+                                {
+                                    src: "url",
+                                    url: "https://example.com/1.txt",
+                                    name: "1.txt",
+                                    dbkey: "?",
+                                    ext: "auto",
+                                    space_to_tab: false,
+                                    to_posix_lines: false,
+                                    auto_decompress: false,
+                                    deferred: false,
+                                },
+                                {
+                                    src: "url",
+                                    url: "https://example.com/2.txt",
+                                    name: "2.txt",
+                                    dbkey: "?",
+                                    ext: "auto",
+                                    space_to_tab: false,
+                                    to_posix_lines: false,
+                                    auto_decompress: false,
+                                    deferred: false,
+                                },
+                            ],
+                        },
+                    ],
+                    auto_decompress: true,
+                    files: [],
+                },
+                success: successCallback,
+            });
+
+            expect(createTusUpload).not.toHaveBeenCalled();
+            expect(successCallback).toHaveBeenCalledWith({ jobs: [{ id: "job_hdca" }] });
+        });
+
+        it("should upload HDCA collection with local files via TUS", async () => {
+            const file1 = new File(["content1"], "file1.txt");
+            const file2 = new File(["content2"], "file2.txt");
+            const successCallback = vi.fn();
+
+            vi.mocked(createTusUpload)
+                .mockResolvedValueOnce({
+                    sessionId: "session1",
+                    fileName: "file1.txt",
+                })
+                .mockResolvedValueOnce({
+                    sessionId: "session2",
+                    fileName: "file2.txt",
+                });
+
+            server.use(
+                http.post("/api/tools/fetch", () => {
+                    return HttpResponse.json({ jobs: [{ id: "job_hdca_files" }] });
+                }),
+            );
+
+            await submitUpload({
+                data: {
+                    history_id: "hist123",
+                    targets: [
+                        {
+                            destination: { type: "hdca" },
+                            collection_type: "list",
+                            name: "File Collection",
+                            auto_decompress: false,
+                            elements: [
+                                {
+                                    src: "files",
+                                    name: "file1.txt",
+                                    dbkey: "?",
+                                    ext: "auto",
+                                    space_to_tab: false,
+                                    to_posix_lines: false,
+                                    auto_decompress: false,
+                                    deferred: false,
+                                },
+                                {
+                                    src: "files",
+                                    name: "file2.txt",
+                                    dbkey: "?",
+                                    ext: "auto",
+                                    space_to_tab: false,
+                                    to_posix_lines: false,
+                                    auto_decompress: false,
+                                    deferred: false,
+                                },
+                            ],
+                        },
+                    ],
+                    auto_decompress: true,
+                    files: [file1, file2],
+                },
+                success: successCallback,
+            });
+
+            expect(createTusUpload).toHaveBeenCalledTimes(2);
+            expect(successCallback).toHaveBeenCalledWith({ jobs: [{ id: "job_hdca_files" }] });
         });
     });
 });

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -46,14 +46,18 @@ import {
     type PastedDataElement,
     type UrlDataElement,
 } from "@/api/tools";
+import {
+    COMMON_FILTERS,
+    DEFAULT_FILTER,
+    guessInitialFilterType,
+    guessNameForPair,
+} from "@/components/Collections/pairing";
 import type { UploadRowModel } from "@/components/Upload/model";
 import type { SupportedCollectionType } from "@/composables/upload/collectionTypes";
 import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
 import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString } from "@/utils/simple-error";
 import { isUrl } from "@/utils/url";
-
-import { COMMON_FILTERS, DEFAULT_FILTER, guessInitialFilterType, guessNameForPair } from "@/components/Collections/pairing";
 
 import { createTusUpload, type FileStream, type NamedBlob, type UploadableFile } from "./tusUpload";
 
@@ -714,8 +718,7 @@ function buildPairedElements(items: ApiUploadItem[], dataElements: ApiDataElemen
         const item2 = items[i + 1]!;
 
         const basePairName =
-            guessNameForPair(item1, item2, forwardFilter, reverseFilter, true) ||
-            `pair_${Math.floor(i / 2) + 1}`;
+            guessNameForPair(item1, item2, forwardFilter, reverseFilter, true) || `pair_${Math.floor(i / 2) + 1}`;
         let pairName = basePairName;
         let counter = 1;
         while (usedNames.has(pairName)) {

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -41,10 +41,13 @@ import {
     type FetchDatasetsCallbacks,
     type FileDataElement,
     type HdasUploadTarget,
+    type HdcaUploadTarget,
+    type NestedElement,
     type PastedDataElement,
     type UrlDataElement,
 } from "@/api/tools";
 import type { UploadRowModel } from "@/components/Upload/model";
+import type { SupportedCollectionType } from "@/composables/upload/collectionTypes";
 import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
 import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString } from "@/utils/simple-error";
@@ -68,6 +71,8 @@ export type {
     FetchDatasetsCallbacks,
     FileDataElement,
     HdasUploadTarget,
+    HdcaUploadTarget,
+    NestedElement,
     PastedDataElement,
     UrlDataElement,
 } from "@/api/tools";
@@ -152,8 +157,8 @@ export type ApiUploadItem = LocalFileUploadItem | PastedContentUploadItem | UrlU
 export interface UploadPayload {
     /** Target history ID */
     history_id: string;
-    /** Upload targets with elements */
-    targets: HdasUploadTarget[];
+    /** Upload targets with elements (HDA for individual datasets, HDCA for collections) */
+    targets: (HdasUploadTarget | HdcaUploadTarget)[];
     /** Whether to auto-decompress uploads */
     auto_decompress: boolean;
     /** Local files to upload via TUS (not part of API, processed by submitUpload) */
@@ -667,6 +672,160 @@ export function buildUploadPayload(items: ApiUploadItem[], options: BuildPayload
 }
 
 // ============================================================================
+// Collection Upload Payload Building
+// ============================================================================
+
+/** Options for building collection upload payloads */
+export interface CollectionUploadOptions {
+    /** Collection display name */
+    collectionName: string;
+    /** Collection type: 'list' or 'list:paired' */
+    collectionType: SupportedCollectionType;
+}
+
+/**
+ * Extracts common prefix from pair of file names for smart pair naming.
+ * Removes common suffixes like _R1/_R2, _1/_2, _F/_R, etc.
+ */
+export function extractPairName(name1: string, name2: string): string {
+    const base1 = name1.replace(/\.[^.]+$/, "");
+    const base2 = name2.replace(/\.[^.]+$/, "");
+
+    const patterns = [
+        { regex: /[._-]?R?[12]$/, replace: "" },
+        { regex: /[._-]?[FR]$/, replace: "" },
+        { regex: /[._-]?read[12]$/i, replace: "" },
+        { regex: /[._-]?fwd$|[._-]?rev$/i, replace: "" },
+        { regex: /[._-]?forward$|[._-]?reverse$/i, replace: "" },
+    ];
+
+    for (const pattern of patterns) {
+        const test1 = base1.replace(pattern.regex, pattern.replace);
+        const test2 = base2.replace(pattern.regex, pattern.replace);
+        if (test1 === test2 && test1.length > 0) {
+            return test1;
+        }
+    }
+
+    let i = 0;
+    while (i < Math.min(base1.length, base2.length) && base1[i] === base2[i]) {
+        i++;
+    }
+    if (i > 0) {
+        return base1.slice(0, i).replace(/[._-]+$/, "");
+    }
+
+    return base1;
+}
+
+/**
+ * Builds nested paired elements from a flat list of data elements.
+ * Groups consecutive pairs with "forward"/"reverse" names inside NestedElement wrappers.
+ *
+ * IMPORTANT: The files array order must match depth-first element traversal order.
+ * For list:paired, the backend's replace_file_srcs iterates depth-first:
+ * pair1-forward, pair1-reverse, pair2-forward, pair2-reverse, etc.
+ * This matches the original item order, so no reordering is needed.
+ */
+function buildPairedElements(items: ApiUploadItem[], dataElements: ApiDataElement[]): NestedElement[] {
+    const pairs: NestedElement[] = [];
+    const usedNames = new Set<string>();
+
+    for (let i = 0; i < items.length; i += 2) {
+        if (i + 1 >= items.length) {
+            console.warn(`Skipping unpaired file at index ${i}: ${items[i]?.name}`);
+            break;
+        }
+
+        const item1 = items[i]!;
+        const item2 = items[i + 1]!;
+
+        const basePairName = extractPairName(item1.name, item2.name) || `pair_${Math.floor(i / 2) + 1}`;
+        let pairName = basePairName;
+        let counter = 1;
+        while (usedNames.has(pairName)) {
+            pairName = `${basePairName}_${counter}`;
+            counter++;
+        }
+        usedNames.add(pairName);
+
+        const nestedElement: NestedElement = {
+            name: pairName,
+            elements: [
+                { ...dataElements[i]!, name: "forward" },
+                { ...dataElements[i + 1]!, name: "reverse" },
+            ],
+            auto_decompress: false,
+            dbkey: "?",
+            ext: "auto",
+            space_to_tab: false,
+            to_posix_lines: false,
+            deferred: false,
+        };
+        pairs.push(nestedElement);
+    }
+
+    return pairs;
+}
+
+/**
+ * Builds an API-ready upload payload that creates a dataset collection directly.
+ * Uses HdcaDataItemsTarget with destination { type: "hdca" } so the collection
+ * is created atomically in a single /api/tools/fetch request.
+ *
+ * @param items - The upload items to include in the collection
+ * @param options - Collection configuration (name and type)
+ * @returns API-ready payload for submitUpload
+ * @throws Error if no valid items are provided or validation fails
+ */
+export function buildCollectionUploadPayload(items: ApiUploadItem[], options: CollectionUploadOptions): UploadPayload {
+    if (items.length === 0) {
+        throw new Error("No upload items provided.");
+    }
+
+    const historyId = items[0]!.historyId;
+    if (items.some((item) => item.historyId !== historyId)) {
+        throw new Error("All upload items must target the same history.");
+    }
+
+    const files: UploadableFile[] = [];
+    const dataElements: ApiDataElement[] = [];
+
+    for (const item of items) {
+        validateItemContent(item);
+        dataElements.push(buildDataElement(item));
+        if (item.src === "files") {
+            files.push(item.fileData);
+        }
+    }
+
+    let elements: HdcaUploadTarget["elements"];
+
+    if (options.collectionType === "list") {
+        elements = dataElements;
+    } else if (options.collectionType === "list:paired") {
+        elements = buildPairedElements(items, dataElements);
+    } else {
+        throw new Error(`Unsupported collection type: ${options.collectionType}`);
+    }
+
+    const target: HdcaUploadTarget = {
+        auto_decompress: false,
+        destination: { type: "hdca" },
+        collection_type: options.collectionType,
+        name: options.collectionName,
+        elements,
+    };
+
+    return {
+        history_id: historyId,
+        targets: [target],
+        auto_decompress: true,
+        files,
+    };
+}
+
+// ============================================================================
 // Upload Submission
 // ============================================================================
 
@@ -767,10 +926,20 @@ export async function submitUpload(config: UploadSubmitConfig): Promise<void> {
         // Upload files via TUS, then submit payload
         await uploadFilesViaTus(data, tusEndpoint, chunkSize, callbacks);
     } else if (data.targets && data.targets.length > 0) {
-        // Handle URL or pasted content
         const firstTarget = data.targets[0];
 
-        if (firstTarget && "elements" in firstTarget && firstTarget.elements && firstTarget.elements.length > 0) {
+        // Check if this is a collection (HDCA) target
+        if (firstTarget && "destination" in firstTarget && firstTarget.destination.type === "hdca") {
+            // HDCA collection target with no local files (all URLs/pasted) - submit directly
+            const apiPayload = toApiPayload(data);
+            await fetchDatasets(apiPayload, callbacks);
+        } else if (
+            firstTarget &&
+            "elements" in firstTarget &&
+            firstTarget.elements &&
+            firstTarget.elements.length > 0
+        ) {
+            // Handle HDA URL or pasted content
             const firstElement = firstTarget.elements[0];
 
             if (firstElement && "src" in firstElement) {
@@ -850,6 +1019,56 @@ export async function uploadDatasets(items: ApiUploadItem[], config: UploadDatas
     } catch (err) {
         const errorMessage = errorMessageAsString(err);
         config.error?.(errorMessage);
+    }
+}
+
+/**
+ * Uploads datasets as a collection directly via a single /api/tools/fetch request.
+ * Uses HdcaDataItemsTarget to create the collection atomically during the fetch.
+ *
+ * @param items - The upload items to include in the collection
+ * @param collectionOptions - Collection name and type
+ * @param config - Upload configuration and callbacks
+ *
+ * @example
+ * ```typescript
+ * await uploadCollectionDatasets(
+ *   [
+ *     createUrlUploadItem("https://example.com/1.txt", "history123"),
+ *     createUrlUploadItem("https://example.com/2.txt", "history123"),
+ *   ],
+ *   { collectionName: "My List", collectionType: "list" },
+ *   { success: (response) => console.log("Collection created", response) },
+ * );
+ * ```
+ */
+export async function uploadCollectionDatasets(
+    items: ApiUploadItem[],
+    collectionOptions: CollectionUploadOptions,
+    config: UploadDatasetsConfig = {},
+): Promise<void> {
+    const { chunkSize, success, error, warning, progress } = config;
+
+    try {
+        const payload = buildCollectionUploadPayload(items, collectionOptions);
+
+        const data: UploadDataPayload = {
+            history_id: payload.history_id,
+            targets: payload.targets,
+            auto_decompress: payload.auto_decompress,
+            files: payload.files,
+        };
+
+        await submitUpload({
+            data,
+            chunkSize,
+            success,
+            error,
+            warning,
+            progress,
+        });
+    } catch (err) {
+        config.error?.(errorMessageAsString(err));
     }
 }
 

--- a/lib/galaxy/selenium/smart_components.py
+++ b/lib/galaxy/selenium/smart_components.py
@@ -152,6 +152,10 @@ class SmartTarget:
         self._has_driver.aggressive_clear(dom_element)
         dom_element.send_keys(*text)
 
+    def select_by_value(self, value: str):
+        """Select an option from a <select> element by its value attribute."""
+        self._has_driver.select_by_value(self._target, value)
+
     def axe_eval(self) -> AxeResults:
         return self._has_driver.axe_eval(context=self._target.element_locator[1])
 

--- a/lib/galaxy_test/selenium/test_beta_upload_collection.py
+++ b/lib/galaxy_test/selenium/test_beta_upload_collection.py
@@ -26,6 +26,12 @@ class TestBetaUploadCollection(SeleniumTestCase, UsesHistoryItemAssertions):
         which navigates to the upload method view via router.push().
         """
         self.home()
+        # Wait for the activity bar to be fully synced before interacting.
+        # The tools activity (#activity-tools) is rendered by the v-for loop
+        # over synced activities, so its presence confirms sync() has completed.
+        # Without this, clicking #activity-settings (hardcoded in the footer)
+        # can race with sync() which resets toggledSideBar.
+        self.components.tools.activity.wait_for_visible()
         # Open activity settings panel
         self.components.preferences.activity.wait_for_and_click()
         # Click the Beta Upload activity in settings to open its sidebar panel

--- a/lib/galaxy_test/selenium/test_beta_upload_collection.py
+++ b/lib/galaxy_test/selenium/test_beta_upload_collection.py
@@ -1,0 +1,109 @@
+"""Tests for the beta upload panel's direct collection creation flow.
+
+These tests verify that the beta upload UI creates dataset collections
+directly via HdcaDataItemsTarget (destination: hdca) in a single
+/api/tools/fetch request, rather than using the older two-step approach
+of uploading individual datasets then creating a collection separately.
+"""
+
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+    UsesHistoryItemAssertions,
+)
+
+
+class TestBetaUploadCollection(SeleniumTestCase, UsesHistoryItemAssertions):
+    """Tests for direct collection creation through the beta upload panel."""
+
+    ensure_registered = True
+
+    def _navigate_to_beta_upload_method(self, method_id):
+        """Navigate to a specific beta upload method via the activity bar.
+
+        Opens the activity settings panel, clicks the Beta Upload activity
+        to open its sidebar panel, then clicks the desired upload method
+        which navigates to the upload method view via router.push().
+        """
+        self.home()
+        # Open activity settings panel
+        self.components.preferences.activity.wait_for_and_click()
+        # Click the Beta Upload activity in settings to open its sidebar panel
+        self.components.beta_upload.activity.wait_for_and_click()
+        # Wait for and click the specific upload method card in the sidebar
+        self.components.beta_upload.method_card(method_id=method_id).wait_for_and_click()
+
+    def _paste_urls_and_add(self, urls):
+        """Paste URLs into the paste-links textarea and click Add URLs."""
+        textarea = self.components.beta_upload.paste_textarea.wait_for_visible()
+        textarea.send_keys("\n".join(urls))
+        # Click the Add URLs button
+        self.components.beta_upload.add_urls_button.wait_for_and_click()
+
+    def _enable_collection_creation(self, name, collection_type="list"):
+        """Enable collection creation toggle and set name/type."""
+        # Click the "Create a collection" toggle checkbox
+        self.components.beta_upload.collection_section.wait_for_and_click()
+
+        # Wait for the collection config form to appear
+        name_input = self.components.beta_upload.collection_name_input.wait_for_visible()
+        name_input.clear()
+        name_input.send_keys(name)
+
+        # Set collection type if not default
+        if collection_type != "list":
+            self.components.beta_upload.collection_type_select.wait_for_visible()
+            self.components.beta_upload.collection_type_select.select_by_value(collection_type)
+
+    def _click_start_upload(self):
+        """Click the Start button in the upload footer."""
+        self.components.beta_upload.start_button.wait_for_and_click()
+
+    @selenium_test
+    def test_beta_upload_paste_links_as_list_collection(self):
+        """Test creating a list collection directly from pasted URLs."""
+        self._navigate_to_beta_upload_method("paste-links")
+
+        # Paste two URLs
+        test_urls = [
+            "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed",
+            "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/2.bed",
+        ]
+        self._paste_urls_and_add(test_urls)
+
+        # Enable collection creation
+        self._enable_collection_creation("Test List Collection")
+
+        # Start the upload
+        self._click_start_upload()
+
+        # The direct HDCA creation should create a collection directly in history.
+        # With direct collection creation (destination: hdca), only the collection
+        # appears in history - no individual datasets are created.
+        # The collection will be at HID 1 since it's created directly.
+        self.history_panel_wait_for_hid_ok(1)
+
+        # Verify the collection name
+        self.assert_item_name(1, "Test List Collection")
+
+    @selenium_test
+    def test_beta_upload_paste_links_as_paired_collection(self):
+        """Test creating a list:paired collection directly from pasted URLs."""
+        self._navigate_to_beta_upload_method("paste-links")
+
+        # Paste two URLs (will be paired as forward/reverse)
+        test_urls = [
+            "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed",
+            "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/2.bed",
+        ]
+        self._paste_urls_and_add(test_urls)
+
+        # Enable collection creation as list:paired
+        self._enable_collection_creation("Test Paired Collection", collection_type="list:paired")
+
+        # Start the upload
+        self._click_start_upload()
+
+        # Collection should appear directly
+        self.history_panel_wait_for_hid_ok(1)
+        self.assert_item_name(1, "Test Paired Collection")


### PR DESCRIPTION
Instead of the two-step process (upload individual HDAs then create collection separately), the beta upload UI now builds a single /api/tools/fetch request with destination { type: "hdca" } when collection creation is enabled. This creates the collection atomically during the fetch, avoiding temporary individual datasets in history.

Changes:
- Add buildCollectionUploadPayload() and uploadCollectionDatasets() to utils/upload.ts for building HdcaUploadTarget payloads
- Add extractPairName() for smart pair naming in list:paired collections
- Update UploadPayload.targets type to support both HDA and HDCA targets
- Update submitUpload() to handle HDCA targets without local files
- Add processCollectionBatch() to uploadQueue.ts for batch processing
- Modify processNext() to process collection batches as single requests
- Add directCreation flag to CollectionBatchState for state tracking
- Update recovery logic to handle direct-creation batch interruptions
- Add Playwright test for beta upload collection creation flow
- Add 19 new unit tests covering collection payload building

Fixes https://github.com/galaxyproject/galaxy/issues/21850

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
