### PR TITLE
[26.0] Backport chat API improvements

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -121,6 +121,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/exchange/{exchange_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Exchange
+         * @description **Warning**: This API is unstable and may change without notice.
+         */
+        delete: operations["delete_exchange_api_chat_exchange__exchange_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chat/exchange/{exchange_id}/feedback": {
         parameters: {
             query?: never;
@@ -154,6 +174,26 @@ export interface paths {
          */
         get: operations["get_exchange_messages_api_chat_exchange__exchange_id__messages_get"];
         put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/exchanges/batch/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Batch Delete Exchanges
+         * @description **Warning**: This API is unstable and may change without notice.
+         */
+        put: operations["batch_delete_exchanges_api_chat_exchanges_batch_delete_put"];
         post?: never;
         delete?: never;
         options?: never;
@@ -8195,6 +8235,14 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** ChatExchangeBatchDeletePayload */
+        ChatExchangeBatchDeletePayload: {
+            /**
+             * Exchange IDs
+             * @description List of chat exchange IDs to delete.
+             */
+            ids: string[];
+        };
         /** ChatMessage */
         ChatMessage: {
             /** Content */
@@ -8225,7 +8273,7 @@ export interface components {
              * Exchange ID
              * @description The ID of an existing chat exchange to continue.
              */
-            exchange_id?: number | null;
+            exchange_id?: string | null;
             /**
              * Query
              * @description The query to be sent to the chatbot.
@@ -8258,7 +8306,7 @@ export interface components {
              * Exchange ID
              * @description The ID of the chat exchange for continuing conversations.
              */
-            exchange_id?: number | null;
+            exchange_id?: string | null;
             /**
              * Processing Time
              * @description Time taken to process the query in seconds.
@@ -26083,6 +26131,51 @@ export interface operations {
             };
         };
     };
+    delete_exchange_api_chat_exchange__exchange_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                exchange_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
     set_exchange_feedback_api_chat_exchange__exchange_id__feedback_put: {
         parameters: {
             query?: never;
@@ -26091,7 +26184,7 @@ export interface operations {
                 "run-as"?: string | null;
             };
             path: {
-                exchange_id: number;
+                exchange_id: string;
             };
             cookie?: never;
         };
@@ -26140,7 +26233,7 @@ export interface operations {
                 "run-as"?: string | null;
             };
             path: {
-                exchange_id: number;
+                exchange_id: string;
             };
             cookie?: never;
         };
@@ -26155,6 +26248,53 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     }[];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    batch_delete_exchanges_api_chat_exchanges_batch_delete_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChatExchangeBatchDeletePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
                 };
             };
             /** @description Request Error */

--- a/client/src/components/ChatGXY.vue
+++ b/client/src/components/ChatGXY.vue
@@ -44,7 +44,7 @@ interface Message {
 }
 
 interface ChatHistoryItem {
-    id: number;
+    id: string;
     query: string;
     response: string;
     agent_type: string;
@@ -62,7 +62,7 @@ const selectedAgentType = ref("auto");
 const showHistory = ref(false);
 const chatHistory = ref<ChatHistoryItem[]>([]);
 const loadingHistory = ref(false);
-const currentChatId = ref<number | null>(null);
+const currentChatId = ref<string | null>(null);
 const hasLoadedInitialChat = ref(false);
 
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true, removeNewlinesAfterList: true });

--- a/lib/galaxy/managers/chat.py
+++ b/lib/galaxy/managers/chat.py
@@ -287,6 +287,29 @@ class ChatManager:
                     pydantic_messages.append(ModelResponse(parts=[TextPart(content=msg.message)]))
             return pydantic_messages
 
+    def delete_exchange(self, trans: ProvidesUserContext, exchange_id: int) -> None:
+        """Delete a single chat exchange and its messages."""
+        exchange = self.get_exchange_by_id(trans, exchange_id)
+        if not exchange:
+            raise RequestParameterInvalidException("No accessible chat exchange found with the ID provided.")
+        for message in exchange.messages:
+            trans.sa_session.delete(message)
+        trans.sa_session.delete(exchange)
+        trans.sa_session.commit()
+
+    def delete_exchanges(self, trans: ProvidesUserContext, exchange_ids: list[int]) -> int:
+        """Delete multiple chat exchanges and their messages. Returns the count deleted."""
+        count = 0
+        for exchange_id in exchange_ids:
+            exchange = self.get_exchange_by_id(trans, exchange_id)
+            if exchange:
+                for message in exchange.messages:
+                    trans.sa_session.delete(message)
+                trans.sa_session.delete(exchange)
+                count += 1
+        trans.sa_session.commit()
+        return count
+
     def get_user_chat_history(
         self, trans: ProvidesUserContext, limit: int = 50, include_job_chats: bool = False
     ) -> list[ChatExchange]:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3881,7 +3881,7 @@ class ChatPayload(Model):
         title="Context",
         description="The context for the chatbot.",
     )
-    exchange_id: Optional[int] = Field(
+    exchange_id: Optional[DecodedDatabaseIdField] = Field(
         default=None,
         title="Exchange ID",
         description="The ID of an existing chat exchange to continue.",
@@ -3914,7 +3914,7 @@ class ChatResponse(BaseModel):
         title="Agent Response",
         description="Full structured agent response with metadata and suggestions.",
     )
-    exchange_id: Optional[int] = Field(
+    exchange_id: Optional[EncodedDatabaseIdField] = Field(
         default=None,
         title="Exchange ID",
         description="The ID of the chat exchange for continuing conversations.",
@@ -3923,6 +3923,14 @@ class ChatResponse(BaseModel):
         default=None,
         title="Processing Time",
         description="Time taken to process the query in seconds.",
+    )
+
+
+class ChatExchangeBatchDeletePayload(Model):
+    ids: list[DecodedDatabaseIdField] = Field(
+        ...,
+        title="Exchange IDs",
+        description="List of chat exchange IDs to delete.",
     )
 
 

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -27,8 +27,12 @@ from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.jobs import JobManager
 from galaxy.model import User
 from galaxy.schema.agents import AgentResponse
-from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    encode_id,
+)
 from galaxy.schema.schema import (
+    ChatExchangeBatchDeletePayload,
     ChatPayload,
     ChatResponse,
 )
@@ -246,9 +250,6 @@ class ChatAPI:
         user: User = DependsOnUser,
     ) -> list[dict[str, Any]]:
         """Get user's chat history."""
-        if not user:
-            return []
-
         exchanges = self.chat_manager.get_user_chat_history(trans, limit=limit, include_job_chats=False)
 
         # Format exchanges for frontend
@@ -264,7 +265,7 @@ class ChatAPI:
                     data = json.loads(message.message)
                     history.append(
                         {
-                            "id": exchange.id,
+                            "id": encode_id(exchange.id),
                             "query": data.get("query", ""),
                             "response": data.get("response", ""),
                             "agent_type": data.get("agent_type", "unknown"),
@@ -289,9 +290,6 @@ class ChatAPI:
         user: User = DependsOnUser,
     ) -> dict[str, str]:
         """Clear user's chat history (non-job chats only)."""
-        if not user:
-            return {"message": "No user logged in"}
-
         try:
             # Get all non-job chat exchanges for user
             exchanges = self.chat_manager.get_user_chat_history(trans, limit=1000, include_job_chats=False)
@@ -317,6 +315,28 @@ class ChatAPI:
             log.exception("Error clearing chat history")
             return {"message": "Error clearing history"}
 
+    @router.delete("/api/chat/exchange/{exchange_id}", unstable=True)
+    def delete_exchange(
+        self,
+        exchange_id: DecodedDatabaseIdField,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user: User = DependsOnUser,
+    ) -> dict[str, str]:
+        """Delete a single chat exchange."""
+        self.chat_manager.delete_exchange(trans, exchange_id)
+        return {"message": "Deleted"}
+
+    @router.put("/api/chat/exchanges/batch/delete", unstable=True)
+    def batch_delete_exchanges(
+        self,
+        payload: ChatExchangeBatchDeletePayload,
+        trans: ProvidesUserContext = DependsOnTrans,
+        user: User = DependsOnUser,
+    ) -> dict[str, str]:
+        """Delete multiple chat exchanges."""
+        count = self.chat_manager.delete_exchanges(trans, payload.ids)
+        return {"message": f"Deleted {count} exchanges"}
+
     @router.put("/api/chat/{job_id}/feedback", unstable=True)
     def feedback(
         self,
@@ -333,7 +353,7 @@ class ChatAPI:
     @router.put("/api/chat/exchange/{exchange_id}/feedback", unstable=True)
     def set_exchange_feedback(
         self,
-        exchange_id: int,
+        exchange_id: DecodedDatabaseIdField,
         feedback: int = Body(..., description="Feedback value: 0 for negative, 1 for positive"),
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
@@ -348,7 +368,7 @@ class ChatAPI:
     @router.get("/api/chat/exchange/{exchange_id}/messages", unstable=True)
     def get_exchange_messages(
         self,
-        exchange_id: int,
+        exchange_id: DecodedDatabaseIdField,
         trans: ProvidesUserContext = DependsOnTrans,
         user: User = DependsOnUser,
     ) -> list[dict[str, Any]]:

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -235,6 +235,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route("/tours")
     webapp.add_client_route("/tours/{tour_id}")
     webapp.add_client_route("/chatgxy")
+    webapp.add_client_route("/chatgxy/{exchange_id}")
     webapp.add_client_route("/user")
     webapp.add_client_route("/user/notifications{path:.*?}")
     webapp.add_client_route("/user/{form_id}")


### PR DESCRIPTION
With the release still pending per discussion in https://github.com/galaxyproject/galaxy/pull/21950 this pops out the API tweaks as a backport.

Use encoded/decoded IDs for chat exchange endpoints matching Galaxy conventions, add individual and batch deletion endpoints, and remove unreachable `if not user` guards (DependsOnUser already handles auth).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
