### PR TITLE
Prevent uploads to non-active histories in Beta Upload Activity

### DIFF
--- a/client/src/components/History/TargetHistorySelector.test.ts
+++ b/client/src/components/History/TargetHistorySelector.test.ts
@@ -1,18 +1,22 @@
+import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
-import { createPinia } from "pinia";
-import { describe, expect, it } from "vitest";
+import flushPromises from "flush-promises";
+import { setActivePinia } from "pinia";
+import { describe, expect, it, vi } from "vitest";
 
 import type { HistorySummary } from "@/api";
-import { useHistoryStore } from "@/stores/historyStore";
+import { useServerMock } from "@/api/client/__mocks__";
 
 import TargetHistorySelector from "./TargetHistorySelector.vue";
 
-const localVue = getLocalVue();
+const localVue = getLocalVue(true);
 
-const mockHistory: HistorySummary = {
-    id: "mock-history",
-    name: "Mock History",
+const { server, http } = useServerMock();
+
+const ACTIVE_HISTORY: HistorySummary = {
+    id: "active-history",
+    name: "Active History",
     archived: false,
     deleted: false,
     annotation: "",
@@ -25,8 +29,29 @@ const mockHistory: HistorySummary = {
     url: "/api/histories/mock-history",
 };
 
+const ARCHIVED_HISTORY: HistorySummary = {
+    ...ACTIVE_HISTORY,
+    id: "archived-history",
+    name: "Archived History",
+    archived: true,
+};
+
+const DELETED_HISTORY: HistorySummary = {
+    ...ACTIVE_HISTORY,
+    id: "deleted-history",
+    name: "Deleted History",
+    deleted: true,
+};
+
 async function mountWithHistory(history: HistorySummary) {
-    const pinia = createPinia();
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    setActivePinia(pinia);
+
+    server.use(
+        http.get("/api/histories/{history_id}", ({ response }) => {
+            return response(200).json(history);
+        }),
+    );
 
     const wrapper = mount(TargetHistorySelector as object, {
         propsData: {
@@ -40,47 +65,26 @@ async function mountWithHistory(history: HistorySummary) {
         },
     });
 
-    const historyStore = useHistoryStore();
-    historyStore.setHistory(history as any);
-
-    await wrapper.vm.$nextTick();
+    await flushPromises();
 
     return wrapper;
 }
 
 describe("TargetHistorySelector", () => {
     it("shows warning for archived history", async () => {
-        const wrapper = await mountWithHistory({
-            ...mockHistory,
-            id: "history-archived",
-            name: "Archived History",
-            archived: true,
-            deleted: false,
-        });
+        const wrapper = await mountWithHistory(ARCHIVED_HISTORY);
 
         expect(wrapper.text()).toContain("This history has been archived and cannot receive uploads.");
     });
 
     it("shows warning for deleted history", async () => {
-        const wrapper = await mountWithHistory({
-            ...mockHistory,
-            id: "history-deleted",
-            name: "Deleted History",
-            archived: false,
-            deleted: true,
-        });
+        const wrapper = await mountWithHistory(DELETED_HISTORY);
 
         expect(wrapper.text()).toContain("This history has been deleted and cannot receive uploads.");
     });
 
     it("does not show warning for active history", async () => {
-        const wrapper = await mountWithHistory({
-            ...mockHistory,
-            id: "history-active",
-            name: "Active History",
-            archived: false,
-            deleted: false,
-        });
+        const wrapper = await mountWithHistory(ACTIVE_HISTORY);
 
         expect(wrapper.text()).not.toContain("cannot receive uploads");
     });

--- a/client/src/components/History/TargetHistorySelector.test.ts
+++ b/client/src/components/History/TargetHistorySelector.test.ts
@@ -1,0 +1,87 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import { createPinia } from "pinia";
+import { describe, expect, it } from "vitest";
+
+import type { HistorySummary } from "@/api";
+import { useHistoryStore } from "@/stores/historyStore";
+
+import TargetHistorySelector from "./TargetHistorySelector.vue";
+
+const localVue = getLocalVue();
+
+const mockHistory: HistorySummary = {
+    id: "mock-history",
+    name: "Mock History",
+    archived: false,
+    deleted: false,
+    annotation: "",
+    count: 0,
+    model_class: "History",
+    published: false,
+    purged: false,
+    tags: [],
+    update_time: "2024-01-01T00:00:00Z",
+    url: "/api/histories/mock-history",
+};
+
+async function mountWithHistory(history: HistorySummary) {
+    const pinia = createPinia();
+
+    const wrapper = mount(TargetHistorySelector as object, {
+        propsData: {
+            targetHistoryId: history.id,
+        },
+        localVue,
+        pinia,
+        stubs: {
+            SelectorModal: true,
+            TargetHistoryLink: true,
+        },
+    });
+
+    const historyStore = useHistoryStore();
+    historyStore.setHistory(history as any);
+
+    await wrapper.vm.$nextTick();
+
+    return wrapper;
+}
+
+describe("TargetHistorySelector", () => {
+    it("shows warning for archived history", async () => {
+        const wrapper = await mountWithHistory({
+            ...mockHistory,
+            id: "history-archived",
+            name: "Archived History",
+            archived: true,
+            deleted: false,
+        });
+
+        expect(wrapper.text()).toContain("This history has been archived and cannot receive uploads.");
+    });
+
+    it("shows warning for deleted history", async () => {
+        const wrapper = await mountWithHistory({
+            ...mockHistory,
+            id: "history-deleted",
+            name: "Deleted History",
+            archived: false,
+            deleted: true,
+        });
+
+        expect(wrapper.text()).toContain("This history has been deleted and cannot receive uploads.");
+    });
+
+    it("does not show warning for active history", async () => {
+        const wrapper = await mountWithHistory({
+            ...mockHistory,
+            id: "history-active",
+            name: "Active History",
+            archived: false,
+            deleted: false,
+        });
+
+        expect(wrapper.text()).not.toContain("cannot receive uploads");
+    });
+});

--- a/client/src/components/History/TargetHistorySelector.vue
+++ b/client/src/components/History/TargetHistorySelector.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
+import { useTargetHistoryUploadState } from "@/composables/history/useTargetHistoryUploadState";
 import { useHistoryStore } from "@/stores/historyStore";
 import { useUserStore } from "@/stores/userStore";
 
@@ -16,7 +18,7 @@ interface Props {
     modalTitle?: string;
 }
 
-const _props = withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     historyCaption: "Target history",
     changeLinkText: "change",
     changeLinkTooltip: "Change target history",
@@ -38,6 +40,8 @@ const { histories } = storeToRefs(historyStore);
 const canChangeHistory = computed(() => {
     return !isAnonymous.value && Array.isArray(histories.value) && histories.value.length > 1;
 });
+
+const { warningMessage } = useTargetHistoryUploadState(computed(() => props.targetHistoryId));
 
 function openHistorySelector() {
     console.debug("Opening history selector modal");
@@ -64,6 +68,10 @@ function handleHistorySelected(history: { id: string }) {
                 {{ changeLinkText }}
             </a>
         </div>
+
+        <BAlert v-if="warningMessage" show variant="warning" class="mb-2 py-1">
+            {{ warningMessage }}
+        </BAlert>
 
         <SelectorModal
             v-if="canChangeHistory"

--- a/client/src/components/ImportData/zip/ZipImportWizard.vue
+++ b/client/src/components/ImportData/zip/ZipImportWizard.vue
@@ -121,10 +121,9 @@ async function importItems() {
                 regularFileCount: String(filesToImport.value.filter((file) => file.type === "file").length),
             },
         });
-        await importArtifacts(
-            filesToImport.value,
-            hasRegularFilesToImport.value ? effectiveTargetHistoryId.value ?? null : null,
-        );
+        // Workflows can be imported without a target history, but regular files require a target history.
+        const targetHistoryId = hasRegularFilesToImport.value ? (effectiveTargetHistoryId.value ?? null) : null;
+        await importArtifacts(filesToImport.value, targetHistoryId);
     } catch (error) {
         errorMessage.value = errorMessageAsString(error);
     } finally {

--- a/client/src/components/ImportData/zip/ZipImportWizard.vue
+++ b/client/src/components/ImportData/zip/ZipImportWizard.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { useWizard } from "@/components/Common/Wizard/useWizard";
+import { useTargetHistoryUploadState } from "@/composables/history/useTargetHistoryUploadState";
 import {
     archiveExplorerEventBus,
     type ArchiveSource,
@@ -30,17 +32,22 @@ interface Props {
      * Useful when embedding the wizard in other components that already provide their own heading.
      */
     shouldDisplayHeading?: boolean;
+    targetHistoryId?: string;
+    showTargetHistoryWarning?: boolean;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     shouldDisplayHeading: true,
+    targetHistoryId: undefined,
+    showTargetHistoryWarning: true,
 });
 
 const router = useRouter();
 
 const { importArtifacts, isZipArchiveAvailable, zipExplorer, reset: resetExplorer } = useZipExplorer();
 
-const { currentHistoryId } = storeToRefs(useHistoryStore());
+const historyStore = useHistoryStore();
+const { currentHistoryId } = storeToRefs(historyStore);
 
 const zipSource = ref<ArchiveSource>();
 
@@ -62,6 +69,17 @@ const isValidSource = computed(() => {
     }
     return false;
 });
+
+const effectiveTargetHistoryId = computed(() => {
+    return props.targetHistoryId ?? currentHistoryId.value;
+});
+
+const { uploadBlockReason, warningMessage: targetHistoryWarning } = useTargetHistoryUploadState(
+    computed(() => effectiveTargetHistoryId.value),
+);
+
+const hasRegularFilesToImport = computed(() => filesToImport.value.some((file) => file.type === "file"));
+const isBlockedForSelectedItems = computed(() => Boolean(uploadBlockReason.value && hasRegularFilesToImport.value));
 
 const wizard = useWizard({
     "zip-file-selector": {
@@ -85,12 +103,15 @@ const wizard = useWizard({
     "import-summary": {
         label: "Summary",
         instructions: `Review and confirm the items you are about to import. You can go back to select different items if needed:`,
-        isValid: () => true,
+        isValid: () => !isBlockedForSelectedItems.value,
         isSkippable: () => false,
     },
 });
 
 async function importItems() {
+    if (isBlockedForSelectedItems.value) {
+        return;
+    }
     isWizardBusy.value = true;
     try {
         router.push({
@@ -100,7 +121,10 @@ async function importItems() {
                 regularFileCount: String(filesToImport.value.filter((file) => file.type === "file").length),
             },
         });
-        await importArtifacts(filesToImport.value, currentHistoryId.value);
+        await importArtifacts(
+            filesToImport.value,
+            hasRegularFilesToImport.value ? effectiveTargetHistoryId.value ?? null : null,
+        );
     } catch (error) {
         errorMessage.value = errorMessageAsString(error);
     } finally {
@@ -164,6 +188,13 @@ archiveExplorerEventBus.on((key, source) => {
 
 <template>
     <div>
+        <BAlert
+            v-if="props.showTargetHistoryWarning && targetHistoryWarning && hasRegularFilesToImport"
+            show
+            variant="warning">
+            {{ targetHistoryWarning }}
+        </BAlert>
+
         <BAlert v-if="errorMessage" show dismissible fade variant="danger" @dismissed="errorMessage = undefined">
             {{ errorMessage }}
         </BAlert>

--- a/client/src/components/Panels/Upload/methods/ExploreZipUpload.vue
+++ b/client/src/components/Panels/Upload/methods/ExploreZipUpload.vue
@@ -1,7 +1,19 @@
 <script setup lang="ts">
+import type { UploadMethodConfig } from "../types";
+
 import ZipImportWizard from "@/components/ImportData/zip/ZipImportWizard.vue";
+
+interface Props {
+    method: UploadMethodConfig;
+    targetHistoryId: string;
+}
+
+defineProps<Props>();
 </script>
 
 <template>
-    <ZipImportWizard :should-display-heading="false" />
+    <ZipImportWizard
+        :should-display-heading="false"
+        :target-history-id="targetHistoryId"
+        :show-target-history-warning="false" />
 </template>

--- a/client/src/composables/history/useTargetHistoryUploadState.ts
+++ b/client/src/composables/history/useTargetHistoryUploadState.ts
@@ -1,0 +1,35 @@
+import { computed, type ComputedRef } from "vue";
+
+import type { AnyHistory } from "@/api";
+import { useHistoryStore } from "@/stores/historyStore";
+import {
+    getHistoryUploadBlockReason,
+    getHistoryUploadWarningMessage,
+    type HistoryUploadBlockReason,
+} from "@/utils/historyUpload";
+
+interface TargetHistoryUploadState {
+    targetHistory: ComputedRef<AnyHistory | null>;
+    uploadBlockReason: ComputedRef<HistoryUploadBlockReason | null>;
+    warningMessage: ComputedRef<string>;
+}
+
+export function useTargetHistoryUploadState(
+    targetHistoryId: ComputedRef<string | null | undefined>,
+): TargetHistoryUploadState {
+    const historyStore = useHistoryStore();
+
+    const targetHistory = computed(() => {
+        const historyId = targetHistoryId.value;
+        return historyId ? historyStore.getHistoryById(historyId, false) : null;
+    });
+
+    const uploadBlockReason = computed(() => getHistoryUploadBlockReason(targetHistory.value));
+    const warningMessage = computed(() => getHistoryUploadWarningMessage(uploadBlockReason.value));
+
+    return {
+        targetHistory,
+        uploadBlockReason,
+        warningMessage,
+    };
+}

--- a/client/src/composables/zipExplorer.ts
+++ b/client/src/composables/zipExplorer.ts
@@ -97,6 +97,10 @@ export function useZipExplorer() {
             return;
         }
 
+        if (toUploadToHistory.length === 0) {
+            return;
+        }
+
         if (!historyId) {
             throw new Error("There is no history available to upload the selected files.");
         }
@@ -162,6 +166,10 @@ export function useZipExplorer() {
             }
         }
 
+        if (toUploadToHistory.length === 0) {
+            return;
+        }
+
         if (!historyId) {
             throw new Error("There is no history available to upload the selected files.");
         }
@@ -189,6 +197,7 @@ export function useZipExplorer() {
             };
             uploadItems.push(uploadItem);
         }
+
         try {
             const payload = buildUploadPayload(uploadItems);
             submitUpload({ data: payload });

--- a/client/src/utils/historyUpload.test.ts
+++ b/client/src/utils/historyUpload.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    getHistoryUploadActionErrorMessage,
+    getHistoryUploadBlockReason,
+    getHistoryUploadWarningMessage,
+} from "./historyUpload";
+
+describe("historyUpload", () => {
+    it("returns archived when history is archived", () => {
+        const reason = getHistoryUploadBlockReason({ archived: true, deleted: false });
+        expect(reason).toBe("archived");
+        expect(getHistoryUploadWarningMessage(reason)).toContain("archived");
+        expect(getHistoryUploadActionErrorMessage(reason)).toContain("archived");
+    });
+
+    it("returns deleted when history is deleted", () => {
+        const reason = getHistoryUploadBlockReason({ archived: false, deleted: true });
+        expect(reason).toBe("deleted");
+        expect(getHistoryUploadWarningMessage(reason)).toContain("deleted");
+        expect(getHistoryUploadActionErrorMessage(reason)).toContain("deleted");
+    });
+
+    it("returns null for active histories", () => {
+        const reason = getHistoryUploadBlockReason({ archived: false, deleted: false });
+        expect(reason).toBeNull();
+        expect(getHistoryUploadWarningMessage(reason)).toBe("");
+        expect(getHistoryUploadActionErrorMessage(reason)).toBe("");
+    });
+});

--- a/client/src/utils/historyUpload.ts
+++ b/client/src/utils/historyUpload.ts
@@ -1,0 +1,37 @@
+export type HistoryUploadBlockReason = "archived" | "deleted";
+
+type UploadTargetHistory = {
+    archived?: boolean;
+    deleted?: boolean;
+};
+
+const BLOCK_WARNING_BY_REASON: Record<HistoryUploadBlockReason, string> = {
+    archived: "This history has been archived and cannot receive uploads. Select a different history to continue.",
+    deleted: "This history has been deleted and cannot receive uploads. Select a different history to continue.",
+};
+
+const ACTION_ERROR_BY_REASON: Record<HistoryUploadBlockReason, string> = {
+    archived: "Cannot upload: target history is archived. Select a different history and try again.",
+    deleted: "Cannot upload: target history is deleted. Select a different history and try again.",
+};
+
+export function getHistoryUploadBlockReason(history?: UploadTargetHistory | null): HistoryUploadBlockReason | null {
+    if (!history) {
+        return null;
+    }
+    if (history.archived) {
+        return "archived";
+    }
+    if (history.deleted) {
+        return "deleted";
+    }
+    return null;
+}
+
+export function getHistoryUploadWarningMessage(reason?: HistoryUploadBlockReason | null): string {
+    return reason ? BLOCK_WARNING_BY_REASON[reason] : "";
+}
+
+export function getHistoryUploadActionErrorMessage(reason?: HistoryUploadBlockReason | null): string {
+    return reason ? ACTION_ERROR_BY_REASON[reason] : "";
+}


### PR DESCRIPTION
A clear warning is now displayed if the user has an `archived` or `deleted` history set as current and then tries to upload files to it using any of the available methods.

The user can still stage upload items, but the "Start" upload will be disabled until a valid history is selected.

<img width="945" height="165" alt="Screenshot from 2026-02-19 18-58-08" src="https://github.com/user-attachments/assets/9b523d09-b520-41f3-bca5-e4c90b76cf58" />

The Zip Explorer Wizard has also been updated to support target history selection instead of relying on the current history.

<img width="1261" height="881" alt="image" src="https://github.com/user-attachments/assets/22222ebd-f024-4468-98c2-b5e7272ffd31" />

If the users only select workflows from the Zip contents, they will still be able to import them regardless of the target history, as expected, but the warning will be displayed and the import button will be disabled if some other file is selected while targeting an invalid history.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
