### PR TITLE
Improve Type and Reference selectors in Upload Activity

### DIFF
--- a/client/src/components/Panels/Upload/shared/UploadTableBulkDbKeyHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableBulkDbKeyHeader.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { BFormSelect } from "bootstrap-vue";
+import { computed } from "vue";
 
 import type { DbKey } from "@/composables/uploadConfigurations";
+
+import SingleItemSelector from "@/components/SingleItemSelector.vue";
 
 interface Props {
     /** Selected bulk dbKey value */
@@ -14,7 +16,7 @@ interface Props {
     tooltip?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     disabled: false,
     tooltip: "Set database key for all items",
 });
@@ -23,26 +25,25 @@ const emit = defineEmits<{
     (e: "input", value: string): void;
 }>();
 
-function handleInput(value: string) {
-    emit("input", value);
+const optionsWithDefault = computed(() => [{ id: "", text: "Set all..." }, ...(props.dbKeys || [])]);
+
+function onItemSelection(item: DbKey) {
+    emit("input", item.id);
 }
 </script>
 
 <template>
     <div class="column-header-vertical">
         <span class="column-title">Reference</span>
-        <BFormSelect
+        <SingleItemSelector
             v-b-tooltip.hover.noninteractive
-            :value="value"
-            size="sm"
+            class="w-100"
+            collection-name="References"
             :title="tooltip"
+            :items="optionsWithDefault"
+            :current-item="props.dbKeys.find((dbKey) => dbKey.id === props.value) || optionsWithDefault[0]"
             :disabled="disabled"
-            @input="handleInput">
-            <option value="">Set all...</option>
-            <option v-for="(dbKey, dbKeyIndex) in dbKeys" :key="dbKeyIndex" :value="dbKey.id">
-                {{ dbKey.text }}
-            </option>
-        </BFormSelect>
+            @update:selected-item="onItemSelection" />
     </div>
 </template>
 

--- a/client/src/components/Panels/Upload/shared/UploadTableBulkExtensionHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableBulkExtensionHeader.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BFormSelect } from "bootstrap-vue";
+import { computed } from "vue";
 
 import type { ExtensionDetails } from "@/composables/uploadConfigurations";
+
+import SingleItemSelector from "@/components/SingleItemSelector.vue";
 
 interface Props {
     /** Selected bulk extension value */
@@ -18,7 +20,7 @@ interface Props {
     tooltip?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
     disabled: false,
     tooltip: "Set file format for all items",
     warning: undefined,
@@ -28,26 +30,24 @@ const emit = defineEmits<{
     (e: "input", value: string): void;
 }>();
 
-function handleInput(value: string) {
-    emit("input", value);
+const optionsWithDefault = computed(() => [{ id: "", text: "Set all..." }, ...(props.extensions || [])]);
+
+function onItemSelection(item: ExtensionDetails) {
+    emit("input", item.id);
 }
 </script>
 
 <template>
     <div class="column-header-vertical">
         <span class="column-title">Type</span>
-        <BFormSelect
+        <SingleItemSelector
             v-b-tooltip.hover.noninteractive
-            :value="value"
-            size="sm"
+            collection-name="Data Types"
             :title="tooltip"
+            :items="optionsWithDefault"
+            :current-item="props.extensions.find((e) => e.id === props.value) || optionsWithDefault[0]"
             :disabled="disabled"
-            @input="handleInput">
-            <option value="">Set all...</option>
-            <option v-for="(ext, extIndex) in extensions" :key="extIndex" :value="ext.id">
-                {{ ext.text }}
-            </option>
-        </BFormSelect>
+            @update:selected-item="onItemSelection" />
         <FontAwesomeIcon
             v-if="warning"
             v-b-tooltip.hover.noninteractive

--- a/client/src/components/Panels/Upload/shared/UploadTableDbKeyCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableDbKeyCell.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { BFormSelect } from "bootstrap-vue";
-
 import type { DbKey } from "@/composables/uploadConfigurations";
+
+import SingleItemSelector from "@/components/SingleItemSelector.vue";
 
 interface Props {
     /** Currently selected database key for this item */
@@ -23,21 +23,18 @@ const emit = defineEmits<{
     (e: "input", value: string): void;
 }>();
 
-function handleInput(value: string) {
-    emit("input", value);
+function onItemSelection(item: DbKey) {
+    emit("input", item.id);
 }
 </script>
 
 <template>
-    <BFormSelect
+    <SingleItemSelector
         v-b-tooltip.hover.noninteractive
-        :value="value"
-        size="sm"
+        collection-name="References"
         :title="tooltip"
+        :items="dbKeys"
+        :current-item="dbKeys.find((dbKey) => dbKey.id === value)"
         :disabled="disabled"
-        @input="handleInput">
-        <option v-for="(dbKey, dbKeyIndex) in dbKeys" :key="dbKeyIndex" :value="dbKey.id">
-            {{ dbKey.text }}
-        </option>
-    </BFormSelect>
+        @update:selected-item="onItemSelection" />
 </template>

--- a/client/src/components/Panels/Upload/shared/UploadTableExtensionCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableExtensionCell.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BFormSelect } from "bootstrap-vue";
 
 import type { ExtensionDetails } from "@/composables/uploadConfigurations";
+
+import SingleItemSelector from "@/components/SingleItemSelector.vue";
 
 interface Props {
     /** Currently selected extension for this item */
@@ -28,24 +29,23 @@ const emit = defineEmits<{
     (e: "input", value: string): void;
 }>();
 
-function handleInput(value: string) {
-    emit("input", value);
+function onItemSelection(value: ExtensionDetails) {
+    emit("input", value.id);
 }
 </script>
 
 <template>
-    <div class="d-flex align-items-center">
-        <BFormSelect
+    <div class="d-flex align-items-center w-100">
+        <SingleItemSelector
             v-b-tooltip.hover.noninteractive
-            :value="value"
-            size="sm"
+            class="flex-grow-1"
+            collection-name="Data Types"
             :title="tooltip"
+            :items="extensions"
+            :current-item="extensions.find((ext) => ext.id === value)"
             :disabled="disabled"
-            @input="handleInput">
-            <option v-for="(ext, extIndex) in extensions" :key="extIndex" :value="ext.id">
-                {{ ext.text }}
-            </option>
-        </BFormSelect>
+            @update:selected-item="onItemSelection">
+        </SingleItemSelector>
         <FontAwesomeIcon
             v-if="warning"
             v-b-tooltip.hover.noninteractive

--- a/client/src/components/SingleItemSelector.test.ts
+++ b/client/src/components/SingleItemSelector.test.ts
@@ -1,0 +1,104 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import Multiselect from "vue-multiselect";
+
+import SingleItemSelector from "./SingleItemSelector.vue";
+
+const localVue = getLocalVue();
+
+const ITEMS = [
+    { id: "a", text: "Alpha" },
+    { id: "b", text: "Beta" },
+    { id: "c", text: "Gamma" },
+];
+
+function mountComponent(propsData: object = {}) {
+    return mount(SingleItemSelector as object, {
+        propsData,
+        localVue,
+    });
+}
+
+describe("SingleItemSelector", () => {
+    describe("loading state", () => {
+        it("shows a loading message when loading is true", () => {
+            const wrapper = mountComponent({ loading: true, collectionName: "Things" });
+            const span = wrapper.findComponent({ name: "LoadingSpan" });
+            expect(span.exists()).toBe(true);
+            expect(span.props("message")).toBe("Loading Things...");
+        });
+
+        it("does not show the selector while loading", () => {
+            const wrapper = mountComponent({ loading: true, items: ITEMS });
+            expect(wrapper.findComponent({ name: "LoadingSpan" }).exists()).toBe(true);
+        });
+    });
+
+    describe("empty items", () => {
+        it("does not render the selector when items is empty", () => {
+            const wrapper = mountComponent({ items: [] });
+            expect(wrapper.findComponent(Multiselect).exists()).toBe(false);
+        });
+
+        it("does not render the selector when items prop is omitted", () => {
+            const wrapper = mountComponent({});
+            expect(wrapper.findComponent(Multiselect).exists()).toBe(false);
+        });
+    });
+
+    describe("initial selection", () => {
+        it("selects the first item by default when no currentItem is given", () => {
+            const wrapper = mountComponent({ items: ITEMS });
+            expect(wrapper.findComponent(Multiselect).props("value")).toEqual(ITEMS[0]);
+        });
+
+        it("selects the matching currentItem when provided", () => {
+            const wrapper = mountComponent({ items: ITEMS, currentItem: ITEMS[1] });
+            expect(wrapper.findComponent(Multiselect).props("value")).toEqual(ITEMS[1]);
+        });
+
+        it("falls back to the currentItem object itself when it is not in items", () => {
+            const externalItem = { id: "z", text: "External" };
+            const wrapper = mountComponent({ items: ITEMS, currentItem: externalItem });
+            expect(wrapper.findComponent(Multiselect).props("value")).toEqual(externalItem);
+        });
+    });
+
+    describe("emitting selection", () => {
+        it("emits update:selected-item when an item is selected", async () => {
+            const wrapper = mountComponent({ items: ITEMS });
+
+            // Open the dropdown then click the third option
+            await wrapper.find(".multiselect").trigger("click");
+            const options = wrapper.findAll(".multiselect__option");
+            await options.at(2).trigger("click");
+
+            const emitted = wrapper.emitted("update:selected-item");
+            expect(emitted).toBeTruthy();
+            expect(emitted![0]![0]).toEqual(ITEMS[2]);
+        });
+    });
+
+    describe("reactivity", () => {
+        it("resets selection to first item when items prop changes", async () => {
+            const wrapper = mountComponent({ items: ITEMS, currentItem: ITEMS[2] });
+
+            const newItems = [
+                { id: "x", text: "X-Ray" },
+                { id: "y", text: "Yankee" },
+            ];
+            await wrapper.setProps({ items: newItems, currentItem: undefined });
+
+            expect(wrapper.findComponent(Multiselect).props("value")).toEqual(newItems[0]);
+        });
+
+        it("updates selection when currentItem prop changes", async () => {
+            const wrapper = mountComponent({ items: ITEMS, currentItem: ITEMS[0] });
+
+            await wrapper.setProps({ currentItem: ITEMS[2] });
+
+            expect(wrapper.findComponent(Multiselect).props("value")).toEqual(ITEMS[2]);
+        });
+    });
+});

--- a/client/src/components/SingleItemSelector.vue
+++ b/client/src/components/SingleItemSelector.vue
@@ -2,92 +2,96 @@
     <div>
         <LoadingSpan v-if="loading" :message="loadingMessage" />
         <Multiselect
-            v-if="items"
+            v-if="items && items.length"
             v-model="selectedItem"
+            class="single-item-selector"
+            :allow-empty="false"
             :deselect-label="null"
-            :track-by="trackBy"
+            :select-label="null"
+            :disabled="disabled"
             :label="label"
             :options="items"
             :searchable="true"
-            :allow-empty="false"
+            :title="title"
+            :track-by="trackBy"
             @select="onSelectItem" />
     </div>
 </template>
 
-<script>
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
 import Multiselect from "vue-multiselect";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
-/** A simple item selector that allows searching/filtering of the available items.
- * The items must have {id, text} properties. The `id` will be used for selection
- * and the `text` for displaying the item in the selector.
- *
- * This component is meant to be used in combination with a Provider with the
- * `items` and the `loading` status.
- *
- * The selected value will be available through the `update:selected-item` event.
- */
-export default {
-    components: {
-        Multiselect,
-        LoadingSpan,
+// Using `any` here until we can use generics in Vue3
+type Item = any;
+
+interface SingleItemSelectorProps {
+    /** Indicates if the available items are still loading. */
+    loading?: boolean;
+    /** The name of the items. Displayed in the loading message. */
+    collectionName?: string;
+    /** The items that can be selected. */
+    items?: Item[];
+    /** Whether the selector is disabled. */
+    disabled?: boolean;
+    /** The initially selected item. */
+    currentItem?: Item;
+    /** Tooltip/title for the control. */
+    title?: string;
+    /** The property of the item to display in the dropdown. */
+    label?: string;
+    /** The property of the item to use as a unique identifier. */
+    trackBy?: string;
+}
+
+const props = withDefaults(defineProps<SingleItemSelectorProps>(), {
+    disabled: false,
+    loading: false,
+    title: "",
+    collectionName: "items",
+    items: () => [],
+    currentItem: undefined,
+    label: "text",
+    trackBy: "id",
+});
+
+const emit = defineEmits<{
+    (e: "update:selected-item", item: Item | null): void;
+}>();
+
+const selectedItem = ref<Item | null>(getInitialSelection());
+
+const loadingMessage = computed(() => `Loading ${props.collectionName}...`);
+
+watch(
+    () => [props.items, props.currentItem],
+    () => {
+        selectedItem.value = getInitialSelection();
     },
-    props: {
-        /** Indicates if the available items are still loading.
-         * While this is true a spinner with a loading message will
-         * be displayed instead.
-         */
-        loading: {
-            type: Boolean,
-            required: false,
-        },
-        /** The name of the items. It will be displayed in the loading message. */
-        collectionName: {
-            type: String,
-            required: false,
-            default: "items",
-        },
-        /** The items that can be selected. */
-        items: {
-            type: Array,
-            required: false,
-            default: null,
-        },
-        /** The initially selected item. */
-        currentItem: {
-            type: Object,
-            default: null,
-        },
-        label: {
-            type: String,
-            default: "text",
-        },
-        trackBy: {
-            type: String,
-            default: "id",
-        },
-    },
-    data() {
-        return {
-            selectedItem: {},
-        };
-    },
-    computed: {
-        /** @return {String} */
-        loadingMessage() {
-            return `Loading ${this.collectionName}...`;
-        },
-    },
-    watch: {
-        items: function () {
-            this.selectedItem = this.currentItem;
-        },
-    },
-    methods: {
-        onSelectItem(item) {
-            this.$emit("update:selected-item", item);
-        },
-    },
-};
+);
+
+function getInitialSelection(): Item | null {
+    const list = props.items || [];
+    if (props.currentItem) {
+        return list.find((item) => item[props.trackBy] === props.currentItem![props.trackBy]) || props.currentItem;
+    }
+    if (list.length) {
+        return list[0]!;
+    }
+    return null;
+}
+
+function onSelectItem(item: Item | null) {
+    emit("update:selected-item", item);
+}
 </script>
+
+<style scoped lang="scss">
+@import "@/style/scss/theme/blue.scss";
+
+.single-item-selector :deep(.multiselect__tags) {
+    background-color: $white;
+}
+</style>


### PR DESCRIPTION
Resolves #21879

Instead of BFormSelect, we now use a modernized (composition API + Typescript) version of the SingleItemSelector component based on Multiselect. This makes the component more consistent and addresses the filtering issue mentioned in the original report.

<img width="1176" height="529" alt="image" src="https://github.com/user-attachments/assets/8712bb9e-992d-494b-962c-62171bfa22b5" />


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
