### PR TITLE
Add Workflow Report generator agent

### DIFF
--- a/client/src/api/chat.ts
+++ b/client/src/api/chat.ts
@@ -16,5 +16,5 @@ export async function generateAIReport(workflowId: string, version?: number, ins
         rethrowSimple(error);
     }
 
-    return data as string;
+    return data;
 }

--- a/client/src/api/chat.ts
+++ b/client/src/api/chat.ts
@@ -1,0 +1,20 @@
+import { rethrowSimple } from "@/utils/simple-error";
+
+import { GalaxyApi } from "./client";
+
+export async function generateAIReport(workflowId: string, version?: number, instance?: boolean) {
+    const { data, error } = await GalaxyApi().GET("/api/chat/{workflow_id}/generate_report", {
+        params: {
+            path: { workflow_id: workflowId },
+            query: {
+                version: version,
+                instance: instance,
+            },
+        },
+    });
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data as string;
+}

--- a/client/src/api/invocations.ts
+++ b/client/src/api/invocations.ts
@@ -1,3 +1,6 @@
+import { rethrowSimple } from "@/utils/simple-error";
+
+import { GalaxyApi } from "./client";
 import type { components } from "./schema";
 
 export type WorkflowInvocationElementView = components["schemas"]["WorkflowInvocationElementView"];
@@ -7,6 +10,7 @@ export type InvocationInputParameter = components["schemas"]["InvocationInputPar
 export type InvocationOutput = components["schemas"]["InvocationOutput"];
 export type InvocationOutputCollection = components["schemas"]["InvocationOutputCollection"];
 export type InvocationJobsSummary = components["schemas"]["InvocationJobsResponse"];
+type InvocationReport = components["schemas"]["InvocationReport"];
 export type InvocationState = components["schemas"]["InvocationState"];
 export type InvocationStep = components["schemas"]["InvocationStep"];
 export type InvocationMessage = components["schemas"]["InvocationMessageResponseUnion"];
@@ -24,4 +28,23 @@ export function isWorkflowInvocationElementView(
     item: WorkflowInvocation | null,
 ): item is WorkflowInvocationElementView {
     return item !== null && "steps" in item;
+}
+
+/**
+ * Fetches the invocation report for a given invocation ID
+ * @param {string} invocationId The ID of the invocation to fetch the report for
+ * @returns {Promise<InvocationReport>} A promise that resolves to the invocation report
+ */
+export async function fetchInvocationReport(invocationId: string): Promise<InvocationReport> {
+    const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}/report", {
+        params: {
+            path: { invocation_id: invocationId },
+        },
+    });
+
+    if (error) {
+        rethrowSimple(error);
+    }
+
+    return data as InvocationReport;
 }

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -26415,6 +26415,27 @@ export interface components {
              */
             workflow_target_type: "stored_workflow" | "workflow" | "trs_url" | "url";
         };
+        /**
+         * WorkflowReportResponse
+         * @description Response from the workflow report generation agent.
+         */
+        WorkflowReportResponse: {
+            /**
+             * Model
+             * @description LLM model used to generate the report
+             */
+            model?: string | null;
+            /**
+             * Report
+             * @description Generated markdown report for the workflow
+             */
+            report: string;
+            /**
+             * Total Tokens
+             * @description Total tokens consumed by the generation
+             */
+            total_tokens?: number | null;
+        };
         /** WorkflowTypeVersion */
         WorkflowTypeVersion: {
             /**
@@ -31173,7 +31194,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": string | null;
+                    "application/json": components["schemas"]["WorkflowReportResponse"];
                 };
             };
             /** @description Request Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -265,6 +265,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/{workflow_id}/generate_report": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Generate Report
+         * @description **Warning**: This API is unstable and may change without notice.
+         */
+        get: operations["generate_report_api_chat__workflow_id__generate_report_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/configuration": {
         parameters: {
             query?: never;
@@ -31105,6 +31125,55 @@ export interface operations {
                 };
                 content: {
                     "application/json": number | null;
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    generate_report_api_chat__workflow_id__generate_report_get: {
+        parameters: {
+            query?: {
+                /** @description Version of the workflow */
+                version?: number | null;
+                /** @description Whether the workflow_id is an instance ID */
+                instance?: boolean;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description Workflow ID to generate the report for */
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string | null;
                 };
             };
             /** @description Request Error */

--- a/client/src/components/Markdown/Sections/MarkdownGalaxy.vue
+++ b/client/src/components/Markdown/Sections/MarkdownGalaxy.vue
@@ -197,7 +197,7 @@ watch(
                 :dataset-id="args.history_dataset_id"
                 :embedded="name == 'history_dataset_embedded'" />
             <HistoryDatasetIndex v-else-if="name == 'history_dataset_index'" :args="args" />
-            <HistoryDatasetLink v-else-if="name == 'history_dataset_link'" :args="args" />
+            <HistoryDatasetLink v-else-if="name == 'history_dataset_link' && args.history_dataset_id" :args="args" />
             <HistoryLink v-else-if="name == 'history_link'" :history-id="args.history_id" />
             <InstanceUrl
                 v-else-if="name == 'instance_access_link'"

--- a/client/src/components/PageDisplay/PageForm.vue
+++ b/client/src/components/PageDisplay/PageForm.vue
@@ -36,6 +36,7 @@ import { ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { GalaxyApi } from "@/api";
+import { fetchInvocationReport } from "@/api/invocations";
 import { FORM_LABELS } from "@/components/Page/constants";
 import pageTemplate from "@/components/PageDisplay/pageTemplate.yml";
 
@@ -64,19 +65,18 @@ const buttonText = props.mode === "edit" ? "Update" : "Create";
 
 async function fetchData() {
     if (props.mode === "create" && props.invocationId) {
-        loading.value = true;
-        const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}/report", {
-            params: { path: { invocation_id: props.invocationId } },
-        });
-        if (error) {
-            errorMessage.value = error.err_msg;
-        } else {
+        try {
+            loading.value = true;
+            const data = await fetchInvocationReport(props.invocationId);
             errorMessage.value = "";
             content.value = data.invocation_markdown || "";
             slug.value = `invocation-${data.id}`;
             title.value = data.title;
+        } catch (error) {
+            errorMessage.value = error as string;
+        } finally {
+            loading.value = false;
         }
-        loading.value = false;
     } else if (props.mode === "edit" && props.id) {
         loading.value = true;
         const { data, error } = await GalaxyApi().GET("/api/pages/{id}", {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1136,9 +1136,12 @@ export default {
 
             this.onWorkflowMessage("Generating AI Report", "progress");
             try {
-                const generatedReport = await generateAIReport(this.id, this.version);
-                this.onReportUpdate(generatedReport);
-                Toast.success("AI Report generated successfully.");
+                const { model, report, total_tokens } = await generateAIReport(this.id, this.version);
+                this.onReportUpdate(report);
+                Toast.success(
+                    `Report generated using ${model}${total_tokens ? `, total tokens used: ${total_tokens}` : ""}.`,
+                    "AI Report generated successfully.",
+                );
             } catch (e) {
                 this.onWorkflowError(
                     "Generating AI report failed",

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1142,6 +1142,7 @@ export default {
                     `Report generated using ${model}${total_tokens ? `, total tokens used: ${total_tokens}` : ""}.`,
                     "AI Report generated successfully.",
                 );
+                this.hideModal();
             } catch (e) {
                 this.onWorkflowError(
                     "Generating AI report failed",
@@ -1152,8 +1153,6 @@ export default {
                         },
                     },
                 );
-            } finally {
-                this.hideModal();
             }
         },
         onReportUpdate(markdown) {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -129,6 +129,17 @@
                 @insert="insertMarkdown"
                 @update="onReportUpdate">
                 <template v-slot:buttons>
+                    <GButton
+                        tooltip
+                        title="Generate AI ChatGXY report based on the workflow and its expected results"
+                        variant="link"
+                        color="blue"
+                        transparent
+                        size="large"
+                        @click="generateAIReport">
+                        <FontAwesomeIcon :icon="faMagic" />
+                    </GButton>
+
                     <b-button
                         id="workflow-canvas-button"
                         v-g-tooltip.hover.bottom
@@ -254,7 +265,17 @@
 </template>
 
 <script>
-import { faCog, faKey, faRedo, faSave, faSitemap, faTimes, faUndo, faWrench } from "@fortawesome/free-solid-svg-icons";
+import {
+    faCog,
+    faKey,
+    faMagic,
+    faRedo,
+    faSave,
+    faSitemap,
+    faTimes,
+    faUndo,
+    faWrench,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { until, whenever } from "@vueuse/core";
 import { logicAnd, logicNot, logicOr } from "@vueuse/math";
@@ -262,6 +283,7 @@ import { BDropdown, BDropdownDivider, BDropdownItem, BDropdownText } from "boots
 import { storeToRefs } from "pinia";
 import Vue, { computed, nextTick, onUnmounted, ref, unref, watch } from "vue";
 
+import { generateAIReport } from "@/api/chat";
 import { getUntypedWorkflowParameters } from "@/components/Workflow/Editor/modules/parameters";
 import { getWorkflowFull } from "@/components/Workflow/workflows.services";
 import { ConfirmDialog, useConfirmDialog } from "@/composables/confirmDialog";
@@ -304,6 +326,7 @@ import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
 import GForm from "@/components/BaseComponents/Form/GForm.vue";
 import GFormInput from "@/components/BaseComponents/Form/GFormInput.vue";
 import GFormLabel from "@/components/BaseComponents/Form/GFormLabel.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
 import GModal from "@/components/BaseComponents/GModal.vue";
 import MarkdownEditor from "@/components/Markdown/MarkdownEditor.vue";
 import InputPanel from "@/components/Panels/InputPanel.vue";
@@ -337,6 +360,7 @@ export default {
         BDropdown,
         BDropdownText,
         BDropdownDivider,
+        GButton,
         GForm,
         GFormLabel,
         GFormInput,
@@ -766,6 +790,7 @@ export default {
             navUrl: "",
             faTimes,
             faCog,
+            faMagic,
             faSave,
             faRedo,
             faUndo,
@@ -1097,6 +1122,36 @@ export default {
         },
         onUpgrade() {
             this.onAttemptRefactor([{ action_type: "upgrade_all_steps" }]);
+        },
+        async generateAIReport() {
+            if (this.hasChanges) {
+                Toast.error("Please save your workflow before generating the AI report.");
+                return;
+            }
+
+            if (!this.id || this.isNewTempWorkflow) {
+                Toast.error("Workflow must be saved before generating the AI report.");
+                return;
+            }
+
+            this.onWorkflowMessage("Generating AI Report", "progress");
+            try {
+                const generatedReport = await generateAIReport(this.id, this.version);
+                this.onReportUpdate(generatedReport);
+                Toast.success("AI Report generated successfully.");
+            } catch (e) {
+                this.onWorkflowError(
+                    "Generating AI report failed",
+                    errorMessageAsString(e) || "Please contact an administrator.",
+                    {
+                        Ok: () => {
+                            this.hideModal();
+                        },
+                    },
+                );
+            } finally {
+                this.hideModal();
+            }
         },
         onReportUpdate(markdown) {
             this.hasChanges = true;

--- a/client/src/components/Workflow/InvocationReport.vue
+++ b/client/src/components/Workflow/InvocationReport.vue
@@ -1,79 +1,53 @@
+<script setup lang="ts">
+import { computed, provide, ref } from "vue";
+import { useRouter } from "vue-router/composables";
+
+import { fetchInvocationReport } from "@/api/invocations";
+import { useConfig } from "@/composables/config";
+import { useToast } from "@/composables/toast";
+
+import Markdown from "@/components/Markdown/Markdown.vue";
+
+const props = defineProps<{
+    invocationId: string;
+}>();
+
+const { config, isConfigLoaded } = useConfig(true);
+
+const Toast = useToast();
+
+const router = useRouter();
+
+const markdownConfig = ref({});
+
+const exportUrl = computed(() => `/api/invocations/${props.invocationId}/report.pdf`);
+
+fetchReport();
+
+async function fetchReport() {
+    try {
+        const data = await fetchInvocationReport(props.invocationId);
+        markdownConfig.value = data;
+    } catch (error) {
+        Toast.error("Failed to load invocation report.");
+    }
+}
+
+function onEdit() {
+    router.push(`/pages/create?invocation_id=${props.invocationId}`);
+}
+
+// Provide invocationId to all descendant components for inline directive resolution
+provide("invocationId", props.invocationId);
+</script>
+
 <template>
     <Markdown
         v-if="isConfigLoaded"
         :markdown-config="markdownConfig"
         :enable_beta_markdown_export="config.enable_beta_markdown_export"
         :export-link="exportUrl"
-        :download-endpoint="stsUrl(config)"
+        :download-endpoint="exportUrl"
         direct-download-link
         @onEdit="onEdit" />
 </template>
-
-<script>
-import BootstrapVue from "bootstrap-vue";
-import Vue from "vue";
-
-import { useConfig } from "@/composables/config";
-import { Toast } from "@/composables/toast";
-import { withPrefix } from "@/utils/redirect";
-import { urlData } from "@/utils/url";
-
-import Markdown from "@/components/Markdown/Markdown.vue";
-
-Vue.use(BootstrapVue);
-
-export default {
-    components: {
-        Markdown,
-    },
-    // Provide invocationId to all descendant components for inline directive resolution
-    provide() {
-        return {
-            invocationId: this.invocationId,
-        };
-    },
-    props: {
-        invocationId: {
-            type: String,
-            required: true,
-        },
-    },
-    setup() {
-        const { config, isConfigLoaded } = useConfig(true);
-        return { config, isConfigLoaded };
-    },
-    data() {
-        return {
-            markdownConfig: {},
-            invocationMarkdown: null,
-        };
-    },
-    computed: {
-        dataUrl() {
-            return `/api/invocations/${this.invocationId}/report`;
-        },
-        exportUrl() {
-            return `${this.dataUrl}.pdf`;
-        },
-    },
-    created() {
-        const url = this.dataUrl;
-        urlData({ url })
-            .then((response) => {
-                this.markdownConfig = response;
-                this.invocationMarkdown = response.invocation_markdown;
-            })
-            .catch((error) => {
-                Toast.error(`Failed to load invocation markdown: ${error}`);
-            });
-    },
-    methods: {
-        onEdit() {
-            window.location = withPrefix(`/pages/create?invocation_id=${this.invocationId}`);
-        },
-        stsUrl(config) {
-            return `${this.dataUrl}.pdf`;
-        },
-    },
-};
-</script>

--- a/lib/galaxy/agents/__init__.py
+++ b/lib/galaxy/agents/__init__.py
@@ -21,6 +21,7 @@ from .registry import (
 )
 from .router import QueryRouterAgent
 from .tools import ToolRecommendationAgent
+from .workflow_report import WorkflowReportAgent
 
 __all__ = [
     "AgentType",
@@ -36,4 +37,5 @@ __all__ = [
     "ToolRecommendationAgent",
     "HistoryAgent",
     "GTNTrainingAgent",
+    "WorkflowReportAgent",
 ]

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -238,6 +238,7 @@ class AgentType:
     HISTORY = "history"
     GTN_TRAINING = "gtn_training"
     PAGE_ASSISTANT = "page_assistant"
+    WORKFLOW_REPORT = "workflow_report"
 
 
 # For API responses, use galaxy.schema.agents.AgentResponse

--- a/lib/galaxy/agents/prompts/workflow_report.md
+++ b/lib/galaxy/agents/prompts/workflow_report.md
@@ -1,0 +1,1 @@
+You are a Galaxy workflow report generator. Given a workflow name, produce a prediction of what a workflow report would look like for that workflow.

--- a/lib/galaxy/agents/prompts/workflow_report.md
+++ b/lib/galaxy/agents/prompts/workflow_report.md
@@ -26,17 +26,19 @@ Prefer terminal outputs (higher step numbers) over early intermediates. Always i
 
 ## Classifying outputs
 
-Use `tool_id` and the output label to infer type:
+Use `tool_id` and the output label to infer type, then pick the directive from the reference below.
 
-| Type | Directive |
-|------|-----------|
-| Image / image collection | `history_dataset_as_image(output="<label>")` |
-| Tabular / TSV / CSV | `history_dataset_as_table(output="<label>", show_column_headers=true, compact=true)` + `history_dataset_link(output="<label>", label="Download ...")` |
-| HTML / embedded report | `history_dataset_embedded(output="<label>")` |
-| VCF / binary / unknown | `history_dataset_link(output="<label>", label="Download ...")` |
-| Any dataset (fallback) | `history_dataset_display(output="<label>")` |
+Quick guide:
+- Image / image collection → `history_dataset_as_image(output="<label>")`
+- Tabular / TSV / CSV → `history_dataset_as_table(output="<label>", show_column_headers=true, compact=true)` + `history_dataset_link(output="<label>", label="Download ...")`
+- HTML / embedded report → `history_dataset_embedded(output="<label>")`
+- VCF / binary / unknown → `history_dataset_link(output="<label>", label="Download ...")`
 
 For inputs: image collections → `history_dataset_as_image(input="<label>")`, otherwise → `invocation_inputs()`.
+
+**Note on workflow template syntax:** in workflow report templates, directives reference data by label, not by ID. Use `output="<label>"`, `input="<label>"`, or `step="<label>"` — never `history_dataset_id=` or `job_id=`.
+
+{directive_docs}
 
 ---
 

--- a/lib/galaxy/agents/prompts/workflow_report.md
+++ b/lib/galaxy/agents/prompts/workflow_report.md
@@ -1,1 +1,289 @@
-You are a Galaxy workflow report generator. Given a workflow name, produce a prediction of what a workflow report would look like for that workflow.
+You are a Galaxy workflow report generator. You will receive a pre-extracted workflow description (name, readme, inputs, tool steps, and workflow outputs). Your task is to draft a reusable Galaxy markdown report template for the Workflow Editor's **Report** tab.
+
+Output **ONLY** the final Galaxy markdown report. No preamble, no explanation, no notes — just the report.
+
+---
+
+## Core Philosophy
+
+Reports are **templates** — they are written before knowing what inputs the user will provide or whether the run will succeed. Never assume:
+- Inputs are valid, in the expected format, or of the expected type
+- The run completed successfully or produced expected outputs
+- Biological/scientific meaning of results (the same workflow can be used in different contexts)
+
+Use conditional, descriptive language throughout:
+- Summary: "is designed to", "expects", "should produce"
+- Output sections: "if the run completed successfully, this should show..."
+- Column descriptions: what a column *measures*, not what it *means*
+
+---
+
+## How to read the workflow description
+
+The query contains a structured text description with these sections:
+
+**`Workflow name:`** — use as the report title.
+
+**`Readme:`** (if present) — primary source for Summary prose.
+
+**`Inputs:`** — each entry is:
+  `- "<label>" (type: <type>): <annotation>`
+  - `label` → used verbatim in `input="..."` directives
+  - `type` → `data_collection_input` means a list/paired collection; `data_input` means a single dataset
+  - `annotation` → use for prose only, never in directives
+
+**`Tool steps with labels:`** — each entry is:
+  `N. "<label>" [tool_id: <tool_id>]`
+  - `label` → used verbatim in `step="..."` directives
+  - `tool_id` → use to infer what kind of output the step produces (image tool → image, tabular tool → table, etc.)
+
+**`Workflow outputs:`** — each entry is:
+  `- "<output_label>" [from step N: "<step_label>", tool_id: <tool_id>]`
+  - `output_label` → used verbatim in `output="..."` directives
+  - `step_label` and `tool_id` → use to infer output type and write informed prose
+  - Higher step numbers are later in the pipeline — prefer them as "terminal" outputs
+
+---
+
+## Step 1 — Select which outputs to feature
+
+Not every workflow output deserves its own section. Apply these rules:
+
+**Always include:**
+- The primary result — the final, most informative output (e.g. a results table, a report, a processed dataset, a visual summary)
+- Any output that is the direct basis for the primary result and helps the user validate the pipeline worked correctly (e.g. an intermediate QC plot, a filtered file, a mask used for quantification)
+
+**Include selectively:**
+- Intermediate outputs that give meaningful insight into pipeline behaviour — useful for debugging or understanding a step's contribution
+- Prefer outputs from higher step numbers (later in the pipeline) over early intermediates
+
+**Skip or collapse:**
+- Purely intermediate outputs that are only consumed by subsequent steps and add no standalone value
+- Outputs that duplicate information already shown elsewhere in the report
+
+**When in doubt:** ask yourself — if the run produced unexpected results, which output would a user look at first to diagnose the problem? That's the one to feature.
+
+If no outputs are marked, fall back to `invocation_outputs()` with a note in prose that all outputs will appear here.
+
+---
+
+## Step 2 — Classify selected outputs
+
+Use the `tool_id` and output label to infer the likely data type:
+
+| Likely type | Directive |
+|-------------|-----------|
+| Image (TIFF, PNG, JPEG, any imaging tool) | `history_dataset_as_image(output="<label>")` — also works for image collections |
+| Tabular / TSV / CSV | `history_dataset_as_table(output="<label>", show_column_headers=true, compact=true)` + `history_dataset_link(output="<label>", label="Download ...")` |
+| HTML / text report | `history_dataset_embedded(output="<label>")` |
+| Unknown / mixed | `history_dataset_display(output="<label>")` |
+
+For **inputs**:
+- Image-type input (`data_collection_input` or clearly image data) → `history_dataset_as_image(input="<label>")`
+- Non-image or multiple inputs → `invocation_inputs()`
+
+---
+
+## Step 3 — Build the report
+
+### Required sections
+
+**1. Title + run timestamp**
+
+````
+# <Workflow Name>
+
+```galaxy
+invocation_time()
+```
+````
+
+**2. Summary**
+- One paragraph: what the workflow is designed to do, what inputs it expects, what outputs it should produce.
+- Drawn from `readme` and step annotations — do not copy verbatim.
+- End the section with `workflow_image()`.
+
+**3. Inputs**
+- Brief prose: what the input(s) represent and what format/type is expected.
+- Follow with the appropriate directive.
+
+**4. Key output sections** (one subsection per selected output)
+- Brief prose: what this output represents and how it was produced — phrased conditionally.
+- The appropriate directive immediately follows.
+- For processed images (masks, segmentations): explain the visual encoding conditionally ("in a successful run, white pixels should represent...").
+
+**5. Results** (when tabular outputs exist)
+- A markdown table of expected columns: name and description (factual/definitional only) — goes **before** the directive.
+- Then `history_dataset_as_table(...)` followed by `history_dataset_link(...)`.
+
+**6. Reproducibility**
+
+```galaxy
+history_link()
+```
+
+### Optional sections
+
+- `job_parameters(step="<label>", collapse="Show <step> parameters")` — for analytical steps where parameters significantly affect interpretation
+- `invocation_outputs()` — useful when the workflow has many outputs
+- `workflow_display(collapse="Show full workflow details")`
+
+---
+
+## Directive Syntax Rules
+
+**Block syntax only — no exceptions:**
+
+```galaxy
+directive_name(arg=value)
+```
+
+One directive per fenced block. Never stack multiple directives in one block. The `${galaxy ...}` inline syntax does **not** work.
+
+**Use only exact labels from the workflow description** — never invent, guess, abbreviate, or paraphrase a label. Copy the label string exactly as it appears (without the surrounding quotes from the description).
+
+---
+
+## Directive Reference
+
+### Dataset directives
+
+| Directive | Renders | When to use |
+|-----------|---------|-------------|
+| `history_dataset_display` | Interactive dataset card | Default fallback for any dataset |
+| `history_dataset_as_image` | Embedded image | Plots, images, visual outputs — also works for collections |
+| `history_dataset_as_table` | Formatted table | Tabular results; supports `compact`, `title`, `footer`, `show_column_headers` |
+| `history_dataset_embedded` | Raw content | Small text or HTML outputs |
+| `history_dataset_link` | Download link | Inline download with custom `label` |
+| `history_dataset_peek` | First rows preview | Data snippets |
+| `history_dataset_info` | Dataset metadata | Tool output metadata |
+| `history_dataset_name` | Dataset name text | References in prose |
+| `history_dataset_type` | Datatype string | References in prose |
+| `history_dataset_index` | Composite file listing | Multi-file composite datasets |
+| `history_dataset_collection_display` | Collection browser | Paired/list collections |
+
+### Invocation directives
+
+| Directive | Renders | When to use |
+|-----------|---------|-------------|
+| `invocation_inputs()` | All workflow inputs | Summary of submitted inputs |
+| `invocation_outputs()` | All workflow outputs | Summary of all outputs |
+| `invocation_time()` | Run timestamp | Always include at top of report |
+| `history_link()` | History import link | Always include in Reproducibility section |
+
+### Job directives
+
+Use only for steps listed under "Tool steps with labels" — never for inputs or outputs.
+
+| Directive | Renders | When to use |
+|-----------|---------|-------------|
+| `job_parameters(step=, collapse=)` | Tool parameters table | Key analytical steps |
+| `job_metrics(step=, collapse=)` | Runtime metrics | Performance documentation |
+| `tool_stdout(step=)` | Tool standard output | Capturing logs |
+| `tool_stderr(step=)` | Tool standard error | Capturing warnings |
+
+### Workflow directives
+
+| Directive | Renders | When to use |
+|-----------|---------|-------------|
+| `workflow_image()` | SVG workflow diagram | Always include in Summary section |
+| `workflow_display(collapse=)` | Step-by-step breakdown | Optional, usually collapsible |
+| `workflow_license()` | License info | Attribution / reproducibility |
+
+`collapse="<link text>"` — wraps any block directive in a collapsible section.
+
+---
+
+## Example
+
+Input description:
+
+```
+Workflow name: Histological Staining Area Quantification
+
+Inputs:
+  - 'ROI image for staining analysis' (type: data_collection_input): Brightfield TIFF images, RGB
+
+Tool steps with labels:
+  3. 'Color Deconvolution' [tool_id: toolshed.g2.bx.psu.edu/repos/.../color_deconvolution]
+  11. 'Threshold Stain Channel Collection' [tool_id: toolshed.g2.bx.psu.edu/repos/.../threshold]
+  13. 'Extract Image Features' [tool_id: toolshed.g2.bx.psu.edu/repos/.../extract_features]
+
+Workflow outputs:
+  - 'Selected Stain Channel Thresholded' [from step 11: 'Threshold Stain Channel Collection', tool_id: ...]
+  - 'Tabular File: Staining Feature Results' [from step 25: 'Tabular: Staining Feature Results', tool_id: ...]
+```
+
+Expected output:
+
+````markdown
+# Histological Staining Area Quantification
+
+```galaxy
+invocation_time()
+```
+
+---
+
+## Summary
+
+This workflow is designed to quantify the area and intensity of a specific stain in brightfield
+histological images. It takes a collection of input images, applies colour deconvolution to
+separate the target stain channel, then uses automated thresholding to segment positive-staining
+pixels. Per-sample measurements are collated into a single tabular output.
+
+```galaxy
+workflow_image()
+```
+
+---
+
+## Input Images
+
+The input is a list collection of brightfield microscopy images. Each element should represent
+one region of interest from a tissue section.
+
+```galaxy
+history_dataset_as_image(input="ROI image for staining analysis")
+```
+
+---
+
+## Staining Mask
+
+If the run completed successfully, each input image will have been converted into a binary mask
+via colour deconvolution and automated thresholding. In a successful run, white pixels represent
+positively stained regions and black pixels represent background.
+
+```galaxy
+history_dataset_as_image(output="Selected Stain Channel Thresholded")
+```
+
+---
+
+## Results
+
+If the workflow completed successfully, the table below shows per-sample staining measurements.
+
+| Column | Description |
+|--------|-------------|
+| `sample_id` | Identifier derived from the input image filename |
+| `label` | Region label assigned by the thresholding step |
+| `area` | Pixel count of the positively stained region |
+
+```galaxy
+history_dataset_as_table(output="Tabular File: Staining Feature Results", show_column_headers=true, compact=true)
+```
+
+```galaxy
+history_dataset_link(output="Tabular File: Staining Feature Results", label="Download results (TSV)")
+```
+
+---
+
+## Reproducibility
+
+```galaxy
+history_link()
+```
+````

--- a/lib/galaxy/agents/prompts/workflow_report.md
+++ b/lib/galaxy/agents/prompts/workflow_report.md
@@ -1,223 +1,87 @@
-You are a Galaxy workflow report generator. You will receive a pre-extracted workflow description (name, readme, inputs, tool steps, and workflow outputs). Your task is to draft a reusable Galaxy markdown report template for the Workflow Editor's **Report** tab.
+You are a Galaxy workflow report generator. You will receive a pre-extracted workflow description. Draft a reusable Galaxy markdown report template for the Workflow Editor's **Report** tab.
 
-Output **ONLY** the final Galaxy markdown report. No preamble, no explanation, no notes — just the report.
-
----
-
-## Core Philosophy
-
-Reports are **templates** — they are written before knowing what inputs the user will provide or whether the run will succeed. Never assume:
-- Inputs are valid, in the expected format, or of the expected type
-- The run completed successfully or produced expected outputs
-- Biological/scientific meaning of results (the same workflow can be used in different contexts)
-
-Use conditional, descriptive language throughout:
-- Summary: "is designed to", "expects", "should produce"
-- Output sections: "if the run completed successfully, this should show..."
-- Column descriptions: what a column *measures*, not what it *means*
+Output **ONLY** the final report. No preamble, no explanation.
 
 ---
 
-## How to read the workflow description
+## Rules
 
-The query contains a structured text description with these sections:
+**Reports are templates** — written before the run, so never assume inputs are valid, the run succeeded, or what the results mean scientifically. Use conditional language: "is designed to", "expects", "if the run completed successfully".
 
-**`Workflow name:`** — use as the report title.
+**Label accuracy** — every `input=`, `output=`, and `step=` value must be copied exactly from the workflow description. Never invent or paraphrase a label.
 
-**`Readme:`** (if present) — primary source for Summary prose.
-
-**`Inputs:`** — each entry is:
-  `- "<label>" (type: <type>): <annotation>`
-  - `label` → used verbatim in `input="..."` directives
-  - `type` → `data_collection_input` means a list/paired collection; `data_input` means a single dataset
-  - `annotation` → use for prose only, never in directives
-
-**`Tool steps with labels:`** — each entry is:
-  `N. "<label>" [tool_id: <tool_id>]`
-  - `label` → used verbatim in `step="..."` directives
-  - `tool_id` → use to infer what kind of output the step produces (image tool → image, tabular tool → table, etc.)
-
-**`Workflow outputs:`** — each entry is:
-  `- "<output_label>" [from step N: "<step_label>", tool_id: <tool_id>]`
-  - `output_label` → used verbatim in `output="..."` directives
-  - `step_label` and `tool_id` → use to infer output type and write informed prose
-  - Higher step numbers are later in the pipeline — prefer them as "terminal" outputs
-
----
-
-## Step 1 — Select which outputs to feature
-
-Not every workflow output deserves its own section. Apply these rules:
-
-**Always include:**
-- The primary result — the final, most informative output (e.g. a results table, a report, a processed dataset, a visual summary)
-- Any output that is the direct basis for the primary result and helps the user validate the pipeline worked correctly (e.g. an intermediate QC plot, a filtered file, a mask used for quantification)
-
-**Include selectively:**
-- Intermediate outputs that give meaningful insight into pipeline behaviour — useful for debugging or understanding a step's contribution
-- Prefer outputs from higher step numbers (later in the pipeline) over early intermediates
-
-**Skip or collapse:**
-- Purely intermediate outputs that are only consumed by subsequent steps and add no standalone value
-- Outputs that duplicate information already shown elsewhere in the report
-
-**When in doubt:** ask yourself — if the run produced unexpected results, which output would a user look at first to diagnose the problem? That's the one to feature.
-
-If no outputs are marked, fall back to `invocation_outputs()` with a note in prose that all outputs will appear here.
-
----
-
-## Step 2 — Classify selected outputs
-
-Use the `tool_id` and output label to infer the likely data type:
-
-| Likely type | Directive |
-|-------------|-----------|
-| Image (TIFF, PNG, JPEG, any imaging tool) | `history_dataset_as_image(output="<label>")` — also works for image collections |
-| Tabular / TSV / CSV | `history_dataset_as_table(output="<label>", show_column_headers=true, compact=true)` + `history_dataset_link(output="<label>", label="Download ...")` |
-| HTML / text report | `history_dataset_embedded(output="<label>")` |
-| Unknown / mixed | `history_dataset_display(output="<label>")` |
-
-For **inputs**:
-- Image-type input (`data_collection_input` or clearly image data) → `history_dataset_as_image(input="<label>")`
-- Non-image or multiple inputs → `invocation_inputs()`
-
----
-
-## Step 3 — Build the report
-
-### Required sections
-
-**1. Title + run timestamp**
-
-````
-# <Workflow Name>
-
-```galaxy
-invocation_time()
-```
-````
-
-**2. Summary**
-- One paragraph: what the workflow is designed to do, what inputs it expects, what outputs it should produce.
-- Drawn from `readme` and step annotations — do not copy verbatim.
-- End the section with `workflow_image()`.
-
-**3. Inputs**
-- Brief prose: what the input(s) represent and what format/type is expected.
-- Follow with the appropriate directive.
-
-**4. Key output sections** (one subsection per selected output)
-- Brief prose: what this output represents and how it was produced — phrased conditionally.
-- The appropriate directive immediately follows.
-- For processed images (masks, segmentations): explain the visual encoding conditionally ("in a successful run, white pixels should represent...").
-
-**5. Results** (when tabular outputs exist)
-- A markdown table of expected columns: name and description (factual/definitional only) — goes **before** the directive.
-- Then `history_dataset_as_table(...)` followed by `history_dataset_link(...)`.
-
-**6. Reproducibility**
-
-```galaxy
-history_link()
-```
-
-### Optional sections
-
-- `job_parameters(step="<label>", collapse="Show <step> parameters")` — for analytical steps where parameters significantly affect interpretation
-- `invocation_outputs()` — useful when the workflow has many outputs
-- `workflow_display(collapse="Show full workflow details")`
-
----
-
-## Directive Syntax Rules
-
-**Block syntax only — no exceptions:**
+**Block syntax only** — one directive per fenced block, no exceptions:
 
 ```galaxy
 directive_name(arg=value)
 ```
 
-One directive per fenced block. Never stack multiple directives in one block. The `${galaxy ...}` inline syntax does **not** work.
+---
 
-**Use only exact labels from the workflow description** — never invent, guess, abbreviate, or paraphrase a label. Copy the label string exactly as it appears (without the surrounding quotes from the description).
+## Selecting outputs
+
+Prefer terminal outputs (higher step numbers) over early intermediates. Always include the primary result. Include intermediate outputs only when they help the user validate the pipeline. Skip outputs that are consumed by subsequent steps with no standalone value. If no outputs are marked, fall back to `invocation_outputs()`.
 
 ---
 
-## Directive Reference
+## Classifying outputs
 
-### Dataset directives
+Use `tool_id` and the output label to infer type:
 
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `history_dataset_display` | Interactive dataset card | Default fallback for any dataset |
-| `history_dataset_as_image` | Embedded image | Plots, images, visual outputs — also works for collections |
-| `history_dataset_as_table` | Formatted table | Tabular results; supports `compact`, `title`, `footer`, `show_column_headers` |
-| `history_dataset_embedded` | Raw content | Small text or HTML outputs |
-| `history_dataset_link` | Download link | Inline download with custom `label` |
-| `history_dataset_peek` | First rows preview | Data snippets |
-| `history_dataset_info` | Dataset metadata | Tool output metadata |
-| `history_dataset_name` | Dataset name text | References in prose |
-| `history_dataset_type` | Datatype string | References in prose |
-| `history_dataset_index` | Composite file listing | Multi-file composite datasets |
-| `history_dataset_collection_display` | Collection browser | Paired/list collections |
+| Type | Directive |
+|------|-----------|
+| Image / image collection | `history_dataset_as_image(output="<label>")` |
+| Tabular / TSV / CSV | `history_dataset_as_table(output="<label>", show_column_headers=true, compact=true)` + `history_dataset_link(output="<label>", label="Download ...")` |
+| HTML / embedded report | `history_dataset_embedded(output="<label>")` |
+| VCF / binary / unknown | `history_dataset_link(output="<label>", label="Download ...")` |
+| Any dataset (fallback) | `history_dataset_display(output="<label>")` |
 
-### Invocation directives
+For inputs: image collections → `history_dataset_as_image(input="<label>")`, otherwise → `invocation_inputs()`.
 
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `invocation_inputs()` | All workflow inputs | Summary of submitted inputs |
-| `invocation_outputs()` | All workflow outputs | Summary of all outputs |
-| `invocation_time()` | Run timestamp | Always include at top of report |
-| `history_link()` | History import link | Always include in Reproducibility section |
+---
 
-### Job directives
+## Report structure
 
-Use only for steps listed under "Tool steps with labels" — never for inputs or outputs.
+**Required:**
+1. `# <Workflow Name>` + `invocation_time()`
+2. **Summary** — what it does, what it expects, what it should produce. End with `workflow_image()`.
+3. **Inputs** — brief prose + directive.
+4. **One section per featured output** — conditional prose + directive.
+5. **Reproducibility** — `history_link()`.
 
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `job_parameters(step=, collapse=)` | Tool parameters table | Key analytical steps |
-| `job_metrics(step=, collapse=)` | Runtime metrics | Performance documentation |
-| `tool_stdout(step=)` | Tool standard output | Capturing logs |
-| `tool_stderr(step=)` | Tool standard error | Capturing warnings |
-
-### Workflow directives
-
-| Directive | Renders | When to use |
-|-----------|---------|-------------|
-| `workflow_image()` | SVG workflow diagram | Always include in Summary section |
-| `workflow_display(collapse=)` | Step-by-step breakdown | Optional, usually collapsible |
-| `workflow_license()` | License info | Attribution / reproducibility |
-
-`collapse="<link text>"` — wraps any block directive in a collapsible section.
+**Optional:** `job_parameters(step="<label>", collapse="Show parameters")` for key analytical steps; `invocation_outputs()`; `workflow_display(collapse="...")`.
 
 ---
 
 ## Example
 
-Input description:
+**Input:**
 
 ```
-Workflow name: Histological Staining Area Quantification
+Workflow name: RNA-seq Differential Expression
+
+Readme: Quantify gene expression from RNA-seq reads and identify differentially expressed genes
+between two conditions using DESeq2. Produces a normalised count matrix and a DE results table.
 
 Inputs:
-  - 'ROI image for staining analysis' (type: data_collection_input): Brightfield TIFF images, RGB
+  - 'FASTQ reads' (type: data_collection_input): Paired-end RNA-seq reads, one collection element per sample
+  - 'Reference annotation' (type: data_input): GTF gene annotation matching the reference genome
 
-Tool steps with labels:
-  3. 'Color Deconvolution' [tool_id: toolshed.g2.bx.psu.edu/repos/.../color_deconvolution]
-  11. 'Threshold Stain Channel Collection' [tool_id: toolshed.g2.bx.psu.edu/repos/.../threshold]
-  13. 'Extract Image Features' [tool_id: toolshed.g2.bx.psu.edu/repos/.../extract_features]
+Tool steps with labels (usable in job_parameters/job_metrics):
+  2. 'HISAT2' [tool_id: toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.2.1]
+  3. 'featureCounts' [tool_id: toolshed.g2.bx.psu.edu/repos/iuc/featurecounts/featurecounts/2.0.1]
+  4. 'DESeq2' [tool_id: toolshed.g2.bx.psu.edu/repos/iuc/deseq2/deseq2/2.11.40]
 
-Workflow outputs:
-  - 'Selected Stain Channel Thresholded' [from step 11: 'Threshold Stain Channel Collection', tool_id: ...]
-  - 'Tabular File: Staining Feature Results' [from step 25: 'Tabular: Staining Feature Results', tool_id: ...]
+Workflow outputs (usable in output= directives):
+  - 'DE results' [from step 4: 'DESeq2', tool_id: toolshed.g2.bx.psu.edu/repos/iuc/deseq2/...]
+  - 'Normalised counts' [from step 4: 'DESeq2', tool_id: toolshed.g2.bx.psu.edu/repos/iuc/deseq2/...]
+  - 'MultiQC Report' [from step 1: 'MultiQC', tool_id: toolshed.g2.bx.psu.edu/repos/iuc/multiqc/...]
 ```
 
-Expected output:
+**Output:**
 
 ````markdown
-# Histological Staining Area Quantification
+# RNA-seq Differential Expression
 
 ```galaxy
 invocation_time()
@@ -227,10 +91,10 @@ invocation_time()
 
 ## Summary
 
-This workflow is designed to quantify the area and intensity of a specific stain in brightfield
-histological images. It takes a collection of input images, applies colour deconvolution to
-separate the target stain channel, then uses automated thresholding to segment positive-staining
-pixels. Per-sample measurements are collated into a single tabular output.
+This workflow is designed to quantify gene expression from paired-end RNA-seq reads and identify
+differentially expressed genes between two conditions. It expects a collection of paired-end FASTQ
+files and a GTF annotation file. If the run completes successfully, it should produce a table of
+differential expression results and a normalised count matrix.
 
 ```galaxy
 workflow_image()
@@ -238,45 +102,50 @@ workflow_image()
 
 ---
 
-## Input Images
+## Inputs
 
-The input is a list collection of brightfield microscopy images. Each element should represent
-one region of interest from a tissue section.
+The workflow expects a collection of paired-end RNA-seq FASTQ files (one element per sample) and
+a GTF gene annotation file matching the reference genome used for alignment.
 
 ```galaxy
-history_dataset_as_image(input="ROI image for staining analysis")
+invocation_inputs()
 ```
 
 ---
 
-## Staining Mask
+## Quality Control
 
-If the run completed successfully, each input image will have been converted into a binary mask
-via colour deconvolution and automated thresholding. In a successful run, white pixels represent
-positively stained regions and black pixels represent background.
+If the run completed successfully, the MultiQC report below summarises per-sample read quality,
+alignment rates, and gene body coverage across all samples.
 
 ```galaxy
-history_dataset_as_image(output="Selected Stain Channel Thresholded")
+history_dataset_embedded(output="MultiQC Report")
 ```
 
 ---
 
-## Results
+## Differential Expression Results
 
-If the workflow completed successfully, the table below shows per-sample staining measurements.
+If DESeq2 completed successfully, the table below lists genes tested for differential expression.
+Each row represents one gene.
 
 | Column | Description |
 |--------|-------------|
-| `sample_id` | Identifier derived from the input image filename |
-| `label` | Region label assigned by the thresholding step |
-| `area` | Pixel count of the positively stained region |
+| `GeneID` | Gene identifier from the annotation |
+| `baseMean` | Mean normalised count across all samples |
+| `log2FoldChange` | Estimated log2 fold change between conditions |
+| `padj` | Benjamini–Hochberg adjusted p-value |
 
 ```galaxy
-history_dataset_as_table(output="Tabular File: Staining Feature Results", show_column_headers=true, compact=true)
+history_dataset_as_table(output="DE results", show_column_headers=true, compact=true)
 ```
 
 ```galaxy
-history_dataset_link(output="Tabular File: Staining Feature Results", label="Download results (TSV)")
+history_dataset_link(output="DE results", label="Download DE results (TSV)")
+```
+
+```galaxy
+job_parameters(step="DESeq2", collapse="Show DESeq2 parameters")
 ```
 
 ---

--- a/lib/galaxy/agents/workflow_report.py
+++ b/lib/galaxy/agents/workflow_report.py
@@ -1,0 +1,25 @@
+"""
+Workflow report agent for generating markdown reports from Galaxy workflows.
+"""
+
+import logging
+from pathlib import Path
+
+from .base import (
+    GalaxyAgentDependencies,
+    SimpleGalaxyAgent,
+)
+
+log = logging.getLogger(__name__)
+
+
+class WorkflowReportAgent(SimpleGalaxyAgent):
+    """
+    Agent that generates a markdown report for a Galaxy workflow.
+    """
+
+    agent_type = "workflow_report"
+
+    def get_system_prompt(self) -> str:
+        prompt_path = Path(__file__).parent / "prompts" / "workflow_report.md"
+        return prompt_path.read_text()

--- a/lib/galaxy/agents/workflow_report.py
+++ b/lib/galaxy/agents/workflow_report.py
@@ -23,7 +23,21 @@ class WorkflowReportAgent(SimpleGalaxyAgent):
     agent_type = "workflow_report"
 
     def get_system_prompt(self) -> str:
-        return (Path(__file__).parent / "prompts" / "workflow_report.md").read_text()
+        prompts_dir = Path(__file__).parent / "prompts"
+        prompt = (prompts_dir / "workflow_report.md").read_text()
+
+        # Inject directive descriptions from page_assistant.md (single source of truth).
+        # Extract from ## Directive Descriptions up to (not including) ## Directive Examples
+        # to get the tables only — the examples use history_dataset_id= syntax which
+        # does not apply in workflow report templates.
+        page_prompt = (prompts_dir / "page_assistant.md").read_text()
+        start = page_prompt.find("## Directive Descriptions")
+        end = page_prompt.find("## Directive Examples")
+        if start != -1 and end != -1:
+            directive_docs = page_prompt[start:end].strip()
+            prompt = prompt.replace("{directive_docs}", directive_docs)
+
+        return prompt
 
     def _get_agent_config(self, key: str, default: Any = None) -> Any:
         if key == "max_query_length":

--- a/lib/galaxy/agents/workflow_report.py
+++ b/lib/galaxy/agents/workflow_report.py
@@ -4,6 +4,7 @@ Workflow report agent for generating markdown reports from Galaxy workflows.
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from galaxy.model import Workflow
 from .base import (
@@ -23,6 +24,16 @@ class WorkflowReportAgent(SimpleGalaxyAgent):
 
     def get_system_prompt(self) -> str:
         return (Path(__file__).parent / "prompts" / "workflow_report.md").read_text()
+
+    def _get_agent_config(self, key: str, default: Any = None) -> Any:
+        if key == "max_query_length":
+            # Workflow serializations are structured data that legitimately exceed the
+            # default chat query length. Raise the ceiling while still respecting any
+            # explicit admin override in inference_services config.
+            # NOTE: all other validation (prompt injection checks) still runs normally —
+            # workflow fields like readme and annotations are user-controlled.
+            default = 50000
+        return super()._get_agent_config(key, default)
 
     def _serialize_workflow(self, workflow: Workflow) -> str:
         """Serialize a Workflow into a compact structured string for the LLM prompt.

--- a/lib/galaxy/agents/workflow_report.py
+++ b/lib/galaxy/agents/workflow_report.py
@@ -5,8 +5,9 @@ Workflow report agent for generating markdown reports from Galaxy workflows.
 import logging
 from pathlib import Path
 
+from galaxy.model import Workflow
 from .base import (
-    GalaxyAgentDependencies,
+    AgentResponse,
     SimpleGalaxyAgent,
 )
 
@@ -15,11 +16,75 @@ log = logging.getLogger(__name__)
 
 class WorkflowReportAgent(SimpleGalaxyAgent):
     """
-    Agent that generates a markdown report for a Galaxy workflow.
+    Agent that generates a markdown report template for a Galaxy workflow.
     """
 
     agent_type = "workflow_report"
 
     def get_system_prompt(self) -> str:
-        prompt_path = Path(__file__).parent / "prompts" / "workflow_report.md"
-        return prompt_path.read_text()
+        return (Path(__file__).parent / "prompts" / "workflow_report.md").read_text()
+
+    def _serialize_workflow(self, workflow: Workflow) -> str:
+        """Serialize a Workflow into a compact structured string for the LLM prompt.
+
+        Extracts exactly the fields needed for report generation: input labels/types,
+        labeled tool steps (for job_parameters), and workflow output labels with their
+        originating step info (for output= directives and type inference).
+        """
+        lines = []
+
+        lines.append(f"Workflow name: {workflow.name}")
+
+        if workflow.readme:
+            lines.append(f"\nReadme:\n{workflow.readme}")
+
+        # Inputs — include type so the LLM can pick the right directive
+        # (data_collection_input → history_dataset_as_image for image collections,
+        #  data_input → depends on content, but invocation_inputs() always works)
+        input_steps = [s for s in workflow.input_steps if s.label or s.effective_label]
+        if input_steps:
+            lines.append("\nInputs:")
+            for step in input_steps:
+                label = step.effective_label or step.label
+                annotation = step.annotations[0].annotation if step.annotations else ""
+                lines.append(f"  - {label!r} (type: {step.type}): {annotation}")
+
+        # Labeled tool steps — the only ones referenceable via step= directives
+        tool_steps = [
+            s for s in workflow.steps if not s.is_input_type and s.type == "tool" and (s.label or s.effective_label)
+        ]
+        if tool_steps:
+            lines.append("\nTool steps with labels (usable in job_parameters/job_metrics):")
+            for step in sorted(tool_steps, key=lambda s: s.order_index):
+                label = step.effective_label or step.label
+                annotation = f" — {step.annotations[0].annotation}" if step.annotations else ""
+                lines.append(f"  {step.order_index + 1}. {label!r} [tool_id: {step.tool_id}]{annotation}")
+
+        # Workflow outputs — include the originating step label and tool_id so the LLM
+        # can infer the likely output type (image, tabular, HTML) for directive selection
+        outputs = list(workflow.workflow_outputs)
+        if outputs:
+            lines.append("\nWorkflow outputs (usable in output= directives):")
+            for out in outputs:
+                out_label = out.label or out.output_name
+                step = out.workflow_step
+                if step:
+                    step_label = step.effective_label or step.label or f"step {step.order_index + 1}"
+                    tool_id = step.tool_id or ""
+                    lines.append(
+                        f"  - {out_label!r} [from step {step.order_index + 1}: {step_label!r}, tool_id: {tool_id}]"
+                    )
+                else:
+                    lines.append(f"  - {out_label!r}")
+
+        return "\n".join(lines)
+
+    async def generate_workflow_report(self, workflow: Workflow) -> AgentResponse:
+        """Generate a markdown report template for the given workflow."""
+        serialized = self._serialize_workflow(workflow)
+        query = (
+            "Generate a Galaxy workflow report template for the following workflow.\n\n"
+            "Output ONLY the Galaxy markdown report — no preamble, notes, or explanation.\n\n"
+            f"{serialized}"
+        )
+        return await self.process(query)

--- a/lib/galaxy/schema/agents.py
+++ b/lib/galaxy/schema/agents.py
@@ -233,3 +233,11 @@ class SystemStatus(BaseModel):
     agent_statuses: list[AgentStatus] = Field(description="Status of each agent")
     system_health: str = Field(description="Overall system health")
     last_check: str = Field(description="Last health check timestamp")
+
+
+class WorkflowReportResponse(BaseModel):
+    """Response from the workflow report generation agent."""
+
+    report: str = Field(description="Generated markdown report for the workflow")
+    total_tokens: Optional[int] = Field(default=None, description="Total tokens consumed by the generation")
+    model: Optional[str] = Field(default=None, description="LLM model used to generate the report")

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -24,6 +24,7 @@ from pydantic import Field
 from galaxy.config import GalaxyAppConfiguration
 from galaxy.exceptions import (
     ConfigurationError,
+    MessageException,
     ObjectNotFound,
 )
 from galaxy.managers.agents import AgentService
@@ -428,6 +429,10 @@ class ChatAPI:
         agent = WorkflowReportAgent(deps)
 
         response = await agent.generate_workflow_report(workflow)
+        if response.metadata.get("validation_error"):
+            raise MessageException(response.content)
+        if response.metadata.get("error"):
+            raise MessageException(response.metadata.get("error"))
         return WorkflowReportResponse(
             report=response.content,
             total_tokens=response.metadata.get("total_tokens"),

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -33,7 +33,10 @@ from galaxy.managers.jobs import JobManager
 from galaxy.managers.markdown_util import ready_galaxy_markdown_for_export
 from galaxy.managers.workflows import WorkflowsManager
 from galaxy.model import User
-from galaxy.schema.agents import AgentResponse
+from galaxy.schema.agents import (
+    AgentResponse,
+    WorkflowReportResponse,
+)
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     ChatExchangeBatchDeletePayload,
@@ -409,7 +412,7 @@ class ChatAPI:
         instance: bool = Query(False, description="Whether the workflow_id is an instance ID"),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
-    ) -> str | None:
+    ) -> WorkflowReportResponse:
         """Generate a report for the specified workflow."""
         if not HAS_AGENTS:
             raise ConfigurationError("AI agent system is not available.")
@@ -423,8 +426,13 @@ class ChatAPI:
 
         deps = self.agent_service.create_dependencies(trans, user)
         agent = WorkflowReportAgent(deps)
+
         response = await agent.generate_workflow_report(workflow)
-        return response.content
+        return WorkflowReportResponse(
+            report=response.content,
+            total_tokens=response.metadata.get("total_tokens"),
+            model=response.metadata.get("model"),
+        )
 
     @router.put("/api/chat/exchange/{exchange_id}/feedback", unstable=True)
     def set_exchange_feedback(

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -69,7 +69,10 @@ except ImportError:
 
 # Import pydantic-ai components (required dependency)
 from pydantic_ai import Agent
-from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.exceptions import (
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+)
 
 # Keep OpenAI as a fallback option
 try:
@@ -428,7 +431,16 @@ class ChatAPI:
         deps = self.agent_service.create_dependencies(trans, user)
         agent = WorkflowReportAgent(deps)
 
-        response = await agent.generate_workflow_report(workflow)
+        try:
+            response = await agent.generate_workflow_report(workflow)
+        except ModelHTTPError as e:
+            body_msg = e.body.get("message", str(e)) if isinstance(e.body, dict) else str(e)
+            raise MessageException(f"AI model error ({e.status_code}): {body_msg}")
+        except UnexpectedModelBehavior as e:
+            raise MessageException(f"AI model returned an unexpected response: {e}")
+        except Exception as e:
+            raise MessageException(f"Failed to generate workflow report: {e}")
+
         if response.metadata.get("validation_error"):
             raise MessageException(response.content)
         if response.metadata.get("error"):

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -22,12 +22,16 @@ from fastapi import (
 from pydantic import Field
 
 from galaxy.config import GalaxyAppConfiguration
-from galaxy.exceptions import ConfigurationError
+from galaxy.exceptions import (
+    ConfigurationError,
+    ObjectNotFound,
+)
 from galaxy.managers.agents import AgentService
 from galaxy.managers.chat import ChatManager
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.jobs import JobManager
 from galaxy.managers.markdown_util import ready_galaxy_markdown_for_export
+from galaxy.managers.workflows import WorkflowsManager
 from galaxy.model import User
 from galaxy.schema.agents import AgentResponse
 from galaxy.schema.fields import DecodedDatabaseIdField
@@ -46,11 +50,15 @@ from galaxy.webapps.galaxy.api import (
 
 # Import agent system
 try:
-    from galaxy.agents import GalaxyAgentDependencies
+    from galaxy.agents import (
+        AgentType,
+        GalaxyAgentDependencies,
+    )
 
     HAS_AGENTS = True
 except ImportError:
     HAS_AGENTS = False
+    AgentType = None  # type: ignore[assignment,misc,unused-ignore]
     GalaxyAgentDependencies = None  # type: ignore[assignment,misc,unused-ignore]
 
 # Import pydantic-ai components (required dependency)
@@ -99,6 +107,7 @@ class ChatAPI:
     chat_manager: ChatManager = depends(ChatManager)
     job_manager: JobManager = depends(JobManager)
     agent_service: AgentService = depends(AgentService)
+    workflow_manager: WorkflowsManager = depends(WorkflowsManager)
 
     @router.post("/api/chat", unstable=True)
     async def query(
@@ -389,6 +398,32 @@ class ChatAPI:
         job = self.job_manager.get_accessible_job(trans, job_id)
         chat_response = self.chat_manager.set_feedback_for_job(trans, job.id, feedback)
         return chat_response.messages[0].feedback
+
+    @router.get("/api/chat/{workflow_id}/generate_report", unstable=True)
+    async def generate_report(
+        self,
+        workflow_id: str = Path(..., description="Workflow ID to generate the report for"),
+        version: Optional[int] = Query(None, description="Version of the workflow"),
+        instance: bool = Query(False, description="Whether the workflow_id is an instance ID"),
+        trans: ProvidesUserContext = DependsOnTrans,
+        user: User = DependsOnUser,
+    ) -> str | None:
+        """Generate a report for the specified workflow."""
+        # TODO: Need to handle version (ik there's a way to first deal with version, then check instance)
+        workflow = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id, by_stored_id=not instance)
+        if not workflow:
+            raise ObjectNotFound("Workflow not found.")
+        if not HAS_AGENTS:
+            raise ConfigurationError("AI agent system is not available.")
+        assert AgentType is not None
+
+        response = await self.agent_service.execute_agent(
+            agent_type=AgentType.WORKFLOW_REPORT,
+            query=workflow.name,
+            trans=trans,
+            user=user,
+        )
+        return response.content
 
     @router.put("/api/chat/exchange/{exchange_id}/feedback", unstable=True)
     def set_exchange_feedback(

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -53,6 +53,7 @@ try:
     from galaxy.agents import (
         AgentType,
         GalaxyAgentDependencies,
+        WorkflowReportAgent,
     )
 
     HAS_AGENTS = True
@@ -60,6 +61,7 @@ except ImportError:
     HAS_AGENTS = False
     AgentType = None  # type: ignore[assignment,misc,unused-ignore]
     GalaxyAgentDependencies = None  # type: ignore[assignment,misc,unused-ignore]
+    WorkflowReportAgent = None  # type: ignore[assignment,misc,unused-ignore]
 
 # Import pydantic-ai components (required dependency)
 from pydantic_ai import Agent
@@ -409,20 +411,19 @@ class ChatAPI:
         user: User = DependsOnUser,
     ) -> str | None:
         """Generate a report for the specified workflow."""
-        # TODO: Need to handle version (ik there's a way to first deal with version, then check instance)
-        workflow = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id, by_stored_id=not instance)
-        if not workflow:
-            raise ObjectNotFound("Workflow not found.")
         if not HAS_AGENTS:
             raise ConfigurationError("AI agent system is not available.")
-        assert AgentType is not None
+        assert WorkflowReportAgent is not None
 
-        response = await self.agent_service.execute_agent(
-            agent_type=AgentType.WORKFLOW_REPORT,
-            query=workflow.name,
-            trans=trans,
-            user=user,
-        )
+        stored = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id, by_stored_id=not instance)
+        if not stored:
+            raise ObjectNotFound("Workflow not found.")
+
+        workflow = stored.get_internal_version(version) if version is not None else stored.latest_workflow
+
+        deps = self.agent_service.create_dependencies(trans, user)
+        agent = WorkflowReportAgent(deps)
+        response = await agent.generate_workflow_report(workflow)
         return response.content
 
     @router.put("/api/chat/exchange/{exchange_id}/feedback", unstable=True)


### PR DESCRIPTION
This adds a `WorkflowReportAgent` to the existing Galaxy agentic framework that summarizes a workflow and creates a report template in the workflow editor.

The new `/api/chat/{workflow_id}/generate_report"` API serializes workflow information (steps, inputs, outputs, comments, readme etc.) into the query, creates an allowlist of exact step/input/output labels that can be used and a very repeatable report structure it should create.

From there we use the `WorkflowReportAgent` to generate the report. This is fully based on the `workflow-reports` skill in the https://github.com/galaxyproject/galaxy-skills repo (https://github.com/galaxyproject/galaxy-skills/tree/600e1a68435e9f240dc3c4fdcd8e2d73df5790fb/workflow-reports).

https://github.com/user-attachments/assets/fb62ffde-470a-48e1-96eb-234466e408c0
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
