### PR TITLE
[26.0] Fix HTML dataset extra files 404 in preview

### DIFF
--- a/client/src/components/Dataset/DatasetDisplay.vue
+++ b/client/src/components/Dataset/DatasetDisplay.vue
@@ -37,7 +37,7 @@ const sanitizedToolId = ref<string | null>(null);
 const { isAdmin } = storeToRefs(useUserStore());
 
 const dataset = computed(() => getDataset(props.datasetId));
-const datasetUrl = computed(() => `/datasets/${props.datasetId}/display`);
+const datasetUrl = computed(() => `/datasets/${props.datasetId}/display/`);
 const downloadUrl = computed(() => withPrefix(`${datasetUrl.value}?to_ext=${dataset.value?.file_ext}`));
 const isLoading = computed(() => isLoadingDataset(props.datasetId));
 const previewUrl = computed(() => `${datasetUrl.value}?preview=True`);

--- a/lib/galaxy_test/selenium/test_dataset_display_extra_files.py
+++ b/lib/galaxy_test/selenium/test_dataset_display_extra_files.py
@@ -1,0 +1,53 @@
+from .framework import (
+    managed_history,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestDatasetDisplayExtraFiles(SeleniumTestCase):
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_html_display_extra_files_relative_path(self):
+        """Test that HTML datasets with extra files resolve relative paths correctly.
+
+        Regression test for https://github.com/galaxyproject/galaxy/pull/21981.
+        Without the trailing slash on the display URL, the browser resolves
+        relative paths (like 'image.jpg') against the wrong directory, causing 404s.
+        """
+        history_id = self.current_history_id()
+        run_response = self.dataset_populator.run_tool(
+            "html_output_with_extra_files",
+            {},
+            history_id,
+        )
+        hda_id = run_response["outputs"][0]["id"]
+        self.dataset_populator.wait_for_dataset(history_id, dataset_id=hda_id, assert_ok=True)
+
+        self.navigate_to(self.build_url(f"datasets/{hda_id}/preview"))
+        self.wait_for_selector_visible(".dataset-display")
+        # Wait for the iframe to be present and loaded
+        self.wait_for_selector_visible("iframe#frame")
+        self.sleep_for(self.wait_types.UX_RENDER)
+        # The critical assertion: verify the display URL has a trailing slash.
+        # Without this slash, relative paths like 'image.jpg' in HTML extra files
+        # resolve against /datasets/{id}/ instead of /datasets/{id}/display/,
+        # causing 404 errors for sub-resources.
+        iframe_src = self.execute_script('return document.getElementById("frame").src;')
+        assert (
+            "/display/" in iframe_src
+        ), f"Expected iframe src to contain '/display/' (with trailing slash), got: {iframe_src}"
+        # Verify the extra file is actually accessible via the correct relative path.
+        # The browser would resolve 'image.jpg' relative to /datasets/{id}/display/
+        # which should serve the extra file.
+        extra_file_url = iframe_src.split("?")[0] + "image.jpg"
+        extra_file_status = self.execute_script(f"""
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', '{extra_file_url}', false);
+            xhr.send();
+            return xhr.status;
+            """)
+        assert extra_file_status == 200, f"Extra file not accessible at {extra_file_url}, got HTTP {extra_file_status}"
+        self.screenshot("dataset_display_extra_files_loaded")

--- a/test/functional/tools/html_output_with_extra_files.xml
+++ b/test/functional/tools/html_output_with_extra_files.xml
@@ -1,0 +1,27 @@
+<tool id="html_output_with_extra_files" name="html_output_with_extra_files" version="1.0.0">
+    <command><![CDATA[
+mkdir -p '$output.extra_files_path' &&
+cp '$html_file' '$output' &&
+cp '$__tool_directory__/data/rgWebLogo3_test.jpg' '$output.extra_files_path/image.jpg'
+    ]]></command>
+    <configfiles>
+        <configfile name="html_file"><![CDATA[
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title data-description="extra-files-test">Extra Files Test</title>
+</head>
+<body>
+    <main>
+       <h1 id="main-heading">HTML with Extra Files</h1>
+       <img id="extra-file-image" src="image.jpg" alt="test image" />
+    </main>
+</body>
+</html>
+        ]]></configfile>
+    </configfiles>
+    <outputs>
+        <data name="output" format="html" />
+    </outputs>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -257,6 +257,7 @@
   <tool file="multiple_versions_changes_v01.xml" />
   <tool file="multiple_versions_changes_v02.xml" />
   <tool file="html_output.xml" />
+  <tool file="html_output_with_extra_files.xml" />
 
   <tool file="interactivetool_simple.xml" />
   <tool file="interactivetool_two_entry_points.xml" />


### PR DESCRIPTION
The switch from srcdoc to iframe src (d3b31b05540) broke HTML datasets that reference extra files via relative paths (JBrowse2, FastQC, etc). Without a trailing slash on the display URL, the browser resolves relative paths against /datasets/{id}/ instead of /datasets/{id}/display/, so sub-resources like static/js/main.js hit routes that don't exist. Adding the trailing slash fixes resolution and matches the existing pattern in HistoryDatasetDisplay.vue.

This fixes https://github.com/galaxyproject/usegalaxy-tools/issues/1380

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
