### PR TITLE
[26.0] Allow connecting sample sheet inputs to compatible collection inputs in editor

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -689,6 +689,80 @@ describe("canAccept", () => {
         dataIn.disconnect(filterFailedOutput);
         expect(stepStore.stepMapOver[filterFailedOutput.stepId]?.isCollection).toBe(true);
     });
+    it("accepts sample_sheet data -> data connection (maps like list)", () => {
+        const collectionOut = terminals["sample_sheet input"]!["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["simple data"]!["input"] as InputTerminal;
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        dataIn.connect(collectionOut);
+        expect(dataIn.mapOver).toEqual({ collectionType: "sample_sheet", isCollection: true, rank: 1 });
+        dataIn.disconnect(collectionOut);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        expect(dataIn.mapOver).toEqual(NULL_COLLECTION_TYPE_DESCRIPTION);
+    });
+    it("accepts sample_sheet -> list connection (canMatch)", () => {
+        const collectionOut = terminals["sample_sheet input"]!["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["list collection input"]!["input1"] as InputCollectionTerminal;
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        dataIn.connect(collectionOut);
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+    });
+    it("accepts sample_sheet:paired -> paired connection (maps over like list:paired)", () => {
+        const collectionOut = terminals["sample_sheet:paired input"]!["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["paired collection input"]!["f1"] as InputTerminal;
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        dataIn.connect(collectionOut);
+        expect(dataIn.mapOver).toEqual({ collectionType: "sample_sheet", isCollection: true, rank: 1 });
+    });
+    it("accepts sample_sheet:paired -> list:paired connection (canMatch)", () => {
+        const collectionOut = terminals["sample_sheet:paired input"]!["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["list:paired collection input"]!["input1"] as InputCollectionTerminal;
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        dataIn.connect(collectionOut);
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+    });
+    it("accepts sample_sheet -> paired_or_unpaired connection", () => {
+        const collectionOut = terminals["sample_sheet input"]!["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["paired_or_unpaired collection input"]!["f1"] as InputTerminal;
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        dataIn.connect(collectionOut);
+        expect(dataIn.mapOver).toEqual({ collectionType: "sample_sheet", isCollection: true, rank: 1 });
+    });
+    it("accepts sample_sheet:paired -> paired_or_unpaired connection", () => {
+        const collectionOut = terminals["sample_sheet:paired input"]!["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["paired_or_unpaired collection input"]!["f1"] as InputTerminal;
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        dataIn.connect(collectionOut);
+        expect(dataIn.mapOver).toEqual({ collectionType: "sample_sheet", isCollection: true, rank: 1 });
+    });
+    it("accepts sample_sheet:paired_or_unpaired -> list:paired_or_unpaired connection (canMatch)", () => {
+        const collectionOut = terminals["sample_sheet:paired_or_unpaired input"]!["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["list:paired_or_unpaired collection input"]!["f1"] as InputTerminal;
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+        expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
+        dataIn.connect(collectionOut);
+        expect(dataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+    });
+    it("rejects list -> sample_sheet connection (asymmetry)", () => {
+        const listOut = terminals["list input"]!["output"] as OutputCollectionTerminal;
+        const collectionIn = terminals["sample_sheet collection input"]!["input1"] as InputCollectionTerminal;
+        expect(collectionIn.canAccept(listOut).canAccept).toBe(false);
+    });
+    it("rejects list:paired -> sample_sheet:paired connection (asymmetry)", () => {
+        const listPairedOut = terminals["list:paired input"]!["output"] as OutputCollectionTerminal;
+        const collectionIn = terminals["sample_sheet:paired collection input"]!["input1"] as InputCollectionTerminal;
+        expect(collectionIn.canAccept(listPairedOut).canAccept).toBe(false);
+    });
+    it("accepts sample_sheet -> sample_sheet connection", () => {
+        const sampleSheetOut = terminals["sample_sheet input"]!["output"] as OutputCollectionTerminal;
+        const collectionIn = terminals["sample_sheet collection input"]!["input1"] as InputCollectionTerminal;
+        expect(collectionIn.canAccept(sampleSheetOut).canAccept).toBe(true);
+    });
     it("rejects connecting paired -> list", () => {
         const pairedOut = terminals["paired input"]!["output"] as OutputCollectionTerminal;
         const collectionIn = terminals["list collection input"]!["input1"] as InputCollectionTerminal;

--- a/client/src/components/Workflow/Editor/test-data/parameter_steps.json
+++ b/client/src/components/Workflow/Editor/test-data/parameter_steps.json
@@ -1329,5 +1329,202 @@
       "left": 12.8729248046875,
       "top": 501.7839660644531
     }
+  },
+  "29": {
+    "id": 29,
+    "type": "data_collection_input",
+    "label": "sample_sheet input",
+    "content_id": null,
+    "name": "Input dataset collection",
+    "tool_state": {
+      "collection_type": "\"sample_sheet\"",
+      "optional": "\"false\"",
+      "tag": "\"\"",
+      "__page__": null,
+      "__rerun_remap_job_id__": null
+    },
+    "errors": null,
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "output",
+        "extensions": [
+          "input"
+        ],
+        "collection": true,
+        "collection_type": "sample_sheet",
+        "optional": false
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "workflow_outputs": [],
+    "input_connections": {},
+    "position": {
+      "left": 12.8729248046875,
+      "top": 601.7839660644531
+    }
+  },
+  "30": {
+    "id": 30,
+    "type": "data_collection_input",
+    "label": "sample_sheet:paired input",
+    "content_id": null,
+    "name": "Input dataset collection",
+    "tool_state": {
+      "collection_type": "\"sample_sheet:paired\"",
+      "optional": "\"false\"",
+      "tag": "\"\"",
+      "__page__": null,
+      "__rerun_remap_job_id__": null
+    },
+    "errors": null,
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "output",
+        "extensions": [
+          "input"
+        ],
+        "collection": true,
+        "collection_type": "sample_sheet:paired",
+        "optional": false
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "workflow_outputs": [],
+    "input_connections": {},
+    "position": {
+      "left": 12.8729248046875,
+      "top": 701.7839660644531
+    }
+  },
+  "31": {
+    "id": 31,
+    "type": "data_collection_input",
+    "label": "sample_sheet:paired_or_unpaired input",
+    "content_id": null,
+    "name": "Input dataset collection",
+    "tool_state": {
+      "collection_type": "\"sample_sheet:paired_or_unpaired\"",
+      "optional": "\"false\"",
+      "tag": "\"\"",
+      "__page__": null,
+      "__rerun_remap_job_id__": null
+    },
+    "errors": null,
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "output",
+        "extensions": [
+          "input"
+        ],
+        "collection": true,
+        "collection_type": "sample_sheet:paired_or_unpaired",
+        "optional": false
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "workflow_outputs": [],
+    "input_connections": {},
+    "position": {
+      "left": 12.8729248046875,
+      "top": 801.7839660644531
+    }
+  },
+  "32": {
+    "id": 32,
+    "type": "tool",
+    "label": "sample_sheet collection input",
+    "content_id": "count_list",
+    "name": "count_list",
+    "tool_state": {
+      "input1": "{\"__class__\": \"RuntimeValue\"}",
+      "__page__": null,
+      "__rerun_remap_job_id__": null
+    },
+    "errors": null,
+    "inputs": [
+      {
+        "name": "input1",
+        "label": "Concatenate Dataset",
+        "multiple": false,
+        "input_type": "dataset_collection",
+        "collection_types": [
+          "sample_sheet"
+        ],
+        "optional": false,
+        "extensions": [
+          "data"
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "out_file1",
+        "extensions": [
+          "txt"
+        ],
+        "type": "data",
+        "optional": false
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "workflow_outputs": [],
+    "input_connections": {},
+    "position": {
+      "left": 12.8729248046875,
+      "top": 901.7839660644531
+    }
+  },
+  "33": {
+    "id": 33,
+    "type": "tool",
+    "label": "sample_sheet:paired collection input",
+    "content_id": "count_list",
+    "name": "count_list",
+    "tool_state": {
+      "input1": "{\"__class__\": \"RuntimeValue\"}",
+      "__page__": null,
+      "__rerun_remap_job_id__": null
+    },
+    "errors": null,
+    "inputs": [
+      {
+        "name": "input1",
+        "label": "Concatenate Dataset",
+        "multiple": false,
+        "input_type": "dataset_collection",
+        "collection_types": [
+          "sample_sheet:paired"
+        ],
+        "optional": false,
+        "extensions": [
+          "data"
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "out_file1",
+        "extensions": [
+          "txt"
+        ],
+        "type": "data",
+        "optional": false
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "workflow_outputs": [],
+    "input_connections": {},
+    "position": {
+      "left": 12.8729248046875,
+      "top": 1001.7839660644531
+    }
   }
 }

--- a/lib/galaxy/model/dataset_collections/type_description.py
+++ b/lib/galaxy/model/dataset_collections/type_description.py
@@ -84,7 +84,8 @@ class CollectionTypeDescription:
         """
         if hasattr(other_collection_type, "collection_type"):
             other_collection_type = other_collection_type.collection_type
-        collection_type = self.collection_type
+        collection_type = _normalize_collection_type(self.collection_type)
+        other_collection_type = _normalize_collection_type(other_collection_type)
         if collection_type == other_collection_type:
             return False
         if collection_type.endswith(other_collection_type):
@@ -106,7 +107,8 @@ class CollectionTypeDescription:
     def can_match_type(self, other_collection_type) -> bool:
         if hasattr(other_collection_type, "collection_type"):
             other_collection_type = other_collection_type.collection_type
-        collection_type = self.collection_type
+        collection_type = _normalize_collection_type(self.collection_type)
+        other_collection_type = _normalize_collection_type(other_collection_type)
         if other_collection_type == collection_type:
             return True
         elif other_collection_type == "paired" and collection_type == "paired_or_unpaired":
@@ -170,6 +172,16 @@ def map_over_collection_type(mapped_over_collection_type, target_collection_type
             target_collection_type = target_collection_type.collection_type
 
         return f"{mapped_over_collection_type}:{target_collection_type}"
+
+
+def _normalize_collection_type(collection_type: str) -> str:
+    """Normalize collection type for comparison purposes.
+
+    sample_sheet behaves like list for mapping/matching.
+    """
+    if collection_type.startswith("sample_sheet"):
+        return "list" + collection_type[len("sample_sheet") :]
+    return collection_type
 
 
 COLLECTION_TYPE_DESCRIPTION_FACTORY = CollectionTypeDescriptionFactory()

--- a/test/unit/data/dataset_collections/test_type_descriptions.py
+++ b/test/unit/data/dataset_collections/test_type_descriptions.py
@@ -46,6 +46,46 @@ def test_paired_or_unpaired_handling():
     assert mixed_list_type_description.can_match_type("list")
 
 
+def test_sample_sheet_acts_like_list():
+    """sample_sheet should behave like list for mapping/matching purposes."""
+    sample_sheet = c_t("sample_sheet")
+    sample_sheet_paired = c_t("sample_sheet:paired")
+    sample_sheet_paired_or_unpaired = c_t("sample_sheet:paired_or_unpaired")
+    list_type = c_t("list")
+    paired_type = c_t("paired")
+
+    # sample_sheet matches list
+    assert sample_sheet.can_match_type("list")
+    assert sample_sheet.can_match_type(list_type)
+    assert list_type.can_match_type("sample_sheet")
+
+    # sample_sheet:paired matches list:paired
+    assert sample_sheet_paired.can_match_type("list:paired")
+    assert c_t("list:paired").can_match_type("sample_sheet:paired")
+
+    # sample_sheet:paired_or_unpaired matches list:paired_or_unpaired
+    assert sample_sheet_paired_or_unpaired.can_match_type("list:paired_or_unpaired")
+    # and can match list:paired and list (like list:paired_or_unpaired does)
+    assert sample_sheet_paired_or_unpaired.can_match_type("list:paired")
+    assert sample_sheet_paired_or_unpaired.can_match_type("list")
+    assert sample_sheet_paired_or_unpaired.can_match_type("sample_sheet")
+    assert sample_sheet_paired_or_unpaired.can_match_type("sample_sheet:paired")
+
+    # sample_sheet:paired has subcollections of type paired
+    assert sample_sheet_paired.has_subcollections_of_type("paired")
+    assert sample_sheet_paired.has_subcollections_of_type(paired_type)
+
+    # sample_sheet has subcollections of type paired_or_unpaired (like list does)
+    assert sample_sheet.has_subcollections_of_type("paired_or_unpaired")
+
+    # sample_sheet does NOT have subcollections of itself
+    assert not sample_sheet.has_subcollections_of_type("sample_sheet")
+    assert not sample_sheet.has_subcollections_of_type("list")
+
+    # effective collection type works correctly
+    assert sample_sheet_paired.effective_collection_type(paired_type) == "sample_sheet"
+
+
 def test_validate():
     c_t("list").validate()
     c_t("list:paired").validate()


### PR DESCRIPTION
sample_sheet collections should behave like list for mapping/matching purposes: sample_sheet matches list, sample_sheet:paired matches list:paired, sample_sheet:paired_or_unpaired matches list:paired_or_unpaired, etc.

Add normalizeCollectionType functions (frontend TS and backend Python) that convert sample_sheet to list for comparison in canMatch, canMapOver, effectiveMapOver, has_subcollections_of_type, and can_match_type. The actual collection_type string is preserved in results so sample_sheet identity is maintained.

Enforce asymmetry: sample_sheet output can satisfy list input, but list output cannot satisfy sample_sheet input. This is guarded at the terminal level in InputCollectionTerminal.attachable() for both canMatch and canMapOver paths.


https://github.com/user-attachments/assets/e83a9999-070c-445f-b0ac-1576eea40ac3

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
