### PR TITLE
[25.1] Restore file doesn't match sniffed datatype message

### DIFF
--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -398,6 +398,9 @@ def _fetch_target(upload_config: "UploadConfig", target: dict[str, Any]):
             effective_state = "deferred"
             registry = upload_config.registry
             ext = sniff.guess_ext_from_file_name(name, registry=registry, requested_ext=requested_ext)
+        info = f"uploaded {ext} file"
+        if stdout:
+            info = f"{info}\n{stdout}"
         rval = {
             "name": name,
             "dbkey": dbkey,
@@ -405,7 +408,7 @@ def _fetch_target(upload_config: "UploadConfig", target: dict[str, Any]):
             "link_data_only": link_data_only,
             "sources": sources,
             "hashes": hashes,
-            "info": f"uploaded {ext} file",
+            "info": info,
             "state": effective_state,
         }
         if path:

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -306,6 +306,7 @@ def _fetch_target(upload_config: "UploadConfig", target: dict[str, Any]):
             requested_transform.append({"action": "to_posix_lines"})
         source_dict["requested_transform"] = requested_transform
         effective_state = "ok"
+        stdout: Optional[str] = None
         if not deferred and not error_message:
             in_place = item.get("in_place", default_in_place)
             purge_source = item.get("purge_source", True)

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -993,6 +993,12 @@ class TestToolsUpload(ApiTestCase):
         history_id, new_dataset = self._upload("  https://usegalaxy.org/api/version  ")
         self.dataset_populator.get_history_dataset_details(history_id, dataset_id=new_dataset["id"], assert_ok=True)
 
+    def test_fetch_data_type_mismatch_warning(self):
+        details = self._upload_and_get_details("ATGC", api="fetch", ext="fasta")
+        assert details["state"] == "ok"
+        assert details["file_ext"] == "fasta"
+        assert "does not appear to be of that type" in details.get("misc_info", ""), details
+
     def test_upload_and_validate_invalid(self):
         path = TestDataResolver().get_filename("1.fastqsanger")
         with open(path, "rb") as fh:


### PR DESCRIPTION
That's something the upload1 tool used to do and it was somewhat useful.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
