### PR TITLE
[26.0] Fix missing sharable link URL in TS2.0 emails

### DIFF
--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -249,10 +249,13 @@ def create_repository(
 
 
 def generate_sharable_link_for_repository_in_tool_shed(
-    repository: model.Repository, changeset_revision: Optional[str] = None
+    repository: model.Repository, changeset_revision: Optional[str] = None, base_url: Optional[str] = None
 ) -> str:
     """Generate the URL for sharing a repository that is in the tool shed."""
-    base_url = web.url_for("/", qualified=True).rstrip("/")
+    if base_url is None:
+        base_url = web.url_for("/", qualified=True).rstrip("/")
+    else:
+        base_url = base_url.rstrip("/")
     sharable_url = f"{base_url}/view/{repository.user.username}/{repository.name}"
     if changeset_revision:
         sharable_url += f"/{changeset_revision}"

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -223,7 +223,7 @@ def handle_email_alerts(
     sa_session = app.model.session
     repo = repository.hg_repo
     sharable_link = repository_util.generate_sharable_link_for_repository_in_tool_shed(
-        repository, changeset_revision=None
+        repository, changeset_revision=None, base_url=app.config.tool_shed_url
     )
     smtp_server = app.config.smtp_server
     if smtp_server and (new_repo_alert or repository.email_alerts):

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -1623,7 +1623,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         repo_name = kwd.get("repo_name", repository.name)
         changeset_revision = kwd.get("changeset_revision", repository.tip())
         repository.share_url = repository_util.generate_sharable_link_for_repository_in_tool_shed(
-            repository, changeset_revision=changeset_revision
+            repository, changeset_revision=changeset_revision, base_url=trans.app.config.tool_shed_url
         )
         repository.clone_url = common_util.generate_clone_url_for_repository_in_tool_shed(trans.user, repository)
         remote_repository_url = kwd.get("remote_repository_url", repository.remote_repository_url)
@@ -2449,7 +2449,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         changeset_revision = kwd.get("changeset_revision", repository.tip())
         self.validate_changeset_revision(trans, changeset_revision, id)
         repository.share_url = repository_util.generate_sharable_link_for_repository_in_tool_shed(
-            repository, changeset_revision=changeset_revision
+            repository, changeset_revision=changeset_revision, base_url=trans.app.config.tool_shed_url
         )
         repository.clone_url = common_util.generate_clone_url_for_repository_in_tool_shed(trans.user, repository)
         alerts = kwd.get("alerts", "")

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/repository/common.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/repository/common.mako
@@ -51,7 +51,7 @@
 <%def name="render_sharable_str( repository, changeset_revision=None )">
     <%
         from tool_shed.util.repository_util import generate_sharable_link_for_repository_in_tool_shed
-        sharable_link = generate_sharable_link_for_repository_in_tool_shed( repository, changeset_revision=changeset_revision )
+        sharable_link = generate_sharable_link_for_repository_in_tool_shed( repository, changeset_revision=changeset_revision, base_url=trans.app.config.tool_shed_url )
     %>
     <a href="${ sharable_link }" target="_blank">${ sharable_link }</a>
 </%def>

--- a/test/unit/tool_shed/_util.py
+++ b/test/unit/tool_shed/_util.py
@@ -47,6 +47,7 @@ class TestToolShedConfig:
     file_path: str
     id_secret: str = "thisistheshedunittestsecret"
     smtp_server: Optional[str] = None
+    tool_shed_url: Optional[str] = "shed_unit_test://localhost"
     hgweb_repo_prefix = "repos/"
     config_hg_for_dev = False
 


### PR DESCRIPTION
Use configured tool_shed_url instead of deprecated web.url_for() which returns a placeholder string in ASGI/FastAPI mode.

Reusing fix strategy from https://github.com/galaxyproject/galaxy/pull/21499. 

Should fix #21871.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Deploy it and see if it works?

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
