### PR TITLE
packages: include the tests & test-data in the sdists

### DIFF
--- a/packages/tool_util/MANIFEST.in
+++ b/packages/tool_util/MANIFEST.in
@@ -7,3 +7,4 @@ include galaxy/tool_util/xsd/*
 include galaxy/tool_util/ontologies/*tsv
 include galaxy/tool_util/linters/datatypes_conf.xml.sample
 include galaxy/tool_util/upgrade/upgrade_codes.json
+recursive-include tests *.py

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -81,6 +81,8 @@ test =
     Beaker
     pytest
     pytest-mock
+    CT3>=3.3.3
+    fissix;python_version>='3.13'
 [options.packages.find]
 exclude =
     tests*

--- a/packages/tool_util_models/MANIFEST.in
+++ b/packages/tool_util_models/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst *.txt LICENSE */py.typed
+recursive-include tests *.py

--- a/packages/util/MANIFEST.in
+++ b/packages/util/MANIFEST.in
@@ -2,3 +2,17 @@ include *.rst *.txt LICENSE */py.typed
 include galaxy/util/docutils_template.txt
 include galaxy/util/rules_dsl_spec.yml
 include galaxy/exceptions/error_codes.json
+include test-data/1.bam
+include test-data/1.tiff
+include test-data/4.bed.bz2
+include test-data/4.bed.gz
+include test-data/4.bed.zip
+include test-data/454Score.png
+include test-data/testdir.tar
+include test-data/testdir1.tar.gz
+include test-data/safetar_with_symlink.tar
+include test-data/safe_relative_symlink.tar
+include test-data/unsafe.tar
+include test-data/unsafe.zip
+include test-data/unsafe_relative_symlink.tar
+recursive-include tests *.py


### PR DESCRIPTION
This will enable downstream packages, such as Debian, to run the tests. This will not impact users, these files won't be copied into the Python wheels.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
