### PR TITLE
Support URL and TRS references for subworkflows in workflow import

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -350,8 +350,17 @@ class WorkflowsAPIController(
             history = self.history_manager.get_accessible(
                 self.decode_id(history_id), trans.user, current_history=trans.history
             )
+        preserve_external_subworkflow_links = util.string_as_bool(
+            kwd.get("preserve_external_subworkflow_links", "false")
+        )
         ret_dict = self.workflow_contents_manager.workflow_to_dict(
-            trans, stored_workflow, style=style, version=version, history=history, instance_id=instance_id
+            trans,
+            stored_workflow,
+            style=style,
+            version=version,
+            history=history,
+            instance_id=instance_id,
+            preserve_external_subworkflow_links=preserve_external_subworkflow_links,
         )
         if download_format == "json-download":
             sname = stored_workflow.name

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1533,48 +1533,13 @@ steps:
         reuploaded_workflow = self._download_workflow(reuploaded_workflow_id)
         assert reuploaded_workflow.get("source_metadata") is None
 
-    def test_import_ga_workflow_with_url_subworkflow(self):
-        """Test importing a .ga workflow where a subworkflow is referenced via a base64:// URL."""
-        inner_workflow = {
+    @staticmethod
+    def _build_outer_ga_workflow(subworkflow_step_props: dict, input_name: str = "WorkflowInput1") -> dict:
+        """Build a .ga outer workflow with a data input connected to a subworkflow step."""
+        return {
             "a_galaxy_workflow": "true",
             "format-version": "0.1",
-            "name": "Inner Workflow",
-            "annotation": "",
-            "steps": {
-                "0": {
-                    "type": "data_input",
-                    "id": 0,
-                    "tool_id": None,
-                    "tool_version": None,
-                    "tool_state": json.dumps({"name": "inner_input"}),
-                    "input_connections": {},
-                    "inputs": [{"name": "inner_input", "description": ""}],
-                    "outputs": [],
-                    "annotation": "",
-                },
-                "1": {
-                    "type": "tool",
-                    "id": 1,
-                    "tool_id": "cat1",
-                    "tool_version": None,
-                    "name": "Concatenate datasets",
-                    "tool_state": "{}",
-                    "input_connections": {"input1": {"id": 0, "output_name": "output"}},
-                    "inputs": [],
-                    "outputs": [{"name": "out_file1", "type": "input"}],
-                    "post_job_actions": {},
-                    "annotation": "",
-                    "workflow_outputs": [{"output_name": "out_file1", "label": "inner_output"}],
-                },
-            },
-        }
-        inner_json = json.dumps(inner_workflow)
-        base64_url = "base64://" + base64.b64encode(inner_json.encode("utf-8")).decode("utf-8")
-
-        outer_workflow = {
-            "a_galaxy_workflow": "true",
-            "format-version": "0.1",
-            "name": "Outer Workflow with URL Subworkflow",
+            "name": "Outer Workflow",
             "annotation": "",
             "steps": {
                 "0": {
@@ -1591,27 +1556,30 @@ steps:
                 "1": {
                     "type": "subworkflow",
                     "id": 1,
-                    "content_source": "url",
-                    "content_id": base64_url,
-                    "input_connections": {"inner_input": {"id": 0, "output_name": "output"}},
+                    "input_connections": {input_name: {"id": 0, "output_name": "output"}},
                     "annotation": "",
+                    **subworkflow_step_props,
                 },
             },
         }
-        response = self._post("workflows", data={"workflow": json.dumps(outer_workflow)})
-        response.raise_for_status()
-        workflow_id = response.json()["id"]
-        workflow = self._download_workflow(workflow_id)
-        assert workflow["name"] == "Outer Workflow with URL Subworkflow"
-        # Find the subworkflow step
-        subworkflow_step = None
+
+    @staticmethod
+    def _get_subworkflow_dict(workflow: dict) -> dict:
+        """Find the subworkflow step in a downloaded workflow and return its embedded subworkflow dict."""
         for step in workflow["steps"].values():
             if step["type"] == "subworkflow":
-                subworkflow_step = step
-                break
-        assert subworkflow_step is not None, "No subworkflow step found"
-        subworkflow = subworkflow_step["subworkflow"]
-        assert subworkflow["name"] == "Inner Workflow"
+                return step["subworkflow"]
+        raise AssertionError("No subworkflow step found in downloaded workflow")
+
+    def test_import_ga_workflow_with_url_subworkflow(self):
+        """Test importing a .ga workflow where a subworkflow is referenced via a base64:// URL."""
+        inner_workflow = self.workflow_populator.load_workflow("inner_workflow")
+        base64_url = "base64://" + base64.b64encode(json.dumps(inner_workflow).encode()).decode()
+        outer_workflow = self._build_outer_ga_workflow({"content_source": "url", "content_id": base64_url})
+        workflow_id = self.workflow_populator.create_workflow(outer_workflow)
+        workflow = self._download_workflow(workflow_id)
+        subworkflow = self._get_subworkflow_dict(workflow)
+        assert subworkflow["name"] == "inner_workflow"
         assert subworkflow.get("source_metadata") == {"url": base64_url}
 
     def test_import_gxformat2_workflow_with_url_subworkflow(self):
@@ -1620,42 +1588,23 @@ steps:
         Uses server-side conversion (client_convert=False) because the gxformat2 client-side
         converter does not support URL references in the 'run' field.
         """
-        inner_yaml = """
-class: GalaxyWorkflow
-inputs:
-  inner_input: data
-outputs:
-  inner_output:
-    outputSource: cat_step/out_file1
-steps:
-  cat_step:
-    tool_id: cat1
-    in:
-      input1: inner_input
-"""
-        base64_url = "base64://" + base64.b64encode(inner_yaml.strip().encode("utf-8")).decode("utf-8")
+        base64_url = "base64://" + base64.b64encode(WORKFLOW_SIMPLE.strip().encode()).decode()
         outer_yaml = f"""
 class: GalaxyWorkflow
 inputs:
   outer_input: data
 outputs:
   outer_output:
-    outputSource: nested_workflow/inner_output
+    outputSource: nested_workflow/wf_output_1
 steps:
   nested_workflow:
     run: "{base64_url}"
     in:
-      inner_input: outer_input
+      input1: outer_input
 """
         workflow_id = self._upload_yaml_workflow(outer_yaml, client_convert=False)
         workflow = self._download_workflow(workflow_id)
-        subworkflow_step = None
-        for step in workflow["steps"].values():
-            if step["type"] == "subworkflow":
-                subworkflow_step = step
-                break
-        assert subworkflow_step is not None, "No subworkflow step found"
-        subworkflow = subworkflow_step["subworkflow"]
+        subworkflow = self._get_subworkflow_dict(workflow)
         assert subworkflow.get("source_metadata") == {"url": base64_url}
 
     @skip_if_github_down
@@ -1666,98 +1615,43 @@ steps:
             "%23workflow%2Fgithub.com%2Fjmchilton%2Fgalaxy-workflow-dockstore-example-1%2Fmycoolworkflow/"
             "versions/master"
         )
-        outer_workflow = {
-            "a_galaxy_workflow": "true",
-            "format-version": "0.1",
-            "name": "Outer Workflow with TRS URL Subworkflow",
-            "annotation": "",
-            "steps": {
-                "0": {
-                    "type": "data_input",
-                    "id": 0,
-                    "tool_id": None,
-                    "tool_version": None,
-                    "tool_state": json.dumps({"name": "outer_input"}),
-                    "input_connections": {},
-                    "inputs": [{"name": "outer_input", "description": ""}],
-                    "outputs": [],
-                    "annotation": "",
-                },
-                "1": {
-                    "type": "subworkflow",
-                    "id": 1,
-                    "content_source": "trs_url",
-                    "content_id": trs_url,
-                    "input_connections": {"WorkflowInput1": {"id": 0, "output_name": "output"}},
-                    "annotation": "",
-                },
-            },
-        }
-        response = self._post("workflows", data={"workflow": json.dumps(outer_workflow)})
-        response.raise_for_status()
-        workflow_id = response.json()["id"]
+        outer_workflow = self._build_outer_ga_workflow(
+            {"content_source": "trs_url", "content_id": trs_url},
+        )
+        workflow_id = self.workflow_populator.create_workflow(outer_workflow)
         workflow = self._download_workflow(workflow_id)
-        subworkflow_step = None
-        for step in workflow["steps"].values():
-            if step["type"] == "subworkflow":
-                subworkflow_step = step
-                break
-        assert subworkflow_step is not None, "No subworkflow step found"
-        subworkflow = subworkflow_step["subworkflow"]
+        subworkflow = self._get_subworkflow_dict(workflow)
         assert "Test Workflow" in subworkflow["name"]
         source_metadata = subworkflow.get("source_metadata")
         assert source_metadata is not None
-        assert source_metadata["trs_tool_id"] == "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow"
+        assert (
+            source_metadata["trs_tool_id"]
+            == "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow"
+        )
         assert source_metadata["trs_version_id"] == "master"
         assert source_metadata["trs_url"] == trs_url
 
     @skip_if_github_down
     def test_import_ga_workflow_with_trs_id_subworkflow(self):
         """Test importing a .ga workflow where a subworkflow is referenced via TRS server + tool ID + version."""
-        outer_workflow = {
-            "a_galaxy_workflow": "true",
-            "format-version": "0.1",
-            "name": "Outer Workflow with TRS ID Subworkflow",
-            "annotation": "",
-            "steps": {
-                "0": {
-                    "type": "data_input",
-                    "id": 0,
-                    "tool_id": None,
-                    "tool_version": None,
-                    "tool_state": json.dumps({"name": "outer_input"}),
-                    "input_connections": {},
-                    "inputs": [{"name": "outer_input", "description": ""}],
-                    "outputs": [],
-                    "annotation": "",
-                },
-                "1": {
-                    "type": "subworkflow",
-                    "id": 1,
-                    "content_source": "trs_id",
-                    "trs_server": "dockstore",
-                    "trs_tool_id": "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow",
-                    "trs_version_id": "master",
-                    "input_connections": {"WorkflowInput1": {"id": 0, "output_name": "output"}},
-                    "annotation": "",
-                },
-            },
-        }
-        response = self._post("workflows", data={"workflow": json.dumps(outer_workflow)})
-        response.raise_for_status()
-        workflow_id = response.json()["id"]
+        outer_workflow = self._build_outer_ga_workflow(
+            {
+                "content_source": "trs_id",
+                "trs_server": "dockstore",
+                "trs_tool_id": "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow",
+                "trs_version_id": "master",
+            }
+        )
+        workflow_id = self.workflow_populator.create_workflow(outer_workflow)
         workflow = self._download_workflow(workflow_id)
-        subworkflow_step = None
-        for step in workflow["steps"].values():
-            if step["type"] == "subworkflow":
-                subworkflow_step = step
-                break
-        assert subworkflow_step is not None, "No subworkflow step found"
-        subworkflow = subworkflow_step["subworkflow"]
+        subworkflow = self._get_subworkflow_dict(workflow)
         assert "Test Workflow" in subworkflow["name"]
         source_metadata = subworkflow.get("source_metadata")
         assert source_metadata is not None
-        assert source_metadata["trs_tool_id"] == "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow"
+        assert (
+            source_metadata["trs_tool_id"]
+            == "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow"
+        )
         assert source_metadata["trs_version_id"] == "master"
 
     def test_anonymous_published(self):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1597,11 +1597,7 @@ steps:
         assert subworkflow.get("source_metadata") == {"url": base64_url}
 
     def test_import_gxformat2_workflow_with_url_subworkflow(self):
-        """Test importing a gxformat2 workflow where a subworkflow is referenced via a base64:// URL.
-
-        Uses server-side conversion (client_convert=False) because the gxformat2 client-side
-        converter does not support URL references in the 'run' field.
-        """
+        """Test importing a gxformat2 workflow where a subworkflow is referenced via a base64:// URL."""
         base64_url = "base64://" + base64.b64encode(WORKFLOW_SIMPLE.strip().encode()).decode()
         outer_yaml = f"""
 class: GalaxyWorkflow
@@ -1616,7 +1612,7 @@ steps:
     in:
       input1: outer_input
 """
-        workflow_id = self._upload_yaml_workflow(outer_yaml, client_convert=False)
+        workflow_id = self._upload_yaml_workflow(outer_yaml)
         workflow = self._download_workflow(workflow_id)
         subworkflow = self._get_subworkflow_dict(workflow)
         assert subworkflow.get("source_metadata") == {"url": base64_url}
@@ -1742,7 +1738,7 @@ steps:
     in:
       input1: outer_input
 """
-        workflow_id = self._upload_yaml_workflow(outer_yaml, client_convert=False)
+        workflow_id = self._upload_yaml_workflow(outer_yaml)
         # Download as format2 with preserved links
         exported = self._download_workflow(
             workflow_id,
@@ -1751,8 +1747,8 @@ steps:
         )
         nested_step = exported["steps"]["nested_workflow"]
         assert nested_step["run"] == base64_url
-        # Re-import the exported format2 workflow as YAML string (server-side conversion)
-        reimported_id = self._upload_yaml_workflow(yaml.dump(dict(exported)), client_convert=False)
+        # Re-import the exported format2 workflow
+        reimported_id = self._upload_yaml_workflow(exported)
         reimported = self._download_workflow(reimported_id)
         subworkflow = self._get_subworkflow_dict(reimported)
         assert subworkflow.get("source_metadata") == {"url": base64_url}

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1627,6 +1627,7 @@ steps:
         )
         outer_workflow = self._build_outer_ga_workflow(
             {"content_source": "trs_url", "content_id": trs_url},
+            input_name="input1",
         )
         workflow_id = self.workflow_populator.create_workflow(outer_workflow)
         workflow = self._download_workflow(workflow_id)
@@ -1650,7 +1651,8 @@ steps:
                 "trs_server": "dockstore",
                 "trs_tool_id": "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow",
                 "trs_version_id": "master",
-            }
+            },
+            input_name="input1",
         )
         workflow_id = self.workflow_populator.create_workflow(outer_workflow)
         workflow = self._download_workflow(workflow_id)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2134,6 +2134,7 @@ class BaseWorkflowPopulator(BasePopulator):
 
     def create_workflow(self, workflow: dict[str, Any], **create_kwds) -> str:
         upload_response = self.create_workflow_response(workflow, **create_kwds)
+        api_asserts.assert_status_code_is(upload_response, 200)
         uploaded_workflow_id = upload_response.json()["id"]
         return uploaded_workflow_id
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2378,6 +2378,7 @@ class BaseWorkflowPopulator(BasePopulator):
         history_id: Optional[str] = None,
         instance: Optional[bool] = None,
         version: Optional[int] = None,
+        preserve_external_subworkflow_links: Optional[bool] = None,
     ) -> dict:
         params: dict[str, Any] = {}
         if style is not None:
@@ -2388,6 +2389,8 @@ class BaseWorkflowPopulator(BasePopulator):
             params["instance"] = instance
         if version is not None:
             params["version"] = version
+        if preserve_external_subworkflow_links is not None:
+            params["preserve_external_subworkflow_links"] = preserve_external_subworkflow_links
         response = self._get(f"workflows/{workflow_id}/download", data=params)
         api_asserts.assert_status_code_is(response, 200)
         if style != "format2":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "future>=1.0.0",  # Python 3.12 support
     "gravity>=1.2.0",  # Python 3.14 support
     "gunicorn!=25.1.0",  # https://github.com/benoitc/gunicorn/discussions/3509
-    "gxformat2>=0.21.0",
+    "gxformat2>=0.22.0",
     "h5grove>=1.2.1",
     "h5py>=3.12",  # Python 3.13 support
     "httpx",


### PR DESCRIPTION
This adds basic support for resolving and maintaining metadata for imported subworkflows.
It should make it nicer to maintain workflows containing (IWC) subworkflows.

Enable workflow import (.ga and gxformat2) where subworkflow steps reference external workflows via URL, TRS URL, or TRS ID instead of embedding the full subworkflow definition inline.

New `content_source` field on subworkflow steps declares resolution strategy: "url" for HTTP/HTTPS/base64 URLs, "trs_url" for TRS API URLs, "trs_id" for TRS server + tool ID + version. Fallback URL detection from content_id supports gxformat2 `run:` references without content_source.

Source metadata (url, trs_tool_id, etc.) is preserved on each fetched subworkflow. Cycle prevention via resolving_urls frozenset threaded through the build chain.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
