### PR TITLE
[26.0] Fix ascp download retries

### DIFF
--- a/lib/galaxy/files/sources/ascp_fsspec.py
+++ b/lib/galaxy/files/sources/ascp_fsspec.py
@@ -327,6 +327,8 @@ class AscpFileSystem(AbstractFileSystem):
             "timed out",
             "refused",
             "unreachable",
+            "session stop",  # Session Stop  (Error: Client unable to connect to server (check UDP port and firewall))
+            "connect via ssh",  # Unable to connect via SSH, exiting
         ]
 
         return any(pattern in error_msg for pattern in retryable_patterns)

--- a/lib/galaxy/files/sources/ascp_fsspec.py
+++ b/lib/galaxy/files/sources/ascp_fsspec.py
@@ -237,8 +237,9 @@ class AscpFileSystem(AbstractFileSystem):
             if self.disable_encryption:
                 cmd.append("-T")
 
-            # Add resume flag if enabled and this is a retry attempt
-            if self.enable_resume and attempt > 0:
+            # Add resume flag if enabled
+            # Note that this must be specified for your first transfer; otherwise, it will not work for subsequent transfers
+            if self.enable_resume:
                 cmd.extend(["-k", "1"])  # Resume level 1: check file size
                 log.debug(f"Resume enabled for retry attempt {attempt + 1}")
 


### PR DESCRIPTION
Retries never worked because -k needs to be passed starting at the first attempt.
Also extends the conditions to retry.

Fixes https://github.com/galaxyproject/galaxy/issues/21854

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
