### PR TITLE
[26.0] Fix infinite request loop on dataset preview fetch failure

### DIFF
--- a/client/src/api/datasets.ts
+++ b/client/src/api/datasets.ts
@@ -8,7 +8,7 @@ import {
     type HDADetailed,
 } from "@/api";
 import { withPrefix } from "@/utils/redirect";
-import { rethrowSimple } from "@/utils/simple-error";
+import { rethrowSimple, rethrowSimpleWithStatus } from "@/utils/simple-error";
 
 export async function fetchDatasetTextContentDetails(params: { id: string }): Promise<DatasetTextContentDetails> {
     const { data, error } = await GalaxyApi().GET("/api/datasets/{dataset_id}/get_content_as_text", {
@@ -26,7 +26,7 @@ export async function fetchDatasetTextContentDetails(params: { id: string }): Pr
 }
 
 export async function fetchDatasetDetails(params: { id: string }, view: string = "detailed"): Promise<HDADetailed> {
-    const { data, error } = await GalaxyApi().GET("/api/datasets/{dataset_id}", {
+    const { data, error, response } = await GalaxyApi().GET("/api/datasets/{dataset_id}", {
         params: {
             path: {
                 dataset_id: params.id,
@@ -36,7 +36,7 @@ export async function fetchDatasetDetails(params: { id: string }, view: string =
     });
 
     if (error) {
-        rethrowSimple(error);
+        rethrowSimpleWithStatus(error, response);
     }
     return data as HDADetailed;
 }

--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -42,6 +42,7 @@ const props = withDefaults(defineProps<Props>(), {
 const iframeLoading = ref(true);
 
 const dataset = computed(() => datasetStore.getDataset(props.datasetId));
+const loadError = computed(() => datasetStore.getDatasetError(props.datasetId));
 const downloadUrl = computed(() => withPrefix(`/datasets/${props.datasetId}/display`));
 const headerState = computed(() => (headerCollapsed.value ? "closed" : "open"));
 
@@ -102,7 +103,16 @@ watch(
 </script>
 
 <template>
-    <LoadingSpan v-if="isLoading || !dataset" message="Loading dataset details" />
+    <div v-if="loadError" class="alert alert-danger m-4">
+        <h4 class="alert-heading">Dataset Not Available</h4>
+        <p>
+            {{
+                loadError.message ||
+                "This dataset could not be loaded. It may not exist or you may not have permission to access it."
+            }}
+        </p>
+    </div>
+    <LoadingSpan v-else-if="isLoading || !dataset" message="Loading dataset details" />
     <div v-else class="dataset-view d-flex flex-column">
         <header v-if="!displayOnly" :key="`dataset-header-${dataset.id}`" class="dataset-header flex-shrink-0">
             <div class="d-flex">

--- a/client/src/composables/keyedCache.test.ts
+++ b/client/src/composables/keyedCache.test.ts
@@ -193,6 +193,27 @@ describe("useKeyedCache", () => {
         expect(shouldFetch).toHaveBeenCalled();
     });
 
+    it("should not re-fetch after a failed request", async () => {
+        const id = "1";
+
+        fetchItem.mockRejectedValue(new Error("Request failed"));
+
+        const { getItemById, getItemLoadError, isLoadingItem } = useKeyedCache<ItemData>(fetchItem);
+
+        getItemById.value(id);
+        await flushPromises();
+
+        expect(isLoadingItem.value(id)).toBeFalsy();
+        expect(getItemLoadError.value(id)).toBeInstanceOf(Error);
+        expect(fetchItem).toHaveBeenCalledTimes(1);
+
+        // Calling getItemById again should not trigger another fetch
+        getItemById.value(id);
+        await flushPromises();
+
+        expect(fetchItem).toHaveBeenCalledTimes(1);
+    });
+
     it("should handle fake timers without hanging when advanced manually", async () => {
         vi.useFakeTimers();
         const id = "1";

--- a/client/src/composables/keyedCache.ts
+++ b/client/src/composables/keyedCache.ts
@@ -53,7 +53,9 @@ export function useKeyedCache<T>(
     const getItemById = computed(() => {
         return (id: string) => {
             const item = storedItems.value[id];
-            if (shouldFetch(item)) {
+            // TODO: consider allowing retries for transient errors (e.g. 5xx, network)
+            // while still blocking on permanent ones (403, 404).
+            if (shouldFetch(item) && !loadingErrors.value[id]) {
                 fetchItemById({ id: id });
             }
             return item ?? null;

--- a/client/src/utils/simple-error.ts
+++ b/client/src/utils/simple-error.ts
@@ -24,3 +24,18 @@ export function rethrowSimple(e: any): never {
     }
     throw Error(errorMessageAsString(e));
 }
+
+export class ApiError extends Error {
+    status?: number;
+    constructor(message: string, status?: number) {
+        super(message);
+        this.status = status;
+    }
+}
+
+export function rethrowSimpleWithStatus(e: any, response?: { status: number }): never {
+    if (process.env.NODE_ENV != "test") {
+        console.debug(e);
+    }
+    throw new ApiError(errorMessageAsString(e), response?.status);
+}


### PR DESCRIPTION
When navigating to a dataset preview for a dataset you can't access (or with a bad ID), the `useKeyedCache` composable would retry the failed fetch indefinitely. On error, nothing was written to `storedItems`, so the next reactive evaluation of `getItemById` would see `undefined` and fire off another request. This adds a check against `loadingErrors` to stop that loop, and updates `DatasetView` to show an error message instead of spinning forever.

Fixes #21863