### PR TITLE
Use ``os.path.join()`` or ``pathlib.Path`` instead of f-strings for filesystem paths

### DIFF
--- a/doc/source/admin/gen_diagrams.py
+++ b/doc/source/admin/gen_diagrams.py
@@ -80,4 +80,4 @@ class_to_diagram = {
 }
 
 for clazz, diagram_name in class_to_diagram.items():
-    erd.draw(clazz, out=f"{DOC_SOURCE_DIR}/{diagram_name}.png")
+    erd.draw(clazz, out=os.path.join(DOC_SOURCE_DIR, f"{diagram_name}.png"))

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -113,7 +113,7 @@ def build_command(
     # it should be preferred - at least if the directory exists.
     io_directory = "../metadata" if for_pulsar else "../outputs"
     commands_builder.capture_stdout_stderr(
-        f"{io_directory}/tool_stdout", f"{io_directory}/tool_stderr", stream_stdout_stderr=stream_stdout_stderr
+        join(io_directory, "tool_stdout"), join(io_directory, "tool_stderr"), stream_stdout_stderr=stream_stdout_stderr
     )
 
     # Don't need to create a separate tool working directory for Pulsar

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -273,7 +273,7 @@ class ChronosJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         if not os.path.exists(job_wrapper.working_directory):
             LOGGER.error("No working directory found")
 
-        path = f"{job_wrapper.working_directory}/chronos_{job_wrapper.get_id_tag()}.sh"
+        path = os.path.join(job_wrapper.working_directory, f"chronos_{job_wrapper.get_id_tag()}.sh")
         mode = 0o755
 
         with open(path, "w", encoding="utf-8") as f:

--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -237,9 +237,9 @@ class PBSJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             return
 
         # define job attributes
-        ofile = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.o"
-        efile = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.e"
-        ecfile = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.ec"
+        ofile = os.path.join(job_wrapper.working_directory, f"{job_wrapper.job_id}.o")
+        efile = os.path.join(job_wrapper.working_directory, f"{job_wrapper.job_id}.e")
+        ecfile = os.path.join(job_wrapper.working_directory, f"{job_wrapper.job_id}.ec")
 
         output_fnames = job_wrapper.job_io.get_output_fnames()
 
@@ -293,7 +293,7 @@ class PBSJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         script = self.get_job_file(
             job_wrapper, exit_code_path=ecfile, env_setup_commands=env_setup_commands, shell=job_wrapper.shell
         )
-        job_file = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.sh"
+        job_file = os.path.join(job_wrapper.working_directory, f"{job_wrapper.job_id}.sh")
         self.write_executable_script(job_file, script, job_io=job_wrapper.job_io)
         # job was deleted while we were preparing it
         if job_wrapper.get_state() in (model.Job.states.DELETED, model.Job.states.STOPPED):
@@ -537,10 +537,10 @@ class PBSJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             job_wrapper=job_wrapper,
             job_destination=job_wrapper.job_destination,
             job_id=job_id,
-            job_file=f"{job_wrapper.working_directory}/{job.id}.sh",
-            output_file=f"{job_wrapper.working_directory}/{job.id}.o",
-            error_file=f"{job_wrapper.working_directory}/{job.id}.e",
-            exit_code_file=f"{job_wrapper.working_directory}/{job.id}.ec",
+            job_file=os.path.join(job_wrapper.working_directory, f"{job.id}.sh"),
+            output_file=os.path.join(job_wrapper.working_directory, f"{job.id}.o"),
+            error_file=os.path.join(job_wrapper.working_directory, f"{job.id}.e"),
+            exit_code_file=os.path.join(job_wrapper.working_directory, f"{job.id}.ec"),
         )
         job_wrapper.command_line = job.command_line
         if job.state in (model.Job.states.RUNNING, model.Job.states.STOPPED):

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -8,7 +8,8 @@ A shallow search (default for singularity and conda generation scripts) just che
 
 import json
 import logging
-from glob import glob
+import os.path
+from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -153,7 +154,7 @@ def open_recipe_file(file, recipes_path=None, github_repo="bioconda/bioconda-rec
     Open a file at a particular location and return contents as string
     """
     if recipes_path:
-        return open(f"{recipes_path}/{file}").read()
+        return open(os.path.join(recipes_path, file)).read()
     else:  # if no clone of the repo is available locally, download from GitHub
         r = requests.get(
             f"https://raw.githubusercontent.com/{github_repo}/master/{file}",
@@ -170,7 +171,7 @@ def get_alternative_versions(filepath, filename, recipes_path=None, github_repo=
     Return files that match ``filepath/*/filename`` in the bioconda-recipes repository
     """
     if recipes_path:
-        return [n.replace(f"{recipes_path}/", "") for n in glob(f"{recipes_path}/{filepath}/*/{filename}")]
+        return [str(p.relative_to(recipes_path)) for p in Path(recipes_path).glob(f"{filepath}/*/{filename}")]
     # else use the GitHub API:
     versions = []
     r = requests.get(

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_files.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_files.py
@@ -12,10 +12,9 @@ Build all recipes discovered in tsv files in a single directory.
 
 """
 
-import glob
-import os
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import (
     Any,
     Iterator,
@@ -76,9 +75,9 @@ def main(argv=None):
 
 def generate_targets(target_source) -> Iterator[Target]:
     """Generate all targets from TSV files in specified file or directory."""
-    target_source = os.path.abspath(target_source)
-    if os.path.isdir(target_source):
-        target_source_files = glob.glob(f"{target_source}/*.tsv")
+    target_source = Path(target_source).resolve()
+    if target_source.is_dir():
+        target_source_files = target_source.glob("*.tsv")
     else:
         target_source_files = [target_source]
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_list.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_list.py
@@ -2,8 +2,8 @@
 
 import argparse
 import logging
-from glob import glob
 from html.parser import HTMLParser
+from pathlib import Path
 
 from galaxy.util import requests
 from .util import MULLED_SOCKET_TIMEOUT
@@ -61,7 +61,7 @@ def get_conda_envs(filepath):
     """
     Get list of already existing envs
     """
-    return [n.split("__")[-1].replace("@", ":") for n in glob(f"{filepath}/*")]
+    return [p.name.split("__")[-1].replace("@", ":") for p in Path(filepath).iterdir()]
 
 
 def get_missing_containers(quay_list, singularity_list, blocklist_file=None):

--- a/lib/galaxy/tool_util/loader_directory.py
+++ b/lib/galaxy/tool_util/loader_directory.py
@@ -266,12 +266,12 @@ def _find_tool_files(path_or_uri_like, recursive, enable_beta_formats):
     else:
         if enable_beta_formats:
             if not recursive:
-                files = glob.glob(f"{path}/*")
+                files = glob.glob(os.path.join(path, "*"))
             else:
                 files = _find_files(path, "*")
         else:
             if not recursive:
-                files = glob.glob(f"{path}/*.xml")
+                files = glob.glob(os.path.join(path, "*.xml"))
             else:
                 files = _find_files(path, "*.xml")
         return [os.path.abspath(_) for _ in files]

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -532,6 +532,6 @@ def _to_validator(app, validator_model: AnyValidatorModel) -> Validator:
         as_dict["tool_data_table"] = tool_data_table
     if "filename" in as_dict and app is not None:
         filename = as_dict.pop("filename")
-        as_dict["filename"] = f"{app.config.tool_data_path}/{filename}"
+        as_dict["filename"] = os.path.join(app.config.tool_data_path, filename)
 
     return validator_types[validator_type](**as_dict)

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -477,7 +477,7 @@ def _is_of_exact_type(object: Any, target_type: Type):
 
 def acts_as_simple_path_component(value: str):
     cwd = os.getcwd()
-    abs_path = os.path.abspath(f"{cwd}/{value}")
+    abs_path = os.path.abspath(os.path.join(cwd, value))
     unaffected_by_normpath = os.path.normpath(abs_path) == abs_path
     if not unaffected_by_normpath:
         return False

--- a/lib/galaxy/visualization/plugins/plugin.py
+++ b/lib/galaxy/visualization/plugins/plugin.py
@@ -48,7 +48,7 @@ class VisualizationPlugin:
         if self.static_path:
             supported_formats = ["png", "svg"]
             for file_format in supported_formats:
-                logo_path = f".{self.static_path}/logo.{file_format}"
+                logo_path = os.path.join(f".{self.static_path}", f"logo.{file_format}")
                 if os.path.isfile(logo_path):
                     self.config["logo"] = logo_path
                     return

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -1161,17 +1161,23 @@ def build_url_map(app, global_conf, **local_conf):
     # Define static mappings from config
     static_dir = get_static_from_config("static_dir", "static/")
     static_dir_bare = static_dir.directory.rstrip("/")
-    static_dist_dir = get_static_from_config("static_dist_dir", default_static_dist_dir or f"{static_dir_bare}/dist/")
+    static_dist_dir = get_static_from_config(
+        "static_dist_dir", default_static_dist_dir or os.path.join(static_dir_bare, "dist/")
+    )
     urlmap["/static"] = static_dir
     urlmap["/static/dist"] = static_dist_dir
-    urlmap["/images"] = get_static_from_config("static_images_dir", f"{static_dir_bare}/images")
-    urlmap["/static/scripts"] = get_static_from_config("static_scripts_dir", f"{static_dir_bare}/scripts/")
+    urlmap["/images"] = get_static_from_config("static_images_dir", os.path.join(static_dir_bare, "images"))
+    urlmap["/static/scripts"] = get_static_from_config("static_scripts_dir", os.path.join(static_dir_bare, "scripts/"))
 
     urlmap["/static/welcome.html"] = get_static_from_config(
-        "static_welcome_html", f"{static_dir_bare}/welcome.html", sample=default_url_path("static/welcome.sample.html")
+        "static_welcome_html",
+        os.path.join(static_dir_bare, "welcome.html"),
+        sample=default_url_path("static/welcome.sample.html"),
     )
     urlmap["/favicon.ico"] = get_static_from_config(
-        "static_favicon_dir", f"{static_dir_bare}/favicon.ico", sample=default_url_path("static/favicon.ico")
+        "static_favicon_dir",
+        os.path.join(static_dir_bare, "favicon.ico"),
+        sample=default_url_path("static/favicon.ico"),
     )
     urlmap["/robots.txt"] = get_static_from_config(
         "static_robots_txt", f"{static_dir_bare}/robots.txt", sample=default_url_path("static/robots.txt")

--- a/lib/galaxy_test/workflow/test_framework_workflows.py
+++ b/lib/galaxy_test/workflow/test_framework_workflows.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import tempfile
 from pathlib import Path
@@ -35,7 +34,7 @@ TEST_WORKFLOW_AFTER_RERUN = asbool(os.environ.get("GALAXY_TEST_WORKFLOW_AFTER_RE
 
 
 def find_workflows():
-    return [Path(p) for p in glob.glob(f"{SCRIPT_DIRECTORY}/*.gxwf.yml")]
+    return list(Path(SCRIPT_DIRECTORY).glob("*.gxwf.yml"))
 
 
 def pytest_generate_tests(metafunc):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -173,7 +173,7 @@ class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         super().handle_galaxy_config_kwds(config)
         temp_directory = cls._test_driver.mkdtemp()
         cls.object_stores_parent = temp_directory
-        cls.object_store_cache_path = f"{temp_directory}/object_store_cache"
+        cls.object_store_cache_path = os.path.join(temp_directory, "object_store_cache")
         config_path = os.path.join(temp_directory, "object_store_conf.xml")
         config["object_store_store_by"] = "uuid"
         config["metadata_strategy"] = "extended"
@@ -216,7 +216,7 @@ class BaseAzureObjectStoreIntegrationTestCase(
         cls._disable_workflow_scheduling(config)
         temp_directory = cls._test_driver.mkdtemp()
         cls.object_stores_parent = temp_directory
-        cls.object_store_cache_path = f"{temp_directory}/object_store_cache"
+        cls.object_store_cache_path = os.path.join(temp_directory, "object_store_cache")
         config_path = os.path.join(temp_directory, "object_store_conf.yml")
         config["object_store_store_by"] = "uuid"
         config["metadata_strategy"] = "extended"
@@ -264,7 +264,7 @@ class BaseRucioObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         super().handle_galaxy_config_kwds(config)
         temp_directory = cls._test_driver.mkdtemp()
         cls.object_stores_parent = temp_directory
-        cls.object_store_cache_path = f"{temp_directory}/object_store_cache"
+        cls.object_store_cache_path = os.path.join(temp_directory, "object_store_cache")
         config_path = os.path.join(temp_directory, "object_store_conf.yml")
         config["object_store_store_by"] = "uuid"
         config["metadata_strategy"] = "extended"
@@ -325,7 +325,7 @@ class BaseOnedataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCa
         super().handle_galaxy_config_kwds(config)
         temp_directory = cls._test_driver.mkdtemp()
         cls.object_stores_parent = temp_directory
-        cls.object_store_cache_path = f"{temp_directory}/object_store_cache"
+        cls.object_store_cache_path = os.path.join(temp_directory, "object_store_cache")
         config_path = os.path.join(temp_directory, "object_store_conf.xml")
         config["object_store_store_by"] = "uuid"
         config["metadata_strategy"] = "extended"

--- a/test/integration/test_datatype_upload.py
+++ b/test/integration/test_datatype_upload.py
@@ -18,9 +18,9 @@ from galaxy_test.driver import integration_util
 from .test_upload_configuration_options import BaseUploadContentConfigurationIntegrationInstance
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
-TEST_FILE_DIR = f"{SCRIPT_DIRECTORY}/../../lib/galaxy/datatypes/test"
+GALAXY_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(SCRIPT_DIRECTORY)))
+TEST_FILE_DIR = os.path.join(GALAXY_ROOT, "lib/galaxy/datatypes/test")
 TestData = collections.namedtuple("TestData", "path datatype uploadable")
-GALAXY_ROOT = os.path.abspath(f"{SCRIPT_DIRECTORY}/../../")
 DATATYPES_CONFIG = os.path.join(GALAXY_ROOT, "lib/galaxy/config/sample/datatypes_conf.xml.sample")
 PARENT_SNIFFER_MAP = {"fastqsolexa": "fastq"}
 

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -250,7 +250,7 @@ class TestAdminsCanPasteFilePaths(BaseUploadContentConfigurationTestCase):
 
     def test_admin_path_paste_libraries(self) -> None:
         library = self.library_populator.new_private_library("pathpasteallowedlibraries")
-        path = f"{TEST_DATA_DIRECTORY}/1.txt"
+        path = os.path.join(TEST_DATA_DIRECTORY, "1.txt")
         assert os.path.exists(path)
         payload, files = self.library_populator.create_dataset_request(
             library, upload_option="upload_paths", paths=path
@@ -263,7 +263,7 @@ class TestAdminsCanPasteFilePaths(BaseUploadContentConfigurationTestCase):
 
     def test_admin_path_paste_libraries_link(self) -> None:
         library = self.library_populator.new_private_library("pathpasteallowedlibraries")
-        path = f"{TEST_DATA_DIRECTORY}/1.txt"
+        path = os.path.join(TEST_DATA_DIRECTORY, "1.txt")
         assert os.path.exists(path)
         payload, files = self.library_populator.create_dataset_request(
             library, upload_option="upload_paths", paths=path, link_data=True

--- a/test/integration_selenium/test_user_library_permissions.py
+++ b/test/integration_selenium/test_user_library_permissions.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 
 from galaxy_test.selenium.framework import retry_assertion_during_transitions
 from .framework import (
@@ -28,9 +29,8 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         current_user_import_dir = os.path.join(self.user_import_dir(), email)
         os.makedirs(current_user_import_dir)
         random_filename = self._get_random_name()
-        file = open(f"{current_user_import_dir}/{random_filename}", "w")
-        file.write(random_filename)
-        file.close()
+        with open(os.path.join(current_user_import_dir, random_filename), "w") as f:
+            f.write(random_filename)
 
         # allow user to add new datasets in the newly created library
         self.create_lib_and_permit_adding(email)

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -57,7 +57,9 @@ class TestCommandFactory(TestCase):
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
         self._assert_command_is(
-            self._surround_command(f"{self.job_wrapper.shell} {self.job_wrapper.working_directory}/tool_script.sh")
+            self._surround_command(
+                f"{self.job_wrapper.shell} {os.path.join(self.job_wrapper.working_directory, 'tool_script.sh')}"
+            )
         )
         self.__assert_tool_script_is(f"#!/bin/sh\n{dep_commands[0]}; {MOCK_COMMAND_LINE}")
 

--- a/test/unit/app/tools/test_evaluation.py
+++ b/test/unit/app/tools/test_evaluation.py
@@ -133,8 +133,8 @@ class TestToolEvaluator(TestCase, UsesApp):
         # splitting, config.outputs_to_working_directory). This tests that
         # functionality.
         self._setup_test_bwa_job()
-        job_path_1 = f"{self.test_directory}/dataset_1.dat"
-        job_path_2 = f"{self.test_directory}/dataset_2.dat"
+        job_path_1 = os.path.join(self.test_directory, "dataset_1.dat")
+        job_path_2 = os.path.join(self.test_directory, "dataset_2.dat")
         self._set_compute_environment(
             input_paths=[DatasetPath(1, "/galaxy/files/dataset_1.dat", false_path=job_path_1)],
             output_paths=[DatasetPath(2, "/galaxy/files/dataset_2.dat", false_path=job_path_2)],

--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -1,3 +1,4 @@
+import os.path
 from unittest import SkipTest
 
 from galaxy.tool_util.deps.mulled.get_tests import (
@@ -14,6 +15,8 @@ from galaxy.tool_util.deps.mulled.get_tests import (
 )
 from galaxy.util import smart_str
 from ..util import external_dependency_management
+
+SCRIPT_DIRECTORY = os.path.dirname(__file__)
 
 TEST_RECIPE = r"""
 {% set name = "eagle" %}
@@ -99,6 +102,9 @@ def test_open_recipe_file():
 
 @external_dependency_management
 def test_get_alternative_versions():
+    local_versions = get_alternative_versions("recipes/my_recipe", "meta.yaml", recipes_path=SCRIPT_DIRECTORY)
+    assert local_versions == ["recipes/my_recipe/1.0/meta.yaml"]
+
     try:
         versions = get_alternative_versions("recipes/bioblend", "meta.yaml")
     except Exception as e:

--- a/test/unit/tool_util/mulled/test_mulled_list.py
+++ b/test/unit/tool_util/mulled/test_mulled_list.py
@@ -1,3 +1,4 @@
+import os.path
 import shutil
 import tempfile
 
@@ -25,7 +26,7 @@ def test_get_singularity_containers():
 def test_get_missing_containers():
     test_dir = tempfile.mkdtemp()
     try:
-        exclude_list = f"{test_dir}/blocklist.txt"
+        exclude_list = os.path.join(test_dir, "blocklist.txt")
         with open(exclude_list, "w") as f:
             f.write("a\n\nb\nc\nd")
         containers = get_missing_containers(
@@ -39,7 +40,7 @@ def test_get_missing_containers():
 def test_get_missing_envs():
     test_dir = tempfile.mkdtemp()
     try:
-        exclude_list = f"{test_dir}/blocklist.txt"
+        exclude_list = os.path.join(test_dir, "blocklist.txt")
         with open(exclude_list, "w") as f:
             f.write("a\n\nb\nc\nd")
         envs = get_missing_envs(

--- a/test/unit/util/test_checkers.py
+++ b/test/unit/util/test_checkers.py
@@ -25,6 +25,6 @@ def test_check_html():
 
 def test_check_image():
     for filename, expected in (("1.tiff", True), ("454Score.png", True), ("1.bam", False)):
-        path = f"test-data/{filename}"
+        path = os.path.join("test-data", filename)
         assert os.path.exists(path)
         assert check_image(path) is expected


### PR DESCRIPTION
More portable and idiomatic.

Also:
- Replace `os.path.abspath(f"{dir}/../..")` with `os.path.dirname()` calls.
- Add test for `get_alternative_versions()` with `recipes_path` argument specified.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
