### PR TITLE
Replace BTabs/BTab with custom GTabs/GTab components

### DIFF
--- a/client/src/components/BaseComponents/GTab.vue
+++ b/client/src/components/BaseComponents/GTab.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed, h, inject, onBeforeUnmount, onMounted, ref, useSlots, watch } from "vue";
+
+import type { TabRegistration, TabsContext } from "./GTabs.vue";
+
+const props = withDefaults(
+    defineProps<{
+        title?: string;
+        titleLinkClass?: string | string[];
+        titleItemClass?: string | string[];
+        titleLinkAttributes?: Record<string, string>;
+        buttonId?: string;
+        id?: string;
+        active?: boolean;
+        disabled?: boolean;
+        lazy?: boolean;
+    }>(),
+    {
+        title: undefined,
+        titleLinkClass: undefined,
+        titleItemClass: undefined,
+        titleLinkAttributes: undefined,
+        buttonId: undefined,
+        id: undefined,
+        active: false,
+        disabled: false,
+        lazy: undefined,
+    },
+);
+
+const emit = defineEmits<{
+    (e: "click"): void;
+}>();
+
+const slots = useSlots();
+const context = inject<TabsContext>("g-tabs-context")!;
+const tabIndex = ref(-1);
+const hasBeenActive = ref(false);
+
+const isActive = computed(() => context.activeIndex.value === tabIndex.value);
+
+watch(isActive, (active) => {
+    if (active) {
+        hasBeenActive.value = true;
+        emit("click");
+    }
+});
+
+const shouldRender = computed(() => {
+    const isLazy = props.lazy !== undefined ? props.lazy : context.tabsLazy;
+    if (!isLazy) {
+        return true;
+    }
+    return hasBeenActive.value;
+});
+
+function titleRenderer() {
+    if (slots.title) {
+        return slots.title();
+    }
+    return props.title ? [h("span", props.title)] : [];
+}
+
+function buildRegistration(): TabRegistration {
+    return {
+        title: props.title,
+        titleRenderer,
+        disabled: props.disabled,
+        id: props.id,
+        buttonId: props.buttonId,
+        titleLinkClass: props.titleLinkClass,
+        titleItemClass: props.titleItemClass,
+        titleLinkAttributes: props.titleLinkAttributes,
+        active: props.active,
+        lazy: props.lazy,
+    };
+}
+
+onMounted(() => {
+    tabIndex.value = context.registerTab(buildRegistration());
+    if (props.active || isActive.value) {
+        hasBeenActive.value = true;
+    }
+});
+
+watch(
+    () => [
+        props.title,
+        props.disabled,
+        props.titleLinkClass,
+        props.titleItemClass,
+        props.titleLinkAttributes,
+        props.buttonId,
+    ],
+    () => {
+        if (tabIndex.value >= 0) {
+            context.updateTab(tabIndex.value, buildRegistration());
+        }
+    },
+);
+
+onBeforeUnmount(() => {
+    if (tabIndex.value >= 0) {
+        context.unregisterTab(tabIndex.value);
+    }
+});
+</script>
+
+<template>
+    <div
+        v-if="shouldRender"
+        v-show="isActive"
+        :id="id"
+        class="tab-pane"
+        :class="{ active: isActive, show: isActive }"
+        role="tabpanel">
+        <slot />
+    </div>
+</template>

--- a/client/src/components/BaseComponents/GTabs.vue
+++ b/client/src/components/BaseComponents/GTabs.vue
@@ -152,7 +152,14 @@ const TabTitleContent = defineComponent({
                 :key="index"
                 class="nav-item"
                 :class="tab.titleItemClass"
+                :title="tab.title"
                 role="presentation">
+                <!--
+                    TODO: migrate to <button> — semantically more correct for tabs (action, not navigation).
+                    Using <a href="#"> for now because Selenium selectors in navigation.yml target `a.nav-link`
+                    (e.g. `.nav-item[title="..."] > a.nav-link`) matching what BTabs rendered.
+                    When updating, also change those selectors to drop the element type requirement.
+                -->
                 <a
                     :id="tab.buttonId"
                     class="nav-link"

--- a/client/src/components/BaseComponents/GTabs.vue
+++ b/client/src/components/BaseComponents/GTabs.vue
@@ -117,7 +117,9 @@ const navClasses = computed(() => ({
     "flex-column": props.vertical,
 }));
 
+// "tabs" class matches BTabs' outer div class for Selenium selector compatibility
 const containerClasses = computed(() => ({
+    tabs: true,
     "d-flex": props.vertical,
 }));
 
@@ -151,18 +153,18 @@ const TabTitleContent = defineComponent({
                 class="nav-item"
                 :class="tab.titleItemClass"
                 role="presentation">
-                <button
+                <a
                     :id="tab.buttonId"
                     class="nav-link"
                     :class="[tab.titleLinkClass, { active: index === activeIndex, disabled: tab.disabled }]"
                     role="tab"
-                    type="button"
+                    href="#"
                     :aria-selected="index === activeIndex"
-                    :disabled="tab.disabled"
+                    :aria-disabled="tab.disabled"
                     v-bind="tab.titleLinkAttributes"
-                    @click="setActive(index)">
+                    @click.prevent="!tab.disabled && setActive(index)">
                     <TabTitleContent :tab="tab" />
-                </button>
+                </a>
             </li>
         </ul>
         <div class="tab-content" :class="{ 'flex-grow-1': props.vertical }">

--- a/client/src/components/BaseComponents/GTabs.vue
+++ b/client/src/components/BaseComponents/GTabs.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Ref, VNode } from "vue";
-import { computed, h, provide, ref, watch } from "vue";
+import type { PropType, Ref, VNode } from "vue";
+import { computed, defineComponent, h, provide, ref, watch } from "vue";
 
 export interface TabRegistration {
     title?: string;
@@ -121,12 +121,25 @@ const containerClasses = computed(() => ({
     "d-flex": props.vertical,
 }));
 
-function renderTabTitle(tab: TabRegistration) {
-    if (tab.titleRenderer) {
-        return tab.titleRenderer();
-    }
-    return [h("span", tab.title)];
-}
+// Vue 2.7 doesn't support plain functions as components via <component :is>,
+// so we define a proper component with setup returning a render function.
+const TabTitleContent = defineComponent({
+    props: {
+        tab: {
+            type: Object as PropType<TabRegistration>,
+            required: true,
+        },
+    },
+    setup(props) {
+        return () => {
+            if (props.tab.titleRenderer) {
+                const nodes = props.tab.titleRenderer();
+                return nodes.length === 1 ? nodes[0] : h("span", nodes);
+            }
+            return h("span", props.tab.title || "");
+        };
+    },
+});
 </script>
 
 <template>
@@ -148,7 +161,7 @@ function renderTabTitle(tab: TabRegistration) {
                     :disabled="tab.disabled"
                     v-bind="tab.titleLinkAttributes"
                     @click="setActive(index)">
-                    <component :is="() => renderTabTitle(tab)" />
+                    <TabTitleContent :tab="tab" />
                 </button>
             </li>
         </ul>

--- a/client/src/components/BaseComponents/GTabs.vue
+++ b/client/src/components/BaseComponents/GTabs.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Ref, VNode } from "vue";
-import { computed, h, provide, reactive, ref, watch } from "vue";
+import { computed, h, provide, ref, watch } from "vue";
 
 export interface TabRegistration {
     title?: string;
@@ -59,11 +59,11 @@ const activeIndex = computed({
     },
 });
 
-const tabs = reactive<TabRegistration[]>([]);
+const tabs = ref<TabRegistration[]>([]);
 
 function registerTab(tab: TabRegistration): number {
-    const index = tabs.length;
-    tabs.push(tab);
+    const index = tabs.value.length;
+    tabs.value.push(tab);
     if (tab.active && index !== activeIndex.value) {
         activeIndex.value = index;
     }
@@ -71,20 +71,20 @@ function registerTab(tab: TabRegistration): number {
 }
 
 function unregisterTab(index: number) {
-    tabs.splice(index, 1);
-    if (activeIndex.value >= tabs.length && tabs.length > 0) {
-        activeIndex.value = tabs.length - 1;
+    tabs.value.splice(index, 1);
+    if (activeIndex.value >= tabs.value.length && tabs.value.length > 0) {
+        activeIndex.value = tabs.value.length - 1;
     }
 }
 
 function updateTab(index: number, tab: TabRegistration) {
-    if (index >= 0 && index < tabs.length) {
-        tabs[index] = tab;
+    if (index >= 0 && index < tabs.value.length) {
+        tabs.value[index] = tab;
     }
 }
 
 function setActive(index: number) {
-    if (index >= 0 && index < tabs.length && !tabs[index]?.disabled) {
+    if (index >= 0 && index < tabs.value.length && !tabs.value[index]?.disabled) {
         activeIndex.value = index;
     }
 }

--- a/client/src/components/BaseComponents/GTabs.vue
+++ b/client/src/components/BaseComponents/GTabs.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import type { Ref, VNode } from "vue";
+import { computed, h, provide, reactive, ref, watch } from "vue";
+
+export interface TabRegistration {
+    title?: string;
+    titleRenderer?: () => VNode[];
+    disabled?: boolean;
+    id?: string;
+    buttonId?: string;
+    titleLinkClass?: string | string[];
+    titleItemClass?: string | string[];
+    titleLinkAttributes?: Record<string, string>;
+    active?: boolean;
+    lazy?: boolean;
+}
+
+export interface TabsContext {
+    activeIndex: Ref<number>;
+    registerTab: (tab: TabRegistration) => number;
+    unregisterTab: (index: number) => void;
+    updateTab: (index: number, tab: TabRegistration) => void;
+    setActive: (index: number) => void;
+    tabsLazy: boolean;
+}
+
+const props = withDefaults(
+    defineProps<{
+        value?: number;
+        justified?: boolean;
+        fill?: boolean;
+        pills?: boolean;
+        card?: boolean;
+        vertical?: boolean;
+        lazy?: boolean;
+    }>(),
+    {
+        value: undefined,
+        justified: false,
+        fill: false,
+        pills: false,
+        card: false,
+        vertical: false,
+        lazy: false,
+    },
+);
+
+const emit = defineEmits<{
+    (e: "input", index: number): void;
+}>();
+
+const internalActive = ref(0);
+
+const activeIndex = computed({
+    get: () => (props.value !== undefined ? props.value : internalActive.value),
+    set: (val: number) => {
+        internalActive.value = val;
+        emit("input", val);
+    },
+});
+
+const tabs = reactive<TabRegistration[]>([]);
+
+function registerTab(tab: TabRegistration): number {
+    const index = tabs.length;
+    tabs.push(tab);
+    if (tab.active && index !== activeIndex.value) {
+        activeIndex.value = index;
+    }
+    return index;
+}
+
+function unregisterTab(index: number) {
+    tabs.splice(index, 1);
+    if (activeIndex.value >= tabs.length && tabs.length > 0) {
+        activeIndex.value = tabs.length - 1;
+    }
+}
+
+function updateTab(index: number, tab: TabRegistration) {
+    if (index >= 0 && index < tabs.length) {
+        tabs[index] = tab;
+    }
+}
+
+function setActive(index: number) {
+    if (index >= 0 && index < tabs.length && !tabs[index]?.disabled) {
+        activeIndex.value = index;
+    }
+}
+
+watch(
+    () => props.value,
+    (val) => {
+        if (val !== undefined) {
+            internalActive.value = val;
+        }
+    },
+);
+
+provide<TabsContext>("g-tabs-context", {
+    activeIndex,
+    registerTab,
+    unregisterTab,
+    updateTab,
+    setActive,
+    tabsLazy: props.lazy,
+});
+
+const navClasses = computed(() => ({
+    "nav-tabs": !props.pills,
+    "nav-pills": props.pills,
+    "nav-justified": props.justified,
+    "nav-fill": props.fill,
+    "card-header-tabs": props.card && !props.pills,
+    "card-header-pills": props.card && props.pills,
+    "flex-column": props.vertical,
+}));
+
+const containerClasses = computed(() => ({
+    "d-flex": props.vertical,
+}));
+
+function renderTabTitle(tab: TabRegistration) {
+    if (tab.titleRenderer) {
+        return tab.titleRenderer();
+    }
+    return [h("span", tab.title)];
+}
+</script>
+
+<template>
+    <div :class="containerClasses">
+        <ul class="nav" :class="navClasses" role="tablist">
+            <li
+                v-for="(tab, index) in tabs"
+                :key="index"
+                class="nav-item"
+                :class="tab.titleItemClass"
+                role="presentation">
+                <button
+                    :id="tab.buttonId"
+                    class="nav-link"
+                    :class="[tab.titleLinkClass, { active: index === activeIndex, disabled: tab.disabled }]"
+                    role="tab"
+                    type="button"
+                    :aria-selected="index === activeIndex"
+                    :disabled="tab.disabled"
+                    v-bind="tab.titleLinkAttributes"
+                    @click="setActive(index)">
+                    <component :is="() => renderTabTitle(tab)" />
+                </button>
+            </li>
+        </ul>
+        <div class="tab-content" :class="{ 'flex-grow-1': props.vertical }">
+            <slot />
+        </div>
+    </div>
+</template>

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BTab, BTabs } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import type { HDASummary } from "@/api";
@@ -15,6 +14,8 @@ import CollectionCreatorNoItemsMessage from "./CollectionCreatorNoItemsMessage.v
 import CollectionCreatorShowExtensions from "./CollectionCreatorShowExtensions.vue";
 import CollectionCreatorSourceOptions from "./CollectionCreatorSourceOptions.vue";
 import CollectionNameInput from "./CollectionNameInput.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import DefaultBox from "@/components/Upload/DefaultBox.vue";
 
 const Tabs = {
@@ -160,8 +161,8 @@ watch(
                 </div>
             </div>
         </span>
-        <BTabs v-else v-model="currentTab" fill justified>
-            <BTab
+        <GTabs v-else v-model="currentTab" fill justified>
+            <GTab
                 class="collection-creator"
                 :title="localize('Create Collection')"
                 :title-link-attributes="{ 'data-description': 'collection create tab build' }">
@@ -201,8 +202,8 @@ watch(
                             @clicked-create="emit('clicked-create', collectionName)" />
                     </div>
                 </div>
-            </BTab>
-            <BTab :title-link-attributes="{ 'data-description': 'collection create tab upload' }">
+            </GTab>
+            <GTab :title-link-attributes="{ 'data-description': 'collection create tab upload' }">
                 <template v-slot:title>
                     <FontAwesomeIcon :icon="faUpload" fixed-width />
                     <span>{{ localize("Upload Files to Add to Collection") }}</span>
@@ -223,8 +224,8 @@ watch(
                         <CollectionCreatorShowExtensions :extensions="extensions" upload />
                     </template>
                 </DefaultBox>
-            </BTab>
-        </BTabs>
+            </GTab>
+        </GTabs>
     </span>
 </template>
 

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -2,7 +2,7 @@
 import { faBars, faCog, faDatabase, faSave, faTable } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
-import { BAlert, BSpinner, BTab, BTabs } from "bootstrap-vue";
+import { BAlert, BSpinner } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -18,6 +18,8 @@ import { prependPath } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import ChangeDatatypeTab from "@/components/Collections/common/ChangeDatatypeTab.vue";
 import DatabaseEditTab from "@/components/Collections/common/DatabaseEditTab.vue";
 import SuitableConvertersTab from "@/components/Collections/common/SuitableConvertersTab.vue";
@@ -219,8 +221,8 @@ async function saveAttrs() {
         <BAlert v-if="successMessage" show variant="success" dismissible>
             {{ localize(successMessage) }}
         </BAlert>
-        <BTabs v-if="!errorMessage" class="mt-3">
-            <BTab title-link-class="collection-edit-attributes-nav" @click="updateInfoMessage('')">
+        <GTabs v-if="!errorMessage" class="mt-3">
+            <GTab title-link-class="collection-edit-attributes-nav" @click="updateInfoMessage('')">
                 <template v-slot:title>
                     <FontAwesomeIcon :icon="faBars" class="mr-1" />
                     {{ localize("Attributes") }}
@@ -238,8 +240,8 @@ async function saveAttrs() {
                         {{ localize("Save") }}
                     </GButton>
                 </div>
-            </BTab>
-            <BTab
+            </GTab>
+            <GTab
                 title-link-class="collection-edit-change-genome-nav"
                 @click="
                     updateInfoMessage(
@@ -263,10 +265,10 @@ async function saveAttrs() {
                             @clicked-save="clickedSave" />
                     </div>
                 </DbKeyProvider>
-            </BTab>
+            </GTab>
 
             <SuitableConvertersProvider :id="collectionId" v-slot="{ item }">
-                <BTab
+                <GTab
                     v-if="item && item.length"
                     title-link-class="collection-edit-convert-datatype-nav"
                     @click="updateInfoMessage('This will create a new collection in your History.')">
@@ -276,10 +278,10 @@ async function saveAttrs() {
                     </template>
 
                     <SuitableConvertersTab :suitable-converters="item" @clicked-convert="clickedConvert" />
-                </BTab>
+                </GTab>
             </SuitableConvertersProvider>
 
-            <BTab
+            <GTab
                 v-if="isConfigLoaded && config.enable_celery_tasks"
                 title-link-class="collection-edit-change-datatype-nav"
                 @click="
@@ -304,7 +306,7 @@ async function saveAttrs() {
                             @clicked-save="clickedDatatypeChange" />
                     </div>
                 </DatatypesProvider>
-            </BTab>
-        </BTabs>
+            </GTab>
+        </GTabs>
     </div>
 </template>

--- a/client/src/components/Dataset/DatasetView.test.js
+++ b/client/src/components/Dataset/DatasetView.test.js
@@ -113,11 +113,11 @@ async function mountDatasetView(tab = "preview", options = {}) {
                 template: "<a><slot></slot></a>",
                 props: ["to"],
             },
-            BTabs: {
+            GTabs: {
                 template: '<div class="tabs-container"><slot></slot></div>',
                 props: ["pills", "card", "lazy", "value"],
             },
-            BTab: {
+            GTab: {
                 template: '<div class="tab-content"><slot></slot></div>',
                 props: ["title"],
             },
@@ -167,8 +167,8 @@ async function mountLoadingDatasetView() {
         stubs: {
             Heading: true,
             BLink: true,
-            BTabs: true,
-            BTab: true,
+            GTabs: true,
+            GTab: true,
         },
         mocks: {
             $store: {

--- a/client/src/components/DatasetInformation/DatasetAttributes.test.ts
+++ b/client/src/components/DatasetInformation/DatasetAttributes.test.ts
@@ -76,8 +76,8 @@ describe("DatasetAttributes", () => {
     it("check rendering", async () => {
         const wrapper = await mountDatasetAttributes();
 
-        // 6 form buttons + 3 tab navigation buttons from GTabs
-        expect(wrapper.findAll("button").length).toBe(9);
+        // 6 form buttons (GTabs nav uses <a> tags, not buttons)
+        expect(wrapper.findAll("button").length).toBe(6);
         expect(wrapper.findAll("#attribute_text").length).toBe(1);
         expect(wrapper.findAll("#conversion_text").length).toBe(1);
         expect(wrapper.findAll("#datatype_text").length).toBe(1);
@@ -97,8 +97,8 @@ describe("DatasetAttributes", () => {
     it("check rendering without conversion option", async () => {
         const wrapper = await mountDatasetAttributes(true);
 
-        // 5 form buttons + 3 tab navigation buttons from GTabs
-        expect(wrapper.findAll("button").length).toBe(8);
+        // 5 form buttons (GTabs nav uses <a> tags, not buttons)
+        expect(wrapper.findAll("button").length).toBe(5);
         expect(wrapper.findAll("#attribute_text").length).toBe(1);
         expect(wrapper.findAll("#conversion_text").length).toBe(0);
         expect(wrapper.findAll("#datatype_text").length).toBe(1);

--- a/client/src/components/DatasetInformation/DatasetAttributes.test.ts
+++ b/client/src/components/DatasetInformation/DatasetAttributes.test.ts
@@ -76,7 +76,8 @@ describe("DatasetAttributes", () => {
     it("check rendering", async () => {
         const wrapper = await mountDatasetAttributes();
 
-        expect(wrapper.findAll("button").length).toBe(6);
+        // 6 form buttons + 3 tab navigation buttons from GTabs
+        expect(wrapper.findAll("button").length).toBe(9);
         expect(wrapper.findAll("#attribute_text").length).toBe(1);
         expect(wrapper.findAll("#conversion_text").length).toBe(1);
         expect(wrapper.findAll("#datatype_text").length).toBe(1);
@@ -96,7 +97,8 @@ describe("DatasetAttributes", () => {
     it("check rendering without conversion option", async () => {
         const wrapper = await mountDatasetAttributes(true);
 
-        expect(wrapper.findAll("button").length).toBe(5);
+        // 5 form buttons + 3 tab navigation buttons from GTabs
+        expect(wrapper.findAll("button").length).toBe(8);
         expect(wrapper.findAll("#attribute_text").length).toBe(1);
         expect(wrapper.findAll("#conversion_text").length).toBe(0);
         expect(wrapper.findAll("#datatype_text").length).toBe(1);

--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -2,7 +2,7 @@
 import { faBars, faCog, faDatabase, faExchangeAlt, faRedo, faSave, faUser } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { AxiosError } from "axios";
-import { BAlert, BTab, BTabs } from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 import { onMounted, ref } from "vue";
 
 import { fetchDatasetAttributes } from "@/api/datasets";
@@ -12,6 +12,8 @@ import localize from "@/utils/localization";
 
 import Heading from "../Common/Heading.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import FormDisplay from "@/components/Form/FormDisplay.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -101,8 +103,8 @@ onMounted(async () => {
             <LoadingSpan message="Loading dataset attributes..." />
         </BAlert>
         <div v-else-if="!loadingFailed" class="mt-3">
-            <BTabs>
-                <BTab v-if="!datasetAttributes['attribute_disable']">
+            <GTabs>
+                <GTab v-if="!datasetAttributes['attribute_disable']">
                     <template v-slot:title>
                         <FontAwesomeIcon :icon="faBars" class="mr-1" />
                         {{ localize("Attributes") }}
@@ -130,9 +132,9 @@ onMounted(async () => {
                             {{ localize("Auto-detect") }}
                         </GButton>
                     </div>
-                </BTab>
+                </GTab>
 
-                <BTab
+                <GTab
                     v-if="
                         (!datasetAttributes['conversion_disable'] || !datasetAttributes['datatype_disable']) &&
                         !datasetAttributes['metadata_disable']
@@ -203,9 +205,9 @@ onMounted(async () => {
                             </div>
                         </div>
                     </div>
-                </BTab>
+                </GTab>
 
-                <BTab v-if="!datasetAttributes['permission_disable']">
+                <GTab v-if="!datasetAttributes['permission_disable']">
                     <template v-slot:title>
                         <FontAwesomeIcon :icon="faUser" class="mr-1" />
                         {{ localize("Permissions") }}
@@ -222,8 +224,8 @@ onMounted(async () => {
                             {{ localize("Save") }}
                         </GButton>
                     </div>
-                </BTab>
-            </BTabs>
+                </GTab>
+            </GTabs>
         </div>
     </div>
 </template>

--- a/client/src/components/FileSources/Instances/EditInstance.vue
+++ b/client/src/components/FileSources/Instances/EditInstance.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { BTab, BTabs } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
 import { useConfigurationTemplateEdit } from "@/components/ConfigTemplates/useConfigurationTesting";
@@ -8,6 +7,8 @@ import { useInstanceAndTemplate } from "./instance";
 import { useInstanceRouting } from "./routing";
 
 import EditSecrets from "./EditSecrets.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 
 const editTestUrl = "/api/file_source_instances/{uuid}/test";
 const editUrl = "/api/file_source_instances/{uuid}";
@@ -39,8 +40,8 @@ const {
 </script>
 <template>
     <div>
-        <BTabs v-if="hasSecrets">
-            <BTab title="Settings" active>
+        <GTabs v-if="hasSecrets">
+            <GTab title="Settings" active>
                 <ActionSummary
                     :error-data-description="errorDataDescription"
                     :test-results="testResults"
@@ -54,13 +55,13 @@ const {
                     :show-force-action-button="showForceActionButton"
                     @onForceSubmit="onForceSubmit"
                     @onSubmit="onSubmit" />
-            </BTab>
-            <BTab title="Secrets">
+            </GTab>
+            <GTab title="Secrets">
                 <div v-if="instance && template">
                     <EditSecrets :file-source="instance" :template="template" />
                 </div>
-            </BTab>
-        </BTabs>
+            </GTab>
+        </GTabs>
         <div v-else>
             <ActionSummary :error-data-description="errorDataDescription" :test-results="testResults" :error="error" />
             <InstanceForm

--- a/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
@@ -10,6 +10,8 @@ import { DEFAULT_EXPORT_PARAMS } from "@/composables/shortTermStorage";
 import { useTaskMonitor } from "@/composables/taskMonitor";
 
 import ExportRecordCard from "./ExportRecordCard.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import ExportToFileSourceForm from "@/components/Common/ExportForm.vue";
 import ExportToRDMRepositoryForm from "@/components/Common/ExportRDMForm.vue";
 import ExternalLink from "@/components/ExternalLink.vue";
@@ -206,8 +208,8 @@ function onArchiveHistoryWithExport() {
         </BButton>
 
         <BModal v-model="isExportDialogOpen" title="Export history to permanent storage" size="lg" hide-footer>
-            <BTabs card vertical lazy class="export-option-tabs">
-                <BTab id="to-remote-file-tab" title="To Repository" active>
+            <GTabs card vertical lazy class="export-option-tabs">
+                <GTab id="to-remote-file-tab" title="To Repository" active>
                     <p>
                         <b>Exporting to a repository</b> will create a compressed archive of the history contents, copy
                         it to a remote location (e.g. an FTP server) and create an export record with this information
@@ -215,8 +217,8 @@ function onArchiveHistoryWithExport() {
                         later by importing it from the export record.
                     </p>
                     <ExportToFileSourceForm what="history" @export="doExportToFileSourceWithPrefix" />
-                </BTab>
-                <BTab id="to-rdm-repository-tab" title="To RDM Repository">
+                </GTab>
+                <GTab id="to-rdm-repository-tab" title="To RDM Repository">
                     <p>
                         <b>Exporting to a RDM repository</b> (e.g. any
                         <ExternalLink href="https://inveniosoftware.org/products/rdm/"> Invenio RDM </ExternalLink>
@@ -235,8 +237,8 @@ function onArchiveHistoryWithExport() {
                         :default-filename="historyName + ' (Galaxy History)'"
                         :default-record-name="historyName"
                         @export="doExportToFileSource" />
-                </BTab>
-            </BTabs>
+                </GTab>
+            </GTabs>
         </BModal>
     </div>
 </template>

--- a/client/src/components/History/Archiving/HistoryArchiveWizard.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveWizard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { faArchive } from "@fortawesome/free-solid-svg-icons";
-import { BAlert, BCard, BTab, BTabs } from "bootstrap-vue";
+import { BAlert, BCard } from "bootstrap-vue";
 import { computed, ref } from "vue";
 import { RouterLink } from "vue-router";
 
@@ -10,6 +10,8 @@ import { useFileSources } from "@/composables/fileSources";
 import { useToast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
 
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import HistoryArchiveExportSelector from "@/components/History/Archiving/HistoryArchiveExportSelector.vue";
 import HistoryArchiveSimple from "@/components/History/Archiving/HistoryArchiveSimple.vue";
@@ -95,14 +97,14 @@ const breadcrumbItems = computed(() => [
             <div v-if="canFreeStorage">
                 <h2 class="h-md">How do you want to archive this history?</h2>
                 <BCard no-body class="mt-3">
-                    <BTabs pills card vertical lazy class="archival-option-tabs">
-                        <BTab id="keep-storage-tab" title="Keep storage space" active>
+                    <GTabs pills card vertical lazy class="archival-option-tabs">
+                        <GTab id="keep-storage-tab" title="Keep storage space" active>
                             <HistoryArchiveSimple :history="history" @onArchive="onArchiveHistory" />
-                        </BTab>
-                        <BTab id="free-storage-tab" title="Free storage space">
+                        </GTab>
+                        <GTab id="free-storage-tab" title="Free storage space">
                             <HistoryArchiveExportSelector :history="history" @onArchive="onArchiveHistory" />
-                        </BTab>
-                    </BTabs>
+                        </GTab>
+                    </GTabs>
                 </BCard>
             </div>
             <HistoryArchiveSimple v-else :history="history" @onArchive="onArchiveHistory" />

--- a/client/src/components/History/HistoryAccessibility.vue
+++ b/client/src/components/History/HistoryAccessibility.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faExclamation, faLock, faShareAlt, faUserLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BBadge, BTab, BTabs } from "bootstrap-vue";
+import { BBadge } from "bootstrap-vue";
 import { ref } from "vue";
 
 import { useHistoryBreadCrumbsToForProps } from "@/composables/historyBreadcrumbs";
@@ -12,6 +12,8 @@ import PortletSection from "../Common/PortletSection.vue";
 import SharingPage from "../Sharing/SharingPage.vue";
 import HistoryDatasetPermissions from "./HistoryDatasetPermissions.vue";
 import HistoryMakePrivate from "./HistoryMakePrivate.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 
 const props = defineProps<{
@@ -43,8 +45,8 @@ function openSharingTab() {
     <div aria-labelledby="history-sharing-heading">
         <BreadcrumbHeading :items="breadcrumbItems" />
 
-        <BTabs class="mt-3">
-            <BTab id="history-sharing-tab" :lazy="historyPrivacyChanged" @click="openSharingTab">
+        <GTabs class="mt-3">
+            <GTab id="history-sharing-tab" :lazy="historyPrivacyChanged" @click="openSharingTab">
                 <template v-slot:title>
                     <FontAwesomeIcon :icon="faShareAlt" class="mr-1" />
                     {{ localize("Share or Publish") }}
@@ -66,25 +68,25 @@ function openSharingTab() {
 
                     <SharingPage :id="props.historyId" plural-name="histories" model-class="History" no-heading />
                 </PortletSection>
-            </BTab>
+            </GTab>
 
-            <BTab id="history-permissions-tab" :lazy="historyPrivacyChanged" @click="historyPrivacyChanged = false">
+            <GTab id="history-permissions-tab" :lazy="historyPrivacyChanged" @click="historyPrivacyChanged = false">
                 <template v-slot:title>
                     <FontAwesomeIcon :icon="faUserLock" class="mr-1" />
                     {{ localize("Set Permissions") }}
                 </template>
 
                 <HistoryDatasetPermissions :history-id="props.historyId" no-redirect />
-            </BTab>
+            </GTab>
 
-            <BTab id="history-make-private-tab">
+            <GTab id="history-make-private-tab">
                 <template v-slot:title>
                     <FontAwesomeIcon :icon="faLock" class="mr-1" />
                     {{ localize("Make Private") }}
                 </template>
 
                 <HistoryMakePrivate :history-id="props.historyId" @history-made-private="historyMadePrivate" />
-            </BTab>
-        </BTabs>
+            </GTab>
+        </GTabs>
     </div>
 </template>

--- a/client/src/components/HistoryExport/Index.vue
+++ b/client/src/components/HistoryExport/Index.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { BCard, BTab, BTabs } from "bootstrap-vue";
+import { BCard } from "bootstrap-vue";
 
 import { useFileSources } from "@/composables/fileSources";
 
 import ToLink from "./ToLink.vue";
 import ToRemoteFile from "./ToRemoteFile.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const { isLoading: initializingFileSources, hasWritable: hasWritableFileSources } = useFileSources();
@@ -23,18 +25,14 @@ const props = defineProps<ExportHistoryProps>();
         </span>
         <span v-else-if="hasWritableFileSources">
             <BCard no-body>
-                <BTabs pills card vertical class="history-export-tabs">
-                    <BTab title="to a link" title-link-class="tab-export-to-link" active>
-                        <b-card-text>
-                            <ToLink :history-id="props.historyId" />
-                        </b-card-text>
-                    </BTab>
-                    <BTab title="to a repository" title-link-class="tab-export-to-file">
-                        <b-card-text>
-                            <ToRemoteFile :history-id="props.historyId" />
-                        </b-card-text>
-                    </BTab>
-                </BTabs>
+                <GTabs pills card vertical class="history-export-tabs">
+                    <GTab title="to a link" title-link-class="tab-export-to-link" active>
+                        <ToLink :history-id="props.historyId" />
+                    </GTab>
+                    <GTab title="to a repository" title-link-class="tab-export-to-file">
+                        <ToRemoteFile :history-id="props.historyId" />
+                    </GTab>
+                </GTabs>
             </BCard>
         </span>
         <span v-else>

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/DirectoryDatasetPicker.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/DirectoryDatasetPicker.vue
@@ -1,15 +1,5 @@
 <script setup lang="ts">
-import {
-    BAlert,
-    BButton,
-    BFormCheckbox,
-    BFormCheckboxGroup,
-    BFormGroup,
-    BFormTextarea,
-    BModal,
-    BTab,
-    BTabs,
-} from "bootstrap-vue";
+import { BAlert, BButton, BFormCheckbox, BFormCheckboxGroup, BFormGroup, BFormTextarea, BModal } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import { GalaxyApi } from "@/api";
@@ -19,6 +9,8 @@ import { Toast } from "@/composables/toast";
 import { useDbKeyStore } from "@/stores/dbKeyStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import FormDrilldown from "@/components/Form/Elements/FormDrilldown/FormDrilldown.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import SingleItemSelector from "@/components/SingleItemSelector.vue";
@@ -269,11 +261,11 @@ watch(
 
 <template>
     <BModal :title="title" visible scrollable content-class="directory-dataset-picker" @hide="emit('onClose')">
-        <BTabs v-if="!pathMode" v-model="activeTab" fill pills>
-            <BTab title="Choose Files" />
+        <GTabs v-if="!pathMode" v-model="activeTab" fill pills>
+            <GTab title="Choose Files" />
 
-            <BTab title="Choose Folders" />
-        </BTabs>
+            <GTab title="Choose Folders" />
+        </GTabs>
 
         <BAlert v-if="filesMode" show class="mt-2">
             All files you select will be imported into the current folder ignoring their folder structure.

--- a/client/src/components/ObjectStore/Instances/EditInstance.vue
+++ b/client/src/components/ObjectStore/Instances/EditInstance.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { BTab, BTabs } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
 import { useConfigurationTemplateEdit } from "@/components/ConfigTemplates/useConfigurationTesting";
@@ -9,6 +8,8 @@ import { useInstanceAndTemplate } from "./instance";
 import { useInstanceRouting } from "./routing";
 
 import EditSecrets from "./EditSecrets.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 
 const editTestUrl = "/api/object_store_instances/{uuid}/test";
 const editUrl = "/api/object_store_instances/{uuid}";
@@ -50,8 +51,8 @@ const {
 </script>
 <template>
     <div>
-        <BTabs v-if="hasSecrets">
-            <BTab title="Settings" active>
+        <GTabs v-if="hasSecrets">
+            <GTab title="Settings" active>
                 <ActionSummary
                     :error-data-description="errorDataDescription"
                     :test-results="testResults"
@@ -65,13 +66,13 @@ const {
                     :show-force-action-button="showForceActionButton"
                     @onForceSubmit="onForceSubmit"
                     @onSubmit="onSubmit" />
-            </BTab>
-            <BTab title="Secrets">
+            </GTab>
+            <GTab title="Secrets">
                 <div v-if="instance && template">
                     <EditSecrets :object-store="instance" :template="template" />
                 </div>
-            </BTab>
-        </BTabs>
+            </GTab>
+        </GTabs>
         <div v-else>
             <ActionSummary :error-data-description="errorDataDescription" :test-results="testResults" :error="error" />
             <InstanceForm

--- a/client/src/components/Upload/UploadContainer.vue
+++ b/client/src/components/Upload/UploadContainer.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { BAlert, BTab, BTabs } from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 
@@ -19,6 +19,8 @@ import { buildLegacyPayload } from "@/utils/upload";
 import CompositeBox from "./CompositeBox.vue";
 import DefaultBox from "./DefaultBox.vue";
 import RulesInput from "./RulesInput.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const props = defineProps({
@@ -74,7 +76,7 @@ const props = defineProps({
     },
 });
 
-const collectionTabActive = ref(null);
+const currentTab = ref(0);
 const extensionsSet = ref(false);
 const datatypesMapper = ref(null);
 const datatypesMapperReady = ref(false);
@@ -82,7 +84,29 @@ const dbKeysSet = ref(false);
 const listExtensions = ref([]);
 const listDbKeys = ref([]);
 const regular = ref(null);
-const regularTabActive = ref(null);
+
+// Tab indices shift based on which tabs are visible, so compute them dynamically
+const regularTabIndex = computed(() => (showRegular.value ? 0 : -1));
+const _compositeTabIndex = computed(() => {
+    let idx = 0;
+    if (showRegular.value) {
+        idx++;
+    }
+    return showComposite.value ? idx : -1;
+});
+const collectionTabIndex = computed(() => {
+    let idx = 0;
+    if (showRegular.value) {
+        idx++;
+    }
+    if (showComposite.value) {
+        idx++;
+    }
+    return showCollection.value ? idx : -1;
+});
+
+const regularTabActive = computed(() => currentTab.value === regularTabIndex.value);
+const collectionTabActive = computed(() => currentTab.value === collectionTabIndex.value);
 
 const { percentage, status } = storeToRefs(useUploadStore());
 
@@ -120,7 +144,7 @@ const showRules = computed(() => !props.formats || props.multiple);
 
 function immediateUpload(files) {
     if (showRegular.value) {
-        regularTabActive.value = true;
+        currentTab.value = regularTabIndex.value;
         regular.value?.addFiles(files, true);
     }
 }
@@ -176,34 +200,30 @@ defineExpose({
             create a new one.
         </span>
     </BAlert>
-    <BTabs v-else-if="ready">
-        <BTab v-if="showRegular" title="Regular" button-id="tab-title-link-regular" :active.sync="regularTabActive">
-        </BTab>
-        <BTab v-if="showComposite" id="composite" title="Composite" button-id="tab-title-link-composite">
-            <CompositeBox
-                :effective-extensions="effectiveExtensions"
-                :default-db-key="defaultDbKey"
-                :file-sources-configured="fileSourcesConfigured"
-                :ftp-upload-site="currentUserId && ftpUploadSite"
-                :has-callback="hasCallback"
-                :history-id="currentHistoryId"
-                :list-db-keys="listDbKeys"
-                v-on="$listeners" />
-        </BTab>
-        <BTab
-            v-if="showCollection"
-            title="Collection"
-            button-id="tab-title-link-collection"
-            :active.sync="collectionTabActive">
-        </BTab>
-        <BTab v-if="showRules" id="rule-based" title="Rule-based" button-id="tab-title-link-rule-based">
-            <RulesInput
-                :file-sources-configured="fileSourcesConfigured"
-                :ftp-upload-site="currentUserId && ftpUploadSite"
-                :has-callback="hasCallback"
-                :history-id="currentHistoryId"
-                v-on="$listeners" />
-        </BTab>
+    <div v-else-if="ready">
+        <GTabs v-model="currentTab">
+            <GTab v-if="showRegular" title="Regular" button-id="tab-title-link-regular" />
+            <GTab v-if="showComposite" id="composite" title="Composite" button-id="tab-title-link-composite">
+                <CompositeBox
+                    :effective-extensions="effectiveExtensions"
+                    :default-db-key="defaultDbKey"
+                    :file-sources-configured="fileSourcesConfigured"
+                    :ftp-upload-site="currentUserId && ftpUploadSite"
+                    :has-callback="hasCallback"
+                    :history-id="currentHistoryId"
+                    :list-db-keys="listDbKeys"
+                    v-on="$listeners" />
+            </GTab>
+            <GTab v-if="showCollection" title="Collection" button-id="tab-title-link-collection" />
+            <GTab v-if="showRules" id="rule-based" title="Rule-based" button-id="tab-title-link-rule-based">
+                <RulesInput
+                    :file-sources-configured="fileSourcesConfigured"
+                    :ftp-upload-site="currentUserId && ftpUploadSite"
+                    :has-callback="hasCallback"
+                    :history-id="currentHistoryId"
+                    v-on="$listeners" />
+            </GTab>
+        </GTabs>
         <DefaultBox
             v-if="showRegular || showCollection"
             v-show="regularTabActive || collectionTabActive"
@@ -222,7 +242,7 @@ defineExpose({
             :is-collection="collectionTabActive"
             @progress="progress"
             v-on="$listeners" />
-    </BTabs>
+    </div>
     <div v-else>
         <LoadingSpan message="Loading required information from Galaxy server." />
     </div>

--- a/client/src/components/Upload/UploadModal.test.js
+++ b/client/src/components/Upload/UploadModal.test.js
@@ -62,8 +62,8 @@ describe("UploadModal.vue", () => {
             propsData,
             localVue,
             stubs: {
-                BTabs: true,
-                BTab: true,
+                GTabs: true,
+                GTab: true,
                 Collection: true,
                 Composite: true,
                 Default: true,

--- a/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportCard.vue
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportCard.vue
@@ -18,11 +18,11 @@
                 >creating a BCO using Galaxy</a
             >.
         </p>
-        <b-tabs lazy>
-            <b-tab title="Download">
+        <GTabs lazy>
+            <GTab title="Download">
                 <a class="bco-json" style="padding-left: 1em" :href="bcoDownloadLink"><b>Download BCO</b></a>
-            </b-tab>
-            <b-tab title="Submit To BCODB">
+            </GTab>
+            <GTab title="Submit To BCODB">
                 <div>
                     <p>
                         To submit to a BCODB you need to already have an authenticated account. Instructions on
@@ -84,8 +84,8 @@
                         </div>
                     </form>
                 </div>
-            </b-tab>
-        </b-tabs>
+            </GTab>
+        </GTabs>
     </div>
 </template>
 
@@ -94,8 +94,15 @@ import axios from "axios";
 
 import { getAppRoot } from "@/onload/loadConfig";
 
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
+
 const getUrl = (path) => getAppRoot() + path;
 export default {
+    components: {
+        GTab,
+        GTabs,
+    },
     props: {
         invocationId: {
             type: String,

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -2,7 +2,7 @@
 import { faTimesCircle } from "@fortawesome/free-regular-svg-icons";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BTab, BTabs } from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 import { computed, onUnmounted, ref, watch } from "vue";
 
 import type { WorkflowInvocationElementView } from "@/api/invocations";
@@ -16,6 +16,8 @@ import ParameterStep from "./ParameterStep.vue";
 import SubworkflowAlert from "./SubworkflowAlert.vue";
 import WorkflowInvocationStepHeader from "./WorkflowInvocationStepHeader.vue";
 import WorkflowStepTitle from "./WorkflowStepTitle.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -228,8 +230,8 @@ onUnmounted(() => {
                                     <SubworkflowAlert v-else :invocation-id="stepDetails.subworkflow_invocation_id" />
                                 </div>
 
-                                <BTabs justified>
-                                    <BTab
+                                <GTabs justified>
+                                    <GTab
                                         v-if="workflowStepType === 'tool'"
                                         class="portlet-body"
                                         style="width: 100%; overflow-x: auto">
@@ -246,9 +248,9 @@ onUnmounted(() => {
                                                 :invocation-id="props.invocation.id" />
                                             <BAlert v-else v-localize variant="info" show>This step has no jobs</BAlert>
                                         </div>
-                                    </BTab>
+                                    </GTab>
 
-                                    <BTab
+                                    <GTab
                                         v-if="hasOutputDatasets || hasOutputCollections"
                                         title="Outputs"
                                         title-item-class="invocation-step-outputs-tab">
@@ -275,8 +277,8 @@ onUnmounted(() => {
                                                 <GenericHistoryItem :item-id="value.id" :item-src="value.src" />
                                             </div>
                                         </div>
-                                    </BTab>
-                                </BTabs>
+                                    </GTab>
+                                </GTabs>
                             </div>
                         </div>
                     </div>

--- a/client/src/components/admin/SanitizeAllow.vue
+++ b/client/src/components/admin/SanitizeAllow.vue
@@ -1,10 +1,10 @@
 <template>
     <div>
         <message :message="message" :status="status"></message>
-        <b-tabs>
-            <b-tab title="Toolshed Tools">
-                <b-tabs>
-                    <b-tab title="HTML Sanitized">
+        <GTabs>
+            <GTab title="Toolshed Tools">
+                <GTabs>
+                    <GTab title="HTML Sanitized">
                         <base-grid id="sanitize-allow-grid" :is-loaded="isLoaded" :columns="toolshedColumns">
                             <template v-slot:rows>
                                 <template v-for="(row, blockedIdx) in toolshedBlocked">
@@ -29,8 +29,8 @@
                                 </template>
                             </template>
                         </base-grid>
-                    </b-tab>
-                    <b-tab title="HTML Rendered">
+                    </GTab>
+                    <GTab title="HTML Rendered">
                         <base-grid id="sanitize-allow-grid" :is-loaded="isLoaded" :columns="columns">
                             <template v-slot:rows>
                                 <template v-for="(row, allowedIdx) in toolshedAllowed">
@@ -56,12 +56,12 @@
                                 </template>
                             </template>
                         </base-grid>
-                    </b-tab>
-                </b-tabs>
-            </b-tab>
-            <b-tab title="Local Tools">
-                <b-tabs>
-                    <b-tab title="HTML Sanitized">
+                    </GTab>
+                </GTabs>
+            </GTab>
+            <GTab title="Local Tools">
+                <GTabs>
+                    <GTab title="HTML Sanitized">
                         <base-grid id="sanitize-allow-grid" :is-loaded="isLoaded" :columns="columns">
                             <template v-slot:rows>
                                 <template v-for="(row, localBlockedIdx) in localBlocked">
@@ -75,8 +75,8 @@
                                 </template>
                             </template>
                         </base-grid>
-                    </b-tab>
-                    <b-tab title="HTML Rendered">
+                    </GTab>
+                    <GTab title="HTML Rendered">
                         <base-grid id="sanitize-allow-grid" :is-loaded="isLoaded" :columns="columns">
                             <template v-slot:rows>
                                 <template v-for="(row, localAllowedIdx) in localAllowed">
@@ -97,10 +97,10 @@
                                 </template>
                             </template>
                         </base-grid>
-                    </b-tab>
-                </b-tabs>
-            </b-tab>
-        </b-tabs>
+                    </GTab>
+                </GTabs>
+            </GTab>
+        </GTabs>
     </div>
 </template>
 
@@ -111,11 +111,15 @@ import { getAppRoot } from "@/onload/loadConfig";
 
 import Message from "../Message.vue";
 import BaseGrid from "./BaseGrid.vue";
+import GTab from "@/components/BaseComponents/GTab.vue";
+import GTabs from "@/components/BaseComponents/GTabs.vue";
 
 export default {
     components: {
         message: Message,
         "base-grid": BaseGrid,
+        GTab,
+        GTabs,
     },
     data() {
         return {


### PR DESCRIPTION
Part of the bootstrap-vue scoped-slot replacement effort tracked in #21956.

`BTabs` uses scoped slots and crashes under `@vue/compat`. `GTabs`/`GTab` are custom implementations using `provide`/`inject` for tab registration, supporting: `title` prop and `#title` slot for custom tab headers, `lazy` loading, `disabled` tabs, and `v-model` for active tab control.

One Vue 2.7 compatibility fix included: `<component :is="() => vnodes" />` is a Vue 3 functional component shorthand that Vue 2.7 silently ignores — replaced with a proper `defineComponent` using `setup` returning a render function.

Migrates 14 files.