### PR TITLE
Fix dbkey filter returning no options when dbkey unset

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -220,10 +220,10 @@ class DataMetaFilter(Filter):
             ref = _get_ref_data(other_values, self.ref_name)
         except KeyError:  # no such dataset
             log.warning(f"could not filter by metadata: {self.ref_name} unknown")
-            return []
+            return copy.deepcopy(options)
         except ValueError:  # not a valid dataset
             log.warning(f"could not filter by metadata: {self.ref_name} not a data or collection parameter")
-            return []
+            return copy.deepcopy(options)
         # get the metadata value.
         # - for lists: (of data sets) and collections the meta data values of all
         #   elements is determined

--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -60,11 +60,11 @@ def populate_model(request_context, inputs, state_inputs, group_inputs: list[dic
                 tool_dict["default_value"] = input.value_to_basic(initial_value, request_context.app, use_security=True)
                 tool_dict["text_value"] = input.value_to_display_text(tool_dict["value"])
             except ImplicitConversionRequired:
-                tool_dict = input.to_dict(request_context)
+                tool_dict = input.to_dict(request_context, other_values=other_values)
                 # This hack leads client to display a text field
                 tool_dict["textable"] = True
             except Exception:
-                tool_dict = input.to_dict(request_context)
+                tool_dict = input.to_dict(request_context, other_values=other_values)
                 log.exception("tools::to_json() - Skipping parameter expansion '%s'", input.name)
         if input_index >= len(group_inputs):
             group_inputs.append(tool_dict)

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -261,6 +261,44 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert galaxy_url.startswith("http")
             assert galaxy_url.endswith("tool_runner?tool_id=ratmine")
 
+    @skip_without_tool("dbkey_filter_input")
+    def test_build_request_dbkey_filter_set(self):
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content="test", dbkey="hg19", wait=True)
+            dataset_id = hda["id"]
+            payload = {
+                "history_id": history_id,
+                "inputs": {"inputs": {"src": "hda", "id": dataset_id}},
+            }
+            response = self.dataset_populator._post("tools/dbkey_filter_input/build", data=payload, json=True)
+            response.raise_for_status()
+            build = response.json()
+            index_input = [i for i in build["inputs"] if i["name"] == "index"][0]
+            options = index_input["options"]
+            option_values = [o[1] for o in options]
+            assert "hg19_value" in option_values
+            assert "hg18_value" not in option_values
+
+    @skip_without_tool("dbkey_filter_input")
+    def test_build_request_dbkey_filter_unset(self):
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content="test", wait=True)
+            dataset_id = hda["id"]
+            payload = {
+                "history_id": history_id,
+                "inputs": {"inputs": {"src": "hda", "id": dataset_id}},
+            }
+            response = self.dataset_populator._post("tools/dbkey_filter_input/build", data=payload, json=True)
+            response.raise_for_status()
+            build = response.json()
+            index_input = [i for i in build["inputs"] if i["name"] == "index"][0]
+            options = index_input["options"]
+            option_values = [o[1] for o in options]
+            # with no dbkey set, all options from test_fasta_indexes should be available
+            assert "hg19_value" in option_values
+            assert "hg18_value" in option_values
+            assert "mm10_value" in option_values
+
     @skip_without_tool("cheetah_problem_unbound_var_input")
     def test_legacy_biotools_xref_injection(self):
         url = self._api_url("tools/cheetah_problem_unbound_var_input")

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -72,6 +72,10 @@ class TestsTools:
         hdca_id = create_response.json()["outputs"][0]["id"]
         return hdca_id
 
+    def _get_build_option_values(self, build, input_name):
+        matching = [i for i in build["inputs"] if i["name"] == input_name][0]
+        return [o[1] for o in matching["options"]]
+
     def _run_cat(self, history_id, inputs, assert_ok=False, **kwargs):
         return self._run("cat", history_id, inputs, assert_ok=assert_ok, **kwargs)
 
@@ -265,17 +269,9 @@ class TestToolsApi(ApiTestCase, TestsTools):
     def test_build_request_dbkey_filter_set(self):
         with self.dataset_populator.test_history() as history_id:
             hda = self.dataset_populator.new_dataset(history_id, content="test", dbkey="hg19", wait=True)
-            dataset_id = hda["id"]
-            payload = {
-                "history_id": history_id,
-                "inputs": {"inputs": {"src": "hda", "id": dataset_id}},
-            }
-            response = self.dataset_populator._post("tools/dbkey_filter_input/build", data=payload, json=True)
-            response.raise_for_status()
-            build = response.json()
-            index_input = [i for i in build["inputs"] if i["name"] == "index"][0]
-            options = index_input["options"]
-            option_values = [o[1] for o in options]
+            inputs = {"inputs": {"src": "hda", "id": hda["id"]}}
+            build = self.dataset_populator.build_tool_state("dbkey_filter_input", history_id, inputs=inputs)
+            option_values = self._get_build_option_values(build, "index")
             assert "hg19_value" in option_values
             assert "hg18_value" not in option_values
 
@@ -283,17 +279,9 @@ class TestToolsApi(ApiTestCase, TestsTools):
     def test_build_request_dbkey_filter_unset(self):
         with self.dataset_populator.test_history() as history_id:
             hda = self.dataset_populator.new_dataset(history_id, content="test", wait=True)
-            dataset_id = hda["id"]
-            payload = {
-                "history_id": history_id,
-                "inputs": {"inputs": {"src": "hda", "id": dataset_id}},
-            }
-            response = self.dataset_populator._post("tools/dbkey_filter_input/build", data=payload, json=True)
-            response.raise_for_status()
-            build = response.json()
-            index_input = [i for i in build["inputs"] if i["name"] == "index"][0]
-            options = index_input["options"]
-            option_values = [o[1] for o in options]
+            inputs = {"inputs": {"src": "hda", "id": hda["id"]}}
+            build = self.dataset_populator.build_tool_state("dbkey_filter_input", history_id, inputs=inputs)
+            option_values = self._get_build_option_values(build, "index")
             # with no dbkey set, all options from test_fasta_indexes should be available
             assert "hg19_value" in option_values
             assert "hg18_value" in option_values

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1216,8 +1216,12 @@ class BaseDatasetPopulator(BasePopulator):
 
         return dict(tool_id=tool_id, inputs=json.dumps(inputs), history_id=history_id, **kwds)
 
-    def build_tool_state(self, tool_id: str, history_id: str):
-        response = self._post(f"tools/{tool_id}/build?history_id={history_id}")
+    def build_tool_state(self, tool_id: str, history_id: str, inputs: Optional[dict] = None):
+        if inputs is not None:
+            payload = {"history_id": history_id, "inputs": inputs}
+            response = self._post(f"tools/{tool_id}/build", data=payload, json=True)
+        else:
+            response = self._post(f"tools/{tool_id}/build?history_id={history_id}")
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
DataMetaFilter.filter_options() returned empty list when the referenced dataset was missing or invalid, hiding all options. Now returns all options (matching existing behavior when metadata is unset). Also preserve other_values context in populate_model.py exception handlers.

Fixes https://github.com/galaxyproject/galaxy/issues/21904

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
