### PR TITLE
Attempt to fix transient failure in selenium test test_advanced_search

### DIFF
--- a/lib/galaxy_test/selenium/test_histories_list.py
+++ b/lib/galaxy_test/selenium/test_histories_list.py
@@ -285,11 +285,11 @@ class TestSavedHistories(SharedStateSeleniumTestCase):
         input_element = self.components.histories.advanced_search_tag_input.wait_for_visible()
         input_element.send_keys(self.history3_tags[0])
         self.send_enter(input_element)
-        self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_histories_present([self.history3_name])
 
     @retry_assertion_during_transitions
     def assert_histories_present(self, expected_histories, sort_by_matters=False):
+        self.sleep_for(self.wait_types.UX_RENDER)
         actual_histories = self.get_history_titles(len(expected_histories))
         assert len(actual_histories) == len(expected_histories)
 


### PR DESCRIPTION
I've seen this selenium test fail more and more often:
```
FAILED lib/galaxy_test/selenium/test_histories_list.py::TestSavedHistories::test_advanced_search - AssertionError: assert 14 == 1
 +  where 14 = len(['xq1i7tzort', 'f11nj2vkdv', 'j8ravov4sq', 'f95y8sw68h', 'o7cqjvxmw4', 'x9wrskhmnk', 'i4d2ymlo2f', 'fh0t9opcfq', 'u2030ifbpu', 'ubehr9ge0v', 'mgjvv76739', '167pf02eet', 'ejuhew0gi3', 'Unnamed history'])
 +  and   1 = len(['167pf02eet'])
```

It seems that when `assert_histories_present` fires, `.history-card-list` already exists (all the time), so there is a chance we can get stale histories before the filtering. Hopefully, this can mitigate the issue, although I don't love it since it still depends on "timing".


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
