### PR TITLE
Migrate Library components from BTable to GTable and improve GTable

### DIFF
--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -602,6 +602,21 @@ function getIconProps(item: T, index: number) {
 const getFieldId = (tableId: string, fieldKey: string) => `g-table-field-${fieldKey}-${tableId}`;
 const getRowId = (tableId: string, index: number) => `g-table-row-${index}-${tableId}`;
 const getCellId = (tableId: string, fieldKey: string, index: number) => `g-table-cell-${fieldKey}-${index}-${tableId}`;
+
+/**
+ * Refresh the table - useful for manual recalculation of computed properties
+ */
+function refresh() {
+    // Force reactivity by re-assigning the expanded rows set
+    expandedRows.value = new Set(expandedRows.value);
+}
+
+/**
+ * Expose refresh method to parent components
+ */
+defineExpose({
+    refresh,
+});
 </script>
 
 <template>

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -87,6 +87,19 @@ interface Props {
     filter?: string;
 
     /**
+     * Array of field keys to exclude from filtering
+     * @default undefined
+     */
+    filterIgnoredFields?: string[];
+
+    /**
+     * Array of field keys to include in filtering
+     * If specified, only these fields will be searched
+     * @default undefined
+     */
+    filterIncludedFields?: string[];
+
+    /**
      * Whether to use fixed table layout (BootstrapVue `fixed`)
      * @default false
      */
@@ -232,6 +245,8 @@ const props = withDefaults(defineProps<Props>(), {
     emptyState: () => ({ message: "No data available" }),
     fields: () => [],
     filter: "",
+    filterIgnoredFields: undefined,
+    filterIncludedFields: undefined,
     fixed: false,
     hover: true,
     hideHeader: false,
@@ -333,11 +348,23 @@ const localItems = computed(() => {
     if (props.localFiltering && props.filter && props.filter.trim() !== "") {
         const filterLower = props.filter.toLowerCase().trim();
         items = items.filter((item) => {
-            // Search through all field values
-            return Object.values(item).some((value) => {
+            // Search through specified fields based on filterIncludedFields and filterIgnoredFields
+            return Object.entries(item).some(([key, value]) => {
+                // Skip if field is in ignored list
+                if (props.filterIgnoredFields && props.filterIgnoredFields.includes(key)) {
+                    return false;
+                }
+
+                // Skip if included list is specified and field is not in it
+                if (props.filterIncludedFields && !props.filterIncludedFields.includes(key)) {
+                    return false;
+                }
+
+                // Skip null/undefined values
                 if (value == null) {
                     return false;
                 }
+
                 return String(value).toLowerCase().includes(filterLower);
             });
         });

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -716,7 +716,7 @@ defineExpose({
                     </thead>
 
                     <tbody>
-                        <tr v-if="props.showEmpty && !props.items.length">
+                        <tr v-if="props.showEmpty && !props.items.length" class="g-table-empty-row">
                             <td :colspan="(selectable ? 1 : 0) + props.fields.length + (props.actions ? 1 : 0)">
                                 <slot name="empty">
                                     <BAlert v-if="!loading" variant="info" show class="w-100 m-0">

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -190,6 +190,12 @@ interface Props {
     selectedItems?: number[];
 
     /**
+     * Whether to show the empty state message when no items are available
+     * @default false
+     */
+    showEmpty?: boolean;
+
+    /**
      * Current sort field key
      * @default ""
      */
@@ -261,6 +267,7 @@ const props = withDefaults(defineProps<Props>(), {
     perPage: undefined,
     selectable: false,
     selectedItems: () => [],
+    showEmpty: false,
     showSelectAll: false,
     sortBy: "",
     sortDesc: false,
@@ -695,7 +702,7 @@ defineExpose({
                     </thead>
 
                     <tbody>
-                        <tr v-if="!props.items.length">
+                        <tr v-if="props.showEmpty && !props.items.length">
                             <td :colspan="(selectable ? 1 : 0) + props.fields.length + (props.actions ? 1 : 0)">
                                 <slot name="empty">
                                     <BAlert v-if="!loading" variant="info" show class="w-100 m-0">

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -323,7 +323,7 @@ const emit = defineEmits<{
 }>();
 
 const sortBy = ref<string>(props.sortBy || "update_time");
-const sortDesc = ref<boolean>(props.sortDesc || true);
+const sortDesc = ref<boolean>(props.sortDesc ?? false);
 const expandedRows = ref<Set<number>>(new Set());
 
 const stackedClass = computed(() => {

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -79,9 +79,9 @@
                 <div v-else-if="row.item.deleted && includeDeleted" class="deleted-item">
                     {{ row.item.name }}
                 </div>
-                <BLink v-else :to="{ path: `/libraries/folders/${row.item.root_folder_id}` }">
+                <GLink v-else :to="{ path: `/libraries/folders/${row.item.root_folder_id}` }">
                     {{ row.item.name }}
-                </BLink>
+                </GLink>
             </template>
 
             <template v-slot:cell(description)="{ item }">
@@ -225,7 +225,6 @@ import {
     BFormCheckbox,
     BFormInput,
     BInputGroup,
-    BLink,
     BPagination,
     BRow,
 } from "bootstrap-vue";
@@ -240,6 +239,7 @@ import _l from "@/utils/localization";
 import { Services } from "./services";
 import { fields } from "./table-fields";
 
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import LibraryEditField from "@/components/Libraries/LibraryEditField.vue";
 import SearchField from "@/components/Libraries/LibraryFolder/SearchField.vue";
@@ -255,10 +255,10 @@ export default {
         BFormCheckbox,
         BFormInput,
         BInputGroup,
-        BLink,
         BPagination,
         BRow,
         FontAwesomeIcon,
+        GLink,
         GTable,
         LibraryEditField,
         SearchField,

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -1,10 +1,11 @@
 <template>
     <div>
         <div class="form-inline d-flex align-items-center mb-2">
-            <b-button class="mr-1" title="go to first page" @click="gotoFirstPage">
+            <BButton class="mr-1" title="go to first page" @click="gotoFirstPage">
                 <FontAwesomeIcon :icon="faHome" />
-            </b-button>
-            <b-button
+            </BButton>
+
+            <BButton
                 v-if="currentUser && currentUser.is_admin"
                 id="create-new-lib"
                 v-b-toggle.collapse-2
@@ -12,36 +13,44 @@
                 class="mr-1">
                 <FontAwesomeIcon :icon="faPlus" />
                 {{ titleLibrary }}
-            </b-button>
+            </BButton>
+
             <SearchField :typing-delay="0" @updateSearch="searchValue($event)" />
-            <b-form-checkbox
+
+            <BFormCheckbox
                 v-if="currentUser && currentUser.is_admin"
                 v-localize
                 class="mr-1"
                 @input="toggle_include_deleted($event)">
                 include deleted
-            </b-form-checkbox>
-            <b-form-checkbox v-localize class="mr-1" @input="toggle_exclude_restricted($event)">
+            </BFormCheckbox>
+
+            <BFormCheckbox v-localize class="mr-1" @input="toggle_exclude_restricted($event)">
                 exclude restricted
-            </b-form-checkbox>
+            </BFormCheckbox>
         </div>
-        <b-collapse id="collapse-2" v-model="isNewLibFormVisible">
-            <b-card>
-                <b-form @submit.prevent="newLibrary">
-                    <b-input-group class="mb-2 new-row">
-                        <b-form-input v-model="newLibraryForm.name" required :placeholder="titleName" />
-                        <b-form-input v-model="newLibraryForm.description" required :placeholder="titleDescription" />
-                        <b-form-input v-model="newLibraryForm.synopsis" :placeholder="titleSynopsis" />
+
+        <BCollapse id="collapse-2" v-model="isNewLibFormVisible">
+            <BCard>
+                <BForm @submit.prevent="newLibrary">
+                    <BInputGroup class="mb-2 new-row">
+                        <BFormInput v-model="newLibraryForm.name" required :placeholder="titleName" />
+
+                        <BFormInput v-model="newLibraryForm.description" required :placeholder="titleDescription" />
+
+                        <BFormInput v-model="newLibraryForm.synopsis" :placeholder="titleSynopsis" />
+
                         <template v-slot:append>
-                            <b-button id="save_new_library" type="submit" :title="titleSave">
+                            <BButton id="save_new_library" type="submit" :title="titleSave">
                                 <FontAwesomeIcon :icon="faSave" />
                                 {{ titleSave }}
-                            </b-button>
+                            </BButton>
                         </template>
-                    </b-input-group>
-                </b-form>
-            </b-card>
-        </b-collapse>
+                    </BInputGroup>
+                </BForm>
+            </BCard>
+        </BCollapse>
+
         <GTable
             id="libraries_list"
             ref="libraryTable"
@@ -67,12 +76,14 @@
                     aria-label="Library name"
                     class="form-control input_library_name"
                     rows="3" />
-
-                <div v-else-if="row.item.deleted && includeDeleted" class="deleted-item">{{ row.item.name }}</div>
-                <b-link v-else :to="{ path: `/libraries/folders/${row.item.root_folder_id}` }">
+                <div v-else-if="row.item.deleted && includeDeleted" class="deleted-item">
                     {{ row.item.name }}
-                </b-link>
+                </div>
+                <BLink v-else :to="{ path: `/libraries/folders/${row.item.root_folder_id}` }">
+                    {{ row.item.name }}
+                </BLink>
             </template>
+
             <template v-slot:cell(description)="{ item }">
                 <LibraryEditField
                     :ref="`description-${item.id}`"
@@ -82,6 +93,7 @@
                     :changed-value.sync="item[newDescriptionProperty]"
                     @toggleDescriptionExpand="toggleDescriptionExpand(item)" />
             </template>
+
             <template v-slot:cell(synopsis)="{ item }">
                 <LibraryEditField
                     :ref="`synopsis-${item.id}`"
@@ -91,19 +103,22 @@
                     :changed-value.sync="item[newSynopsisProperty]"
                     @toggleDescriptionExpand="toggleDescriptionExpand(item)" />
             </template>
+
             <template v-slot:cell(is_unrestricted)="row">
                 <FontAwesomeIcon v-if="row.item.public && !row.item.deleted" title="Public library" :icon="faGlobe" />
             </template>
+
             <template v-slot:cell(buttons)="row">
-                <b-button
+                <BButton
                     v-if="row.item.deleted"
                     size="sm"
                     :title="'Undelete ' + row.item.name"
                     @click="undelete(row.item)">
                     <FontAwesomeIcon :icon="faUnlock" />
                     {{ titleUndelete }}
-                </b-button>
-                <b-button
+                </BButton>
+
+                <BButton
                     v-if="row.item.can_user_modify && row.item.editMode"
                     size="sm"
                     class="lib-btn permission_folder_btn"
@@ -111,8 +126,9 @@
                     @click="saveChanges(row.item)">
                     <FontAwesomeIcon :icon="faSave" />
                     {{ titleSave }}
-                </b-button>
-                <b-button
+                </BButton>
+
+                <BButton
                     v-if="row.item.can_user_modify && !row.item.deleted"
                     size="sm"
                     class="lib-btn edit_library_btn save_library_btn"
@@ -126,8 +142,9 @@
                         <FontAwesomeIcon :icon="faTimes" />
                         {{ titleCancel }}
                     </div>
-                </b-button>
-                <b-button
+                </BButton>
+
+                <BButton
                     v-if="currentUser && currentUser.is_admin && !row.item.deleted"
                     size="sm"
                     class="lib-btn permission_library_btn"
@@ -135,8 +152,9 @@
                     :to="{ path: `/libraries/${row.item.id}/permissions` }">
                     <FontAwesomeIcon :icon="faUsers" />
                     Manage
-                </b-button>
-                <b-button
+                </BButton>
+
+                <BButton
                     v-if="currentUser && currentUser.is_admin && row.item.editMode && !row.item.deleted"
                     size="sm"
                     class="lib-btn delete-lib-btn"
@@ -144,25 +162,25 @@
                     @click="deleteLibrary(row.item)">
                     <FontAwesomeIcon :icon="faTrash" />
                     {{ titleDelete }}
-                </b-button>
+                </BButton>
             </template>
         </GTable>
 
-        <b-container>
-            <b-row class="justify-content-md-center">
-                <b-col md="auto">
-                    <b-pagination
+        <BContainer>
+            <BRow class="justify-content-md-center">
+                <BCol md="auto">
+                    <BPagination
                         v-model="currentPage"
                         :total-rows="rows"
                         :per-page="perPage"
-                        aria-controls="libraries_list">
-                    </b-pagination>
-                </b-col>
-                <b-col cols="1.5">
+                        aria-controls="libraries_list" />
+                </BCol>
+
+                <BCol cols="1.5">
                     <table>
                         <tr>
                             <td class="m-0 p-0">
-                                <b-form-input
+                                <BFormInput
                                     id="paginationPerPage"
                                     v-model="perPage"
                                     class="pagination-input-field"
@@ -170,16 +188,17 @@
                                     type="number"
                                     onkeyup="this.value|=0;if(this.value<1)this.value=1" />
                             </td>
+
                             <td class="text-muted ml-1 paginator-text">
-                                <span class="pagination-total-pages-text"
-                                    >{{ titlePerPage }}, {{ rows }} {{ titleTotal }}</span
-                                >
+                                <span class="pagination-total-pages-text">
+                                    {{ titlePerPage }}, {{ rows }} {{ titleTotal }}
+                                </span>
                             </td>
                         </tr>
                     </table>
-                </b-col>
-            </b-row>
-        </b-container>
+                </BCol>
+            </BRow>
+        </BContainer>
     </div>
 </template>
 
@@ -196,9 +215,21 @@ import {
     faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import BootstrapVue from "bootstrap-vue";
+import {
+    BButton,
+    BCard,
+    BCol,
+    BCollapse,
+    BContainer,
+    BForm,
+    BFormCheckbox,
+    BFormInput,
+    BInputGroup,
+    BLink,
+    BPagination,
+    BRow,
+} from "bootstrap-vue";
 import { mapState } from "pinia";
-import Vue from "vue";
 
 import { DEFAULT_PER_PAGE, MAX_DESCRIPTION_LENGTH, onError } from "@/components/Libraries/library-utils";
 import { Toast } from "@/composables/toast";
@@ -213,10 +244,20 @@ import GTable from "@/components/Common/GTable.vue";
 import LibraryEditField from "@/components/Libraries/LibraryEditField.vue";
 import SearchField from "@/components/Libraries/LibraryFolder/SearchField.vue";
 
-Vue.use(BootstrapVue);
-
 export default {
     components: {
+        BButton,
+        BCard,
+        BCol,
+        BCollapse,
+        BContainer,
+        BForm,
+        BFormCheckbox,
+        BFormInput,
+        BInputGroup,
+        BLink,
+        BPagination,
+        BRow,
         FontAwesomeIcon,
         GTable,
         LibraryEditField,

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -167,11 +167,7 @@
         <BContainer>
             <BRow class="justify-content-md-center">
                 <BCol md="auto">
-                    <BPagination
-                        v-model="currentPage"
-                        :total-rows="totalRows"
-                        :per-page="perPage"
-                        aria-controls="libraries_list" />
+                    <BPagination v-model="currentPage" :total-rows="totalRows" :per-page="perPage" />
                 </BCol>
 
                 <BCol cols="1.5">

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -65,8 +65,6 @@
             :per-page="perPage"
             :current-page="currentPage"
             :filter="filter"
-            :filter-included-fields="filterOn"
-            :filter-ignored-fields="excluded"
             @sort-changed="onSortChanged"
             @filtered="onFiltered">
             <template v-slot:cell(name)="row">
@@ -121,8 +119,8 @@
                 <BButton
                     v-if="row.item.can_user_modify && row.item.editMode"
                     size="sm"
-                    class="lib-btn permission_folder_btn"
-                    :title="'Permissions of ' + row.item.name"
+                    class="lib-btn save_changes_btn"
+                    :title="'Save changes to ' + row.item.name"
                     @click="saveChanges(row.item)">
                     <FontAwesomeIcon :icon="faSave" />
                     {{ titleSave }}
@@ -171,7 +169,7 @@
                 <BCol md="auto">
                     <BPagination
                         v-model="currentPage"
-                        :total-rows="rows"
+                        :total-rows="totalRows"
                         :per-page="perPage"
                         aria-controls="libraries_list" />
                 </BCol>
@@ -191,7 +189,7 @@
 
                             <td class="text-muted ml-1 paginator-text">
                                 <span class="pagination-total-pages-text">
-                                    {{ titlePerPage }}, {{ rows }} {{ titleTotal }}
+                                    {{ titlePerPage }}, {{ totalRows }} {{ titleTotal }}
                                 </span>
                             </td>
                         </tr>
@@ -230,7 +228,7 @@ import {
 } from "bootstrap-vue";
 import { mapState } from "pinia";
 
-import { DEFAULT_PER_PAGE, MAX_DESCRIPTION_LENGTH, onError } from "@/components/Libraries/library-utils";
+import { DEFAULT_PER_PAGE, onError } from "@/components/Libraries/library-utils";
 import { Toast } from "@/composables/toast";
 import { getAppRoot } from "@/onload/loadConfig";
 import { useUserStore } from "@/stores/userStore";
@@ -283,11 +281,9 @@ export default {
             fields: fields,
             perPage: DEFAULT_PER_PAGE,
             librariesList: [],
-            maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
+            totalRows: 0,
             includeDeleted: false,
             exclude_restricted: false,
-            filterOn: [],
-            excluded: [],
             filter: null,
             newLibraryForm: {
                 name: "",
@@ -311,21 +307,21 @@ export default {
     },
     computed: {
         ...mapState(useUserStore, ["currentUser"]),
-        rows() {
-            return this.librariesList.length;
-        },
     },
     created() {
         this.root = getAppRoot();
         this.services = new Services({ root: this.root });
-        this.loadLibraries(this.includeDeleted);
+        this.loadLibraries();
     },
     methods: {
         refreshTable() {
             this.$refs.libraryTable.refresh();
         },
-        loadLibraries(includeDeleted = false) {
-            this.services.getLibraries(includeDeleted).then((result) => (this.librariesList = result));
+        loadLibraries() {
+            this.services.getLibraries(this.includeDeleted).then((result) => {
+                this.librariesList = this.exclude_restricted ? result.filter((lib) => lib.public) : result;
+                this.totalRows = this.librariesList.length;
+            });
         },
         toggleEditMode(item) {
             item.editMode = !item.editMode;
@@ -365,7 +361,8 @@ export default {
                     deletedLib.deleted = true;
                     this.toggleEditMode(deletedLib);
                     if (!this.includeDeleted) {
-                        this.hideOn("deleted", false);
+                        this.librariesList = this.librariesList.filter((lib) => !lib.deleted);
+                        this.totalRows = this.librariesList.length;
                     }
                 },
                 (error) => onError(error),
@@ -375,7 +372,6 @@ export default {
             this.currentPage = 1;
         },
         onFiltered(filteredItems) {
-            // Trigger pagination to update the number of buttons/pages due to filtering
             this.totalRows = filteredItems.length;
             this.currentPage = 1;
         },
@@ -384,33 +380,11 @@ export default {
         },
         toggle_include_deleted(isDeletedIncluded) {
             this.includeDeleted = isDeletedIncluded;
-            if (this.includeDeleted) {
-                this.services.getLibraries(this.includeDeleted).then((result) => {
-                    this.librariesList = this.librariesList.concat(result);
-                    this.refreshTable();
-                });
-            } else {
-                this.hideOn("deleted", false);
-            }
+            this.loadLibraries();
         },
-        toggle_exclude_restricted(isRestrictedIncluded) {
-            this.exclude_restricted = isRestrictedIncluded;
-            if (this.exclude_restricted) {
-                this.excluded = this.hideOn("public", true);
-            } else {
-                this.librariesList = this.librariesList.concat(this.excluded);
-            }
-        },
-        hideOn(property, value) {
-            const filtered = [];
-            this.librariesList = this.librariesList.filter((lib) => {
-                if (lib[property] === value) {
-                    return lib;
-                } else {
-                    filtered.push(lib);
-                }
-            });
-            return filtered;
+        toggle_exclude_restricted(isRestrictedExcluded) {
+            this.exclude_restricted = isRestrictedExcluded;
+            this.loadLibraries();
         },
         undelete(item) {
             this.services.deleteLibrary(
@@ -431,6 +405,7 @@ export default {
                 this.newLibraryForm.synopsis,
                 (newLib) => {
                     this.librariesList.push(newLib);
+                    this.totalRows = this.librariesList.length;
                     this.newLibraryForm.name = "";
                     this.newLibraryForm.description = "";
                     this.newLibraryForm.synopsis = "";

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -84,7 +84,6 @@
 
             <template v-slot:cell(description)="{ item }">
                 <LibraryEditField
-                    v-if="item?.editMode"
                     :ref="`description-${item.id}`"
                     :is-expanded="item.isExpanded"
                     :is-edit-mode="item.editMode"
@@ -95,7 +94,6 @@
 
             <template v-slot:cell(synopsis)="{ item }">
                 <LibraryEditField
-                    v-if="item?.editMode"
                     :ref="`synopsis-${item.id}`"
                     :is-expanded="item.isExpanded"
                     :is-edit-mode="item.editMode"
@@ -320,9 +318,15 @@ export default {
             this.$refs.libraryTable.refresh();
         },
         loadLibraries() {
-            this.services.getLibraries(this.includeDeleted).then((result) => {
-                this.librariesList = this.exclude_restricted ? result.filter((lib) => lib.public) : result;
-                this.totalRows = this.librariesList.length;
+            const active = this.services.getLibraries(false);
+            const deleted = this.includeDeleted ? this.services.getLibraries(true) : Promise.resolve([]);
+            Promise.all([active, deleted]).then(([activeLibs, deletedLibs]) => {
+                let result = [...activeLibs, ...deletedLibs];
+                if (this.exclude_restricted) {
+                    result = result.filter((lib) => lib.public);
+                }
+                this.librariesList = result;
+                this.totalRows = result.length;
             });
         },
         toggleEditMode(item) {

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -77,13 +77,14 @@
                 <div v-else-if="row.item.deleted && includeDeleted" class="deleted-item">
                     {{ row.item.name }}
                 </div>
-                <GLink v-else :to="{ path: `/libraries/folders/${row.item.root_folder_id}` }">
+                <GLink v-else :to="`/libraries/folders/${row.item.root_folder_id}`">
                     {{ row.item.name }}
                 </GLink>
             </template>
 
             <template v-slot:cell(description)="{ item }">
                 <LibraryEditField
+                    v-if="item?.editMode"
                     :ref="`description-${item.id}`"
                     :is-expanded="item.isExpanded"
                     :is-edit-mode="item.editMode"
@@ -94,6 +95,7 @@
 
             <template v-slot:cell(synopsis)="{ item }">
                 <LibraryEditField
+                    v-if="item?.editMode"
                     :ref="`synopsis-${item.id}`"
                     :is-expanded="item.isExpanded"
                     :is-edit-mode="item.editMode"

--- a/client/src/components/Libraries/LibraryEditField.vue
+++ b/client/src/components/Libraries/LibraryEditField.vue
@@ -11,7 +11,7 @@
                 <span
                     class="shrinked-description"
                     :title="text"
-                    v-html="linkify(purify.sanitize(text.substring(0, maxDescriptionLength)))">
+                    v-html="linkify(sanitize(text.substring(0, maxDescriptionLength)))">
                 </span>
                 <!-- eslint-enable vue/no-v-html -->
                 <span :title="text">...</span>
@@ -20,7 +20,7 @@
             <!-- Regular -->
             <div v-else>
                 <!-- eslint-disable-next-line vue/no-v-html -->
-                <div v-html="linkify(purify.sanitize(text ?? ''))"></div>
+                <div v-html="linkify(sanitize(text ?? ''))"></div>
                 <!-- hide toggle expand if text is too short -->
                 <a
                     v-if="text && text.length > maxDescriptionLength"
@@ -66,7 +66,9 @@ export default {
         };
     },
     methods: {
-        purify,
+        sanitize(text) {
+            return purify.sanitize(text);
+        },
         updateValue(value) {
             this.$emit("update:changedValue", value);
         },

--- a/client/src/components/Libraries/LibraryEditField.vue
+++ b/client/src/components/Libraries/LibraryEditField.vue
@@ -3,7 +3,7 @@
         <div class="text-field">
             <!-- edit mode -->
             <div v-if="isEditMode">
-                <b-form-textarea class="form-control" :value="text" rows="3" no-resize @change="updateValue" />
+                <BFormTextarea class="form-control" :value="text" rows="3" no-resize @change="updateValue" />
             </div>
             <!-- shrink long text -->
             <div v-else-if="text && text.length > maxDescriptionLength && !isExpanded">
@@ -13,6 +13,7 @@
                     :title="text"
                     v-html="linkify(sanitize(text.substring(0, maxDescriptionLength)))">
                 </span>
+
                 <!-- eslint-enable vue/no-v-html -->
                 <span :title="text">...</span>
                 <a class="more-text-btn" href="javascript:void(0)" @click="toggleDescriptionExpand">(more) </a>
@@ -21,13 +22,14 @@
             <div v-else>
                 <!-- eslint-disable-next-line vue/no-v-html -->
                 <div v-html="linkify(sanitize(text ?? ''))"></div>
+
                 <!-- hide toggle expand if text is too short -->
                 <a
                     v-if="text && text.length > maxDescriptionLength"
                     class="more-text-btn"
                     href="javascript:void(0)"
-                    @click="toggleDescriptionExpand"
-                    >(less)
+                    @click="toggleDescriptionExpand">
+                    (less)
                 </a>
             </div>
         </div>
@@ -35,16 +37,16 @@
 </template>
 
 <script>
-import BootstrapVue from "bootstrap-vue";
+import { BFormTextarea } from "bootstrap-vue";
 import purify from "dompurify";
 import linkifyHtml from "linkify-html";
-import Vue from "vue";
 
 import { MAX_DESCRIPTION_LENGTH } from "@/components/Libraries/library-utils";
 
-Vue.use(BootstrapVue);
-
 export default {
+    components: {
+        BFormTextarea,
+    },
     props: {
         text: {
             type: String,

--- a/client/src/components/Libraries/LibraryFolder/FolderDetails/FolderDetails.vue
+++ b/client/src/components/Libraries/LibraryFolder/FolderDetails/FolderDetails.vue
@@ -18,29 +18,30 @@
             <div>
                 <b-alert :show="hasError" variant="danger" data-testid="error-alert"> {{ error }} </b-alert>
                 <div v-if="libraryDetails">
-                    <b-table-lite
+                    <GTable
+                        caption-top
+                        compact
+                        hide-header
+                        striped
                         :fields="fields"
                         :items="libraryDetails"
-                        striped
-                        small
-                        caption-top
-                        thead-class="d-none"
                         data-testid="library-table">
                         <template v-slot:table-caption>
                             <h2 class="h-sm">
                                 <b>{{ libraryHeader }}</b>
                             </h2>
                         </template>
-                    </b-table-lite>
+                    </GTable>
                 </div>
+
                 <div>
-                    <b-table-lite
+                    <GTable
+                        caption-top
+                        compact
+                        hide-header
+                        striped
                         :fields="fields"
                         :items="folderDetails"
-                        striped
-                        small
-                        caption-top
-                        thead-class="d-none"
                         data-testid="folder-table">
                         <template v-slot:table-caption>
                             <h2 class="h-sm">
@@ -53,7 +54,7 @@
                             </div>
                             <div v-else>{{ row.item.value }}</div>
                         </template>
-                    </b-table-lite>
+                    </GTable>
                 </div>
             </div>
         </b-modal>
@@ -69,11 +70,13 @@ import { buildFields } from "@/components/Libraries/library-utils";
 import { getAppRoot } from "@/onload/loadConfig";
 import _l from "@/utils/localization";
 
+import GTable from "@/components/Common/GTable.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
 export default {
     components: {
         FontAwesomeIcon,
+        GTable,
         UtcDate,
     },
     props: {
@@ -101,9 +104,13 @@ export default {
             fields: [
                 {
                     key: "name",
-                    tdClass: "name-column",
+                    label: _l("Name"),
+                    class: "name-column",
                 },
-                { key: "value" },
+                {
+                    key: "value",
+                    label: _l("Value"),
+                },
             ],
             folderFieldTitles: { folder_name: _l("Name"), folder_description: _l("Description"), id: "ID" },
             libraryFieldTitles: {

--- a/client/src/components/Libraries/LibraryFolder/FolderDetails/FolderDetails.vue
+++ b/client/src/components/Libraries/LibraryFolder/FolderDetails/FolderDetails.vue
@@ -1,14 +1,15 @@
 <template>
     <div>
-        <b-button
+        <BButton
             v-b-modal.details-modal
             class="details-btn"
             title="Show location details"
             data-testid="loc-details-btn">
-            <FontAwesomeIcon :icon="faInfoCircle" /> {{ detailsCaption }}
-        </b-button>
+            <FontAwesomeIcon :icon="faInfoCircle" />
+            {{ detailsCaption }}
+        </BButton>
 
-        <b-modal
+        <BModal
             id="details-modal"
             :static="isStatic"
             :title="titleLocationDetails"
@@ -16,7 +17,10 @@
             ok-only
             @show="getDetails">
             <div>
-                <b-alert :show="hasError" variant="danger" data-testid="error-alert"> {{ error }} </b-alert>
+                <BAlert :show="hasError" variant="danger" data-testid="error-alert">
+                    {{ error }}
+                </BAlert>
+
                 <div v-if="libraryDetails">
                     <GTable
                         caption-top
@@ -48,6 +52,7 @@
                                 <b>{{ folderHeader }}</b>
                             </h2>
                         </template>
+
                         <template v-slot:cell(value)="row">
                             <div v-if="row.item.name === libraryFieldTitles.create_time_pretty">
                                 <UtcDate :date="row.item.value" mode="elapsed" />
@@ -57,7 +62,7 @@
                     </GTable>
                 </div>
             </div>
-        </b-modal>
+        </BModal>
     </div>
 </template>
 
@@ -65,6 +70,7 @@
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
+import { BAlert, BButton, BModal } from "bootstrap-vue";
 
 import { buildFields } from "@/components/Libraries/library-utils";
 import { getAppRoot } from "@/onload/loadConfig";
@@ -75,6 +81,9 @@ import UtcDate from "@/components/UtcDate.vue";
 
 export default {
     components: {
+        BAlert,
+        BButton,
+        BModal,
         FontAwesomeIcon,
         GTable,
         UtcDate,

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -20,6 +20,7 @@
         <GTable
             id="folder_list_body"
             ref="folderTable"
+            class="mb-4"
             clickable-rows
             hover
             selectable
@@ -52,35 +53,45 @@
 
             <!-- Name -->
             <template v-slot:cell(name)="row">
-                <div v-if="row.item.editMode" @click="onRowClick">
-                    <textarea
-                        v-if="row.item.isNewFolder"
-                        :ref="'name' + row.item.id"
-                        v-model="row.item.name"
-                        class="form-control"
-                        name="input_folder_name"
-                        rows="3" />
-                    <textarea v-else :ref="'name' + row.item.id" class="form-control" :value="row.item.name" rows="3" />
-                </div>
-                <div v-else-if="!row.item.deleted">
-                    <b-link
-                        v-if="row.item.type === 'folder'"
-                        :to="{ name: `LibraryFolder`, params: { folder_id: `${row.item.id}` } }">
-                        {{ row.item.name }}
-                    </b-link>
+                <div class="d-flex flex-gapx-1 align-items-center">
+                    <FontAwesomeIcon v-if="row.item.type === 'folder'" :icon="faFolder" title="Folder" fixed-width />
+                    <FontAwesomeIcon v-else-if="row.item.type === 'file'" :icon="faFile" title="Dataset" fixed-width />
 
-                    <b-link
-                        v-else
-                        :to="{
-                            name: `LibraryDataset`,
-                            params: { folder_id: folder_id, dataset_id: `${row.item.id}` },
-                        }">
-                        {{ row.item.name }}
-                    </b-link>
-                </div>
-                <!-- Deleted Item-->
-                <div v-else>
-                    <div class="deleted-item">{{ row.item.name }}</div>
+                    <div v-if="row.item.editMode" @click="onRowClick">
+                        <textarea
+                            v-if="row.item.isNewFolder"
+                            :ref="'name' + row.item.id"
+                            v-model="row.item.name"
+                            class="form-control"
+                            name="input_folder_name"
+                            rows="3" />
+                        <textarea
+                            v-else
+                            :ref="'name' + row.item.id"
+                            class="form-control"
+                            :value="row.item.name"
+                            rows="3" />
+                    </div>
+                    <div v-else-if="!row.item.deleted">
+                        <b-link
+                            v-if="row.item.type === 'folder'"
+                            :to="{ name: `LibraryFolder`, params: { folder_id: `${row.item.id}` } }">
+                            {{ row.item.name }}
+                        </b-link>
+
+                        <b-link
+                            v-else
+                            :to="{
+                                name: `LibraryDataset`,
+                                params: { folder_id: folder_id, dataset_id: `${row.item.id}` },
+                            }">
+                            {{ row.item.name }}
+                        </b-link>
+                    </div>
+                    <!-- Deleted Item-->
+                    <div v-else>
+                        <div class="deleted-item">{{ row.item.name }}</div>
+                    </div>
                 </div>
             </template>
 
@@ -125,11 +136,6 @@
                         <div v-else v-html="linkify(purify.sanitize(getMessage(row.item)))"></div>
                     </div>
                 </div>
-            </template>
-
-            <template v-slot:cell(type_icon)="row">
-                <FontAwesomeIcon v-if="row.item.type === 'folder'" :icon="faFolder" title="Folder" />
-                <FontAwesomeIcon v-else-if="row.item.type === 'file'" title="Dataset" :icon="faFile" />
             </template>
 
             <template v-slot:cell(type)="row">

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -17,6 +17,7 @@
             @deleteFromTable="deleteFromTable"
             @setBusy="setBusy($event)"
             @newFolder="newFolder" />
+
         <GTable
             id="folder_list_body"
             ref="folderTable"
@@ -39,7 +40,7 @@
             @row-select="onRowSelect">
             <template v-slot:empty>
                 <div v-if="isBusy" class="text-center my-2">
-                    <b-spinner class="align-middle"></b-spinner>
+                    <BSpinner class="align-middle" />
                     <strong>Loading...</strong>
                 </div>
                 <div v-else class="empty-folder-message">
@@ -73,20 +74,19 @@
                             rows="3" />
                     </div>
                     <div v-else-if="!row.item.deleted">
-                        <b-link
+                        <BLink
                             v-if="row.item.type === 'folder'"
                             :to="{ name: `LibraryFolder`, params: { folder_id: `${row.item.id}` } }">
                             {{ row.item.name }}
-                        </b-link>
-
-                        <b-link
+                        </BLink>
+                        <BLink
                             v-else
                             :to="{
                                 name: `LibraryDataset`,
                                 params: { folder_id: folder_id, dataset_id: `${row.item.id}` },
                             }">
                             {{ row.item.name }}
-                        </b-link>
+                        </BLink>
                     </div>
                     <!-- Deleted Item-->
                     <div v-else>
@@ -103,13 +103,13 @@
                         :ref="'description' + row.item.id"
                         v-model="row.item.description"
                         class="form-control input_folder_description"
-                        rows="3"></textarea>
+                        rows="3" />
                     <textarea
                         v-else
                         :ref="'description' + row.item.id"
                         class="form-control input_folder_description"
                         :value="row.item.description"
-                        rows="3"></textarea>
+                        rows="3" />
                 </div>
                 <div v-else>
                     <div v-if="getMessage(row.item)" class="description-field">
@@ -126,6 +126,7 @@
                                     linkify(purify.sanitize(getMessage(row.item).substring(0, maxDescriptionLength)))
                                 ">
                             </span>
+
                             <!-- eslint-enable vue/no-v-html -->
                             <span :title="getMessage(row.item)"> ...</span>
                             <a class="more-text-btn" href="javascript:void(0)" @click="expandMessage(row.item)">
@@ -133,7 +134,7 @@
                             </a>
                         </div>
                         <!-- eslint-disable-next-line vue/no-v-html -->
-                        <div v-else v-html="linkify(purify.sanitize(getMessage(row.item)))"></div>
+                        <div v-else v-html="linkify(purify.sanitize(getMessage(row.item)))" />
                     </div>
                 </div>
             </template>
@@ -144,7 +145,7 @@
             </template>
 
             <template v-slot:cell(raw_size)="row">
-                <div v-if="row.item.type === 'file'" v-html="bytesToString(row.item.raw_size)"></div>
+                <div v-if="row.item.type === 'file'" v-html="bytesToString(row.item.raw_size)" />
             </template>
 
             <template v-slot:cell(state)="row">
@@ -159,7 +160,7 @@
 
             <template v-slot:cell(is_unrestricted)="row">
                 <FontAwesomeIcon v-if="row.item.is_unrestricted" title="Unrestricted dataset" :icon="faGlobe" />
-                <FontAwesomeIcon v-else-if="row.item.deleted" title="Marked deleted" :icon="faBan"></FontAwesomeIcon>
+                <FontAwesomeIcon v-else-if="row.item.deleted" title="Marked deleted" :icon="faBan" />
                 <FontAwesomeIcon v-else-if="row.item.is_private" title="Private dataset" :icon="faKey" />
                 <FontAwesomeIcon
                     v-else-if="row.item.is_private === false && row.item.is_unrestricted === false"
@@ -176,6 +177,7 @@
                         <FontAwesomeIcon :icon="faSave" />
                         Save
                     </button>
+
                     <button
                         class="primary-button btn-sm permission_folder_btn"
                         title="Discard Changes"
@@ -185,7 +187,7 @@
                     </button>
                 </div>
                 <div v-else>
-                    <b-button
+                    <BButton
                         v-if="row.item.can_manage && !row.item.deleted && row.item.type === 'folder'"
                         data-toggle="tooltip"
                         data-placement="top"
@@ -195,8 +197,9 @@
                         @click.stop="toggleEditMode(row.item)">
                         <FontAwesomeIcon :icon="faPencilAlt" />
                         Edit
-                    </b-button>
-                    <b-button
+                    </BButton>
+
+                    <BButton
                         v-if="currentUser?.is_admin"
                         size="sm"
                         class="lib-btn permission_lib_btn"
@@ -205,7 +208,8 @@
                         @click.stop>
                         <FontAwesomeIcon :icon="faUsers" />
                         Manage
-                    </b-button>
+                    </BButton>
+
                     <button
                         v-if="row.item.deleted"
                         :title="'Undelete ' + row.item.name"
@@ -220,29 +224,29 @@
         </GTable>
 
         <!-- hide pagination if the table is loading-->
-        <b-container>
-            <b-row align-v="center" class="justify-content-md-center">
-                <b-col md="auto">
+        <BContainer>
+            <BRow align-v="center" class="justify-content-md-center">
+                <BCol md="auto">
                     <div v-if="isBusy">
-                        <b-spinner small type="grow"></b-spinner>
-                        <b-spinner small type="grow"></b-spinner>
-                        <b-spinner small type="grow"></b-spinner>
+                        <BSpinner small type="grow" />
+                        <BSpinner small type="grow" />
+                        <BSpinner small type="grow" />
                     </div>
-                    <b-pagination
+                    <BPagination
                         v-else
                         :value="currentPage"
                         :total-rows="total_rows"
                         :per-page="perPage"
                         aria-controls="folder_list_body"
                         @input="changePage">
-                    </b-pagination>
-                </b-col>
+                    </BPagination>
+                </BCol>
 
-                <b-col cols="1.5">
+                <BCol cols="1.5">
                     <table>
                         <tr>
                             <td class="m-0 p-0">
-                                <b-form-input
+                                <BFormInput
                                     id="paginationPerPage"
                                     v-model="perPage"
                                     class="pagination-input-field"
@@ -254,9 +258,9 @@
                             </td>
                         </tr>
                     </table>
-                </b-col>
-            </b-row>
-        </b-container>
+                </BCol>
+            </BRow>
+        </BContainer>
     </div>
 </template>
 
@@ -273,11 +277,10 @@ import {
     faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import BootstrapVue from "bootstrap-vue";
+import { BButton, BCol, BContainer, BFormInput, BLink, BPagination, BRow, BSpinner } from "bootstrap-vue";
 import purify from "dompurify";
 import linkifyHtml from "linkify-html";
 import { mapState } from "pinia";
-import Vue from "vue";
 
 import { DEFAULT_PER_PAGE, MAX_DESCRIPTION_LENGTH } from "@/components/Libraries/library-utils";
 import { usePersistentRef } from "@/composables/persistentRef";
@@ -293,8 +296,6 @@ import FolderTopBar from "./TopToolbar/FolderTopBar.vue";
 import GTable from "@/components/Common/GTable.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
-Vue.use(BootstrapVue);
-
 function initialFolderState() {
     return {
         canAddLibraryItem: false,
@@ -308,10 +309,18 @@ function initialFolderState() {
 }
 export default {
     components: {
+        BButton,
+        BCol,
+        BContainer,
+        BFormInput,
+        BLink,
+        BPagination,
+        BRow,
+        BSpinner,
         FolderTopBar,
+        FontAwesomeIcon,
         GTable,
         UtcDate,
-        FontAwesomeIcon,
     },
     beforeRouteUpdate(to, from, next) {
         this.getFolder(to.params.folder_id, to.params.page);

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -237,7 +237,6 @@
                         :value="currentPage"
                         :total-rows="total_rows"
                         :per-page="perPage"
-                        aria-controls="folder_list_body"
                         @input="changePage">
                     </BPagination>
                 </BCol>

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
@@ -57,19 +57,21 @@
                 :text="currentRouteName"
                 title="Copy link to this dataset " />
         </div>
+
         <!-- Table -->
-        <b-table
+        <GTable
             v-if="table_items"
+            class="dataset_table mt-2"
+            compact
+            hide-header
+            striped
             :fields="fields"
             :items="table_items"
-            class="dataset_table mt-2"
-            thead-class="d-none"
-            striped
-            small
             data-test-id="dataset-table">
             <template v-slot:cell(name)="row">
                 <strong>{{ row.item.name }}</strong>
             </template>
+
             <template v-slot:cell(value)="row">
                 <div v-if="isEditMode">
                     <b-form-input
@@ -110,7 +112,8 @@
                     <div>{{ row.item.value }}</div>
                 </div>
             </template>
-        </b-table>
+        </GTable>
+
         <!-- Edit Controls -->
         <div v-if="isEditMode">
             <b-button class="mr-1 mb-2" @click="isEditMode = false">
@@ -142,6 +145,7 @@ import { DatatypesProvider, DbKeyProvider } from "@/components/providers";
 import { Toast } from "@/composables/toast";
 import { useUserStore } from "@/stores/userStore";
 
+import GTable from "@/components/Common/GTable.vue";
 import CopyToClipboard from "@/components/CopyToClipboard.vue";
 import LibraryBreadcrumb from "@/components/Libraries/LibraryFolder/LibraryBreadcrumb.vue";
 import SingleItemSelector from "@/components/SingleItemSelector.vue";
@@ -151,6 +155,7 @@ export default {
         LibraryBreadcrumb,
         CopyToClipboard,
         FontAwesomeIcon,
+        GTable,
         DbKeyProvider,
         DatatypesProvider,
         SingleItemSelector,

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
@@ -2,42 +2,47 @@
     <div v-if="dataset">
         <div v-if="!isEditMode">
             <LibraryBreadcrumb :current-id="dataset_id" :full_path="dataset.full_path" />
+
             <!-- Toolbar -->
-            <b-button
+            <BButton
                 title="Download dataset"
                 class="mr-1 mb-2"
                 data-test-id="download-btn"
                 @click="download(datasetDownloadFormat, dataset_id)">
                 <FontAwesomeIcon :icon="faDownload" />
                 Download
-            </b-button>
-            <b-button
+            </BButton>
+
+            <BButton
                 title="Import dataset into history"
                 class="mr-1 mb-2"
                 data-test-id="import-history-btn"
                 @click="importToHistory">
                 <FontAwesomeIcon :icon="faBook" />
                 to History
-            </b-button>
+            </BButton>
+
             <span v-if="dataset.can_user_modify">
-                <b-button
+                <BButton
                     title="Modify library item"
                     class="mr-1 mb-2"
                     data-test-id="modify-btn"
                     @click="isEditMode = true">
                     <FontAwesomeIcon :icon="faPencilAlt" />
                     Modify
-                </b-button>
-                <b-button
+                </BButton>
+
+                <BButton
                     title="Attempt to detect the format of dataset"
                     class="mr-1 mb-2"
                     data-test-id="auto-detect-btn"
                     @click="detectDatatype">
                     <FontAwesomeIcon :icon="faRedo" />
                     Auto-detect datatype
-                </b-button>
+                </BButton>
             </span>
-            <b-button
+
+            <BButton
                 v-if="currentUser?.is_admin"
                 title="Manage permissions"
                 class="mr-1 mb-2"
@@ -48,8 +53,9 @@
                 data-test-id="permissions-btn">
                 <FontAwesomeIcon :icon="faUsers" />
                 Permissions
-            </b-button>
+            </BButton>
         </div>
+
         <div v-if="dataset.is_unrestricted" data-test-id="unrestricted-msg">
             This dataset is unrestricted so everybody with the link can access it.
             <CopyToClipboard
@@ -74,7 +80,7 @@
 
             <template v-slot:cell(value)="row">
                 <div v-if="isEditMode">
-                    <b-form-input
+                    <BFormInput
                         v-if="row.item.name === fieldTitles.name"
                         v-model="modifiedDataset.name"
                         :value="row.item.value" />
@@ -98,11 +104,11 @@
                             :current-item="dbkeys?.find((dbkey) => dbkey.id === dataset.genome_build)"
                             @update:selected-item="onSelectedDbKey" />
                     </DbKeyProvider>
-                    <b-form-input
+                    <BFormInput
                         v-else-if="row.item.name === fieldTitles.message"
                         v-model="modifiedDataset.message"
                         :value="row.item.value" />
-                    <b-form-input
+                    <BFormInput
                         v-else-if="row.item.name === fieldTitles.misc_info"
                         v-model="modifiedDataset.misc_info"
                         :value="row.item.value" />
@@ -116,15 +122,17 @@
 
         <!-- Edit Controls -->
         <div v-if="isEditMode">
-            <b-button class="mr-1 mb-2" @click="isEditMode = false">
+            <BButton class="mr-1 mb-2" @click="isEditMode = false">
                 <FontAwesomeIcon :icon="faTimes" />
                 Cancel
-            </b-button>
-            <b-button class="mr-1 mb-2" @click="updateDataset">
+            </BButton>
+
+            <BButton class="mr-1 mb-2" @click="updateDataset">
                 <FontAwesomeIcon :icon="faSave" />
                 Save
-            </b-button>
+            </BButton>
         </div>
+
         <!-- Peek View -->
         <div v-if="dataset.peek" data-test-id="peek-view" class="break-word" v-html="dataset.peek" />
     </div>
@@ -134,6 +142,7 @@
 import { faSave } from "@fortawesome/free-regular-svg-icons";
 import { faBook, faDownload, faPencilAlt, faRedo, faTimes, faUsers } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton, BFormInput } from "bootstrap-vue";
 import { mapState } from "pinia";
 
 import { buildFields } from "@/components/Libraries/library-utils";
@@ -152,6 +161,8 @@ import SingleItemSelector from "@/components/SingleItemSelector.vue";
 
 export default {
     components: {
+        BButton,
+        BFormInput,
         LibraryBreadcrumb,
         CopyToClipboard,
         FontAwesomeIcon,

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
@@ -126,7 +126,7 @@
             </b-button>
         </div>
         <!-- Peek View -->
-        <div v-if="dataset.peek" data-test-id="peek-view" v-html="dataset.peek" />
+        <div v-if="dataset.peek" data-test-id="peek-view" class="break-word" v-html="dataset.peek" />
     </div>
 </template>
 

--- a/client/src/components/Libraries/LibraryFolder/table-fields.js
+++ b/client/src/components/Libraries/LibraryFolder/table-fields.js
@@ -4,11 +4,6 @@ export const fields = [
         key: "type_icon",
     },
     {
-        label: "&check;",
-        key: "selected",
-        sortable: false,
-    },
-    {
         label: "Name",
         key: "name",
         sortable: true,

--- a/client/src/components/Libraries/LibraryFolder/table-fields.js
+++ b/client/src/components/Libraries/LibraryFolder/table-fields.js
@@ -1,9 +1,5 @@
 export const fields = [
     {
-        label: "",
-        key: "type_icon",
-    },
-    {
         label: "Name",
         key: "name",
         sortable: true,

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1282,9 +1282,9 @@ libraries:
       clear_filters: "button.clear-filters-link"
       import_progress_bar: '.progress-bar-import'
       import_from_path_textarea: '#import_paths'
-      select_all: '#g-table-select-all-folder_list_body'
-      select_one: '#g-table-row-0-folder_list_body-select'
-      select_dataset: '#g-table-row-${row_index}-folder_list_body-select'
+      select_all: 'thead .g-table-select-column .custom-control'
+      select_one: '#g-table-row-0-folder_list_body .g-table-select-column .custom-control'
+      select_dataset: '#g-table-row-${row_index}-folder_list_body .g-table-select-column .custom-control'
       empty_folder_message: '.empty-folder-message'
       btn_open_parent_folder:
         type: xpath

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1282,9 +1282,9 @@ libraries:
       clear_filters: "button.clear-filters-link"
       import_progress_bar: '.progress-bar-import'
       import_from_path_textarea: '#import_paths'
-      select_all: '#select-all-checkboxes'
-      select_one: '.lib-folder-checkbox'
-      select_dataset: 'tr[aria-rowindex="${rowindex}"] .lib-folder-checkbox'
+      select_all: '#g-table-select-all-folder_list_body'
+      select_one: '#g-table-row-0-folder_list_body-select'
+      select_dataset: '#g-table-row-${row_index}-folder_list_body-select'
       empty_folder_message: '.empty-folder-message'
       btn_open_parent_folder:
         type: xpath

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1232,7 +1232,7 @@ admin:
 libraries:
 
   selectors:
-    _: '#libraries_list'
+    _: '#g-table-libraries_list'
     activity: '#activity-libraries'
     create_new_library_btn: '#create-new-lib'
     permission_library_btn: '.permission_library_btn'

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1684,7 +1684,7 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         else:
             assert len(elements) == 1
             element = elements[0]
-            return element.find_elements(By.CSS_SELECTOR, "tr")  # [style='display: table-row']
+            return element.find_elements(By.CSS_SELECTOR, "tr:not(.g-table-empty-row)")
 
     def libraries_index_create(self, name):
         self.components.libraries.create_new_library_btn.wait_for_and_click()
@@ -1762,8 +1762,8 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
             )
 
     def libraries_table_elements(self):
-        tbody_element = self.wait_for_selector_visible("#folder_list_body > tbody")
-        return tbody_element.find_elements(By.CSS_SELECTOR, "tr:not(.b-table-empty-row)")
+        tbody_element = self.wait_for_selector_visible("#g-table-folder_list_body > tbody")
+        return tbody_element.find_elements(By.CSS_SELECTOR, "tr:not(.g-table-empty-row)")
 
     def populate_library_folder_from_import_dir(self, library_name, filenames):
         self.libraries_open_with_name(library_name)

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1647,6 +1647,7 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         quota_component.add_form_submit.wait_for_and_click()
 
     def select_dataset_from_lib_import_modal(self, filenames):
+        self.wait_for_selector_visible(".directory-dataset-picker-list")
         for name in filenames:
             self.components.libraries.folder.select_import_dir_item(name=name).wait_for_and_click()
         self.components.libraries.folder.import_dir_btn.wait_for_and_click()
@@ -1701,11 +1702,8 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         search_element.click()
         return search_element
 
-    def libraries_index_sort_selector(self):
-        return "th[aria-sort]"
-
     def libraries_index_sort_click(self):
-        sort_element = self.wait_for_selector_clickable(self.libraries_index_sort_selector())
+        sort_element = self.wait_for_selector_clickable(".g-table-sortable")
         sort_element.click()
         return sort_element
 
@@ -1746,6 +1744,7 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
                 self.navigation.libraries.folder.selectors.import_datasets_from_history_modal_dataset_search,
                 to_select_item,
             )
+            self.sleep_for(self.wait_types.UX_RENDER)
             self.components.libraries.folder.import_datasets_from_history_modal_select_list_item_by_index(
                 row_index=1
             ).wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_library_to_collections.py
+++ b/lib/galaxy_test/selenium/test_library_to_collections.py
@@ -48,7 +48,7 @@ class TestLibraryToCollections(SeleniumTestCase, UsesLibraryAssertions):
         self.assert_num_displayed_items_is(0)
         self.populate_library_folder_from_import_dir(self.name, files_to_import)
         for i in range(len(files_to_import)):
-            self.components.libraries.folder.select_dataset(rowindex=i + 1).wait_for_and_click()
+            self.components.libraries.folder.select_dataset(row_index=i).wait_for_and_click()
         self.components.libraries.folder.add_to_history.wait_for_and_click()
         self.components.libraries.folder.add_to_history_collection.wait_for_and_click()
         if history_name is not None:


### PR DESCRIPTION
This PR migrates Library components (`Libraries/LibrariesList.vue` `Libraries/LibraryFolder/FolderDetails/FolderDetails.vue`, `Libraries/LibraryFolder/LibraryFolder.vue`, `Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue`) from Bootstrap-Vue's components to our `GComponents` as part of the ongoing effort tracked in #21703, and also adds `refresh` method, `filterIgnoredFields`, `filterIncludedFields`, `showEmpty`, and `noSelectOnClick` props to `GTable`, and improves its.

|Before|After|
|---|---|
|<img width="1920" height="1113" alt="image" src="https://github.com/user-attachments/assets/edcfa0eb-2271-4397-a335-e3855dcaa9af" />|<img width="1920" height="1113" alt="image" src="https://github.com/user-attachments/assets/7324ec30-5dea-4de2-8df0-3f6420f51922" />|
|<img width="1920" height="1113" alt="image" src="https://github.com/user-attachments/assets/69a67d3e-2216-4571-b8ea-12e16a5f1712" />|<img width="1920" height="1113" alt="image" src="https://github.com/user-attachments/assets/7c8a4906-1e50-4742-8b74-3612866f996e" />|
|<img width="1920" height="1113" alt="image" src="https://github.com/user-attachments/assets/7ac424f9-0228-48c0-bf3a-e79d53ba08d9" />|<img width="1920" height="1113" alt="image" src="https://github.com/user-attachments/assets/d67b5afd-ffa4-427f-bf3b-2a7fd6606a79" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to `/libraries`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
