### PR TITLE
Add basic upload queue tests

### DIFF
--- a/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
+++ b/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
@@ -22,6 +22,7 @@ describe("uploadMethodRegistry", () => {
         it("returns the matching config for a known ID", () => {
             const config = getUploadMethod("local-file");
             expect(config?.id).toBe("local-file");
+            expect(config?.name).toBe("Upload from Computer");
         });
 
         it("returns undefined for an unknown ID", () => {

--- a/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
+++ b/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import { getUploadMethod, uploadMethodRegistry, useAllUploadMethods } from "./uploadMethodRegistry";
+
+// The advancedMode ref is declared before the vi.mock call so both the mock factory
+// and the test bodies share the same reactive reference.
+const advancedMode = ref(false);
+
+vi.mock("@/composables/upload/uploadAdvancedMode", () => ({
+    useUploadAdvancedMode: () => ({ advancedMode }),
+}));
+
+// All registered upload method IDs derived from the registry itself, so this list
+// stays in sync automatically whenever a method is added or removed.
+const ALL_METHOD_IDS = Object.keys(uploadMethodRegistry) as Array<keyof typeof uploadMethodRegistry>;
+
+describe("uploadMethodRegistry", () => {
+    describe("getUploadMethod", () => {
+        it("returns the matching config for a known ID", () => {
+            const config = getUploadMethod("local-file");
+            expect(config?.id).toBe("local-file");
+            expect(config?.name).toBe("Upload from Computer");
+        });
+
+        it("returns undefined for an unknown ID", () => {
+            expect(getUploadMethod("nonexistent" as never)).toBeUndefined();
+        });
+    });
+
+    describe("useAllUploadMethods", () => {
+        beforeEach(() => {
+            advancedMode.value = false;
+        });
+
+        it("excludes rule-based-import when advancedMode is false", () => {
+            const methods = useAllUploadMethods();
+            const ids = methods.value.map((m) => m.id);
+
+            expect(ids).not.toContain("rule-based-import");
+        });
+
+        it("includes all 10 methods when advancedMode is true", () => {
+            advancedMode.value = true;
+            const methods = useAllUploadMethods();
+            const ids = methods.value.map((m) => m.id);
+
+            expect(ids).toContain("rule-based-import");
+        });
+
+        it("reacts to advancedMode changes without creating a new composable instance", () => {
+            const methods = useAllUploadMethods();
+
+            expect(methods.value).toHaveLength(9);
+
+            advancedMode.value = true;
+            expect(methods.value).toHaveLength(10);
+
+            advancedMode.value = false;
+            expect(methods.value).toHaveLength(9);
+        });
+    });
+});

--- a/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
+++ b/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
@@ -11,16 +11,17 @@ vi.mock("@/composables/upload/uploadAdvancedMode", () => ({
     useUploadAdvancedMode: () => ({ advancedMode }),
 }));
 
-// All registered upload method IDs derived from the registry itself, so this list
-// stays in sync automatically whenever a method is added or removed.
+// Derive method ID lists from the registry so they stay in sync automatically
+// whenever a method is added, removed, or promoted/demoted to advanced mode.
 const ALL_METHOD_IDS = Object.keys(uploadMethodRegistry) as Array<keyof typeof uploadMethodRegistry>;
+const ADVANCED_METHOD_IDS = ALL_METHOD_IDS.filter((id) => uploadMethodRegistry[id].requiresAdvancedMode);
+const STANDARD_METHOD_IDS = ALL_METHOD_IDS.filter((id) => !uploadMethodRegistry[id].requiresAdvancedMode);
 
 describe("uploadMethodRegistry", () => {
     describe("getUploadMethod", () => {
         it("returns the matching config for a known ID", () => {
             const config = getUploadMethod("local-file");
             expect(config?.id).toBe("local-file");
-            expect(config?.name).toBe("Upload from Computer");
         });
 
         it("returns undefined for an unknown ID", () => {
@@ -33,31 +34,26 @@ describe("uploadMethodRegistry", () => {
             advancedMode.value = false;
         });
 
-        it("excludes rule-based-import when advancedMode is false", () => {
+        it("excludes all advanced-mode methods when advancedMode is false", () => {
             const methods = useAllUploadMethods();
             const ids = methods.value.map((m) => m.id);
 
-            expect(ids).not.toContain("rule-based-import");
-        });
-
-        it("includes all 10 methods when advancedMode is true", () => {
-            advancedMode.value = true;
-            const methods = useAllUploadMethods();
-            const ids = methods.value.map((m) => m.id);
-
-            expect(ids).toContain("rule-based-import");
+            for (const advancedId of ADVANCED_METHOD_IDS) {
+                expect(ids).not.toContain(advancedId);
+            }
+            expect(ids).toHaveLength(STANDARD_METHOD_IDS.length);
         });
 
         it("reacts to advancedMode changes without creating a new composable instance", () => {
             const methods = useAllUploadMethods();
 
-            expect(methods.value).toHaveLength(9);
+            expect(methods.value).toHaveLength(STANDARD_METHOD_IDS.length);
 
             advancedMode.value = true;
-            expect(methods.value).toHaveLength(10);
+            expect(methods.value).toHaveLength(ALL_METHOD_IDS.length);
 
             advancedMode.value = false;
-            expect(methods.value).toHaveLength(9);
+            expect(methods.value).toHaveLength(STANDARD_METHOD_IDS.length);
         });
     });
 });

--- a/client/src/components/Panels/Upload/uploadState.test.ts
+++ b/client/src/components/Panels/Upload/uploadState.test.ts
@@ -1,0 +1,294 @@
+import { suppressExpectedErrorMessages } from "@tests/vitest/helpers";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
+import type { CollectionConfig } from "@/composables/uploadQueue";
+
+import { useUploadState } from "./uploadState";
+
+// useUserLocalStorage is auto-mocked globally (returns a plain ref) — see tests/vitest/setup.ts
+// The module-level singleton refs persist between tests, so we call clearAll() in beforeEach.
+
+function makePastedItem(name = "file.txt", content = "hello world"): NewUploadItem {
+    return {
+        uploadMode: "paste-content",
+        name,
+        content,
+        size: content.length,
+        targetHistoryId: "hist_1",
+        dbkey: "?",
+        extension: "auto",
+        spaceToTab: false,
+        toPosixLines: false,
+        deferred: false,
+    };
+}
+
+const BATCH_CONFIG: CollectionConfig = {
+    name: "My Collection",
+    type: "list",
+    hideSourceItems: false,
+    historyId: "hist_1",
+};
+
+describe("useUploadState", () => {
+    let state: ReturnType<typeof useUploadState>;
+
+    beforeEach(() => {
+        state = useUploadState();
+        state.clearAll();
+    });
+
+    describe("initial state", () => {
+        it("has no uploads and all counters at zero", () => {
+            expect(state.activeItems.value).toHaveLength(0);
+            expect(state.activeBatches.value).toHaveLength(0);
+            expect(state.hasUploads.value).toBe(false);
+            expect(state.isUploading.value).toBe(false);
+            expect(state.hasCompleted.value).toBe(false);
+            expect(state.uploadingCount.value).toBe(0);
+            expect(state.completedCount.value).toBe(0);
+            expect(state.errorCount.value).toBe(0);
+            expect(state.totalProgress.value).toBe(0);
+            expect(state.orderedUploadItems.value).toHaveLength(0);
+        });
+    });
+
+    describe("addUploadItem", () => {
+        it("returns a unique ID and adds item to activeItems", () => {
+            const id = state.addUploadItem(makePastedItem());
+
+            expect(id).toBeTruthy();
+            expect(state.activeItems.value).toHaveLength(1);
+            expect(state.hasUploads.value).toBe(true);
+        });
+
+        it("initializes item with queued status, zero progress, and correct name", () => {
+            const id = state.addUploadItem(makePastedItem("report.txt", "content"));
+
+            const item = state.activeItems.value.find((i) => i.id === id);
+            expect(item?.status).toBe("queued");
+            expect(item?.progress).toBe(0);
+            expect(item?.name).toBe("report.txt");
+        });
+
+        it("standalone item appears in standaloneUploads and orderedUploadItems", () => {
+            const id = state.addUploadItem(makePastedItem());
+
+            expect(state.standaloneUploads.value.map((i) => i.id)).toContain(id);
+            expect(state.orderedUploadItems.value).toHaveLength(1);
+            expect(state.orderedUploadItems.value[0]?.type).toBe("upload");
+        });
+
+        it("item associated with a batchId does not appear in standaloneUploads", () => {
+            const batchId = state.addBatch(BATCH_CONFIG, []);
+            const id = state.addUploadItem(makePastedItem(), batchId);
+
+            const item = state.activeItems.value.find((i) => i.id === id);
+            expect(item?.batchId).toBe(batchId);
+            expect(state.standaloneUploads.value.map((i) => i.id)).not.toContain(id);
+        });
+    });
+
+    describe("addBatch", () => {
+        it("creates a batch with uploading status, the provided upload IDs, and no collectionId", () => {
+            const id1 = state.addUploadItem(makePastedItem("a.txt"));
+            const id2 = state.addUploadItem(makePastedItem("b.txt"));
+
+            const batchId = state.addBatch(BATCH_CONFIG, [id1, id2]);
+
+            const batch = state.getBatch(batchId);
+            expect(batch?.status).toBe("uploading");
+            expect(batch?.uploadIds).toEqual([id1, id2]);
+            expect(batch?.datasetIds).toEqual([]);
+            expect(batch?.collectionId).toBeUndefined();
+        });
+
+        it("batch appears in batchesWithProgress with aggregated upload data", () => {
+            const id = state.addUploadItem(makePastedItem());
+            const batchId = state.addBatch(BATCH_CONFIG, [id]);
+
+            const bwp = state.batchesWithProgress.value.find((b) => b.id === batchId);
+            expect(bwp?.uploads).toHaveLength(1);
+            expect(bwp?.progress).toBe(0);
+            expect(bwp?.allCompleted).toBe(false);
+            expect(bwp?.hasError).toBe(false);
+        });
+    });
+
+    describe("computed counts", () => {
+        it("tallies uploading, completed, and errored items independently", () => {
+            const uploadingId = state.addUploadItem(makePastedItem("uploading.txt"));
+            const completedId = state.addUploadItem(makePastedItem("done.txt"));
+            const erroredId = state.addUploadItem(makePastedItem("failed.txt"));
+
+            state.setStatus(uploadingId, "uploading");
+            state.updateProgress(completedId, 100); // auto-marks as completed
+            state.setError(erroredId, "network error");
+
+            expect(state.uploadingCount.value).toBe(1);
+            expect(state.completedCount.value).toBe(1);
+            expect(state.errorCount.value).toBe(1);
+            expect(state.isUploading.value).toBe(true);
+            expect(state.hasCompleted.value).toBe(true);
+        });
+
+        it("isUploading is false when no items are in uploading or processing state", () => {
+            const id = state.addUploadItem(makePastedItem());
+            state.updateProgress(id, 100); // completed
+
+            expect(state.isUploading.value).toBe(false);
+        });
+    });
+
+    describe("progress tracking", () => {
+        it("updateProgress updates the item's progress value", () => {
+            const id = state.addUploadItem(makePastedItem());
+            state.setStatus(id, "uploading");
+            state.updateProgress(id, 50);
+
+            const item = state.activeItems.value.find((i) => i.id === id)!;
+            expect(item.progress).toBe(50);
+        });
+
+        it("reaching 100% auto-transitions item status to completed", () => {
+            const id = state.addUploadItem(makePastedItem());
+            state.setStatus(id, "uploading");
+            state.updateProgress(id, 100);
+
+            const item = state.activeItems.value.find((i) => i.id === id)!;
+            expect(item.status).toBe("completed");
+        });
+
+        it("totalProgress is the average progress across all items", () => {
+            const id1 = state.addUploadItem(makePastedItem("a.txt"));
+            const id2 = state.addUploadItem(makePastedItem("b.txt"));
+            state.setStatus(id1, "uploading");
+            state.setStatus(id2, "uploading");
+            state.updateProgress(id1, 40);
+            state.updateProgress(id2, 60);
+
+            expect(state.totalProgress.value).toBe(50);
+        });
+
+        it("totalSizeBytes sums item sizes and uploadedSizeBytes reflects partial progress", () => {
+            // makePastedItem uses content.length as size: "hello" = 5, "world!" = 6
+            const id1 = state.addUploadItem(makePastedItem("a.txt", "hello"));
+            const id2 = state.addUploadItem(makePastedItem("b.txt", "world!"));
+            state.setStatus(id1, "uploading");
+            state.setStatus(id2, "uploading");
+            state.updateProgress(id1, 100);
+            state.updateProgress(id2, 0);
+
+            expect(state.totalSizeBytes.value).toBe(11);
+            expect(state.uploadedSizeBytes.value).toBe(5); // only id1 is fully uploaded
+        });
+    });
+
+    describe("batch lifecycle", () => {
+        function setupBatch() {
+            const id1 = state.addUploadItem(makePastedItem("a.txt"));
+            const id2 = state.addUploadItem(makePastedItem("b.txt"));
+            const batchId = state.addBatch(BATCH_CONFIG, [id1, id2]);
+            return { id1, id2, batchId };
+        }
+
+        it("updateBatchStatus transitions the batch through status stages", () => {
+            const { batchId } = setupBatch();
+
+            state.updateBatchStatus(batchId, "creating-collection");
+            expect(state.getBatch(batchId)?.status).toBe("creating-collection");
+
+            state.updateBatchStatus(batchId, "completed");
+            expect(state.getBatch(batchId)?.status).toBe("completed");
+        });
+
+        it("setBatchCollectionId stores the created collection ID on the batch", () => {
+            const { batchId } = setupBatch();
+            state.setBatchCollectionId(batchId, "col_abc");
+            expect(state.getBatch(batchId)?.collectionId).toBe("col_abc");
+        });
+
+        it("addBatchDatasetId accumulates dataset IDs in order", () => {
+            const { batchId } = setupBatch();
+            state.addBatchDatasetId(batchId, "ds_1");
+            state.addBatchDatasetId(batchId, "ds_2");
+            expect(state.getBatch(batchId)?.datasetIds).toEqual(["ds_1", "ds_2"]);
+        });
+
+        it("batchesWithProgress.allCompleted is true when all uploads reach 100%", () => {
+            const { id1, id2, batchId } = setupBatch();
+            state.setStatus(id1, "uploading");
+            state.setStatus(id2, "uploading");
+            state.updateProgress(id1, 100);
+            state.updateProgress(id2, 100);
+
+            const bwp = state.batchesWithProgress.value.find((b) => b.id === batchId)!;
+            expect(bwp.allCompleted).toBe(true);
+            expect(bwp.progress).toBe(100);
+        });
+
+        it("batchesWithProgress.hasError is true when any upload fails", () => {
+            const { id1, batchId } = setupBatch();
+            state.setError(id1, "upload error");
+
+            const bwp = state.batchesWithProgress.value.find((b) => b.id === batchId)!;
+            expect(bwp.hasError).toBe(true);
+        });
+    });
+
+    describe("error handling", () => {
+        it("setError marks the item with error status and stores the message", () => {
+            const id = state.addUploadItem(makePastedItem());
+            state.setError(id, "network failure");
+
+            const item = state.activeItems.value.find((i) => i.id === id)!;
+            expect(item.status).toBe("error");
+            expect(item.error).toBe("network failure");
+        });
+
+        it("setBatchError marks the batch with error status and stores the message", () => {
+            const expectedMessage = "collection creation failed";
+            suppressExpectedErrorMessages([expectedMessage]);
+
+            const batchId = state.addBatch(BATCH_CONFIG, []);
+            state.setBatchError(batchId, expectedMessage);
+
+            const batch = state.getBatch(batchId)!;
+            expect(batch.status).toBe("error");
+            expect(batch.error).toBe(expectedMessage);
+        });
+    });
+
+    describe("clearCompleted", () => {
+        it("removes completed items while preserving uploading and errored items", () => {
+            const uploadingId = state.addUploadItem(makePastedItem("active.txt"));
+            const completedId = state.addUploadItem(makePastedItem("done.txt"));
+            const erroredId = state.addUploadItem(makePastedItem("failed.txt"));
+
+            state.setStatus(uploadingId, "uploading");
+            state.updateProgress(completedId, 100);
+            state.setError(erroredId, "oops");
+
+            state.clearCompleted();
+
+            const remainingIds = state.activeItems.value.map((i) => i.id);
+            expect(remainingIds).toContain(uploadingId);
+            expect(remainingIds).toContain(erroredId);
+            expect(remainingIds).not.toContain(completedId);
+        });
+    });
+
+    describe("clearAll", () => {
+        it("empties all items, batches, and resets computed flags", () => {
+            state.addUploadItem(makePastedItem());
+            state.addBatch(BATCH_CONFIG, []);
+
+            state.clearAll();
+
+            expect(state.activeItems.value).toHaveLength(0);
+            expect(state.activeBatches.value).toHaveLength(0);
+            expect(state.hasUploads.value).toBe(false);
+        });
+    });
+});

--- a/client/src/components/Panels/Upload/uploadState.test.ts
+++ b/client/src/components/Panels/Upload/uploadState.test.ts
@@ -167,8 +167,6 @@ describe("useUploadState", () => {
         it("totalProgress is the average progress across all items", () => {
             const id1 = state.addUploadItem(makePastedItem("a.txt"));
             const id2 = state.addUploadItem(makePastedItem("b.txt"));
-            state.setStatus(id1, "uploading");
-            state.setStatus(id2, "uploading");
             state.updateProgress(id1, 40);
             state.updateProgress(id2, 60);
 
@@ -179,8 +177,6 @@ describe("useUploadState", () => {
             // makePastedItem uses content.length as size: "hello" = 5, "world!" = 6
             const id1 = state.addUploadItem(makePastedItem("a.txt", "hello"));
             const id2 = state.addUploadItem(makePastedItem("b.txt", "world!"));
-            state.setStatus(id1, "uploading");
-            state.setStatus(id2, "uploading");
             state.updateProgress(id1, 100);
             state.updateProgress(id2, 0);
 

--- a/client/src/components/Panels/Upload/uploadState.test.ts
+++ b/client/src/components/Panels/Upload/uploadState.test.ts
@@ -1,5 +1,5 @@
 import { suppressExpectedErrorMessages } from "@tests/vitest/helpers";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
 import type { CollectionConfig } from "@/composables/uploadQueue";
@@ -37,6 +37,10 @@ describe("useUploadState", () => {
     beforeEach(() => {
         state = useUploadState();
         state.clearAll();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     describe("initial state", () => {
@@ -276,6 +280,34 @@ describe("useUploadState", () => {
             expect(remainingIds).toContain(uploadingId);
             expect(remainingIds).toContain(erroredId);
             expect(remainingIds).not.toContain(completedId);
+        });
+
+        it("removes a completed batch after all its items are cleared", () => {
+            const id1 = state.addUploadItem(makePastedItem("a.txt"));
+            const id2 = state.addUploadItem(makePastedItem("b.txt"));
+            const batchId = state.addBatch(BATCH_CONFIG, [id1, id2]);
+            state.updateBatchStatus(batchId, "completed");
+            state.updateProgress(id1, 100);
+            state.updateProgress(id2, 100);
+
+            state.clearCompleted();
+
+            expect(state.activeBatches.value.find((b) => b.id === batchId)).toBeUndefined();
+        });
+
+        it("keeps a batch with at least one non-completed item after clearing", () => {
+            const completedId = state.addUploadItem(makePastedItem("done.txt"));
+            const uploadingId = state.addUploadItem(makePastedItem("active.txt"));
+            const batchId = state.addBatch(BATCH_CONFIG, [completedId, uploadingId]);
+            state.updateProgress(completedId, 100);
+            state.setStatus(uploadingId, "uploading");
+
+            state.clearCompleted();
+
+            // Batch stays because uploadingId is still active
+            expect(state.activeBatches.value.find((b) => b.id === batchId)).toBeDefined();
+            // But the completed item is gone
+            expect(state.activeItems.value.find((i) => i.id === completedId)).toBeUndefined();
         });
     });
 

--- a/client/src/composables/uploadQueue.test.ts
+++ b/client/src/composables/uploadQueue.test.ts
@@ -1,0 +1,397 @@
+import { suppressExpectedErrorMessages } from "@tests/vitest/helpers";
+import assert from "assert";
+import flushPromises from "flush-promises";
+import { http, HttpResponse } from "msw";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useServerMock } from "@/api/client/__mocks__";
+import { useUploadState } from "@/components/Panels/Upload/uploadState";
+import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
+
+import { type CollectionConfig, useUploadQueue, validateUploadItem } from "./uploadQueue";
+
+// TUS upload is a non-HTTP protocol — mock it so tests never attempt real TUS connections.
+vi.mock("@/utils/tusUpload", () => ({
+    createTusUpload: vi.fn(),
+    NamedBlob: class {},
+}));
+
+const { server } = useServerMock();
+
+/** Creates a paste-content upload item, used only for validateUploadItem tests. */
+function makePastedItem(overrides: Partial<NewUploadItem> = {}): NewUploadItem {
+    return {
+        uploadMode: "paste-content",
+        name: "file.txt",
+        content: "hello world",
+        size: 11,
+        targetHistoryId: "hist_1",
+        dbkey: "?",
+        extension: "auto",
+        spaceToTab: false,
+        toPosixLines: false,
+        deferred: false,
+        ...overrides,
+    } as NewUploadItem;
+}
+
+/** Creates a paste-links (URL) upload item. URL items use direct fetchDatasets — no TUS involved. */
+function makeUrlItem(overrides: Partial<NewUploadItem> = {}): NewUploadItem {
+    return {
+        uploadMode: "paste-links",
+        name: "file.txt",
+        url: "http://example.com/file.txt",
+        size: 0,
+        targetHistoryId: "hist_1",
+        dbkey: "?",
+        extension: "auto",
+        spaceToTab: false,
+        toPosixLines: false,
+        deferred: false,
+        ...overrides,
+    } as NewUploadItem;
+}
+
+/** Creates a remote-files upload item. Same shape as paste-links but with a different uploadMode. */
+function makeRemoteFilesItem(overrides: Partial<NewUploadItem> = {}): NewUploadItem {
+    return {
+        uploadMode: "remote-files",
+        name: "file.txt",
+        url: "ftp://server/file.txt",
+        size: 0,
+        targetHistoryId: "hist_1",
+        dbkey: "?",
+        extension: "auto",
+        spaceToTab: false,
+        toPosixLines: false,
+        deferred: false,
+        ...overrides,
+    } as NewUploadItem;
+}
+
+/** Creates a data-library upload item for testing the two-step collection path. */
+function makeLibraryItem(overrides: Partial<NewUploadItem> = {}): NewUploadItem {
+    return {
+        uploadMode: "data-library",
+        name: "library.txt",
+        size: 0,
+        targetHistoryId: "hist_1",
+        dbkey: "?",
+        extension: "auto",
+        spaceToTab: false,
+        toPosixLines: false,
+        deferred: false,
+        libraryId: "lib_1",
+        folderId: "folder_1",
+        lddaId: "ldda_1",
+        url: "/api/libraries/lib_1/datasets/ldda_1",
+        ...overrides,
+    } as NewUploadItem;
+}
+
+function makeCollectionConfig(overrides: Partial<CollectionConfig> = {}): CollectionConfig {
+    return {
+        name: "My Collection",
+        type: "list",
+        historyId: "hist_1",
+        hideSourceItems: false,
+        ...overrides,
+    };
+}
+
+describe("validateUploadItem", () => {
+    it("accepts a valid paste-content item", () => {
+        expect(validateUploadItem(makePastedItem())).toBeUndefined();
+    });
+
+    it("accepts a valid paste-links item", () => {
+        expect(validateUploadItem(makeUrlItem())).toBeUndefined();
+    });
+
+    it("accepts a valid remote-files item", () => {
+        expect(validateUploadItem(makeRemoteFilesItem())).toBeUndefined();
+    });
+
+    it("accepts a valid data-library item", () => {
+        expect(validateUploadItem(makeLibraryItem())).toBeUndefined();
+    });
+
+    it("accepts a valid local-file item", () => {
+        const file = new File(["content"], "test.txt");
+        const item: NewUploadItem = {
+            uploadMode: "local-file",
+            name: "test.txt",
+            size: file.size,
+            targetHistoryId: "hist_1",
+            dbkey: "?",
+            extension: "auto",
+            spaceToTab: false,
+            toPosixLines: false,
+            deferred: false,
+            fileData: file,
+        };
+        expect(validateUploadItem(item)).toBeUndefined();
+    });
+
+    it("rejects paste-content with empty content", () => {
+        const item = makePastedItem({ content: "   " });
+        expect(validateUploadItem(item)).toMatch(/No content provided/);
+    });
+
+    it("rejects paste-links with missing URL", () => {
+        expect(validateUploadItem(makeUrlItem({ url: "" }))).toMatch(/No URL provided/);
+    });
+
+    it("rejects remote-files with missing URL", () => {
+        expect(validateUploadItem(makeRemoteFilesItem({ url: "  " }))).toMatch(/No URL provided/);
+    });
+
+    it("rejects data-library with no lddaId", () => {
+        expect(validateUploadItem(makeLibraryItem({ lddaId: "" }))).toMatch(/No library dataset ID/);
+    });
+
+    it("rejects local-file with no file data", () => {
+        const item: NewUploadItem = {
+            uploadMode: "local-file",
+            name: "missing.txt",
+            size: 0,
+            targetHistoryId: "hist_1",
+            dbkey: "?",
+            extension: "auto",
+            spaceToTab: false,
+            toPosixLines: false,
+            deferred: false,
+        };
+        expect(validateUploadItem(item)).toMatch(/No file selected/);
+    });
+
+    it("rejects local-file with an empty file", () => {
+        const emptyFile = new File([], "empty.txt");
+        const item: NewUploadItem = {
+            uploadMode: "local-file",
+            name: "empty.txt",
+            size: 0,
+            targetHistoryId: "hist_1",
+            dbkey: "?",
+            extension: "auto",
+            spaceToTab: false,
+            toPosixLines: false,
+            deferred: false,
+            fileData: emptyFile,
+        };
+        expect(validateUploadItem(item)).toMatch(/is empty/);
+    });
+
+    it("rejects an unknown upload mode", () => {
+        const item = { ...makePastedItem(), uploadMode: "unknown-mode" } as unknown as NewUploadItem;
+        expect(validateUploadItem(item)).toMatch(/Unknown upload mode/);
+    });
+});
+
+describe("useUploadQueue", () => {
+    let queue: ReturnType<typeof useUploadQueue>;
+
+    beforeEach(() => {
+        // Fresh Pinia instance for each test to prevent cross-test store state.
+        setActivePinia(createPinia());
+        // Reset the shared upload state singleton before creating a new queue.
+        useUploadState().clearAll();
+        // Each call creates fresh local queue/batch state and re-runs recoverIncompleteBatches.
+        queue = useUploadQueue();
+    });
+
+    describe("enqueue — single item", () => {
+        it("marks the item as completed after a successful upload", async () => {
+            server.use(http.post("/api/tools/fetch", () => HttpResponse.json({})));
+
+            const [id] = queue.enqueue([makeUrlItem()]);
+            await flushPromises();
+
+            expect(queue.state.activeItems.value.find((i) => i.id === id)?.status).toBe("completed");
+        });
+
+        it("processes multiple items sequentially — all reach completed status", async () => {
+            server.use(http.post("/api/tools/fetch", () => HttpResponse.json({})));
+
+            const ids = queue.enqueue([
+                makeUrlItem({ name: "a.txt" }),
+                makeUrlItem({ name: "b.txt" }),
+                makeUrlItem({ name: "c.txt" }),
+            ]);
+            await flushPromises();
+
+            for (const id of ids) {
+                expect(queue.state.activeItems.value.find((i) => i.id === id)?.status).toBe("completed");
+            }
+        });
+
+        it("marks the item as error when the upload endpoint returns an error", async () => {
+            server.use(
+                http.post("/api/tools/fetch", () =>
+                    HttpResponse.json({ err_msg: "Server unavailable" }, { status: 500 }),
+                ),
+            );
+
+            const [id] = queue.enqueue([makeUrlItem()]);
+            await flushPromises();
+
+            const item = queue.state.activeItems.value.find((i) => i.id === id);
+            expect(item?.status).toBe("error");
+            expect(item?.error).toBeTruthy();
+        });
+    });
+
+    describe("enqueue — direct collection batch", () => {
+        it("marks the batch as completed after a successful collection upload", async () => {
+            server.use(http.post("/api/tools/fetch", () => HttpResponse.json({})));
+
+            queue.enqueue([makeUrlItem({ name: "a.txt" }), makeUrlItem({ name: "b.txt" })], makeCollectionConfig());
+            await flushPromises();
+
+            const batch = queue.state.activeBatches.value[0];
+            expect(batch?.status).toBe("completed");
+        });
+
+        it("marks the batch as error when the upload endpoint fails", async () => {
+            suppressExpectedErrorMessages(["Upload failed"]);
+            server.use(
+                http.post("/api/tools/fetch", () => HttpResponse.json({ err_msg: "Upload failed" }, { status: 500 })),
+            );
+
+            queue.enqueue([makeUrlItem()], makeCollectionConfig());
+            await flushPromises();
+
+            const batch = queue.state.activeBatches.value[0];
+            expect(batch?.status).toBe("error");
+        });
+    });
+
+    // ── Two-step collection batch (data-library items) ───────────────────────
+    //
+    // data-library items cannot use direct HDCA creation (they use copyDataset instead
+    // of /api/tools/fetch). Each item is uploaded individually; after all items complete,
+    // the collection is created via POST /api/dataset_collections.
+
+    describe("enqueue — two-step collection batch (data-library)", () => {
+        it("creates the collection after all library items are successfully copied", async () => {
+            server.use(
+                http.post("/api/histories/:historyId/contents/:type", () => HttpResponse.json({ id: "ds_lib_1" })),
+                http.post("/api/dataset_collections", () => HttpResponse.json({ id: "col_1" })),
+            );
+
+            queue.enqueue([makeLibraryItem()], makeCollectionConfig());
+            await flushPromises();
+
+            const batch = queue.state.activeBatches.value[0];
+            expect(batch?.status).toBe("completed");
+            expect(batch?.collectionId).toBe("col_1");
+        });
+
+        it("marks the batch as error when collection creation fails after successful uploads", async () => {
+            suppressExpectedErrorMessages(["Collection creation failed:", "Collection error"]);
+            server.use(
+                http.post("/api/histories/:historyId/contents/:type", () => HttpResponse.json({ id: "ds_lib_1" })),
+                http.post("/api/dataset_collections", () =>
+                    HttpResponse.json({ err_msg: "Collection error" }, { status: 500 }),
+                ),
+            );
+
+            queue.enqueue([makeLibraryItem()], makeCollectionConfig());
+            await flushPromises();
+
+            const batch = queue.state.activeBatches.value[0];
+            expect(batch?.status).toBe("error");
+            expect(batch?.collectionId).toBeUndefined();
+        });
+    });
+
+    describe("retryCollectionCreation", () => {
+        it("re-attempts collection creation and resolves the batch after a previous failure", async () => {
+            suppressExpectedErrorMessages(["Collection creation failed:", "Temporary error"]);
+
+            // Phase 1: uploads succeed, collection creation fails.
+            server.use(
+                http.post("/api/histories/:historyId/contents/:type", () => HttpResponse.json({ id: "ds_lib_1" })),
+                http.post("/api/dataset_collections", () =>
+                    HttpResponse.json({ err_msg: "Temporary error" }, { status: 500 }),
+                ),
+            );
+
+            queue.enqueue([makeLibraryItem()], makeCollectionConfig());
+            await flushPromises();
+
+            const batchId = queue.state.activeBatches.value[0]?.id;
+            assert(batchId, "Expected a batch to be created");
+            expect(queue.state.getBatch(batchId)?.status).toBe("error");
+
+            // Phase 2: collection creation now succeeds.
+            server.use(http.post("/api/dataset_collections", () => HttpResponse.json({ id: "col_retried" })));
+
+            await queue.retryCollectionCreation(batchId);
+            await flushPromises();
+
+            expect(queue.state.getBatch(batchId)?.status).toBe("completed");
+            expect(queue.state.getBatch(batchId)?.collectionId).toBe("col_retried");
+        });
+    });
+
+    describe("clearCompleted", () => {
+        it("removes completed uploads from state", async () => {
+            server.use(http.post("/api/tools/fetch", () => HttpResponse.json({})));
+
+            const [completedId] = queue.enqueue([makeUrlItem()]);
+            await flushPromises();
+
+            expect(queue.state.activeItems.value.find((i) => i.id === completedId)?.status).toBe("completed");
+
+            queue.clearCompleted();
+
+            expect(queue.state.activeItems.value.find((i) => i.id === completedId)).toBeUndefined();
+        });
+    });
+
+    describe("clearAll", () => {
+        it("empties all items, batches, and internal queue state", async () => {
+            server.use(http.post("/api/tools/fetch", () => HttpResponse.json({})));
+
+            queue.enqueue([makeUrlItem(), makeUrlItem()], makeCollectionConfig());
+            await flushPromises();
+
+            queue.clearAll();
+
+            expect(queue.state.activeItems.value).toHaveLength(0);
+            expect(queue.state.activeBatches.value).toHaveLength(0);
+        });
+    });
+
+    // On initialization, the queue checks for two-step batches where uploads completed
+    // in a previous session but collection creation did not finish (e.g. page was refreshed).
+    describe("recoverIncompleteBatches", () => {
+        it("automatically creates the collection for a two-step batch with completed uploads and dataset IDs", async () => {
+            const uploadState = useUploadState();
+
+            // Simulate state left from a previous browser session:
+            // one completed upload item and a pending two-step batch with a dataset ID.
+            const itemId = uploadState.addUploadItem(makeUrlItem({ name: "recovered.txt" }));
+            uploadState.setStatus(itemId, "uploading");
+            uploadState.updateProgress(itemId, 100); // auto-marks as completed
+
+            const batchId = uploadState.addBatch(
+                { name: "Recovery Collection", type: "list", hideSourceItems: false, historyId: "hist_1" },
+                [itemId],
+                false, // not directCreation — qualifies for recovery
+            );
+            uploadState.addBatchDatasetId(batchId, "ds_recovered");
+
+            server.use(http.post("/api/dataset_collections", () => HttpResponse.json({ id: "col_recovered" })));
+
+            // Creating a new queue instance triggers recoverIncompleteBatches.
+            const recoveryQueue = useUploadQueue();
+            await flushPromises();
+
+            expect(recoveryQueue.state.getBatch(batchId)?.collectionId).toBe("col_recovered");
+            expect(recoveryQueue.state.getBatch(batchId)?.status).toBe("completed");
+        });
+    });
+});

--- a/client/src/composables/uploadQueue.test.ts
+++ b/client/src/composables/uploadQueue.test.ts
@@ -239,6 +239,15 @@ describe("useUploadQueue", () => {
             expect(item?.status).toBe("error");
             expect(item?.error).toBeTruthy();
         });
+
+        it("marks item as error when enqueued with invalid content (no server call needed)", async () => {
+            const [id] = queue.enqueue([makePastedItem({ content: "   " })]);
+            await flushPromises();
+
+            const item = queue.state.activeItems.value.find((i) => i.id === id);
+            expect(item?.status).toBe("error");
+            expect(item?.error).toMatch(/No content provided/);
+        });
     });
 
     describe("enqueue — direct collection batch", () => {

--- a/client/src/composables/uploadQueue.test.ts
+++ b/client/src/composables/uploadQueue.test.ts
@@ -3,7 +3,7 @@ import assert from "assert";
 import flushPromises from "flush-promises";
 import { http, HttpResponse } from "msw";
 import { createPinia, setActivePinia } from "pinia";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useServerMock } from "@/api/client/__mocks__";
 import { useUploadState } from "@/components/Panels/Upload/uploadState";
@@ -19,7 +19,7 @@ vi.mock("@/utils/tusUpload", () => ({
 
 const { server } = useServerMock();
 
-/** Creates a paste-content upload item, used only for validateUploadItem tests. */
+/** Creates a paste-content upload item. */
 function makePastedItem(overrides: Partial<NewUploadItem> = {}): NewUploadItem {
     return {
         uploadMode: "paste-content",
@@ -100,37 +100,32 @@ function makeCollectionConfig(overrides: Partial<CollectionConfig> = {}): Collec
     };
 }
 
+/** Creates a local-file upload item with a real File object. */
+function makeLocalFileItem(overrides: Partial<NewUploadItem> = {}): NewUploadItem {
+    const file = new File(["content"], "test.txt");
+    return {
+        uploadMode: "local-file",
+        name: "test.txt",
+        size: file.size,
+        targetHistoryId: "hist_1",
+        dbkey: "?",
+        extension: "auto",
+        spaceToTab: false,
+        toPosixLines: false,
+        deferred: false,
+        fileData: file,
+        ...overrides,
+    } as NewUploadItem;
+}
+
 describe("validateUploadItem", () => {
-    it("accepts a valid paste-content item", () => {
-        expect(validateUploadItem(makePastedItem())).toBeUndefined();
-    });
-
-    it("accepts a valid paste-links item", () => {
-        expect(validateUploadItem(makeUrlItem())).toBeUndefined();
-    });
-
-    it("accepts a valid remote-files item", () => {
-        expect(validateUploadItem(makeRemoteFilesItem())).toBeUndefined();
-    });
-
-    it("accepts a valid data-library item", () => {
-        expect(validateUploadItem(makeLibraryItem())).toBeUndefined();
-    });
-
-    it("accepts a valid local-file item", () => {
-        const file = new File(["content"], "test.txt");
-        const item: NewUploadItem = {
-            uploadMode: "local-file",
-            name: "test.txt",
-            size: file.size,
-            targetHistoryId: "hist_1",
-            dbkey: "?",
-            extension: "auto",
-            spaceToTab: false,
-            toPosixLines: false,
-            deferred: false,
-            fileData: file,
-        };
+    it.each([
+        ["paste-content", makePastedItem()],
+        ["paste-links", makeUrlItem()],
+        ["remote-files", makeRemoteFilesItem()],
+        ["data-library", makeLibraryItem()],
+        ["local-file", makeLocalFileItem()],
+    ] as [string, NewUploadItem][])("accepts a valid %s item", (_mode, item) => {
         expect(validateUploadItem(item)).toBeUndefined();
     });
 
@@ -201,6 +196,10 @@ describe("useUploadQueue", () => {
         queue = useUploadQueue();
     });
 
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     describe("enqueue — single item", () => {
         it("marks the item as completed after a successful upload", async () => {
             server.use(http.post("/api/tools/fetch", () => HttpResponse.json({})));
@@ -211,7 +210,7 @@ describe("useUploadQueue", () => {
             expect(queue.state.activeItems.value.find((i) => i.id === id)?.status).toBe("completed");
         });
 
-        it("processes multiple items sequentially — all reach completed status", async () => {
+        it("all items reach completed status when multiple items are enqueued", async () => {
             server.use(http.post("/api/tools/fetch", () => HttpResponse.json({})));
 
             const ids = queue.enqueue([

--- a/client/tests/vitest/helpers.js
+++ b/client/tests/vitest/helpers.js
@@ -75,6 +75,17 @@ export function suppressLucideVue2Deprecation() {
     );
 }
 
+export function suppressExpectedErrorMessages(expectedMessages = []) {
+    const originalError = console.error;
+    vi.spyOn(console, "error").mockImplementation(
+        vi.fn((msg) => {
+            if (!expectedMessages.some((expected) => msg.indexOf(expected) >= 0)) {
+                originalError(msg);
+            }
+        }),
+    );
+}
+
 function isTestLocalized(received) {
     return received && received.indexOf && received.indexOf("test_localized<") == 0;
 }

--- a/client/tests/vitest/helpers.js
+++ b/client/tests/vitest/helpers.js
@@ -4,7 +4,7 @@
 import { createLocalVue } from "@vue/test-utils";
 import BootstrapVue from "bootstrap-vue";
 import { PiniaVuePlugin } from "pinia";
-import { expect, test, vi } from "vitest";
+import { expect, vi } from "vitest";
 import VueRouter from "vue-router";
 
 import { localizationPlugin } from "@/components/plugins/localization";
@@ -39,51 +39,43 @@ export function getLocalVue(instrumentLocalization = false) {
 }
 
 export function suppressDebugConsole() {
-    vi.spyOn(console, "debug").mockImplementation(vi.fn());
+    vi.spyOn(console, "debug").mockImplementation(() => {});
 }
 
 export function suppressBootstrapVueWarnings() {
     const originalWarn = console.warn;
-    vi.spyOn(console, "warn").mockImplementation(
-        vi.fn((msg) => {
-            if (typeof msg !== "string" || msg.indexOf("BootstrapVue warn") < 0) {
-                originalWarn(msg);
-            }
-        }),
-    );
+    vi.spyOn(console, "warn").mockImplementation((msg) => {
+        if (!String(msg).includes("BootstrapVue warn")) {
+            originalWarn(msg);
+        }
+    });
 }
 
 export function suppressErrorForCustomIcons() {
     const originalError = console.error;
-    vi.spyOn(console, "error").mockImplementation(
-        vi.fn((msg) => {
-            if (msg.indexOf("Could not find one or more icon(s)") < 0) {
-                originalError(msg);
-            }
-        }),
-    );
+    vi.spyOn(console, "error").mockImplementation((msg) => {
+        if (!String(msg).includes("Could not find one or more icon(s)")) {
+            originalError(msg);
+        }
+    });
 }
 
 export function suppressLucideVue2Deprecation() {
     const originalWarn = console.warn;
-    vi.spyOn(console, "warn").mockImplementation(
-        vi.fn((msg) => {
-            if (msg.indexOf("[Lucide Vue] This package will be deprecated") < 0) {
-                originalWarn(msg);
-            }
-        }),
-    );
+    vi.spyOn(console, "warn").mockImplementation((msg) => {
+        if (!String(msg).includes("[Lucide Vue] This package will be deprecated")) {
+            originalWarn(msg);
+        }
+    });
 }
 
 export function suppressExpectedErrorMessages(expectedMessages = []) {
     const originalError = console.error;
-    vi.spyOn(console, "error").mockImplementation(
-        vi.fn((msg) => {
-            if (!expectedMessages.some((expected) => msg.indexOf(expected) >= 0)) {
-                originalError(msg);
-            }
-        }),
-    );
+    vi.spyOn(console, "error").mockImplementation((msg) => {
+        if (!expectedMessages.some((expected) => String(msg).includes(expected))) {
+            originalError(msg);
+        }
+    });
 }
 
 function isTestLocalized(received) {


### PR DESCRIPTION
xref #21878

Adds some basic unit tests for the new core `uploadState.ts` and `uploadQueue.ts` modules.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
