### PR TITLE
Add a stop job button that allows users to stop jobs

### DIFF
--- a/client/src/api/jobs.ts
+++ b/client/src/api/jobs.ts
@@ -15,8 +15,8 @@ export type JobMessage =
     | components["schemas"]["RegexJobMessage"]
     | components["schemas"]["MaxDiscoveredFilesJobMessage"];
 
-export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting", "paused", "resubmitted", "stop"];
-export const ERROR_STATES = ["error", "deleted", "deleting"];
+export const NON_TERMINAL_STATES = ["new", "queued", "running", "waiting", "paused", "resubmitted", "upload"];
+export const ERROR_STATES = ["error", "deleted", "deleting", "failed"];
 export const TERMINAL_STATES = ["ok", "skipped", "stop", "stopping"].concat(ERROR_STATES);
 
 interface JobDef {

--- a/client/src/api/jobs.ts
+++ b/client/src/api/jobs.ts
@@ -1,4 +1,7 @@
 import type { components } from "@/api/schema";
+import { rethrowSimple } from "@/utils/simple-error";
+
+import { GalaxyApi } from "./client";
 
 export type JobDestinationParams = components["schemas"]["JobDestinationParams"];
 export type ShowFullJobResponse = components["schemas"]["ShowFullJobResponse"];
@@ -39,4 +42,23 @@ export interface ResponseVal {
     jobDef: JobDef;
     jobResponse: JobResponse;
     toolName: string;
+}
+
+/**
+ * Delete/Stop a job.
+ * @param jobId The ID of the job to delete.
+ * @param message An optional message to be set on the job and output dataset(s) to explain the reason for stopping.
+ * @returns A promise that resolves to a boolean indicating whether the job was successfully deleted or job was already in a terminal state.
+ */
+export async function deleteJob(jobId: string, message?: string): Promise<boolean> {
+    const { data, error } = await GalaxyApi().DELETE("/api/jobs/{job_id}", {
+        params: { path: { job_id: jobId } },
+        data: { message },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data;
 }

--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -2,12 +2,15 @@
 import { faDownload, faInfoCircle, faRedo, faTable } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
-import { useRouter } from "vue-router/composables";
+import { useRoute } from "vue-router/composables";
 
 import type { HDCASummary } from "@/api";
 import { getAppRoot } from "@/onload/loadConfig";
 
-const router = useRouter();
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
+
+const route = useRoute();
 
 const props = defineProps<{
     dsc: HDCASummary; // typescript recognizes HDCADetailed IS_A HDCASummary
@@ -26,62 +29,68 @@ const hasSampleSheet = computed(() => {
     return props.dsc.collection_type && props.dsc.collection_type.startsWith("sample_sheet");
 });
 
-const sheetUrl = computed(() => {
-    return `${getAppRoot()}collection/${props.dsc.id}/sheet`;
-});
-
-function onDownload() {
-    window.location.href = downloadUrl.value;
-}
+const sheetUrl = computed(() => `/collection/${props.dsc.id}/sheet`);
 </script>
 <template>
     <section>
         <nav class="content-operations d-flex justify-content-between bg-secondary">
-            <b-button-group>
-                <b-button
+            <GButtonGroup class="collection-operations-btn-group">
+                <GButton
                     title="Download Collection"
                     :disabled="disableDownload"
-                    class="rounded-0 text-decoration-none"
-                    size="sm"
-                    variant="link"
-                    :href="downloadUrl"
-                    @click="onDownload">
-                    <FontAwesomeIcon class="mr-1" :icon="faDownload" />
+                    size="small"
+                    color="blue"
+                    transparent
+                    :href="downloadUrl">
+                    <FontAwesomeIcon fixed-width :icon="faDownload" />
                     <span>Download</span>
-                </b-button>
-                <b-button
+                </GButton>
+                <GButton
                     v-if="showCollectionDetailsUrl"
-                    class="collection-job-details-btn px-1"
+                    class="collection-job-details-btn"
                     title="Show Details"
-                    size="sm"
-                    variant="link"
-                    :href="showCollectionDetailsUrl"
-                    @click.prevent.stop="router.push(showCollectionDetailsUrl)">
-                    <FontAwesomeIcon class="mr-1" :icon="faInfoCircle" />
+                    size="small"
+                    color="blue"
+                    transparent
+                    :pressed="route.fullPath === showCollectionDetailsUrl"
+                    :to="showCollectionDetailsUrl">
+                    <FontAwesomeIcon fixed-width :icon="faInfoCircle" />
                     <span>Show Details</span>
-                </b-button>
-                <b-button
+                </GButton>
+                <GButton
                     v-if="rerunUrl"
                     title="Rerun job"
-                    class="rounded-0 text-decoration-none"
-                    size="sm"
-                    variant="link"
-                    :href="rerunUrl"
-                    @click.prevent.stop="router.push(rerunUrl)">
-                    <FontAwesomeIcon class="mr-1" :icon="faRedo" />
+                    size="small"
+                    color="blue"
+                    transparent
+                    :pressed="route.fullPath === rerunUrl"
+                    :to="rerunUrl">
+                    <FontAwesomeIcon fixed-width :icon="faRedo" />
                     <span>Run Job Again</span>
-                </b-button>
-                <b-button
+                </GButton>
+                <GButton
                     v-if="hasSampleSheet && sheetUrl"
-                    class="rounded-0 text-decoration-none"
-                    size="sm"
-                    variant="link"
-                    :href="sheetUrl"
-                    @click.prevent.stop="router.push(sheetUrl)">
-                    <FontAwesomeIcon class="mr-1" :icon="faTable" />
+                    title="View Sample Sheet"
+                    size="small"
+                    color="blue"
+                    transparent
+                    :pressed="route.fullPath === sheetUrl"
+                    :to="sheetUrl">
+                    <FontAwesomeIcon fixed-width :icon="faTable" />
                     <span>View Sheet</span>
-                </b-button>
-            </b-button-group>
+                </GButton>
+            </GButtonGroup>
         </nav>
     </section>
 </template>
+
+<style scoped lang="scss">
+.collection-operations-btn-group {
+    display: flex;
+    flex-wrap: wrap;
+    :deep(.g-button) {
+        border-radius: 0;
+        white-space: nowrap;
+    }
+}
+</style>

--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faDownload, faInfoCircle, faRedo, faTable } from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faInfoCircle, faTable } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 import { useRoute } from "vue-router/composables";
@@ -9,6 +9,7 @@ import { getAppRoot } from "@/onload/loadConfig";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
+import RerunJobButton from "@/components/JobInformation/RerunJobButton.vue";
 
 const route = useRoute();
 
@@ -17,9 +18,6 @@ const props = defineProps<{
 }>();
 
 const downloadUrl = computed(() => `${getAppRoot()}api/dataset_collections/${props.dsc.id}/download`);
-const rerunUrl = computed(() =>
-    props.dsc.job_source_type == "Job" ? `/root?job_id=${props.dsc.job_source_id}` : null,
-);
 const showCollectionDetailsUrl = computed(() =>
     props.dsc.job_source_type == "Job" ? `/jobs/${props.dsc.job_source_id}/view` : null,
 );
@@ -57,17 +55,9 @@ const sheetUrl = computed(() => `/collection/${props.dsc.id}/sheet`);
                     <FontAwesomeIcon fixed-width :icon="faInfoCircle" />
                     <span>Show Details</span>
                 </GButton>
-                <GButton
-                    v-if="rerunUrl"
-                    title="Rerun job"
-                    size="small"
-                    color="blue"
-                    transparent
-                    :pressed="route.fullPath === rerunUrl"
-                    :to="rerunUrl">
-                    <FontAwesomeIcon fixed-width :icon="faRedo" />
-                    <span>Run Job Again</span>
-                </GButton>
+                <RerunJobButton
+                    v-if="props.dsc.job_source_type === 'Job' && props.dsc.job_source_id"
+                    :job-id="props.dsc.job_source_id" />
                 <GButton
                     v-if="hasSampleSheet && sheetUrl"
                     title="View Sample Sheet"

--- a/client/src/components/JobInformation/JobInformation.test.js
+++ b/client/src/components/JobInformation/JobInformation.test.js
@@ -1,5 +1,6 @@
 import "@tests/vitest/mockHelpPopovers";
 
+import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
@@ -61,6 +62,7 @@ describe("JobInformation/JobInformation.vue", () => {
         wrapper = mount(JobInformation, {
             propsData,
             localVue,
+            pinia: createTestingPinia({ createSpy: vi.fn }),
         });
         await flushPromises();
         jobInfoTable = wrapper.find("#job-information");

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -11,6 +11,7 @@ import { getJobDuration } from "./utilities";
 
 import Heading from "../Common/Heading.vue";
 import DecodedId from "../DecodedId.vue";
+import JobState from "../JobStates/JobState.vue";
 import CodeRow from "./CodeRow.vue";
 import CopyToClipboard from "@/components/CopyToClipboard.vue";
 import HelpText from "@/components/Help/HelpText.vue";
@@ -144,7 +145,10 @@ watch(
             :stderr_position="stderr_position"
             :stderr_length="stderr_length"
             @update:result="updateConsoleOutputs" />
-        <Heading id="job-information-heading" h1 separator inline size="md"> Job Information </Heading>
+        <Heading id="job-information-heading" h1 separator inline size="md">
+            Job Information
+            <JobState v-if="job" class="job-information-state-badge" :job="job" />
+        </Heading>
         <table id="job-information" class="tabletip info_data_table">
             <tbody>
                 <tr v-if="job && job.tool_id">
@@ -261,9 +265,15 @@ watch(
         </table>
     </div>
 </template>
-<style scoped>
+<style scoped lang="scss">
+@import "@/style/scss/theme/blue.scss";
+
 .tooltipJobInfo {
     text-decoration-line: underline;
     text-decoration-style: dashed;
+}
+
+.job-information-state-badge {
+    font-size: $h5-font-size;
 }
 </style>

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -13,6 +13,7 @@ import Heading from "../Common/Heading.vue";
 import DecodedId from "../DecodedId.vue";
 import JobState from "../JobStates/JobState.vue";
 import CodeRow from "./CodeRow.vue";
+import RerunJobButton from "./RerunJobButton.vue";
 import CopyToClipboard from "@/components/CopyToClipboard.vue";
 import HelpText from "@/components/Help/HelpText.vue";
 import UtcDate from "@/components/UtcDate.vue";
@@ -47,6 +48,13 @@ function jobStateIsRunning(jobState: string) {
 const jobIsTerminal = computed(() => (job.value?.state ? jobStateIsTerminal(job.value?.state) : false));
 const jobIsRunning = computed(() => (job.value?.state ? jobStateIsRunning(job.value.state) : false));
 const routeToInvocation = computed(() => `/workflows/invocations/${fetchedInvocationId.value}`);
+
+/** Whether the job can be rerun; actually decided based on if the tool `is_workflow_compatible`,
+ * but that would require an extra fetch. Just going by known non-rerunnable tool ids for now.
+ */
+const jobIsRerunnable = computed(
+    () => !!job.value?.tool_id && !job.value.tool_id.startsWith("upload") && job.value.tool_id !== "__DATA_FETCH__",
+);
 
 // Curious as to why we're trying to access tool_version and traceback like this, when they don't exist on
 // `ShowFullJobResponse`? Possibly historical reasons or maybe the `JobProvider` can return different types (doesn't seem like it)?
@@ -145,10 +153,15 @@ watch(
             :stderr_position="stderr_position"
             :stderr_length="stderr_length"
             @update:result="updateConsoleOutputs" />
-        <Heading id="job-information-heading" h1 separator inline size="md">
-            Job Information
-            <JobState v-if="job" class="job-information-state-badge" :job="job" />
-        </Heading>
+        <div class="d-flex justify-content-between flex-gapx-1">
+            <Heading id="job-information-heading" class="flex-grow-1" h1 separator inline size="md">
+                Job Information
+                <JobState v-if="job" class="job-information-state-badge" :job="job" />
+            </Heading>
+            <div v-if="job && jobIsRerunnable">
+                <RerunJobButton :job-id="props.jobId" outline />
+            </div>
+        </div>
         <table id="job-information" class="tabletip info_data_table">
             <tbody>
                 <tr v-if="job && job.tool_id">

--- a/client/src/components/JobInformation/RerunJobButton.vue
+++ b/client/src/components/JobInformation/RerunJobButton.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { faRedo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed } from "vue";
+import { useRoute } from "vue-router/composables";
+
+import GButton from "../BaseComponents/GButton.vue";
+
+const route = useRoute();
+
+const props = defineProps<{
+    jobId: string;
+    outline?: boolean;
+}>();
+
+const rerunUrl = computed(() => `/?job_id=${props.jobId}`);
+</script>
+
+<template>
+    <GButton
+        title="Rerun job"
+        size="small"
+        color="blue"
+        :outline="props.outline"
+        :transparent="!props.outline"
+        :pressed="route.fullPath === rerunUrl"
+        :to="rerunUrl">
+        <FontAwesomeIcon fixed-width :icon="faRedo" />
+        <span>Run Job Again</span>
+    </GButton>
+</template>

--- a/client/src/components/JobStates/JobState.test.ts
+++ b/client/src/components/JobStates/JobState.test.ts
@@ -1,0 +1,147 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getFakeRegisteredUser } from "@tests/test-data";
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RegisteredUser } from "@/api";
+import { useServerMock } from "@/api/client/__mocks__";
+import type { JobBaseModel, JobState as JobStateType, ShowFullJobResponse } from "@/api/jobs";
+import { useUserStore } from "@/stores/userStore";
+
+import JobState from "./JobState.vue";
+
+vi.mock("vue-router/composables", () => ({
+    useRoute: vi.fn(() => ({})),
+}));
+
+const localVue = getLocalVue();
+const { server, http } = useServerMock();
+
+const FAKE_USER = getFakeRegisteredUser({ id: "user-123" });
+
+const BASE_JOB: JobBaseModel = {
+    model_class: "Job",
+    id: "job-abc",
+    state: "running",
+    tool_id: "some_tool",
+    create_time: "2024-01-01T00:00:00",
+    update_time: "2024-01-01T00:01:00",
+};
+
+const FULL_JOB = {
+    ...BASE_JOB,
+    inputs: {},
+    outputs: {},
+    output_collections: {},
+    params: {},
+    user_id: "user-123",
+} as ShowFullJobResponse;
+
+const SELECTORS = {
+    STOP_BTN: ".stop-job-btn",
+    STATE_BADGE: ".job-state-badge",
+};
+
+function mountJobState(job: JobBaseModel | ShowFullJobResponse, user: RegisteredUser | null = FAKE_USER) {
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    const userStore = useUserStore();
+    userStore.currentUser = user;
+    return mount(JobState as object, {
+        propsData: { job },
+        localVue,
+        pinia,
+    });
+}
+
+describe("JobState.vue", () => {
+    beforeEach(() => {
+        server.use(
+            http.delete("/api/jobs/{job_id}", ({ response }) => {
+                return response(200).json(true);
+            }),
+        );
+    });
+
+    it("renders the job state badge with the job state text", async () => {
+        const wrapper = mountJobState(BASE_JOB);
+        await flushPromises();
+        expect(wrapper.find(SELECTORS.STATE_BADGE).text()).toContain("running");
+    });
+
+    it("shows the stop button for a non-terminal state when using JobBaseModel (no user_id)", async () => {
+        const wrapper = mountJobState({ ...BASE_JOB, state: "running" });
+        await flushPromises();
+        expect(wrapper.find(SELECTORS.STOP_BTN).exists()).toBe(true);
+    });
+
+    it("hides the stop button for terminal states", async () => {
+        for (const state of ["ok", "error", "deleted", "failed"] as JobStateType[]) {
+            const wrapper = mountJobState({ ...BASE_JOB, state });
+            await flushPromises();
+            expect(wrapper.find(SELECTORS.STOP_BTN).exists()).toBe(false);
+        }
+    });
+
+    it("shows the stop button when ShowFullJobResponse user_id matches current user", async () => {
+        const wrapper = mountJobState({ ...FULL_JOB, state: "running", user_id: FAKE_USER.id });
+        await flushPromises();
+        expect(wrapper.find(SELECTORS.STOP_BTN).exists()).toBe(true);
+    });
+
+    it("hides the stop button when ShowFullJobResponse user_id does not match current user", async () => {
+        const wrapper = mountJobState({ ...FULL_JOB, state: "running", user_id: "someone-else" });
+        await flushPromises();
+        expect(wrapper.find(SELECTORS.STOP_BTN).exists()).toBe(false);
+    });
+
+    it("hides the stop button when no user is logged in", async () => {
+        const wrapper = mountJobState(BASE_JOB, null);
+        await flushPromises();
+        expect(wrapper.find(SELECTORS.STOP_BTN).exists()).toBe(false);
+    });
+
+    it("calls DELETE /api/jobs/{job_id} when stop button is clicked", async () => {
+        let deletedJobId: string | undefined;
+        server.use(
+            http.delete("/api/jobs/{job_id}", ({ response, params }) => {
+                deletedJobId = params.job_id;
+                return response(200).json(true);
+            }),
+        );
+
+        const wrapper = mountJobState({ ...BASE_JOB, state: "running" });
+        await flushPromises();
+
+        await wrapper.find(SELECTORS.STOP_BTN).trigger("click");
+        await flushPromises();
+
+        expect(deletedJobId).toBe(BASE_JOB.id);
+    });
+
+    it("disables the stop button while stopping is in progress", async () => {
+        let resolveDelete!: () => void;
+        server.use(
+            http.delete("/api/jobs/{job_id}", ({ response }) => {
+                return new Promise((resolve) => {
+                    resolveDelete = () => resolve(response(200).json(true));
+                });
+            }),
+        );
+
+        const wrapper = mountJobState({ ...BASE_JOB, state: "running" });
+        await flushPromises();
+
+        const stopBtn = wrapper.find(SELECTORS.STOP_BTN);
+        stopBtn.trigger("click");
+        await flushPromises();
+
+        expect(stopBtn.classes()).toContain("g-disabled");
+
+        resolveDelete();
+        await flushPromises();
+
+        expect(stopBtn.classes()).not.toContain("g-disabled");
+    });
+});

--- a/client/src/components/JobStates/JobState.vue
+++ b/client/src/components/JobStates/JobState.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { faSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
-import type { JobBaseModel } from "@/api/jobs";
+import { type JobBaseModel, NON_TERMINAL_STATES } from "@/api/jobs";
+import { useToast } from "@/composables/toast";
 import { getHeaderClass, iconClasses } from "@/composables/useInvocationGraph";
+
+import GButton from "../BaseComponents/GButton.vue";
 
 const props = defineProps<{
     job: JobBaseModel;
@@ -17,11 +21,110 @@ const badgeClass = computed(() => {
 });
 
 const stateIcon = computed(() => iconClasses[props.job.state] || null);
+
+const Toast = useToast();
+
+/** Whether the current user owns the job (can stop it) */
+const userOwnsJob = computed(() => {
+    return true; // TODO: For testing i have true, will have proper implementation later
+});
+
+/** Whether to render this button
+ * 1. If the job is not the user's own
+ * 2. Job is not in a terminal state
+ */
+const canStopJob = computed(() => userOwnsJob.value && NON_TERMINAL_STATES.includes(props.job.state));
+
+/** Whether the stop job action is currently being performed */
+const stopping = ref(false);
+
+async function stopJob() {
+    stopping.value = true;
+    try {
+        // TODO: To be implemented: Call the API to stop the job, and handle any errors that may occur.
+        //      Ideally, we would want a job object returned from the API after stopping,
+        //      and we would want to update the job state in the UI accordingly. For now, I am just
+        //      using a Toast.
+
+        Toast.success("Job stopped successfully.");
+
+        // TODO: Handle job state returned by the API
+    } catch (error) {
+        // TODO: Handle string errorMessageAsString, just casting to string for now
+        Toast.error(error as string, "Failed to stop the job.");
+    } finally {
+        stopping.value = false;
+    }
+}
 </script>
 
 <template>
-    <span class="rounded px-2 py-1 text-nowrap" :class="badgeClass">
-        <FontAwesomeIcon v-if="stateIcon" :icon="stateIcon.icon" :spin="stateIcon.spin" />
+    <span class="job-state-badge rounded px-2 py-1 text-nowrap" :class="badgeClass">
+        <FontAwesomeIcon
+            v-if="stateIcon"
+            :icon="stateIcon.icon"
+            :spin="stateIcon.spin"
+            :class="{ 'hoverable-icon': canStopJob }" />
+        <GButton
+            v-if="canStopJob"
+            transparent
+            inline
+            icon-only
+            pill
+            size="small"
+            class="stop-job-btn"
+            title="Stop the execution of this job"
+            :disabled="stopping"
+            disabled-title="Stopping job..."
+            @click.stop.prevent="stopJob">
+            <FontAwesomeIcon :icon="faSquare" />
+        </GButton>
         {{ props.job.state }}
     </span>
 </template>
+
+<style lang="scss" scoped>
+// If the job is in a stoppable state, we want to make the default state
+// icon hide on hover, and show the stop button instead.
+.job-state-badge {
+    position: relative;
+
+    &:hover {
+        .hoverable-icon {
+            visibility: hidden;
+        }
+        .stop-job-btn {
+            display: inline-block;
+        }
+    }
+}
+
+.stop-job-btn {
+    display: none;
+    position: absolute;
+    left: 0.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 1em;
+    width: 1em;
+    line-height: 1;
+    padding: 0 !important;
+    min-height: unset !important;
+}
+
+.hoverable-icon {
+    display: inline-block;
+    height: 1em;
+    width: 1em;
+    line-height: 1;
+}
+
+// When canStopJob is true, ensure only one shows at a time
+.job-state-badge:not(:hover) .stop-job-btn {
+    display: none;
+}
+
+.job-state-badge:hover .hoverable-icon {
+    visibility: hidden;
+}
+</style>

--- a/client/src/components/JobStates/JobState.vue
+++ b/client/src/components/JobStates/JobState.vue
@@ -3,9 +3,10 @@ import { faSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, ref } from "vue";
 
-import { type JobBaseModel, NON_TERMINAL_STATES } from "@/api/jobs";
+import { deleteJob, type JobBaseModel, NON_TERMINAL_STATES } from "@/api/jobs";
 import { useToast } from "@/composables/toast";
 import { getHeaderClass, iconClasses } from "@/composables/useInvocationGraph";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import GButton from "../BaseComponents/GButton.vue";
 
@@ -41,17 +42,11 @@ const stopping = ref(false);
 async function stopJob() {
     stopping.value = true;
     try {
-        // TODO: To be implemented: Call the API to stop the job, and handle any errors that may occur.
-        //      Ideally, we would want a job object returned from the API after stopping,
-        //      and we would want to update the job state in the UI accordingly. For now, I am just
-        //      using a Toast.
+        await deleteJob(props.job.id);
 
-        Toast.success("Job stopped successfully.");
-
-        // TODO: Handle job state returned by the API
+        Toast.success("Job scheduled to be stopped.");
     } catch (error) {
-        // TODO: Handle string errorMessageAsString, just casting to string for now
-        Toast.error(error as string, "Failed to stop the job.");
+        Toast.error(errorMessageAsString(error), "Failed to stop the job.");
     } finally {
         stopping.value = false;
     }

--- a/client/src/components/JobStates/JobState.vue
+++ b/client/src/components/JobStates/JobState.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
 import { faSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
-import { deleteJob, type JobBaseModel, NON_TERMINAL_STATES } from "@/api/jobs";
+import { isRegisteredUser } from "@/api";
+import { deleteJob, type JobBaseModel, NON_TERMINAL_STATES, type ShowFullJobResponse } from "@/api/jobs";
 import { useToast } from "@/composables/toast";
 import { getHeaderClass, iconClasses } from "@/composables/useInvocationGraph";
+import { useUserStore } from "@/stores/userStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import GButton from "../BaseComponents/GButton.vue";
 
 const props = defineProps<{
-    job: JobBaseModel;
+    job: JobBaseModel | ShowFullJobResponse;
 }>();
 
 const badgeClass = computed(() => {
@@ -25,9 +28,18 @@ const stateIcon = computed(() => iconClasses[props.job.state] || null);
 
 const Toast = useToast();
 
+const { currentUser } = storeToRefs(useUserStore());
+
 /** Whether the current user owns the job (can stop it) */
 const userOwnsJob = computed(() => {
-    return true; // TODO: For testing i have true, will have proper implementation later
+    if (!currentUser.value || !isRegisteredUser(currentUser.value)) {
+        return false;
+    }
+    if ("user_id" in props.job && props.job.user_id) {
+        return props.job.user_id === currentUser.value.id;
+    }
+    // `user_id` not available on `JobBaseModel` — caller context implies ownership
+    return true;
 });
 
 /** Whether to render this button

--- a/client/src/components/WorkflowInvocationState/JobStep.test.ts
+++ b/client/src/components/WorkflowInvocationState/JobStep.test.ts
@@ -1,6 +1,7 @@
+import { createTestingPinia } from "@pinia/testing";
 import { mount, shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { JobBaseModel } from "@/api/jobs";
 import { statePlaceholders } from "@/composables/useInvocationGraph";
@@ -27,6 +28,7 @@ describe("Job Step", () => {
                 jobs: TEST_JOBS_JSON,
                 invocationId: TEST_INVOCATION_ID,
             },
+            pinia: createTestingPinia({ createSpy: vi.fn }),
         });
         await flushPromises();
 
@@ -75,6 +77,7 @@ describe("Job Step", () => {
                 jobs: TEST_JOBS_JSON,
                 invocationId: TEST_INVOCATION_ID,
             },
+            pinia: createTestingPinia({ createSpy: vi.fn }),
         });
         await flushPromises();
 
@@ -124,6 +127,7 @@ describe("Job Step", () => {
                 jobs: [singleJob],
                 invocationId: TEST_INVOCATION_ID,
             },
+            pinia: createTestingPinia({ createSpy: vi.fn }),
         });
         await flushPromises();
 

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.test.ts
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.test.ts
@@ -13,6 +13,10 @@ import TEST_JOBS_JSON from "./test/json/jobs.json";
 
 import JobStepJobs from "./JobStepJobs.vue";
 
+vi.mock("vue-router/composables", () => ({
+    useRoute: vi.fn(() => ({})),
+}));
+
 const localVue = getLocalVue();
 
 const { server, http } = useServerMock();

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.vue
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.vue
@@ -162,16 +162,12 @@ watch(
         <GModal :show.sync="showModal" fixed-height size="medium" @close="viewedJob = null">
             <template v-slot:header>
                 <div v-if="viewedJob" class="w-100 d-flex justify-content-between align-items-center">
-                    <div class="d-flex flex-gapx-1 align-items-center">
-                        <Heading h2 size="sm" style="margin-bottom: 0">
-                            Job
-                            <code>
-                                {{ viewedJob.id }}
-                            </code>
-                        </Heading>
-
-                        <JobState :job="viewedJob" />
-                    </div>
+                    <Heading h2 size="sm">
+                        Job
+                        <code>
+                            {{ viewedJob.id }}
+                        </code>
+                    </Heading>
 
                     <div class="d-flex align-items-center">
                         <GButtonGroup>

--- a/client/src/components/admin/JobsList.vue
+++ b/client/src/components/admin/JobsList.vue
@@ -167,11 +167,10 @@
 </template>
 
 <script>
-import axios from "axios";
 import { ref } from "vue";
 
 import { GalaxyApi } from "@/api";
-import { NON_TERMINAL_STATES } from "@/api/jobs";
+import { deleteJob, NON_TERMINAL_STATES } from "@/api/jobs";
 import { jobsProvider } from "@/components/providers/JobProvider";
 import { getAppRoot } from "@/onload/loadConfig";
 import Filtering, { contains } from "@/utils/filtering";
@@ -183,11 +182,6 @@ import JobLock from "./JobLock.vue";
 import JobsTable from "@/components/admin/JobsTable.vue";
 import FilterMenu from "@/components/Common/FilterMenu.vue";
 import Heading from "@/components/Common/Heading.vue";
-
-function cancelJob(jobId, message) {
-    const url = `${getAppRoot()}api/jobs/${jobId}`;
-    return axios.delete(url, { data: { message: message } });
-}
 
 export default {
     components: { FilterMenu, JobLock, JobsTable, Heading },
@@ -395,15 +389,14 @@ export default {
         getJobViewLink(jobId) {
             return `${getAppRoot()}jobs/${jobId}/view`;
         },
-        onStopJobs() {
-            axios.all(this.selectedStopJobIds.map((jobId) => cancelJob(jobId, this.stopMessage))).then((res) => {
-                if (this.sendNotification) {
-                    this.sendNotificationToUsers();
-                }
-                this.update();
-                this.selectedStopJobIds = [];
-                this.stopMessage = "";
-            });
+        async onStopJobs() {
+            await Promise.all(this.selectedStopJobIds.map((jobId) => deleteJob(jobId, this.stopMessage)));
+            if (this.sendNotification) {
+                this.sendNotificationToUsers();
+            }
+            this.update();
+            this.selectedStopJobIds = [];
+            this.stopMessage = "";
         },
         toggleAll(checked) {
             this.selectedStopJobIds = checked ? this.jobsItemsModel.reduce((acc, j) => [...acc, j["id"]], []) : [];

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -156,6 +156,12 @@ $galaxy-state-bg: (
     "paused": $state-info-bg,
     "skipped": $state-default-bg,
     "uninitialized": $gray-200,
+    // Some `JobState`s:
+    "resubmitted": $state-default-bg,
+    "failed": $state-danger-bg,
+    "deleting": darken($state-default-bg, 30%),
+    "stop": $state-default-border,
+    "stopped": darken($state-default-bg, 30%),
 );
 
 // Replace all occurrences of $search in $string with $replace.


### PR DESCRIPTION
Uses the jobs `DELETE` endpoint to cancel the job.

![firefox_Y8KwRWJOE6](https://github.com/user-attachments/assets/b7b20fae-d6f3-41d3-b204-8c944e6a8d1f)

Is a step in the direction of fixing #21911 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
