### PR TITLE
Make sure emails are stored in lowercase

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -133,6 +133,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         """
         Create a new user.
         """
+        email = email.lower()
         self._error_on_duplicate_email(email)
         user = self.model_class(email=email, username=username)
         if password:
@@ -163,6 +164,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         message = validate_email(trans, new_email, user)
         if message:
             raise exceptions.RequestParameterInvalidException(message)
+        new_email = new_email.lower()
         if user.email == new_email:
             return
         private_role = trans.app.security_agent.get_private_user_role(user)
@@ -670,7 +672,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                     self.app.security_agent.user_set_default_permissions(user, history=True, dataset=True)
         elif user is None:
             random.seed()
-            user = self.app.model.User(email=remote_user_email)
+            user = self.app.model.User(email=remote_user_email.lower())
             user.set_random_password(length=12)
             user.external = True
             user.username = username_from_email(self.session(), remote_user_email, self.app.model.User)

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -619,6 +619,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         # now.
         if self.app.config.use_remote_user:
             remote_user_email = self.environ.get(self.app.config.remote_user_header, None)
+            remote_user_email = remote_user_email.lower() if remote_user_email else None
             if galaxy_session:
                 if remote_user_email and galaxy_session.user is None:
                     # No user, associate

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -31,7 +31,6 @@ user2_data = dict(email="user2@user2.user2", username="user2", password=default_
 user3_data = dict(email="user3@user3.user3", username="user3", password=default_password)
 user4_data = dict(email="user4@user4.user4", username="user4", password=default_password)
 uppercase_email_user = dict(email="USER5@USER5.USER5", username="USER5", password=default_password)
-lowercase_email_user = dict(email="user5@user5.user5", username="user5", password=default_password)
 
 
 # =============================================================================
@@ -261,21 +260,12 @@ class TestUserManager(BaseTestCase):
         # return None if username/email not found
         assert self.user_manager.get_user_by_identity("xyz") is None
         uppercase_user = self.user_manager.create(**uppercase_email_user)
-        assert uppercase_user.email == uppercase_email_user["email"]
+        assert uppercase_user.email == uppercase_email_user["email"].lower()
         assert uppercase_user.username == uppercase_email_user["username"]
         assert self.user_manager.get_user_by_identity(uppercase_user.email) == uppercase_user
         assert self.user_manager.get_user_by_identity(uppercase_user.username) == uppercase_user
-        # Create another user with the same email just differently capitalized.
-        # This is not normally allowed now, since registration goes through user_manager.register(),
-        # which checks for that, but was possible in earlier releases of Galaxy
-        lowercase_user = self.user_manager.create(**lowercase_email_user)
-        assert lowercase_user.email == lowercase_email_user["email"]
-        assert lowercase_user.username == lowercase_email_user["username"]
-        assert self.user_manager.get_user_by_identity(lowercase_user.email) == lowercase_user
-        assert self.user_manager.get_user_by_identity(lowercase_user.username) == lowercase_user
-        # assert uppercase user can still be retrieved
-        assert self.user_manager.get_user_by_identity(uppercase_user.email) == uppercase_user
-        assert self.user_manager.get_user_by_identity(uppercase_user.username) == uppercase_user
+        # Email lookups should remain case-insensitive.
+        assert self.user_manager.get_user_by_identity(uppercase_email_user["email"]) == uppercase_user
         # username matches need to be exact
         assert self.user_manager.get_user_by_identity(uppercase_user.username.capitalize()) is None
         # email matches can ignore capitalization

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -104,6 +104,21 @@ class TestUserManager(BaseTestCase):
         assert message is None
         assert user2c.username == "user2c"
 
+    def test_register_lowercases_email(self):
+        user, message = self.user_manager.register(
+            self.trans,
+            email="User2D@User2.User2",
+            username="user2d",
+            password=default_password,
+            confirm=default_password,
+        )
+        assert message is None
+        assert user.email == "user2d@user2.user2"
+
+        persisted_user = self.user_manager.by_id(user.id)
+        assert persisted_user is not None
+        assert persisted_user.email == "user2d@user2.user2"
+
     def test_email_queries(self):
         user2 = self.user_manager.create(**user2_data)
 

--- a/test/unit/webapps/test_login.py
+++ b/test/unit/webapps/test_login.py
@@ -35,7 +35,7 @@ class TestLoginController(TestCase):
         self.app.security.encode_id(user2.id)
         assert isinstance(user2, model.User)
         assert user2.id is not None
-        assert user2.email == user2_data["email"]
+        assert user2.email == user2_data["email"].lower()
         assert check_password(default_password, user2.password)
 
         controller = User(self.app)


### PR DESCRIPTION
It looks like there are more places where the email could slip into the database with mismatching case. In particular, `set_information` when updating the user profile. This patches more of those locations and adds tests.

xref: https://github.com/galaxyproject/galaxy/pull/20893

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
