### PR TITLE
Fix Selenium select_by_value: wait for element before find

### DIFF
--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -577,6 +577,12 @@ class HasDriver(TimeoutMessageMixin, WaitMethodsMixin, Generic[WaitTypeT]):
             selector_template: Either a Target or a (locator_type, value) tuple for the select element
             value: The value attribute of the option to select
         """
+        # Wait for element to be present before trying to find it
+        if isinstance(selector_template, Target):
+            locator = selector_template.element_locator
+        else:
+            locator = selector_template
+        self._wait_on_condition_visible(locator, f"select element {locator} to become visible")
         select_element = _protocol_to_webelement(self.find_element(selector_template))
         select = Select(select_element)
         select.select_by_value(value)


### PR DESCRIPTION
select_by_value used raw find_element (no wait), causing NoSuchElementException when the select wasn't in the DOM yet (e.g. library collection modal fade-in).

This was regressed in https://github.com/galaxyproject/galaxy/pull/21841. 

```
❯ Is it clear that before our recent change this was using a method that would wait for Selenium tests?
⏺ Looking back at the test, the old approach used SmartTarget methods that have built-in waits:
  # Old approach (had waits):
  self.components.libraries.folder.export_to_history_options.wait_for_and_click()
  self.components.libraries.folder.export_to_history_paired_option(...).wait_for_and_click()
                                                                                                                 # New approach (no wait):
  self.select_by_value(                                                                                              self.navigation.libraries.folder.selectors.export_to_history_options, collection_option
  )
  Let me verify this by checking the migration commit.
                                                                                                               ⏺ Bash(git show 1575561be8 -- lib/galaxy_test/selenium/test_library_to_collections.py)
  ⎿  commit 1575561be8d0e447e48d1b27615a350f0ce28279                                                                Author: John Chilton <jmchilton@gmail.com>
     Date:   Thu Feb 12 14:49:38 2026 -0500                                                                         … +35 lines (ctrl+o to expand)
                                                                                                               ⏺ Yes, very clear. The old code used wait_for_and_click() which has a built-in visibility wait:

  # Before migration - had waits:
  self.components.libraries.folder.export_to_history_options.wait_for_and_click()
  self.components.libraries.folder.export_to_history_paired_option(...).wait_for_and_click()

  # After migration - no wait:
  self.select_by_value(
      self.navigation.libraries.folder.selectors.export_to_history_options, collection_option
  )

  The migration replaced SmartTarget's wait_for_and_click() (which waits for visibility) with select_by_value()
   (which did a raw find_element with no wait). That's the regression - the fix we just applied restores the
  wait behavior.
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
