### PR TITLE
Fix tool.parameters initialization

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -100,6 +100,7 @@ from galaxy.tool_util.parameters import (
     dereference,
     RequestInternalDereferencedToolState,
     RequestInternalToolState,
+    ToolParameterBundleModel,
 )
 from galaxy.tools import Tool
 from galaxy.tools._types import (
@@ -2169,7 +2170,13 @@ class JobSubmitter:
             return DataRequestInternalHda(id=hda.id, src="hda")
 
         tool_state = RequestInternalToolState(tool_request.request)
-        return dereference(tool_state, tool, dereference_callback, dereference_collection_callback), new_hdas
+        if tool.parameters is None:
+            raise RequestParameterInvalidException(f"Tool {tool.id} has no parameters defined")
+        parameter_bundle = ToolParameterBundleModel(parameters=tool.parameters)
+        return (
+            dereference(tool_state, parameter_bundle, dereference_callback, dereference_collection_callback),
+            new_hdas,
+        )
 
     def queue_jobs(self, tool: Tool, request: QueueJobs) -> None:
         tool_request: ToolRequest = self._tool_request(request.tool_request_id)

--- a/lib/galaxy/managers/landing.py
+++ b/lib/galaxy/managers/landing.py
@@ -56,6 +56,7 @@ from galaxy.tool_util.parameters import (
 from galaxy.tool_util_models.parameters import (
     DataOrCollectionRequestAdapter,
     DataRequestCollectionUri,
+    ToolParameterBundleModel,
 )
 from galaxy.util import safe_str_cmp
 from .context import ProvidesUserContext
@@ -104,10 +105,13 @@ class LandingRequestManager:
         landing_request_state = LandingRequestToolState(request_state or {})
         # Okay this is a hack until tool request API commit is merged, tools don't yet have a parameter
         # schema - so we can't do this properly.
-        if hasattr(tool, "parameters"):
-            internal_landing_request_state = landing_decode(landing_request_state, tool, self.security.decode_id)
+        if tool.parameters is not None:
+            parameter_bundle = ToolParameterBundleModel(parameters=tool.parameters)
+            internal_landing_request_state = landing_decode(
+                landing_request_state, parameter_bundle, self.security.decode_id
+            )
         else:
-            assert tool.id == FETCH_TOOL_ID
+            assert tool.id == FETCH_TOOL_ID, f"tool '{tool.id}' has no parameter schema but is not {FETCH_TOOL_ID}"
             # we have validated the payload as part of the API request
             # nothing else to decode ideally so just swap to internal model state object
             internal_landing_request_state = LandingRequestInternalToolState(

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -2141,6 +2141,12 @@ RepeatParameterModel.model_rebuild()
 CwlUnionParameterModel.model_rebuild()
 
 
+class MaybeToolParameterBundle(Protocol):
+    """An object that may or may not be a ToolParameterModel, but if it is a model, it has a root that is a ToolParameterT"""
+
+    parameters: Optional[List[ToolParameterT]]
+
+
 class ToolParameterBundle(Protocol):
     """An object having a dictionary of input models (i.e. a 'Tool')"""
 
@@ -2159,7 +2165,9 @@ def to_simple_model(input_parameter: Union[ToolParameterModel, ToolParameterT]) 
         return cast(ToolParameterT, input_parameter)
 
 
-def simple_input_models(parameters: Union[List[ToolParameterModel], List[ToolParameterT]]) -> Iterable[ToolParameterT]:
+def simple_input_models(
+    parameters: Union[List[ToolParameterModel], List[ToolParameterT]],
+) -> Iterable[ToolParameterT]:
     return [to_simple_model(m) for m in parameters]
 
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -39,6 +39,7 @@ from galaxy import (
     model,
 )
 from galaxy.exceptions import (
+    RequestParameterInvalidException,
     ToolInputsNotOKException,
     ToolInputsNotReadyException,
 )
@@ -89,7 +90,6 @@ from galaxy.tool_util.parameters import (
     input_models_for_pages,
     JobInternalToolState,
     RequestInternalDereferencedToolState,
-    ToolParameterBundle,
 )
 from galaxy.tool_util.parser import (
     get_tool_source,
@@ -125,6 +125,11 @@ from galaxy.tool_util.verify.test_data import TestDataNotFoundError
 from galaxy.tool_util.version import (
     LegacyVersion,
     parse_version,
+)
+from galaxy.tool_util_models.parameters import (
+    MaybeToolParameterBundle,
+    ToolParameterBundleModel,
+    ToolParameterT,
 )
 from galaxy.tool_util_models.tool_source import (
     FileSourceConfigFile,
@@ -1026,7 +1031,7 @@ class JobContext(BaseJobContext):
         return self.job.implicit_collection_jobs_association and self.job.implicit_collection_jobs_association.id
 
 
-class Tool(UsesDictVisibleKeys, ToolParameterBundle):
+class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
     """
     Represents a computational tool that can be executed through Galaxy.
     """
@@ -1120,6 +1125,10 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
         self.credentials: Optional[list[CredentialsRequirement]] = None
         self._is_workflow_compatible = None
         self.__tests: Optional[str] = None
+        self.parameters: Optional[list[ToolParameterT]] = None
+        self.template_macro_params: dict = {}
+        self._macro_paths: list = []
+        self.ports: list = []
         try:
             self.parse(tool_source, guid=guid, dynamic=dynamic)
         except Exception as e:
@@ -1597,9 +1606,7 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
 
     def parse_tests(self):
         if self.tool_source:
-            test_descriptions = parse_tool_test_descriptions(
-                self.tool_source, self.id, getattr(self, "parameters", None)
-            )
+            test_descriptions = parse_tool_test_descriptions(self.tool_source, self.id, self.parameters)
             try:
                 self.__tests = json.dumps([t.to_dict() for t in test_descriptions], indent=None)
             except Exception:
@@ -2152,15 +2159,18 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
         all_errors = []
         all_params: list[ToolStateJobInstancePopulatedT] = []
         internal_states: list[JobInternalToolState] = []
+        if self.parameters is None:
+            raise RequestParameterInvalidException(f"Tool {self.id} has no parameters defined")
+        parameter_bundle = ToolParameterBundleModel(parameters=self.parameters)
         for expanded_incoming, job_tool_state in zip(expanded_incomings, job_tool_states):
-            expanded_incoming = fill_static_defaults(expanded_incoming, self, self.profile)
-            job_tool_state = fill_static_defaults(job_tool_state, self, self.profile)
+            expanded_incoming = fill_static_defaults(expanded_incoming, parameter_bundle, self.profile)
+            job_tool_state = fill_static_defaults(job_tool_state, parameter_bundle, self.profile)
             params, errors = self._populate_async(request_context, expanded_incoming)
             # params have had dynamic defaults requiring like dataset contents expanded out
             # so we can use that backfill job_tool_state
             fill_dynamic_defaults(request_context, self.inputs, job_tool_state, params)
             internal_tool_state = JobInternalToolState(job_tool_state)
-            internal_tool_state.validate(self, f"{self.id} (job internal model)")
+            internal_tool_state.validate(parameter_bundle, f"{self.id} (job internal model)")
 
             internal_states.append(internal_tool_state)
             all_errors.append(errors)

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -19,6 +19,7 @@ from packaging.version import Version
 
 from galaxy import model
 from galaxy.authnz.util import provider_name_to_backend
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.job_execution.compute_environment import ComputeEnvironment
 from galaxy.job_execution.datasets import DeferrableObjectsT
 from galaxy.job_execution.setup import ensure_configs_directory
@@ -43,6 +44,7 @@ from galaxy.structured_app import (
 from galaxy.tool_util.data import TabularToolDataTable
 from galaxy.tool_util.parameters import JobInternalToolState
 from galaxy.tool_util.parser.output_objects import ToolOutput
+from galaxy.tool_util_models.parameters import ToolParameterBundleModel
 from galaxy.tool_util_models.tool_source import (
     FileSourceConfigFile,
     InputConfigFile,
@@ -672,7 +674,7 @@ class ToolEvaluator:
         Populate InteractiveTools templated values.
         """
         it = []
-        for ep in getattr(self.tool, "ports", []):
+        for ep in self.tool.ports:
             ep_dict = {}
             for key in (
                 "port",
@@ -1094,7 +1096,10 @@ class UserToolEvaluator(ToolEvaluator):
             hda_references, adapt_datasets, adapt_collections = setup_for_runtimeify(
                 self.app, compute_environment, input_datasets, input_dataset_collections
             )
-            job_runtime_state = runtimeify(validated_tool_state, self.tool, adapt_datasets, adapt_collections)
+            if self.tool.parameters is None:
+                raise RequestParameterInvalidException(f"Tool {self.tool.id} has no parameters defined")
+            parameter_bundle = ToolParameterBundleModel(parameters=self.tool.parameters)
+            job_runtime_state = runtimeify(validated_tool_state, parameter_bundle, adapt_datasets, adapt_collections)
             cwl_style_inputs = job_runtime_state.input_state
         else:
             from galaxy.workflow.modules import to_cwl

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -57,6 +57,7 @@ from galaxy.tool_util.parameters import (
     RelaxedRequestToolState,
     RequestToolState,
     strictify,
+    ToolParameterBundleModel,
 )
 from galaxy.webapps.galaxy.services.base import (
     async_task_summary,
@@ -246,14 +247,17 @@ class JobsService(ServiceBase):
             target_history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
         inputs = job_request.inputs
         strict = job_request.strict
+        if tool.parameters is None:
+            raise exceptions.RequestParameterInvalidException(f"Tool {tool.id} has no parameters defined")
+        parameter_bundle = ToolParameterBundleModel(parameters=tool.parameters)
         if not strict:
             relaxed_request_state = RelaxedRequestToolState(inputs or {})
-            relaxed_request_state.validate(tool, f"{tool.id} (relaxed request model)")
-            request_state = strictify(relaxed_request_state, tool)
+            relaxed_request_state.validate(parameter_bundle, f"{tool.id} (relaxed request model)")
+            request_state = strictify(relaxed_request_state, parameter_bundle)
         else:
             request_state = RequestToolState(inputs or {})
-        request_state.validate(tool, f"{tool.id} (request model)")
-        request_internal_state = decode(request_state, tool, trans.security.decode_id)
+        request_state.validate(parameter_bundle, f"{tool.id} (request model)")
+        request_internal_state = decode(request_state, parameter_bundle, trans.security.decode_id)
         tool_request = ToolRequest()
         # TODO: hash and such...
         tool_source_model = ToolSourceModel(

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -258,6 +258,8 @@ class ToolsService(ServiceBase):
         tool_ref: ToolRunReference,
     ) -> list[ToolParameterT]:
         tool = get_tool(trans, tool_ref)
+        if tool.parameters is None:
+            raise exceptions.RequestParameterInvalidException("Tool input parameter schema could not be retrieved.")
         return tool.parameters
 
     def create_fetch(


### PR DESCRIPTION
Initialize `parameters`, `template_macro_params`, `_macro_paths`, and `ports` in `Tool.__init__` so they always exist as attributes. Update `ToolParameterBundle` protocol to reflect that `parameters` may be `None`. Replace defensive `hasattr`/`getattr` patterns with direct attribute access and `None` comparisons.

Fixes https://github.com/galaxyproject/galaxy/issues/21843

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
