### PR TITLE
[26.0] Fix OMERO file source download multi channel TIFF

### DIFF
--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -34,7 +34,7 @@ except ImportError:
 try:
     import tifffile
 except ImportError:
-    tifffile = None  # type: ignore[assignment]
+    tifffile = None  # type: ignore[assignment,unused-ignore]
 
 
 class OmeroFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -495,7 +495,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
         if self._try_download_original_file(image, native_path):
             return
 
-        self._export_pixel_data(image, native_path)
+        self._export_as_tiff(image, native_path)
 
     def _try_download_original_file(self, image, native_path: str) -> bool:
         """Attempt to download the original imported file. Returns True if successful.
@@ -522,13 +522,6 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
         with open(native_path, "wb") as f:
             for chunk in orig_file.getFileInChunks():
                 f.write(chunk)
-
-    def _export_pixel_data(self, image, native_path: str):
-        """Export pixel data as TIFF or fallback to thumbnail."""
-        try:
-            self._export_as_tiff(image, native_path)
-        except Exception:
-            self._export_as_thumbnail(image, native_path)
 
     def _export_as_tiff(self, image, native_path: str):
         """Export all Z-planes and channels of the image as a multi-dimensional TIFF.
@@ -557,12 +550,6 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
 
         # Write as TIFF with proper axis metadata
         tifffile.imwrite(native_path, image_array, metadata={"axes": "ZCYX"})
-
-    def _export_as_thumbnail(self, image, native_path: str):
-        """Export the rendered thumbnail as final fallback."""
-        img_data = image.getThumbnail()
-        with open(native_path, "wb") as f:
-            f.write(img_data)
 
     def _write_from(
         self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[OmeroFileSourceConfiguration]

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -34,7 +34,7 @@ except ImportError:
 try:
     import tifffile
 except ImportError:
-    tifffile = None
+    tifffile = None  # type: ignore[assignment]
 
 
 class OmeroFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -6,8 +6,6 @@ from typing import (
     Union,
 )
 
-import tifffile
-
 from galaxy.exceptions import (
     AuthenticationFailed,
     ObjectNotFound,
@@ -32,6 +30,11 @@ try:
 except ImportError:
     omero = None
     BlitzGateway = None
+
+try:
+    import tifffile
+except ImportError:
+    tifffile = None
 
 
 class OmeroFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
@@ -531,6 +534,9 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
 
         Memory usage: O(Y*X) per plane instead of O(Z*C*Y*X) for entire image.
         """
+        if tifffile is None:
+            raise ImportError("The tifffile library is required to export OMERO images as TIFF. Please install it.")
+
         pixels = image.getPrimaryPixels()
         size_z = image.getSizeZ()
         size_c = image.getSizeC()


### PR DESCRIPTION
Fixes #21744

And improves memory handling for images with many planes.

https://github.com/user-attachments/assets/3df5291a-d985-4a44-926f-2c73270c219b



## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #21744
  - See that the TIFF contains all planes now (one per page)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
