### PR TITLE
Drop use of pkg_resources

### DIFF
--- a/test/unit/data/test_dataset_materialization.py
+++ b/test/unit/data/test_dataset_materialization.py
@@ -1,4 +1,3 @@
-from pkg_resources import resource_string
 from sqlalchemy import select
 
 from galaxy.files.unittest_utils import TestPosixConfiguredFileSources
@@ -19,6 +18,7 @@ from galaxy.model.unittest_utils.store_fixtures import (
     deferred_hda_model_store_dict_space_to_tab,
     one_ld_library_deferred_model_store_dict,
 )
+from galaxy.util.resources import resource_string
 from .model.test_model_store import (
     perform_import_from_store_dict,
     setup_fixture_context_with_history,
@@ -26,7 +26,7 @@ from .model.test_model_store import (
 )
 from .test_model_copy import _create_hda
 
-CONTENTS_2_BED = resource_string(__name__, "model/2.bed").decode("UTF-8")
+CONTENTS_2_BED = resource_string(__name__, "model/2.bed")
 
 
 def test_undeferred_hdas_untouched(tmpdir):


### PR DESCRIPTION
Removed in setuptools 82.0.0:

https://setuptools.pypa.io/en/stable/history.html#v82-0-0

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
