### PR TITLE
[25.1] Fix AttributeError when requesting invalid metadata file

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -734,13 +734,19 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         """
         hda = self.hda_manager.get_accessible(history_content_id, trans.user)
         self.hda_manager.ensure_dataset_on_disk(trans, hda)
-        file_ext = hda.metadata.spec.get(metadata_file).get("file_ext", metadata_file)
+        metadata_spec = hda.metadata.spec.get(metadata_file)
+        if metadata_spec is None:
+            raise galaxy_exceptions.RequestParameterInvalidException(f"Unknown metadata file: {metadata_file}")
+        file_ext = metadata_spec.get("file_ext", metadata_file)
         fname = "".join(c in util.FILENAME_VALID_CHARS and c or "_" for c in hda.name)[0:150]
         headers = {}
         headers["Content-Type"] = "application/octet-stream"
         headers["Content-Disposition"] = f'attachment; filename="Galaxy{hda.hid}-[{fname}].{file_ext}"'
         mf = hda.metadata.get(metadata_file)
-        assert mf
+        if mf is None:
+            raise galaxy_exceptions.RequestParameterInvalidException(
+                f"Metadata file {metadata_file} is not set for this dataset"
+            )
         file_path = mf.get_file_name()
         if open_file:
             return open(file_path, "rb"), headers


### PR DESCRIPTION
Raise RequestParameterInvalidException instead of crashing when the requested metadata file name doesn't exist in the dataset's metadata spec.

Fixes https://github.com/galaxyproject/galaxy/issues/21968

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
