### PR TITLE
[26.0] Parse input collections as well in markdown editor

### DIFF
--- a/client/src/components/Markdown/Editor/types.ts
+++ b/client/src/components/Markdown/Editor/types.ts
@@ -13,7 +13,7 @@ export interface DatasetLabel {
 
 export interface Invocation {
     history_id: string;
-    inputs: Record<string, { label?: string; id?: string }>;
+    inputs: Record<string, { label?: string; id?: string; src?: string }>;
     outputs: Record<string, { id?: string }>;
     output_collections: Record<string, { id?: string }>;
     steps: { workflow_step_label?: string; job_id?: string; implicit_collection_jobs_id?: string }[];

--- a/client/src/components/Markdown/Utilities/parseInvocation.test.js
+++ b/client/src/components/Markdown/Utilities/parseInvocation.test.js
@@ -18,6 +18,11 @@ const INVOCATION = {
             label: "input_3",
             id: "input_id_3",
         },
+        {
+            label: "input_collection_1",
+            id: "input_collection_id_1",
+            src: "hdca",
+        },
     ],
     outputs: {
         output_1: {
@@ -83,6 +88,17 @@ describe("parseInvocation.ts", () => {
                 }).implicit_collection_jobs_id,
             ).toBe("implicit_id_2");
             expect(parseInvocation(INVOCATION, STORED_WORKFLOW_ID, "", {}).invocation.id).toBe("invocation_id_1");
+            // collection inputs (src=hdca) route to history_dataset_collection_id, not history_dataset_id
+            expect(
+                parseInvocation(INVOCATION, STORED_WORKFLOW_ID, "history_dataset_as_image", {
+                    input: "input_collection_1",
+                }).history_dataset_collection_id,
+            ).toBe("input_collection_id_1");
+            expect(
+                parseInvocation(INVOCATION, STORED_WORKFLOW_ID, "history_dataset_as_image", {
+                    input: "input_collection_1",
+                }).history_dataset_id,
+            ).toBeUndefined();
         });
     });
 });

--- a/client/src/components/Markdown/Utilities/parseInvocation.ts
+++ b/client/src/components/Markdown/Utilities/parseInvocation.ts
@@ -20,7 +20,15 @@ interface ParsedAttributes {
 export function parseInput(invocation: Invocation, name: string | undefined) {
     if (name && invocation.inputs) {
         const inputs = Object.values(invocation.inputs);
-        const input = inputs.find((i) => i.label && i.label === name);
+        const input = inputs.find((i) => i.label && i.label === name && i.src !== "hdca");
+        return input?.id;
+    }
+}
+
+export function parseInputCollection(invocation: Invocation, name: string | undefined) {
+    if (name && invocation.inputs) {
+        const inputs = Object.values(invocation.inputs);
+        const input = inputs.find((i) => i.label && i.label === name && i.src === "hdca");
         return input?.id;
     }
 }
@@ -59,6 +67,7 @@ export function parseInvocation(
 ): ParsedAttributes {
     const result: ParsedAttributes = { ...attributes, invocation };
     const inputId = parseInput(invocation, result.input);
+    const inputCollectionId = parseInputCollection(invocation, result.input);
     const outputId = parseOutput(invocation, result.output);
     const outputCollectionId = parseOutputCollection(invocation, result.output);
     const step = parseStep(invocation, result.step);
@@ -67,6 +76,11 @@ export function parseInvocation(
         result.history_id = invocation.history_id;
     } else if (["workflow_display", "workflow_image", "workflow_license"].includes(name)) {
         result.workflow_id = workflowId;
+    } else if (inputCollectionId && "history_dataset_id" === requiredObject) {
+        // asked for a history_dataset_id but the input is a collection
+        result.history_dataset_collection_id = inputCollectionId;
+    } else if (inputCollectionId && "history_dataset_collection_id" === requiredObject) {
+        result.history_dataset_collection_id = inputCollectionId;
     } else if (inputId && "history_dataset_id" === requiredObject) {
         result.history_dataset_id = inputId;
     } else if (inputId && "history_dataset_collection_id" === requiredObject) {


### PR DESCRIPTION
For markdown objects that fetch invocations like:
```
history_dataset_as_image(invocation_id=b7c1d0811979026c, input="ROI image for staining analysis")
```

We were not parsing workflow inputs that are collections. So, these inputs were being treated as `history_dataset_id`s. Now, we check the input.src and if it is an `hdca` we return a `history_dataset_collection_id` instead of a `history_dataset_id`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
