### PR TITLE
[25.1] Fix optional parameter persisting ``NO_REPLACEMENT`` sentinel when not provided

### DIFF
--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -517,6 +517,8 @@ class WorkflowProgress:
                     dependent_workflow_step_id=output_step_id,
                 )
             )
+        if isinstance(replacement, NoReplacement):
+            return NO_REPLACEMENT
         if isinstance(replacement, MutableMapping) and replacement.get("__class__") == "NoReplacement":
             return NO_REPLACEMENT
         if isinstance(replacement, model.HistoryDatasetCollectionAssociation):
@@ -622,7 +624,9 @@ class WorkflowProgress:
                 outputs["output"] = step.get_input_default_value(NO_REPLACEMENT)
 
         if step.label and step.type == "parameter_input" and "output" in outputs:
-            self.runtime_replacements[step.label] = str(outputs["output"])
+            output_value = outputs["output"]
+            if output_value is not NO_REPLACEMENT:
+                self.runtime_replacements[step.label] = str(output_value)
         invocation = invocation_step.workflow_invocation
         if not invocation.has_input_for_step(step.id):
             content = outputs.get("output", NO_REPLACEMENT)

--- a/lib/galaxy_test/workflow/optional_param_default_value.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_param_default_value.gxwf-tests.yml
@@ -1,0 +1,15 @@
+- doc: |
+    Test that omitting an optional text parameter from the invocation does not
+    leak sentinel values into output renames. The rename template uses
+    ${optional_text} which should remain unexpanded (kept as-is) when the
+    parameter is not provided, rather than being replaced with a stringified
+    NO_REPLACEMENT sentinel.
+  job:
+    required_input:
+      class: File
+      path: 1.fasta
+  outputs:
+    out:
+      class: File
+      metadata:
+        name: "prefix_${optional_text}_suffix"

--- a/lib/galaxy_test/workflow/optional_param_default_value.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_param_default_value.gxwf-tests.yml
@@ -6,8 +6,8 @@
     NO_REPLACEMENT sentinel.
   job:
     required_input:
-      class: File
-      path: 1.fasta
+      type: File
+      value: 1.fasta
   outputs:
     out:
       class: File

--- a/lib/galaxy_test/workflow/optional_param_default_value.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_param_default_value.gxwf.yml
@@ -1,0 +1,24 @@
+class: GalaxyWorkflow
+doc: |
+  Test that omitting an optional parameter_input from an invocation does not
+  leak NO_REPLACEMENT sentinel into runtime replacements used in post-job
+  actions (e.g. output renames).
+  Regression test for https://github.com/galaxyproject/galaxy/issues/21947
+inputs:
+  required_input:
+    type: data
+  optional_text:
+    type: text
+    optional: true
+outputs:
+  out:
+    outputSource: cat/out_file1
+steps:
+  cat:
+    tool_id: cat
+    in:
+      input1:
+        source: required_input
+    outputs:
+      out_file1:
+        rename: "prefix_${optional_text}_suffix"


### PR DESCRIPTION
Instead of converting NO_REPLACEMENT to None early (which overrides downstream tool parameter defaults), handle it at the boundaries:

1. In replacement_for_connection: detect raw NoReplacement sentinel objects stored in step outputs and return NO_REPLACEMENT, so the existing visit_input_values logic correctly falls through to tool-level defaults.

2. In set_outputs_for_input: skip runtime_replacements when output is NO_REPLACEMENT to prevent stringified sentinel in tool commands.

This preserves the semantic distinction between "not provided" (NO_REPLACEMENT) and "explicitly null" (None), letting downstream steps use their own defaults when an optional parameter is omitted.

The framework test uses a workflow with:
- A required data input (making inputs_by_step_id non-empty)
- An optional text parameter connected to a rename post-job action
- Verification that the output name matches the unexpanded template

and fails with without this fix
```
FAILED lib/galaxy_test/workflow/test_framework_workflows.py::TestWorkflow::test_workflow[optional_param_default_value_0] - Exception: Dataset metadata verification for [name] failed, expected [prefix_${optional_text}_suffix] but found [prefix_NO_REPLACEMENT singleton_suffix]
```

Addresses galaxyproject/galaxy#21947

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
