### PR TITLE
[25.1] Fix loading non-tool files from watched tool directories

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -1146,6 +1146,8 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         force_watch: bool = False,
     ) -> None:
         def quick_load(tool_file: "StrPath", async_load: bool = True) -> Union[str, None]:
+            if not self._looks_like_a_tool(str(tool_file)):
+                return None
             try:
                 tool = self.load_tool(tool_file)
                 self.__add_tool(tool, load_panel_dict, elems)


### PR DESCRIPTION
The quick_load callback in __watch_directory is used both during the initial directory scan (where _looks_like_a_tool is checked beforehand) and as a callback for the ToolWatcher (where no such check occurs). When the watcher detects a file system event for any .xml file in a watched directory, it calls quick_load directly without verifying the file is actually a tool. This causes files like macros.xml to be loaded as tools and fail with "Missing tool 'id'" errors.

Add a _looks_like_a_tool guard inside quick_load itself so the check is always applied regardless of the caller.
Noticed in planemo CI.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
