### PR TITLE
ChatGXY UI improvements and exchange management

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -121,6 +121,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/exchange/{exchange_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Exchange
+         * @description **Warning**: This API is unstable and may change without notice.
+         */
+        delete: operations["delete_exchange_api_chat_exchange__exchange_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chat/exchange/{exchange_id}/feedback": {
         parameters: {
             query?: never;
@@ -154,6 +174,26 @@ export interface paths {
          */
         get: operations["get_exchange_messages_api_chat_exchange__exchange_id__messages_get"];
         put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/exchanges/batch/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Batch Delete Exchanges
+         * @description **Warning**: This API is unstable and may change without notice.
+         */
+        put: operations["batch_delete_exchanges_api_chat_exchanges_batch_delete_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -8194,6 +8234,14 @@ export interface components {
             tools?: components["schemas"]["ChatTool"][] | null;
         } & {
             [key: string]: unknown;
+        };
+        /** ChatExchangeBatchDeletePayload */
+        ChatExchangeBatchDeletePayload: {
+            /**
+             * Exchange IDs
+             * @description List of chat exchange IDs to delete.
+             */
+            ids: string[];
         };
         /** ChatMessage */
         ChatMessage: {
@@ -26085,6 +26133,51 @@ export interface operations {
             };
         };
     };
+    delete_exchange_api_chat_exchange__exchange_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                exchange_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
     set_exchange_feedback_api_chat_exchange__exchange_id__feedback_put: {
         parameters: {
             query?: never;
@@ -26157,6 +26250,53 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     }[];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    batch_delete_exchanges_api_chat_exchanges_batch_delete_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChatExchangeBatchDeletePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
                 };
             };
             /** @description Request Error */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8225,7 +8225,7 @@ export interface components {
              * Exchange ID
              * @description The ID of an existing chat exchange to continue.
              */
-            exchange_id?: number | null;
+            exchange_id?: string | null;
             /**
              * Query
              * @description The query to be sent to the chatbot.
@@ -8258,7 +8258,7 @@ export interface components {
              * Exchange ID
              * @description The ID of the chat exchange for continuing conversations.
              */
-            exchange_id?: number | null;
+            exchange_id?: string | null;
             /**
              * Processing Time
              * @description Time taken to process the query in seconds.
@@ -26093,7 +26093,7 @@ export interface operations {
                 "run-as"?: string | null;
             };
             path: {
-                exchange_id: number;
+                exchange_id: string;
             };
             cookie?: never;
         };
@@ -26142,7 +26142,7 @@ export interface operations {
                 "run-as"?: string | null;
             };
             path: {
-                exchange_id: number;
+                exchange_id: string;
             };
             cookie?: never;
         };

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -16,6 +16,7 @@ import { useUnprivilegedToolStore } from "@/stores/unprivilegedToolStore";
 import { useUserStore } from "@/stores/userStore";
 import localize from "@/utils/localization";
 
+import ChatHistoryPanel from "../ChatGXY/ChatHistoryPanel.vue";
 import InvocationsPanel from "../Panels/InvocationsPanel.vue";
 import ActivityItem from "./ActivityItem.vue";
 import InteractiveItem from "./Items/InteractiveItem.vue";
@@ -390,6 +391,7 @@ defineExpose({
             <InvocationsPanel v-else-if="isActiveSideBar('invocation')" />
             <VisualizationPanel v-else-if="isActiveSideBar('visualizations')" />
             <MultiviewPanel v-else-if="isActiveSideBar('multiview')" />
+            <ChatHistoryPanel v-else-if="isActiveSideBar('chatgxy')" />
             <NotificationsPanel v-else-if="isActiveSideBar('notifications')" />
             <UserToolPanel v-if="isActiveSideBar('user-defined-tools')" in-panel />
             <InteractiveToolsPanel v-else-if="isActiveSideBar('interactivetools')" />

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -304,6 +304,7 @@ defineExpose({
                                 :tooltip="activity.tooltip"
                                 :to="activity.to ?? undefined"
                                 :variant="activity.variant"
+                                :window-title="activity.windowTitle"
                                 @click="onActivityClicked(activity)" />
                         </div>
                     </div>

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -6,6 +6,7 @@ import type { Placement } from "@popperjs/core";
 import { computed } from "vue";
 import { useRouter } from "vue-router/composables";
 
+import { getGalaxyInstance } from "@/app";
 import { useActivityStore } from "@/stores/activityStore";
 import type { ActivityVariant } from "@/stores/activityStoreTypes";
 import localize from "@/utils/localization";
@@ -36,6 +37,7 @@ export interface Props {
     options?: Option[];
     to?: string;
     variant?: ActivityVariant;
+    windowTitle?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -51,6 +53,7 @@ const props = withDefaults(defineProps<Props>(), {
     tooltip: undefined,
     tooltipPlacement: "right",
     variant: "primary",
+    windowTitle: undefined,
 });
 
 const emit = defineEmits<{
@@ -60,7 +63,14 @@ const emit = defineEmits<{
 function onClick(evt: MouseEvent): void {
     emit("click");
     if (props.to) {
-        router.push(props.to);
+        const Galaxy = getGalaxyInstance();
+        if (props.windowTitle && Galaxy?.frame?.active) {
+            const compactUrl = props.to + (props.to.includes("?") ? "&" : "?") + "compact=true";
+            // @ts-ignore - monkeypatched router, second arg is RouterPushOptions
+            router.push(compactUrl, { title: props.windowTitle });
+        } else {
+            router.push(props.to);
+        }
     }
 }
 

--- a/client/src/components/ChatGXY.vue
+++ b/client/src/components/ChatGXY.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { faClock, faHistory, faMagic, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faClock, faExternalLinkAlt, faHistory, faMagic, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BSkeleton } from "bootstrap-vue";
 import { nextTick, onMounted, ref, watch } from "vue";
 
 import { GalaxyApi } from "@/api";
+import { getGalaxyInstance } from "@/app";
 import { type AgentResponse, useAgentActions } from "@/composables/agentActions";
 import { useMarkdown } from "@/composables/markdown";
 import { errorMessageAsString } from "@/utils/simple-error";
@@ -20,7 +21,7 @@ import LoadingSpan from "@/components/LoadingSpan.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
 interface ChatHistoryItem {
-    id: number;
+    id: string;
     query: string;
     response: string;
     agent_type: string;
@@ -31,7 +32,7 @@ interface ChatHistoryItem {
 
 const props = withDefaults(
     defineProps<{
-        exchangeId?: number;
+        exchangeId?: string;
         compact?: boolean;
     }>(),
     {
@@ -49,7 +50,7 @@ const selectedAgentType = ref("auto");
 const showHistory = ref(false);
 const chatHistory = ref<ChatHistoryItem[]>([]);
 const loadingHistory = ref(false);
-const currentChatId = ref<number | null>(null);
+const currentChatId = ref<string | null>(null);
 const hasLoadedInitialChat = ref(false);
 
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true, removeNewlinesAfterList: true });
@@ -253,7 +254,7 @@ async function clearHistory() {
     }
 }
 
-async function fetchConversation(exchangeId: number): Promise<boolean> {
+async function fetchConversation(exchangeId: string): Promise<boolean> {
     const { data: fullConversation } = await GalaxyApi().GET(`/api/chat/exchange/{exchange_id}/messages`, {
         params: {
             path: { exchange_id: exchangeId },
@@ -335,7 +336,7 @@ function loadSingleMessageFallback(item: ChatHistoryItem) {
     nextTick(() => scrollToBottom(chatContainer.value));
 }
 
-async function loadChatById(exchangeId: number) {
+async function loadChatById(exchangeId: string) {
     try {
         const loaded = await fetchConversation(exchangeId);
         if (loaded) {
@@ -382,6 +383,13 @@ function startNewChat() {
     errorMessage.value = "";
 }
 
+function popOutToScratchbook() {
+    const Galaxy = getGalaxyInstance();
+    const path = currentChatId.value ? `/chatgxy/${currentChatId.value}` : "/chatgxy";
+    const url = `${path}?compact=true`;
+    Galaxy.frame.add({ title: "ChatGXY", url });
+}
+
 function toggleHistory() {
     showHistory.value = !showHistory.value;
     if (showHistory.value && chatHistory.value.length === 0) {
@@ -407,6 +415,12 @@ function toggleHistory() {
                     :title="showHistory ? 'Hide History' : 'Show History'"
                     @click="toggleHistory">
                     <FontAwesomeIcon :icon="faHistory" fixed-width />
+                </button>
+                <button
+                    class="btn btn-sm btn-outline-primary"
+                    title="Open in floating window"
+                    @click="popOutToScratchbook">
+                    <FontAwesomeIcon :icon="faExternalLinkAlt" fixed-width />
                 </button>
             </div>
         </div>

--- a/client/src/components/ChatGXY.vue
+++ b/client/src/components/ChatGXY.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faClock, faExternalLinkAlt, faHistory, faMagic, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faMagic, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BSkeleton } from "bootstrap-vue";
 import { nextTick, onMounted, ref, watch } from "vue";
@@ -10,15 +10,13 @@ import { type AgentResponse, useAgentActions } from "@/composables/agentActions"
 import { useMarkdown } from "@/composables/markdown";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import { getAgentIcon, getAgentLabel } from "./ChatGXY/agentTypes";
+import { getAgentIcon } from "./ChatGXY/agentTypes";
 import type { ChatMessage } from "./ChatGXY/chatTypes";
 import { generateId, scrollToBottom } from "./ChatGXY/chatUtils";
 
 import ChatInput from "./ChatGXY/ChatInput.vue";
 import ChatMessageCell from "./ChatGXY/ChatMessageCell.vue";
 import Heading from "@/components/Common/Heading.vue";
-import LoadingSpan from "@/components/LoadingSpan.vue";
-import UtcDate from "@/components/UtcDate.vue";
 
 interface ChatHistoryItem {
     id: string;
@@ -47,9 +45,6 @@ const errorMessage = ref("");
 const busy = ref(false);
 const chatContainer = ref<HTMLElement>();
 const selectedAgentType = ref("auto");
-const showHistory = ref(false);
-const chatHistory = ref<ChatHistoryItem[]>([]);
-const loadingHistory = ref(false);
 const currentChatId = ref<string | null>(null);
 const hasLoadedInitialChat = ref(false);
 
@@ -64,20 +59,38 @@ onMounted(async () => {
     }
 
     if (!hasLoadedInitialChat.value) {
-        messages.value.push({
-            id: generateId(),
-            role: "assistant",
-            content:
-                "Welcome to ChatGXY. Ask about tools, workflows, errors, or data quality " +
-                "and your question will be routed to the appropriate specialist agent.",
-            timestamp: new Date(),
-            agentType: "router",
-            confidence: "high",
-            feedback: null,
-            isSystemMessage: true,
-        });
+        showWelcome();
     }
 });
+
+watch(
+    () => props.exchangeId,
+    async (newId, oldId) => {
+        if (newId === oldId) {
+            return;
+        }
+        if (newId) {
+            await loadChatById(newId);
+        } else {
+            startNewChat();
+        }
+    },
+);
+
+function showWelcome() {
+    messages.value.push({
+        id: generateId(),
+        role: "assistant",
+        content:
+            "Welcome to ChatGXY. Ask about tools, workflows, errors, or data quality " +
+            "and your question will be routed to the appropriate specialist agent.",
+        timestamp: new Date(),
+        agentType: "router",
+        confidence: "high",
+        feedback: null,
+        isSystemMessage: true,
+    });
+}
 
 async function submitQuery() {
     if (!query.value.trim()) {
@@ -121,7 +134,7 @@ async function submitQuery() {
             const errorMsg: ChatMessage = {
                 id: generateId(),
                 role: "assistant",
-                content: `❌ Error: ${errorMessage.value}`,
+                content: `Error: ${errorMessage.value}`,
                 timestamp: new Date(),
                 agentType: selectedAgentType.value,
                 confidence: "low",
@@ -162,7 +175,7 @@ async function submitQuery() {
         const errorMsg: ChatMessage = {
             id: generateId(),
             role: "assistant",
-            content: `❌ Unexpected error occurred. Please try again.`,
+            content: "Unexpected error occurred. Please try again.",
             timestamp: new Date(),
             agentType: selectedAgentType.value,
             confidence: "low",
@@ -212,48 +225,6 @@ async function sendFeedback(messageId: string, value: "up" | "down") {
     }
 }
 
-async function loadChatHistory() {
-    loadingHistory.value = true;
-    try {
-        const { data, error } = await GalaxyApi().GET("/api/chat/history", {
-            params: {
-                query: { limit: 50 },
-            },
-        });
-
-        if (data && !error) {
-            chatHistory.value = data as unknown as ChatHistoryItem[];
-        }
-    } catch (e) {
-        console.error("Failed to load chat history:", e);
-    } finally {
-        loadingHistory.value = false;
-    }
-}
-
-async function clearHistory() {
-    if (!confirm("Are you sure you want to clear your chat history?")) {
-        return;
-    }
-
-    try {
-        const { data, error } = await GalaxyApi().DELETE("/api/chat/history");
-        if (!error && data) {
-            console.log("Clear history response:", data);
-            chatHistory.value = [];
-            if (currentChatId.value) {
-                startNewChat();
-            }
-        } else if (error) {
-            console.error("Failed to clear history - API error:", error);
-            alert("Failed to clear history. Please try again.");
-        }
-    } catch (e) {
-        console.error("Failed to clear history - exception:", e);
-        alert("Failed to clear history. Please try again.");
-    }
-}
-
 async function fetchConversation(exchangeId: string): Promise<boolean> {
     const { data: fullConversation } = await GalaxyApi().GET(`/api/chat/exchange/{exchange_id}/messages`, {
         params: {
@@ -293,49 +264,6 @@ async function fetchConversation(exchangeId: string): Promise<boolean> {
     return true;
 }
 
-async function loadPreviousChat(item: ChatHistoryItem) {
-    try {
-        const loaded = await fetchConversation(item.id);
-        if (!loaded) {
-            loadSingleMessageFallback(item);
-        }
-        showHistory.value = false;
-    } catch (error) {
-        console.error("Error loading full conversation:", error);
-        loadSingleMessageFallback(item);
-    }
-}
-
-function loadSingleMessageFallback(item: ChatHistoryItem) {
-    const userMessage: ChatMessage = {
-        id: `hist-user-${item.id}`,
-        role: "user",
-        content: item.query,
-        timestamp: new Date(item.timestamp),
-        feedback: null,
-    };
-
-    const assistantMessage: ChatMessage = {
-        id: `hist-assistant-${item.id}`,
-        role: "assistant",
-        content: item.response,
-        timestamp: new Date(item.timestamp),
-        agentType: item.agent_type,
-        confidence: item.agent_response?.confidence || "medium",
-        feedback: item.feedback === 1 ? "up" : item.feedback === 0 ? "down" : null,
-    };
-
-    if (item.agent_response) {
-        assistantMessage.agentResponse = item.agent_response;
-        assistantMessage.suggestions = item.agent_response.suggestions || [];
-    }
-
-    messages.value = [userMessage, assistantMessage];
-    currentChatId.value = item.id;
-    showHistory.value = false;
-    nextTick(() => scrollToBottom(chatContainer.value));
-}
-
 async function loadChatById(exchangeId: string) {
     try {
         const loaded = await fetchConversation(exchangeId);
@@ -357,8 +285,14 @@ async function loadLatestChat() {
 
         if (data && !error && data.length > 0) {
             const latestChat = data[0] as unknown as ChatHistoryItem;
-            await loadPreviousChat(latestChat);
-            hasLoadedInitialChat.value = true;
+            try {
+                const loaded = await fetchConversation(latestChat.id);
+                if (loaded) {
+                    hasLoadedInitialChat.value = true;
+                }
+            } catch (e) {
+                console.error("Error loading latest conversation:", e);
+            }
         }
     } catch (e) {
         console.error("Failed to load latest chat:", e);
@@ -389,13 +323,6 @@ function popOutToScratchbook() {
     const url = `${path}?compact=true`;
     Galaxy.frame.add({ title: "ChatGXY", url });
 }
-
-function toggleHistory() {
-    showHistory.value = !showHistory.value;
-    if (showHistory.value && chatHistory.value.length === 0) {
-        loadChatHistory();
-    }
-}
 </script>
 
 <template>
@@ -410,13 +337,6 @@ function toggleHistory() {
                     New
                 </button>
                 <button
-                    class="btn btn-sm"
-                    :class="showHistory ? 'btn-primary' : 'btn-outline-primary'"
-                    :title="showHistory ? 'Hide History' : 'Show History'"
-                    @click="toggleHistory">
-                    <FontAwesomeIcon :icon="faHistory" fixed-width />
-                </button>
-                <button
                     class="btn btn-sm btn-outline-primary"
                     title="Open in floating window"
                     @click="popOutToScratchbook">
@@ -425,64 +345,27 @@ function toggleHistory() {
             </div>
         </div>
 
-        <div class="chatgxy-body">
-            <!-- History Sidebar -->
-            <div v-if="showHistory && !compact" class="history-sidebar">
-                <div class="history-header">
-                    <h5>Chat History</h5>
-                    <button class="btn btn-sm btn-link text-danger p-0" title="Clear History" @click="clearHistory">
-                        <FontAwesomeIcon :icon="faTrash" />
-                    </button>
-                </div>
+        <div ref="chatContainer" class="chat-messages">
+            <ChatMessageCell
+                v-for="message in messages"
+                :key="message.id"
+                :message="message"
+                :render-markdown="renderMarkdown"
+                :processing-action="processingAction"
+                @feedback="sendFeedback"
+                @handle-action="handleAction" />
 
-                <div v-if="loadingHistory" class="text-center p-3">
-                    <LoadingSpan message="Loading history..." />
-                </div>
-
-                <div v-else-if="chatHistory.length === 0" class="text-muted p-3 text-center">No chat history yet</div>
-
-                <div v-else class="history-list">
-                    <div
-                        v-for="item in chatHistory"
-                        :key="item.id"
-                        class="history-item"
-                        @click="() => loadPreviousChat(item)">
-                        <div class="history-query">{{ item.query }}</div>
-                        <div class="history-meta">
-                            <span class="history-agent">
-                                <FontAwesomeIcon :icon="getAgentIcon(item.agent_type)" fixed-width />
-                            </span>
-                            <span class="history-time">
-                                <FontAwesomeIcon :icon="faClock" class="mr-1" />
-                                <UtcDate :date="item.timestamp" mode="elapsed" />
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Main Chat Area -->
-            <div ref="chatContainer" class="chat-messages flex-grow-1">
-                <ChatMessageCell
-                    v-for="message in messages"
-                    :key="message.id"
-                    :message="message"
-                    :render-markdown="renderMarkdown"
-                    :processing-action="processingAction"
-                    @feedback="sendFeedback"
-                    @handle-action="handleAction" />
-
-                <!-- Loading state -->
-                <div v-if="busy" class="notebook-cell response-cell loading-cell">
-                    <div class="cell-label">
+            <!-- Loading state -->
+            <div v-if="busy" class="loading-entry">
+                <div class="loading-gutter">
+                    <span class="loading-indicator">
                         <FontAwesomeIcon :icon="getAgentIcon(selectedAgentType)" fixed-width />
-                        <span>{{ getAgentLabel(selectedAgentType) }}</span>
-                    </div>
-                    <div class="cell-content">
-                        <BSkeleton animation="wave" width="85%" />
-                        <BSkeleton animation="wave" width="55%" />
-                        <BSkeleton animation="wave" width="70%" />
-                    </div>
+                    </span>
+                </div>
+                <div class="loading-body">
+                    <BSkeleton animation="wave" width="85%" />
+                    <BSkeleton animation="wave" width="55%" />
+                    <BSkeleton animation="wave" width="70%" />
                 </div>
             </div>
         </div>
@@ -531,12 +414,6 @@ function toggleHistory() {
     }
 }
 
-.chatgxy-body {
-    flex: 1;
-    display: flex;
-    overflow: hidden;
-}
-
 .chatgxy-footer {
     padding: 0.75rem 1rem;
     background: $panel-bg-color;
@@ -551,113 +428,35 @@ function toggleHistory() {
     background: $white;
 }
 
-// Loading skeleton cell (stays in parent since it's not a real message)
-.notebook-cell {
-    margin-bottom: 1rem;
+// Loading skeleton
+.loading-entry {
+    display: flex;
+    gap: 0;
+    margin-top: 1.25rem;
     animation: fadeIn 0.2s ease-out;
-
-    &.response-cell {
-        .cell-label {
-            color: $text-muted;
-        }
-
-        .cell-content {
-            border-left: 3px solid $brand-secondary;
-            background: $panel-bg-color;
-            padding: 0.75rem 1rem;
-        }
-
-        &.loading-cell {
-            .cell-content {
-                opacity: 0.7;
-            }
-        }
-    }
 }
 
-.cell-label {
-    display: flex;
+.loading-gutter {
+    flex-shrink: 0;
+    width: 2rem;
+    padding-top: 0.125rem;
+}
+
+.loading-indicator {
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.025em;
-    margin-bottom: 0.375rem;
-    padding-left: 0.25rem;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: rgba($brand-primary, 0.08);
+    color: $brand-primary;
+    font-size: 0.65rem;
 }
 
-.cell-content {
-    border-radius: $border-radius-base;
-    word-wrap: break-word;
-    line-height: 1.6;
-}
-
-// History sidebar
-.history-sidebar {
-    width: 280px;
-    border-right: $border-default;
-    background: $panel-bg-color;
-    display: flex;
-    flex-direction: column;
-
-    .history-header {
-        padding: 0.75rem 1rem;
-        border-bottom: $border-default;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-
-        h5 {
-            margin: 0;
-            font-size: 0.875rem;
-            font-weight: 600;
-            color: $text-color;
-        }
-    }
-
-    .history-list {
-        flex: 1;
-        overflow-y: auto;
-    }
-
-    .history-item {
-        padding: 0.625rem 1rem;
-        border-bottom: 1px solid darken($panel-bg-color, 5%);
-        cursor: pointer;
-        transition: background-color 0.15s;
-
-        &:hover {
-            background: darken($panel-bg-color, 3%);
-        }
-
-        .history-query {
-            font-size: 0.8rem;
-            color: $text-color;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-            margin-bottom: 0.25rem;
-        }
-
-        .history-meta {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            font-size: 0.7rem;
-            color: $text-light;
-
-            .history-agent {
-                color: $brand-primary;
-            }
-
-            .history-time {
-                display: flex;
-                align-items: center;
-                gap: 0.25rem;
-            }
-        }
-    }
+.loading-body {
+    flex: 1;
+    opacity: 0.6;
 }
 
 @keyframes fadeIn {
@@ -668,12 +467,6 @@ function toggleHistory() {
     to {
         opacity: 1;
         transform: translateY(0);
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .notebook-cell {
-        animation: none;
     }
 }
 </style>

--- a/client/src/components/ChatGXY.vue
+++ b/client/src/components/ChatGXY.vue
@@ -11,22 +11,12 @@ import { useMarkdown } from "@/composables/markdown";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { getAgentIcon } from "./ChatGXY/agentTypes";
-import type { ChatMessage } from "./ChatGXY/chatTypes";
+import type { ChatHistoryItem, ChatMessage } from "./ChatGXY/chatTypes";
 import { generateId, scrollToBottom } from "./ChatGXY/chatUtils";
 
 import ChatInput from "./ChatGXY/ChatInput.vue";
 import ChatMessageCell from "./ChatGXY/ChatMessageCell.vue";
 import Heading from "@/components/Common/Heading.vue";
-
-interface ChatHistoryItem {
-    id: string;
-    query: string;
-    response: string;
-    agent_type: string;
-    agent_response?: AgentResponse;
-    timestamp: string;
-    feedback?: number | null;
-}
 
 const props = withDefaults(
     defineProps<{
@@ -41,7 +31,6 @@ const props = withDefaults(
 
 const query = ref("");
 const messages = ref<ChatMessage[]>([]);
-const errorMessage = ref("");
 const busy = ref(false);
 const chatContainer = ref<HTMLElement>();
 const selectedAgentType = ref("auto");
@@ -113,7 +102,6 @@ async function submitQuery() {
     scrollToBottom(chatContainer.value);
 
     busy.value = true;
-    errorMessage.value = "";
 
     try {
         const { data, error } = await GalaxyApi().POST("/api/chat", {
@@ -130,11 +118,11 @@ async function submitQuery() {
         });
 
         if (error) {
-            errorMessage.value = errorMessageAsString(error, "Failed to get response from ChatGXY.");
+            const errorText = errorMessageAsString(error, "Failed to get response from ChatGXY.");
             const errorMsg: ChatMessage = {
                 id: generateId(),
                 role: "assistant",
-                content: `Error: ${errorMessage.value}`,
+                content: `Error: ${errorText}`,
                 timestamp: new Date(),
                 agentType: selectedAgentType.value,
                 confidence: "low",
@@ -171,7 +159,7 @@ async function submitQuery() {
             scrollToBottom(chatContainer.value);
         }
     } catch (e) {
-        errorMessage.value = `Unexpected error: ${e}`;
+        console.error("Unexpected chat error:", e);
         const errorMsg: ChatMessage = {
             id: generateId(),
             role: "assistant",
@@ -314,7 +302,6 @@ function startNewChat() {
     ];
     currentChatId.value = null;
     query.value = "";
-    errorMessage.value = "";
 }
 
 async function deleteCurrentChat() {

--- a/client/src/components/ChatGXY.vue
+++ b/client/src/components/ChatGXY.vue
@@ -29,6 +29,17 @@ interface ChatHistoryItem {
     feedback?: number | null;
 }
 
+const props = withDefaults(
+    defineProps<{
+        exchangeId?: number;
+        compact?: boolean;
+    }>(),
+    {
+        exchangeId: undefined,
+        compact: false,
+    },
+);
+
 const query = ref("");
 const messages = ref<ChatMessage[]>([]);
 const errorMessage = ref("");
@@ -45,7 +56,11 @@ const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true, removeNewline
 const { processingAction, handleAction } = useAgentActions();
 
 onMounted(async () => {
-    await loadLatestChat();
+    if (props.exchangeId) {
+        await loadChatById(props.exchangeId);
+    } else {
+        await loadLatestChat();
+    }
 
     if (!hasLoadedInitialChat.value) {
         messages.value.push({
@@ -242,48 +257,52 @@ async function clearHistory() {
     }
 }
 
-async function loadPreviousChat(item: ChatHistoryItem) {
-    try {
-        const { data: fullConversation } = await GalaxyApi().GET(`/api/chat/exchange/{exchange_id}/messages`, {
-            params: {
-                path: {
-                    exchange_id: item.id,
-                },
-            },
-        });
+async function fetchConversation(exchangeId: number): Promise<boolean> {
+    const { data: fullConversation } = await GalaxyApi().GET(`/api/chat/exchange/{exchange_id}/messages`, {
+        params: {
+            path: { exchange_id: exchangeId },
+        },
+    });
 
-        if (fullConversation && fullConversation.length > 0) {
-            messages.value = [];
+    if (!fullConversation || fullConversation.length === 0) {
+        return false;
+    }
 
-            fullConversation.forEach((msg: any, index: number) => {
-                const message: ChatMessage = {
-                    id: `hist-${msg.role}-${item.id}-${index}`,
-                    role: msg.role as "user" | "assistant",
-                    content: msg.content,
-                    timestamp: msg.timestamp ? new Date(msg.timestamp) : new Date(),
-                    feedback: null,
-                };
+    messages.value = fullConversation.map((msg: any, index: number) => {
+        const message: ChatMessage = {
+            id: `hist-${msg.role}-${exchangeId}-${index}`,
+            role: msg.role as "user" | "assistant",
+            content: msg.content,
+            timestamp: msg.timestamp ? new Date(msg.timestamp) : new Date(),
+            feedback: null,
+        };
 
-                if (msg.role === "assistant") {
-                    message.agentType = msg.agent_type;
-                    message.confidence = msg.agent_response?.confidence || "medium";
-                    message.feedback = msg.feedback === 1 ? "up" : msg.feedback === 0 ? "down" : null;
+        if (msg.role === "assistant") {
+            message.agentType = msg.agent_type;
+            message.confidence = msg.agent_response?.confidence || "medium";
+            message.feedback = msg.feedback === 1 ? "up" : msg.feedback === 0 ? "down" : null;
 
-                    if (msg.agent_response) {
-                        message.agentResponse = msg.agent_response;
-                        message.suggestions = msg.agent_response.suggestions || [];
-                    }
-                }
-
-                messages.value.push(message);
-            });
-        } else {
-            loadSingleMessageFallback(item);
+            if (msg.agent_response) {
+                message.agentResponse = msg.agent_response;
+                message.suggestions = msg.agent_response.suggestions || [];
+            }
         }
 
-        currentChatId.value = item.id;
+        return message;
+    });
+
+    currentChatId.value = exchangeId;
+    nextTick(() => scrollToBottom(chatContainer.value));
+    return true;
+}
+
+async function loadPreviousChat(item: ChatHistoryItem) {
+    try {
+        const loaded = await fetchConversation(item.id);
+        if (!loaded) {
+            loadSingleMessageFallback(item);
+        }
         showHistory.value = false;
-        nextTick(() => scrollToBottom(chatContainer.value));
     } catch (error) {
         console.error("Error loading full conversation:", error);
         loadSingleMessageFallback(item);
@@ -318,6 +337,17 @@ function loadSingleMessageFallback(item: ChatHistoryItem) {
     currentChatId.value = item.id;
     showHistory.value = false;
     nextTick(() => scrollToBottom(chatContainer.value));
+}
+
+async function loadChatById(exchangeId: number) {
+    try {
+        const loaded = await fetchConversation(exchangeId);
+        if (loaded) {
+            hasLoadedInitialChat.value = true;
+        }
+    } catch (e) {
+        console.error("Failed to load chat by ID:", e);
+    }
 }
 
 async function loadLatestChat() {
@@ -365,8 +395,8 @@ function toggleHistory() {
 </script>
 
 <template>
-    <div class="chatgxy-container">
-        <div class="chatgxy-header">
+    <div class="chatgxy-container" :class="{ 'chatgxy-compact': compact }">
+        <div v-if="!compact" class="chatgxy-header">
             <Heading h2 :icon="faMagic" size="lg">
                 <span>ChatGXY</span>
             </Heading>
@@ -387,7 +417,7 @@ function toggleHistory() {
 
         <div class="chatgxy-body">
             <!-- History Sidebar -->
-            <div v-if="showHistory" class="history-sidebar">
+            <div v-if="showHistory && !compact" class="history-sidebar">
                 <div class="history-header">
                     <h5>Chat History</h5>
                     <button class="btn btn-sm btn-link text-danger p-0" title="Clear History" @click="clearHistory">
@@ -463,6 +493,18 @@ function toggleHistory() {
     background: $white;
     border-radius: $border-radius-large;
     overflow: hidden;
+}
+
+.chatgxy-compact {
+    height: 100vh;
+
+    .chat-messages {
+        padding: 0.75rem 1rem;
+    }
+
+    .chatgxy-footer {
+        padding: 0.5rem 0.75rem;
+    }
 }
 
 .chatgxy-header {

--- a/client/src/components/ChatGXY.vue
+++ b/client/src/components/ChatGXY.vue
@@ -67,12 +67,8 @@ onMounted(async () => {
             id: generateId(),
             role: "assistant",
             content:
-                "👋 Welcome to ChatGXY! I can help you with:\n\n" +
-                "• **Finding the right tools** for your analysis\n" +
-                "• **Debugging errors** in your workflows\n" +
-                "• **Optimizing performance** of your pipelines\n" +
-                "• **Checking data quality** issues\n\n" +
-                "Just ask me anything about Galaxy and I'll route your question to the right specialist!",
+                "Welcome to ChatGXY. Ask about tools, workflows, errors, or data quality " +
+                "and your question will be routed to the appropriate specialist agent.",
             timestamp: new Date(),
             agentType: "router",
             confidence: "high",
@@ -373,7 +369,7 @@ function startNewChat() {
         {
             id: generateId(),
             role: "assistant",
-            content: "👋 Starting a new conversation! How can I help you today?",
+            content: "New conversation started. How can I help?",
             timestamp: new Date(),
             agentType: "router",
             confidence: "high",
@@ -491,7 +487,7 @@ function toggleHistory() {
     display: flex;
     flex-direction: column;
     background: $white;
-    border-radius: $border-radius-large;
+    border-radius: 0.5rem;
     overflow: hidden;
 }
 
@@ -531,6 +527,7 @@ function toggleHistory() {
     padding: 0.75rem 1rem;
     background: $panel-bg-color;
     border-top: $border-default;
+    box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .chat-messages {
@@ -657,6 +654,12 @@ function toggleHistory() {
     to {
         opacity: 1;
         transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .notebook-cell {
+        animation: none;
     }
 }
 </style>

--- a/client/src/components/ChatGXY.vue
+++ b/client/src/components/ChatGXY.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faExternalLinkAlt, faMagic, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt, faMagic, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BSkeleton } from "bootstrap-vue";
 import { nextTick, onMounted, ref, watch } from "vue";
@@ -317,6 +317,22 @@ function startNewChat() {
     errorMessage.value = "";
 }
 
+async function deleteCurrentChat() {
+    if (!currentChatId.value) {
+        return;
+    }
+    try {
+        const { error } = await GalaxyApi().DELETE("/api/chat/exchange/{exchange_id}", {
+            params: { path: { exchange_id: currentChatId.value } },
+        });
+        if (!error) {
+            startNewChat();
+        }
+    } catch (e) {
+        console.error("Failed to delete chat:", e);
+    }
+}
+
 function popOutToScratchbook() {
     const Galaxy = getGalaxyInstance();
     const path = currentChatId.value ? `/chatgxy/${currentChatId.value}` : "/chatgxy";
@@ -335,6 +351,13 @@ function popOutToScratchbook() {
                 <button class="btn btn-sm btn-outline-primary" title="Start New Chat" @click="startNewChat">
                     <FontAwesomeIcon :icon="faPlus" fixed-width />
                     New
+                </button>
+                <button
+                    v-if="currentChatId"
+                    class="btn btn-sm btn-outline-danger"
+                    title="Delete this conversation"
+                    @click="deleteCurrentChat">
+                    <FontAwesomeIcon :icon="faTrash" fixed-width />
                 </button>
                 <button
                     class="btn btn-sm btn-outline-primary"

--- a/client/src/components/ChatGXY/ActionCard.vue
+++ b/client/src/components/ChatGXY/ActionCard.vue
@@ -111,7 +111,7 @@ function getButtonClass(priority: number): string {
     transition: all 0.15s ease;
 
     &:hover:not(:disabled) {
-        transform: translateY(-1px);
+        background: rgba($brand-primary, 0.08);
     }
 
     &:disabled {
@@ -122,5 +122,11 @@ function getButtonClass(priority: number): string {
 
 .action-text {
     white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .action-button {
+        transition: none;
+    }
 }
 </style>

--- a/client/src/components/ChatGXY/ActionCard.vue
+++ b/client/src/components/ChatGXY/ActionCard.vue
@@ -2,16 +2,17 @@
     <div v-if="suggestions.length > 0" class="action-card">
         <div class="action-header">Suggested Actions</div>
         <div class="action-list">
-            <button
+            <GButton
                 v-for="action in sortedSuggestions"
                 :key="`${action.action_type}-${action.description}`"
-                class="btn action-button"
-                :class="getButtonClass(action.priority)"
+                outline
+                size="small"
+                :color="action.priority === 1 ? 'blue' : 'grey'"
                 :disabled="processingAction"
                 @click="$emit('handle-action', action)">
                 <FontAwesomeIcon :icon="getIcon(action.action_type)" fixed-width />
-                <span class="action-text">{{ action.description }}</span>
-            </button>
+                <span>{{ action.description }}</span>
+            </GButton>
         </div>
     </div>
 </template>
@@ -32,6 +33,8 @@ import { computed } from "vue";
 
 import { type ActionSuggestion, ActionType } from "@/composables/agentActions";
 
+import GButton from "@/components/BaseComponents/GButton.vue";
+
 interface Props {
     suggestions: ActionSuggestion[];
     processingAction?: boolean;
@@ -45,7 +48,6 @@ defineEmits<{
     "handle-action": [action: ActionSuggestion];
 }>();
 
-// Sort suggestions by priority (1 = highest)
 const sortedSuggestions = computed(() => {
     return [...props.suggestions].sort((a, b) => a.priority - b.priority);
 });
@@ -61,17 +63,6 @@ const iconMap: Record<ActionType, IconDefinition> = {
 
 function getIcon(actionType: ActionType): IconDefinition {
     return iconMap[actionType] || faWrench;
-}
-
-function getButtonClass(priority: number): string {
-    switch (priority) {
-        case 1:
-            return "btn-outline-primary";
-        case 2:
-            return "btn-outline-secondary";
-        default:
-            return "btn-outline-secondary";
-    }
 }
 </script>
 
@@ -99,34 +90,5 @@ function getButtonClass(priority: number): string {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
-}
-
-.action-button {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.375rem 0.75rem;
-    font-size: 0.8rem;
-    border-radius: $border-radius-large;
-    transition: all 0.15s ease;
-
-    &:hover:not(:disabled) {
-        background: rgba($brand-primary, 0.08);
-    }
-
-    &:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
-}
-
-.action-text {
-    white-space: nowrap;
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .action-button {
-        transition: none;
-    }
 }
 </style>

--- a/client/src/components/ChatGXY/ActionCard.vue
+++ b/client/src/components/ChatGXY/ActionCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="suggestions.length > 0" class="action-card">
-        <div class="action-header">Suggested Actions</div>
+        <div class="action-header">Quick Actions</div>
         <div class="action-list">
             <GButton
                 v-for="action in sortedSuggestions"

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -49,9 +49,26 @@ async function loadHistory() {
     }
 }
 
-function handleItemClick(item: ChatHistoryItem) {
+const lastClickedIndex = ref<number | null>(null);
+
+function handleItemClick(item: ChatHistoryItem, event: MouseEvent) {
     if (selectionMode.value) {
-        toggleSelection(item.id);
+        const currentIndex = chatHistory.value.findIndex((i) => i.id === item.id);
+        if (event.shiftKey && lastClickedIndex.value !== null) {
+            const start = Math.min(lastClickedIndex.value, currentIndex);
+            const end = Math.max(lastClickedIndex.value, currentIndex);
+            const next = new Set(selectedIds.value);
+            for (let i = start; i <= end; i++) {
+                const id = chatHistory.value[i]?.id;
+                if (id) {
+                    next.add(id);
+                }
+            }
+            selectedIds.value = next;
+        } else {
+            toggleSelection(item.id);
+        }
+        lastClickedIndex.value = currentIndex;
     } else {
         router.push(`/chatgxy/${item.id}`);
     }
@@ -148,7 +165,7 @@ async function deleteSelected() {
                     :key="item.id"
                     class="history-item"
                     :class="{ selected: selectedIds.has(item.id) }"
-                    @click="handleItemClick(item)">
+                    @click="handleItemClick(item, $event)">
                     <div class="history-row">
                         <span v-if="selectionMode" class="history-checkbox">
                             <FontAwesomeIcon :icon="selectedIds.has(item.id) ? faCheckSquare : faSquare" fixed-width />

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -6,19 +6,14 @@ import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { GalaxyApi } from "@/api";
+import { getGalaxyInstance } from "@/app";
 
 import { getAgentIcon } from "./agentTypes";
+import type { ChatHistoryItem } from "./chatTypes";
 
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import UtcDate from "@/components/UtcDate.vue";
-
-interface ChatHistoryItem {
-    id: string;
-    query: string;
-    agent_type: string;
-    timestamp: string;
-}
 
 const router = useRouter();
 
@@ -70,7 +65,13 @@ function handleItemClick(item: ChatHistoryItem, event: MouseEvent) {
         }
         lastClickedIndex.value = currentIndex;
     } else {
-        router.push(`/chatgxy/${item.id}`, { title: "ChatGXY" });
+        const Galaxy = getGalaxyInstance();
+        if (Galaxy?.frame?.active) {
+            // @ts-ignore - monkeypatched router, second arg is RouterPushOptions
+            router.push(`/chatgxy/${item.id}?compact=true`, { title: "ChatGXY" });
+        } else {
+            router.push(`/chatgxy/${item.id}`);
+        }
     }
 }
 
@@ -100,7 +101,13 @@ function toggleSelectAll() {
 }
 
 function startNewChat() {
-    router.push("/chatgxy", { title: "ChatGXY" });
+    const Galaxy = getGalaxyInstance();
+    if (Galaxy?.frame?.active) {
+        // @ts-ignore - monkeypatched router, second arg is RouterPushOptions
+        router.push("/chatgxy?compact=true", { title: "ChatGXY" });
+    } else {
+        router.push("/chatgxy");
+    }
 }
 
 async function deleteSelected() {

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { faClock, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faCheckSquare, faClock, faPlus, faSquare, faTimes, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { GalaxyApi } from "@/api";
@@ -23,6 +23,10 @@ const router = useRouter();
 
 const chatHistory = ref<ChatHistoryItem[]>([]);
 const loading = ref(false);
+const selectionMode = ref(false);
+const selectedIds = ref(new Set<string>());
+
+const allSelected = computed(() => chatHistory.value.length > 0 && selectedIds.value.size === chatHistory.value.length);
 
 onMounted(() => {
     loadHistory();
@@ -44,25 +48,61 @@ async function loadHistory() {
     }
 }
 
-function selectChat(item: ChatHistoryItem) {
-    router.push(`/chatgxy/${item.id}`);
+function handleItemClick(item: ChatHistoryItem) {
+    if (selectionMode.value) {
+        toggleSelection(item.id);
+    } else {
+        router.push(`/chatgxy/${item.id}`);
+    }
+}
+
+function toggleSelectionMode() {
+    selectionMode.value = !selectionMode.value;
+    if (!selectionMode.value) {
+        selectedIds.value.clear();
+    }
+}
+
+function toggleSelection(id: string) {
+    const next = new Set(selectedIds.value);
+    if (next.has(id)) {
+        next.delete(id);
+    } else {
+        next.add(id);
+    }
+    selectedIds.value = next;
+}
+
+function toggleSelectAll() {
+    if (allSelected.value) {
+        selectedIds.value = new Set();
+    } else {
+        selectedIds.value = new Set(chatHistory.value.map((item) => item.id));
+    }
 }
 
 function startNewChat() {
     router.push("/chatgxy");
 }
 
-async function clearHistory() {
-    if (!confirm("Are you sure you want to clear your chat history?")) {
+async function deleteSelected() {
+    if (selectedIds.value.size === 0) {
         return;
     }
+    const ids = Array.from(selectedIds.value);
     try {
-        const { error } = await GalaxyApi().DELETE("/api/chat/history");
+        const { error } = await GalaxyApi().PUT("/api/chat/exchanges/batch/delete", {
+            body: { ids },
+        });
         if (!error) {
-            chatHistory.value = [];
+            chatHistory.value = chatHistory.value.filter((item) => !selectedIds.value.has(item.id));
+            selectedIds.value = new Set();
+            if (chatHistory.value.length === 0) {
+                selectionMode.value = false;
+            }
         }
     } catch (e) {
-        console.error("Failed to clear history:", e);
+        console.error("Failed to delete exchanges:", e);
     }
 }
 </script>
@@ -73,8 +113,12 @@ async function clearHistory() {
             <button class="btn btn-sm btn-outline-primary" title="New Chat" @click="startNewChat">
                 <FontAwesomeIcon :icon="faPlus" fixed-width />
             </button>
-            <button class="btn btn-sm btn-outline-danger" title="Clear History" @click="clearHistory">
-                <FontAwesomeIcon :icon="faTrash" fixed-width />
+            <button
+                class="btn btn-sm"
+                :class="selectionMode ? 'btn-outline-secondary' : 'btn-outline-danger'"
+                :title="selectionMode ? 'Cancel selection' : 'Select chats to delete'"
+                @click="toggleSelectionMode">
+                <FontAwesomeIcon :icon="selectionMode ? faTimes : faTrash" fixed-width />
             </button>
         </template>
 
@@ -84,26 +128,72 @@ async function clearHistory() {
 
         <div v-else-if="chatHistory.length === 0" class="text-muted p-3 text-center small">No chat history yet</div>
 
-        <div v-else class="history-list">
-            <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
-            <div v-for="item in chatHistory" :key="item.id" class="history-item" @click="selectChat(item)">
-                <div class="history-query">{{ item.query }}</div>
-                <div class="history-meta">
-                    <span class="history-agent">
-                        <FontAwesomeIcon :icon="getAgentIcon(item.agent_type)" fixed-width />
-                    </span>
-                    <span class="history-time">
-                        <FontAwesomeIcon :icon="faClock" class="mr-1" />
-                        <UtcDate :date="item.timestamp" mode="elapsed" />
-                    </span>
+        <template v-else>
+            <div v-if="selectionMode" class="selection-toolbar">
+                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
+                <span class="select-all-toggle" @click="toggleSelectAll">
+                    <FontAwesomeIcon :icon="allSelected ? faCheckSquare : faSquare" fixed-width />
+                    {{ allSelected ? "Deselect all" : "Select all" }}
+                </span>
+                <button class="btn btn-sm btn-danger" :disabled="selectedIds.size === 0" @click="deleteSelected">
+                    Delete {{ selectedIds.size > 0 ? selectedIds.size : "" }}
+                </button>
+            </div>
+
+            <div class="history-list">
+                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
+                <div
+                    v-for="item in chatHistory"
+                    :key="item.id"
+                    class="history-item"
+                    :class="{ selected: selectedIds.has(item.id) }"
+                    @click="handleItemClick(item)">
+                    <div class="history-row">
+                        <span v-if="selectionMode" class="history-checkbox">
+                            <FontAwesomeIcon :icon="selectedIds.has(item.id) ? faCheckSquare : faSquare" fixed-width />
+                        </span>
+                        <div class="history-content">
+                            <div class="history-query">{{ item.query }}</div>
+                            <div class="history-meta">
+                                <span class="history-agent">
+                                    <FontAwesomeIcon :icon="getAgentIcon(item.agent_type)" fixed-width />
+                                </span>
+                                <span class="history-time">
+                                    <FontAwesomeIcon :icon="faClock" class="mr-1" />
+                                    <UtcDate :date="item.timestamp" mode="elapsed" />
+                                </span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
+        </template>
     </ActivityPanel>
 </template>
 
 <style lang="scss" scoped>
 @import "@/style/scss/theme/blue.scss";
+
+.selection-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.375rem 0.5rem;
+    border-bottom: 1px solid darken($panel-bg-color, 5%);
+    font-size: 0.75rem;
+}
+
+.select-all-toggle {
+    cursor: pointer;
+    color: $text-muted;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+
+    &:hover {
+        color: $text-color;
+    }
+}
 
 .history-list {
     flex: 1;
@@ -119,6 +209,27 @@ async function clearHistory() {
 
     &:hover {
         background: darken($panel-bg-color, 3%);
+    }
+
+    &.selected {
+        background: rgba($brand-primary, 0.06);
+    }
+
+    .history-row {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.375rem;
+    }
+
+    .history-checkbox {
+        flex-shrink: 0;
+        color: $text-muted;
+        padding-top: 0.1rem;
+    }
+
+    .history-content {
+        flex: 1;
+        min-width: 0;
     }
 
     .history-query {

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { faClock, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { onMounted, ref } from "vue";
+import { useRouter } from "vue-router/composables";
+
+import { GalaxyApi } from "@/api";
+
+import { getAgentIcon } from "./agentTypes";
+
+import LoadingSpan from "@/components/LoadingSpan.vue";
+import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
+import UtcDate from "@/components/UtcDate.vue";
+
+interface ChatHistoryItem {
+    id: string;
+    query: string;
+    agent_type: string;
+    timestamp: string;
+}
+
+const router = useRouter();
+
+const chatHistory = ref<ChatHistoryItem[]>([]);
+const loading = ref(false);
+
+onMounted(() => {
+    loadHistory();
+});
+
+async function loadHistory() {
+    loading.value = true;
+    try {
+        const { data, error } = await GalaxyApi().GET("/api/chat/history", {
+            params: { query: { limit: 50 } },
+        });
+        if (data && !error) {
+            chatHistory.value = data as unknown as ChatHistoryItem[];
+        }
+    } catch (e) {
+        console.error("Failed to load chat history:", e);
+    } finally {
+        loading.value = false;
+    }
+}
+
+function selectChat(item: ChatHistoryItem) {
+    router.push(`/chatgxy/${item.id}`);
+}
+
+function startNewChat() {
+    router.push("/chatgxy");
+}
+
+async function clearHistory() {
+    if (!confirm("Are you sure you want to clear your chat history?")) {
+        return;
+    }
+    try {
+        const { error } = await GalaxyApi().DELETE("/api/chat/history");
+        if (!error) {
+            chatHistory.value = [];
+        }
+    } catch (e) {
+        console.error("Failed to clear history:", e);
+    }
+}
+</script>
+
+<template>
+    <ActivityPanel title="ChatGXY" go-to-all-title="Open ChatGXY" href="/chatgxy">
+        <template v-slot:header-buttons>
+            <button class="btn btn-sm btn-outline-primary" title="New Chat" @click="startNewChat">
+                <FontAwesomeIcon :icon="faPlus" fixed-width />
+            </button>
+            <button class="btn btn-sm btn-outline-danger" title="Clear History" @click="clearHistory">
+                <FontAwesomeIcon :icon="faTrash" fixed-width />
+            </button>
+        </template>
+
+        <div v-if="loading" class="text-center p-3">
+            <LoadingSpan message="Loading history..." />
+        </div>
+
+        <div v-else-if="chatHistory.length === 0" class="text-muted p-3 text-center small">No chat history yet</div>
+
+        <div v-else class="history-list">
+            <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
+            <div v-for="item in chatHistory" :key="item.id" class="history-item" @click="selectChat(item)">
+                <div class="history-query">{{ item.query }}</div>
+                <div class="history-meta">
+                    <span class="history-agent">
+                        <FontAwesomeIcon :icon="getAgentIcon(item.agent_type)" fixed-width />
+                    </span>
+                    <span class="history-time">
+                        <FontAwesomeIcon :icon="faClock" class="mr-1" />
+                        <UtcDate :date="item.timestamp" mode="elapsed" />
+                    </span>
+                </div>
+            </div>
+        </div>
+    </ActivityPanel>
+</template>
+
+<style lang="scss" scoped>
+@import "@/style/scss/theme/blue.scss";
+
+.history-list {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.history-item {
+    padding: 0.5rem 0.25rem;
+    border-bottom: 1px solid darken($panel-bg-color, 5%);
+    cursor: pointer;
+    transition: background-color 0.15s;
+    border-radius: $border-radius-base;
+
+    &:hover {
+        background: darken($panel-bg-color, 3%);
+    }
+
+    .history-query {
+        font-size: 0.8rem;
+        color: $text-color;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        margin-bottom: 0.2rem;
+    }
+
+    .history-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.7rem;
+        color: $text-light;
+
+        .history-agent {
+            color: $brand-primary;
+        }
+
+        .history-time {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+        }
+    }
+}
+</style>

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -70,7 +70,7 @@ function handleItemClick(item: ChatHistoryItem, event: MouseEvent) {
         }
         lastClickedIndex.value = currentIndex;
     } else {
-        router.push(`/chatgxy/${item.id}`);
+        router.push(`/chatgxy/${item.id}`, { title: "ChatGXY" });
     }
 }
 
@@ -100,7 +100,7 @@ function toggleSelectAll() {
 }
 
 function startNewChat() {
-    router.push("/chatgxy");
+    router.push("/chatgxy", { title: "ChatGXY" });
 }
 
 async function deleteSelected() {

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { faCheckSquare, faClock, faPlus, faSquare, faTimes, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faCheckSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
+import { faClock, faPlus, faTimes, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";

--- a/client/src/components/ChatGXY/ChatInput.vue
+++ b/client/src/components/ChatGXY/ChatInput.vue
@@ -69,7 +69,7 @@ function onInput(event: Event) {
 
         &:focus {
             border-color: $brand-primary;
-            box-shadow: 0 0 0 2px rgba($brand-primary, 0.1);
+            box-shadow: 0 0 0 2px rgba($brand-primary, 0.25);
             outline: none;
         }
     }

--- a/client/src/components/ChatGXY/ChatMessageCell.test.ts
+++ b/client/src/components/ChatGXY/ChatMessageCell.test.ts
@@ -50,64 +50,48 @@ function mountCell(message: ChatMessage, props: Record<string, unknown> = {}) {
 
 describe("ChatMessageCell", () => {
     describe("user messages", () => {
-        it("renders query cell with user content", () => {
+        it("renders user query with content", () => {
             const wrapper = mountCell(makeUserMessage());
-            expect(wrapper.find(".notebook-cell").classes()).toContain("query-cell");
-            expect(wrapper.find(".cell-content").text()).toBe("What tools can analyze my data?");
-        });
-
-        it("shows 'Query' label", () => {
-            const wrapper = mountCell(makeUserMessage());
-            expect(wrapper.find(".cell-label").text()).toContain("Query");
+            expect(wrapper.find(".exchange-entry").classes()).toContain("entry-query");
+            expect(wrapper.find(".query-text").text()).toBe("What tools can analyze my data?");
         });
 
         it("does not render feedback buttons", () => {
             const wrapper = mountCell(makeUserMessage());
-            expect(wrapper.find(".cell-footer").exists()).toBe(false);
+            expect(wrapper.find(".response-meta").exists()).toBe(false);
         });
     });
 
     describe("assistant messages", () => {
-        it("renders response cell", () => {
+        it("renders response entry", () => {
             const wrapper = mountCell(makeAssistantMessage());
-            expect(wrapper.find(".notebook-cell").classes()).toContain("response-cell");
+            expect(wrapper.find(".exchange-entry").classes()).toContain("entry-response");
         });
 
         it("renders markdown via renderMarkdown prop", () => {
             const wrapper = mountCell(makeAssistantMessage());
-            expect(wrapper.find(".cell-content").html()).toContain("<p>You can use the **Dataset Analyzer** tool.</p>");
+            expect(wrapper.find(".response-content").html()).toContain(
+                "<p>You can use the **Dataset Analyzer** tool.</p>",
+            );
         });
 
-        it("shows agent label from agentType", () => {
+        it("shows agent label in metadata", () => {
             const wrapper = mountCell(makeAssistantMessage({ agentType: "error_analysis" }));
-            expect(wrapper.find(".cell-label").text()).toContain("Error Analysis");
-        });
-
-        it("shows default label for unknown agentType", () => {
-            const wrapper = mountCell(makeAssistantMessage({ agentType: undefined }));
-            expect(wrapper.find(".cell-label").text()).toContain("AI Assistant");
+            const tags = wrapper.findAll(".meta-tag");
+            const labels = tags.wrappers.map((w) => w.text());
+            expect(labels.some((l) => l.includes("Error Analysis"))).toBe(true);
         });
     });
 
-    describe("routing badge", () => {
-        it("shows routing badge when handoff_info present", () => {
-            const message = makeAssistantMessage({
-                agentResponse: {
-                    content: "test",
-                    agent_type: "auto",
-                    confidence: "high",
-                    suggestions: [],
-                    metadata: { handoff_info: { source_agent: "router" } },
-                },
-            });
-            const wrapper = mountCell(message);
-            expect(wrapper.find(".routing-badge").exists()).toBe(true);
-            expect(wrapper.find(".routing-badge").text()).toContain("via Router");
+    describe("system messages", () => {
+        it("renders system notice", () => {
+            const wrapper = mountCell(makeAssistantMessage({ isSystemMessage: true, content: "Welcome" }));
+            expect(wrapper.find(".system-notice").text()).toBe("Welcome");
         });
 
-        it("hides routing badge when no handoff_info", () => {
-            const wrapper = mountCell(makeAssistantMessage());
-            expect(wrapper.find(".routing-badge").exists()).toBe(false);
+        it("does not render feedback for system messages", () => {
+            const wrapper = mountCell(makeAssistantMessage({ isSystemMessage: true }));
+            expect(wrapper.find(".response-meta").exists()).toBe(false);
         });
     });
 
@@ -141,21 +125,16 @@ describe("ChatMessageCell", () => {
 
         it("shows thanks text after feedback", () => {
             const wrapper = mountCell(makeAssistantMessage({ feedback: "up" }));
-            expect(wrapper.find(".feedback-text").text()).toBe("Thanks!");
+            expect(wrapper.find(".feedback-ack").text()).toBe("Thanks!");
         });
 
-        it("hides footer for error messages", () => {
+        it("hides meta for error messages", () => {
             const wrapper = mountCell(makeAssistantMessage({ content: "❌ Something failed" }));
-            expect(wrapper.find(".cell-footer").exists()).toBe(false);
-        });
-
-        it("hides footer for system messages", () => {
-            const wrapper = mountCell(makeAssistantMessage({ isSystemMessage: true }));
-            expect(wrapper.find(".cell-footer").exists()).toBe(false);
+            expect(wrapper.find(".response-meta").exists()).toBe(false);
         });
     });
 
-    describe("response stats", () => {
+    describe("response metadata", () => {
         it("shows model name when metadata.model present", () => {
             const message = makeAssistantMessage({
                 agentResponse: {
@@ -167,7 +146,9 @@ describe("ChatMessageCell", () => {
                 },
             });
             const wrapper = mountCell(message);
-            expect(wrapper.find(".response-stats").text()).toContain("gpt-4");
+            const tags = wrapper.findAll(".meta-tag");
+            const text = tags.wrappers.map((w) => w.text()).join(" ");
+            expect(text).toContain("gpt-4");
         });
 
         it("shows token count when metadata.total_tokens present", () => {
@@ -181,7 +162,9 @@ describe("ChatMessageCell", () => {
                 },
             });
             const wrapper = mountCell(message);
-            expect(wrapper.find(".response-stats").text()).toContain("150 tokens");
+            const tags = wrapper.findAll(".meta-tag");
+            const text = tags.wrappers.map((w) => w.text()).join(" ");
+            expect(text).toContain("150 tok");
         });
     });
 
@@ -234,7 +217,7 @@ describe("ChatMessageCell", () => {
                     FontAwesomeIcon: true,
                 },
             });
-            await wrapper.find(".action-button").trigger("click");
+            await wrapper.find(".g-button").trigger("click");
 
             const emitted = wrapper.emitted("handle-action");
             expect(emitted).toHaveLength(1);

--- a/client/src/components/ChatGXY/ChatMessageCell.vue
+++ b/client/src/components/ChatGXY/ChatMessageCell.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faThumbsDown, faThumbsUp, faUser } from "@fortawesome/free-solid-svg-icons";
+import { faThumbsDown, faThumbsUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 import type { ActionSuggestion, AgentResponse } from "@/composables/agentActions";
@@ -22,80 +22,75 @@ const emit = defineEmits<{
 </script>
 
 <template>
-    <div :class="['notebook-cell', props.message.role === 'user' ? 'query-cell' : 'response-cell']">
-        <!-- Query cell (user input) -->
-        <template v-if="props.message.role === 'user'">
-            <div class="cell-label">
-                <FontAwesomeIcon :icon="faUser" fixed-width />
-                <span>Query</span>
-            </div>
-            <div class="cell-content">{{ props.message.content }}</div>
+    <div
+        :class="[
+            'exchange-entry',
+            props.message.role === 'user' ? 'entry-query' : 'entry-response',
+            { 'entry-system': props.message.isSystemMessage },
+        ]">
+        <!-- System/welcome messages -->
+        <template v-if="props.message.isSystemMessage">
+            <div class="system-notice">{{ props.message.content }}</div>
         </template>
 
-        <!-- Response cell (assistant output) -->
+        <!-- User query -->
+        <template v-else-if="props.message.role === 'user'">
+            <div class="query-text">{{ props.message.content }}</div>
+        </template>
+
+        <!-- Assistant response -->
         <template v-else>
-            <div class="cell-label">
-                <FontAwesomeIcon :icon="getAgentIcon(props.message.agentType)" fixed-width />
-                <span>{{ getAgentLabel(props.message.agentType) }}</span>
-                <span
-                    v-if="props.message.agentResponse?.metadata?.handoff_info"
-                    class="routing-badge"
-                    :title="'Routed by ' + props.message.agentResponse.metadata.handoff_info.source_agent">
-                    via Router
-                </span>
-            </div>
-            <div class="cell-content">
-                <!-- eslint-disable-next-line vue/no-v-html -->
-                <div v-html="props.renderMarkdown(props.message.content)" />
-
-                <!-- Action suggestions -->
-                <ActionCard
-                    v-if="props.message.suggestions?.length"
-                    :suggestions="props.message.suggestions"
-                    :processing-action="props.processingAction"
-                    @handle-action="
-                        (action) => emit('handle-action', action, getAgentResponseOrEmpty(props.message.agentResponse))
-                    " />
-
-                <slot name="after-content" />
-            </div>
-            <div v-if="!props.message.content.startsWith('❌') && !props.message.isSystemMessage" class="cell-footer">
-                <div class="feedback-actions">
-                    <button
-                        class="feedback-btn"
-                        :disabled="props.message.feedback !== null"
-                        :class="{ active: props.message.feedback === 'up' }"
-                        title="Helpful"
-                        @click="emit('feedback', props.message.id, 'up')">
-                        <FontAwesomeIcon :icon="faThumbsUp" fixed-width />
-                    </button>
-                    <button
-                        class="feedback-btn"
-                        :disabled="props.message.feedback !== null"
-                        :class="{ active: props.message.feedback === 'down' }"
-                        title="Not helpful"
-                        @click="emit('feedback', props.message.id, 'down')">
-                        <FontAwesomeIcon :icon="faThumbsDown" fixed-width />
-                    </button>
-                    <span v-if="props.message.feedback" class="feedback-text">Thanks!</span>
-                </div>
-                <div class="response-stats">
-                    <span class="stat-item" :title="'Agent: ' + getAgentLabel(props.message.agentType)">
+            <div class="response-body">
+                <div class="response-gutter">
+                    <span class="agent-indicator" :title="getAgentLabel(props.message.agentType)">
                         <FontAwesomeIcon :icon="getAgentIcon(props.message.agentType)" fixed-width />
-                        {{ getAgentLabel(props.message.agentType) }}
                     </span>
-                    <span
-                        v-if="props.message.agentResponse?.metadata?.model"
-                        class="stat-item"
-                        :title="'Model: ' + props.message.agentResponse.metadata.model">
-                        {{ formatModelName(props.message.agentResponse.metadata.model) }}
-                    </span>
-                    <span
-                        v-if="props.message.agentResponse?.metadata?.total_tokens"
-                        class="stat-item"
-                        title="Tokens used">
-                        {{ props.message.agentResponse.metadata.total_tokens }} tokens
-                    </span>
+                </div>
+                <div class="response-main">
+                    <!-- eslint-disable-next-line vue/no-v-html -->
+                    <div class="response-content" v-html="props.renderMarkdown(props.message.content)" />
+
+                    <ActionCard
+                        v-if="props.message.suggestions?.length"
+                        :suggestions="props.message.suggestions"
+                        :processing-action="props.processingAction"
+                        @handle-action="
+                            (action) =>
+                                emit('handle-action', action, getAgentResponseOrEmpty(props.message.agentResponse))
+                        " />
+
+                    <slot name="after-content" />
+
+                    <div v-if="!props.message.content.startsWith('❌')" class="response-meta">
+                        <div class="meta-left">
+                            <button
+                                class="feedback-btn"
+                                :disabled="props.message.feedback !== null"
+                                :class="{ active: props.message.feedback === 'up' }"
+                                title="Helpful"
+                                @click="emit('feedback', props.message.id, 'up')">
+                                <FontAwesomeIcon :icon="faThumbsUp" fixed-width />
+                            </button>
+                            <button
+                                class="feedback-btn"
+                                :disabled="props.message.feedback !== null"
+                                :class="{ active: props.message.feedback === 'down' }"
+                                title="Not helpful"
+                                @click="emit('feedback', props.message.id, 'down')">
+                                <FontAwesomeIcon :icon="faThumbsDown" fixed-width />
+                            </button>
+                            <span v-if="props.message.feedback" class="feedback-ack">Thanks!</span>
+                        </div>
+                        <div class="meta-right">
+                            <span class="meta-tag">{{ getAgentLabel(props.message.agentType) }}</span>
+                            <span v-if="props.message.agentResponse?.metadata?.model" class="meta-tag">
+                                {{ formatModelName(props.message.agentResponse.metadata.model) }}
+                            </span>
+                            <span v-if="props.message.agentResponse?.metadata?.total_tokens" class="meta-tag">
+                                {{ props.message.agentResponse.metadata.total_tokens }} tok
+                            </span>
+                        </div>
+                    </div>
                 </div>
             </div>
         </template>
@@ -105,90 +100,111 @@ const emit = defineEmits<{
 <style lang="scss" scoped>
 @import "@/style/scss/theme/blue.scss";
 
-.notebook-cell {
-    margin-bottom: 1rem;
-    animation: fadeIn 0.2s ease-out;
+.exchange-entry {
+    animation: entryReveal 0.25s ease-out both;
 
-    &.query-cell {
-        .cell-label {
-            color: $brand-primary;
-        }
-
-        .cell-content {
-            border-left: 3px solid $brand-primary;
-            background: rgba($brand-primary, 0.07);
-            padding: 0.75rem 1rem;
-            font-size: 0.95rem;
-            color: $text-color;
-        }
-    }
-
-    &.response-cell {
-        .cell-label {
-            color: $text-muted;
-        }
-
-        .cell-content {
-            border-left: 3px solid $brand-secondary;
-            background: $panel-bg-color;
-            padding: 0.75rem 1rem;
-        }
+    & + & {
+        margin-top: 1.25rem;
     }
 }
 
-.cell-label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.025em;
-    margin-bottom: 0.375rem;
-    padding-left: 0.25rem;
-}
-
-.routing-badge {
-    font-weight: 400;
-    font-size: 0.65rem;
+// --- System messages: centered, quiet ---
+.system-notice {
+    text-align: center;
+    font-size: 0.8rem;
     color: $text-light;
-    text-transform: none;
-    cursor: help;
+    padding: 0.75rem 2rem;
+    position: relative;
+
+    &::before,
+    &::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        width: 2rem;
+        height: 1px;
+        background: $border-color;
+    }
 
     &::before {
-        content: "·";
-        margin: 0 0.25rem;
+        right: calc(100% - 2rem);
+        left: 0;
+    }
+
+    &::after {
+        left: calc(100% - 2rem);
+        right: 0;
     }
 }
 
-.cell-content {
-    border-radius: $border-radius-base;
-    word-wrap: break-word;
-    line-height: 1.6;
-
-    :deep(p:last-child) {
-        margin-bottom: 0;
+// --- User query: lightweight prompt marker ---
+.entry-query {
+    .query-text {
+        font-size: 0.925rem;
+        color: $text-color;
+        padding: 0.5rem 0.75rem;
+        border-left: 2px solid $brand-primary;
+        margin-left: 0.25rem;
     }
+}
+
+// --- Assistant response: the main content ---
+.response-body {
+    display: flex;
+    gap: 0;
+}
+
+.response-gutter {
+    flex-shrink: 0;
+    width: 2rem;
+    padding-top: 0.125rem;
+}
+
+.agent-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: rgba($brand-primary, 0.08);
+    color: $brand-primary;
+    font-size: 0.65rem;
+    cursor: default;
+}
+
+.response-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.response-content {
+    line-height: 1.65;
+    color: $text-color;
 
     :deep(p:first-child) {
         margin-top: 0;
     }
 
+    :deep(p:last-child) {
+        margin-bottom: 0;
+    }
+
     :deep(code) {
-        background: rgba($brand-dark, 0.08);
-        padding: 0.125rem 0.375rem;
+        background: rgba($brand-dark, 0.06);
+        padding: 0.1rem 0.35rem;
         border-radius: $border-radius-base;
         font-family: $font-family-monospace;
-        font-size: 0.85em;
+        font-size: 0.84em;
     }
 
     :deep(pre) {
-        background: $white;
+        background: darken($white, 1%);
         border: $border-default;
         padding: 0.75rem;
         border-radius: $border-radius-base;
         overflow-x: auto;
-        margin: 0.75rem 0;
+        margin: 0.625rem 0;
 
         code {
             background: none;
@@ -198,77 +214,121 @@ const emit = defineEmits<{
 
     :deep(ul),
     :deep(ol) {
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.625rem;
         padding-left: 1.5rem;
     }
 
     :deep(li) {
-        margin-bottom: 0.25rem;
+        margin-bottom: 0.2rem;
+    }
+
+    :deep(h1),
+    :deep(h2),
+    :deep(h3),
+    :deep(h4) {
+        margin-top: 1rem;
+        margin-bottom: 0.5rem;
+        font-weight: 600;
+
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+
+    :deep(table) {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 0.625rem 0;
+        font-size: 0.85em;
+
+        th,
+        td {
+            padding: 0.375rem 0.625rem;
+            border: $border-default;
+            text-align: left;
+        }
+
+        th {
+            background: $panel-bg-color;
+            font-weight: 600;
+        }
+    }
+
+    :deep(blockquote) {
+        border-left: 2px solid $border-color;
+        padding-left: 0.75rem;
+        color: $text-muted;
+        margin: 0.625rem 0;
     }
 }
 
-.cell-footer {
+// --- Footer metadata: compact, secondary ---
+.response-meta {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: 0.5rem;
-    padding-left: 0.25rem;
+    margin-top: 0.625rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid rgba($border-color, 0.5);
 }
 
-.feedback-actions {
+.meta-left {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.125rem;
 }
 
-.response-stats {
+.meta-right {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    font-size: 0.7rem;
+    gap: 0.5rem;
+}
+
+.meta-tag {
+    font-size: 0.675rem;
     color: $text-light;
-
-    .stat-item {
-        display: flex;
-        align-items: center;
-        gap: 0.25rem;
-    }
+    letter-spacing: 0.01em;
 }
 
 .feedback-btn {
     background: none;
     border: none;
-    padding: 0.25rem 0.5rem;
+    padding: 0.2rem 0.375rem;
     color: $text-light;
     cursor: pointer;
     border-radius: $border-radius-base;
-    transition: all 0.15s;
+    font-size: 0.75rem;
+    transition:
+        color 0.15s,
+        background 0.15s;
 
     &:hover:not(:disabled) {
         color: $brand-primary;
-        background: rgba($brand-primary, 0.08);
+        background: rgba($brand-primary, 0.06);
     }
 
     &:disabled {
         cursor: default;
-        opacity: 0.5;
+        opacity: 0.4;
     }
 
     &.active {
         color: $brand-success;
+        opacity: 1;
     }
 }
 
-.feedback-text {
-    font-size: 0.7rem;
+.feedback-ack {
+    font-size: 0.675rem;
     color: $text-light;
     margin-left: 0.25rem;
 }
 
-@keyframes fadeIn {
+// --- Animation ---
+@keyframes entryReveal {
     from {
         opacity: 0;
-        transform: translateY(4px);
+        transform: translateY(6px);
     }
     to {
         opacity: 1;
@@ -277,7 +337,7 @@ const emit = defineEmits<{
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .notebook-cell {
+    .exchange-entry {
         animation: none;
     }
 }

--- a/client/src/components/ChatGXY/ChatMessageCell.vue
+++ b/client/src/components/ChatGXY/ChatMessageCell.vue
@@ -116,7 +116,7 @@ const emit = defineEmits<{
 
         .cell-content {
             border-left: 3px solid $brand-primary;
-            background: rgba($brand-primary, 0.04);
+            background: rgba($brand-primary, 0.07);
             padding: 0.75rem 1rem;
             font-size: 0.95rem;
             color: $text-color;
@@ -273,6 +273,12 @@ const emit = defineEmits<{
     to {
         opacity: 1;
         transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .notebook-cell {
+        animation: none;
     }
 }
 </style>

--- a/client/src/components/ChatGXY/chatTypes.ts
+++ b/client/src/components/ChatGXY/chatTypes.ts
@@ -12,3 +12,13 @@ export interface ChatMessage {
     suggestions?: ActionSuggestion[];
     isSystemMessage?: boolean;
 }
+
+export interface ChatHistoryItem {
+    id: string;
+    query: string;
+    response: string;
+    agent_type: string;
+    agent_response?: AgentResponse;
+    timestamp: string;
+    feedback?: number | null;
+}

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -570,9 +570,13 @@ export function getRouter(Galaxy) {
                         component: TourList,
                     },
                     {
-                        path: "chatgxy",
+                        path: "chatgxy/:exchangeId?",
                         component: ChatGXY,
                         redirect: redirectAnon(),
+                        props: (route) => ({
+                            exchangeId: route.params.exchangeId ? parseInt(route.params.exchangeId) : undefined,
+                            compact: route.query.compact === "true",
+                        }),
                     },
                     {
                         path: "wizard",

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -574,7 +574,7 @@ export function getRouter(Galaxy) {
                         component: ChatGXY,
                         redirect: redirectAnon(),
                         props: (route) => ({
-                            exchangeId: route.params.exchangeId ? parseInt(route.params.exchangeId) : undefined,
+                            exchangeId: route.params.exchangeId || undefined,
                             compact: route.query.compact === "true",
                         }),
                     },

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -75,6 +75,7 @@ export const defaultActivities = [
         to: "/chatgxy",
         tooltip: "Chat with Galaxy AI Assistant",
         visible: true,
+        windowTitle: "ChatGXY",
     },
     {
         anonymous: true,

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -70,7 +70,7 @@ export const defaultActivities = [
         id: "chatgxy",
         mutable: false,
         optional: true,
-        panel: false,
+        panel: true,
         title: "ChatGXY",
         to: "/chatgxy",
         tooltip: "Chat with Galaxy AI Assistant",

--- a/client/src/stores/activityStoreTypes.ts
+++ b/client/src/stores/activityStoreTypes.ts
@@ -32,4 +32,6 @@ export interface Activity {
     // if activity should cause a click event
     click?: true;
     variant?: ActivityVariant;
+    // optional title for opening in scratchbook window manager
+    windowTitle?: string;
 }

--- a/lib/galaxy/managers/chat.py
+++ b/lib/galaxy/managers/chat.py
@@ -287,6 +287,29 @@ class ChatManager:
                     pydantic_messages.append(ModelResponse(parts=[TextPart(content=msg.message)]))
             return pydantic_messages
 
+    def delete_exchange(self, trans: ProvidesUserContext, exchange_id: int) -> None:
+        """Delete a single chat exchange and its messages."""
+        exchange = self.get_exchange_by_id(trans, exchange_id)
+        if not exchange:
+            raise RequestParameterInvalidException("No accessible chat exchange found with the ID provided.")
+        for message in exchange.messages:
+            trans.sa_session.delete(message)
+        trans.sa_session.delete(exchange)
+        trans.sa_session.commit()
+
+    def delete_exchanges(self, trans: ProvidesUserContext, exchange_ids: list[int]) -> int:
+        """Delete multiple chat exchanges and their messages. Returns the count deleted."""
+        count = 0
+        for exchange_id in exchange_ids:
+            exchange = self.get_exchange_by_id(trans, exchange_id)
+            if exchange:
+                for message in exchange.messages:
+                    trans.sa_session.delete(message)
+                trans.sa_session.delete(exchange)
+                count += 1
+        trans.sa_session.commit()
+        return count
+
     def get_user_chat_history(
         self, trans: ProvidesUserContext, limit: int = 50, include_job_chats: bool = False
     ) -> list[ChatExchange]:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3928,6 +3928,14 @@ class ChatResponse(BaseModel):
     )
 
 
+class ChatExchangeBatchDeletePayload(Model):
+    ids: list[DecodedDatabaseIdField] = Field(
+        ...,
+        title="Exchange IDs",
+        description="List of chat exchange IDs to delete.",
+    )
+
+
 class GenerateTourResponse(Model):
     use_datasets: bool = Field(
         ...,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3883,7 +3883,7 @@ class ChatPayload(Model):
         title="Context",
         description="The context for the chatbot.",
     )
-    exchange_id: Optional[int] = Field(
+    exchange_id: Optional[DecodedDatabaseIdField] = Field(
         default=None,
         title="Exchange ID",
         description="The ID of an existing chat exchange to continue.",
@@ -3916,7 +3916,7 @@ class ChatResponse(BaseModel):
         title="Agent Response",
         description="Full structured agent response with metadata and suggestions.",
     )
-    exchange_id: Optional[int] = Field(
+    exchange_id: Optional[EncodedDatabaseIdField] = Field(
         default=None,
         title="Exchange ID",
         description="The ID of the chat exchange for continuing conversations.",

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -27,7 +27,10 @@ from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.jobs import JobManager
 from galaxy.model import User
 from galaxy.schema.agents import AgentResponse
-from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    encode_id,
+)
 from galaxy.schema.schema import (
     ChatPayload,
     ChatResponse,
@@ -264,7 +267,7 @@ class ChatAPI:
                     data = json.loads(message.message)
                     history.append(
                         {
-                            "id": exchange.id,
+                            "id": encode_id(exchange.id),
                             "query": data.get("query", ""),
                             "response": data.get("response", ""),
                             "agent_type": data.get("agent_type", "unknown"),
@@ -333,7 +336,7 @@ class ChatAPI:
     @router.put("/api/chat/exchange/{exchange_id}/feedback", unstable=True)
     def set_exchange_feedback(
         self,
-        exchange_id: int,
+        exchange_id: DecodedDatabaseIdField,
         feedback: int = Body(..., description="Feedback value: 0 for negative, 1 for positive"),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
@@ -348,7 +351,7 @@ class ChatAPI:
     @router.get("/api/chat/exchange/{exchange_id}/messages", unstable=True)
     def get_exchange_messages(
         self,
-        exchange_id: int,
+        exchange_id: DecodedDatabaseIdField,
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
     ) -> list[dict[str, Any]]:

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -32,6 +32,7 @@ from galaxy.schema.fields import (
     encode_id,
 )
 from galaxy.schema.schema import (
+    ChatExchangeBatchDeletePayload,
     ChatPayload,
     ChatResponse,
 )
@@ -319,6 +320,32 @@ class ChatAPI:
             trans.sa_session.rollback()
             log.exception("Error clearing chat history")
             return {"message": "Error clearing history"}
+
+    @router.delete("/api/chat/exchange/{exchange_id}", unstable=True)
+    def delete_exchange(
+        self,
+        exchange_id: DecodedDatabaseIdField,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user: User = DependsOnUser,
+    ) -> dict[str, str]:
+        """Delete a single chat exchange."""
+        if not user:
+            return {"message": "No user logged in"}
+        self.chat_manager.delete_exchange(trans, exchange_id)
+        return {"message": "Deleted"}
+
+    @router.put("/api/chat/exchanges/batch/delete", unstable=True)
+    def batch_delete_exchanges(
+        self,
+        payload: ChatExchangeBatchDeletePayload,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user: User = DependsOnUser,
+    ) -> dict[str, str]:
+        """Delete multiple chat exchanges."""
+        if not user:
+            return {"message": "No user logged in"}
+        count = self.chat_manager.delete_exchanges(trans, payload.ids)
+        return {"message": f"Deleted {count} exchanges"}
 
     @router.put("/api/chat/{job_id}/feedback", unstable=True)
     def feedback(

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -235,6 +235,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route("/tours")
     webapp.add_client_route("/tours/{tour_id}")
     webapp.add_client_route("/chatgxy")
+    webapp.add_client_route("/chatgxy/{exchange_id}")
     webapp.add_client_route("/user")
     webapp.add_client_route("/user/notifications{path:.*?}")
     webapp.add_client_route("/user/{form_id}")


### PR DESCRIPTION
Polish pass on ChatGXY — better integration with Galaxy's UI patterns, conversation management, and visual cleanup.

**Routing and scratchbook support.** Conversations are now routable by exchange ID (`/chatgxy/{id}`), which means they can be opened in scratchbook floating windows just like other Galaxy views. The activity bar history panel is scratchbook-aware too — clicking a conversation opens it in a floating window when scratchbook mode is active.

**Encoded IDs.** The chat exchange API now uses Galaxy's standard encoded ID system instead of raw integers, bringing it in line with every other entity in the API.

**Message cell redesign.** The old layout had some issues — redundant "QUERY" labels on user messages, "AUTO (ROUTER)" headers that exposed internal routing plumbing, and a visually monotonous treatment where every message got the same heavy cell styling. The new layout uses a compact agent-icon gutter for assistant responses, moves metadata (agent type, model, token count) into a subtle footer, and keeps user messages lightweight. System/welcome messages are visually distinct.

**Activity bar history panel.** Chat history is now accessible from the activity bar sidebar rather than being buried inside the chat view. Supports multiselect deletion with shift-click range selection, select-all, and batch delete. There's also a delete button in the main chat header for the current conversation.

**Backend.** New `DELETE /api/chat/exchange/{exchange_id}` and `PUT /api/chat/exchanges/batch/delete` endpoints, with corresponding manager methods that handle cascade deletion of exchange messages.