### PR TITLE
[25.1] Fix recording duplicate workflow_request_input_step_parameter rows

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9902,6 +9902,9 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         for content in self.input_dataset_collections:
             if content.workflow_step_id == step_id:
                 return True
+        for content in self.input_step_parameters:
+            if content.workflow_step_id == step_id:
+                return True
         return False
 
     def set_handler(self, handler):

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -627,7 +627,7 @@ class WorkflowProgress:
         if not invocation.has_input_for_step(step.id):
             content = outputs.get("output", NO_REPLACEMENT)
             if content is not NO_REPLACEMENT:
-                log.info("ADDING INPUT FOR STEP %s: %s", step.id, content, exc_info=True)
+                log.debug("Adding input for step %s: %s", step.id, content)
                 invocation.add_input(content, step.id)
         self.set_step_outputs(invocation_step, outputs, already_persisted=already_persisted)
 


### PR DESCRIPTION
We have a ton of duplicate values in
`workflow_request_input_step_parameter`:
```
galaxy_main=> select count(*) from workflow_request_input_step_parameter where workflow_invocation_id = 943614;
 count
-------
 26820
(1 row)
```

This broke in https://github.com/galaxyproject/galaxy/commit/1e48e15ffb65b15e570ffce4f2a9dcd2ce330432

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
