### PR TITLE
Add `delete_completed_jobs` option to GCP Batch runner

### DIFF
--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -90,6 +90,8 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
             ),
             # Custom VM image (optional)
             "custom_vm_image": dict(map=str, default=None),
+            # Job cleanup: if true, delete GCP Batch jobs after Galaxy marks them complete
+            "delete_completed_jobs": dict(map=bool, default=True),
             # Object store fallback (for future use)
             "use_object_store": dict(map=bool, default=False),
             "object_store_path": dict(map=str, default=None),
@@ -759,12 +761,30 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
 
         batch_job_name = job.get_job_runner_external_id()
         if batch_job_name:
+            if not self.runner_params.get("delete_completed_jobs", True):
+                try:
+                    job_path = f"projects/{self.runner_params['project_id']}/locations/{self.runner_params['region']}/jobs/{batch_job_name}"
+                    batch_job = self.batch_client.get_job(name=job_path)
+                    if batch_job.status.state in (
+                        batch_v1.JobStatus.State.SUCCEEDED,
+                        batch_v1.JobStatus.State.FAILED,
+                    ):
+                        log.info("Retaining completed Batch job %s (delete_completed_jobs=false)", batch_job_name)
+                        return
+                except gcp_exceptions.NotFound:
+                    log.debug("Batch job %s already deleted", batch_job_name)
+                    return
+                except Exception as e:
+                    log.warning("Failed to check Batch job %s status, proceeding with delete: %s", batch_job_name, e)
+
             try:
                 job_path = f"projects/{self.runner_params['project_id']}/locations/{self.runner_params['region']}/jobs/{batch_job_name}"
                 self.batch_client.delete_job(name=job_path)
-                log.info("Cancelled Batch job %s", batch_job_name)
+                log.info("Deleted Batch job %s", batch_job_name)
+            except gcp_exceptions.NotFound:
+                log.debug("Batch job %s already deleted", batch_job_name)
             except Exception as e:
-                log.error("Failed to cancel Batch job %s: %s", batch_job_name, e)
+                log.error("Failed to delete Batch job %s: %s", batch_job_name, e)
         else:
             log.warning("Could not stop job %s - no external job ID", job.id)
 


### PR DESCRIPTION
By default, Galaxy deletes GCP Batch jobs when they finish (via `stop_job`). This makes it impossible to inspect completed jobs in the Google Cloud console for debugging or auditing.

### Changes

**`lib/galaxy/jobs/runners/gcp_batch.py`**
- Added `delete_completed_jobs` runner param (boolean, default `true`) to preserve existing behavior
- When set to `false`, `stop_job` checks the Batch job status before deleting. Jobs in `SUCCEEDED` or `FAILED` state are retained so they remain visible in the Google Cloud console
- Jobs that are still running are still deleted (cancelled) as before
- Handles `NotFound` gracefully if the job was already cleaned up
- Fixed log messages to say "Deleted" instead of "Cancelled" for clarity

### Configuration

```yaml
runners:
gcp_batch:
  delete_completed_jobs: false  # retain finished jobs in GCP console
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
