### PR TITLE
[25.1] Ensure markdown elements do not render if argument is undefined

### DIFF
--- a/client/src/components/Markdown/Sections/MarkdownGalaxy.vue
+++ b/client/src/components/Markdown/Sections/MarkdownGalaxy.vue
@@ -157,11 +157,11 @@ watch(
                 :content="`Galaxy Version ${config.version_major}`" />
             <TextContent v-else-if="name == 'generate_time'" class="galaxy-time" :content="new Date().toUTCString()" />
             <HistoryDatasetAsImage
-                v-else-if="name == 'history_dataset_as_image'"
+                v-else-if="name == 'history_dataset_as_image' && args.history_dataset_id"
                 :dataset-id="args.history_dataset_id"
                 :path="args.path" />
             <HistoryDatasetAsTable
-                v-else-if="name == 'history_dataset_as_table'"
+                v-else-if="name == 'history_dataset_as_table' && args.history_dataset_id"
                 :compact="compact"
                 :dataset-id="args.history_dataset_id"
                 :footer="args.footer"
@@ -178,12 +178,14 @@ watch(
                         'history_dataset_info',
                         'history_dataset_peek',
                         'history_dataset_type',
-                    ].includes(name)
+                    ].includes(name) && args.history_dataset_id
                 "
                 :dataset-id="args.history_dataset_id"
                 :name="name" />
             <HistoryDatasetDisplay
-                v-else-if="['history_dataset_embedded', 'history_dataset_display'].includes(name)"
+                v-else-if="
+                    ['history_dataset_embedded', 'history_dataset_display'].includes(name) && args.history_dataset_id
+                "
                 :dataset-id="args.history_dataset_id"
                 :embedded="name == 'history_dataset_embedded'" />
             <HistoryDatasetIndex v-else-if="name == 'history_dataset_index'" :args="args" />


### PR DESCRIPTION
Added undefined checks to markdown elements. For example, in the `DatasetAsImage.vue` component, we had an unlimited fetch for `/api/datasets/%7Bdataset_id%7D/extra_files` because the `dataset_id` can potentially be undefined; if we have an problematic request for, say:

```
history_dataset_as_image(invocation_id=b7c1d0811979026c, output="Output Name")
```

where this can sometimes return arguments without a `history_dataset_id` key (e.g.: the output is a collection, not a dataset).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
