### PR TITLE
Disallow gunicorn 25.1.0

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -102,7 +102,7 @@ griffelib==2.0.0
 groq==1.0.0
 grpcio==1.78.1
 grpcio-status==1.78.1
-gunicorn==25.1.0
+gunicorn==25.0.3
 gxformat2==0.22.0
 h11==0.16.0
 h5grove==3.0.0

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     Mako
     Markdown
     MarkupSafe
-    mercurial>=6.8.2
+    mercurial>=7.2
     more-itertools
     nodejs-wheel>=22,<23
     packaging

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     fastapi>=0.124.0
     Mako
     MarkupSafe
-    mercurial>=6.8.2
+    mercurial>=7.2
     Paste
     playwright
     pydantic>=2.7.4

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     Babel
     CT3>=3.3.3
     fastapi>=0.124.0
-    gunicorn
+    gunicorn!=25.1.0
     httpx
     gxformat2
     Mako

--- a/packages/web_stack/setup.cfg
+++ b/packages/web_stack/setup.cfg
@@ -41,7 +41,7 @@ python_requires = >=3.10
 [options.extras_require]
 test =
     pytest
-    gunicorn
+    gunicorn!=25.1.0
 
 [options.packages.find]
 exclude =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ dependencies = [
     "Mako",
     "Markdown",
     "MarkupSafe",
-    "mercurial>=6.8.2 ; python_version<'3.14'",  # Python 3.13 support
-    "mercurial>=7.2rc0 ; python_version>='3.14'",  # Python 3.14 support
+    "mercurial>=7.2",  # Python 3.14 support
     "mrcfile",
     "more-itertools",
     "msal",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "fs",
     "future>=1.0.0",  # Python 3.12 support
     "gravity>=1.2.0",  # Python 3.14 support
-    "gunicorn",
+    "gunicorn!=25.1.0",  # https://github.com/benoitc/gunicorn/discussions/3509
     "gxformat2>=0.21.0",
     "h5grove>=1.2.1",
     "h5py>=3.12",  # Python 3.13 support


### PR DESCRIPTION
The new gunicornc Control Interface breaks workers, see:

https://github.com/benoitc/gunicorn/discussions/3509
https://github.com/galaxyproject/gravity/pull/141

Also:
- Unify minimum mercurial version

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
