### PR TITLE
[26.0] Adds ImageJ metadata support to TIFF export

### DIFF
--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -557,7 +557,7 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
                     else:
                         yield pixels.getPlane(z, c, 0)
 
-        with tifffile.TiffWriter(native_path, bigtiff=True, ome=True) as tif:
+        with tifffile.TiffWriter(native_path, bigtiff=True, imagej=True) as tif:
             tif.write(
                 data=plane_generator(),
                 shape=(size_z, size_c, size_y, size_x),


### PR DESCRIPTION
Switches TIFF writer to use ImageJ metadata, enabling richer metadata and improved compatibility with downstream tools. This better aligns with the image metadata returned by the `toolshed.g2.bx.psu.edu/repos/iuc/idr_download_by_ids/idr_download_by_ids/0.45` tool results for consistency.

## Before

```
Checking file format [OME-TIFF]
Initializing reader
OMETiffReader initializing /home/dlopez/sandbox/data-gx/dev/objects/default/0/f/a/dataset_0fa28f50-d767-4535-91f6-331549048819.dat
Reading IFDs
Populating metadata
Initialization took 0.042s

Reading core metadata
filename = /home/dlopez/sandbox/data-gx/dev/objects/default/0/f/a/dataset_0fa28f50-d767-4535-91f6-331549048819.dat
Series count = 1
Series #0 :
	Image count = 45
	RGB = false (1) 
	Interleaved = false
	Indexed = false (false color)
	Width = 1024
	Height = 1024
	SizeZ = 9
	SizeT = 1
	SizeC = 5
	Thumbnail size = 128 x 128
	Endianness = intel (little)
	Dimension order = XYCZT (certain)
	Pixel type = uint16
	Valid bits per pixel = 16
	Metadata complete = true
	Thumbnail series = false
	-----
	Plane #0 <=> Z 0, C 0, T 0
	Plane #20 <=> Z 4, C 0, T 0
	Plane #21 <=> Z 4, C 1, T 0
	Plane #22 <=> Z 4, C 2, T 0
	Plane #23 <=> Z 4, C 3, T 0
	Plane #24 <=> Z 4, C 4, T 0
	Plane #44 <=> Z 8, C 4, T 0


Reading global metadata

Reading metadata
```

## After

```
Checking file format [Tagged Image File Format]
Initializing reader
TiffDelegateReader initializing /home/dlopez/sandbox/data-gx/dev/objects/default/f/7/a/dataset_f7a57639-7c1b-4d12-bfe3-a5f2a80fca1f.dat
Reading IFDs
Populating metadata
Checking comment style
Populating OME metadata
Initialization took 0.064s

Reading core metadata
filename = /home/dlopez/sandbox/data-gx/dev/objects/default/f/7/a/dataset_f7a57639-7c1b-4d12-bfe3-a5f2a80fca1f.dat
Series count = 1
Series #0 :
	Image count = 45
	RGB = false (1) 
	Interleaved = false
	Indexed = false (false color)
	Width = 1024
	Height = 1024
	SizeZ = 9
	SizeT = 1
	SizeC = 5
	Thumbnail size = 128 x 128
	Endianness = intel (little)
	Dimension order = XYCZT (uncertain)
	Pixel type = uint16
	Valid bits per pixel = 16
	Metadata complete = true
	Thumbnail series = false
	-----
	Plane #0 <=> Z 0, C 0, T 0
	Plane #20 <=> Z 4, C 0, T 0
	Plane #21 <=> Z 4, C 1, T 0
	Plane #22 <=> Z 4, C 2, T 0
	Plane #23 <=> Z 4, C 3, T 0
	Plane #24 <=> Z 4, C 4, T 0
	Plane #44 <=> Z 8, C 4, T 0


Reading global metadata
BitsPerSample: 16
Color mode: grayscale
Compression: Uncompressed
ImageJ: 1.11a
ImageLength: 1024
ImageWidth: 1024
MetaDataPhotometricInterpretation: Monochrome
MetaMorph: no
NumberOfChannels: 1
PhotometricInterpretation: BlackIsZero
ResolutionUnit: None
SamplesPerPixel: 1
Software: tifffile.py
XResolution: 1.0
YResolution: 1.0
hyperstack: true

Reading metadata
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Set up an OMERO file source using IDR connection settings
  - Export one of the images
  - Run the `toolshed.g2.bx.psu.edu/repos/imgteam/image_info/ip_imageinfo/5.7.1+galaxy1` tool on it
  - Check the metadata

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
