### PR TITLE
Replace v-b-tooltip directive with custom v-g-tooltip

### DIFF
--- a/client/src/components/Annotation.vue
+++ b/client/src/components/Annotation.vue
@@ -2,7 +2,7 @@
     <ClickToEdit
         ref="annotationInput"
         v-slot="{ toggleEdit, placeholder, stateValidator }"
-        v-b-tooltip.hover="{ boundary: 'viewport', placement: tooltipPlacement }"
+        v-g-tooltip.hover="{ boundary: 'viewport', placement: tooltipPlacement }"
         class="annotation"
         tag-name="p"
         :value="annotation"

--- a/client/src/components/Annotation.vue
+++ b/client/src/components/Annotation.vue
@@ -2,7 +2,7 @@
     <ClickToEdit
         ref="annotationInput"
         v-slot="{ toggleEdit, placeholder, stateValidator }"
-        v-g-tooltip.hover="{ boundary: 'viewport', placement: tooltipPlacement }"
+        v-g-tooltip.hover="{ placement: tooltipPlacement }"
         class="annotation"
         tag-name="p"
         :value="annotation"

--- a/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
+++ b/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
@@ -60,7 +60,7 @@ const edamLink = (edamIRI: string) => `https://edamontology.github.io/edam-brows
                     :href="item.descriptionUrl">
                     {{ item.extension }}
                 </GLink>
-                <span v-else v-b-tooltip.hover :title="optionalString(item.description)">
+                <span v-else v-g-tooltip.hover :title="optionalString(item.description)">
                     {{ item.extension }}
                 </span>
             </template>

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -153,7 +153,7 @@ function citationsToBibtexAsText() {
                     </BNav>
                     <BButton
                         v-if="outputFormat === outputFormats.CITATION"
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         title="Copy all references as APA"
                         variant="link"
                         size="sm"
@@ -163,7 +163,7 @@ function citationsToBibtexAsText() {
                     </BButton>
                     <div v-if="outputFormat === outputFormats.BIBTEX" class="bibtex-actions">
                         <BButton
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             title="Copy all references as BibTeX"
                             variant="link"
                             size="sm"
@@ -172,7 +172,7 @@ function citationsToBibtexAsText() {
                             <FontAwesomeIcon :icon="faCopy" />
                         </BButton>
                         <BButton
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             title="Download references as .bib file"
                             variant="link"
                             size="sm"

--- a/client/src/components/Collections/BuildFileSetWizard.vue
+++ b/client/src/components/Collections/BuildFileSetWizard.vue
@@ -270,7 +270,7 @@ const {
             </BAlert>
             <h2 data-galaxy-file-drop-target>
                 {{ title }}
-                <a v-b-tooltip.hover aria-label="Upload Completed Workbook" :title="dropWorkbookTitle" href="#">
+                <a v-g-tooltip.hover aria-label="Upload Completed Workbook" :title="dropWorkbookTitle" href="#">
                     <FontAwesomeIcon
                         class="workbook-upload-helper mr-1"
                         :class="dropZoneClasses"

--- a/client/src/components/Common/Abbreviation.vue
+++ b/client/src/components/Common/Abbreviation.vue
@@ -7,7 +7,7 @@ const props = defineProps<Props>();
 </script>
 
 <template>
-    <abbr v-b-tooltip.hover :title="props.explanation">
+    <abbr v-g-tooltip.hover :title="props.explanation">
         <slot></slot>
     </abbr>
 </template>

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -30,7 +30,7 @@ function isPathActive(path: RawLocation): boolean {
                 <BLink
                     v-if="item.to && !isPathActive(item.to)"
                     :key="index"
-                    v-b-tooltip.hover.bottom.noninteractive
+                    v-g-tooltip.hover.bottom.noninteractive
                     :title="`Go back to ${localize(item.title)}`"
                     :to="item.to"
                     class="breadcrumb-heading-header-active">

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -30,7 +30,7 @@ function isPathActive(path: RawLocation): boolean {
                 <BLink
                     v-if="item.to && !isPathActive(item.to)"
                     :key="index"
-                    v-g-tooltip.hover.bottom.noninteractive
+                    v-g-tooltip.hover.bottom
                     :title="`Go back to ${localize(item.title)}`"
                     :to="item.to"
                     class="breadcrumb-heading-header-active">

--- a/client/src/components/Common/BreadcrumbNavigation.vue
+++ b/client/src/components/Common/BreadcrumbNavigation.vue
@@ -24,7 +24,7 @@ function handleNavigate(index: number | undefined) {
             <button
                 v-if="idx < items.length - 1"
                 :key="`link-${idx}`"
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 class="breadcrumb-link"
                 :title="`Navigate to ${item.title}`"
                 @click="handleNavigate(item.index)">

--- a/client/src/components/Common/BreadcrumbNavigation.vue
+++ b/client/src/components/Common/BreadcrumbNavigation.vue
@@ -24,7 +24,7 @@ function handleNavigate(index: number | undefined) {
             <button
                 v-if="idx < items.length - 1"
                 :key="`link-${idx}`"
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 class="breadcrumb-link"
                 :title="`Navigate to ${item.title}`"
                 @click="handleNavigate(item.index)">

--- a/client/src/components/Common/DOILink.vue
+++ b/client/src/components/Common/DOILink.vue
@@ -14,7 +14,7 @@ const doiLink = computed(() => `https://doi.org/${props.doi}`);
 </script>
 
 <template>
-    <BBadge v-b-tooltip.hover.noninteractive class="doi-badge" size="sm" title="DOI link">
+    <BBadge v-g-tooltip.hover.noninteractive class="doi-badge" size="sm" title="DOI link">
         <ExternalLink :href="doiLink">
             {{ props.doi }}
         </ExternalLink>

--- a/client/src/components/Common/DOILink.vue
+++ b/client/src/components/Common/DOILink.vue
@@ -14,7 +14,7 @@ const doiLink = computed(() => `https://doi.org/${props.doi}`);
 </script>
 
 <template>
-    <BBadge v-g-tooltip.hover.noninteractive class="doi-badge" size="sm" title="DOI link">
+    <BBadge v-g-tooltip.hover class="doi-badge" size="sm" title="DOI link">
         <ExternalLink :href="doiLink">
             {{ props.doi }}
         </ExternalLink>

--- a/client/src/components/Common/FilterMenuInput.vue
+++ b/client/src/components/Common/FilterMenuInput.vue
@@ -76,7 +76,7 @@ watch(
                 :id="`${identifier}-advanced-filter-${props.name}`"
                 ref="filterMenuInput"
                 v-model="localValue"
-                v-b-tooltip.focus.v-danger="props.error"
+                v-g-tooltip.focus.v-danger="props.error"
                 class="mw-100"
                 size="sm"
                 :state="props.error ? false : null"

--- a/client/src/components/Common/FilterMenuRanged.vue
+++ b/client/src/components/Common/FilterMenuRanged.vue
@@ -90,7 +90,7 @@ watch(
             <BFormInput
                 :id="`${props.identifier}-advanced-filter-${localNameGt}`"
                 v-model="localValueGt"
-                v-b-tooltip.focus.v-danger="hasError(localNameGt)"
+                v-g-tooltip.focus.v-danger="hasError(localNameGt)"
                 size="sm"
                 :state="hasError(localNameGt) ? false : null"
                 :placeholder="localPlaceholder('gt')"
@@ -107,7 +107,7 @@ watch(
             <BFormInput
                 :id="`${props.identifier}-advanced-filter-${localNameLt}`"
                 v-model="localValueLt"
-                v-b-tooltip.focus.v-danger="hasError(localNameLt)"
+                v-g-tooltip.focus.v-danger="hasError(localNameLt)"
                 size="sm"
                 :state="hasError(localNameLt) ? false : null"
                 :placeholder="localPlaceholder('lt')"

--- a/client/src/components/Common/FilterObjectStoreLink.vue
+++ b/client/src/components/Common/FilterObjectStoreLink.vue
@@ -48,7 +48,7 @@ const selectionText = computed(() => {
             <ObjectStoreSelect :object-stores="objectStores" @select="onSelect" />
         </SelectModal>
         <b-link href="#" @click="showModal = true">{{ selectionText }}</b-link>
-        <span v-if="value" v-b-tooltip.hover title="Remove Filter">
+        <span v-if="value" v-g-tooltip.hover title="Remove Filter">
             <FontAwesomeIcon :icon="faTimes" @click="onSelect(undefined)" />
         </span>
     </span>

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -330,7 +330,7 @@ function onKeyDown(event: KeyboardEvent) {
                                     <slot name="select">
                                         <BFormCheckbox
                                             :id="getElementId(props.id, 'select')"
-                                            v-b-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover.noninteractive
                                             :checked="selected"
                                             :title="props.selectTitle || localize('Select for bulk actions')"
                                             @change="emit('select')" />
@@ -356,7 +356,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             <BLink
                                                 v-if="typeof title === 'object'"
                                                 :id="getElementId(props.id, 'title-link')"
-                                                v-b-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover.noninteractive
                                                 :title="localize(title.title)"
                                                 :class="{ 'g-card-title-truncate': props.titleNLines }"
                                                 @click.stop.prevent="title.handler">
@@ -365,7 +365,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             <template v-else>
                                                 <span
                                                     :id="getElementId(props.id, 'title-text')"
-                                                    v-b-tooltip.hover.noninteractive
+                                                    v-g-tooltip.hover.noninteractive
                                                     :title="localize(title)"
                                                     :class="{ 'g-card-title-truncate': props.titleNLines }">
                                                     {{ title }}
@@ -376,7 +376,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 <BButton
                                                     v-if="props.canRenameTitle"
                                                     :id="getElementId(props.id, 'rename')"
-                                                    v-b-tooltip.hover.noninteractive
+                                                    v-g-tooltip.hover.noninteractive
                                                     class="inline-icon-button g-card-rename"
                                                     variant="link"
                                                     :title="localize(props.renameTitle)"
@@ -396,7 +396,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             v-if="badge.visible ?? true"
                                             :id="getBadgeId(props.id, badge.id)"
                                             :key="badge.id"
-                                            v-b-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover.noninteractive
                                             :pill="badge.type !== 'badge'"
                                             class="mt-1"
                                             :class="{
@@ -427,7 +427,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 props.bookmarked ? 'bookmark-remove' : 'bookmark-add',
                                             )
                                         "
-                                        v-b-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover.noninteractive
                                         class="inline-icon-button"
                                         variant="link"
                                         :title="props.bookmarked ? 'Remove bookmark' : 'Add to bookmarks'"
@@ -437,7 +437,7 @@ function onKeyDown(event: KeyboardEvent) {
                                     <BButton
                                         v-else
                                         :id="getElementId(props.id, 'bookmark-loading')"
-                                        v-b-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover.noninteractive
                                         class="inline-icon-button"
                                         variant="link"
                                         :title="localize('Bookmarking...')"
@@ -453,7 +453,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             props.extraActions.some((ea) => ea.visible ?? true)
                                         "
                                         :id="getElementId(props.id, 'extra-actions')"
-                                        v-b-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover.noninteractive
                                         right
                                         no-caret
                                         title="More options"
@@ -496,7 +496,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-if="badge.visible ?? true"
                                                 :id="getBadgeId(props.id, badge.id)"
                                                 :key="badge.id"
-                                                v-b-tooltip.hover.top.noninteractive
+                                                v-g-tooltip.hover.top.noninteractive
                                                 :pill="badge.type !== 'badge'"
                                                 :class="{
                                                     'outline-badge': badge.variant?.includes('outline'),
@@ -526,7 +526,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-if="(indicator.visible ?? true) && !indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
                                                 :key="`${indicator.id}-button`"
-                                                v-b-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover.noninteractive
                                                 class="inline-icon-button"
                                                 :title="localize(indicator.title)"
                                                 :variant="indicator.variant || 'outline-secondary'"
@@ -546,7 +546,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-else-if="(indicator.visible ?? true) && indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
                                                 :key="`${indicator.id}-icon`"
-                                                v-b-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover.noninteractive
                                                 :title="localize(indicator.title)"
                                                 :icon="indicator.icon"
                                                 :size="indicator.size || 'sm'"
@@ -595,7 +595,7 @@ function onKeyDown(event: KeyboardEvent) {
                                 :id="`g-card-${props.id}-update-time`"
                                 class="align-self-end mt-1">
                                 <BBadge
-                                    v-b-tooltip.hover.noninteractive
+                                    v-g-tooltip.hover.noninteractive
                                     pill
                                     variant="secondary"
                                     :title="localize(props.updateTimeTitle)">
@@ -618,7 +618,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             v-if="sa.visible ?? true"
                                             :id="getActionId(props.id, sa.id)"
                                             :key="sa.id"
-                                            v-b-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover.noninteractive
                                             :disabled="sa.disabled"
                                             :title="localize(sa.title)"
                                             :variant="sa.variant || 'outline-primary'"
@@ -648,7 +648,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-if="pa.visible ?? true"
                                                 :id="getActionId(props.id, pa.id)"
                                                 :key="pa.id"
-                                                v-b-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover.noninteractive
                                                 class="mt-1"
                                                 :disabled="pa.disabled"
                                                 :title="localize(pa.title)"

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -330,7 +330,7 @@ function onKeyDown(event: KeyboardEvent) {
                                     <slot name="select">
                                         <BFormCheckbox
                                             :id="getElementId(props.id, 'select')"
-                                            v-g-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover
                                             :checked="selected"
                                             :title="props.selectTitle || localize('Select for bulk actions')"
                                             @change="emit('select')" />
@@ -356,7 +356,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             <BLink
                                                 v-if="typeof title === 'object'"
                                                 :id="getElementId(props.id, 'title-link')"
-                                                v-g-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover
                                                 :title="localize(title.title)"
                                                 :class="{ 'g-card-title-truncate': props.titleNLines }"
                                                 @click.stop.prevent="title.handler">
@@ -365,7 +365,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             <template v-else>
                                                 <span
                                                     :id="getElementId(props.id, 'title-text')"
-                                                    v-g-tooltip.hover.noninteractive
+                                                    v-g-tooltip.hover
                                                     :title="localize(title)"
                                                     :class="{ 'g-card-title-truncate': props.titleNLines }">
                                                     {{ title }}
@@ -376,7 +376,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 <BButton
                                                     v-if="props.canRenameTitle"
                                                     :id="getElementId(props.id, 'rename')"
-                                                    v-g-tooltip.hover.noninteractive
+                                                    v-g-tooltip.hover
                                                     class="inline-icon-button g-card-rename"
                                                     variant="link"
                                                     :title="localize(props.renameTitle)"
@@ -396,7 +396,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             v-if="badge.visible ?? true"
                                             :id="getBadgeId(props.id, badge.id)"
                                             :key="badge.id"
-                                            v-g-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover
                                             :pill="badge.type !== 'badge'"
                                             class="mt-1"
                                             :class="{
@@ -427,7 +427,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 props.bookmarked ? 'bookmark-remove' : 'bookmark-add',
                                             )
                                         "
-                                        v-g-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover
                                         class="inline-icon-button"
                                         variant="link"
                                         :title="props.bookmarked ? 'Remove bookmark' : 'Add to bookmarks'"
@@ -437,7 +437,7 @@ function onKeyDown(event: KeyboardEvent) {
                                     <BButton
                                         v-else
                                         :id="getElementId(props.id, 'bookmark-loading')"
-                                        v-g-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover
                                         class="inline-icon-button"
                                         variant="link"
                                         :title="localize('Bookmarking...')"
@@ -453,7 +453,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             props.extraActions.some((ea) => ea.visible ?? true)
                                         "
                                         :id="getElementId(props.id, 'extra-actions')"
-                                        v-g-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover
                                         right
                                         no-caret
                                         title="More options"
@@ -496,7 +496,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-if="badge.visible ?? true"
                                                 :id="getBadgeId(props.id, badge.id)"
                                                 :key="badge.id"
-                                                v-g-tooltip.hover.top.noninteractive
+                                                v-g-tooltip.hover.top
                                                 :pill="badge.type !== 'badge'"
                                                 :class="{
                                                     'outline-badge': badge.variant?.includes('outline'),
@@ -526,7 +526,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-if="(indicator.visible ?? true) && !indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
                                                 :key="`${indicator.id}-button`"
-                                                v-g-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover
                                                 class="inline-icon-button"
                                                 :title="localize(indicator.title)"
                                                 :variant="indicator.variant || 'outline-secondary'"
@@ -546,7 +546,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-else-if="(indicator.visible ?? true) && indicator.disabled"
                                                 :id="getIndicatorId(props.id, indicator.id)"
                                                 :key="`${indicator.id}-icon`"
-                                                v-g-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover
                                                 :title="localize(indicator.title)"
                                                 :icon="indicator.icon"
                                                 :size="indicator.size || 'sm'"
@@ -595,7 +595,7 @@ function onKeyDown(event: KeyboardEvent) {
                                 :id="`g-card-${props.id}-update-time`"
                                 class="align-self-end mt-1">
                                 <BBadge
-                                    v-g-tooltip.hover.noninteractive
+                                    v-g-tooltip.hover
                                     pill
                                     variant="secondary"
                                     :title="localize(props.updateTimeTitle)">
@@ -618,7 +618,7 @@ function onKeyDown(event: KeyboardEvent) {
                                             v-if="sa.visible ?? true"
                                             :id="getActionId(props.id, sa.id)"
                                             :key="sa.id"
-                                            v-g-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover
                                             :disabled="sa.disabled"
                                             :title="localize(sa.title)"
                                             :variant="sa.variant || 'outline-primary'"
@@ -648,7 +648,7 @@ function onKeyDown(event: KeyboardEvent) {
                                                 v-if="pa.visible ?? true"
                                                 :id="getActionId(props.id, pa.id)"
                                                 :key="pa.id"
-                                                v-g-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover
                                                 class="mt-1"
                                                 :disabled="pa.disabled"
                                                 :title="localize(pa.title)"

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -684,7 +684,7 @@ defineExpose({
                                     <BFormCheckbox
                                         v-if="showSelectAll"
                                         :id="`g-table-select-all-${props.id}`"
-                                        v-g-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover
                                         :disabled="selectAllDisabled"
                                         :checked="allSelected"
                                         :indeterminate="indeterminateSelected"
@@ -753,7 +753,7 @@ defineExpose({
                                     <td v-if="selectable" class="g-table-select-column">
                                         <BFormCheckbox
                                             :id="`${getRowId(props.id, getGlobalIndex(paginatedIndex))}-select`"
-                                            v-g-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover
                                             :checked="isRowSelected(getGlobalIndex(paginatedIndex))"
                                             title="Select for bulk actions"
                                             @click.stop
@@ -779,7 +779,7 @@ defineExpose({
                                             ">
                                             <FontAwesomeIcon
                                                 v-if="getStatusIcon(item, getGlobalIndex(paginatedIndex))"
-                                                v-g-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover
                                                 v-bind="getIconProps(item, getGlobalIndex(paginatedIndex))"
                                                 fixed-width />
                                         </template>
@@ -798,7 +798,7 @@ defineExpose({
                                     <td v-if="props.actions" class="g-table-actions-column">
                                         <slot name="actions" :item="item" :index="getGlobalIndex(paginatedIndex)">
                                             <BDropdown
-                                                v-g-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover
                                                 no-caret
                                                 right
                                                 title="More actions"

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -684,7 +684,7 @@ defineExpose({
                                     <BFormCheckbox
                                         v-if="showSelectAll"
                                         :id="`g-table-select-all-${props.id}`"
-                                        v-b-tooltip.hover.noninteractive
+                                        v-g-tooltip.hover.noninteractive
                                         :disabled="selectAllDisabled"
                                         :checked="allSelected"
                                         :indeterminate="indeterminateSelected"
@@ -753,7 +753,7 @@ defineExpose({
                                     <td v-if="selectable" class="g-table-select-column">
                                         <BFormCheckbox
                                             :id="`${getRowId(props.id, getGlobalIndex(paginatedIndex))}-select`"
-                                            v-b-tooltip.hover.noninteractive
+                                            v-g-tooltip.hover.noninteractive
                                             :checked="isRowSelected(getGlobalIndex(paginatedIndex))"
                                             title="Select for bulk actions"
                                             @click.stop
@@ -779,7 +779,7 @@ defineExpose({
                                             ">
                                             <FontAwesomeIcon
                                                 v-if="getStatusIcon(item, getGlobalIndex(paginatedIndex))"
-                                                v-b-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover.noninteractive
                                                 v-bind="getIconProps(item, getGlobalIndex(paginatedIndex))"
                                                 fixed-width />
                                         </template>
@@ -798,7 +798,7 @@ defineExpose({
                                     <td v-if="props.actions" class="g-table-actions-column">
                                         <slot name="actions" :item="item" :index="getGlobalIndex(paginatedIndex)">
                                             <BDropdown
-                                                v-b-tooltip.hover.noninteractive
+                                                v-g-tooltip.hover.noninteractive
                                                 no-caret
                                                 right
                                                 title="More actions"

--- a/client/src/components/Common/ItemListEditor.vue
+++ b/client/src/components/Common/ItemListEditor.vue
@@ -131,7 +131,7 @@ function resetForm() {
                 <div v-for="(item, index) in itemsCurrent" :key="index">
                     {{ item }}
                     <b-button
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         class="inline-icon-button"
                         variant="link"
                         size="sm"
@@ -140,7 +140,7 @@ function resetForm() {
                         <FontAwesomeIcon :icon="faEdit" />
                     </b-button>
                     <b-button
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         class="inline-icon-button"
                         variant="link"
                         size="sm"

--- a/client/src/components/Common/TextSummary.vue
+++ b/client/src/components/Common/TextSummary.vue
@@ -47,7 +47,7 @@ const textTooLong = computed(() => {
 
         <span
             v-if="!noExpand && textTooLong"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             class="text-summary-expand-button"
             :class="{ 'text-summary-expand-float': !props.showExpandText }"
             :title="showDetails ? 'Show less' : 'Show more'"

--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -338,7 +338,7 @@ onMounted(() => {
         <div class="d-flex mt-1 align-items-center mt-2">
             <div v-if="selectedItemIds.length > 0" class="d-flex gap-1 w-100 position-absolute">
                 <BButton
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     size="sm"
                     variant="primary"
                     :disabled="bulkDeleteOrRestoreLoading"

--- a/client/src/components/DatasetInformation/DatasetSource.vue
+++ b/client/src/components/DatasetInformation/DatasetSource.vue
@@ -29,7 +29,7 @@ function copyLink() {
 
 <template>
     <li class="dataset-source">
-        <a v-if="browserCompatUri" v-b-tooltip.hover title="Dataset Source URL" :href="sourceUri" target="_blank">
+        <a v-if="browserCompatUri" v-g-tooltip.hover title="Dataset Source URL" :href="sourceUri" target="_blank">
             {{ source.source_uri }}
             <FontAwesomeIcon :icon="faExternalLinkAlt" />
         </a>
@@ -37,7 +37,7 @@ function copyLink() {
             {{ source.source_uri }}
         </span>
 
-        <span v-b-tooltip.hover title="Copy URI">
+        <span v-g-tooltip.hover title="Copy URI">
             <FontAwesomeIcon :icon="faCopy" style="cursor: pointer" @click="copyLink" />
         </span>
 

--- a/client/src/components/DatasetInformation/DatasetSourceTransform.vue
+++ b/client/src/components/DatasetInformation/DatasetSourceTransform.vue
@@ -72,7 +72,7 @@ function actionLongDescription(transformAction: DatasetTransform) {
             <ul>
                 <li v-for="(transformAction, index) in transform" :key="index">
                     <span
-                        v-g-tooltip.hover.noninteractive.nofade.bottom
+                        v-g-tooltip.hover.bottom
                         :title="actionLongDescription(transformAction)"
                         class="dataset-source-transform-element"
                         :data-transform-action="transformAction.action">

--- a/client/src/components/DatasetInformation/DatasetSourceTransform.vue
+++ b/client/src/components/DatasetInformation/DatasetSourceTransform.vue
@@ -72,7 +72,7 @@ function actionLongDescription(transformAction: DatasetTransform) {
             <ul>
                 <li v-for="(transformAction, index) in transform" :key="index">
                     <span
-                        v-b-tooltip.hover.noninteractive.nofade.bottom
+                        v-g-tooltip.hover.noninteractive.nofade.bottom
                         :title="actionLongDescription(transformAction)"
                         class="dataset-source-transform-element"
                         :data-transform-action="transformAction.action">

--- a/client/src/components/FileBrowser/RemoteFileBrowserContent.vue
+++ b/client/src/components/FileBrowser/RemoteFileBrowserContent.vue
@@ -246,13 +246,13 @@ defineExpose({
                 <template v-slot:cell(user)="{ item }">
                     <span
                         v-if="urlTracker.isAtRoot.value && !item.isLeaf && item.url.startsWith(USER_FILE_PREFIX)"
-                        v-b-tooltip.hover.noninteractive
+                        v-g-tooltip.hover.noninteractive
                         title="You created this file source">
                         <FontAwesomeIcon :icon="faUser" class="text-primary" fixed-width />
                     </span>
                     <span
                         v-else-if="urlTracker.isAtRoot.value && !item.isLeaf"
-                        v-b-tooltip.hover.noninteractive
+                        v-g-tooltip.hover.noninteractive
                         title="This file source was created by an administrator and is globally available">
                         <FontAwesomeIcon :icon="faGlobe" class="text-primary" fixed-width />
                     </span>

--- a/client/src/components/FileBrowser/RemoteFileBrowserContent.vue
+++ b/client/src/components/FileBrowser/RemoteFileBrowserContent.vue
@@ -246,13 +246,13 @@ defineExpose({
                 <template v-slot:cell(user)="{ item }">
                     <span
                         v-if="urlTracker.isAtRoot.value && !item.isLeaf && item.url.startsWith(USER_FILE_PREFIX)"
-                        v-g-tooltip.hover.noninteractive
+                        v-g-tooltip.hover
                         title="You created this file source">
                         <FontAwesomeIcon :icon="faUser" class="text-primary" fixed-width />
                     </span>
                     <span
                         v-else-if="urlTracker.isAtRoot.value && !item.isLeaf"
-                        v-g-tooltip.hover.noninteractive
+                        v-g-tooltip.hover
                         title="This file source was created by an administrator and is globally available">
                         <FontAwesomeIcon :icon="faGlobe" class="text-primary" fixed-width />
                     </span>

--- a/client/src/components/FileSources/FileSourceTypeSpan.vue
+++ b/client/src/components/FileSources/FileSourceTypeSpan.vue
@@ -17,7 +17,7 @@ const title = computed<string>(() => MESSAGES[props.type] ?? "");
 </script>
 
 <template>
-    <span v-b-tooltip.hover class="file-source-type file-source-help-on-hover" :title="title">{{ type }}</span>
+    <span v-g-tooltip.hover class="file-source-type file-source-help-on-hover" :title="title">{{ type }}</span>
 </template>
 
 <style scoped>

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -130,7 +130,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         </BButtonGroup>
         <BButton
             v-if="props.showViewCreateOptions && props.isPopulated"
-            v-g-tooltip.bottom.hover.noninteractive
+            v-g-tooltip.bottom.hover
             class="d-flex flex-gapx-1 align-items-center"
             title="View currently selected"
             :pressed="props.workflowTab === 'view'"
@@ -142,7 +142,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
              that has a single builder exposed, or source is dataset(s). -->
         <template v-if="props.showViewCreateOptions && sourceIsCollection && !hasSingleAvailableCollectionBuilderType">
             <BDropdown
-                v-g-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover
                 class="d-flex"
                 data-description="upload"
                 :title="createTitle"
@@ -158,7 +158,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
             </BDropdown>
             <BButton
                 v-if="props.workflowTab === 'create'"
-                v-g-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover
                 title="Hide Collection Creator"
                 variant="link"
                 @click="emit('update:workflow-tab', '')">
@@ -168,7 +168,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         </template>
         <BButton
             v-else-if="props.showViewCreateOptions && sourceIsCollection"
-            v-g-tooltip.bottom.hover.noninteractive
+            v-g-tooltip.bottom.hover
             class="d-flex flex-gapx-1 align-items-center"
             data-description="upload"
             :title="createTitle"
@@ -179,7 +179,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         </BButton>
         <template v-else-if="props.showViewCreateOptions && !sourceIsCollection">
             <BButton
-                v-g-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover
                 class="d-flex flex-gapx-1 align-items-center"
                 data-description="upload"
                 :title="createTitle"
@@ -189,7 +189,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
                 <span v-localize>Upload</span>
             </BButton>
             <BButton
-                v-g-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover
                 class="d-flex flex-gapx-1 align-items-center"
                 data-description="upload-beta"
                 title="Try our new upload experience"

--- a/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataContextButtons.vue
@@ -108,7 +108,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
             <BButton
                 v-for="(v, index) in props.variant"
                 :key="index"
-                v-b-tooltip.hover.bottom
+                v-g-tooltip.hover.bottom
                 :pressed="props.currentField === index"
                 :title="localize(v.tooltip)"
                 :style="v.icon === faFolder && v.multiple ? 'padding: 2px' : ''"
@@ -121,7 +121,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
             </BButton>
             <BButton
                 v-if="props.canBrowse && !props.workflowRun"
-                v-b-tooltip.hover.bottom
+                v-g-tooltip.hover.bottom
                 :title="localize('Browse or Upload Datasets')"
                 @click="emit('on-browse')">
                 <FontAwesomeIcon v-if="props.loading" :icon="faSpinner" spin />
@@ -130,7 +130,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         </BButtonGroup>
         <BButton
             v-if="props.showViewCreateOptions && props.isPopulated"
-            v-b-tooltip.bottom.hover.noninteractive
+            v-g-tooltip.bottom.hover.noninteractive
             class="d-flex flex-gapx-1 align-items-center"
             title="View currently selected"
             :pressed="props.workflowTab === 'view'"
@@ -142,7 +142,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
              that has a single builder exposed, or source is dataset(s). -->
         <template v-if="props.showViewCreateOptions && sourceIsCollection && !hasSingleAvailableCollectionBuilderType">
             <BDropdown
-                v-b-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover.noninteractive
                 class="d-flex"
                 data-description="upload"
                 :title="createTitle"
@@ -158,7 +158,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
             </BDropdown>
             <BButton
                 v-if="props.workflowTab === 'create'"
-                v-b-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover.noninteractive
                 title="Hide Collection Creator"
                 variant="link"
                 @click="emit('update:workflow-tab', '')">
@@ -168,7 +168,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         </template>
         <BButton
             v-else-if="props.showViewCreateOptions && sourceIsCollection"
-            v-b-tooltip.bottom.hover.noninteractive
+            v-g-tooltip.bottom.hover.noninteractive
             class="d-flex flex-gapx-1 align-items-center"
             data-description="upload"
             :title="createTitle"
@@ -179,7 +179,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
         </BButton>
         <template v-else-if="props.showViewCreateOptions && !sourceIsCollection">
             <BButton
-                v-b-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover.noninteractive
                 class="d-flex flex-gapx-1 align-items-center"
                 data-description="upload"
                 :title="createTitle"
@@ -189,7 +189,7 @@ const defaultCollectionBuilderType = computed<CollectionBuilderType>(() => {
                 <span v-localize>Upload</span>
             </BButton>
             <BButton
-                v-b-tooltip.bottom.hover.noninteractive
+                v-g-tooltip.bottom.hover.noninteractive
                 class="d-flex flex-gapx-1 align-items-center"
                 data-description="upload-beta"
                 title="Try our new upload experience"

--- a/client/src/components/Form/Elements/FormData/FormDataExtensions.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataExtensions.vue
@@ -38,7 +38,7 @@ const localFormatsVisible = computed({
     <div v-else>
         <GButton
             :id="props.formatsButtonId"
-            v-g-tooltip.hover.bottom.noninteractive="!formatsVisible ? orList([...props.extensions]) : ''"
+            v-g-tooltip.hover.bottom="!formatsVisible ? orList([...props.extensions]) : ''"
             size="small"
             color="blue"
             transparent

--- a/client/src/components/Form/Elements/FormData/FormDataExtensions.vue
+++ b/client/src/components/Form/Elements/FormData/FormDataExtensions.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BPopover, BTooltip } from "bootstrap-vue";
+import { BPopover } from "bootstrap-vue";
 import { computed } from "vue";
 
 import { orList } from "@/utils/strings";
@@ -38,6 +38,7 @@ const localFormatsVisible = computed({
     <div v-else>
         <GButton
             :id="props.formatsButtonId"
+            v-g-tooltip.hover.bottom.noninteractive="!formatsVisible ? orList([...props.extensions]) : ''"
             size="small"
             color="blue"
             transparent
@@ -62,15 +63,5 @@ const localFormatsVisible = computed({
                 <li v-for="extension in props.extensions" :key="extension">{{ extension }}</li>
             </ul>
         </GCollapse>
-        <BTooltip
-            v-if="!formatsVisible"
-            :target="props.formatsButtonId"
-            noninteractive
-            placement="bottom"
-            triggers="hover">
-            <div class="form-data-props.extensions-tooltip">
-                <span>{{ orList([...props.extensions]) }}</span>
-            </div>
-        </BTooltip>
     </div>
 </template>

--- a/client/src/components/Form/Elements/FormInputMismatchBadge.vue
+++ b/client/src/components/Form/Elements/FormInputMismatchBadge.vue
@@ -12,7 +12,7 @@ const emit = defineEmits(["stop-flagging"]);
     <BBadge class="form-input-changed-input-badge" pill size="sm">
         <span
             v-localize
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             title="This input has a different value than in the original run">
             Changed Input
         </span>

--- a/client/src/components/Form/Elements/FormInputMismatchBadge.vue
+++ b/client/src/components/Form/Elements/FormInputMismatchBadge.vue
@@ -10,10 +10,7 @@ const emit = defineEmits(["stop-flagging"]);
 
 <template>
     <BBadge class="form-input-changed-input-badge" pill size="sm">
-        <span
-            v-localize
-            v-g-tooltip.hover.noninteractive
-            title="This input has a different value than in the original run">
+        <span v-localize v-g-tooltip.hover title="This input has a different value than in the original run">
             Changed Input
         </span>
         <GButton

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -330,7 +330,7 @@ const extendedCollectionType = computed<ExtendedCollectionType>(() => {
 
                 <span
                     v-if="isRequired && isRequiredType && props.title"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="ui-form-title-star"
                     title="required"
                     :class="{ warning: isEmpty }">

--- a/client/src/components/Form/FormElementHeader.vue
+++ b/client/src/components/Form/FormElementHeader.vue
@@ -42,7 +42,7 @@ const badgeData = computed(() => {
         <slot name="badges" />
         <BBadge
             v-if="badgeData.message && props.type !== 'boolean'"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="flex-gapx-1 form-element-header-badge"
             :class="populatedClass"
             :title="badgeData.message">

--- a/client/src/components/Form/FormElementHeader.vue
+++ b/client/src/components/Form/FormElementHeader.vue
@@ -42,7 +42,7 @@ const badgeData = computed(() => {
         <slot name="badges" />
         <BBadge
             v-if="badgeData.message && props.type !== 'boolean'"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="flex-gapx-1 form-element-header-badge"
             :class="populatedClass"
             :title="badgeData.message">

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -379,7 +379,7 @@ watch(operationMessage, () => {
                 </a>
                 or
                 <a
-                    v-b-tooltip.noninteractive.hover
+                    v-g-tooltip.noninteractive.hover
                     title="Note that this might produce inaccurate results"
                     href="javascript:void(0)"
                     class="ui-link"

--- a/client/src/components/Grid/GridList.vue
+++ b/client/src/components/Grid/GridList.vue
@@ -379,7 +379,7 @@ watch(operationMessage, () => {
                 </a>
                 or
                 <a
-                    v-g-tooltip.noninteractive.hover
+                    v-g-tooltip.hover
                     title="Note that this might produce inaccurate results"
                     href="javascript:void(0)"
                     class="ui-link"

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -16,22 +16,22 @@ defineProps<Props>();
         <BProgress v-if="!summary.isTerminal" :max="summary.jobCount">
             <BProgressBar
                 v-if="summary.errorCount"
-                v-b-tooltip.hover="summary.errorCountText"
+                v-g-tooltip.hover="summary.errorCountText"
                 :value="summary.errorCount"
                 variant="danger" />
             <BProgressBar
                 v-if="summary.okCount"
-                v-b-tooltip.hover="summary.okCountText"
+                v-g-tooltip.hover="summary.okCountText"
                 :value="summary.okCount"
                 variant="success" />
             <BProgressBar
                 v-if="summary.runningCount"
-                v-b-tooltip.hover="summary.runningCountText"
+                v-g-tooltip.hover="summary.runningCountText"
                 :value="summary.runningCount"
                 variant="warning" />
             <BProgressBar
                 v-if="summary.waitingCount"
-                v-b-tooltip.hover="summary.waitingCountText"
+                v-g-tooltip.hover="summary.waitingCountText"
                 :value="summary.waitingCount"
                 variant="secondary" />
         </BProgress>

--- a/client/src/components/History/Content/Collection/DatasetProgress.vue
+++ b/client/src/components/History/Content/Collection/DatasetProgress.vue
@@ -14,22 +14,22 @@ defineProps<Props>();
         <BProgress v-if="!summary.isTerminal" :max="summary.datasetCount">
             <BProgressBar
                 v-if="summary.errorCount"
-                v-b-tooltip.hover="`${summary.errorCount} Error`"
+                v-g-tooltip.hover="`${summary.errorCount} Error`"
                 :value="summary.errorCount"
                 variant="danger" />
             <BProgressBar
                 v-if="summary.okCount"
-                v-b-tooltip.hover="`${summary.okCount} OK`"
+                v-g-tooltip.hover="`${summary.okCount} OK`"
                 :value="summary.okCount"
                 variant="success" />
             <BProgressBar
                 v-if="summary.runningCount"
-                v-b-tooltip.hover="`${summary.runningCount} Running`"
+                v-g-tooltip.hover="`${summary.runningCount} Running`"
                 :value="summary.runningCount"
                 variant="warning" />
             <BProgressBar
                 v-if="summary.waitingCount"
-                v-b-tooltip.hover="`${summary.waitingCount} Waiting`"
+                v-g-tooltip.hover="`${summary.waitingCount} Waiting`"
                 :value="summary.waitingCount"
                 variant="secondary" />
         </BProgress>

--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -157,7 +157,7 @@ const variant = computed(() => {
 </script>
 <template>
     <span v-if="canExpire" class="expiration-indicator">
-        <BBadge v-b-tooltip.noninteractive.hover.left :variant="variant" :title="expirationTooltip">
+        <BBadge v-g-tooltip.noninteractive.hover.left :variant="variant" :title="expirationTooltip">
             <FontAwesomeIcon :icon="faHourglass" /> {{ expirationMessage }}
         </BBadge>
     </span>

--- a/client/src/components/History/Content/ContentExpirationIndicator.vue
+++ b/client/src/components/History/Content/ContentExpirationIndicator.vue
@@ -157,7 +157,7 @@ const variant = computed(() => {
 </script>
 <template>
     <span v-if="canExpire" class="expiration-indicator">
-        <BBadge v-g-tooltip.noninteractive.hover.left :variant="variant" :title="expirationTooltip">
+        <BBadge v-g-tooltip.hover.left :variant="variant" :title="expirationTooltip">
             <FontAwesomeIcon :icon="faHourglass" /> {{ expirationMessage }}
         </BBadge>
     </span>

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -345,7 +345,7 @@ function unexpandedClick(event: Event) {
                     </BButton>
                     <BButton
                         v-if="highlight == 'input'"
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         variant="link"
                         class="p-0"
                         title="Input"
@@ -354,7 +354,7 @@ function unexpandedClick(event: Event) {
                     </BButton>
                     <BButton
                         v-else-if="highlight == 'active'"
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         variant="link"
                         class="p-0"
                         title="Inputs/Outputs highlighted for this item"
@@ -364,7 +364,7 @@ function unexpandedClick(event: Event) {
                     </BButton>
                     <BButton
                         v-else-if="highlight == 'output'"
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         variant="link"
                         class="p-0"
                         title="Output"
@@ -389,7 +389,7 @@ function unexpandedClick(event: Event) {
                 <span class="align-self-start btn-group">
                     <BButton
                         v-if="item.sub_items?.length && !isSubItem"
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         title="Show converted items"
                         tabindex="0"
                         class="display-btn px-1 align-items-center"

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -111,7 +111,7 @@ function onDisplay($event: MouseEvent) {
         <!-- Special case for collections -->
         <BButton
             v-if="isCollection && canShowCollectionDetails"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             class="collection-job-details-btn px-1"
             :title="localize('Show Details')"
             size="sm"
@@ -123,7 +123,7 @@ function onDisplay($event: MouseEvent) {
         <!-- Common for all content items -->
         <BButton
             v-if="isDataset"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             :title="localize('View')"
             tabindex="0"
             class="display-btn px-1"
@@ -135,7 +135,7 @@ function onDisplay($event: MouseEvent) {
         </BButton>
         <BButton
             v-if="writable && isHistoryItem"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             :disabled="editDisabled"
             :title="localize(editButtonTitle)"
             tabindex="0"
@@ -148,7 +148,7 @@ function onDisplay($event: MouseEvent) {
         </BButton>
         <BButton
             v-if="isRunningInteractiveTool"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             class="delete-btn px-1"
             :title="localize('Stop this Interactive Tool')"
             size="sm"
@@ -158,7 +158,7 @@ function onDisplay($event: MouseEvent) {
         </BButton>
         <BButton
             v-else-if="writable && isHistoryItem && !isDeleted"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             :tabindex="isDataset ? '0' : '-1'"
             class="delete-btn px-1"
             :title="localize('Delete')"
@@ -182,7 +182,7 @@ function onDisplay($event: MouseEvent) {
         </BButton>
         <BButton
             v-if="writable && isHistoryItem && isDeleted"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             tabindex="0"
             class="undelete-btn px-1"
             :title="localize('Undelete')"
@@ -193,7 +193,7 @@ function onDisplay($event: MouseEvent) {
         </BButton>
         <BButton
             v-if="writable && isHistoryItem && !isVisible"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             tabindex="0"
             class="unhide-btn px-1"
             :title="localize('Unhide')"

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -97,7 +97,7 @@ function onRerun() {
             <div class="btn-group float-left">
                 <BButton
                     v-if="showError"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="px-1"
                     title="Error"
                     size="sm"
@@ -111,7 +111,7 @@ function onRerun() {
 
                 <BButton
                     v-if="showDownloads"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="px-1"
                     title="Copy Link"
                     size="sm"
@@ -122,7 +122,7 @@ function onRerun() {
 
                 <BButton
                     v-if="showInfo"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="info-btn px-1"
                     title="Dataset Details"
                     size="sm"
@@ -134,7 +134,7 @@ function onRerun() {
 
                 <BButton
                     v-if="showVisualizations"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="visualize-btn px-1"
                     title="Visualize"
                     size="sm"
@@ -146,7 +146,7 @@ function onRerun() {
 
                 <BButton
                     v-if="showHighlight"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="highlight-btn px-1"
                     title="Show Related Items"
                     size="sm"
@@ -157,7 +157,7 @@ function onRerun() {
 
                 <BButton
                     v-if="writable && showRerun"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="rerun-btn px-1"
                     title="Run Job Again"
                     size="sm"

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -36,7 +36,7 @@ function onDownload(resource: string, extension = "") {
 <template>
     <BDropdown
         v-if="hasMetaFiles"
-        v-b-tooltip.hover
+        v-g-tooltip.hover
         dropup
         no-caret
         no-flip
@@ -66,7 +66,7 @@ function onDownload(resource: string, extension = "") {
 
     <BButton
         v-else
-        v-b-tooltip.hover
+        v-g-tooltip.hover
         class="download-btn px-1"
         title="Download"
         size="sm"

--- a/client/src/components/History/CurrentCollection/CollectionNavigation.vue
+++ b/client/src/components/History/CurrentCollection/CollectionNavigation.vue
@@ -39,7 +39,7 @@ function close() {
 <template>
     <div class="mx-1 mt-1">
         <BButton
-            v-b-tooltip:hover="historyName"
+            v-g-tooltip:hover="historyName"
             size="sm"
             class="text-left text-decoration-none overflow-hidden text-nowrap w-100"
             style="text-overflow: ellipsis"

--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -130,7 +130,7 @@ onMounted(() => {
         <BButtonGroup v-if="currentUser">
             <BButtonGroup>
                 <BButton
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="localize('Show active')"
                     variant="link"
                     size="sm"
@@ -143,7 +143,7 @@ onMounted(() => {
 
                 <BButton
                     v-if="numItemsDeleted"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="localize('Include deleted')"
                     variant="link"
                     size="sm"
@@ -157,7 +157,7 @@ onMounted(() => {
 
                 <BButton
                     v-if="numItemsHidden"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="localize('Include hidden')"
                     variant="link"
                     size="sm"
@@ -171,7 +171,7 @@ onMounted(() => {
 
                 <BButton
                     v-if="!hideReload"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="reloadButtonTitle"
                     :variant="reloadButtonVariant"
                     size="sm"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -58,7 +58,7 @@ function userTitle(title: string) {
             <BButtonGroup>
                 <BButton
                     v-if="!props.minimal"
-                    v-b-tooltip.top.hover.noninteractive
+                    v-g-tooltip.top.hover.noninteractive
                     class="create-hist-btn"
                     data-description="create new history"
                     size="sm"
@@ -71,7 +71,7 @@ function userTitle(title: string) {
 
                 <BButton
                     v-if="!props.minimal"
-                    v-b-tooltip.top.hover.noninteractive
+                    v-g-tooltip.top.hover.noninteractive
                     data-description="switch to another history"
                     size="sm"
                     variant="link"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -58,7 +58,7 @@ function userTitle(title: string) {
             <BButtonGroup>
                 <BButton
                     v-if="!props.minimal"
-                    v-g-tooltip.top.hover.noninteractive
+                    v-g-tooltip.top.hover
                     class="create-hist-btn"
                     data-description="create new history"
                     size="sm"
@@ -71,7 +71,7 @@ function userTitle(title: string) {
 
                 <BButton
                     v-if="!props.minimal"
-                    v-g-tooltip.top.hover.noninteractive
+                    v-g-tooltip.top.hover
                     data-description="switch to another history"
                     size="sm"
                     variant="link"

--- a/client/src/components/History/CurrentHistory/HistoryOperations/DefaultOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/DefaultOperations.vue
@@ -44,7 +44,7 @@ async function runOperation(operation: () => Promise<unknown>) {
 <template>
     <section v-if="numItemsHidden || numItemsHidden || numItemsDeleted">
         <BDropdown
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             no-caret
             size="sm"
             variant="link"

--- a/client/src/components/History/CurrentHistory/HistoryOperations/DefaultOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/DefaultOperations.vue
@@ -44,7 +44,7 @@ async function runOperation(operation: () => Promise<unknown>) {
 <template>
     <section v-if="numItemsHidden || numItemsHidden || numItemsDeleted">
         <BDropdown
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             no-caret
             size="sm"
             variant="link"

--- a/client/src/components/History/CurrentHistory/HistoryOperations/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/HistoryOperations.vue
@@ -34,7 +34,7 @@ function onUpdateOperationStatus(updateTime: number) {
         <nav v-if="editable" class="content-operations d-flex justify-content-between bg-secondary">
             <BButtonGroup>
                 <BButton
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="localize('Select Items')"
                     class="show-history-content-selectors-btn rounded-0"
                     size="sm"
@@ -46,7 +46,7 @@ function onUpdateOperationStatus(updateTime: number) {
                 </BButton>
 
                 <BButton
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="localize('Collapse Items')"
                     class="rounded-0"
                     size="sm"
@@ -69,7 +69,7 @@ function onUpdateOperationStatus(updateTime: number) {
         </nav>
         <nav v-else-if="isMultiViewItem" class="content-operations bg-secondary">
             <BButton
-                v-b-tooltip.hover
+                v-g-tooltip.hover
                 :title="localize('Collapse Items')"
                 class="rounded-0"
                 size="sm"

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.vue
@@ -28,7 +28,7 @@ function resetSelection() {
     <BButtonGroup size="sm">
         <BButton
             v-if="hasSelection"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             :title="localize('Clear selection')"
             variant="link"
             data-test-id="clear-btn"

--- a/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
+++ b/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
@@ -54,7 +54,7 @@ function toggleSelectPreferredStore() {
 <template>
     <div class="storage-location-indicator">
         <BButton
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="ui-link"
             :title="storageLocationButtonTitle"
             :disabled="isAnonymous"

--- a/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
+++ b/client/src/components/History/CurrentHistory/StorageLocationIndicator.vue
@@ -54,7 +54,7 @@ function toggleSelectPreferredStore() {
 <template>
     <div class="storage-location-indicator">
         <BButton
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="ui-link"
             :title="storageLocationButtonTitle"
             :disabled="isAnonymous"

--- a/client/src/components/History/HistoryAccessibility.vue
+++ b/client/src/components/History/HistoryAccessibility.vue
@@ -52,7 +52,7 @@ function openSharingTab() {
                     {{ localize("Share or Publish") }}
                     <BBadge
                         v-if="sharingStatusChanged"
-                        v-g-tooltip.hover.noninteractive
+                        v-g-tooltip.hover
                         class="ml-1"
                         :title="localize('Sharing status for this history has changed.')"
                         variant="primary">

--- a/client/src/components/History/HistoryAccessibility.vue
+++ b/client/src/components/History/HistoryAccessibility.vue
@@ -52,7 +52,7 @@ function openSharingTab() {
                     {{ localize("Share or Publish") }}
                     <BBadge
                         v-if="sharingStatusChanged"
-                        v-b-tooltip.hover.noninteractive
+                        v-g-tooltip.hover.noninteractive
                         class="ml-1"
                         :title="localize('Sharing status for this history has changed.')"
                         variant="primary">

--- a/client/src/components/History/HistoryDatasetsBadge.vue
+++ b/client/src/components/History/HistoryDatasetsBadge.vue
@@ -83,7 +83,7 @@ onMounted(async () => {
 
 <template>
     <BBadge
-        v-g-tooltip.hover.top.noninteractive
+        v-g-tooltip.hover.top
         class="history-datasets d-flex flex-gapx-1 flex-gapy-1 align-items-center outline-badge cursor-pointer font-size-small"
         pill
         :title="`View history storage overview`"

--- a/client/src/components/History/HistoryDatasetsBadge.vue
+++ b/client/src/components/History/HistoryDatasetsBadge.vue
@@ -83,7 +83,7 @@ onMounted(async () => {
 
 <template>
     <BBadge
-        v-b-tooltip.hover.top.noninteractive
+        v-g-tooltip.hover.top.noninteractive
         class="history-datasets d-flex flex-gapx-1 flex-gapy-1 align-items-center outline-badge cursor-pointer font-size-small"
         pill
         :title="`View history storage overview`"

--- a/client/src/components/History/HistoryList.vue
+++ b/client/src/components/History/HistoryList.vue
@@ -623,7 +623,7 @@ onMounted(async () => {
                         Filter:
                         <BButton
                             id="show-deleted"
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             size="sm"
                             :title="deleteButtonTitle"
                             :pressed="showDeleted"
@@ -699,7 +699,7 @@ onMounted(async () => {
                 <BButton
                     v-if="!showDeleted"
                     id="history-list-footer-bulk-delete-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="bulkDeleteOrRestoreLoading ? 'Deleting histories' : 'Delete selected histories'"
                     :disabled="bulkDeleteOrRestoreLoading"
                     size="sm"
@@ -714,7 +714,7 @@ onMounted(async () => {
                 <BButton
                     v-else
                     id="history-list-footer-bulk-restore-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="bulkDeleteOrRestoreLoading ? 'Restoring histories' : 'Restore selected histories'"
                     :disabled="bulkDeleteOrRestoreLoading"
                     size="sm"
@@ -730,7 +730,7 @@ onMounted(async () => {
                 <BButton
                     v-if="showBulkPurge"
                     id="history-list-footer-bulk-purge-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="bulkPurgeLoading ? 'Purging histories' : 'Purge selected histories'"
                     :disabled="bulkPurgeLoading"
                     size="sm"
@@ -746,7 +746,7 @@ onMounted(async () => {
                 <BButton
                     v-if="!showDeleted"
                     id="history-list-footer-bulk-add-tags-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="bulkTagsLoading ? 'Adding tags' : 'Add tags to selected histories'"
                     :disabled="bulkTagsLoading"
                     size="sm"
@@ -762,7 +762,7 @@ onMounted(async () => {
                 <BButton
                     v-if="showBulkMultiview"
                     id="history-list-footer-bulk-open-multiview-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     title="Open selected histories in multiview"
                     size="sm"
                     variant="primary"

--- a/client/src/components/History/HistoryOptions.vue
+++ b/client/src/components/History/HistoryOptions.vue
@@ -106,7 +106,7 @@ function onDelete() {
 <template>
     <div>
         <BDropdown
-            v-g-tooltip.top.hover.noninteractive
+            v-g-tooltip.top.hover
             no-caret
             size="sm"
             :variant="props.minimal ? 'outline-info' : 'link'"

--- a/client/src/components/History/HistoryOptions.vue
+++ b/client/src/components/History/HistoryOptions.vue
@@ -106,7 +106,7 @@ function onDelete() {
 <template>
     <div>
         <BDropdown
-            v-b-tooltip.top.hover.noninteractive
+            v-g-tooltip.top.hover.noninteractive
             no-caret
             size="sm"
             :variant="props.minimal ? 'outline-info' : 'link'"

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -139,7 +139,7 @@ function selectText() {
                     v-if="renameable"
                     ref="clickToEditRef"
                     v-model="clickToEditName"
-                    v-b-tooltip.hover="clickToEditClamped ? name : ''"
+                    v-g-tooltip.hover="clickToEditClamped ? name : ''"
                     component="h3"
                     title="..."
                     data-description="name display"

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -115,7 +115,7 @@ function showRecent() {
 
             <div class="d-flex justify-content-between">
                 <div>
-                    <BButtonGroup v-g-tooltip.hover.noninteractive :title="showRecentTitle">
+                    <BButtonGroup v-g-tooltip.hover :title="showRecentTitle">
                         <BButton
                             size="sm"
                             data-description="show recent histories"
@@ -128,7 +128,7 @@ function showRecent() {
                         </BButton>
                     </BButtonGroup>
                     <BButton
-                        v-g-tooltip.hover.noninteractive
+                        v-g-tooltip.hover
                         :title="localize('Open modal to select/deselect histories')"
                         size="sm"
                         data-description="open select histories modal"

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -115,7 +115,7 @@ function showRecent() {
 
             <div class="d-flex justify-content-between">
                 <div>
-                    <BButtonGroup v-b-tooltip.hover.noninteractive :title="showRecentTitle">
+                    <BButtonGroup v-g-tooltip.hover.noninteractive :title="showRecentTitle">
                         <BButton
                             size="sm"
                             data-description="show recent histories"
@@ -128,7 +128,7 @@ function showRecent() {
                         </BButton>
                     </BButtonGroup>
                     <BButton
-                        v-b-tooltip.hover.noninteractive
+                        v-g-tooltip.hover.noninteractive
                         :title="localize('Open modal to select/deselect histories')"
                         size="sm"
                         data-description="open select histories modal"

--- a/client/src/components/History/README.md
+++ b/client/src/components/History/README.md
@@ -26,7 +26,7 @@ to interact with each other.
         </Listing>
     </CurrentHistory>
 
-    <!-- When a collection is selected for viewing, send in a 
+    <!-- When a collection is selected for viewing, send in a
     breadcrumbs list of collections the user has selected -->
     <CurrentCollection :selected-collections="breadcrumbs">
         <CollectionNavigation />

--- a/client/src/components/History/TargetHistoryLink.vue
+++ b/client/src/components/History/TargetHistoryLink.vue
@@ -36,7 +36,7 @@ const isCurrentTargetHistory = computed(() => {
             </span>
             <span
                 v-else
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 data-description="not current history indicator"
                 class="text-warning"
                 title="This history is not your currently active history. You can click the link to switch to it.">

--- a/client/src/components/History/TargetHistoryLink.vue
+++ b/client/src/components/History/TargetHistoryLink.vue
@@ -36,7 +36,7 @@ const isCurrentTargetHistory = computed(() => {
             </span>
             <span
                 v-else
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 data-description="not current history indicator"
                 class="text-warning"
                 title="This history is not your currently active history. You can click the link to switch to it.">

--- a/client/src/components/History/TargetHistorySelector.vue
+++ b/client/src/components/History/TargetHistorySelector.vue
@@ -60,7 +60,7 @@ function handleHistorySelected(history: { id: string }) {
             <TargetHistoryLink :target-history-id="targetHistoryId" :target-history-caption="historyCaption" />
             <a
                 v-if="canChangeHistory"
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 href="#"
                 class="change-history-link ml-2"
                 :title="changeLinkTooltip"

--- a/client/src/components/History/TargetHistorySelector.vue
+++ b/client/src/components/History/TargetHistorySelector.vue
@@ -60,7 +60,7 @@ function handleHistorySelected(history: { id: string }) {
             <TargetHistoryLink :target-history-id="targetHistoryId" :target-history-caption="historyCaption" />
             <a
                 v-if="canChangeHistory"
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 href="#"
                 class="change-history-link ml-2"
                 :title="changeLinkTooltip"

--- a/client/src/components/HistoryExport/ExportLink.vue
+++ b/client/src/components/HistoryExport/ExportLink.vue
@@ -3,7 +3,7 @@
         <b
             ><a class="generated-export-link" :href="link">{{ link }}</a></b
         >
-        <span v-b-tooltip.hover title="Copy export URL to your clipboard">
+        <span v-g-tooltip.hover title="Copy export URL to your clipboard">
             <FontAwesomeIcon class="copy-export-link" :icon="faLink" style="cursor: pointer" @click="copyUrl" />
         </span>
         <i

--- a/client/src/components/Indices/IndexFilter.vue
+++ b/client/src/components/Indices/IndexFilter.vue
@@ -16,7 +16,7 @@
             </DebouncedInput>
             <BInputGroupAppend>
                 <BButton
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     aria-haspopup="true"
                     title="Advanced Filtering Help"
                     :size="size"
@@ -24,7 +24,7 @@
                     <FontAwesomeIcon :icon="faQuestion" />
                 </BButton>
                 <BButton
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     aria-haspopup="true"
                     title="Clear Filters (esc)"
                     :size="size"

--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -21,7 +21,7 @@ const props = defineProps<SharingIndicatorsProps>();
     <span v-else>
         <BButton
             v-if="props.object.published"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="sharing-indicator-published"
             size="sm"
             variant="link"
@@ -31,7 +31,7 @@ const props = defineProps<SharingIndicatorsProps>();
         </BButton>
         <BButton
             v-if="props.object.importable"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="sharing-indicator-importable"
             size="sm"
             variant="link"
@@ -41,7 +41,7 @@ const props = defineProps<SharingIndicatorsProps>();
         </BButton>
         <BButton
             v-if="props.object.shared"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="sharing-indicator-shared"
             size="sm"
             variant="link"

--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -21,7 +21,7 @@ const props = defineProps<SharingIndicatorsProps>();
     <span v-else>
         <BButton
             v-if="props.object.published"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="sharing-indicator-published"
             size="sm"
             variant="link"
@@ -31,7 +31,7 @@ const props = defineProps<SharingIndicatorsProps>();
         </BButton>
         <BButton
             v-if="props.object.importable"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="sharing-indicator-importable"
             size="sm"
             variant="link"
@@ -41,7 +41,7 @@ const props = defineProps<SharingIndicatorsProps>();
         </BButton>
         <BButton
             v-if="props.object.shared"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="sharing-indicator-shared"
             size="sm"
             variant="link"

--- a/client/src/components/InteractiveTools/InteractiveTools.vue
+++ b/client/src/components/InteractiveTools/InteractiveTools.vue
@@ -138,7 +138,7 @@ onMounted(() => {
             <template v-slot:cell(actions)="{ item }">
                 <BButton
                     :id="createId('stop', item.id)"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     variant="link"
                     class="p-0"
                     title="Stop this interactive tool"

--- a/client/src/components/JobInformation/CodeRow.vue
+++ b/client/src/components/JobInformation/CodeRow.vue
@@ -14,7 +14,7 @@
                     <pre :class="codeClass">{{ codeItem }}</pre>
                 </b-col>
                 <b-col
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="nopadding pointer"
                     :title="`click to ${action}`"
                     @mousedown="mouseIsDown = true"

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -224,7 +224,7 @@ watch(
                                 <li v-for="(value, name, i) in message" :key="i">
                                     <span
                                         v-if="metadataDetail[name]"
-                                        v-b-tooltip.html
+                                        v-g-tooltip.html
                                         class="tooltipJobInfo"
                                         :title="metadataDetail[name]">
                                         <strong>{{ name }}:</strong>

--- a/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissionCard.vue
+++ b/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissionCard.vue
@@ -19,7 +19,7 @@ function toggleInfo() {
 </script>
 
 <template>
-    <button v-b-tooltip.hover :title="props.explanation" @click="toggleInfo">
+    <button v-g-tooltip.hover :title="props.explanation" @click="toggleInfo">
         <div id="heading">{{ props.heading }}</div>
 
         <div class="value">

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -336,7 +336,7 @@ function onAddDatasetsDirectory(selectedDatasets: Record<string, string | boolea
 
                     <BDropdown
                         v-if="props.canAddLibraryItem"
-                        v-b-tooltip.top.noninteractive
+                        v-g-tooltip.top.noninteractive
                         right
                         no-caret
                         class="add-library-items-datasets mr-1">
@@ -365,7 +365,7 @@ function onAddDatasetsDirectory(selectedDatasets: Record<string, string | boolea
                         </BDropdownGroup>
                     </BDropdown>
 
-                    <BDropdown v-b-tooltip.top.noninteractive right no-caret class="add-to-history mr-1">
+                    <BDropdown v-g-tooltip.top.noninteractive right no-caret class="add-to-history mr-1">
                         <template v-slot:button-content>
                             <FontAwesomeIcon :icon="faBook" />
                             Add to History

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -336,7 +336,7 @@ function onAddDatasetsDirectory(selectedDatasets: Record<string, string | boolea
 
                     <BDropdown
                         v-if="props.canAddLibraryItem"
-                        v-g-tooltip.top.noninteractive
+                        v-g-tooltip.top
                         right
                         no-caret
                         class="add-library-items-datasets mr-1">
@@ -365,7 +365,7 @@ function onAddDatasetsDirectory(selectedDatasets: Record<string, string | boolea
                         </BDropdownGroup>
                     </BDropdown>
 
-                    <BDropdown v-g-tooltip.top.noninteractive right no-caret class="add-to-history mr-1">
+                    <BDropdown v-g-tooltip.top right no-caret class="add-to-history mr-1">
                         <template v-slot:button-content>
                             <FontAwesomeIcon :icon="faBook" />
                             Add to History

--- a/client/src/components/Markdown/Editor/CellButton.vue
+++ b/client/src/components/Markdown/Editor/CellButton.vue
@@ -1,6 +1,6 @@
 <template>
     <BButton
-        v-g-tooltip.noninteractive="tooltipOptions"
+        v-g-tooltip="tooltipOptions"
         class="border-0 m-1 px-1 py-0"
         :class="{ active, 'cell-button-hide': !show }"
         :title="title"

--- a/client/src/components/Markdown/Editor/CellButton.vue
+++ b/client/src/components/Markdown/Editor/CellButton.vue
@@ -1,6 +1,6 @@
 <template>
     <BButton
-        v-b-tooltip.noninteractive="tooltipOptions"
+        v-g-tooltip.noninteractive="tooltipOptions"
         class="border-0 m-1 px-1 py-0"
         :class="{ active, 'cell-button-hide': !show }"
         :title="title"
@@ -15,11 +15,9 @@
 
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, VBTooltipPlugin } from "bootstrap-vue";
+import { BButton } from "bootstrap-vue";
 import type { IconDefinition } from "font-awesome-6";
-import Vue, { computed } from "vue";
-
-Vue.use(VBTooltipPlugin);
+import { computed } from "vue";
 
 const props = withDefaults(
     defineProps<{

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -125,7 +125,7 @@ onMounted(() => {
 
                         <BButton
                             v-if="!readOnly"
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             class="markdown-edit"
                             role="button"
                             size="sm"

--- a/client/src/components/Markdown/MarkdownEditor.vue
+++ b/client/src/components/Markdown/MarkdownEditor.vue
@@ -10,14 +10,14 @@
                         <b-form-radio-group
                             v-if="!hasLabels"
                             v-model="editor"
-                            v-b-tooltip.hover.bottom
+                            v-g-tooltip.hover.bottom
                             button-variant="outline-primary"
                             buttons
                             size="sm"
                             title="Editor"
                             :options="editorOptions" />
                         <slot name="buttons" />
-                        <b-button v-b-tooltip.hover.bottom title="Help" variant="link" role="button" @click="onHelp">
+                        <b-button v-g-tooltip.hover.bottom title="Help" variant="link" role="button" @click="onHelp">
                             <FontAwesomeIcon :icon="faQuestion" />
                         </b-button>
                     </div>

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetCollection/CollectionDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetCollection/CollectionDisplay.vue
@@ -6,7 +6,7 @@
         <b-card-header>
             <span class="float-right">
                 <b-button
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :href="downloadUrl"
                     variant="link"
                     size="sm"
@@ -18,7 +18,7 @@
                 </b-button>
                 <b-button
                     v-if="currentUser && currentHistoryId"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     href="#"
                     role="button"
                     variant="link"

--- a/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.vue
@@ -82,7 +82,7 @@ watch(
         <b-card-header v-if="!embedded">
             <span class="float-right">
                 <b-button
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :href="downloadUrl"
                     variant="link"
                     size="sm"
@@ -94,7 +94,7 @@ watch(
                     <span class="fa fa-download" />
                 </b-button>
                 <b-button
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :href="importUrl"
                     role="button"
                     variant="link"

--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -131,7 +131,7 @@ onMounted(() => {
         <BNavbarNav>
             <BNavbarBrand
                 id="analysis"
-                v-b-tooltip.hover
+                v-g-tooltip.hover
                 class="ml-2 mr-2 p-0"
                 title="Home"
                 aria-label="homepage"

--- a/client/src/components/Masthead/MastheadDropdown.vue
+++ b/client/src/components/Masthead/MastheadDropdown.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BDropdownItem, BNavItemDropdown, VBTooltipPlugin } from "bootstrap-vue";
-import Vue, { type PropType, ref } from "vue";
+import { BDropdownItem, BNavItemDropdown } from "bootstrap-vue";
+import { type PropType, ref } from "vue";
 
 import type { IconLike } from "@/components/icons/galaxyIcons";
 
 import TextShort from "@/components/Common/TextShort.vue";
-
-Vue.use(VBTooltipPlugin);
 
 const dropdown = ref(null);
 
@@ -42,7 +40,7 @@ defineProps({
 </script>
 
 <template>
-    <BNavItemDropdown :id="id" ref="dropdown" v-b-tooltip.noninteractive.hover.bottom :title="tooltip ?? ''" right>
+    <BNavItemDropdown :id="id" ref="dropdown" v-g-tooltip.noninteractive.hover.bottom :title="tooltip ?? ''" right>
         <template v-if="icon" v-slot:button-content>
             <span class="sr-only">{{ tooltip || id }}</span>
             <FontAwesomeIcon fixed-width :icon="icon" />

--- a/client/src/components/Masthead/MastheadDropdown.vue
+++ b/client/src/components/Masthead/MastheadDropdown.vue
@@ -40,7 +40,7 @@ defineProps({
 </script>
 
 <template>
-    <BNavItemDropdown :id="id" ref="dropdown" v-g-tooltip.noninteractive.hover.bottom :title="tooltip ?? ''" right>
+    <BNavItemDropdown :id="id" ref="dropdown" v-g-tooltip.hover.bottom :title="tooltip ?? ''" right>
         <template v-if="icon" v-slot:button-content>
             <span class="sr-only">{{ tooltip || id }}</span>
             <FontAwesomeIcon fixed-width :icon="icon" />

--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -22,7 +22,7 @@ defineProps({
 <template>
     <BNavItem
         :id="id"
-        v-g-tooltip.noninteractive.hover.bottom
+        v-g-tooltip.hover.bottom
         :href="url ? withPrefix(url) : undefined"
         :target="target || '_parent'"
         :link-classes="{ 'nav-icon': !!icon, toggle: toggle }"

--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BNavItem, VBTooltipPlugin } from "bootstrap-vue";
-import Vue, { type PropType } from "vue";
+import { BNavItem } from "bootstrap-vue";
+import type { PropType } from "vue";
 
 import type { IconLike } from "@/components/icons/galaxyIcons";
 import { withPrefix } from "@/utils/redirect";
-
-Vue.use(VBTooltipPlugin);
 
 /* props */
 defineProps({
@@ -24,7 +22,7 @@ defineProps({
 <template>
     <BNavItem
         :id="id"
-        v-b-tooltip.noninteractive.hover.bottom
+        v-g-tooltip.noninteractive.hover.bottom
         :href="url ? withPrefix(url) : undefined"
         :target="target || '_parent'"
         :link-classes="{ 'nav-icon': !!icon, toggle: toggle }"

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -49,7 +49,7 @@ const variant = computed(() => {
 </script>
 
 <template>
-    <div v-g-tooltip.noninteractive.hover.bottom class="quota-meter d-flex align-items-center" :title="quotaTitle">
+    <div v-g-tooltip.hover.bottom class="quota-meter d-flex align-items-center" :title="quotaTitle">
         <BLink class="quota-progress" :to="quotaLink" data-description="storage dashboard link">
             <BProgress :max="100">
                 <BProgressBar aria-label="Quota usage" :value="usage" :variant="variant" />

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -49,7 +49,7 @@ const variant = computed(() => {
 </script>
 
 <template>
-    <div v-b-tooltip.noninteractive.hover.bottom class="quota-meter d-flex align-items-center" :title="quotaTitle">
+    <div v-g-tooltip.noninteractive.hover.bottom class="quota-meter d-flex align-items-center" :title="quotaTitle">
         <BLink class="quota-progress" :to="quotaLink" data-description="storage dashboard link">
             <BProgress :max="100">
                 <BProgressBar aria-label="Quota usage" :value="usage" :variant="variant" />

--- a/client/src/components/Notifications/NotificationCard.vue
+++ b/client/src/components/Notifications/NotificationCard.vue
@@ -164,7 +164,7 @@ function markNotificationAsSeen() {
                 <span>The user</span>{{ " " }}<b>{{ props.notification.content.owner_name }}</b
                 >{{ " " }}<span>shared </span>
                 <BLink
-                    v-b-tooltip.bottom
+                    v-g-tooltip.bottom
                     :title="`View ${props.notification.content.item_type} in new tab`"
                     class="text-primary"
                     :href="absPath(props.notification.content.slug)"

--- a/client/src/components/ObjectStore/ObjectStoreBadge.vue
+++ b/client/src/components/ObjectStore/ObjectStoreBadge.vue
@@ -59,7 +59,7 @@ const title = computed(() => {
 </script>
 
 <template>
-    <span v-g-tooltip.hover.noninteractive="title" class="object-store-badge-wrapper">
+    <span v-g-tooltip.hover="title" class="object-store-badge-wrapper">
         <FontAwesomeLayers :class="layerClasses" :data-badge-type="badgeType">
             <FontAwesomeIcon v-if="badgeType == 'restricted'" :icon="faUserLock" :class="disadvantage" />
             <FontAwesomeIcon v-if="badgeType == 'user_defined'" :icon="faPlug" :class="neutral" />

--- a/client/src/components/ObjectStore/ObjectStoreBadge.vue
+++ b/client/src/components/ObjectStore/ObjectStoreBadge.vue
@@ -59,7 +59,7 @@ const title = computed(() => {
 </script>
 
 <template>
-    <span v-b-tooltip.hover.noninteractive="title" class="object-store-badge-wrapper">
+    <span v-g-tooltip.hover.noninteractive="title" class="object-store-badge-wrapper">
         <FontAwesomeLayers :class="layerClasses" :data-badge-type="badgeType">
             <FontAwesomeIcon v-if="badgeType == 'restricted'" :icon="faUserLock" :class="disadvantage" />
             <FontAwesomeIcon v-if="badgeType == 'user_defined'" :icon="faPlug" :class="neutral" />

--- a/client/src/components/ObjectStore/ObjectStoreRestrictionSpan.vue
+++ b/client/src/components/ObjectStore/ObjectStoreRestrictionSpan.vue
@@ -19,7 +19,7 @@ const title = computed(() => {
 </script>
 
 <template>
-    <span v-b-tooltip.hover class="stored-how object-store-help-on-hover" :title="title">{{ text }}</span>
+    <span v-g-tooltip.hover class="stored-how object-store-help-on-hover" :title="title">{{ text }}</span>
 </template>
 
 <style scoped>

--- a/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
+++ b/client/src/components/ObjectStore/ObjectStoreTypeSpan.vue
@@ -25,7 +25,7 @@ const title = computed<string>(() => MESSAGES[props.type] ?? "");
 </script>
 
 <template>
-    <span v-b-tooltip.hover class="object-store-type object-store-help-on-hover" :title="title">{{ type }}</span>
+    <span v-g-tooltip.hover class="object-store-type object-store-help-on-hover" :title="title">{{ type }}</span>
 </template>
 
 <style scoped>

--- a/client/src/components/PageEditor/PageEditorMarkdown.vue
+++ b/client/src/components/PageEditor/PageEditorMarkdown.vue
@@ -12,7 +12,7 @@
                 :markdown-content="markdownText" />
             <b-button
                 id="permissions-button"
-                v-b-tooltip.hover.bottom
+                v-g-tooltip.hover.bottom
                 v-b-modal:object-permissions-modal
                 title="Permissions"
                 variant="link"
@@ -22,7 +22,7 @@
             </b-button>
             <b-button
                 id="save-button"
-                v-b-tooltip.hover.bottom
+                v-g-tooltip.hover.bottom
                 title="Save"
                 variant="link"
                 role="button"
@@ -31,7 +31,7 @@
             </b-button>
             <b-button
                 id="view-button"
-                v-b-tooltip.hover.bottom
+                v-g-tooltip.hover.bottom
                 title="Save & View"
                 variant="link"
                 role="button"

--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -59,7 +59,7 @@ function onKeydown(event: KeyboardEvent) {
 
 <template>
     <div
-        v-g-tooltip.topright.hover.noninteractive
+        v-g-tooltip.topright.hover
         :class="['tool-panel-label', 'tool-panel-divider', { 'tool-panel-label-clickable': isCollapsible }]"
         :tabindex="isCollapsible ? 0 : undefined"
         :title="description"

--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -59,7 +59,7 @@ function onKeydown(event: KeyboardEvent) {
 
 <template>
     <div
-        v-b-tooltip.topright.hover.noninteractive
+        v-g-tooltip.topright.hover.noninteractive
         :class="['tool-panel-label', 'tool-panel-divider', { 'tool-panel-label-clickable': isCollapsible }]"
         :tabindex="isCollapsible ? 0 : undefined"
         :title="description"

--- a/client/src/components/Panels/Common/ToolPanelLinks.vue
+++ b/client/src/components/Panels/Common/ToolPanelLinks.vue
@@ -16,7 +16,7 @@ const link = computed(() => {
 <template>
     <span v-if="link" class="tool-panel-links">
         <a :href="link" target="_blank" style="display: inline">
-            <FontAwesomeIcon v-b-tooltip.hover title="Link" :icon="faExternalLinkAlt" />
+            <FontAwesomeIcon v-g-tooltip.hover title="Link" :icon="faExternalLinkAlt" />
             <span class="sr-only">Link</span>
         </a>
     </span>

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -174,7 +174,7 @@ function getCollapsedState(id: string): boolean | undefined {
 <template>
     <div v-if="isToolSection(props.category) && elems.length > 0" class="tool-panel-section">
         <div
-            v-g-tooltip.topright.hover.noninteractive
+            v-g-tooltip.topright.hover
             class="toolSectionTitle tool-panel-divider"
             :title="props.category.description || undefined">
             <a
@@ -190,7 +190,7 @@ function getCollapsedState(id: string): boolean | undefined {
                     <ToolPanelLinks v-if="props.category.links" :links="props.category.links" />
                     <button
                         v-if="props.hasFilterButton"
-                        v-g-tooltip.hover.noninteractive.bottom
+                        v-g-tooltip.hover.bottom
                         title="Show full section"
                         class="inline-icon-button"
                         @click.stop="emit('onFilter', `section:${props.category.name}`)">

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -174,7 +174,7 @@ function getCollapsedState(id: string): boolean | undefined {
 <template>
     <div v-if="isToolSection(props.category) && elems.length > 0" class="tool-panel-section">
         <div
-            v-b-tooltip.topright.hover.noninteractive
+            v-g-tooltip.topright.hover.noninteractive
             class="toolSectionTitle tool-panel-divider"
             :title="props.category.description || undefined">
             <a
@@ -190,7 +190,7 @@ function getCollapsedState(id: string): boolean | undefined {
                     <ToolPanelLinks v-if="props.category.links" :links="props.category.links" />
                     <button
                         v-if="props.hasFilterButton"
-                        v-b-tooltip.hover.noninteractive.bottom
+                        v-g-tooltip.hover.noninteractive.bottom
                         title="Show full section"
                         class="inline-icon-button"
                         @click.stop="emit('onFilter', `section:${props.category.name}`)">

--- a/client/src/components/Panels/Menus/PanelViewMenu.vue
+++ b/client/src/components/Panels/Menus/PanelViewMenu.vue
@@ -120,7 +120,7 @@ async function updatePanelView(panel: Panel) {
 
 <template>
     <BDropdown
-        v-g-tooltip.hover.top.noninteractive
+        v-g-tooltip.hover.top
         right
         block
         no-caret

--- a/client/src/components/Panels/Menus/PanelViewMenu.vue
+++ b/client/src/components/Panels/Menus/PanelViewMenu.vue
@@ -120,7 +120,7 @@ async function updatePanelView(panel: Panel) {
 
 <template>
     <BDropdown
-        v-b-tooltip.hover.top.noninteractive
+        v-g-tooltip.hover.top.noninteractive
         right
         block
         no-caret

--- a/client/src/components/Panels/MultiviewPanel.vue
+++ b/client/src/components/Panels/MultiviewPanel.vue
@@ -120,7 +120,7 @@ function userTitle(title: string) {
             <section v-if="!showAdvanced">
                 <BButtonGroup
                     v-if="route.path === '/histories/view_multiple'"
-                    v-g-tooltip.hover.noninteractive.bottom
+                    v-g-tooltip.hover.bottom
                     class="w-100 mt-2"
                     :aria-label="pinRecentTitle"
                     :title="pinRecentTitle">

--- a/client/src/components/Panels/MultiviewPanel.vue
+++ b/client/src/components/Panels/MultiviewPanel.vue
@@ -97,7 +97,7 @@ function userTitle(title: string) {
         <template v-slot:header-buttons>
             <BButtonGroup>
                 <BButton
-                    v-b-tooltip.bottom.hover
+                    v-g-tooltip.bottom.hover
                     data-description="create new history for multiview"
                     size="sm"
                     variant="link"
@@ -120,7 +120,7 @@ function userTitle(title: string) {
             <section v-if="!showAdvanced">
                 <BButtonGroup
                     v-if="route.path === '/histories/view_multiple'"
-                    v-b-tooltip.hover.noninteractive.bottom
+                    v-g-tooltip.hover.noninteractive.bottom
                     class="w-100 mt-2"
                     :aria-label="pinRecentTitle"
                     :title="pinRecentTitle">

--- a/client/src/components/Panels/NotificationsPanel.vue
+++ b/client/src/components/Panels/NotificationsPanel.vue
@@ -44,7 +44,7 @@ async function onMarkAllAsRead() {
         <template v-slot:header-buttons>
             <BButtonGroup>
                 <BButton
-                    v-b-tooltip.bottom.hover
+                    v-g-tooltip.bottom.hover
                     data-description="mark all as read"
                     size="sm"
                     variant="link"

--- a/client/src/components/Panels/SettingsPanel.vue
+++ b/client/src/components/Panels/SettingsPanel.vue
@@ -38,7 +38,7 @@ function onQuery(newQuery: string) {
         </template>
         <template v-slot:header-buttons>
             <BButton
-                v-b-tooltip.bottom.hover
+                v-g-tooltip.bottom.hover
                 data-description="restore factory settings"
                 size="sm"
                 variant="link"

--- a/client/src/components/Panels/Upload/UploadPanel.vue
+++ b/client/src/components/Panels/Upload/UploadPanel.vue
@@ -25,7 +25,7 @@ function showProgressDetails() {
             <h2 id="activity-panel-heading" class="activity-panel-heading h-sm d-inline-flex align-items-center">
                 <span>Import Data</span>
                 <span
-                    v-b-tooltip.hover.noninteractive
+                    v-g-tooltip.hover.noninteractive
                     class="badge badge-warning ml-2"
                     title="This upload experience is in Beta and is intended to gather user feedback.">
                     Beta
@@ -35,7 +35,7 @@ function showProgressDetails() {
         <template v-slot:header-buttons>
             <BFormCheckbox
                 v-model="advancedMode"
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 size="sm"
                 switch
                 class="mx-2"

--- a/client/src/components/Panels/Upload/UploadPanel.vue
+++ b/client/src/components/Panels/Upload/UploadPanel.vue
@@ -25,7 +25,7 @@ function showProgressDetails() {
             <h2 id="activity-panel-heading" class="activity-panel-heading h-sm d-inline-flex align-items-center">
                 <span>Import Data</span>
                 <span
-                    v-g-tooltip.hover.noninteractive
+                    v-g-tooltip.hover
                     class="badge badge-warning ml-2"
                     title="This upload experience is in Beta and is intended to gather user feedback.">
                     Beta
@@ -35,7 +35,7 @@ function showProgressDetails() {
         <template v-slot:header-buttons>
             <BFormCheckbox
                 v-model="advancedMode"
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 size="sm"
                 switch
                 class="mx-2"

--- a/client/src/components/Panels/Upload/methods/CompositeFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/CompositeFileUpload.vue
@@ -223,7 +223,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <label class="font-weight-bold mb-1" for="composite-type-selector"> Composite Type </label>
                     <SingleItemSelector
                         id="composite-type-selector"
-                        v-g-tooltip.hover.noninteractive
+                        v-g-tooltip.hover
                         collection-name="Composite Types"
                         title="Composite Type"
                         :items="availableExtensions"

--- a/client/src/components/Panels/Upload/methods/CompositeFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/CompositeFileUpload.vue
@@ -223,7 +223,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <label class="font-weight-bold mb-1" for="composite-type-selector"> Composite Type </label>
                     <SingleItemSelector
                         id="composite-type-selector"
-                        v-b-tooltip.hover.noninteractive
+                        v-g-tooltip.hover.noninteractive
                         collection-name="Composite Types"
                         title="Composite Type"
                         :items="availableExtensions"

--- a/client/src/components/Panels/Upload/methods/CompositeSlotRow.vue
+++ b/client/src/components/Panels/Upload/methods/CompositeSlotRow.vue
@@ -184,21 +184,21 @@ const display = computed(() => {
             <div class="slot-status-icon flex-shrink-0 mr-2">
                 <FontAwesomeIcon
                     v-if="isFilled"
-                    v-b-tooltip.hover.noninteractive
+                    v-g-tooltip.hover.noninteractive
                     :icon="faCheck"
                     class="text-success"
                     title="Slot filled"
                     fixed-width />
                 <FontAwesomeIcon
                     v-else-if="slotItem.optional"
-                    v-b-tooltip.hover.noninteractive
+                    v-g-tooltip.hover.noninteractive
                     :icon="faCheck"
                     class="text-info"
                     title="Optional — can be left empty"
                     fixed-width />
                 <FontAwesomeIcon
                     v-else
-                    v-b-tooltip.hover.noninteractive
+                    v-g-tooltip.hover.noninteractive
                     :icon="faExclamation"
                     class="text-warning"
                     title="Required — must be filled before upload"

--- a/client/src/components/Panels/Upload/methods/CompositeSlotRow.vue
+++ b/client/src/components/Panels/Upload/methods/CompositeSlotRow.vue
@@ -184,21 +184,21 @@ const display = computed(() => {
             <div class="slot-status-icon flex-shrink-0 mr-2">
                 <FontAwesomeIcon
                     v-if="isFilled"
-                    v-g-tooltip.hover.noninteractive
+                    v-g-tooltip.hover
                     :icon="faCheck"
                     class="text-success"
                     title="Slot filled"
                     fixed-width />
                 <FontAwesomeIcon
                     v-else-if="slotItem.optional"
-                    v-g-tooltip.hover.noninteractive
+                    v-g-tooltip.hover
                     :icon="faCheck"
                     class="text-info"
                     title="Optional — can be left empty"
                     fixed-width />
                 <FontAwesomeIcon
                     v-else
-                    v-g-tooltip.hover.noninteractive
+                    v-g-tooltip.hover
                     :icon="faExclamation"
                     class="text-warning"
                     title="Required — must be filled before upload"

--- a/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
+++ b/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
@@ -894,7 +894,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                     <template v-slot:cell(actions)="{ item }">
                         <GButton
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             class="remove-btn"
                             color="red"
                             outline

--- a/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
+++ b/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
@@ -809,7 +809,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <template v-slot:cell(permission)="{ item }">
                         <span
                             v-if="item.entry && getPermissionIcon(getItemFolderEntry(item))"
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             class="mr-2 text-muted"
                             :title="getPermissionTitle(getItemFolderEntry(item))">
                             <FontAwesomeIcon :icon="getPermissionIcon(getItemFolderEntry(item))" />
@@ -894,7 +894,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                     <template v-slot:cell(actions)="{ item }">
                         <GButton
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             class="remove-btn"
                             color="red"
                             outline

--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -307,7 +307,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                         <template v-slot:cell(actions)="{ index }">
                             <GButton
-                                v-g-tooltip.hover.noninteractive
+                                v-g-tooltip.hover
                                 class="remove-btn"
                                 color="red"
                                 outline

--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -307,7 +307,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                         <template v-slot:cell(actions)="{ index }">
                             <GButton
-                                v-b-tooltip.hover.noninteractive
+                                v-g-tooltip.hover.noninteractive
                                 class="remove-btn"
                                 color="red"
                                 outline

--- a/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
@@ -305,7 +305,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Expand toggle column header -->
                     <template v-slot:head(expand)>
                         <button
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             class="btn btn-link btn-sm p-0"
                             :title="getExpandAllToggleTitle(allExpanded)"
                             :aria-label="getExpandAllToggleTitle(allExpanded)"
@@ -318,7 +318,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <template v-slot:cell(expand)="{ item, toggleDetails }">
                         <span class="sr-only">{{ registerRowToggle(item.id, toggleDetails) }}</span>
                         <button
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             class="btn btn-link btn-sm p-0"
                             :title="getExpandToggleTitle(isExpanded(item.id))"
                             :aria-label="getExpandToggleTitle(isExpanded(item.id))"
@@ -368,7 +368,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             </div>
                             <span
                                 v-else-if="!item.content"
-                                v-b-tooltip.hover.noninteractive
+                                v-g-tooltip.hover.noninteractive
                                 title="This dataset is empty and will be skipped during upload."
                                 class="small font-italic text-danger">
                                 No content
@@ -438,7 +438,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Actions column -->
                     <template v-slot:cell(actions)="{ item }">
                         <GButton
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             class="remove-btn"
                             color="red"
                             outline

--- a/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
@@ -305,7 +305,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Expand toggle column header -->
                     <template v-slot:head(expand)>
                         <button
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             class="btn btn-link btn-sm p-0"
                             :title="getExpandAllToggleTitle(allExpanded)"
                             :aria-label="getExpandAllToggleTitle(allExpanded)"
@@ -318,7 +318,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <template v-slot:cell(expand)="{ item, toggleDetails }">
                         <span class="sr-only">{{ registerRowToggle(item.id, toggleDetails) }}</span>
                         <button
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             class="btn btn-link btn-sm p-0"
                             :title="getExpandToggleTitle(isExpanded(item.id))"
                             :aria-label="getExpandToggleTitle(isExpanded(item.id))"
@@ -368,7 +368,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             </div>
                             <span
                                 v-else-if="!item.content"
-                                v-g-tooltip.hover.noninteractive
+                                v-g-tooltip.hover
                                 title="This dataset is empty and will be skipped during upload."
                                 class="small font-italic text-danger">
                                 No content
@@ -438,7 +438,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Actions column -->
                     <template v-slot:cell(actions)="{ item }">
                         <GButton
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             class="remove-btn"
                             color="red"
                             outline

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -278,7 +278,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         <div class="d-flex align-items-center">
                             <BFormInput
                                 v-model="item.url"
-                                v-g-tooltip.hover.noninteractive
+                                v-g-tooltip.hover
                                 size="sm"
                                 :state="isValidUrl(item.url)"
                                 :title="getUrlValidationMessage(item.url)"
@@ -355,7 +355,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Actions column -->
                     <template v-slot:cell(actions)="{ item }">
                         <GButton
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             class="remove-btn"
                             color="red"
                             outline

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -278,7 +278,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         <div class="d-flex align-items-center">
                             <BFormInput
                                 v-model="item.url"
-                                v-b-tooltip.hover.noninteractive
+                                v-g-tooltip.hover.noninteractive
                                 size="sm"
                                 :state="isValidUrl(item.url)"
                                 :title="getUrlValidationMessage(item.url)"
@@ -355,7 +355,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Actions column -->
                     <template v-slot:cell(actions)="{ item }">
                         <GButton
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             class="remove-btn"
                             color="red"
                             outline

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -855,7 +855,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Actions column -->
                     <template v-slot:cell(actions)="{ item }">
                         <button
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             class="btn btn-link text-danger remove-btn"
                             title="Remove file from list"
                             @click="removeItem(item.id)">

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -855,7 +855,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <!-- Actions column -->
                     <template v-slot:cell(actions)="{ item }">
                         <button
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             class="btn btn-link text-danger remove-btn"
                             title="Remove file from list"
                             @click="removeItem(item.id)">

--- a/client/src/components/Panels/Upload/shared/RemoteEntryMetadata.vue
+++ b/client/src/components/Panels/Upload/shared/RemoteEntryMetadata.vue
@@ -49,7 +49,7 @@ const hasHashes = computed(() => !!fileEntry.value?.hashes && fileEntry.value.ha
         <span v-if="ctime" class="metadata-item">
             <UtcDate :date="ctime" mode="pretty" />
         </span>
-        <span v-if="hasHashes" v-b-tooltip.hover class="metadata-hash" :title="hashTooltip">
+        <span v-if="hasHashes" v-g-tooltip.hover class="metadata-hash" :title="hashTooltip">
             <FontAwesomeIcon :icon="faFingerprint" />
         </span>
     </div>

--- a/client/src/components/Panels/Upload/shared/UploadTableBulkDbKeyHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableBulkDbKeyHeader.vue
@@ -36,7 +36,7 @@ function onItemSelection(item: DbKey) {
     <div class="column-header-vertical">
         <span class="column-title">Reference</span>
         <SingleItemSelector
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="w-100"
             collection-name="References"
             :title="tooltip"

--- a/client/src/components/Panels/Upload/shared/UploadTableBulkDbKeyHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableBulkDbKeyHeader.vue
@@ -36,7 +36,7 @@ function onItemSelection(item: DbKey) {
     <div class="column-header-vertical">
         <span class="column-title">Reference</span>
         <SingleItemSelector
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="w-100"
             collection-name="References"
             :title="tooltip"

--- a/client/src/components/Panels/Upload/shared/UploadTableBulkExtensionHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableBulkExtensionHeader.vue
@@ -41,7 +41,7 @@ function onItemSelection(item: ExtensionDetails) {
     <div class="column-header-vertical">
         <span class="column-title">Type</span>
         <SingleItemSelector
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             collection-name="Data Types"
             :title="tooltip"
             :items="optionsWithDefault"
@@ -50,7 +50,7 @@ function onItemSelection(item: ExtensionDetails) {
             @update:selected-item="onItemSelection" />
         <FontAwesomeIcon
             v-if="warning"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="text-warning warning-icon"
             :icon="faExclamationTriangle"
             :title="warning" />

--- a/client/src/components/Panels/Upload/shared/UploadTableBulkExtensionHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableBulkExtensionHeader.vue
@@ -41,7 +41,7 @@ function onItemSelection(item: ExtensionDetails) {
     <div class="column-header-vertical">
         <span class="column-title">Type</span>
         <SingleItemSelector
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             collection-name="Data Types"
             :title="tooltip"
             :items="optionsWithDefault"
@@ -50,7 +50,7 @@ function onItemSelection(item: ExtensionDetails) {
             @update:selected-item="onItemSelection" />
         <FontAwesomeIcon
             v-if="warning"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="text-warning warning-icon"
             :icon="faExclamationTriangle"
             :title="warning" />

--- a/client/src/components/Panels/Upload/shared/UploadTableDbKeyCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableDbKeyCell.vue
@@ -30,7 +30,7 @@ function onItemSelection(item: DbKey) {
 
 <template>
     <SingleItemSelector
-        v-b-tooltip.hover.noninteractive
+        v-g-tooltip.hover.noninteractive
         collection-name="References"
         :title="tooltip"
         :items="dbKeys"

--- a/client/src/components/Panels/Upload/shared/UploadTableDbKeyCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableDbKeyCell.vue
@@ -30,7 +30,7 @@ function onItemSelection(item: DbKey) {
 
 <template>
     <SingleItemSelector
-        v-g-tooltip.hover.noninteractive
+        v-g-tooltip.hover
         collection-name="References"
         :title="tooltip"
         :items="dbKeys"

--- a/client/src/components/Panels/Upload/shared/UploadTableExtensionCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableExtensionCell.vue
@@ -37,7 +37,7 @@ function onItemSelection(value: ExtensionDetails) {
 <template>
     <div class="d-flex align-items-center w-100">
         <SingleItemSelector
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="flex-grow-1"
             collection-name="Data Types"
             :title="tooltip"
@@ -48,7 +48,7 @@ function onItemSelection(value: ExtensionDetails) {
         </SingleItemSelector>
         <FontAwesomeIcon
             v-if="warning"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             class="text-warning ml-1 flex-shrink-0"
             :icon="faExclamationTriangle"
             :title="warning" />

--- a/client/src/components/Panels/Upload/shared/UploadTableExtensionCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableExtensionCell.vue
@@ -37,7 +37,7 @@ function onItemSelection(value: ExtensionDetails) {
 <template>
     <div class="d-flex align-items-center w-100">
         <SingleItemSelector
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="flex-grow-1"
             collection-name="Data Types"
             :title="tooltip"
@@ -48,7 +48,7 @@ function onItemSelection(value: ExtensionDetails) {
         </SingleItemSelector>
         <FontAwesomeIcon
             v-if="warning"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             class="text-warning ml-1 flex-shrink-0"
             :icon="faExclamationTriangle"
             :title="warning" />

--- a/client/src/components/Panels/Upload/shared/UploadTableNameCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableNameCell.vue
@@ -31,7 +31,7 @@ function handleBlur() {
 
 <template>
     <BFormInput
-        v-g-tooltip.hover.noninteractive
+        v-g-tooltip.hover
         :value="value"
         size="sm"
         :state="state"

--- a/client/src/components/Panels/Upload/shared/UploadTableNameCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableNameCell.vue
@@ -31,7 +31,7 @@ function handleBlur() {
 
 <template>
     <BFormInput
-        v-b-tooltip.hover.noninteractive
+        v-g-tooltip.hover.noninteractive
         :value="value"
         size="sm"
         :state="state"

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
@@ -42,7 +42,7 @@ function updateDeferred(value: boolean) {
 <template>
     <div class="d-flex align-items-center">
         <BFormCheckbox
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             :checked="spaceToTab"
             size="sm"
             :class="{ 'mr-2': showPosix || showDeferred }"
@@ -52,7 +52,7 @@ function updateDeferred(value: boolean) {
         </BFormCheckbox>
         <BFormCheckbox
             v-if="showPosix"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             :checked="toPosixLines"
             size="sm"
             :class="{ 'mr-2': showDeferred }"
@@ -62,7 +62,7 @@ function updateDeferred(value: boolean) {
         </BFormCheckbox>
         <BFormCheckbox
             v-if="showDeferred"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             :checked="deferred"
             size="sm"
             title="Galaxy will store a reference and fetch data only when needed by a tool"

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
@@ -42,7 +42,7 @@ function updateDeferred(value: boolean) {
 <template>
     <div class="d-flex align-items-center">
         <BFormCheckbox
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             :checked="spaceToTab"
             size="sm"
             :class="{ 'mr-2': showPosix || showDeferred }"
@@ -52,7 +52,7 @@ function updateDeferred(value: boolean) {
         </BFormCheckbox>
         <BFormCheckbox
             v-if="showPosix"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             :checked="toPosixLines"
             size="sm"
             :class="{ 'mr-2': showDeferred }"
@@ -62,7 +62,7 @@ function updateDeferred(value: boolean) {
         </BFormCheckbox>
         <BFormCheckbox
             v-if="showDeferred"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             :checked="deferred"
             size="sm"
             title="Galaxy will store a reference and fetch data only when needed by a tool"

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
@@ -51,7 +51,7 @@ function handleToggleDeferred() {
         <span class="options-title">Upload Settings</span>
         <div class="d-flex align-items-center">
             <BFormCheckbox
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 :checked="allSpaceToTab"
                 :indeterminate="spaceToTabIndeterminate"
                 size="sm"
@@ -62,7 +62,7 @@ function handleToggleDeferred() {
             </BFormCheckbox>
             <BFormCheckbox
                 v-if="showPosix"
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 :checked="allToPosixLines"
                 :indeterminate="toPosixLinesIndeterminate"
                 size="sm"
@@ -73,7 +73,7 @@ function handleToggleDeferred() {
             </BFormCheckbox>
             <BFormCheckbox
                 v-if="showDeferred"
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 :checked="allDeferred"
                 :indeterminate="deferredIndeterminate"
                 size="sm"

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
@@ -51,7 +51,7 @@ function handleToggleDeferred() {
         <span class="options-title">Upload Settings</span>
         <div class="d-flex align-items-center">
             <BFormCheckbox
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 :checked="allSpaceToTab"
                 :indeterminate="spaceToTabIndeterminate"
                 size="sm"
@@ -62,7 +62,7 @@ function handleToggleDeferred() {
             </BFormCheckbox>
             <BFormCheckbox
                 v-if="showPosix"
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 :checked="allToPosixLines"
                 :indeterminate="toPosixLinesIndeterminate"
                 size="sm"
@@ -73,7 +73,7 @@ function handleToggleDeferred() {
             </BFormCheckbox>
             <BFormCheckbox
                 v-if="showDeferred"
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 :checked="allDeferred"
                 :indeterminate="deferredIndeterminate"
                 size="sm"

--- a/client/src/components/Panels/WorkflowPanel.vue
+++ b/client/src/components/Panels/WorkflowPanel.vue
@@ -153,7 +153,7 @@ function createNew(event: Event) {
     <ActivityPanel title="Workflows">
         <template v-slot:header-buttons>
             <BButton
-                v-b-tooltip.hover.top.noninteractive
+                v-g-tooltip.hover.top.noninteractive
                 size="sm"
                 variant="link"
                 class="create-button"

--- a/client/src/components/Panels/WorkflowPanel.vue
+++ b/client/src/components/Panels/WorkflowPanel.vue
@@ -153,7 +153,7 @@ function createNew(event: Event) {
     <ActivityPanel title="Workflows">
         <template v-slot:header-buttons>
             <BButton
-                v-g-tooltip.hover.top.noninteractive
+                v-g-tooltip.hover.top
                 size="sm"
                 variant="link"
                 class="create-button"

--- a/client/src/components/RuleBuilder/ColumnSelector.vue
+++ b/client/src/components/RuleBuilder/ColumnSelector.vue
@@ -1,8 +1,8 @@
 <template>
     <div v-if="!multiple || !ordered" class="rule-column-selector">
         <div class="d-flex justify-content-end align-items-center">
-            <span v-b-tooltip.hover class="mr-auto help-text" :title="help">{{ label }}</span>
-            <div v-b-tooltip.hover class="mr-1" :title="title">
+            <span v-g-tooltip.hover class="mr-auto help-text" :title="help">{{ label }}</span>
+            <div v-g-tooltip.hover class="mr-1" :title="title">
                 <SelectBasic :value="target" :multiple="multiple" :options="columnOptions" @input="handleInput" />
             </div>
             <slot></slot>

--- a/client/src/components/RuleBuilder/IdentifierDisplay.vue
+++ b/client/src/components/RuleBuilder/IdentifierDisplay.vue
@@ -1,8 +1,8 @@
 <template>
     <li class="rule">
-        <span v-b-tooltip.hover :title="help">Set {{ columnsLabel }} as {{ typeDisplay }}</span>
-        <span v-b-tooltip.hover :title="titleEdit" class="fa fa-edit" @click="edit"></span>
-        <span v-b-tooltip.hover :title="titleRemove" class="fa fa-times" @click="remove"></span>
+        <span v-g-tooltip.hover :title="help">Set {{ columnsLabel }} as {{ typeDisplay }}</span>
+        <span v-g-tooltip.hover :title="titleEdit" class="fa fa-edit" @click="edit"></span>
+        <span v-g-tooltip.hover :title="titleRemove" class="fa fa-times" @click="remove"></span>
     </li>
 </template>
 

--- a/client/src/components/RuleBuilder/RegularExpressionInput.vue
+++ b/client/src/components/RuleBuilder/RegularExpressionInput.vue
@@ -1,9 +1,9 @@
 <template>
     <div>
-        <label ref="helpTarget" v-b-tooltip.hover for="regular_expression">{{ label }}</label>
+        <label ref="helpTarget" v-g-tooltip.hover for="regular_expression">{{ label }}</label>
         <HelpPopover :target="$refs.helpTarget" term="programming.python.regex" />
         <input
-            v-b-tooltip.hover.left
+            v-g-tooltip.hover.left
             :title="title"
             name="regular_expression"
             class="rule-regular-expression"

--- a/client/src/components/RuleBuilder/RuleDisplay.vue
+++ b/client/src/components/RuleBuilder/RuleDisplay.vue
@@ -2,8 +2,8 @@
     <li class="rule">
         <span class="rule-display">
             <span class="mr-1">{{ title }}</span>
-            <span v-b-tooltip.hover :title="editTitle" class="fa fa-edit mr-1" @click="edit"></span>
-            <span v-b-tooltip.hover :title="removeTitle" class="fa fa-times map" @click="remove"></span>
+            <span v-g-tooltip.hover :title="editTitle" class="fa fa-edit mr-1" @click="edit"></span>
+            <span v-g-tooltip.hover :title="removeTitle" class="fa fa-times map" @click="remove"></span>
         </span>
         <span v-if="rule.warn" class="rule-warning">
             {{ rule.warn }}

--- a/client/src/components/RuleBuilder/SavedRulesSelector.vue
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.vue
@@ -2,7 +2,7 @@
     <div class="btn-group dropdown">
         <span
             id="savedRulesButton"
-            v-b-tooltip.hover.bottom
+            v-g-tooltip.hover.bottom
             class="fas fa-history rule-builder-view-source"
             :class="{ disabled: numOfSavedRules == 0 }"
             :title="savedRulesMenu"
@@ -11,7 +11,7 @@
             <a
                 v-for="(session, index) in sortSavedRules"
                 :key="index"
-                v-b-tooltip.hover.right
+                v-g-tooltip.hover.right
                 class="rule-link dropdown-item saved-rule-item"
                 :title="formatPreview(session.rule)"
                 @click="$emit('update-rules', session.rule)"

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -56,7 +56,7 @@
                             :display-rule-type.sync="displayRuleType"
                             @saveRule="handleRuleSave">
                             <ColumnSelector :target.sync="addSortingTarget" :col-headers="activeRuleColHeaders" />
-                            <label v-g-tooltip.hover.noninteractive :title="titleNumericSort">
+                            <label v-g-tooltip.hover :title="titleNumericSort">
                                 <input v-model="addSortingNumeric" type="checkbox" />
                                 {{ l("Numeric sorting.") }}
                             </label>
@@ -141,7 +141,7 @@
                                 {{ l("Replacement Expression") }}
                                 <input v-model="addColumnRegexReplacement" type="text" class="rule-replacement" />
                             </label>
-                            <label v-g-tooltip.hover.noninteractive>
+                            <label v-g-tooltip.hover>
                                 <input v-model="addColumnRegexAllowUnmatched" type="checkbox" />
                                 {{ l("Allow regular expression unmatched.") }}
                             </label>
@@ -401,7 +401,7 @@
                             <div class="rules-buttons btn-group">
                                 <div class="dropup">
                                     <button
-                                        v-g-tooltip.hover.bottom.noninteractive
+                                        v-g-tooltip.hover.bottom
                                         type="button"
                                         :title="titleRulesMenu"
                                         class="rule-menu-rules-button primary-button dropdown-toggle"
@@ -425,7 +425,7 @@
                                 </div>
                                 <div class="dropup">
                                     <button
-                                        v-g-tooltip.hover.bottom.noninteractive
+                                        v-g-tooltip.hover.bottom
                                         type="button"
                                         :title="titleFilterMenu"
                                         class="rule-menu-filter-button primary-button dropdown-toggle"
@@ -444,7 +444,7 @@
                                 </div>
                                 <div class="dropup">
                                     <button
-                                        v-g-tooltip.hover.bottom.noninteractive
+                                        v-g-tooltip.hover.bottom
                                         type="button"
                                         :title="titleColumMenu"
                                         class="rule-menu-column-button primary-button dropdown-toggle"

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -56,7 +56,7 @@
                             :display-rule-type.sync="displayRuleType"
                             @saveRule="handleRuleSave">
                             <ColumnSelector :target.sync="addSortingTarget" :col-headers="activeRuleColHeaders" />
-                            <label v-b-tooltip.hover.noninteractive :title="titleNumericSort">
+                            <label v-g-tooltip.hover.noninteractive :title="titleNumericSort">
                                 <input v-model="addSortingNumeric" type="checkbox" />
                                 {{ l("Numeric sorting.") }}
                             </label>
@@ -141,7 +141,7 @@
                                 {{ l("Replacement Expression") }}
                                 <input v-model="addColumnRegexReplacement" type="text" class="rule-replacement" />
                             </label>
-                            <label v-b-tooltip.hover.noninteractive>
+                            <label v-g-tooltip.hover.noninteractive>
                                 <input v-model="addColumnRegexAllowUnmatched" type="checkbox" />
                                 {{ l("Allow regular expression unmatched.") }}
                             </label>
@@ -227,7 +227,7 @@
                             @saveRule="handleRuleSave">
                             <ColumnSelector :target.sync="addFilterRegexTarget" :col-headers="activeRuleColHeaders" />
                             <RegularExpressionInput :target.sync="addFilterRegexExpression" />
-                            <label v-b-tooltip.hover :title="titleInvertFilterRegex">
+                            <label v-g-tooltip.hover :title="titleInvertFilterRegex">
                                 <input v-model="addFilterRegexInvert" type="checkbox" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -238,7 +238,7 @@
                             @saveRule="handleRuleSave">
                             <ColumnSelector :target.sync="addFilterMatchesTarget" :col-headers="activeRuleColHeaders" />
                             <input v-model="addFilterMatchesValue" type="text" />
-                            <label v-b-tooltip.hover :title="titleInvertFilterMatches">
+                            <label v-g-tooltip.hover :title="titleInvertFilterMatches">
                                 <input v-model="addFilterMatchesInvert" type="checkbox" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -274,7 +274,7 @@
                                 Filter how many rows?
                                 <input v-model="addFilterCountN" type="number" />
                             </label>
-                            <label v-b-tooltip.hover :title="titleInvertFilterMatches">
+                            <label v-g-tooltip.hover :title="titleInvertFilterMatches">
                                 <input v-model="addFilterCountInvert" type="checkbox" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -284,7 +284,7 @@
                             :display-rule-type.sync="displayRuleType"
                             @saveRule="handleRuleSave">
                             <ColumnSelector :target.sync="addFilterEmptyTarget" :col-headers="activeRuleColHeaders" />
-                            <label v-b-tooltip.hover :title="titleInvertFilterEmpty">
+                            <label v-g-tooltip.hover :title="titleInvertFilterEmpty">
                                 <input v-model="addFilterEmptyInvert" type="checkbox" />
                                 {{ l("Invert filter.") }}
                             </label>
@@ -302,7 +302,7 @@
                                     :ordered="true"
                                     :value-as-list="true">
                                     <span
-                                        v-b-tooltip.hover
+                                        v-g-tooltip.hover
                                         :title="titleRemoveMapping"
                                         class="fa fa-times"
                                         @click="removeMapping(index)"></span>
@@ -359,7 +359,7 @@
                             <span class="title">
                                 {{ l("Rules") }}
                                 <span
-                                    v-b-tooltip.hover
+                                    v-g-tooltip.hover
                                     class="fa fa-wrench rule-builder-view-source"
                                     :title="titleViewSource"
                                     @click="viewSource"></span>
@@ -401,7 +401,7 @@
                             <div class="rules-buttons btn-group">
                                 <div class="dropup">
                                     <button
-                                        v-b-tooltip.hover.bottom.noninteractive
+                                        v-g-tooltip.hover.bottom.noninteractive
                                         type="button"
                                         :title="titleRulesMenu"
                                         class="rule-menu-rules-button primary-button dropdown-toggle"
@@ -425,7 +425,7 @@
                                 </div>
                                 <div class="dropup">
                                     <button
-                                        v-b-tooltip.hover.bottom.noninteractive
+                                        v-g-tooltip.hover.bottom.noninteractive
                                         type="button"
                                         :title="titleFilterMenu"
                                         class="rule-menu-filter-button primary-button dropdown-toggle"
@@ -444,7 +444,7 @@
                                 </div>
                                 <div class="dropup">
                                     <button
-                                        v-b-tooltip.hover.bottom.noninteractive
+                                        v-g-tooltip.hover.bottom.noninteractive
                                         type="button"
                                         :title="titleColumMenu"
                                         class="rule-menu-column-button primary-button dropdown-toggle"
@@ -535,7 +535,7 @@
                     <div v-if="showCollectionNameInput" class="rule-footer-name-group">
                         <b-input
                             v-model="collectionName"
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             class="collection-name"
                             :placeholder="namePlaceholder"
                             :title="namePlaceholder" />

--- a/client/src/components/SchemaOrg/CreatorEditor.vue
+++ b/client/src/components/SchemaOrg/CreatorEditor.vue
@@ -11,7 +11,7 @@
                 <CreatorViewer :creator="creator">
                     <template v-slot:buttons>
                         <BButton
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             class="inline-icon-button"
                             variant="link"
                             size="sm"
@@ -20,7 +20,7 @@
                             <FontAwesomeIcon :icon="faEdit" />
                         </BButton>
                         <BButton
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             class="inline-icon-button"
                             variant="link"
                             size="sm"

--- a/client/src/components/SchemaOrg/OrganizationForm.vue
+++ b/client/src/components/SchemaOrg/OrganizationForm.vue
@@ -3,7 +3,7 @@
     <b-form @submit="onSave" @reset="onReset">
         <div v-for="attribute in displayedAttributes" :key="attribute.key" role="group" class="form-group">
             <label :for="attribute.key">{{ attribute.label }}</label>
-            <span v-b-tooltip.hover title="Hide Attribute"
+            <span v-g-tooltip.hover title="Hide Attribute"
                 ><FontAwesomeIcon :icon="faEyeSlash" @click="onHide(attribute.key)"
             /></span>
             <div v-if="currentErrors[attribute.key]" class="error">{{ currentErrors[attribute.key] }}</div>

--- a/client/src/components/SchemaOrg/OrganizationViewer.vue
+++ b/client/src/components/SchemaOrg/OrganizationViewer.vue
@@ -18,7 +18,7 @@
             {{ email }}
         </span>
 
-        <GLink v-if="url" v-b-tooltip.hover tooltip title="Organization URL" :href="url" target="_blank">
+        <GLink v-if="url" v-g-tooltip.hover tooltip title="Organization URL" :href="url" target="_blank">
             <link itemprop="url" :href="url" />
             <FontAwesomeIcon :icon="faExternalLinkAlt" />
         </GLink>

--- a/client/src/components/SchemaOrg/PersonForm.vue
+++ b/client/src/components/SchemaOrg/PersonForm.vue
@@ -3,7 +3,7 @@
     <b-form @submit="onSave" @reset="onReset">
         <div v-for="attribute in displayedAttributes" :key="attribute.key" role="group" class="form-group">
             <label :for="attribute.key">{{ attribute.label }}</label>
-            <span v-b-tooltip.hover title="Hide Attribute"
+            <span v-g-tooltip.hover title="Hide Attribute"
                 ><FontAwesomeIcon :icon="faEyeSlash" @click="onHide(attribute.key)"
             /></span>
             <div v-if="currentErrors[attribute.key]" class="error">{{ currentErrors[attribute.key] }}</div>

--- a/client/src/components/SchemaOrg/PersonViewer.vue
+++ b/client/src/components/SchemaOrg/PersonViewer.vue
@@ -23,7 +23,7 @@
 
         <GLink
             v-if="orcidLink"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             tooltip
             title="View orcid.org profile"
             :href="orcidLink"
@@ -31,7 +31,7 @@
             <link itemprop="identifier" :href="orcidLink" />
             <FontAwesomeIcon :icon="faOrcid" />
         </GLink>
-        <GLink v-if="url" v-b-tooltip.hover tooltip title="URL" :href="url" target="_blank">
+        <GLink v-if="url" v-g-tooltip.hover tooltip title="URL" :href="url" target="_blank">
             <link itemprop="url" :href="url" />
             <FontAwesomeIcon :icon="faExternalLinkAlt" />
         </GLink>

--- a/client/src/components/Sharing/EditableUrl.vue
+++ b/client/src/components/Sharing/EditableUrl.vue
@@ -70,21 +70,21 @@ function onCopyOut() {
 
         <BButton
             v-if="!editing"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             class="inline-icon-button"
             title="Edit URL"
             size="md"
             @click="onEdit">
             <FontAwesomeIcon :icon="faEdit" fixed-width />
         </BButton>
-        <BButton v-else v-b-tooltip.hover class="inline-icon-button" title="Done" size="md" @click="onSubmit">
+        <BButton v-else v-g-tooltip.hover class="inline-icon-button" title="Done" size="md" @click="onSubmit">
             <FontAwesomeIcon :icon="faCheck" fixed-width />
         </BButton>
 
         <BButton
             v-if="!editing"
             id="tooltip-clipboard"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             :disabled="editing"
             size="md"
             class="inline-icon-button"

--- a/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
+++ b/client/src/components/Sharing/Embeds/WorkflowEmbed.vue
@@ -133,7 +133,7 @@ const clipboardTitle = computed(() => (copied.value ? "Copied!" : "Copy URL"));
                     <BFormInput class="embed-code-input" :value="embed" readonly />
                     <BInputGroupAppend>
                         <BButton
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             :title="clipboardTitle"
                             variant="primary"
                             @click="onCopy"

--- a/client/src/components/TagsMultiselect/StatelessTags.test.js
+++ b/client/src/components/TagsMultiselect/StatelessTags.test.js
@@ -149,7 +149,7 @@ describe("StatelessTags", () => {
             maxVisibleTags: 4,
         });
 
-        const tags = wrapper.findAll(".tag");
+        const tags = wrapper.findAll(".tag").wrappers.filter((w) => !w.element.closest(".g-tooltip"));
         expect(tags.length).toBe(4);
 
         const showMoreLink = wrapper.find(".toggle-link");

--- a/client/src/components/TagsMultiselect/StatelessTags.vue
+++ b/client/src/components/TagsMultiselect/StatelessTags.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { faAngleUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BTooltip } from "bootstrap-vue";
-import { computed, onMounted, ref } from "vue";
+import { BButton } from "bootstrap-vue";
+import { type ComponentPublicInstance, computed, onMounted, ref } from "vue";
 
 import { useToast } from "@/composables/toast";
 import { useUid } from "@/composables/utils/uid";
@@ -12,6 +12,7 @@ import { VALID_TAG_RE } from "../Tags/model";
 
 import HeadlessMultiselect from "./HeadlessMultiselect.vue";
 import Tag from "./Tag.vue";
+import GTooltip from "@/components/BaseComponents/GTooltip.vue";
 
 interface StatelessTagsProps {
     value?: string[];
@@ -70,6 +71,8 @@ const tags = computed(() => props.value.map((tag) => tag.replace(/^name:/, "#"))
 
 const toggledOpen = ref(false);
 const toggleButtonId = useUid("toggle-link-");
+const moreButtonRef = ref<ComponentPublicInstance | null>(null);
+const moreButtonEl = computed(() => (moreButtonRef.value?.$el as HTMLElement) ?? null);
 
 const trimmedTags = computed(() => {
     if (!props.useToggleLink || toggledOpen.value) {
@@ -120,7 +123,7 @@ function onTagClicked(tag: string) {
                 <BButton
                     v-else-if="slicedTags.length > 0 && toggledOpen"
                     :id="toggleButtonId"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     variant="link"
                     title="Show fewer tags"
                     class="toggle-link show-less-tags"
@@ -153,17 +156,14 @@ function onTagClicked(tag: string) {
                 <BButton
                     v-if="slicedTags.length > 0 && !toggledOpen"
                     :id="toggleButtonId"
+                    ref="moreButtonRef"
                     variant="link"
                     class="toggle-link"
                     @click.stop="() => (toggledOpen = true)">
                     {{ slicedTags.length }} more...
                 </BButton>
 
-                <BTooltip
-                    v-if="slicedTags.length > 0 && !toggledOpen"
-                    :target="toggleButtonId"
-                    custom-class="stateless-tags--tag-preview-tooltip"
-                    placement="bottom">
+                <GTooltip v-if="slicedTags.length > 0 && !toggledOpen" :reference="moreButtonEl" placement="bottom">
                     <Tag
                         v-for="tag in slicedTags"
                         :key="tag"
@@ -171,17 +171,11 @@ function onTagClicked(tag: string) {
                         :editable="false"
                         :clickable="props.clickable"
                         @click="onTagClicked" />
-                </BTooltip>
+                </GTooltip>
             </div>
         </div>
     </div>
 </template>
-
-<style lang="scss">
-.stateless-tags--tag-preview-tooltip {
-    opacity: 1 !important;
-}
-</style>
 
 <style lang="scss" scoped>
 .stateless-tags {

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -216,7 +216,7 @@ onBeforeMount(() => {
                     :job-credentials-context="props.options.job_credentials_context" />
                 <BAlert
                     v-else-if="props.allowEditingCredentials"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     variant="info"
                     class="mt-2"
                     show

--- a/client/src/components/Tool/ToolCredentials.vue
+++ b/client/src/components/Tool/ToolCredentials.vue
@@ -235,7 +235,7 @@ onMounted(async () => {
             <div v-if="!isAnonymous && currentServiceGroups" class="d-flex flex-wrap flex-gapx-1 flex-gapy-1">
                 <div v-for="csg in currentServiceGroups" :key="csg.serviceName" class="d-flex align-items-center">
                     <BBadge
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         :title="getBadgeTitle(csg)"
                         :variant="csg.isRequired ? 'primary' : 'secondary'">
                         <FontAwesomeIcon :icon="csg.groupName ? faCheck : faExclamation" fixed-width />

--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -4,7 +4,7 @@
             <Heading h2 separator bold size="sm">
                 <span v-localize>References</span>
                 <b-button
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     title="Copy all references as BibTeX"
                     style="cursor: pointer"
                     variant="link"
@@ -38,11 +38,11 @@
                 <template v-if="xref.type == 'bio.tools'">
                     bio.tools: {{ xref.value }} (<a :href="`https://bio.tools/${xref.value}`" target="_blank"
                         >bio.tools
-                        <FontAwesomeIcon v-b-tooltip.hover title="Visit bio.tools page" :icon="faExternalLinkAlt" /> </a
+                        <FontAwesomeIcon v-g-tooltip.hover title="Visit bio.tools page" :icon="faExternalLinkAlt" /> </a
                     >) (<a :href="`https://openebench.bsc.es/tool/${xref.value}`" target="_blank"
                         >OpenEBench
                         <FontAwesomeIcon
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             title="Visit OpenEBench page"
                             :icon="faExternalLinkAlt" /> </a
                     >)

--- a/client/src/components/ToolEntryPoints/ToolEntryPoints.vue
+++ b/client/src/components/ToolEntryPoints/ToolEntryPoints.vue
@@ -6,7 +6,7 @@
         <p v-else-if="entryPointsForJob(jobId).length == 1">
             <span v-if="entryPointsForJob(jobId)[0].active">
                 There is an InteractiveTool result view available,
-                <a v-b-tooltip title="Open Interactive Tool" :href="entryPointsForJob(jobId)[0].target" target="_blank">
+                <a v-g-tooltip title="Open Interactive Tool" :href="entryPointsForJob(jobId)[0].target" target="_blank">
                     Open
                     <FontAwesomeIcon :icon="faExternalLinkAlt" />
                 </a>
@@ -21,7 +21,7 @@
                 <li v-for="entryPoint of entryPointsForJob(jobId)" :key="entryPoint.id">
                     {{ entryPoint.name }}
                     <span v-if="entryPoint.active">
-                        <a v-b-tooltip title="Open Interactive Tool" :href="entryPoint.target" target="_blank">
+                        <a v-g-tooltip title="Open Interactive Tool" :href="entryPoint.target" target="_blank">
                             (Open
                             <FontAwesomeIcon :icon="faExternalLinkAlt" />)
                         </a>

--- a/client/src/components/ToolsList/ScrollToTopButton.vue
+++ b/client/src/components/ToolsList/ScrollToTopButton.vue
@@ -13,7 +13,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 <template>
     <BButton
-        v-g-tooltip.noninteractive.hover
+        v-g-tooltip.hover
         class="back-to-top"
         :class="{ show: props.offset > 100 }"
         :title="props.offset > 100 ? 'Scroll To Top' : ''"

--- a/client/src/components/ToolsList/ScrollToTopButton.vue
+++ b/client/src/components/ToolsList/ScrollToTopButton.vue
@@ -13,7 +13,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 <template>
     <BButton
-        v-b-tooltip.noninteractive.hover
+        v-g-tooltip.noninteractive.hover
         class="back-to-top"
         :class="{ show: props.offset > 100 }"
         :title="props.offset > 100 ? 'Scroll To Top' : ''"

--- a/client/src/components/Toolshed/Index.vue
+++ b/client/src/components/Toolshed/Index.vue
@@ -10,7 +10,7 @@
                     @input="delayQuery"
                     @change="setQuery"
                     @keydown.esc="setQuery()" />
-                <b-input-group-append v-b-tooltip.hover :title="titleClearSearch">
+                <b-input-group-append v-g-tooltip.hover :title="titleClearSearch">
                     <b-btn @click="setQuery()">
                         <i class="fa fa-times" />
                     </b-btn>

--- a/client/src/components/TooltipOnHover.vue
+++ b/client/src/components/TooltipOnHover.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-b-tooltip.hover :disabled="disabled" :title="title"><slot /></div>
+    <div v-g-tooltip.hover :disabled="disabled" :title="title"><slot /></div>
 </template>
 <script>
 export default {

--- a/client/src/components/User/APIKey/APIKeyItem.vue
+++ b/client/src/components/User/APIKey/APIKeyItem.vue
@@ -57,7 +57,7 @@ const deleteKey = () => {
                             <CopyToClipboard message="Key was copied to clipboard" :text="item.key" title="Copy key" />
                         </b-input-group-text>
 
-                        <b-button v-b-tooltip.hover title="Show/hide key" @click="hover = !hover">
+                        <b-button v-g-tooltip.hover title="Show/hide key" @click="hover = !hover">
                             <FontAwesomeIcon :icon="hover ? faEyeSlash : faEye" />
                         </b-button>
 

--- a/client/src/components/User/Credentials/ServiceCredentials.vue
+++ b/client/src/components/User/Credentials/ServiceCredentials.vue
@@ -555,7 +555,7 @@ const groupIndicators = computed(() => (group: ServiceCredentialGroupResponse): 
                     <template v-if="!currentServiceCredentialsGroup?.id">
                         <BBadge
                             v-if="props.serviceDefinition.optional"
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             pill
                             title="This service is optional. You may choose not to provide credentials for it."
                             variant="secondary"
@@ -564,7 +564,7 @@ const groupIndicators = computed(() => (group: ServiceCredentialGroupResponse): 
                         </BBadge>
                         <BBadge
                             v-else
-                            v-g-tooltip.hover.noninteractive
+                            v-g-tooltip.hover
                             pill
                             title="This service is required. The tool may not function properly without providing credentials for it."
                             :variant="currentServiceCredentialsGroup ? 'success' : 'warning'"

--- a/client/src/components/User/Credentials/ServiceCredentials.vue
+++ b/client/src/components/User/Credentials/ServiceCredentials.vue
@@ -555,7 +555,7 @@ const groupIndicators = computed(() => (group: ServiceCredentialGroupResponse): 
                     <template v-if="!currentServiceCredentialsGroup?.id">
                         <BBadge
                             v-if="props.serviceDefinition.optional"
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             pill
                             title="This service is optional. You may choose not to provide credentials for it."
                             variant="secondary"
@@ -564,7 +564,7 @@ const groupIndicators = computed(() => (group: ServiceCredentialGroupResponse): 
                         </BBadge>
                         <BBadge
                             v-else
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             pill
                             title="This service is required. The tool may not function properly without providing credentials for it."
                             :variant="currentServiceCredentialsGroup ? 'success' : 'warning'"

--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -97,7 +97,7 @@
 
                         <BButton
                             id="save"
-                            v-b-tooltip.bottom.hover
+                            v-g-tooltip.bottom.hover
                             type="submit"
                             variant="primary"
                             title="Create new build">

--- a/client/src/components/User/Notifications/NotificationsCategorySettings.vue
+++ b/client/src/components/User/Notifications/NotificationsCategorySettings.vue
@@ -47,7 +47,7 @@ function onChannelChange(category: NotificationCategory, channel: NotificationCh
 <template>
     <div>
         <div class="category-header">
-            <BFormCheckbox v-model="isCategoryEnabled" v-b-tooltip.hover :title="checkBoxTitle" switch>
+            <BFormCheckbox v-model="isCategoryEnabled" v-g-tooltip.hover :title="checkBoxTitle" switch>
                 <span v-localize class="category-title">{{ snakeCaseToTitleCase(category) }}</span>
             </BFormCheckbox>
         </div>

--- a/client/src/components/User/Notifications/NotificationsChannelSettings.vue
+++ b/client/src/components/User/Notifications/NotificationsChannelSettings.vue
@@ -37,7 +37,7 @@ watch(
 
         <FontAwesomeIcon
             v-if="channel === 'push'"
-            v-b-tooltip.hover="'Push notifications need to be enabled'"
+            v-g-tooltip.hover="'Push notifications need to be enabled'"
             class="mx-2"
             :icon="faExclamationCircle" />
     </div>

--- a/client/src/components/User/Notifications/NotificationsPreferences.vue
+++ b/client/src/components/User/Notifications/NotificationsPreferences.vue
@@ -140,7 +140,7 @@ function onChannelChange(category: NotificationCategory, channel: NotificationCh
             class="card-container push-notifications-notice">
             Allow push and tab notifications. To disable, revoke the site notification privilege in your browser.
             <BButton
-                v-b-tooltip.hover
+                v-g-tooltip.hover
                 class="mx-2"
                 title="Enable push notifications"
                 @click="onTogglePushNotifications">

--- a/client/src/components/User/UserDetailsElement.vue
+++ b/client/src/components/User/UserDetailsElement.vue
@@ -36,7 +36,7 @@ const getStoragePercentageClass = (percentage: number) => {
             <div class="d-flex align-items-center flex-gapx-1">
                 <div class="d-flex align-items-center flex-gapx-1 mr-5">
                     <FontAwesomeIcon :icon="faUser" class="user-details-icon p-2" />
-                    <span v-g-tooltip.hover.noninteractive title="Your username (public name)">
+                    <span v-g-tooltip.hover title="Your username (public name)">
                         {{ userUsername }}
                     </span>
                 </div>
@@ -45,7 +45,7 @@ const getStoragePercentageClass = (percentage: number) => {
                     <FontAwesomeIcon :icon="faAt" class="user-details-icon p-2" />
                     <span
                         id="user-preferences-current-email"
-                        v-g-tooltip.hover.noninteractive
+                        v-g-tooltip.hover
                         class="word-wrap-break"
                         title="Your email address">
                         {{ userEmail }}
@@ -65,7 +65,7 @@ const getStoragePercentageClass = (percentage: number) => {
                 <div>
                     Visit
                     <RouterLink
-                        v-g-tooltip.hover.noninteractive
+                        v-g-tooltip.hover
                         to="/storage/dashboard"
                         title="View and manage your storage usage"
                         data-description="storage dashboard link">

--- a/client/src/components/User/UserDetailsElement.vue
+++ b/client/src/components/User/UserDetailsElement.vue
@@ -36,7 +36,7 @@ const getStoragePercentageClass = (percentage: number) => {
             <div class="d-flex align-items-center flex-gapx-1">
                 <div class="d-flex align-items-center flex-gapx-1 mr-5">
                     <FontAwesomeIcon :icon="faUser" class="user-details-icon p-2" />
-                    <span v-b-tooltip.hover.noninteractive title="Your username (public name)">
+                    <span v-g-tooltip.hover.noninteractive title="Your username (public name)">
                         {{ userUsername }}
                     </span>
                 </div>
@@ -45,7 +45,7 @@ const getStoragePercentageClass = (percentage: number) => {
                     <FontAwesomeIcon :icon="faAt" class="user-details-icon p-2" />
                     <span
                         id="user-preferences-current-email"
-                        v-b-tooltip.hover.noninteractive
+                        v-g-tooltip.hover.noninteractive
                         class="word-wrap-break"
                         title="Your email address">
                         {{ userEmail }}
@@ -65,7 +65,7 @@ const getStoragePercentageClass = (percentage: number) => {
                 <div>
                     Visit
                     <RouterLink
-                        v-b-tooltip.hover.noninteractive
+                        v-g-tooltip.hover.noninteractive
                         to="/storage/dashboard"
                         title="View and manage your storage usage"
                         data-description="storage dashboard link">

--- a/client/src/components/Visualizations/VisualizationExamples.vue
+++ b/client/src/components/Visualizations/VisualizationExamples.vue
@@ -44,7 +44,7 @@ function onSubmit(name: string, url: string, ftype?: string) {
     </div>
     <BDropdown
         v-else-if="urlData && urlData.length > 0"
-        v-b-tooltip.hover
+        v-g-tooltip.hover
         no-caret
         right
         role="button"

--- a/client/src/components/Workflow/Editor/Forms/FormColumnDefinitions.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormColumnDefinitions.vue
@@ -83,7 +83,7 @@ const emit = defineEmits(["onChange"]);
     <div class="ui-form-element section-row" data-description="edit column definitions">
         <div class="ui-form-title">
             <span class="ui-form-title-text">Column definitions</span>
-            <span v-b-tooltip.hover.bottom :title="saveTooltip">
+            <span v-g-tooltip.hover.bottom :title="saveTooltip">
                 <DownloadWorkbookButton
                     title="download example workbook"
                     @click="downloadWorkbook(value || [], props.collectionType)" />
@@ -101,7 +101,7 @@ const emit = defineEmits(["onChange"]);
                     <b-button-group>
                         <b-button
                             :id="getButtonId(index, 'up')"
-                            v-b-tooltip.hover.bottom
+                            v-g-tooltip.hover.bottom
                             title="move up"
                             role="button"
                             variant="link"
@@ -112,7 +112,7 @@ const emit = defineEmits(["onChange"]);
                         </b-button>
                         <b-button
                             :id="getButtonId(index, 'down')"
-                            v-b-tooltip.hover.bottom
+                            v-g-tooltip.hover.bottom
                             title="move down"
                             role="button"
                             variant="link"
@@ -123,7 +123,7 @@ const emit = defineEmits(["onChange"]);
                         </b-button>
                     </b-button-group>
 
-                    <span v-b-tooltip.hover.bottom :title="deleteTooltip">
+                    <span v-g-tooltip.hover.bottom :title="deleteTooltip">
                         <b-button
                             title="delete"
                             role="button"

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -3,7 +3,7 @@
         <template v-slot:operations>
             <b-button
                 v-if="isSubworkflow"
-                v-b-tooltip.hover
+                v-g-tooltip.hover
                 role="button"
                 title="Edit this Subworkflow. You will need to upgrade this Workflow Step afterwards."
                 variant="link"
@@ -14,7 +14,7 @@
             </b-button>
             <b-button
                 v-if="isSubworkflow"
-                v-b-tooltip.hover
+                v-g-tooltip.hover
                 role="button"
                 title="Upgrade this Workflow Step to latest Subworkflow version."
                 variant="link"

--- a/client/src/components/Workflow/Editor/Forms/FormRecordFieldDefinitions.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormRecordFieldDefinitions.vue
@@ -88,10 +88,10 @@ const emit = defineEmits(["onChange"]);
                 <!-- code modelled after FormRepeat -->
                 <span class="float-right">
                     <b-button-group>
-                        <span v-b-tooltip.hover.bottom title="move down">
+                        <span v-g-tooltip.hover.bottom title="move down">
                             <b-button
                                 :id="getButtonId(index, 'up')"
-                                v-b-tooltip.hover.bottom
+                                v-g-tooltip.hover.bottom
                                 title="move up"
                                 role="button"
                                 variant="link"
@@ -101,10 +101,10 @@ const emit = defineEmits(["onChange"]);
                                 <FontAwesomeIcon :icon="faCaretUp" />
                             </b-button>
                         </span>
-                        <span v-b-tooltip.hover.bottom title="move down">
+                        <span v-g-tooltip.hover.bottom title="move down">
                             <b-button
                                 :id="getButtonId(index, 'down')"
-                                v-b-tooltip.hover.bottom
+                                v-g-tooltip.hover.bottom
                                 title="move down"
                                 role="button"
                                 variant="link"
@@ -115,7 +115,7 @@ const emit = defineEmits(["onChange"]);
                             </b-button>
                         </span>
                     </b-button-group>
-                    <span v-b-tooltip.hover.bottom :title="deleteTooltip">
+                    <span v-g-tooltip.hover.bottom :title="deleteTooltip">
                         <b-button
                             title="delete"
                             role="button"

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -120,7 +120,7 @@
                 <template v-slot:buttons>
                     <b-button
                         id="workflow-canvas-button"
-                        v-b-tooltip.hover.bottom
+                        v-g-tooltip.hover.bottom
                         title="Return to Workflow"
                         variant="link"
                         role="button"

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -26,7 +26,7 @@
                 <LoadingSpan v-if="isLoading" spinner-only />
                 <BButton
                     v-if="credentials.length > 0"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="node-credentials py-0 inline-icon-button"
                     variant="primary"
                     size="sm"
@@ -36,7 +36,7 @@
                 </BButton>
                 <b-button
                     v-if="!readonly"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="node-clone py-0"
                     variant="primary"
                     size="sm"
@@ -47,7 +47,7 @@
                 </b-button>
                 <b-button
                     v-if="!readonly"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     class="node-destroy py-0"
                     variant="primary"
                     size="sm"
@@ -81,11 +81,11 @@
                 </b-popover>
             </b-button-group>
             <i :class="iconClass" />
-            <span v-if="step.when" v-b-tooltip.hover title="This step is conditionally executed.">
+            <span v-if="step.when" v-g-tooltip.hover title="This step is conditionally executed.">
                 <FontAwesomeIcon :icon="faCodeBranch" />
             </span>
             <span
-                v-b-tooltip.hover
+                v-g-tooltip.hover
                 title="Index of the step in the workflow run form. Steps are ordered by distance to the upper-left corner of the window; inputs are listed first."
                 >{{ step.id + 1 }}:
             </span>

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -237,7 +237,7 @@ watch(
         </div>
         <button
             v-if="hasConnections && !readonly"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             :title="reason"
             class="delete-terminal-button"
             @click="onRemove">
@@ -246,7 +246,7 @@ watch(
         <span v-if="!blank">{{ label }}</span>
         <span
             v-if="!input.optional && !hasTerminals"
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             class="input-required"
             title="Input is required">
             *

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -406,7 +406,7 @@ const removeTagsAction = computed(() => {
         <DraggableWrapper
             :id="id"
             ref="terminalComponent"
-            v-g-tooltip.hover.noninteractive="!props.blank ? outputDetails : ''"
+            v-g-tooltip.hover="!props.blank ? outputDetails : ''"
             class="output-terminal prevent-zoom"
             :class="{ 'mapped-over': isMultiple, 'blank-output': props.blank }"
             :output-name="output.name"

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -353,7 +353,7 @@ const removeTagsAction = computed(() => {
             <div class="node-output-buttons">
                 <button
                     v-if="showCalloutActiveOutput"
-                    v-b-tooltip
+                    v-g-tooltip
                     class="callout-terminal inline-icon-button mark-terminal"
                     :class="{ 'mark-terminal-active': workflowOutput }"
                     title="Checked outputs will become primary workflow outputs and are available as subworkflow outputs."
@@ -363,7 +363,7 @@ const removeTagsAction = computed(() => {
                 </button>
                 <button
                     v-if="showCalloutVisible"
-                    v-b-tooltip
+                    v-g-tooltip
                     class="callout-terminal inline-icon-button mark-terminal"
                     :class="{ 'mark-terminal-visible': isVisible, 'mark-terminal-hidden': !isVisible }"
                     :title="visibleHint"
@@ -373,7 +373,7 @@ const removeTagsAction = computed(() => {
                 </button>
                 <span>
                     <span
-                        v-b-tooltip
+                        v-g-tooltip
                         :title="labelToolTipTitle"
                         class="d-inline-block rounded"
                         :class="labelClass"
@@ -386,7 +386,7 @@ const removeTagsAction = computed(() => {
 
             <div
                 v-if="addTagsAction.length > 0"
-                v-b-tooltip.left
+                v-g-tooltip.left
                 class="d-flex align-items-center overflow-x-hidden"
                 title="These tags will be added to the output dataset">
                 <FontAwesomeIcon :icon="faPlus" class="mr-1" />
@@ -395,7 +395,7 @@ const removeTagsAction = computed(() => {
 
             <div
                 v-if="removeTagsAction.length > 0"
-                v-b-tooltip.left
+                v-g-tooltip.left
                 class="d-flex align-items-center overflow-x-hidden"
                 title="These tags will be removed from the output dataset">
                 <FontAwesomeIcon :icon="faMinus" class="mr-1" />
@@ -406,7 +406,7 @@ const removeTagsAction = computed(() => {
         <DraggableWrapper
             :id="id"
             ref="terminalComponent"
-            v-b-tooltip.hover.noninteractive="!props.blank ? outputDetails : ''"
+            v-g-tooltip.hover.noninteractive="!props.blank ? outputDetails : ''"
             class="output-terminal prevent-zoom"
             :class="{ 'mapped-over': isMultiple, 'blank-output': props.blank }"
             :output-name="output.name"

--- a/client/src/components/Workflow/Editor/ReadmeEditor.vue
+++ b/client/src/components/Workflow/Editor/ReadmeEditor.vue
@@ -65,7 +65,7 @@ watch(
                 </BButton>
             </BButtonGroup>
             <BButton
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 size="sm"
                 variant="outline-danger"
                 title="Return to Workflow"

--- a/client/src/components/Workflow/Editor/ReadmeEditor.vue
+++ b/client/src/components/Workflow/Editor/ReadmeEditor.vue
@@ -65,7 +65,7 @@ watch(
                 </BButton>
             </BButtonGroup>
             <BButton
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 size="sm"
                 variant="outline-danger"
                 title="Return to Workflow"

--- a/client/src/components/Workflow/Editor/SaveChangesModal.vue
+++ b/client/src/components/Workflow/Editor/SaveChangesModal.vue
@@ -63,7 +63,7 @@ function saveChanges() {
         </div>
         <template v-slot:modal-footer>
             <BButton
-                v-b-tooltip.noninteractive.hover
+                v-g-tooltip.noninteractive.hover
                 :title="buttonTitles['cancel']"
                 variant="secondary"
                 :disabled="busy"
@@ -72,7 +72,7 @@ function saveChanges() {
                 {{ localize("Cancel") }}
             </BButton>
             <BButton
-                v-b-tooltip.noninteractive.hover
+                v-g-tooltip.noninteractive.hover
                 :title="buttonTitles['dontSave']"
                 variant="danger"
                 :disabled="busy"
@@ -81,7 +81,7 @@ function saveChanges() {
                 {{ localize("Don't Save") }}
             </BButton>
             <BButton
-                v-b-tooltip.noninteractive.hover
+                v-g-tooltip.noninteractive.hover
                 :title="buttonTitles['save']"
                 variant="primary"
                 :disabled="busy"

--- a/client/src/components/Workflow/Editor/SaveChangesModal.vue
+++ b/client/src/components/Workflow/Editor/SaveChangesModal.vue
@@ -63,7 +63,7 @@ function saveChanges() {
         </div>
         <template v-slot:modal-footer>
             <BButton
-                v-g-tooltip.noninteractive.hover
+                v-g-tooltip.hover
                 :title="buttonTitles['cancel']"
                 variant="secondary"
                 :disabled="busy"
@@ -72,7 +72,7 @@ function saveChanges() {
                 {{ localize("Cancel") }}
             </BButton>
             <BButton
-                v-g-tooltip.noninteractive.hover
+                v-g-tooltip.hover
                 :title="buttonTitles['dontSave']"
                 variant="danger"
                 :disabled="busy"
@@ -81,7 +81,7 @@ function saveChanges() {
                 {{ localize("Don't Save") }}
             </BButton>
             <BButton
-                v-g-tooltip.noninteractive.hover
+                v-g-tooltip.hover
                 :title="buttonTitles['save']"
                 variant="primary"
                 :disabled="busy"

--- a/client/src/components/Workflow/Editor/ZoomControl.vue
+++ b/client/src/components/Workflow/Editor/ZoomControl.vue
@@ -41,7 +41,7 @@ function onZoomReset() {
             aria-label="Zoom Out"
             @click="onZoomOut" />
         <b-button
-            v-b-tooltip.hover
+            v-g-tooltip.hover
             role="button"
             class="zoom-reset"
             variant="light"

--- a/client/src/components/Workflow/Invocation/Export/ActionButton.vue
+++ b/client/src/components/Workflow/Invocation/Export/ActionButton.vue
@@ -14,7 +14,7 @@ const props = defineProps<Props>();
 </script>
 
 <template>
-    <b-button v-b-tooltip.hover.bottom :title="props.action.title" @click="props.action.run(modal)">
+    <b-button v-g-tooltip.hover.bottom :title="props.action.title" @click="props.action.run(modal)">
         <FontAwesomeIcon v-if="props.action.icon" :icon="props.action.icon" />
         <div v-else>
             {{ props.action.title }}

--- a/client/src/components/Workflow/Invocation/Export/ExportButton.vue
+++ b/client/src/components/Workflow/Invocation/Export/ExportButton.vue
@@ -21,7 +21,7 @@ const emit = defineEmits(["onClick"]);
 </script>
 
 <template>
-    <span v-b-tooltip.hover.bottom :title="title">
+    <span v-g-tooltip.hover.bottom :title="title">
         <BButton :disabled="disabled" @click="() => emit('onClick')">
             <FontAwesomeIcon v-if="isBusy" :icon="faSpinner" spin />
             <FontAwesomeIcon v-else :icon="idleIcon" />

--- a/client/src/components/Workflow/List/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/List/WorkflowIndicators.vue
@@ -154,7 +154,7 @@ function getStepText(steps: number) {
     <div class="workflow-indicators">
         <BButton
             v-if="workflow.published && !publishedView"
-            v-b-tooltip.noninteractive.hover
+            v-g-tooltip.noninteractive.hover
             size="sm"
             class="workflow-published-icon inline-icon-button"
             :title="publishedTitle"
@@ -163,7 +163,7 @@ function getStepText(steps: number) {
         </BButton>
         <FontAwesomeIcon
             v-else-if="workflow.published"
-            v-b-tooltip.noninteractive.hover
+            v-g-tooltip.noninteractive.hover
             title="Published workflow"
             :icon="faGlobe"
             fixed-width
@@ -171,7 +171,7 @@ function getStepText(steps: number) {
 
         <BButton
             v-if="sourceType.includes('trs')"
-            v-b-tooltip.noninteractive.hover
+            v-g-tooltip.noninteractive.hover
             size="sm"
             class="workflow-trs-icon inline-icon-button"
             :title="sourceTitle">
@@ -180,7 +180,7 @@ function getStepText(steps: number) {
 
         <BButton
             v-if="sourceType == 'url'"
-            v-b-tooltip.noninteractive.hover
+            v-g-tooltip.noninteractive.hover
             size="sm"
             class="workflow-external-link inline-icon-button"
             :title="sourceTitle">
@@ -200,7 +200,7 @@ function getStepText(steps: number) {
 
         <BBadge
             v-if="shared && !publishedView"
-            v-b-tooltip.noninteractive.hover
+            v-g-tooltip.noninteractive.hover
             class="outline-badge cursor-pointer mx-1"
             :title="`'${workflow.owner}' shared this workflow with you. Click to view all workflows shared with you by '${workflow.owner}'`"
             @click="onViewMySharedByUser">
@@ -210,7 +210,7 @@ function getStepText(steps: number) {
 
         <BBadge
             v-if="publishedView && workflow.published"
-            v-b-tooltip.noninteractive.hover
+            v-g-tooltip.noninteractive.hover
             data-description="published owner badge"
             class="outline-badge cursor-pointer mx-1"
             :title="publishedTitle"
@@ -223,7 +223,7 @@ function getStepText(steps: number) {
             <BBadge
                 v-for="creator in creatorBadges"
                 :key="creator.name"
-                v-b-tooltip.noninteractive.hover
+                v-g-tooltip.noninteractive.hover
                 data-description="external creator badge"
                 class="mx-1"
                 :class="creator.class"

--- a/client/src/components/Workflow/List/WorkflowIndicators.vue
+++ b/client/src/components/Workflow/List/WorkflowIndicators.vue
@@ -154,7 +154,7 @@ function getStepText(steps: number) {
     <div class="workflow-indicators">
         <BButton
             v-if="workflow.published && !publishedView"
-            v-g-tooltip.noninteractive.hover
+            v-g-tooltip.hover
             size="sm"
             class="workflow-published-icon inline-icon-button"
             :title="publishedTitle"
@@ -163,7 +163,7 @@ function getStepText(steps: number) {
         </BButton>
         <FontAwesomeIcon
             v-else-if="workflow.published"
-            v-g-tooltip.noninteractive.hover
+            v-g-tooltip.hover
             title="Published workflow"
             :icon="faGlobe"
             fixed-width
@@ -171,7 +171,7 @@ function getStepText(steps: number) {
 
         <BButton
             v-if="sourceType.includes('trs')"
-            v-g-tooltip.noninteractive.hover
+            v-g-tooltip.hover
             size="sm"
             class="workflow-trs-icon inline-icon-button"
             :title="sourceTitle">
@@ -180,7 +180,7 @@ function getStepText(steps: number) {
 
         <BButton
             v-if="sourceType == 'url'"
-            v-g-tooltip.noninteractive.hover
+            v-g-tooltip.hover
             size="sm"
             class="workflow-external-link inline-icon-button"
             :title="sourceTitle">
@@ -200,7 +200,7 @@ function getStepText(steps: number) {
 
         <BBadge
             v-if="shared && !publishedView"
-            v-g-tooltip.noninteractive.hover
+            v-g-tooltip.hover
             class="outline-badge cursor-pointer mx-1"
             :title="`'${workflow.owner}' shared this workflow with you. Click to view all workflows shared with you by '${workflow.owner}'`"
             @click="onViewMySharedByUser">
@@ -210,7 +210,7 @@ function getStepText(steps: number) {
 
         <BBadge
             v-if="publishedView && workflow.published"
-            v-g-tooltip.noninteractive.hover
+            v-g-tooltip.hover
             data-description="published owner badge"
             class="outline-badge cursor-pointer mx-1"
             :title="publishedTitle"
@@ -223,7 +223,7 @@ function getStepText(steps: number) {
             <BBadge
                 v-for="creator in creatorBadges"
                 :key="creator.name"
-                v-g-tooltip.noninteractive.hover
+                v-g-tooltip.hover
                 data-description="external creator badge"
                 class="mx-1"
                 :class="creator.class"

--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -446,7 +446,7 @@ onMounted(() => {
                         <span v-localize>Filter:</span>
                         <BButton
                             id="show-deleted"
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             size="sm"
                             :title="deleteButtonTitle"
                             :pressed="showDeleted"
@@ -458,7 +458,7 @@ onMounted(() => {
 
                         <BButton
                             id="show-bookmarked"
-                            v-b-tooltip.hover
+                            v-g-tooltip.hover
                             size="sm"
                             :title="bookmarkButtonTitle"
                             :pressed="showBookmarked"
@@ -531,7 +531,7 @@ onMounted(() => {
                 <BButton
                     v-if="!showDeleted"
                     id="workflow-list-footer-bulk-delete-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="bulkDeleteOrRestoreLoading ? 'Deleting workflows' : 'Delete selected workflows'"
                     :disabled="bulkDeleteOrRestoreLoading"
                     size="sm"
@@ -546,7 +546,7 @@ onMounted(() => {
                 <BButton
                     v-else
                     id="workflow-list-footer-bulk-restore-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="bulkDeleteOrRestoreLoading ? 'Restoring workflows' : 'Restore selected workflows'"
                     :disabled="bulkDeleteOrRestoreLoading"
                     size="sm"
@@ -562,7 +562,7 @@ onMounted(() => {
                 <BButton
                     v-if="!showDeleted"
                     id="workflow-list-footer-bulk-add-tags-button"
-                    v-b-tooltip.hover
+                    v-g-tooltip.hover
                     :title="bulkTagsLoading ? 'Adding tags' : 'Add tags to selected workflows'"
                     :disabled="bulkTagsLoading"
                     size="sm"

--- a/client/src/components/Workflow/Published/WorkflowPublishedButtons.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublishedButtons.vue
@@ -60,7 +60,7 @@ function logInTitle(title: string) {
     <span>
         <BButtonGroup>
             <BButton
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 title="Download workflow in .ga format"
                 variant="outline-primary"
                 size="md"
@@ -69,7 +69,7 @@ function logInTitle(title: string) {
                 Download
             </BButton>
             <BButton
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 title="Copy link to workflow"
                 variant="outline-primary"
                 size="md"
@@ -93,7 +93,7 @@ function logInTitle(title: string) {
 
         <BButton
             v-else-if="!props.embed && !sharedWorkflow"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             :disabled="workflowInfo.deleted"
             class="workflow-edit-button"
             :title="editButtonTitle"

--- a/client/src/components/Workflow/Published/WorkflowPublishedButtons.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublishedButtons.vue
@@ -60,7 +60,7 @@ function logInTitle(title: string) {
     <span>
         <BButtonGroup>
             <BButton
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 title="Download workflow in .ga format"
                 variant="outline-primary"
                 size="md"
@@ -69,7 +69,7 @@ function logInTitle(title: string) {
                 Download
             </BButton>
             <BButton
-                v-g-tooltip.hover.noninteractive
+                v-g-tooltip.hover
                 title="Copy link to workflow"
                 variant="outline-primary"
                 size="md"
@@ -93,7 +93,7 @@ function logInTitle(title: string) {
 
         <BButton
             v-else-if="!props.embed && !sharedWorkflow"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             :disabled="workflowInfo.deleted"
             class="workflow-edit-button"
             :title="editButtonTitle"

--- a/client/src/components/Workflow/Run/WorkflowCredentials.vue
+++ b/client/src/components/Workflow/Run/WorkflowCredentials.vue
@@ -207,7 +207,7 @@ onMounted(async () => {
                     :key="`${wsg.toolName}-${wsg.serviceName}`"
                     class="d-flex align-items-center">
                     <BBadge
-                        v-b-tooltip.hover
+                        v-g-tooltip.hover
                         :title="getBadgeTitle(wsg.toolName, wsg.isRequired, wsg.groupName)"
                         :variant="wsg.isRequired ? 'primary' : 'secondary'">
                         <FontAwesomeIcon :icon="wsg.groupName ? faCheck : faExclamation" fixed-width />

--- a/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
@@ -2,7 +2,7 @@
     <div :step-label="model.step_label">
         <FormCard :title="model.fixed_title" :icon="icon" :collapsible="true" :expanded.sync="expanded">
             <template v-slot:title>
-                <span v-if="credentialInfo?.toolId" v-b-tooltip.hover title="Uses credentials">
+                <span v-if="credentialInfo?.toolId" v-g-tooltip.hover title="Uses credentials">
                     <FontAwesomeIcon :icon="faKey" fixed-width />
                 </span>
             </template>

--- a/client/src/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunForm.vue
@@ -11,7 +11,7 @@
             <div class="float-right d-flex flex-gapx-1">
                 <b-button
                     v-if="!disableSimpleForm"
-                    v-g-tooltip.hover.noninteractive
+                    v-g-tooltip.hover
                     variant="link"
                     class="text-decoration-none"
                     title="Use simplified run form instead"

--- a/client/src/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunForm.vue
@@ -11,7 +11,7 @@
             <div class="float-right d-flex flex-gapx-1">
                 <b-button
                     v-if="!disableSimpleForm"
-                    v-b-tooltip.hover.noninteractive
+                    v-g-tooltip.hover.noninteractive
                     variant="link"
                     class="text-decoration-none"
                     title="Use simplified run form instead"

--- a/client/src/components/Workflow/WorkflowInvocationsCount.vue
+++ b/client/src/components/Workflow/WorkflowInvocationsCount.vue
@@ -34,7 +34,7 @@ const count = computed(() => invocationStore.getInvocationCountByWorkflowId(prop
 
         <BBadge
             v-else-if="count > 0"
-            v-g-tooltip.hover.noninteractive
+            v-g-tooltip.hover
             pill
             :title="localize('View workflow invocations')"
             class="outline-badge cursor-pointer"

--- a/client/src/components/Workflow/WorkflowInvocationsCount.vue
+++ b/client/src/components/Workflow/WorkflowInvocationsCount.vue
@@ -34,7 +34,7 @@ const count = computed(() => invocationStore.getInvocationCountByWorkflowId(prop
 
         <BBadge
             v-else-if="count > 0"
-            v-b-tooltip.hover.noninteractive
+            v-g-tooltip.hover.noninteractive
             pill
             :title="localize('View workflow invocations')"
             class="outline-badge cursor-pointer"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -403,7 +403,7 @@ async function onCancel() {
             <div class="ml-auto d-flex align-items-center">
                 <BBadge
                     v-if="tabsDisabled"
-                    v-b-tooltip.hover.noninteractive
+                    v-g-tooltip.hover.noninteractive
                     class="mr-1"
                     :title="disabledTabTooltip"
                     variant="primary">
@@ -411,7 +411,7 @@ async function onCancel() {
                 </BBadge>
                 <BBadge
                     v-if="isPolling"
-                    v-b-tooltip.hover.noninteractive
+                    v-g-tooltip.hover.noninteractive
                     class="mr-1"
                     title="Polling for updates"
                     variant="link">

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -403,18 +403,13 @@ async function onCancel() {
             <div class="ml-auto d-flex align-items-center">
                 <BBadge
                     v-if="tabsDisabled"
-                    v-g-tooltip.hover.noninteractive
+                    v-g-tooltip.hover
                     class="mr-1"
                     :title="disabledTabTooltip"
                     variant="primary">
                     <FontAwesomeIcon :icon="faExclamation" />
                 </BBadge>
-                <BBadge
-                    v-if="isPolling"
-                    v-g-tooltip.hover.noninteractive
-                    class="mr-1"
-                    title="Polling for updates"
-                    variant="link">
+                <BBadge v-if="isPolling" v-g-tooltip.hover class="mr-1" title="Polling for updates" variant="link">
                     <FontAwesomeIcon :icon="faSpinner" spin />
                 </BBadge>
                 <GButton

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStepHeader.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStepHeader.vue
@@ -66,12 +66,7 @@ const isPolling = computed(() =>
         </div>
 
         <span v-if="props.graphStep">
-            <BBadge
-                v-if="isPolling"
-                v-g-tooltip.hover.noninteractive
-                class="mr-1"
-                title="Polling for updates"
-                variant="link">
+            <BBadge v-if="isPolling" v-g-tooltip.hover class="mr-1" title="Polling for updates" variant="link">
                 <FontAwesomeIcon :icon="faSpinner" spin />
             </BBadge>
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStepHeader.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStepHeader.vue
@@ -68,7 +68,7 @@ const isPolling = computed(() =>
         <span v-if="props.graphStep">
             <BBadge
                 v-if="isPolling"
-                v-b-tooltip.hover.noninteractive
+                v-g-tooltip.hover.noninteractive
                 class="mr-1"
                 title="Polling for updates"
                 variant="link">

--- a/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
@@ -88,7 +88,7 @@ watch(
 <template>
     <span>
         {{ title }}
-        <span v-g-tooltip.noninteractive.hover.v-danger :title="hoverError">
+        <span v-g-tooltip.hover.v-danger :title="hoverError">
             <FontAwesomeIcon v-if="hoverError" class="text-danger" :icon="faExclamationCircle" />
         </span>
     </span>

--- a/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
@@ -88,7 +88,7 @@ watch(
 <template>
     <span>
         {{ title }}
-        <span v-b-tooltip.noninteractive.hover.v-danger :title="hoverError">
+        <span v-g-tooltip.noninteractive.hover.v-danger :title="hoverError">
             <FontAwesomeIcon v-if="hoverError" class="text-danger" :icon="faExclamationCircle" />
         </span>
     </span>

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -133,7 +133,8 @@ function createTooltipEl(state: TooltipState): HTMLDivElement {
 
     const tooltip = document.createElement("div");
     tooltip.setAttribute("role", "tooltip");
-    tooltip.className = "g-tooltip-d sr-only";
+    // "tooltip" class matches v-b-tooltip's rendered element for Selenium selector compatibility
+    tooltip.className = "tooltip g-tooltip-d sr-only";
 
     if (state.danger) {
         tooltip.classList.add("g-tooltip-danger");

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -301,11 +301,6 @@ function inserted(el: HTMLElement, binding: { value?: unknown; modifiers: Record
         danger: !!modifiers["v-danger"],
     };
 
-    // Remove title attribute to prevent native browser tooltip
-    if (el.hasAttribute("title")) {
-        el.removeAttribute("title");
-    }
-
     stateMap.set(el, state);
     setupListeners(el, state, modifiers);
 }
@@ -319,10 +314,6 @@ function componentUpdated(el: HTMLElement, binding: { value?: unknown; modifiers
 
     const modifiers = binding.modifiers || {};
     const newText = resolveText(el, binding.value, state.text);
-
-    if (el.hasAttribute("title")) {
-        el.removeAttribute("title");
-    }
 
     state.text = newText;
     state.placement = resolvePlacement(binding.value, modifiers);

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -61,14 +61,6 @@ const TOOLTIP_STYLES = `
 .g-tooltip-d.g-tooltip-danger {
     background-color: var(--color-red-700, #dc3545);
 }
-.g-tooltip-d .tooltip-inner {
-    background-color: transparent;
-    color: inherit;
-    padding: 0;
-    text-align: inherit;
-    max-width: none;
-    border-radius: 0;
-}
 .g-tooltip-d .g-tooltip-d-arrow,
 .g-tooltip-d .g-tooltip-d-arrow::before {
     position: absolute;
@@ -163,15 +155,15 @@ function createTooltipEl(isDanger: boolean): { tooltipEl: HTMLElement; arrowEl: 
     injectStyles();
     const tooltipEl = document.createElement("div");
     tooltipEl.setAttribute("role", "tooltip");
-    // "tooltip" class matches bootstrap-vue's rendered element for Selenium selector compat
-    tooltipEl.className = "tooltip g-tooltip-d";
+    // "g-tooltip-d" handles the new Selenium selector compat
+    tooltipEl.className = "g-tooltip-d";
     if (isDanger) {
         tooltipEl.classList.add("g-tooltip-danger");
     }
 
-    // "tooltip-inner" matches bootstrap-vue's inner element for Selenium selector compat
+    // "g-tooltip-d-inner" handles the new Selenium selector compat
     const contentEl = document.createElement("div");
-    contentEl.className = "tooltip-inner";
+    contentEl.className = "g-tooltip-d-inner";
     tooltipEl.appendChild(contentEl);
 
     const arrowEl = document.createElement("div");

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -1,0 +1,368 @@
+import { arrow, autoUpdate, computePosition, flip, offset, type Placement, shift } from "@floating-ui/dom";
+
+interface TooltipState {
+    tooltipEl: HTMLDivElement | null;
+    arrowEl: HTMLDivElement | null;
+    cleanup: (() => void) | null;
+    listeners: Array<[string, EventListener]>;
+    showing: boolean;
+    text: string;
+    placement: Placement;
+    noninteractive: boolean;
+    useHtml: boolean;
+    danger: boolean;
+}
+
+const stateMap = new WeakMap<HTMLElement, TooltipState>();
+
+let stylesInjected = false;
+
+function injectStyles() {
+    if (stylesInjected) {
+        return;
+    }
+
+    stylesInjected = true;
+
+    const style = document.createElement("style");
+    style.setAttribute("data-g-tooltip-directive", "");
+    style.textContent = `
+.g-tooltip-d {
+    background-color: var(--color-blue-800);
+    color: var(--color-grey-100);
+    padding: var(--spacing-1) var(--spacing-2);
+    font-size: var(--font-size-small);
+    border-radius: var(--spacing-1);
+    pointer-events: none;
+    font-weight: 400;
+    z-index: 9999;
+    width: max-content;
+    max-width: 300px;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+.g-tooltip-d:not(.sr-only) {
+    display: block;
+}
+.g-tooltip-d.g-tooltip-danger {
+    background-color: var(--color-red-700, #dc3545);
+}
+.g-tooltip-d .g-tooltip-arrow {
+    visibility: hidden;
+}
+.g-tooltip-d .g-tooltip-arrow,
+.g-tooltip-d .g-tooltip-arrow::before {
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    background: inherit;
+    z-index: -1;
+    top: 0;
+    left: 0;
+}
+.g-tooltip-d .g-tooltip-arrow::before {
+    visibility: visible;
+    content: "";
+    transform: rotate(45deg);
+}
+.g-tooltip-d .g-tooltip-arrow[data-placement^="top"] {
+    top: unset;
+    bottom: -4px;
+}
+.g-tooltip-d .g-tooltip-arrow[data-placement^="bottom"] {
+    top: -4px;
+    bottom: unset;
+}
+.g-tooltip-d .g-tooltip-arrow[data-placement^="left"] {
+    left: unset;
+    right: -4px;
+}
+.g-tooltip-d .g-tooltip-arrow[data-placement^="right"] {
+    left: -4px;
+    right: unset;
+}
+`;
+    document.head.appendChild(style);
+}
+
+function getPlacementFromModifiers(modifiers: Record<string, boolean>): Placement {
+    if (modifiers.bottom) {
+        return "bottom";
+    }
+
+    if (modifiers.left) {
+        return "left";
+    }
+
+    if (modifiers.right) {
+        return "right";
+    }
+
+    return "top";
+}
+
+function resolveText(el: HTMLElement, value: unknown, existingText: string): string {
+    if (typeof value === "string" && value) {
+        return value;
+    }
+
+    if (value && typeof value === "object" && "title" in value && (value as { title: string }).title) {
+        return (value as { title: string }).title;
+    }
+
+    const titleAttr = el.getAttribute("title");
+
+    if (titleAttr) {
+        return titleAttr;
+    }
+
+    return existingText;
+}
+
+function resolvePlacement(value: unknown, modifiers: Record<string, boolean>): Placement {
+    if (value && typeof value === "object" && "placement" in value) {
+        return (value as { placement: Placement }).placement;
+    }
+
+    return getPlacementFromModifiers(modifiers);
+}
+
+function createTooltipEl(state: TooltipState): HTMLDivElement {
+    injectStyles();
+
+    const tooltip = document.createElement("div");
+    tooltip.setAttribute("role", "tooltip");
+    tooltip.className = "g-tooltip-d sr-only";
+
+    if (state.danger) {
+        tooltip.classList.add("g-tooltip-danger");
+    }
+
+    if (!state.noninteractive) {
+        tooltip.style.pointerEvents = "auto";
+    }
+
+    const arrowDiv = document.createElement("div");
+    arrowDiv.className = "g-tooltip-arrow";
+    tooltip.appendChild(arrowDiv);
+
+    state.arrowEl = arrowDiv;
+    document.body.appendChild(tooltip);
+
+    return tooltip;
+}
+
+function updateContent(state: TooltipState) {
+    if (!state.tooltipEl || !state.arrowEl) {
+        return;
+    }
+
+    // Remove all children except arrow
+    while (state.tooltipEl.firstChild && state.tooltipEl.firstChild !== state.arrowEl) {
+        state.tooltipEl.removeChild(state.tooltipEl.firstChild);
+    }
+
+    if (state.useHtml) {
+        const wrapper = document.createElement("span");
+        wrapper.innerHTML = state.text;
+        state.tooltipEl.insertBefore(wrapper, state.arrowEl);
+    } else {
+        const textNode = document.createTextNode(state.text);
+        state.tooltipEl.insertBefore(textNode, state.arrowEl);
+    }
+}
+
+async function updatePosition(el: HTMLElement, state: TooltipState) {
+    if (!state.tooltipEl || !state.arrowEl) {
+        return;
+    }
+
+    const { x, y, middlewareData, placement } = await computePosition(el, state.tooltipEl, {
+        placement: state.placement,
+        middleware: [
+            offset(8),
+            flip({ altBoundary: true }),
+            shift({ altBoundary: true }),
+            arrow({ element: state.arrowEl }),
+        ],
+    });
+
+    state.tooltipEl.style.transform = `translate(${x}px, ${y}px)`;
+
+    if (middlewareData.arrow) {
+        const { x: ax, y: ay } = middlewareData.arrow;
+        state.arrowEl.style.transform = `translate(${ax ?? 0}px, ${ay ?? 0}px)`;
+    }
+
+    state.arrowEl.setAttribute("data-placement", placement);
+}
+
+function show(el: HTMLElement, state: TooltipState) {
+    if (state.showing || !state.text) {
+        return;
+    }
+
+    if (el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true") {
+        return;
+    }
+
+    state.showing = true;
+
+    if (!state.tooltipEl) {
+        state.tooltipEl = createTooltipEl(state);
+    }
+
+    updateContent(state);
+    state.tooltipEl.classList.remove("sr-only");
+    state.tooltipEl.setAttribute("data-show", "true");
+
+    state.cleanup = autoUpdate(el, state.tooltipEl, () => updatePosition(el, state));
+}
+
+function hide(_el: HTMLElement, state: TooltipState) {
+    if (!state.showing) {
+        return;
+    }
+
+    state.showing = false;
+    state.cleanup?.();
+    state.cleanup = null;
+
+    if (state.tooltipEl) {
+        state.tooltipEl.classList.add("sr-only");
+        state.tooltipEl.removeAttribute("data-show");
+    }
+}
+
+function setupListeners(el: HTMLElement, state: TooltipState, modifiers: Record<string, boolean>) {
+    for (const [event, handler] of state.listeners) {
+        el.removeEventListener(event, handler);
+    }
+
+    state.listeners = [];
+
+    const focusOnly = modifiers.focus && !modifiers.hover;
+    const showHandler = () => show(el, state);
+    const hideHandler = () => hide(el, state);
+    const keyHandler = (e: Event) => {
+        if ((e as KeyboardEvent).key === "Escape") {
+            hide(el, state);
+        }
+    };
+
+    if (focusOnly) {
+        el.addEventListener("focusin", showHandler);
+        el.addEventListener("focusout", hideHandler);
+        state.listeners.push(["focusin", showHandler], ["focusout", hideHandler]);
+    } else {
+        // Default: hover + focus for accessibility
+        el.addEventListener("mouseenter", showHandler);
+        el.addEventListener("mouseleave", hideHandler);
+        el.addEventListener("focus", showHandler);
+        el.addEventListener("blur", hideHandler);
+        state.listeners.push(
+            ["mouseenter", showHandler],
+            ["mouseleave", hideHandler],
+            ["focus", showHandler],
+            ["blur", hideHandler],
+        );
+    }
+
+    el.addEventListener("keydown", keyHandler);
+    state.listeners.push(["keydown", keyHandler]);
+}
+
+function destroyTooltip(state: TooltipState) {
+    state.cleanup?.();
+    state.cleanup = null;
+
+    if (state.tooltipEl) {
+        state.tooltipEl.remove();
+        state.tooltipEl = null;
+        state.arrowEl = null;
+    }
+}
+
+function inserted(el: HTMLElement, binding: { value?: unknown; modifiers: Record<string, boolean> }) {
+    const modifiers = binding.modifiers || {};
+    const text = resolveText(el, binding.value, "");
+
+    const state: TooltipState = {
+        tooltipEl: null,
+        arrowEl: null,
+        cleanup: null,
+        listeners: [],
+        showing: false,
+        text,
+        placement: resolvePlacement(binding.value, modifiers),
+        noninteractive: !!modifiers.noninteractive,
+        useHtml: !!modifiers.html,
+        danger: !!modifiers["v-danger"],
+    };
+
+    // Remove title attribute to prevent native browser tooltip
+    if (el.hasAttribute("title")) {
+        el.removeAttribute("title");
+    }
+
+    stateMap.set(el, state);
+    setupListeners(el, state, modifiers);
+}
+
+function componentUpdated(el: HTMLElement, binding: { value?: unknown; modifiers: Record<string, boolean> }) {
+    const state = stateMap.get(el);
+
+    if (!state) {
+        return;
+    }
+
+    const modifiers = binding.modifiers || {};
+    const newText = resolveText(el, binding.value, state.text);
+
+    if (el.hasAttribute("title")) {
+        el.removeAttribute("title");
+    }
+
+    state.text = newText;
+    state.placement = resolvePlacement(binding.value, modifiers);
+    state.danger = !!modifiers["v-danger"];
+
+    if (state.tooltipEl) {
+        updateContent(state);
+
+        if (state.danger) {
+            state.tooltipEl.classList.add("g-tooltip-danger");
+        } else {
+            state.tooltipEl.classList.remove("g-tooltip-danger");
+        }
+    }
+
+    // Hide if text became empty
+    if (!state.text && state.showing) {
+        hide(el, state);
+    }
+}
+
+function unbind(el: HTMLElement) {
+    const state = stateMap.get(el);
+
+    if (!state) {
+        return;
+    }
+
+    for (const [event, handler] of state.listeners) {
+        el.removeEventListener(event, handler);
+    }
+
+    destroyTooltip(state);
+    stateMap.delete(el);
+}
+
+export const vGTooltip = {
+    inserted,
+    componentUpdated,
+    unbind,
+};
+
+export default vGTooltip;

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -24,6 +24,7 @@ import {
     type Placement,
     shift,
 } from "@floating-ui/dom";
+import purify from "dompurify";
 import type { DirectiveOptions, VNode } from "vue";
 
 interface TooltipState {
@@ -205,7 +206,7 @@ function showTooltip(el: HTMLElement) {
 
     if (
         (el as HTMLButtonElement).disabled ||
-        el.getAttribute("disabled") === "true" ||
+        el.hasAttribute("disabled") ||
         el.getAttribute("aria-disabled") === "true"
     ) {
         return;
@@ -225,6 +226,7 @@ function showTooltip(el: HTMLElement) {
         document.body.appendChild(state.tooltipEl);
     }
 
+    state.cleanupAutoUpdate?.();
     state.cleanupAutoUpdate = autoUpdate(el, state.tooltipEl, () => updatePosition(el, state));
 }
 
@@ -282,8 +284,7 @@ function setupListeners(el: HTMLElement, modifiers: Record<string, boolean>, arg
 function updateContent(el: HTMLElement, bindingValue: unknown, state: TooltipState, vnode?: VNode) {
     const content = getContent(el, bindingValue, vnode);
     if (state.isHtml) {
-        // lgtm[js/xss-through-dom] — .html modifier is explicit developer opt-in (same pattern as v-html)
-        state.contentEl.innerHTML = content;
+        state.contentEl.innerHTML = purify.sanitize(content);
     } else {
         state.contentEl.textContent = content;
     }

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -42,7 +42,7 @@ function injectStyles() {
     top: 0;
     left: 0;
 }
-.g-tooltip-d:not(.sr-only) {
+.g-tooltip-d {
     display: block;
 }
 .g-tooltip-d.g-tooltip-danger {
@@ -134,7 +134,7 @@ function createTooltipEl(state: TooltipState): HTMLDivElement {
     const tooltip = document.createElement("div");
     tooltip.setAttribute("role", "tooltip");
     // "tooltip" class matches v-b-tooltip's rendered element for Selenium selector compatibility
-    tooltip.className = "tooltip g-tooltip-d sr-only";
+    tooltip.className = "tooltip g-tooltip-d";
 
     if (state.danger) {
         tooltip.classList.add("g-tooltip-danger");
@@ -144,12 +144,19 @@ function createTooltipEl(state: TooltipState): HTMLDivElement {
         tooltip.style.pointerEvents = "auto";
     }
 
+    // "tooltip-inner" matches Bootstrap-Vue's rendered tooltip for Selenium selector compatibility
+    // navigation.yml uses: tooltip_inner: .tooltip-inner
+    const innerDiv = document.createElement("div");
+    innerDiv.className = "tooltip-inner";
+    tooltip.appendChild(innerDiv);
+
     const arrowDiv = document.createElement("div");
     arrowDiv.className = "g-tooltip-arrow";
     tooltip.appendChild(arrowDiv);
 
     state.arrowEl = arrowDiv;
-    document.body.appendChild(tooltip);
+    // Don't append to body yet; we do that in show() and remove in hide()
+    // so that wait_for_absent() finds no .tooltip elements in the DOM when hidden
 
     return tooltip;
 }
@@ -159,18 +166,16 @@ function updateContent(state: TooltipState) {
         return;
     }
 
-    // Remove all children except arrow
-    while (state.tooltipEl.firstChild && state.tooltipEl.firstChild !== state.arrowEl) {
-        state.tooltipEl.removeChild(state.tooltipEl.firstChild);
+    const innerDiv = state.tooltipEl.querySelector(".tooltip-inner");
+
+    if (!innerDiv) {
+        return;
     }
 
     if (state.useHtml) {
-        const wrapper = document.createElement("span");
-        wrapper.innerHTML = state.text;
-        state.tooltipEl.insertBefore(wrapper, state.arrowEl);
+        innerDiv.innerHTML = state.text;
     } else {
-        const textNode = document.createTextNode(state.text);
-        state.tooltipEl.insertBefore(textNode, state.arrowEl);
+        innerDiv.textContent = state.text;
     }
 }
 
@@ -215,8 +220,11 @@ function show(el: HTMLElement, state: TooltipState) {
     }
 
     updateContent(state);
-    state.tooltipEl.classList.remove("sr-only");
-    state.tooltipEl.setAttribute("data-show", "true");
+
+    // Append to body on show so .tooltip is in the DOM (wait_for_present works)
+    if (!state.tooltipEl.isConnected) {
+        document.body.appendChild(state.tooltipEl);
+    }
 
     state.cleanup = autoUpdate(el, state.tooltipEl, () => updatePosition(el, state));
 }
@@ -230,9 +238,9 @@ function hide(_el: HTMLElement, state: TooltipState) {
     state.cleanup?.();
     state.cleanup = null;
 
-    if (state.tooltipEl) {
-        state.tooltipEl.classList.add("sr-only");
-        state.tooltipEl.removeAttribute("data-show");
+    // Remove from DOM on hide so .tooltip is absent (wait_for_absent works)
+    if (state.tooltipEl?.isConnected) {
+        state.tooltipEl.remove();
     }
 }
 

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -6,7 +6,6 @@
  *   Placement: .top (default), .bottom, .left, .right, .topright
  *   Trigger:   .hover (default), .focus
  *   Content:   .html (innerHTML instead of textContent)
- *   Compat:    .noninteractive, .nofade (accepted, no-op — all tooltips are noninteractive)
  *   Styling:   .v-danger
  *
  * Value forms:

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -1,32 +1,47 @@
-import { arrow, autoUpdate, computePosition, flip, offset, type Placement, shift } from "@floating-ui/dom";
+/**
+ * Custom tooltip directive to replace bootstrap-vue's v-b-tooltip.
+ * Uses @floating-ui/dom for positioning (same library as GTooltip component).
+ *
+ * Supports the same modifier API as v-b-tooltip:
+ *   Placement: .top (default), .bottom, .left, .right, .topright
+ *   Trigger:   .hover (default), .focus
+ *   Content:   .html (innerHTML instead of textContent)
+ *   Compat:    .noninteractive, .nofade (accepted, no-op — all tooltips are noninteractive)
+ *   Styling:   .v-danger
+ *
+ * Value forms:
+ *   v-g-tooltip                           → reads element's title attribute
+ *   v-g-tooltip="'text'"                  → string content
+ *   v-g-tooltip="{ title, placement }"    → object config (title optional, falls back to :title)
+ */
+
+import {
+    arrow as arrowMiddleware,
+    autoUpdate,
+    computePosition,
+    flip,
+    offset,
+    type Placement,
+    shift,
+} from "@floating-ui/dom";
+import type { DirectiveOptions, VNode } from "vue";
 
 interface TooltipState {
-    tooltipEl: HTMLDivElement | null;
-    arrowEl: HTMLDivElement | null;
-    cleanup: (() => void) | null;
-    listeners: Array<[string, EventListener]>;
-    showing: boolean;
-    text: string;
+    tooltipEl: HTMLElement;
+    arrowEl: HTMLElement;
+    contentEl: HTMLElement;
+    cleanupAutoUpdate: (() => void) | null;
+    cleanupListeners: () => void;
     placement: Placement;
-    noninteractive: boolean;
-    useHtml: boolean;
-    danger: boolean;
+    isHtml: boolean;
 }
 
 const stateMap = new WeakMap<HTMLElement, TooltipState>();
 
+let tooltipCounter = 0;
 let stylesInjected = false;
 
-function injectStyles() {
-    if (stylesInjected) {
-        return;
-    }
-
-    stylesInjected = true;
-
-    const style = document.createElement("style");
-    style.setAttribute("data-g-tooltip-directive", "");
-    style.textContent = `
+const TOOLTIP_STYLES = `
 .g-tooltip-d {
     background-color: var(--color-blue-800);
     color: var(--color-grey-100);
@@ -41,18 +56,13 @@ function injectStyles() {
     position: absolute;
     top: 0;
     left: 0;
-}
-.g-tooltip-d {
-    display: block;
+    opacity: 1;
 }
 .g-tooltip-d.g-tooltip-danger {
     background-color: var(--color-red-700, #dc3545);
 }
-.g-tooltip-d .g-tooltip-arrow {
-    visibility: hidden;
-}
-.g-tooltip-d .g-tooltip-arrow,
-.g-tooltip-d .g-tooltip-arrow::before {
+.g-tooltip-d .g-tooltip-d-arrow,
+.g-tooltip-d .g-tooltip-d-arrow::before {
     position: absolute;
     width: 8px;
     height: 8px;
@@ -61,308 +71,290 @@ function injectStyles() {
     top: 0;
     left: 0;
 }
-.g-tooltip-d .g-tooltip-arrow::before {
+.g-tooltip-d .g-tooltip-d-arrow {
+    visibility: hidden;
+}
+.g-tooltip-d .g-tooltip-d-arrow::before {
     visibility: visible;
     content: "";
     transform: rotate(45deg);
 }
-.g-tooltip-d .g-tooltip-arrow[data-placement^="top"] {
+.g-tooltip-d .g-tooltip-d-arrow[data-placement^="top"] {
     top: unset;
     bottom: -4px;
 }
-.g-tooltip-d .g-tooltip-arrow[data-placement^="bottom"] {
+.g-tooltip-d .g-tooltip-d-arrow[data-placement^="bottom"] {
     top: -4px;
     bottom: unset;
 }
-.g-tooltip-d .g-tooltip-arrow[data-placement^="left"] {
+.g-tooltip-d .g-tooltip-d-arrow[data-placement^="left"] {
     left: unset;
     right: -4px;
 }
-.g-tooltip-d .g-tooltip-arrow[data-placement^="right"] {
+.g-tooltip-d .g-tooltip-d-arrow[data-placement^="right"] {
     left: -4px;
     right: unset;
 }
 `;
+
+const PLACEMENT_MAP: Record<string, Placement> = {
+    top: "top",
+    bottom: "bottom",
+    left: "left",
+    right: "right",
+    topright: "top-end",
+    topleft: "top-start",
+    bottomright: "bottom-end",
+    bottomleft: "bottom-start",
+};
+
+function injectStyles() {
+    if (stylesInjected) {
+        return;
+    }
+    stylesInjected = true;
+    const style = document.createElement("style");
+    style.textContent = TOOLTIP_STYLES;
     document.head.appendChild(style);
 }
 
-function getPlacementFromModifiers(modifiers: Record<string, boolean>): Placement {
-    if (modifiers.bottom) {
-        return "bottom";
+function getPlacement(modifiers: Record<string, boolean>, bindingValue: unknown): Placement {
+    for (const [mod, placement] of Object.entries(PLACEMENT_MAP)) {
+        if (modifiers[mod]) {
+            return placement;
+        }
     }
-
-    if (modifiers.left) {
-        return "left";
+    if (typeof bindingValue === "object" && bindingValue !== null && "placement" in bindingValue) {
+        return (bindingValue as { placement: Placement }).placement;
     }
-
-    if (modifiers.right) {
-        return "right";
-    }
-
     return "top";
 }
 
-function resolveText(el: HTMLElement, value: unknown, existingText: string): string {
-    if (typeof value === "string" && value) {
-        return value;
+function getContent(el: HTMLElement, bindingValue: unknown, vnode?: VNode): string {
+    if (typeof bindingValue === "string" && bindingValue) {
+        return bindingValue;
     }
-
-    if (value && typeof value === "object" && "title" in value && (value as { title: string }).title) {
-        return (value as { title: string }).title;
+    if (typeof bindingValue === "object" && bindingValue !== null && "title" in bindingValue) {
+        return String((bindingValue as { title: string }).title || "");
     }
-
-    const titleAttr = el.getAttribute("title");
-
-    if (titleAttr) {
-        return titleAttr;
+    // Fall back to element's title attribute.
+    // Also check vnode attrs/props for components with inheritAttrs: false (e.g. BFormCheckbox)
+    // where :title doesn't land on the root DOM element.
+    const title =
+        el.getAttribute("title") ||
+        (vnode?.data?.attrs as Record<string, unknown> | undefined)?.title ||
+        (vnode?.componentOptions?.propsData as Record<string, unknown> | undefined)?.title ||
+        null;
+    if (title) {
+        el.dataset.gTooltipTitle = String(title);
     }
-
-    return existingText;
+    return el.dataset.gTooltipTitle || "";
 }
 
-function resolvePlacement(value: unknown, modifiers: Record<string, boolean>): Placement {
-    if (value && typeof value === "object" && "placement" in value) {
-        return (value as { placement: Placement }).placement;
-    }
-
-    return getPlacementFromModifiers(modifiers);
-}
-
-function createTooltipEl(state: TooltipState): HTMLDivElement {
+function createTooltipEl(isDanger: boolean): { tooltipEl: HTMLElement; arrowEl: HTMLElement; contentEl: HTMLElement } {
     injectStyles();
-
-    const tooltip = document.createElement("div");
-    tooltip.setAttribute("role", "tooltip");
-    // "tooltip" class matches v-b-tooltip's rendered element for Selenium selector compatibility
-    tooltip.className = "tooltip g-tooltip-d";
-
-    if (state.danger) {
-        tooltip.classList.add("g-tooltip-danger");
+    const tooltipEl = document.createElement("div");
+    tooltipEl.setAttribute("role", "tooltip");
+    // "tooltip" class matches bootstrap-vue's rendered element for Selenium selector compat
+    tooltipEl.className = "tooltip g-tooltip-d";
+    if (isDanger) {
+        tooltipEl.classList.add("g-tooltip-danger");
     }
 
-    if (!state.noninteractive) {
-        tooltip.style.pointerEvents = "auto";
-    }
+    // "tooltip-inner" matches bootstrap-vue's inner element for Selenium selector compat
+    const contentEl = document.createElement("div");
+    contentEl.className = "tooltip-inner";
+    tooltipEl.appendChild(contentEl);
 
-    // "tooltip-inner" matches Bootstrap-Vue's rendered tooltip for Selenium selector compatibility
-    // navigation.yml uses: tooltip_inner: .tooltip-inner
-    const innerDiv = document.createElement("div");
-    innerDiv.className = "tooltip-inner";
-    tooltip.appendChild(innerDiv);
+    const arrowEl = document.createElement("div");
+    arrowEl.className = "g-tooltip-d-arrow";
+    tooltipEl.appendChild(arrowEl);
 
-    const arrowDiv = document.createElement("div");
-    arrowDiv.className = "g-tooltip-arrow";
-    tooltip.appendChild(arrowDiv);
-
-    state.arrowEl = arrowDiv;
-    // Don't append to body yet; we do that in show() and remove in hide()
-    // so that wait_for_absent() finds no .tooltip elements in the DOM when hidden
-
-    return tooltip;
-}
-
-function updateContent(state: TooltipState) {
-    if (!state.tooltipEl || !state.arrowEl) {
-        return;
-    }
-
-    const innerDiv = state.tooltipEl.querySelector(".tooltip-inner");
-
-    if (!innerDiv) {
-        return;
-    }
-
-    if (state.useHtml) {
-        innerDiv.innerHTML = state.text;
-    } else {
-        innerDiv.textContent = state.text;
-    }
+    // Don't append to body yet — add on show, remove on hide,
+    // so Selenium wait_for_absent(".tooltip") works correctly
+    return { tooltipEl, arrowEl, contentEl };
 }
 
 async function updatePosition(el: HTMLElement, state: TooltipState) {
-    if (!state.tooltipEl || !state.arrowEl) {
-        return;
-    }
-
     const { x, y, middlewareData, placement } = await computePosition(el, state.tooltipEl, {
         placement: state.placement,
         middleware: [
             offset(8),
             flip({ altBoundary: true }),
             shift({ altBoundary: true }),
-            arrow({ element: state.arrowEl }),
+            arrowMiddleware({ element: state.arrowEl }),
         ],
     });
 
     state.tooltipEl.style.transform = `translate(${x}px, ${y}px)`;
 
     if (middlewareData.arrow) {
-        const { x: ax, y: ay } = middlewareData.arrow;
-        state.arrowEl.style.transform = `translate(${ax ?? 0}px, ${ay ?? 0}px)`;
+        const ax = middlewareData.arrow.x ?? 0;
+        const ay = middlewareData.arrow.y ?? 0;
+        state.arrowEl.style.transform = `translate(${ax}px, ${ay}px)`;
     }
 
-    state.arrowEl.setAttribute("data-placement", placement);
+    state.arrowEl.dataset.placement = placement;
 }
 
-function show(el: HTMLElement, state: TooltipState) {
-    if (state.showing || !state.text) {
+function showTooltip(el: HTMLElement) {
+    const state = stateMap.get(el);
+    if (!state) {
         return;
     }
 
-    if (el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true") {
+    if (
+        (el as HTMLButtonElement).disabled ||
+        el.getAttribute("disabled") === "true" ||
+        el.getAttribute("aria-disabled") === "true"
+    ) {
         return;
     }
 
-    state.showing = true;
-
-    if (!state.tooltipEl) {
-        state.tooltipEl = createTooltipEl(state);
+    const content = state.isHtml ? state.contentEl.innerHTML : state.contentEl.textContent;
+    if (!content) {
+        return;
     }
 
-    updateContent(state);
+    // Suppress native tooltip while ours is visible
+    if (el.hasAttribute("title")) {
+        el.setAttribute("title", "");
+    }
 
-    // Append to body on show so .tooltip is in the DOM (wait_for_present works)
     if (!state.tooltipEl.isConnected) {
         document.body.appendChild(state.tooltipEl);
     }
 
-    state.cleanup = autoUpdate(el, state.tooltipEl, () => updatePosition(el, state));
+    state.cleanupAutoUpdate = autoUpdate(el, state.tooltipEl, () => updatePosition(el, state));
 }
 
-function hide(_el: HTMLElement, state: TooltipState) {
-    if (!state.showing) {
+function hideTooltip(el: HTMLElement) {
+    const state = stateMap.get(el);
+    if (!state) {
         return;
     }
 
-    state.showing = false;
-    state.cleanup?.();
-    state.cleanup = null;
+    state.cleanupAutoUpdate?.();
+    state.cleanupAutoUpdate = null;
 
-    // Remove from DOM on hide so .tooltip is absent (wait_for_absent works)
-    if (state.tooltipEl?.isConnected) {
+    // Restore native title attribute
+    if (el.dataset.gTooltipTitle) {
+        el.setAttribute("title", el.dataset.gTooltipTitle);
+    }
+
+    if (state.tooltipEl.isConnected) {
         state.tooltipEl.remove();
     }
 }
 
-function setupListeners(el: HTMLElement, state: TooltipState, modifiers: Record<string, boolean>) {
-    for (const [event, handler] of state.listeners) {
-        el.removeEventListener(event, handler);
+function setupListeners(el: HTMLElement, modifiers: Record<string, boolean>, arg?: string): () => void {
+    const listeners: Array<[string, EventListener]> = [];
+
+    function addListener(event: string, handler: EventListener) {
+        el.addEventListener(event, handler);
+        listeners.push([event, handler]);
     }
 
-    state.listeners = [];
-
-    const focusOnly = modifiers.focus && !modifiers.hover;
-    const showHandler = () => show(el, state);
-    const hideHandler = () => hide(el, state);
+    const focusOnly = (modifiers.focus || arg === "focus") && !modifiers.hover && arg !== "hover";
+    const showHandler = () => showTooltip(el);
+    const hideHandler = () => hideTooltip(el);
     const keyHandler = (e: Event) => {
         if ((e as KeyboardEvent).key === "Escape") {
-            hide(el, state);
+            hideTooltip(el);
         }
     };
 
-    if (focusOnly) {
-        el.addEventListener("focusin", showHandler);
-        el.addEventListener("focusout", hideHandler);
-        state.listeners.push(["focusin", showHandler], ["focusout", hideHandler]);
+    if (!focusOnly) {
+        addListener("mouseenter", showHandler);
+        addListener("mouseleave", hideHandler);
+    }
+    addListener("focusin", showHandler);
+    addListener("focusout", hideHandler);
+    addListener("keydown", keyHandler);
+
+    return () => {
+        for (const [event, handler] of listeners) {
+            el.removeEventListener(event, handler);
+        }
+    };
+}
+
+function updateContent(el: HTMLElement, bindingValue: unknown, state: TooltipState, vnode?: VNode) {
+    const content = getContent(el, bindingValue, vnode);
+    if (state.isHtml) {
+        // lgtm[js/xss-through-dom] — .html modifier is explicit developer opt-in (same pattern as v-html)
+        state.contentEl.innerHTML = content;
     } else {
-        // Default: hover + focus for accessibility
-        el.addEventListener("mouseenter", showHandler);
-        el.addEventListener("mouseleave", hideHandler);
-        el.addEventListener("focus", showHandler);
-        el.addEventListener("blur", hideHandler);
-        state.listeners.push(
-            ["mouseenter", showHandler],
-            ["mouseleave", hideHandler],
-            ["focus", showHandler],
-            ["blur", hideHandler],
-        );
+        state.contentEl.textContent = content;
     }
-
-    el.addEventListener("keydown", keyHandler);
-    state.listeners.push(["keydown", keyHandler]);
-}
-
-function destroyTooltip(state: TooltipState) {
-    state.cleanup?.();
-    state.cleanup = null;
-
-    if (state.tooltipEl) {
-        state.tooltipEl.remove();
-        state.tooltipEl = null;
-        state.arrowEl = null;
+    // Set aria-label so icon-only buttons have an accessible name
+    if (content) {
+        el.setAttribute("aria-label", content);
+        el.dataset.gTooltipAriaLabel = "1";
+    } else if (el.dataset.gTooltipAriaLabel) {
+        el.removeAttribute("aria-label");
+        el.dataset.gTooltipAriaLabel = "";
     }
 }
 
-function inserted(el: HTMLElement, binding: { value?: unknown; modifiers: Record<string, boolean> }) {
-    const modifiers = binding.modifiers || {};
-    const text = resolveText(el, binding.value, "");
+export const vGTooltip: DirectiveOptions = {
+    inserted(el, binding, vnode) {
+        const modifiers = binding.modifiers || {};
+        const isDanger = !!modifiers["v-danger"];
+        const isHtml = !!modifiers.html;
+        const placement = getPlacement(modifiers, binding.value);
 
-    const state: TooltipState = {
-        tooltipEl: null,
-        arrowEl: null,
-        cleanup: null,
-        listeners: [],
-        showing: false,
-        text,
-        placement: resolvePlacement(binding.value, modifiers),
-        noninteractive: !!modifiers.noninteractive,
-        useHtml: !!modifiers.html,
-        danger: !!modifiers["v-danger"],
-    };
+        const { tooltipEl, arrowEl, contentEl } = createTooltipEl(isDanger);
+        const cleanupListeners = setupListeners(el, modifiers, binding.arg);
 
-    stateMap.set(el, state);
-    setupListeners(el, state, modifiers);
-}
+        const uid = `g-tooltip-${tooltipCounter++}`;
+        tooltipEl.id = uid;
+        el.setAttribute("aria-describedby", uid);
 
-function componentUpdated(el: HTMLElement, binding: { value?: unknown; modifiers: Record<string, boolean> }) {
-    const state = stateMap.get(el);
+        const state: TooltipState = {
+            tooltipEl,
+            arrowEl,
+            contentEl,
+            cleanupAutoUpdate: null,
+            cleanupListeners,
+            placement,
+            isHtml,
+        };
 
-    if (!state) {
-        return;
-    }
+        stateMap.set(el, state);
+        updateContent(el, binding.value, state, vnode);
+    },
 
-    const modifiers = binding.modifiers || {};
-    const newText = resolveText(el, binding.value, state.text);
-
-    state.text = newText;
-    state.placement = resolvePlacement(binding.value, modifiers);
-    state.danger = !!modifiers["v-danger"];
-
-    if (state.tooltipEl) {
-        updateContent(state);
-
-        if (state.danger) {
-            state.tooltipEl.classList.add("g-tooltip-danger");
-        } else {
-            state.tooltipEl.classList.remove("g-tooltip-danger");
+    componentUpdated(el, binding, vnode) {
+        const state = stateMap.get(el);
+        if (!state) {
+            return;
         }
-    }
+        updateContent(el, binding.value, state, vnode);
+        state.placement = getPlacement(binding.modifiers || {}, binding.value);
 
-    // Hide if text became empty
-    if (!state.text && state.showing) {
-        hide(el, state);
-    }
-}
+        // Hide if content became empty
+        const content = state.isHtml ? state.contentEl.innerHTML : state.contentEl.textContent;
+        if (!content && state.tooltipEl.isConnected) {
+            hideTooltip(el);
+        }
+    },
 
-function unbind(el: HTMLElement) {
-    const state = stateMap.get(el);
-
-    if (!state) {
-        return;
-    }
-
-    for (const [event, handler] of state.listeners) {
-        el.removeEventListener(event, handler);
-    }
-
-    destroyTooltip(state);
-    stateMap.delete(el);
-}
-
-export const vGTooltip = {
-    inserted,
-    componentUpdated,
-    unbind,
+    unbind(el) {
+        const state = stateMap.get(el);
+        if (!state) {
+            return;
+        }
+        state.cleanupListeners();
+        state.cleanupAutoUpdate?.();
+        state.tooltipEl.remove();
+        el.removeAttribute("aria-describedby");
+        if (el.dataset.gTooltipAriaLabel) {
+            el.removeAttribute("aria-label");
+        }
+        delete el.dataset.gTooltipAriaLabel;
+        stateMap.delete(el);
+    },
 };
 
 export default vGTooltip;

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -61,6 +61,14 @@ const TOOLTIP_STYLES = `
 .g-tooltip-d.g-tooltip-danger {
     background-color: var(--color-red-700, #dc3545);
 }
+.g-tooltip-d .tooltip-inner {
+    background-color: transparent;
+    color: inherit;
+    padding: 0;
+    text-align: inherit;
+    max-width: none;
+    border-radius: 0;
+}
 .g-tooltip-d .g-tooltip-d-arrow,
 .g-tooltip-d .g-tooltip-d-arrow::before {
     position: absolute;

--- a/client/src/utils/mountVueComponent.js
+++ b/client/src/utils/mountVueComponent.js
@@ -15,14 +15,14 @@ Vue.use(PiniaVuePlugin);
 // Bootstrap components
 Vue.use(BootstrapVue);
 
+// Custom tooltip directive
+Vue.directive("g-tooltip", vGTooltip);
+
 // localization filters and directives
 Vue.use(localizationPlugin);
 
 // rxjs utilities
 Vue.use(vueRxShortcutPlugin);
-
-// Custom tooltip directive (replaces v-b-tooltip)
-Vue.directive("g-tooltip", vGTooltip);
 
 function getOrCreatePinia() {
     // We sometimes use this utility mounting function in a context where there

--- a/client/src/utils/mountVueComponent.js
+++ b/client/src/utils/mountVueComponent.js
@@ -7,6 +7,7 @@ import { createPinia, getActivePinia, PiniaVuePlugin } from "pinia";
 import Vue from "vue";
 
 import { localizationPlugin, vueRxShortcutPlugin } from "@/components/plugins";
+import { vGTooltip } from "@/directives/vGTooltip";
 
 // Load Pinia
 Vue.use(PiniaVuePlugin);
@@ -19,6 +20,9 @@ Vue.use(localizationPlugin);
 
 // rxjs utilities
 Vue.use(vueRxShortcutPlugin);
+
+// Custom tooltip directive (replaces v-b-tooltip)
+Vue.directive("g-tooltip", vGTooltip);
 
 function getOrCreatePinia() {
     // We sometimes use this utility mounting function in a context where there

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -11,8 +11,8 @@ _:  # global stuff
   selectors:
     center_panel: '#center'
     editable_text: '.editable-text'
-    tooltip_balloon: '.tooltip'
-    tooltip_inner: .tooltip-inner
+    tooltip_balloon: '.tooltip, .g-tooltip-d'
+    tooltip_inner: '.tooltip-inner, .g-tooltip-d-inner'
     left_panel: '#left'
     left_panel_drag: '.flex-panel.left .drag-handle'
     left_panel_collapse: '.collapse-button.left'

--- a/client/tests/vitest/helpers.js
+++ b/client/tests/vitest/helpers.js
@@ -34,6 +34,7 @@ export function getLocalVue(instrumentLocalization = false) {
     localVue.use(localizationPlugin, l);
     localVue.use(vueRxShortcutPlugin);
     localVue.directive("b-tooltip", mockedDirective);
+    localVue.directive("g-tooltip", mockedDirective);
     localVue.directive("b-popover", mockedDirective);
     return localVue;
 }

--- a/client/tests/vitest/setup.ts
+++ b/client/tests/vitest/setup.ts
@@ -10,9 +10,7 @@ import Vue from "vue";
 Vue.config.productionTip = false;
 Vue.config.devtools = false;
 
-// Mock the g-tooltip directive globally (same mock as getLocalVue() in helpers.js)
-// so components don't trigger "Failed to resolve directive" warnings. Captures
-// tooltip content in data-mock-directive for assertions without running floating-ui.
+// Mock g-tooltip directive so components don't trigger "Failed to resolve directive" warnings
 Vue.directive("g-tooltip", {
     bind(el: HTMLElement, binding: { value?: string }) {
         el.setAttribute("data-mock-directive", binding.value || el.title || "");

--- a/client/tests/vitest/setup.ts
+++ b/client/tests/vitest/setup.ts
@@ -7,12 +7,17 @@ import { vi } from "vitest";
 // Vue configuration
 import Vue from "vue";
 
-import { vGTooltip } from "@/directives/vGTooltip";
-
 Vue.config.productionTip = false;
 Vue.config.devtools = false;
 
-Vue.directive("g-tooltip", vGTooltip);
+// Mock the g-tooltip directive globally (same mock as getLocalVue() in helpers.js)
+// so components don't trigger "Failed to resolve directive" warnings. Captures
+// tooltip content in data-mock-directive for assertions without running floating-ui.
+Vue.directive("g-tooltip", {
+    bind(el: HTMLElement, binding: { value?: string }) {
+        el.setAttribute("data-mock-directive", binding.value || el.title || "");
+    },
+});
 
 // Mock hashedUserId and userLocalStorage by default
 vi.mock("@/composables/hashedUserId");

--- a/client/tests/vitest/setup.ts
+++ b/client/tests/vitest/setup.ts
@@ -7,8 +7,12 @@ import { vi } from "vitest";
 // Vue configuration
 import Vue from "vue";
 
+import { vGTooltip } from "@/directives/vGTooltip";
+
 Vue.config.productionTip = false;
 Vue.config.devtools = false;
+
+Vue.directive("g-tooltip", vGTooltip);
 
 // Mock hashedUserId and userLocalStorage by default
 vi.mock("@/composables/hashedUserId");

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1884,7 +1884,7 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
             page = self.page
             center_element = page.locator(selector_to_move)
             center_element.hover(force=True)
-        self.wait_for_selector_absent_or_hidden(".b-tooltip", wait_type=WAIT_TYPES.UX_POPUP)
+        self.wait_for_selector_absent_or_hidden(".g-tooltip-d", wait_type=WAIT_TYPES.UX_POPUP)
 
     def pages_index_table_elements(self):
         pages = self.components.pages


### PR DESCRIPTION
Part of the bootstrap-vue scoped-slot replacement effort tracked in #21956.

`v-b-tooltip` technically works through `@vue/compat` (directives don't use scoped slots), but replacing it eliminates one more bootstrap-vue dependency. `v-g-tooltip` is a custom Vue 2.7 directive using `@floating-ui/dom` for positioning, mirroring the full `v-b-tooltip` API: hover/focus trigger modes, placement modifiers (top/bottom/left/right), html rendering, and string/object value forms. Replaces 290 usages across 140 files.

Also replaces the 2 files using `<BTooltip>` as a component (FormDataExtensions, StatelessTags) with the `GTooltip` component, and removes 3 explicit `VBTooltipPlugin` registrations.

The directive uses `tooltip` and `tooltip-inner` CSS classes for Selenium selector compatibility, adds/removes from the DOM on show/hide so `wait_for_absent` works, sets `aria-describedby` for accessibility, and strips `title` attributes to prevent native browser double-tooltips. All directive tooltips are `pointer-events: none` (matching bootstrap-vue's directive behavior).