### PR TITLE
[25.1] Fix "Create New" in workflow editor not resetting editor state

### DIFF
--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -29,7 +29,7 @@ export default {
         };
     },
     watch: {
-        "$route.params": {
+        "$route.query": {
             handler() {
                 this.getEditorConfig();
             },
@@ -50,8 +50,12 @@ export default {
             const workflowId = this.workflowId || this.storedWorkflowId;
             if (!workflowId) {
                 this.newWorkflow = true;
+                if (reloadEditor) {
+                    this.editorReloadKey += 1;
+                }
                 return;
             }
+            this.newWorkflow = false;
             if (this.workflowId) {
                 const { id: storedWorkflowId } = await getWorkflowInfo(workflowId, this.version, true);
                 this.storedWorkflowId = storedWorkflowId;


### PR DESCRIPTION
Watch `$route.query` instead of `$route.params` so the handler fires when navigating between `?id=xxx` and no-id query strings. Also increment `editorReloadKey` when entering a new blank workflow so the Editor component is destroyed and re-created (clearing old state), and reset `newWorkflow` to false when loading an existing workflow.

Fixes https://github.com/galaxyproject/galaxy/issues/21662

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
