### PR TITLE
Replace BCollapse with custom GCollapse component

### DIFF
--- a/client/src/components/BaseComponents/GCollapse.vue
+++ b/client/src/components/BaseComponents/GCollapse.vue
@@ -3,8 +3,8 @@
  * Collapsible content container with animated height transition.
  * Replaces bootstrap-vue's BCollapse for regular (non-navbar) usage.
  *
- * Uses the same transition approach as Bootstrap: animates the `height`
- * property and hides with `display: none` when fully collapsed.
+ * Uses height: 0 / overflow: hidden for the closed state so scrollHeight
+ * is always readable (unlike display: none which returns 0).
  *
  * Supports both one-way `:visible` prop and two-way `v-model` binding.
  * Accordion groups ensure only one collapse is open at a time.
@@ -41,7 +41,6 @@ const emit = defineEmits<{
 
 const contentRef = ref<HTMLElement | null>(null);
 const internalOpen = ref(false);
-const transitioning = ref(false);
 
 const isOpen = computed(() => {
     if (props.value !== undefined) {
@@ -59,8 +58,15 @@ function closeSelf() {
 }
 
 onMounted(() => {
-    if (isOpen.value && props.accordion) {
-        accordionRegistry.set(props.accordion, closeSelf);
+    const el = contentRef.value;
+    if (isOpen.value) {
+        if (el) {
+            el.style.height = "auto";
+            el.style.overflow = "visible";
+        }
+        if (props.accordion) {
+            accordionRegistry.set(props.accordion, closeSelf);
+        }
     }
 });
 
@@ -70,23 +76,16 @@ function onTransitionEnd(e: TransitionEvent) {
         return;
     }
     if (isOpen.value) {
-        el.style.height = "";
-        transitioning.value = false;
+        el.style.height = "auto";
+        el.style.overflow = "visible";
         emit("shown");
     } else {
-        transitioning.value = false;
+        el.style.height = "";
+        el.style.overflow = "";
         emit("hidden");
     }
 }
 
-// Pre-flush watcher: set transitioning BEFORE the DOM update so class
-// bindings include .g-collapsing (which keeps the element visible during
-// the close animation instead of jumping to display:none).
-watch(isOpen, () => {
-    transitioning.value = true;
-});
-
-// Post-flush watcher: run the animation AFTER Vue has applied the new classes.
 watch(
     isOpen,
     (open) => {
@@ -103,11 +102,15 @@ watch(
                 }
                 accordionRegistry.set(props.accordion, closeSelf);
             }
+            // Opening: start from 0, animate to scrollHeight
+            el.style.overflow = "hidden";
             el.style.height = "0px";
             el.offsetHeight; // force reflow
             el.style.height = el.scrollHeight + "px";
         } else {
             emit("hide");
+            // Closing: start from current height, animate to 0
+            el.style.overflow = "hidden";
             el.style.height = el.offsetHeight + "px";
             el.offsetHeight; // force reflow
             el.style.height = "0px";
@@ -124,25 +127,14 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <div
-        ref="contentRef"
-        class="g-collapse"
-        :class="{
-            'g-collapse-open': isOpen,
-            'g-collapse-hidden': !isOpen && !transitioning,
-            'g-collapsing': transitioning,
-        }"
-        @transitionend="onTransitionEnd">
+    <div ref="contentRef" class="g-collapse" :class="{ 'g-collapse-open': isOpen }" @transitionend="onTransitionEnd">
         <slot />
     </div>
 </template>
 
 <style scoped>
-.g-collapse-hidden {
-    display: none;
-}
-.g-collapsing {
-    position: relative;
+.g-collapse {
+    height: 0;
     overflow: hidden;
     transition: height 0.35s ease;
 }

--- a/client/src/components/BaseComponents/GCollapse.vue
+++ b/client/src/components/BaseComponents/GCollapse.vue
@@ -3,6 +3,9 @@
  * Collapsible content container with animated height transition.
  * Replaces bootstrap-vue's BCollapse for regular (non-navbar) usage.
  *
+ * Uses the same transition approach as Bootstrap: animates the `height`
+ * property and hides with `display: none` when fully collapsed.
+ *
  * Supports both one-way `:visible` prop and two-way `v-model` binding.
  * Accordion groups ensure only one collapse is open at a time.
  */
@@ -38,6 +41,7 @@ const emit = defineEmits<{
 
 const contentRef = ref<HTMLElement | null>(null);
 const internalOpen = ref(false);
+const transitioning = ref(false);
 
 const isOpen = computed(() => {
     if (props.value !== undefined) {
@@ -55,33 +59,34 @@ function closeSelf() {
 }
 
 onMounted(() => {
-    const el = contentRef.value;
-    if (!el) {
-        return;
+    if (isOpen.value && props.accordion) {
+        accordionRegistry.set(props.accordion, closeSelf);
     }
-    if (isOpen.value) {
-        // Already open on mount — show at full height without animating
-        el.style.maxHeight = "none";
-        el.style.overflow = "visible";
-    }
-    // If closed, the CSS max-height: 0 handles initial state
 });
 
-function onTransitionEnd() {
+function onTransitionEnd(e: TransitionEvent) {
     const el = contentRef.value;
-    if (!el) {
+    if (!el || e.target !== el) {
         return;
     }
     if (isOpen.value) {
-        // Release height constraint so dynamic content can grow after opening
-        el.style.maxHeight = "none";
-        el.style.overflow = "visible";
+        el.style.height = "";
+        transitioning.value = false;
         emit("shown");
     } else {
+        transitioning.value = false;
         emit("hidden");
     }
 }
 
+// Pre-flush watcher: set transitioning BEFORE the DOM update so class
+// bindings include .g-collapsing (which keeps the element visible during
+// the close animation instead of jumping to display:none).
+watch(isOpen, () => {
+    transitioning.value = true;
+});
+
+// Post-flush watcher: run the animation AFTER Vue has applied the new classes.
 watch(
     isOpen,
     (open) => {
@@ -98,19 +103,14 @@ watch(
                 }
                 accordionRegistry.set(props.accordion, closeSelf);
             }
-            // Keep overflow hidden during animation so content doesn't escape the container
-            el.style.overflow = "hidden";
-            // Explicitly start from 0 so the transition always plays from the closed position
-            el.style.maxHeight = "0";
-            el.offsetHeight; // force reflow to commit the 0 before transitioning to target height
-            el.style.maxHeight = el.scrollHeight + "px";
+            el.style.height = "0px";
+            el.offsetHeight; // force reflow
+            el.style.height = el.scrollHeight + "px";
         } else {
             emit("hide");
-            el.style.overflow = "hidden";
-            // Explicitly set current height so the transition has a defined start point
-            el.style.maxHeight = el.scrollHeight + "px";
+            el.style.height = el.offsetHeight + "px";
             el.offsetHeight; // force reflow
-            el.style.maxHeight = "0";
+            el.style.height = "0px";
         }
     },
     { flush: "post" },
@@ -124,15 +124,26 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <div ref="contentRef" class="g-collapse" :class="{ 'g-collapse-open': isOpen }" @transitionend="onTransitionEnd">
+    <div
+        ref="contentRef"
+        class="g-collapse"
+        :class="{
+            'g-collapse-open': isOpen,
+            'g-collapse-hidden': !isOpen && !transitioning,
+            'g-collapsing': transitioning,
+        }"
+        @transitionend="onTransitionEnd">
         <slot />
     </div>
 </template>
 
 <style scoped>
-.g-collapse {
+.g-collapse-hidden {
+    display: none;
+}
+.g-collapsing {
+    position: relative;
     overflow: hidden;
-    max-height: 0;
-    transition: max-height 0.35s ease;
+    transition: height 0.35s ease;
 }
 </style>

--- a/client/src/components/BaseComponents/GCollapse.vue
+++ b/client/src/components/BaseComponents/GCollapse.vue
@@ -81,6 +81,8 @@ onMounted(() => {
         if (props.accordion) {
             accordionRegistry.set(props.accordion, closeSelf);
         }
+    } else if (el) {
+        el.style.display = "none";
     }
 });
 
@@ -94,6 +96,7 @@ function onTransitionEnd(e: TransitionEvent) {
         el.style.overflow = "visible";
         emit("shown");
     } else {
+        el.style.display = "none";
         el.style.height = "";
         el.style.overflow = "";
         contentActive.value = false;
@@ -118,9 +121,9 @@ watch(
                 }
                 accordionRegistry.set(props.accordion, closeSelf);
             }
-            // Opening: start from 0, animate to scrollHeight.
-            // Use rAF so the browser finishes laying out v-if content
-            // before we read scrollHeight (matches BCollapse's approach).
+            // Switch from display:none to height:0/overflow:hidden so
+            // scrollHeight is readable, then animate to full height.
+            el.style.display = "";
             el.style.overflow = "hidden";
             el.style.height = "0px";
             requestAnimationFrame(() => {

--- a/client/src/components/BaseComponents/GCollapse.vue
+++ b/client/src/components/BaseComponents/GCollapse.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+/**
+ * Collapsible content container with animated height transition.
+ * Replaces bootstrap-vue's BCollapse for regular (non-navbar) usage.
+ *
+ * Supports both one-way `:visible` prop and two-way `v-model` binding.
+ * Accordion groups ensure only one collapse is open at a time.
+ */
+
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+
+// Module-level accordion registry: maps group name to the close callback of the currently open member
+const accordionRegistry = new Map<string, () => void>();
+
+const props = withDefaults(
+    defineProps<{
+        /** Two-way binding for open/closed state (v-model) */
+        value?: boolean;
+        /** One-way visibility control */
+        visible?: boolean;
+        /** Accordion group name — only one in the group can be open */
+        accordion?: string;
+    }>(),
+    {
+        value: undefined,
+        visible: undefined,
+        accordion: undefined,
+    },
+);
+
+const emit = defineEmits<{
+    (e: "input", value: boolean): void;
+    (e: "show"): void;
+    (e: "shown"): void;
+    (e: "hide"): void;
+    (e: "hidden"): void;
+}>();
+
+const contentRef = ref<HTMLElement | null>(null);
+const internalOpen = ref(false);
+
+const isOpen = computed(() => {
+    if (props.value !== undefined) {
+        return props.value;
+    }
+    if (props.visible !== undefined) {
+        return props.visible;
+    }
+    return internalOpen.value;
+});
+
+function close() {
+    internalOpen.value = false;
+    emit("input", false);
+}
+
+watch(isOpen, (newVal, oldVal) => {
+    if (newVal === oldVal) {
+        return;
+    }
+    if (newVal) {
+        emit("show");
+        if (props.accordion) {
+            const existing = accordionRegistry.get(props.accordion);
+            if (existing && existing !== close) {
+                existing();
+            }
+            accordionRegistry.set(props.accordion, close);
+        }
+    } else {
+        emit("hide");
+    }
+});
+
+function onTransitionEnd() {
+    if (isOpen.value) {
+        emit("shown");
+        // After opening transition completes, allow content to reflow naturally
+        if (contentRef.value) {
+            contentRef.value.style.maxHeight = "none";
+        }
+    } else {
+        emit("hidden");
+    }
+}
+
+watch(
+    isOpen,
+    (open) => {
+        const el = contentRef.value;
+        if (!el) {
+            return;
+        }
+        if (open) {
+            el.style.maxHeight = el.scrollHeight + "px";
+        } else {
+            // Force a reflow so the transition starts from the current height
+            el.style.maxHeight = el.scrollHeight + "px";
+            // eslint-disable-next-line no-unused-expressions
+            el.offsetHeight;
+            el.style.maxHeight = "0";
+        }
+    },
+    { flush: "post" },
+);
+
+onBeforeUnmount(() => {
+    if (props.accordion && accordionRegistry.get(props.accordion) === close) {
+        accordionRegistry.delete(props.accordion);
+    }
+});
+</script>
+
+<template>
+    <div
+        ref="contentRef"
+        class="g-collapse"
+        :class="{ 'g-collapse-open': isOpen }"
+        :style="{ maxHeight: isOpen ? undefined : '0px' }"
+        role="region"
+        @transitionend="onTransitionEnd">
+        <slot />
+    </div>
+</template>
+
+<style scoped>
+.g-collapse {
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+.g-collapse-open {
+    overflow: visible;
+}
+</style>

--- a/client/src/components/BaseComponents/GCollapse.vue
+++ b/client/src/components/BaseComponents/GCollapse.vue
@@ -61,8 +61,8 @@ onMounted(() => {
     }
     if (isOpen.value) {
         // Already open on mount — show at full height without animating
-        el.style.maxHeight = "";
-        el.style.overflow = "";
+        el.style.maxHeight = "none";
+        el.style.overflow = "visible";
     }
     // If closed, the CSS max-height: 0 handles initial state
 });
@@ -74,8 +74,8 @@ function onTransitionEnd() {
     }
     if (isOpen.value) {
         // Release height constraint so dynamic content can grow after opening
-        el.style.maxHeight = "";
-        el.style.overflow = "";
+        el.style.maxHeight = "none";
+        el.style.overflow = "visible";
         emit("shown");
     } else {
         emit("hidden");

--- a/client/src/components/BaseComponents/GCollapse.vue
+++ b/client/src/components/BaseComponents/GCollapse.vue
@@ -41,6 +41,8 @@ const emit = defineEmits<{
 
 const contentRef = ref<HTMLElement | null>(null);
 const internalOpen = ref(false);
+// Stays true during close animation so slot content can remain mounted
+const contentActive = ref(false);
 
 const isOpen = computed(() => {
     if (props.value !== undefined) {
@@ -57,9 +59,21 @@ function closeSelf() {
     emit("input", false);
 }
 
+// Sync: set contentActive true immediately so slot renders before post-flush animation
+watch(
+    isOpen,
+    (open) => {
+        if (open) {
+            contentActive.value = true;
+        }
+    },
+    { flush: "sync" },
+);
+
 onMounted(() => {
     const el = contentRef.value;
     if (isOpen.value) {
+        contentActive.value = true;
         if (el) {
             el.style.height = "auto";
             el.style.overflow = "visible";
@@ -82,10 +96,12 @@ function onTransitionEnd(e: TransitionEvent) {
     } else {
         el.style.height = "";
         el.style.overflow = "";
+        contentActive.value = false;
         emit("hidden");
     }
 }
 
+// Post-flush: run animations after DOM updates
 watch(
     isOpen,
     (open) => {
@@ -102,11 +118,14 @@ watch(
                 }
                 accordionRegistry.set(props.accordion, closeSelf);
             }
-            // Opening: start from 0, animate to scrollHeight
+            // Opening: start from 0, animate to scrollHeight.
+            // Use rAF so the browser finishes laying out v-if content
+            // before we read scrollHeight (matches BCollapse's approach).
             el.style.overflow = "hidden";
             el.style.height = "0px";
-            el.offsetHeight; // force reflow
-            el.style.height = el.scrollHeight + "px";
+            requestAnimationFrame(() => {
+                el.style.height = el.scrollHeight + "px";
+            });
         } else {
             emit("hide");
             // Closing: start from current height, animate to 0
@@ -128,7 +147,7 @@ onBeforeUnmount(() => {
 
 <template>
     <div ref="contentRef" class="g-collapse" :class="{ 'g-collapse-open': isOpen }" @transitionend="onTransitionEnd">
-        <slot />
+        <slot :content-active="contentActive" />
     </div>
 </template>
 

--- a/client/src/components/BaseComponents/GCollapse.vue
+++ b/client/src/components/BaseComponents/GCollapse.vue
@@ -7,7 +7,7 @@
  * Accordion groups ensure only one collapse is open at a time.
  */
 
-import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 // Module-level accordion registry: maps group name to the close callback of the currently open member
 const accordionRegistry = new Map<string, () => void>();
@@ -49,36 +49,34 @@ const isOpen = computed(() => {
     return internalOpen.value;
 });
 
-function close() {
+function closeSelf() {
     internalOpen.value = false;
     emit("input", false);
 }
 
-watch(isOpen, (newVal, oldVal) => {
-    if (newVal === oldVal) {
+onMounted(() => {
+    const el = contentRef.value;
+    if (!el) {
         return;
     }
-    if (newVal) {
-        emit("show");
-        if (props.accordion) {
-            const existing = accordionRegistry.get(props.accordion);
-            if (existing && existing !== close) {
-                existing();
-            }
-            accordionRegistry.set(props.accordion, close);
-        }
-    } else {
-        emit("hide");
+    if (isOpen.value) {
+        // Already open on mount — show at full height without animating
+        el.style.maxHeight = "";
+        el.style.overflow = "";
     }
+    // If closed, the CSS max-height: 0 handles initial state
 });
 
 function onTransitionEnd() {
+    const el = contentRef.value;
+    if (!el) {
+        return;
+    }
     if (isOpen.value) {
+        // Release height constraint so dynamic content can grow after opening
+        el.style.maxHeight = "";
+        el.style.overflow = "";
         emit("shown");
-        // After opening transition completes, allow content to reflow naturally
-        if (contentRef.value) {
-            contentRef.value.style.maxHeight = "none";
-        }
     } else {
         emit("hidden");
     }
@@ -92,12 +90,26 @@ watch(
             return;
         }
         if (open) {
+            emit("show");
+            if (props.accordion) {
+                const existing = accordionRegistry.get(props.accordion);
+                if (existing && existing !== closeSelf) {
+                    existing();
+                }
+                accordionRegistry.set(props.accordion, closeSelf);
+            }
+            // Keep overflow hidden during animation so content doesn't escape the container
+            el.style.overflow = "hidden";
+            // Explicitly start from 0 so the transition always plays from the closed position
+            el.style.maxHeight = "0";
+            el.offsetHeight; // force reflow to commit the 0 before transitioning to target height
             el.style.maxHeight = el.scrollHeight + "px";
         } else {
-            // Force a reflow so the transition starts from the current height
+            emit("hide");
+            el.style.overflow = "hidden";
+            // Explicitly set current height so the transition has a defined start point
             el.style.maxHeight = el.scrollHeight + "px";
-            // eslint-disable-next-line no-unused-expressions
-            el.offsetHeight;
+            el.offsetHeight; // force reflow
             el.style.maxHeight = "0";
         }
     },
@@ -105,20 +117,14 @@ watch(
 );
 
 onBeforeUnmount(() => {
-    if (props.accordion && accordionRegistry.get(props.accordion) === close) {
+    if (props.accordion && accordionRegistry.get(props.accordion) === closeSelf) {
         accordionRegistry.delete(props.accordion);
     }
 });
 </script>
 
 <template>
-    <div
-        ref="contentRef"
-        class="g-collapse"
-        :class="{ 'g-collapse-open': isOpen }"
-        :style="{ maxHeight: isOpen ? undefined : '0px' }"
-        role="region"
-        @transitionend="onTransitionEnd">
+    <div ref="contentRef" class="g-collapse" :class="{ 'g-collapse-open': isOpen }" @transitionend="onTransitionEnd">
         <slot />
     </div>
 </template>
@@ -126,10 +132,7 @@ onBeforeUnmount(() => {
 <style scoped>
 .g-collapse {
     overflow: hidden;
-    transition: max-height 0.3s ease;
-}
-
-.g-collapse-open {
-    overflow: visible;
+    max-height: 0;
+    transition: max-height 0.35s ease;
 }
 </style>

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faCopy, faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BCard, BCollapse, BNav, BNavItem, BSpinner } from "bootstrap-vue";
+import { BAlert, BButton, BCard, BNav, BNavItem, BSpinner } from "bootstrap-vue";
 import { computed, onMounted, onUpdated, ref, toRef } from "vue";
 
 import { getCitations } from "@/components/Citation/services";
@@ -12,6 +12,7 @@ import { copy } from "@/utils/clipboard";
 import type { Citation } from ".";
 import { Cite } from "./cite";
 
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import CitationItem from "@/components/Citation/CitationItem.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 
@@ -39,6 +40,7 @@ const outputFormat = ref<string>(outputFormats.CITATION);
 const fetchedCitations = ref<Citation[]>([]);
 const warnings = ref<string[]>([]);
 const isLoading = ref<boolean>(false);
+const citationsOpen = ref(false);
 
 onUpdated(() => {
     emit("rendered");
@@ -201,10 +203,10 @@ function citationsToBibtexAsText() {
                 </div>
             </BCard>
             <div v-else-if="citations.length">
-                <BButton v-b-toggle="id" variant="primary">References</BButton>
+                <BButton variant="primary" @click="citationsOpen = !citationsOpen">References</BButton>
 
-                <BCollapse
-                    :id="id.replace(/ /g, '_')"
+                <GCollapse
+                    v-model="citationsOpen"
                     class="mt-2"
                     @show="$emit('show')"
                     @shown="$emit('shown')"
@@ -218,7 +220,7 @@ function citationsToBibtexAsText() {
                             :citation="citation"
                             :output-format="outputFormat" />
                     </BCard>
-                </BCollapse>
+                </GCollapse>
             </div>
         </div>
     </div>

--- a/client/src/components/Form/Elements/FormData/FormDataExtensions.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataExtensions.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BCollapse, BPopover, BTooltip } from "bootstrap-vue";
+import { BPopover, BTooltip } from "bootstrap-vue";
 import { computed } from "vue";
 
 import { orList } from "@/utils/strings";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 
 const props = defineProps<{
     extensions: string[];
@@ -46,8 +47,8 @@ const localFormatsVisible = computed({
             <FontAwesomeIcon v-if="formatsVisible" :icon="faCaretUp" />
             <FontAwesomeIcon v-else :icon="faCaretDown" />
         </GButton>
-        <component
-            :is="props.popover ? BPopover : BCollapse"
+        <BPopover
+            v-if="props.popover"
             v-model="localFormatsVisible"
             :target="props.formatsButtonId"
             :show.sync="localFormatsVisible"
@@ -55,7 +56,12 @@ const localFormatsVisible = computed({
             <ul class="pl-3 m-0">
                 <li v-for="extension in props.extensions" :key="extension">{{ extension }}</li>
             </ul>
-        </component>
+        </BPopover>
+        <GCollapse v-else :visible="localFormatsVisible">
+            <ul class="pl-3 m-0">
+                <li v-for="extension in props.extensions" :key="extension">{{ extension }}</li>
+            </ul>
+        </GCollapse>
         <BTooltip
             v-if="!formatsVisible"
             :target="props.formatsButtonId"

--- a/client/src/components/Form/Elements/FormData/FormDataUriElement.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataUriElement.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { BCollapse, BLink } from "bootstrap-vue";
+import { BLink } from "bootstrap-vue";
 import { ref } from "vue";
 
 import { type DataUriCollectionElement, isDataUriCollectionElementCollection } from "./types";
+
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 
 const props = defineProps<{
     value: DataUriCollectionElement;
@@ -23,9 +25,9 @@ const expanded = ref(false);
             <i v-if="props.value.collection_type">({{ props.value.collection_type }})</i>
             <span class="float-right"> {{ expanded ? "Hide" : "Show" }} elements </span>
         </div>
-        <BCollapse :visible="expanded" class="pl-2">
+        <GCollapse :visible="expanded" class="pl-2">
             <FormDataUriElement v-for="(element, index) in props.value.elements" :key="index" :value="element" />
-        </BCollapse>
+        </GCollapse>
     </div>
     <div v-else data-description="uri element file">
         <div class="form-example-data-element rounded d-flex justify-content-between align-items-center w-100">

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -438,10 +438,10 @@ function unexpandedClick(event: Event) {
                 @tag-click="onTagClick" />
         </span>
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
-        <GCollapse :visible="expandDataset" class="px-2 pb-2">
+        <GCollapse v-slot="{ contentActive }" :visible="expandDataset" class="px-2 pb-2">
             <div v-if="item.accessible === false">You are not allowed to access this dataset</div>
             <DatasetDetails
-                v-else-if="expandDataset && item.id"
+                v-else-if="contentActive && item.id"
                 :id="item.id"
                 :writable="writable"
                 :show-highlight="(isHistoryItem && filterable) || addHighlightBtn"

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -8,7 +8,7 @@ import {
     faExchangeAlt,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BBadge, BButton, BCollapse } from "bootstrap-vue";
+import { BBadge, BButton } from "bootstrap-vue";
 import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router/composables";
 
@@ -26,6 +26,7 @@ import CollectionDescription from "./Collection/CollectionDescription.vue";
 import ContentExpirationIndicator from "./ContentExpirationIndicator.vue";
 import ContentOptions from "./ContentOptions.vue";
 import DatasetDetails from "./Dataset/DatasetDetails.vue";
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
 const router = useRouter();
@@ -437,7 +438,7 @@ function unexpandedClick(event: Event) {
                 @tag-click="onTagClick" />
         </span>
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
-        <BCollapse :visible="expandDataset" class="px-2 pb-2">
+        <GCollapse :visible="expandDataset" class="px-2 pb-2">
             <div v-if="item.accessible === false">You are not allowed to access this dataset</div>
             <DatasetDetails
                 v-else-if="expandDataset && item.id"
@@ -447,7 +448,7 @@ function unexpandedClick(event: Event) {
                 :item-urls="itemUrls"
                 @edit="onEdit"
                 @toggleHighlights="toggleHighlights" />
-        </BCollapse>
+        </GCollapse>
         <slot name="sub_items" :sub-items-visible="subItemsVisible" />
     </div>
 </template>

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -8,9 +8,9 @@
             <BButton
                 v-if="currentUser && currentUser.is_admin"
                 id="create-new-lib"
-                v-b-toggle.collapse-2
                 title="Create new folder"
-                class="mr-1">
+                class="mr-1"
+                @click="isNewLibFormVisible = !isNewLibFormVisible">
                 <FontAwesomeIcon :icon="faPlus" />
                 {{ titleLibrary }}
             </BButton>
@@ -30,7 +30,7 @@
             </BFormCheckbox>
         </div>
 
-        <BCollapse id="collapse-2" v-model="isNewLibFormVisible">
+        <GCollapse v-model="isNewLibFormVisible">
             <BCard>
                 <BForm @submit.prevent="newLibrary">
                     <BInputGroup class="mb-2 new-row">
@@ -49,7 +49,7 @@
                     </BInputGroup>
                 </BForm>
             </BCard>
-        </BCollapse>
+        </GCollapse>
 
         <GTable
             id="libraries_list"
@@ -180,7 +180,10 @@
                                     class="pagination-input-field"
                                     autocomplete="off"
                                     type="number"
-                                    onkeyup="this.value|=0;if(this.value<1)this.value=1" />
+                                    onkeyup="
+                                        this.value |= 0;
+                                        if (this.value < 1) this.value = 1;
+                                    " />
                             </td>
 
                             <td class="text-muted ml-1 paginator-text">
@@ -213,7 +216,6 @@ import {
     BButton,
     BCard,
     BCol,
-    BCollapse,
     BContainer,
     BForm,
     BFormCheckbox,
@@ -233,6 +235,7 @@ import _l from "@/utils/localization";
 import { Services } from "./services";
 import { fields } from "./table-fields";
 
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import LibraryEditField from "@/components/Libraries/LibraryEditField.vue";
@@ -243,7 +246,6 @@ export default {
         BButton,
         BCard,
         BCol,
-        BCollapse,
         BContainer,
         BForm,
         BFormCheckbox,
@@ -252,6 +254,7 @@ export default {
         BPagination,
         BRow,
         FontAwesomeIcon,
+        GCollapse,
         GLink,
         GTable,
         LibraryEditField,

--- a/client/src/components/Markdown/Sections/MarkdownGalaxy.test.js
+++ b/client/src/components/Markdown/Sections/MarkdownGalaxy.test.js
@@ -94,11 +94,10 @@ describe("MarkdownContainer", () => {
         await wrapper.setProps({ content: `generate_galaxy_version(collapse="${collapse}")` });
         const link = wrapper.find("a");
         expect(link.text()).toBe(collapse);
-        const container = wrapper.find(".collapse");
-        expect(container.attributes("style")).toBe("display: none;");
+        const container = wrapper.find(".g-collapse");
+        expect(container.classes()).not.toContain("g-collapse-open");
         await link.trigger("click");
-        // After click, style attribute is removed
-        expect(container.attributes("style")).toBeFalsy();
+        expect(container.classes()).toContain("g-collapse-open");
     });
 
     it("Renders time stamp", async () => {

--- a/client/src/components/Markdown/Sections/MarkdownGalaxy.vue
+++ b/client/src/components/Markdown/Sections/MarkdownGalaxy.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { BAlert, BCollapse, BLink } from "bootstrap-vue";
+import { BAlert, BLink } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import { getArgs } from "@/components/Markdown/parse";
@@ -33,6 +33,7 @@ import WorkflowDisplay from "./Elements/Workflow/WorkflowDisplay.vue";
 import WorkflowImage from "./Elements/Workflow/WorkflowImage.vue";
 import WorkflowLicense from "./Elements/Workflow/WorkflowLicense.vue";
 import VisualizationWrapper from "./VisualizationWrapper.vue";
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import WorkflowInvocationInputs from "@/components/WorkflowInvocationState/WorkflowInvocationInputs.vue";
 import WorkflowInvocationOutputs from "@/components/WorkflowInvocationState/WorkflowInvocationOutputs.vue";
@@ -151,7 +152,7 @@ watch(
         <BLink v-if="isCollapsible" class="font-weight-bold" @click="toggle = !toggle">
             {{ args.collapse }}
         </BLink>
-        <BCollapse :visible="isVisible">
+        <GCollapse :visible="isVisible">
             <TextContent
                 v-if="name == 'generate_galaxy_version'"
                 class="galaxy-version"
@@ -276,6 +277,6 @@ watch(
                 :size="args.size || 'lg'"
                 :workflow-version="args.workflow_checkpoint || undefined" />
             <WorkflowLicense v-else-if="name == 'workflow_license'" :workflow-id="args.workflow_id" />
-        </BCollapse>
+        </GCollapse>
     </div>
 </template>

--- a/client/src/components/Notifications/NotificationsList.vue
+++ b/client/src/components/Notifications/NotificationsList.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import { faCheck, faCog, faRetweet, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BButtonGroup, BCollapse, BFormCheckbox } from "bootstrap-vue";
+import { BAlert, BButton, BButtonGroup, BFormCheckbox } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
 import type { UserNotification } from "@/api/notifications";
 import { useNotificationsStore } from "@/stores/notificationsStore";
 
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import Heading from "@/components/Common/Heading.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import NotificationCard from "@/components/Notifications/NotificationCard.vue";
@@ -88,11 +89,11 @@ function togglePreferences() {
             </BButton>
         </div>
 
-        <BCollapse v-model="preferencesOpen">
+        <GCollapse v-model="preferencesOpen">
             <div class="notifications-list-preferences card-container">
                 <NotificationsPreferences v-if="preferencesOpen" header-size="h-md" :embedded="false" />
             </div>
-        </BCollapse>
+        </GCollapse>
 
         <BAlert v-if="loadingNotifications" show>
             <LoadingSpan message="Loading notifications" />

--- a/client/src/components/Notifications/NotificationsList.vue
+++ b/client/src/components/Notifications/NotificationsList.vue
@@ -89,9 +89,9 @@ function togglePreferences() {
             </BButton>
         </div>
 
-        <GCollapse v-model="preferencesOpen">
+        <GCollapse v-slot="{ contentActive }" v-model="preferencesOpen">
             <div class="notifications-list-preferences card-container">
-                <NotificationsPreferences v-if="preferencesOpen" header-size="h-md" :embedded="false" />
+                <NotificationsPreferences v-if="contentActive" header-size="h-md" :embedded="false" />
             </div>
         </GCollapse>
 

--- a/client/src/components/Register/RegisterForm.vue
+++ b/client/src/components/Register/RegisterForm.vue
@@ -6,7 +6,6 @@ import {
     BCardBody,
     BCardFooter,
     BCardHeader,
-    BCollapse,
     BForm,
     BFormCheckbox,
     BFormGroup,
@@ -24,6 +23,7 @@ import { errorMessageAsString } from "@/utils/simple-error";
 import GButton from "../BaseComponents/GButton.vue";
 import GLink from "../BaseComponents/GLink.vue";
 import VerticalSeparator from "../Common/VerticalSeparator.vue";
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import ExternalLogin from "@/components/User/ExternalIdentities/ExternalLogin.vue";
 import ExternalRegistration from "@/components/User/ExternalIdentities/ExternalRegistration.vue";
 
@@ -61,6 +61,8 @@ const idpsWithRegistration = computed(() => (props.oidcIdps ? getOIDCIdpsWithReg
 const oidcPreferred = computed(() => {
     return props.enableOidc && props.preferOidcLogin;
 });
+
+const activePanel = ref<"oidc" | "register">(oidcPreferred.value ? "oidc" : "register");
 
 /** This decides if all register options should be displayed in column style
  * (one below the other) or horizontally.
@@ -109,30 +111,26 @@ async function submit() {
                     <BCard no-body>
                         <!-- OIDC enabled and prioritized: encourage users to use it instead of local registration -->
                         <span v-if="oidcPreferred">
-                            <BCardHeader v-b-toggle.accordion-oidc role="button">
+                            <BCardHeader role="button" @click="activePanel = 'oidc'">
                                 Register using institutional account
                             </BCardHeader>
 
-                            <BCollapse id="accordion-oidc" visible role="tabpanel" accordion="registration_acc">
+                            <GCollapse :visible="activePanel === 'oidc'" role="tabpanel">
                                 <BCardBody>
                                     Create a Galaxy account using an institutional account (e.g.:Google/JHU). This will
                                     redirect you to your institutional login through OIDC.
                                     <ExternalLogin class="mt-2" />
                                 </BCardBody>
-                            </BCollapse>
+                            </GCollapse>
                         </span>
 
                         <!-- Local Galaxy Registration -->
                         <BCardHeader v-if="!oidcPreferred" v-localize>Create a Galaxy account</BCardHeader>
-                        <BCardHeader v-else v-localize v-b-toggle.accordion-register role="button">
+                        <BCardHeader v-else v-localize role="button" @click="activePanel = 'register'">
                             Or, register with email
                         </BCardHeader>
 
-                        <BCollapse
-                            id="accordion-register"
-                            :visible="!oidcPreferred"
-                            role="tabpanel"
-                            accordion="registration_acc">
+                        <GCollapse :visible="activePanel === 'register'" role="tabpanel">
                             <BCardBody :class="{ 'd-flex w-100': !registerColumnDisplay }">
                                 <div v-if="!disableLocalAccounts">
                                     <BFormGroup :label="labelEmailAddress" label-for="register-form-email">
@@ -213,7 +211,7 @@ async function submit() {
                                     </div>
                                 </template>
                             </BCardBody>
-                        </BCollapse>
+                        </GCollapse>
 
                         <BCardFooter v-if="!hideLoginLink">
                             <span v-localize>Already have an account?</span>

--- a/client/src/components/Tool/ToolTutorialRecommendations.vue
+++ b/client/src/components/Tool/ToolTutorialRecommendations.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BCollapse } from "bootstrap-vue";
-import slugify from "slugify";
-import { computed } from "vue";
+import { BButton } from "bootstrap-vue";
+import { computed, reactive, ref } from "vue";
 
 import { useToolTrainingMaterial } from "@/composables/toolTrainingMaterial";
-import { useUid } from "@/composables/utils/uid";
 
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import Heading from "@/components/Common/Heading.vue";
 import ExternalLink from "@/components/ExternalLink.vue";
 
@@ -21,11 +20,8 @@ const props = defineProps<{
 const { trainingAvailable, trainingCategories, tutorialDetails, allTutorialsUrl, versionAvailable } =
     useToolTrainingMaterial(props.id, props.name, props.version, props.owner);
 
-const collapseId = useUid("collapse-");
-
-function idForCategory(category: string) {
-    return `${collapseId.value}-${slugify(category)}`;
-}
+const mainOpen = ref(false);
+const categoryOpen = reactive<Record<string, boolean>>({});
 
 function tutorialsInCategory(category: string) {
     return tutorialDetails.value.filter((tut) => tut.category === category);
@@ -53,20 +49,20 @@ const tutorialText = computed(() => {
             </ExternalLink>
         </p>
 
-        <BButton v-b-toggle="collapseId" class="ui-link">
+        <BButton class="ui-link" @click="mainOpen = !mainOpen">
             <b>
                 Tutorials available in {{ trainingCategories.length }}
                 {{ trainingCategories.length > 1 ? "categories" : "category" }}
             </b>
             <FontAwesomeIcon :icon="faCaretDown" />
         </BButton>
-        <BCollapse :id="collapseId">
+        <GCollapse v-model="mainOpen">
             <div v-for="category in trainingCategories" :key="category">
-                <BButton v-b-toggle="idForCategory(category)" class="ui-link ml-3">
+                <BButton class="ui-link ml-3" @click="categoryOpen[category] = !categoryOpen[category]">
                     {{ category }} ({{ tutorialsInCategory(category).length }})
                     <FontAwesomeIcon :icon="faCaretDown" />
                 </BButton>
-                <BCollapse :id="idForCategory(category)">
+                <GCollapse :visible="!!categoryOpen[category]">
                     <ul class="d-flex flex-column my-1">
                         <li v-for="tutorial in tutorialsInCategory(category)" :key="tutorial.title">
                             <ExternalLink :href="tutorial.url.toString()" class="ml-2">
@@ -74,8 +70,8 @@ const tutorialText = computed(() => {
                             </ExternalLink>
                         </li>
                     </ul>
-                </BCollapse>
+                </GCollapse>
             </div>
-        </BCollapse>
+        </GCollapse>
     </div>
 </template>

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -21,7 +21,7 @@
             </datalist>
         </b-form-group>
         <b-link variant="primary" @click="onAdvanced"> {{ advancedTitle }} advanced settings. </b-link>
-        <b-collapse id="advanced-collapse" v-model="advancedShow" class="mt-2">
+        <GCollapse v-model="advancedShow" class="mt-2">
             <b-card>
                 <b-form-group
                     v-if="toolConfigs.length > 1"
@@ -45,14 +45,19 @@
                     <b-form-checkbox v-model="installToolDependencies"> Install tool dependencies </b-form-checkbox>
                 </b-form-group>
             </b-card>
-        </b-collapse>
+        </GCollapse>
     </b-modal>
 </template>
 <script>
 import { GalaxyApi } from "@/api";
 import { useConfig } from "@/composables/config";
 
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
+
 export default {
+    components: {
+        GCollapse,
+    },
     props: {
         repo: {
             type: Object,

--- a/client/src/components/User/Credentials/ServiceCredentials.vue
+++ b/client/src/components/User/Credentials/ServiceCredentials.vue
@@ -36,7 +36,7 @@ import {
     faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BBadge, BButton, BCollapse } from "bootstrap-vue";
+import { BBadge, BButton } from "bootstrap-vue";
 import { faX, faXmark } from "font-awesome-6";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
@@ -56,6 +56,7 @@ import { SECRET_PLACEHOLDER, useUserToolsServiceCredentialsStore } from "@/store
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import GCard from "@/components/Common/GCard.vue";
 import CredentialsGroupForm from "@/components/User/Credentials/CredentialsGroupForm.vue";
 
@@ -583,7 +584,7 @@ const groupIndicators = computed(() => (group: ServiceCredentialGroupResponse): 
             </BButton>
         </div>
 
-        <BCollapse :id="`accordion-${props.serviceDefinition.name}`" v-model="isExpanded" class="px-2">
+        <GCollapse v-model="isExpanded" class="px-2">
             <div class="d-flex flex-column mt-2">
                 <span class="text-md">{{ props.serviceDefinition.description }}</span>
 
@@ -637,7 +638,7 @@ const groupIndicators = computed(() => (group: ServiceCredentialGroupResponse): 
                     </template>
                 </GCard>
             </div>
-        </BCollapse>
+        </GCollapse>
     </div>
 </template>
 


### PR DESCRIPTION
Part of the bootstrap-vue scoped-slot replacement effort tracked in #21956.

`BCollapse` uses scoped slots internally and crashes under `@vue/compat`. `GCollapse` is a CSS max-height transition-based implementation covering the same API: `visible` prop, `v-b-toggle` trigger support via a custom `v-g-collapse-toggle` directive, and toggle events.

Migrates 11 files. Two navbar usages that work fine through compat are left as-is for now.