### PR TITLE
Add try Beta Upload button

### DIFF
--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -162,6 +162,43 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
         set(meta, metaKey, value);
     }
 
+    function findById(activityId: string): Activity | undefined {
+        return activities.value.find((a: Activity) => a.id === activityId);
+    }
+
+    function setPosition(activityId: string, position: number) {
+        const currentIndex = activities.value.findIndex((a: Activity) => a.id === activityId);
+        if (currentIndex === -1) {
+            return;
+        }
+        const boundedPosition = Math.max(0, Math.min(position, activities.value.length - 1));
+        const spliced = activities.value.splice(currentIndex, 1);
+        const activity = spliced[0];
+        if (!activity) {
+            return;
+        }
+        activities.value.splice(boundedPosition, 0, activity);
+        activities.value = [...activities.value];
+    }
+
+    function ensureSideBarOpen(activityId: string) {
+        const activity = findById(activityId);
+        if (!activity || !activity.panel) {
+            return;
+        }
+        if (toggledSideBar.value !== activityId) {
+            toggledSideBar.value = activityId;
+        }
+    }
+
+    function ensureVisible(activityId: string) {
+        const activity = findById(activityId);
+        if (!activity) {
+            return;
+        }
+        activity.visible = true;
+    }
+
     watchImmediate(
         () => hashedUserId.value,
         () => {
@@ -174,13 +211,17 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
         sidePanelWidth,
         toggleSideBar,
         closeSideBar,
+        ensureSideBarOpen,
+        ensureVisible,
         isSideBarOpen,
         activities,
         activityMeta,
         metaForId,
         setMeta,
         getAll,
+        findById,
         remove,
+        setPosition,
         setAll,
         restore,
         sync,

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -129,7 +129,7 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
     }
 
     function setAll(newActivities: Array<Activity>) {
-        activities.value = newActivities;
+        activities.value = [...newActivities];
     }
 
     function remove(activityId: string) {


### PR DESCRIPTION
Resolves #21883

If the activity is hidden, it will be made visible and positioned on top automatically.

Contains some new utility functions for the Activity store to manipulate activities.

This will increase visibility and hopefully feedback for the next cycle before we phase out the old dialog.

<img width="910" height="562" alt="image" src="https://github.com/user-attachments/assets/f001c5bb-6533-44fc-af93-7042bed0f37f" />

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
