### PR TITLE
Add format_xml to galaxy-tool-util for shared XML formatting

### DIFF
--- a/lib/galaxy/tool_util/format.py
+++ b/lib/galaxy/tool_util/format.py
@@ -1,4 +1,10 @@
+import argparse
+import difflib
+import sys
+
 from lxml import etree
+
+DESCRIPTION = """Format Galaxy tool XML files with consistent indentation."""
 
 
 def format_xml(content: str, tab_size: int = 4) -> str:
@@ -14,3 +20,53 @@ def format_xml(content: str, tab_size: int = 4) -> str:
         return etree.tostring(xml, pretty_print=True, encoding=str)
     except etree.XMLSyntaxError:
         return content
+
+
+def arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("xml_files", nargs="+", metavar="FILE", help="Galaxy tool XML file(s) to format")
+    parser.add_argument(
+        "-t", "--tab-size", type=int, default=4, help="Number of spaces per indentation level (default: 4)"
+    )
+    parser.add_argument("-d", "--diff", action="store_true", help="Show diff of changes instead of formatting in-place")
+    return parser
+
+
+def main(argv=None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = arg_parser().parse_args(argv)
+    has_diff = False
+
+    for path in args.xml_files:
+        with open(path) as f:
+            original = f.read()
+
+        formatted = format_xml(original, tab_size=args.tab_size)
+        changed = original != formatted
+
+        if args.diff:
+            if changed:
+                has_diff = True
+                diff = difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    formatted.splitlines(keepends=True),
+                    fromfile=path,
+                    tofile=path,
+                )
+                sys.stdout.writelines(diff)
+        else:
+            if changed:
+                with open(path, "w") as f:
+                    f.write(formatted)
+                print(f"reformatted {path}")
+            else:
+                print(f"{path} already formatted")
+
+    if args.diff and has_diff:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/tool_util/format.py
+++ b/lib/galaxy/tool_util/format.py
@@ -1,0 +1,16 @@
+from lxml import etree
+
+
+def format_xml(content: str, tab_size: int = 4) -> str:
+    """Format XML content with consistent indentation.
+
+    Used by planemo's format command and the Galaxy Language Server
+    to apply uniform formatting to Galaxy tool XML files.
+    """
+    try:
+        parser = etree.XMLParser(strip_cdata=False)
+        xml = etree.fromstring(content, parser=parser)
+        etree.indent(xml, space=" " * tab_size)
+        return etree.tostring(xml, pretty_print=True, encoding=str)
+    except etree.XMLSyntaxError:
+        return content

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -50,6 +50,7 @@ python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =
+        galaxy-tool-format = galaxy.tool_util.format:main
         galaxy-tool-test = galaxy.tool_util.verify.script:main
         galaxy-tool-test-case-validation = galaxy.tool_util.parameters.scripts.validate_test_cases:main
         galaxy-tool-upgrade-advisor = galaxy.tool_util.upgrade.script:main

--- a/test/unit/tool_util/test_format.py
+++ b/test/unit/tool_util/test_format.py
@@ -1,0 +1,71 @@
+from galaxy.tool_util.format import format_xml
+
+SIMPLE_TOOL_XML = """\
+<tool id="test" name="Test" version="1.0">
+<description>A test tool</description>
+<command>echo hello</command>
+<inputs>
+<param name="input1" type="data" format="txt"/>
+</inputs>
+<outputs>
+<data name="output1" format="txt"/>
+</outputs>
+</tool>"""
+
+EXPECTED_FORMATTED = """\
+<tool id="test" name="Test" version="1.0">
+    <description>A test tool</description>
+    <command>echo hello</command>
+    <inputs>
+        <param name="input1" type="data" format="txt"/>
+    </inputs>
+    <outputs>
+        <data name="output1" format="txt"/>
+    </outputs>
+</tool>
+"""
+
+CDATA_XML = """\
+<tool id="test" name="Test" version="1.0">
+<command><![CDATA[echo "hello world"]]></command>
+</tool>"""
+
+COMMENT_XML = """\
+<tool id="test" name="Test" version="1.0">
+<!-- This is a comment -->
+<command>echo hello</command>
+</tool>"""
+
+
+def test_basic_formatting():
+    result = format_xml(SIMPLE_TOOL_XML)
+    assert result == EXPECTED_FORMATTED
+
+
+def test_tab_size_2():
+    result = format_xml(SIMPLE_TOOL_XML, tab_size=2)
+    assert "  <description>" in result
+    assert "    <param" in result
+
+
+def test_cdata_preserved():
+    result = format_xml(CDATA_XML)
+    assert "CDATA" in result
+    assert 'echo "hello world"' in result
+
+
+def test_comments_preserved():
+    result = format_xml(COMMENT_XML)
+    assert "<!-- This is a comment -->" in result
+
+
+def test_invalid_xml_returned_unchanged():
+    bad_xml = "<tool><unclosed>"
+    result = format_xml(bad_xml)
+    assert result == bad_xml
+
+
+def test_idempotent():
+    first = format_xml(SIMPLE_TOOL_XML)
+    second = format_xml(first)
+    assert first == second

--- a/test/unit/tool_util/test_format.py
+++ b/test/unit/tool_util/test_format.py
@@ -1,4 +1,7 @@
-from galaxy.tool_util.format import format_xml
+from galaxy.tool_util.format import (
+    format_xml,
+    main,
+)
 
 SIMPLE_TOOL_XML = """\
 <tool id="test" name="Test" version="1.0">
@@ -69,3 +72,64 @@ def test_idempotent():
     first = format_xml(SIMPLE_TOOL_XML)
     second = format_xml(first)
     assert first == second
+
+
+def test_cli_inplace(tmp_path):
+    tool_file = tmp_path / "tool.xml"
+    tool_file.write_text(SIMPLE_TOOL_XML)
+    main([str(tool_file)])
+    assert tool_file.read_text() == EXPECTED_FORMATTED
+
+
+def test_cli_already_formatted(tmp_path, capsys):
+    tool_file = tmp_path / "tool.xml"
+    tool_file.write_text(EXPECTED_FORMATTED)
+    main([str(tool_file)])
+    assert tool_file.read_text() == EXPECTED_FORMATTED
+    assert "already formatted" in capsys.readouterr().out
+
+
+def test_cli_diff_mode(tmp_path, capsys):
+    tool_file = tmp_path / "tool.xml"
+    tool_file.write_text(SIMPLE_TOOL_XML)
+    try:
+        main(["--diff", str(tool_file)])
+    except SystemExit as e:
+        assert e.code == 1
+    # file should be unchanged in diff mode
+    assert tool_file.read_text() == SIMPLE_TOOL_XML
+    assert "---" in capsys.readouterr().out
+
+
+def test_cli_diff_mode_no_changes(tmp_path):
+    tool_file = tmp_path / "tool.xml"
+    tool_file.write_text(EXPECTED_FORMATTED)
+    # should not raise SystemExit
+    main(["--diff", str(tool_file)])
+
+
+def test_cli_tab_size(tmp_path):
+    tool_file = tmp_path / "tool.xml"
+    tool_file.write_text(SIMPLE_TOOL_XML)
+    main(["--tab-size", "2", str(tool_file)])
+    result = tool_file.read_text()
+    assert "  <description>" in result
+    assert "    <param" in result
+
+
+def test_cli_multiple_files(tmp_path):
+    f1 = tmp_path / "tool1.xml"
+    f2 = tmp_path / "tool2.xml"
+    f1.write_text(SIMPLE_TOOL_XML)
+    f2.write_text(SIMPLE_TOOL_XML)
+    main([str(f1), str(f2)])
+    assert f1.read_text() == EXPECTED_FORMATTED
+    assert f2.read_text() == EXPECTED_FORMATTED
+
+
+def test_cli_invalid_xml_unchanged(tmp_path):
+    bad_xml = "<tool><unclosed>"
+    tool_file = tmp_path / "tool.xml"
+    tool_file.write_text(bad_xml)
+    main([str(tool_file)])
+    assert tool_file.read_text() == bad_xml


### PR DESCRIPTION
Both planemo's format command and the Galaxy Language Server maintain identical XML formatting functions. Adding format_xml here gives both projects a single shared implementation to import from.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
