### PR TITLE
Use (also) case-insensitive comparison for user email

### DIFF
--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -376,6 +376,7 @@ class Genomes:
         dbkey_owner, dbkey = decode_dbkey(dbkey)
         if dbkey_owner:
             dbkey_user = get_user_by_username(trans.sa_session, dbkey_owner)
+            assert dbkey_user is not None
         else:
             dbkey_user = trans.user
 

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -626,7 +626,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                     galaxy_session_requires_flush = True
                 elif (
                     remote_user_email
-                    and galaxy_session.user.email != remote_user_email
+                    and galaxy_session.user.email.lower() != remote_user_email.lower()
                     and (
                         not self.app.config.allow_user_impersonation
                         or remote_user_email not in self.app.config.admin_users_list

--- a/lib/galaxy/webapps/galaxy/services/quotas.py
+++ b/lib/galaxy/webapps/galaxy/services/quotas.py
@@ -131,7 +131,13 @@ class QuotasService(ServiceBase):
             try:
                 return trans.security.decode_id(item)
             except Exception:
-                return get_user_by_email(trans.sa_session, item).id
+                user = get_user_by_email(trans.sa_session, item)
+                if not user:
+                    # Try a case-insensitive match on the email
+                    user = get_user_by_email(trans.sa_session, item, case_sensitive=False)
+                if not user:
+                    raise ValueError(f"User with email address '{item}' not found.")
+                return user.id
 
         def get_group_id(item):
             try:

--- a/lib/galaxy/webapps/galaxy/services/sharable.py
+++ b/lib/galaxy/webapps/galaxy/services/sharable.py
@@ -4,8 +4,6 @@ from typing import (
     Union,
 )
 
-from sqlalchemy import false
-
 from galaxy.managers import base
 from galaxy.managers.sharable import (
     SharableModelManager,
@@ -156,9 +154,12 @@ class ShareableService:
                 email_address = email_or_id.strip()
                 if not email_address:
                     continue
-                send_to_user = self.manager.user_manager.by_email(
-                    email_address, filters=[User.table.c.deleted == false()]
-                )
+                send_to_user = self.manager.user_manager.by_email(email_address, deleted=False)
+                if not send_to_user:
+                    # Try a case-insensitive match on the email
+                    send_to_user = self.manager.user_manager.by_email(
+                        email_address, case_sensitive=False, deleted=False
+                    )
 
             if not send_to_user:
                 send_to_err.add(f"{email_or_id} is not a valid Galaxy user.")

--- a/test/integration/test_user_preferences.py
+++ b/test/integration/test_user_preferences.py
@@ -21,6 +21,7 @@ class TestUserPreferences(integration_util.IntegrationTestCase):
         app = cast(Any, self._test_driver.app if self._test_driver else None)
 
         db_user = get_user_by_email(app.model.session, user["email"])
+        assert db_user is not None
 
         # create some initial data
         put(url)

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -31,7 +31,6 @@ user2_data = dict(email="user2@user2.user2", username="user2", password=default_
 user3_data = dict(email="user3@user3.user3", username="user3", password=default_password)
 user4_data = dict(email="user4@user4.user4", username="user4", password=default_password)
 uppercase_email_user = dict(email="USER5@USER5.USER5", username="USER5", password=default_password)
-lowercase_email_user = dict(email="user5@user5.user5", username="user5", password=default_password)
 
 
 # =============================================================================
@@ -74,12 +73,23 @@ class TestUserManager(BaseTestCase):
         self.log("emails must be unique")
         with self.assertRaises(exceptions.Conflict):
             self.user_manager.create(
-                **dict(email="user2@user2.user2", username="user2a", password=default_password),
+                email=user2_data["email"],
+                username="user2a",
+                password=default_password,
+            )
+        self.log("emails must be case-insensitive unique")
+        with self.assertRaises(exceptions.Conflict):
+            self.user_manager.create(
+                email=user2_data["email"].capitalize(),
+                username="user2a",
+                password=default_password,
             )
         self.log("usernames must be unique")
         with self.assertRaises(exceptions.Conflict):
             self.user_manager.create(
-                **dict(email="user2a@user2.user2", username="user2", password=default_password),
+                email="user2a@user2.user2",
+                username=user2_data["username"],
+                password=default_password,
             )
 
     def test_trimming(self):
@@ -250,27 +260,10 @@ class TestUserManager(BaseTestCase):
         assert uppercase_user.username == uppercase_email_user["username"]
         assert self.user_manager.get_user_by_identity(uppercase_user.email) == uppercase_user
         assert self.user_manager.get_user_by_identity(uppercase_user.username) == uppercase_user
-        # Create another user with the same email just differently capitalized.
-        # This is not normally allowed now, since registration goes through user_manager.register(),
-        # which checks for that, but was possible in earlier releases of Galaxy
-        lowercase_user = self.user_manager.create(**lowercase_email_user)
-        assert lowercase_user.email == lowercase_email_user["email"]
-        assert lowercase_user.username == lowercase_email_user["username"]
-        assert self.user_manager.get_user_by_identity(lowercase_user.email) == lowercase_user
-        assert self.user_manager.get_user_by_identity(lowercase_user.username) == lowercase_user
-        # assert uppercase user can still be retrieved
-        assert self.user_manager.get_user_by_identity(uppercase_user.email) == uppercase_user
-        assert self.user_manager.get_user_by_identity(uppercase_user.username) == uppercase_user
         # username matches need to be exact
-        assert self.user_manager.get_user_by_identity(uppercase_user.username.capitalize()) is None
-        # email matches can ignore capitalization
-        ignore_email_capitalization_user = self.user_manager.create(
-            email="user123@nopassword.com", username="someusername123"
-        )
-        assert (
-            self.user_manager.get_user_by_identity(ignore_email_capitalization_user.email.capitalize())
-            == ignore_email_capitalization_user
-        )
+        assert self.user_manager.get_user_by_identity(uppercase_email_user["username"].capitalize()) is None
+        # Email lookups should be case-insensitive
+        assert self.user_manager.get_user_by_identity(uppercase_email_user["email"].capitalize()) == uppercase_user
 
 
 # =============================================================================

--- a/test/unit/data/model/db/conftest.py
+++ b/test/unit/data/model/db/conftest.py
@@ -37,7 +37,7 @@ def engine(db_url: str) -> "Engine":
 @pytest.fixture
 def session(engine: "Engine") -> Session:
     session = Session(engine)
-    # For sqlite, we need to explicitly enale foreign key constraints.
+    # For sqlite, we need to explicitly enable foreign key constraints.
     if engine.name == "sqlite":
         session.execute(text("PRAGMA foreign_keys = ON;"))
     return session


### PR DESCRIPTION
This PR implements case-insensitive email comparison throughout the codebase as an alternative approach to PR #21861 (which proposed storing emails in lowercase). The changes maintain the original email casing in the database while ensuring lookups can find users regardless of email case differences, improving backward compatibility with existing data where emails may have been stored with varying cases.

**Changes:**
- Enhanced `get_user_by_email` function with `deleted` parameter for flexible email lookups
- Refactored `UserManager` to use case-insensitive email fallbacks in authentication and user lookup flows  
- Added case-insensitive email comparison for remote user authentication
- Added test coverage for case-insensitive email uniqueness checks and lookups

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
