### PR TITLE
Fix workflow implicit mapping of flat collections over paired_or_unpaired

### DIFF
--- a/lib/galaxy/tool_util_models/__init__.py
+++ b/lib/galaxy/tool_util_models/__init__.py
@@ -218,7 +218,7 @@ def _check_collection_type(v: str) -> str:
         raise ValueError("Invalid empty collection_type specified.")
     collection_levels = v.split(":")
     for collection_level in collection_levels:
-        if collection_level not in ["list", "paired"]:
+        if collection_level not in ["list", "paired", "paired_or_unpaired", "record", "sample_sheet"]:
             raise ValueError(f"Invalid collection_type specified [{v}]")
     return v
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -40,6 +40,7 @@ from galaxy.model import (
 )
 from galaxy.model.base import ensure_object_added_to_session
 from galaxy.model.dataset_collections import matching
+from galaxy.model.dataset_collections.adapters import PromoteCollectionElementToCollectionAdapter
 from galaxy.model.dataset_collections.query import HistoryQuery
 from galaxy.model.dataset_collections.type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 from galaxy.model.dataset_collections.types.sample_sheet_util import validate_column_definitions
@@ -638,6 +639,20 @@ class WorkflowModule:
 
                 subcollection_type_description = history_query.can_map_over(data) or None
                 if subcollection_type_description:
+                    # Translate paired_or_unpaired to concrete mapping type for
+                    # flat collections. Mirrors logic in basic.py:2675-2679 that
+                    # the API tool execution path uses.
+                    _sub_ct = subcollection_type_description.collection_type
+                    _hdca_ct = data.collection.collection_type
+                    if _sub_ct == "paired_or_unpaired" and not _hdca_ct.endswith("paired_or_unpaired"):
+                        if _hdca_ct.endswith("paired"):
+                            subcollection_type_description = dataset_collection_type_descriptions.for_collection_type(
+                                "paired"
+                            )
+                        else:
+                            subcollection_type_description = dataset_collection_type_descriptions.for_collection_type(
+                                "single_datasets"
+                            )
                     subcollection_type_list = subcollection_type_description.collection_type.split(":")
                     for collection_type in reversed(subcollection_type_list):
                         if type_list:
@@ -2414,9 +2429,25 @@ class ToolModule(WorkflowModule):
             def callback(input, prefixed_name: str, **kwargs):
                 input_dict = all_inputs_by_name[prefixed_name]
 
-                replacement: Union[model.Dataset, NoReplacement] = NO_REPLACEMENT
+                replacement: Union[model.Dataset, NoReplacement, PromoteCollectionElementToCollectionAdapter] = (
+                    NO_REPLACEMENT
+                )
                 if iteration_elements and prefixed_name in iteration_elements:  # noqa: B023
                     replacement = iteration_elements[prefixed_name]  # noqa: B023
+                    # When mapping flat collections over paired_or_unpaired via
+                    # single_datasets, wrap each element in an adapter so the
+                    # tool sees a paired_or_unpaired collection.
+                    if (
+                        collection_info  # noqa: B023
+                        and isinstance(replacement, model.DatasetCollectionElement)
+                        and not replacement.child_collection
+                    ):
+                        mapping_type = collection_info.subcollection_mapping_type(prefixed_name)  # noqa: B023
+                        if (
+                            hasattr(mapping_type, "collection_type")
+                            and mapping_type.collection_type == "single_datasets"
+                        ):
+                            replacement = PromoteCollectionElementToCollectionAdapter(replacement)
                 else:
                     replacement = progress.replacement_for_input(trans, step, input_dict)
 

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -526,6 +526,18 @@ def test_map_over_paired_or_unpaired_with_list(target_history: TargetHistory, re
 
 
 @requires_tool_id("collection_paired_or_unpaired")
+def test_map_over_paired_or_unpaired_with_sample_sheet(target_history: TargetHistory, required_tool: RequiredTool):
+    contents = [("foo", "text for foo element")]
+    hdca = target_history.with_sample_sheet(contents)
+    execute = required_tool.execute().with_inputs(
+        {"f1": {"batch": True, "values": [{"map_over_type": "single_datasets", **hdca.src_dict}]}}
+    )
+    execute.assert_has_n_jobs(1).assert_creates_n_implicit_collections(1)
+    output_collection = execute.assert_creates_implicit_collection(0)
+    output_collection.assert_has_dataset_element("foo").with_contents_stripped("text for foo element")
+
+
+@requires_tool_id("collection_paired_or_unpaired")
 def test_map_over_paired_or_unpaired_with_list_of_lists(target_history: TargetHistory, required_tool: RequiredTool):
     hdca = target_history.with_example_list_of_lists()
     execute = required_tool.execute().with_inputs(

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -4802,6 +4802,15 @@ class TargetHistory:
             )
         )
 
+    def with_sample_sheet(self, contents: Optional[ListContentsDescription] = None) -> "HasSrcDict":
+        if contents is None:
+            contents = [("foo", "text for foo element")]
+        create_response = self._dataset_collection_populator.create_sample_sheet(
+            self._history_id, contents=contents, column_definitions=[], rows={c[0]: [] for c in contents}
+        )
+        api_asserts.assert_status_code_is_ok(create_response)
+        return HasSrcDict("hdca", create_response.json())
+
     def with_example_list_of_pairs(self) -> "HasSrcDict":
         return HasSrcDict("hdca", self._dataset_collection_populator.example_list_of_pairs(self._history_id))
 

--- a/lib/galaxy_test/workflow/flat_over_paired_or_unpaired.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/flat_over_paired_or_unpaired.gxwf-tests.yml
@@ -1,0 +1,40 @@
+- doc: |
+    A flat list mapped over a paired_or_unpaired tool input via
+    single_datasets produces a list output.
+  job:
+    input1:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          contents: "element 1"
+        - identifier: el2
+          class: File
+          contents: "element 2"
+  outputs:
+    wf_output:
+      class: Collection
+      collection_type: list
+
+- doc: |
+    A flat sample_sheet mapped over a paired_or_unpaired tool input via
+    single_datasets produces a sample_sheet output.
+  job:
+    input1:
+      class: Collection
+      collection_type: sample_sheet
+      rows:
+        el1: []
+        el2: []
+      elements:
+        - identifier: el1
+          class: File
+          contents: "element 1"
+        - identifier: el2
+          class: File
+          contents: "element 2"
+  outputs:
+    wf_output:
+      class: Collection
+      collection_type: sample_sheet

--- a/lib/galaxy_test/workflow/flat_over_paired_or_unpaired.gxwf.yml
+++ b/lib/galaxy_test/workflow/flat_over_paired_or_unpaired.gxwf.yml
@@ -1,0 +1,13 @@
+class: GalaxyWorkflow
+inputs:
+  input1:
+    type: collection
+    collection_type: paired_or_unpaired
+outputs:
+  wf_output:
+    outputSource: tool_step/out1
+steps:
+  tool_step:
+    tool_id: collection_paired_or_unpaired
+    in:
+      f1: input1


### PR DESCRIPTION
This behavior was clarified/fixed in https://github.com/galaxyproject/galaxy/pull/21859 for the workflow editor. I think this fix is needed for that behavior to match the workflow runtime though. 

The workflow engine failed to map flat list/sample_sheet collections over paired_or_unpaired tool inputs. The API tool execution path worked because it explicitly translates paired_or_unpaired to single_datasets and wraps elements in PromoteCollectionElementToCollectionAdapter. The workflow path was missing both steps.

Two fixes in workflow/modules.py:
- _find_collections_to_match: translate paired_or_unpaired subcollection type to single_datasets for flat collections (mirrors basic.py:2675)
- ToolModule.execute callback: wrap flat DCEs in adapter when mapping type is single_datasets

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
