### PR TITLE
[26.0] Fix Pydantic UnsupportedFieldAttributeWarning for Field defaults in Annotated

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -10529,7 +10529,7 @@ export interface components {
              * Populated
              * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
              */
-            populated?: boolean;
+            populated?: boolean | null;
         };
         /** DataCollectionParameterModel */
         DataCollectionParameterModel: {
@@ -14346,7 +14346,7 @@ export interface components {
              * Populated
              * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
              */
-            populated?: boolean;
+            populated?: boolean | null;
             /**
              * Populated State
              * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
@@ -14515,7 +14515,7 @@ export interface components {
              * Populated
              * @description Whether the dataset collection elements (and any subcollections elements) were successfully populated.
              */
-            populated?: boolean;
+            populated?: boolean | null;
             /**
              * Populated State
              * @description Indicates the general state of the elements in the dataset collection:- 'new': new dataset collection, unpopulated elements.- 'ok': collection elements populated (HDAs may or may not have errors).- 'failed': some problem populating, won't be populated.
@@ -15007,7 +15007,7 @@ export interface components {
              * Posts
              * @description The list of posts returned by the search.
              */
-            posts?: components["schemas"]["HelpForumPost"][];
+            posts?: components["schemas"]["HelpForumPost"][] | null;
             /**
              * Tags
              * @description The list of tags returned by the search.
@@ -15017,7 +15017,7 @@ export interface components {
              * Topics
              * @description The list of topics returned by the search.
              */
-            topics?: components["schemas"]["HelpForumTopic"][];
+            topics?: components["schemas"]["HelpForumTopic"][] | null;
             /**
              * Users
              * @description The list of users returned by the search.

--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -163,7 +163,6 @@ class FilesSourceProperties(StrictModel):
     doc: Annotated[
         Optional[str],
         Field(
-            None,
             title="Documentation",
             description="Documentation or extended description for this plugin.",
         ),
@@ -187,7 +186,6 @@ class FilesSourceProperties(StrictModel):
     requires_roles: Annotated[
         Optional[str],
         Field(
-            None,
             title="Requires roles",
             description=(
                 "Only users with the roles specified here can access this source."
@@ -200,7 +198,6 @@ class FilesSourceProperties(StrictModel):
     requires_groups: Annotated[
         Optional[str],
         Field(
-            None,
             title="Requires groups",
             description=(
                 "Only users belonging to the groups specified here can access this source."
@@ -232,7 +229,6 @@ class FilesSourceProperties(StrictModel):
     uri_root: Annotated[
         Optional[str],
         Field(
-            None,
             title="URI root",
             description=(
                 "The URI root used by this type of plugin. This is used to identify the file source and "
@@ -243,7 +239,6 @@ class FilesSourceProperties(StrictModel):
     url: Annotated[
         Optional[str],
         Field(
-            None,
             title="URL",
             description="Optional URL that might be provided by some plugins to link to the remote source.",
         ),
@@ -334,13 +329,10 @@ class RemoteFileHash(StrictModel):
 class RemoteFile(RemoteEntry):
     class_: Annotated[Literal["File"], Field(..., serialization_alias="class")] = "File"
     size: Annotated[int, Field(..., title="Size", description="The size of the file in bytes.")] = 0
-    ctime: Annotated[
-        Optional[str], Field(default=None, title="Creation time", description="The creation time of the file.")
-    ]
+    ctime: Annotated[Optional[str], Field(title="Creation time", description="The creation time of the file.")] = None
     hashes: Annotated[
         Optional[list[RemoteFileHash]],
         Field(
-            default=None,
             title="Hashes",
             description="List of precomputed hashes for the file, if available.",
         ),

--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -38,7 +38,6 @@ class WebDavFileSourceConfiguration(BaseFileSourceConfiguration):
     url: Annotated[
         str,
         Field(
-            None,
             title="WebDAV URL",
             description="The URL of the WebDAV server. This is required for WebDAV file sources.",
         ),

--- a/lib/galaxy/schema/help.py
+++ b/lib/galaxy/schema/help.py
@@ -59,16 +59,14 @@ class HelpForumTopic(Model):
     archetype: Annotated[Any, Field(description="The archetype of the topic.")]
     unseen: Annotated[bool, Field(description="Whether the topic is unseen.")]
     pinned: Annotated[bool, Field(description="Whether the topic is pinned.")]
-    unpinned: Annotated[Optional[bool], Field(default=None, description="Whether the topic is unpinned.")]
+    unpinned: Annotated[Optional[bool], Field(description="Whether the topic is unpinned.")] = None
     visible: Annotated[bool, Field(description="Whether the topic is visible.")]
     closed: Annotated[bool, Field(description="Whether the topic is closed.")]
     archived: Annotated[bool, Field(description="Whether the topic is archived.")]
-    bookmarked: Annotated[Optional[bool], Field(default=None, description="Whether the topic is bookmarked.")]
-    liked: Annotated[Optional[bool], Field(default=None, description="Whether the topic is liked.")]
+    bookmarked: Annotated[Optional[bool], Field(description="Whether the topic is bookmarked.")] = None
+    liked: Annotated[Optional[bool], Field(description="Whether the topic is liked.")] = None
     tags: Annotated[list[HelpForumTag], Field(description="The tags of the topic.")]
-    tags_descriptions: Annotated[
-        Optional[Any], Field(default=None, description="The descriptions of the tags of the topic.")
-    ]
+    tags_descriptions: Annotated[Optional[Any], Field(description="The descriptions of the tags of the topic.")] = None
     category_id: Annotated[int, Field(description="The ID of the category of the topic.")]
     has_accepted_answer: Annotated[bool, Field(description="Whether the topic has an accepted answer.")]
 
@@ -103,23 +101,23 @@ class HelpForumSearchResponse(Model):
     This model is based on the Discourse API response for the search endpoint.
     """
 
-    posts: Annotated[list[HelpForumPost], Field(default=None, description="The list of posts returned by the search.")]
+    posts: Annotated[Optional[list[HelpForumPost]], Field(description="The list of posts returned by the search.")] = (
+        None
+    )
     topics: Annotated[
-        list[HelpForumTopic], Field(default=None, description="The list of topics returned by the search.")
-    ]
-    users: Annotated[
-        Optional[list[HelpForumUser]], Field(default=None, description="The list of users returned by the search.")
-    ]
+        Optional[list[HelpForumTopic]], Field(description="The list of topics returned by the search.")
+    ] = None
+    users: Annotated[Optional[list[HelpForumUser]], Field(description="The list of users returned by the search.")] = (
+        None
+    )
     categories: Annotated[
         Optional[list[HelpForumCategory]],
-        Field(default=None, description="The list of categories returned by the search."),
-    ]
-    tags: Annotated[
-        Optional[list[HelpForumTag]], Field(default=None, description="The list of tags returned by the search.")
-    ]
+        Field(description="The list of categories returned by the search."),
+    ] = None
+    tags: Annotated[Optional[list[HelpForumTag]], Field(description="The list of tags returned by the search.")] = None
     groups: Annotated[
-        Optional[list[HelpForumGroup]], Field(default=None, description="The list of groups returned by the search.")
-    ]
+        Optional[list[HelpForumGroup]], Field(description="The list of groups returned by the search.")
+    ] = None
     grouped_search_result: Annotated[
-        Optional[HelpForumGroupedSearchResult], Field(default=None, description="The grouped search result.")
-    ]
+        Optional[HelpForumGroupedSearchResult], Field(description="The grouped search result.")
+    ] = None

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -76,7 +76,7 @@ INVOCATION_STEP_MODEL_CLASS = Literal["WorkflowInvocationStep"]
 INVOCATION_REPORT_MODEL_CLASS = Literal["Report"]
 IMPLICIT_COLLECTION_JOBS_MODEL_CLASS = Literal["ImplicitCollectionJobs"]
 
-OptionalNumberT = Annotated[Optional[Union[int, float]], Field(None)]
+OptionalNumberT = Annotated[Optional[Union[int, float]], Field()]
 
 TAG_ITEM_PATTERN = r"^([^\s.:])+(\.[^\s.:]+)*(:\S+)?$"
 
@@ -261,9 +261,8 @@ ElementCountField = Annotated[
 ]
 
 PopulatedField = Annotated[
-    bool,
+    Optional[bool],
     Field(
-        None,
         title="Populated",
         description="Whether the dataset collection elements (and any subcollections elements) were successfully populated.",
     ),
@@ -408,8 +407,8 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
 
 
 class UserUpdatePayload(Model):
-    active: Annotated[Optional[bool], Field(None, title="Active", description="User is active")]
-    username: Annotated[Optional[str], Field(None, title="Username", description="The name of the user.")]
+    active: Annotated[Optional[bool], Field(title="Active", description="User is active")] = None
+    username: Annotated[Optional[str], Field(title="Username", description="The name of the user.")] = None
     preferred_object_store_id: Annotated[Optional[str], PreferredObjectStoreIdField]
 
 
@@ -810,16 +809,15 @@ class DatasetSource(Model):
     )
     source_uri: Annotated[RelativeUrl, Field(..., title="Source URI", description="The URI of the dataset source.")]
     extra_files_path: Annotated[
-        Optional[str], Field(None, title="Extra Files Path", description="The path to the extra files.")
-    ]
+        Optional[str], Field(title="Extra Files Path", description="The path to the extra files.")
+    ] = None
     transform: Annotated[
         Optional[list[DatasetSourceTransform]],
         Field(
-            None,
             title="Transform",
             description="The transformations applied to the dataset source.",
         ),
-    ]
+    ] = None
 
 
 class HDADetailed(HDASummary, WithModelClass):
@@ -966,11 +964,11 @@ class HDADetailed(HDASummary, WithModelClass):
         ),
     ]
     copied_from_history_dataset_association_id: Annotated[
-        Optional[EncodedDatabaseIdField], Field(None, description="ID of HDA this HDA was copied from.")
-    ]
+        Optional[EncodedDatabaseIdField], Field(description="ID of HDA this HDA was copied from.")
+    ] = None
     copied_from_library_dataset_dataset_association_id: Annotated[
-        Optional[EncodedDatabaseIdField], Field(None, description="ID of LDDA this HDA was copied from.")
-    ]
+        Optional[EncodedDatabaseIdField], Field(description="ID of LDDA this HDA was copied from.")
+    ] = None
 
 
 class HDAExtended(HDADetailed):
@@ -1029,7 +1027,7 @@ class DCObject(Model, WithModelClass):
     id: DatasetCollectionId
     model_class: DC_MODEL_CLASS = ModelClassField(DC_MODEL_CLASS)
     collection_type: CollectionType = CollectionTypeField
-    populated: PopulatedField
+    populated: PopulatedField = None
     element_count: ElementCountField
     contents_url: Optional[ContentsUrlField] = None
     elements: list["DCESummary"] = ElementsField
@@ -1087,7 +1085,7 @@ DCObject.model_rebuild()
 class DCDetailed(DCSummary):
     """Dataset Collection detailed information."""
 
-    populated: PopulatedField
+    populated: PopulatedField = None
     elements: list[DCESummary] = ElementsField
 
 
@@ -1249,7 +1247,7 @@ class HDCASummary(HDCACommon, WithModelClass):
 class HDCADetailed(HDCASummary):
     """History Dataset Collection Association detailed information."""
 
-    populated: PopulatedField
+    populated: PopulatedField = None
     elements: list[DCESummary] = ElementsField
     implicit_collection_jobs_id: Optional[EncodedDatabaseIdField] = Field(
         None,
@@ -3490,9 +3488,9 @@ ModifyIdsField = Annotated[
 
 
 class UpdateDatasetPermissionsPayload(UpdateDatasetPermissionsPayloadBase):
-    access_ids: Annotated[Optional[RoleIdList], Field(default=None, alias="access_ids[]")] = None
-    manage_ids: Annotated[Optional[RoleIdList], Field(default=None, alias="manage_ids[]")] = None
-    modify_ids: Annotated[Optional[RoleIdList], Field(default=None, alias="modify_ids[]")] = None
+    access_ids: Annotated[Optional[RoleIdList], Field(alias="access_ids[]")] = None
+    manage_ids: Annotated[Optional[RoleIdList], Field(alias="manage_ids[]")] = None
+    modify_ids: Annotated[Optional[RoleIdList], Field(alias="modify_ids[]")] = None
 
 
 class UpdateDatasetPermissionsPayloadAliasB(UpdateDatasetPermissionsPayloadBase):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -76,7 +76,7 @@ INVOCATION_STEP_MODEL_CLASS = Literal["WorkflowInvocationStep"]
 INVOCATION_REPORT_MODEL_CLASS = Literal["Report"]
 IMPLICIT_COLLECTION_JOBS_MODEL_CLASS = Literal["ImplicitCollectionJobs"]
 
-OptionalNumberT = Annotated[Optional[Union[int, float]], Field()]
+OptionalNumberT = Optional[Union[int, float]]
 
 TAG_ITEM_PATTERN = r"^([^\s.:])+(\.[^\s.:]+)*(:\S+)?$"
 

--- a/lib/galaxy/tool_util/toolbox/views/definitions.py
+++ b/lib/galaxy/tool_util/toolbox/views/definitions.py
@@ -13,7 +13,6 @@ from pydantic import (
     Field,
 )
 from typing_extensions import (
-    Annotated,
     Literal,
 )
 
@@ -42,7 +41,7 @@ Exclusions = Union[
     ExcludeToolRegex,
     ExcludeTypes,
 ]
-OptionalExclusionList = Annotated[Optional[List[Exclusions]], Field()]
+OptionalExclusionList = Optional[List[Exclusions]]
 
 
 class Tool(BaseModel):

--- a/lib/galaxy/tool_util/toolbox/views/definitions.py
+++ b/lib/galaxy/tool_util/toolbox/views/definitions.py
@@ -42,7 +42,7 @@ Exclusions = Union[
     ExcludeToolRegex,
     ExcludeTypes,
 ]
-OptionalExclusionList = Annotated[Optional[List[Exclusions]], Field(None)]
+OptionalExclusionList = Annotated[Optional[List[Exclusions]], Field()]
 
 
 class Tool(BaseModel):
@@ -72,7 +72,7 @@ class Workflow(BaseModel):
 class ItemsFrom(BaseModel):
     content_type: Literal["items_from"] = "items_from"
     items_from: str
-    excludes: OptionalExclusionList
+    excludes: OptionalExclusionList = None
 
 
 SectionContent = Union[
@@ -121,7 +121,7 @@ class Section(BaseModel, HasItems):
     id: Optional[str] = None
     name: Optional[str] = None
     items: Optional[List[SectionContent]] = None
-    excludes: OptionalExclusionList
+    excludes: OptionalExclusionList = None
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -164,7 +164,7 @@ class StaticToolBoxView(BaseModel, HasItems):
     description: Optional[str] = None
     view_type: StaticToolBoxViewTypeEnum = Field(alias="type")
     items: Optional[List[RootContent]] = None  # if empty, use integrated tool panel
-    excludes: OptionalExclusionList
+    excludes: OptionalExclusionList = None
 
     @staticmethod
     def from_dict(as_dict):

--- a/lib/galaxy/tool_util_models/tool_outputs.py
+++ b/lib/galaxy/tool_util_models/tool_outputs.py
@@ -22,7 +22,7 @@ from typing_extensions import (
 from ._base import ToolSourceBaseModel
 
 AnyT = TypeVar("AnyT")
-NotRequired = Annotated[Optional[AnyT], Field(None)]
+NotRequired = Annotated[Optional[AnyT], Field()]
 IncomingNotRequiredBoolT = TypeVar("IncomingNotRequiredBoolT")
 IncomingNotRequiredStringT = TypeVar("IncomingNotRequiredStringT")
 
@@ -106,7 +106,12 @@ class IncomingToolOutputDataset(
         NotRequired[bool],
         NotRequired[str],
     ]
-): ...
+):
+    name: Annotated[
+        Optional[str], Field(description="Parameter name. Used when referencing parameter in workflows.")
+    ] = None
+    hidden: Annotated[Optional[bool], Field(description="If true, the output will not be shown in the history.")] = None
+    format: Annotated[Optional[str], Field(description="The short name for the output datatype.")] = None
 
 
 class ToolOutputCollectionStructure(ToolSourceBaseModel):
@@ -128,7 +133,11 @@ class GenericToolOutputCollection(
 class ToolOutputCollection(GenericToolOutputCollection[bool, str]): ...
 
 
-class IncomingToolOutputCollection(GenericToolOutputCollection[NotRequired[bool], NotRequired[str]]): ...
+class IncomingToolOutputCollection(GenericToolOutputCollection[NotRequired[bool], NotRequired[str]]):
+    name: Annotated[
+        Optional[str], Field(description="Parameter name. Used when referencing parameter in workflows.")
+    ] = None
+    hidden: Annotated[Optional[bool], Field(description="If true, the output will not be shown in the history.")] = None
 
 
 class ToolOutputSimple(GenericToolOutputBaseModel):

--- a/lib/galaxy/tool_util_models/tool_outputs.py
+++ b/lib/galaxy/tool_util_models/tool_outputs.py
@@ -22,7 +22,7 @@ from typing_extensions import (
 from ._base import ToolSourceBaseModel
 
 AnyT = TypeVar("AnyT")
-NotRequired = Annotated[Optional[AnyT], Field()]
+NotRequired = Optional[AnyT]
 IncomingNotRequiredBoolT = TypeVar("IncomingNotRequiredBoolT")
 IncomingNotRequiredStringT = TypeVar("IncomingNotRequiredStringT")
 


### PR DESCRIPTION
Remove `default` and positional `None` arguments from `Field()` calls inside `Annotated[]` types, which trigger warnings in Pydantic v2. The default values are moved to field assignments (`= None`) at the usage sites instead.

For type aliases used as generic parameters (NotRequired), the concrete subclasses now override fields with explicit defaults to preserve the original optional behavior.

26.0 so we can get this into packages and avoid these warnings on every planemo command.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
