### PR TITLE
[26.0] Fix collection step Job markdown elements not rendering

### DIFF
--- a/client/src/components/Markdown/Utilities/requirements.test.js
+++ b/client/src/components/Markdown/Utilities/requirements.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { getRequiredLabels, getRequiredObject, hasValidLabel, hasValidName } from "./requirements";
+import { getRequiredLabels, getRequiredObject, hasValidLabel, hasValidName, hasValidObject } from "./requirements";
 
 vi.mock(
     "./requirements.yml",
@@ -76,6 +76,26 @@ describe("requirements utils", () => {
         it("returns true when requiredLabels is empty", () => {
             const args = {};
             expect(hasValidLabel("nonexistent_tool", args, labels)).toBe(true);
+        });
+    });
+
+    describe("hasValidObject", () => {
+        it("returns true when required object is present", () => {
+            expect(hasValidObject("tool_a", { history_dataset_id: "abc" })).toBe(true);
+            expect(hasValidObject("tool_d", { job_id: "abc" })).toBe(true);
+        });
+
+        it("returns false when required object is missing", () => {
+            expect(hasValidObject("tool_a", {})).toBe(false);
+            expect(hasValidObject("tool_d", {})).toBe(false);
+        });
+
+        it("accepts history_dataset_collection_id where history_dataset_id is required", () => {
+            expect(hasValidObject("tool_a", { history_dataset_collection_id: "abc" })).toBe(true);
+        });
+
+        it("accepts implicit_collection_jobs_id where job_id is required", () => {
+            expect(hasValidObject("tool_d", { implicit_collection_jobs_id: "abc" })).toBe(true);
         });
     });
 

--- a/client/src/components/Markdown/Utilities/requirements.ts
+++ b/client/src/components/Markdown/Utilities/requirements.ts
@@ -66,5 +66,9 @@ export function hasValidObject(name: string | undefined, args: Record<string, st
         // we don't control this anyway
         return true;
     }
+    if (requiredObject === "job_id" && args.implicit_collection_jobs_id) {
+        // accept implicit_collection_jobs_id where a job_id is expected for collection steps
+        return true;
+    }
     return !requiredObject || !!args[requiredObject];
 }


### PR DESCRIPTION
We weren't rendering markdown elements that required a `job_id` but instead of a job id in the arguments, had an `implicit_collection_jobs_id` (it's a collection step).

Now, the `hasValidObject` method in `client/src/components/Markdown/Utilities/requirements.ts` checks for this.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
