### PR TITLE
[26.0] Fixes some more optional fields in templates

### DIFF
--- a/lib/galaxy/files/templates/examples/production_dataverse.yml
+++ b/lib/galaxy/files/templates/examples/production_dataverse.yml
@@ -25,6 +25,7 @@
       public_name:
           label: Publication Name
           type: string
+          optional: true
           help: |
               The name of the person or organization creating the datasets. This will be used in the dataset metadata as the
               creator. You can update this information later by editing the dataset in Dataverse. If left blank, an anonymous user will be used as the creator.
@@ -32,6 +33,7 @@
   secrets:
       token:
           label: API Token
+          optional: true
           help: |
               The personal API token used to authenticate with the Dataverse server. You can generate this token in your
               Dataverse account settings under "API Token". It is required to access private data or upload datasets from Galaxy.

--- a/lib/galaxy/files/templates/examples/production_invenio.yml
+++ b/lib/galaxy/files/templates/examples/production_invenio.yml
@@ -22,6 +22,7 @@
       public_name:
           label: Publication Name
           type: string
+          optional: true
           help: |
               The name of the person or organization that is creating the records in InvenioRDM. This will be used as the
               "creator" field in the metadata of the records. You can always change this value later by editing the records in
@@ -29,6 +30,7 @@
   secrets:
       token:
           label: Personal Access Token
+          optional: true
           help: |
               The personal access token to use to connect to the InvenioRDM server. In your InvenioRDM instance, go to your
               Account Settings and then go to Applications to generate a new token if you don't have one yet.

--- a/lib/galaxy/files/templates/examples/production_zenodo.yml
+++ b/lib/galaxy/files/templates/examples/production_zenodo.yml
@@ -19,6 +19,7 @@
       public_name:
           label: Publication Name
           type: string
+          optional: true
           help: |
               The name of the person or organization that is creating the records in Zenodo. This will be used as the
               "creator" field in the metadata of the records. You can always change this value later by editing the records in
@@ -26,6 +27,7 @@
   secrets:
       token:
           label: Personal Access Token
+          optional: true
           help: |
               The personal access token to use to connect to Zenodo. Go to your Account Settings and then go to Applications
               here https://zenodo.org/account/settings/applications/. You can generate a new `Personal Access Token` if you don't have one yet.


### PR DESCRIPTION
Follow up to #21704

These repositories allow access to the contents that are public without having to specify a token or set a publication name if we are going to use them just for read-only purposes.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Include any of these templates in your `config/file_source_templates.yml`
  - Try to create a connection and see that the API token and publication name are now optional.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
