### PR TITLE
Model subcollection mapping (map_over_type) and DCE in tool parameter schema

### DIFF
--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -21,14 +21,14 @@ from galaxy.tool_util_models.parameters import (
     DataCollectionRequestInternal,
     DataColumnParameterModel,
     DataInternalJson,
+    DataJobInternalT,
     DataParameterModel,
     DataRequestCollectionUri,
     DataRequestHda,
-    DataJobInternalT,
     DataRequestInternalHda,
     DataRequestInternalHdca,
-    DatasetCollectionElementReference,
     DataRequestUri,
+    DatasetCollectionElementReference,
     DiscriminatorType,
     DrillDownParameterModel,
     FloatParameterModel,
@@ -549,12 +549,10 @@ def runtimeify(
         src = value.get("src")
         if src == "dce":
             dce_ref = DatasetCollectionElementReference(**value)
-            as_json = adapt_dataset(dce_ref).model_dump()
+            as_json = adapt_dataset(dce_ref).model_dump(by_alias=True)
         else:
             data_request_internal_hda = DataRequestInternalHda(**value)
-            as_json = adapt_dataset(data_request_internal_hda).model_dump()
-        # well this is wrong
-        as_json["class"] = as_json.pop("class_")
+            as_json = adapt_dataset(data_request_internal_hda).model_dump(by_alias=True)
         return as_json
 
     def to_runtime_callback(parameter: ToolParameterT, value: Any):

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -24,9 +24,10 @@ from galaxy.tool_util_models.parameters import (
     DataParameterModel,
     DataRequestCollectionUri,
     DataRequestHda,
-    DataRequestInternalDereferencedT,
+    DataJobInternalT,
     DataRequestInternalHda,
     DataRequestInternalHdca,
+    DatasetCollectionElementReference,
     DataRequestUri,
     DiscriminatorType,
     DrillDownParameterModel,
@@ -525,14 +526,14 @@ def _decode_callback_for(decode_id: DecodeFunctionT) -> Callback:
             if value is None:
                 return VISITOR_NO_REPLACEMENT
             assert isinstance(value, dict), str(value)
-            return decode_src_dict(value)
+            return decode_element(value)
         else:
             return VISITOR_NO_REPLACEMENT
 
     return decode_callback
 
 
-DatasetToRuntimeJson = Callable[[DataRequestInternalDereferencedT], DataInternalJson]
+DatasetToRuntimeJson = Callable[[DataJobInternalT], DataInternalJson]
 CollectionToRuntimeJson = Callable[[DataCollectionRequestInternal, Optional[str]], Any]
 
 
@@ -545,8 +546,13 @@ def runtimeify(
 
     def adapt_dict(value: dict):
         assert isinstance(value, dict), str(value)
-        data_request_internal_hda = DataRequestInternalHda(**value)
-        as_json = adapt_dataset(data_request_internal_hda).model_dump()
+        src = value.get("src")
+        if src == "dce":
+            dce_ref = DatasetCollectionElementReference(**value)
+            as_json = adapt_dataset(dce_ref).model_dump()
+        else:
+            data_request_internal_hda = DataRequestInternalHda(**value)
+            as_json = adapt_dataset(data_request_internal_hda).model_dump()
         # well this is wrong
         as_json["class"] = as_json.pop("class_")
         return as_json

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -1154,9 +1154,7 @@ AdaptedDataCollectionRequestInternalTypeAdapter = TypeAdapter(
     AdaptedDataCollectionRequestInternal
 )  # type: ignore[var-annotated]
 
-DataCollectionJobInternal: Type = union_type(
-    [DataCollectionRequestInternal, AdaptedDataCollectionRequestInternal]
-)
+DataCollectionJobInternal: Type = Union[DataCollectionRequestInternal, AdaptedDataCollectionRequestInternal]  # type: ignore[assignment]
 
 
 class DataCollectionParameterModel(BaseGalaxyToolParameterModelDefinition):

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -537,6 +537,12 @@ class BatchDataHdcaInstance(StrictModel):
     map_over_type: Optional[str] = None
 
 
+class BatchDataDceInstance(StrictModel):
+    src: Literal["dce"]
+    id: StrictStr
+    map_over_type: Optional[str] = None
+
+
 class BatchDataNonCollectionInstance(StrictModel):
     src: Literal["hda", "ldda"]
     id: StrictStr
@@ -544,7 +550,9 @@ class BatchDataNonCollectionInstance(StrictModel):
 
 BatchDataInstance: Type = cast(
     Type,
-    Annotated[Union[BatchDataHdcaInstance, BatchDataNonCollectionInstance], Field(discriminator="src")],
+    Annotated[
+        Union[BatchDataHdcaInstance, BatchDataDceInstance, BatchDataNonCollectionInstance], Field(discriminator="src")
+    ],
 )
 
 
@@ -622,6 +630,9 @@ class DataInternalJson(StrictModel):
     # "secondaryFiles": List[Any],
     checksum: Optional[str] = None
     size: int
+    # When a gx_data param receives a DCE (subcollection mapping), preserve element_identifier
+    # for output naming and collection traceability
+    element_identifier: Optional[str] = None
 
 
 class DataCollectionElementInternalJson(DataInternalJson):
@@ -909,6 +920,12 @@ class BatchDataHdcaInstanceInternal(StrictModel):
     map_over_type: Optional[str] = None
 
 
+class BatchDataDceInstanceInternal(StrictModel):
+    src: Literal["dce"]
+    id: StrictInt
+    map_over_type: Optional[str] = None
+
+
 class BatchDataNonCollectionInstanceInternal(StrictModel):
     src: Literal["hda", "ldda"]
     id: StrictInt
@@ -916,7 +933,10 @@ class BatchDataNonCollectionInstanceInternal(StrictModel):
 
 BatchDataInstanceInternal: Type = cast(
     Type,
-    Annotated[Union[BatchDataHdcaInstanceInternal, BatchDataNonCollectionInstanceInternal], Field(discriminator="src")],
+    Annotated[
+        Union[BatchDataHdcaInstanceInternal, BatchDataDceInstanceInternal, BatchDataNonCollectionInstanceInternal],
+        Field(discriminator="src"),
+    ],
 )
 
 
@@ -1230,9 +1250,7 @@ class DataCollectionParameterModel(BaseGalaxyToolParameterModelDefinition):
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         if state_representation in ["request", "relaxed_request"]:
-            return allow_batching(
-                dynamic_model_information_from_py_type(self, self.py_type), BatchCollectionInstance
-            )
+            return allow_batching(dynamic_model_information_from_py_type(self, self.py_type), BatchCollectionInstance)
         elif state_representation == "landing_request":
             return allow_batching(
                 dynamic_model_information_from_py_type(self, self.py_type, requires_value=False),

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -531,9 +531,21 @@ DataRequestCollectionUri.model_rebuild()
 DataOrCollectionRequestAdapter: TypeAdapter[DataOrCollectionRequest] = TypeAdapter(DataOrCollectionRequest)
 
 
-class BatchDataInstance(StrictModel):
-    src: MultiDataSrcT
+class BatchDataHdcaInstance(StrictModel):
+    src: Literal["hdca"]
     id: StrictStr
+    map_over_type: Optional[str] = None
+
+
+class BatchDataNonCollectionInstance(StrictModel):
+    src: Literal["hda", "ldda"]
+    id: StrictStr
+
+
+BatchDataInstance: Type = cast(
+    Type,
+    Annotated[Union[BatchDataHdcaInstance, BatchDataNonCollectionInstance], Field(discriminator="src")],
+)
 
 
 def multi_data_discriminator(v: Any) -> str:
@@ -877,12 +889,35 @@ DataRequestInternalDereferenced: Type = cast(
     Type,
     Annotated[DataRequestInternalDereferencedT, Field(discriminator="src")],
 )
-DataJobInternal = DataRequestInternalDereferenced
 
 
-class BatchDataInstanceInternal(StrictModel):
-    src: MultiDataSrcT
+class DatasetCollectionElementReference(StrictModel):
+    src: Literal["dce"]
     id: StrictInt
+
+
+DataJobInternalT = Union[DataRequestInternalHda, DataRequestInternalLdda, DatasetCollectionElementReference]
+DataJobInternal: Type = cast(
+    Type,
+    Annotated[DataJobInternalT, Field(discriminator="src")],
+)
+
+
+class BatchDataHdcaInstanceInternal(StrictModel):
+    src: Literal["hdca"]
+    id: StrictInt
+    map_over_type: Optional[str] = None
+
+
+class BatchDataNonCollectionInstanceInternal(StrictModel):
+    src: Literal["hda", "ldda"]
+    id: StrictInt
+
+
+BatchDataInstanceInternal: Type = cast(
+    Type,
+    Annotated[Union[BatchDataHdcaInstanceInternal, BatchDataNonCollectionInstanceInternal], Field(discriminator="src")],
+)
 
 
 MultiDataInstanceInternal: Type = cast(
@@ -956,6 +991,15 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
         return optional_if_needed(base_model, self.optional)
 
     @property
+    def py_type_job_internal(self) -> Type:
+        base_model: Type
+        if self.multiple:
+            base_model = MultiDataRequestInternalDereferenced
+        else:
+            base_model = DataJobInternal
+        return optional_if_needed(base_model, self.optional)
+
+    @property
     def py_type_test_case(self) -> Type:
         base_model: Type
         if self.multiple:
@@ -986,7 +1030,7 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
                 BatchDataInstanceInternal,
             )
         elif state_representation == "job_internal":
-            return dynamic_model_information_from_py_type(self, self.py_type_internal_dereferenced, requires_value=True)
+            return dynamic_model_information_from_py_type(self, self.py_type_job_internal, requires_value=True)
         elif state_representation == "job_runtime":
             return dynamic_model_information_from_py_type(self, self.py_type_internal_json, requires_value=True)
         elif state_representation == "test_case_xml":
@@ -1010,6 +1054,18 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
 class DataCollectionRequest(StrictModel):
     src: CollectionStrT
     id: StrictStr
+
+
+class BatchCollectionInstance(StrictModel):
+    src: CollectionStrT
+    id: StrictStr
+    map_over_type: Optional[str] = None
+
+
+class BatchCollectionInstanceInternal(StrictModel):
+    src: CollectionInternalSrcT
+    id: StrictInt
+    map_over_type: Optional[str] = None
 
 
 DataCollectionRequestOrCollectionUri: Type = union_type([DataCollectionRequest, DataRequestCollectionUri])
@@ -1062,11 +1118,6 @@ AdaptedDataCollectionRequest = Annotated[
     Field(discriminator="adapter_type"),
 ]
 AdaptedDataCollectionRequestTypeAdapter = TypeAdapter(AdaptedDataCollectionRequest)  # type: ignore[var-annotated]
-
-
-class DatasetCollectionElementReference(StrictModel):
-    src: Literal["dce"]
-    id: StrictInt
 
 
 class AdaptedDataCollectionPromoteCollectionElementToCollectionRequestInternal(AdaptedDataCollectionRequestBase):
@@ -1177,17 +1228,29 @@ class DataCollectionParameterModel(BaseGalaxyToolParameterModelDefinition):
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         if state_representation in ["request", "relaxed_request"]:
-            return allow_batching(dynamic_model_information_from_py_type(self, self.py_type))
+            return allow_batching(
+                dynamic_model_information_from_py_type(self, self.py_type), BatchCollectionInstance
+            )
         elif state_representation == "landing_request":
-            return allow_batching(dynamic_model_information_from_py_type(self, self.py_type, requires_value=False))
+            return allow_batching(
+                dynamic_model_information_from_py_type(self, self.py_type, requires_value=False),
+                BatchCollectionInstance,
+            )
         elif state_representation == "landing_request_internal":
             return allow_batching(
-                dynamic_model_information_from_py_type(self, self.py_type_internal, requires_value=False)
+                dynamic_model_information_from_py_type(self, self.py_type_internal, requires_value=False),
+                BatchCollectionInstanceInternal,
             )
         elif state_representation == "request_internal":
-            return allow_batching(dynamic_model_information_from_py_type(self, self.py_type_internal))
+            return allow_batching(
+                dynamic_model_information_from_py_type(self, self.py_type_internal),
+                BatchCollectionInstanceInternal,
+            )
         elif state_representation == "request_internal_dereferenced":
-            return allow_batching(dynamic_model_information_from_py_type(self, self.py_type_internal_dereferenced))
+            return allow_batching(
+                dynamic_model_information_from_py_type(self, self.py_type_internal_dereferenced),
+                BatchCollectionInstanceInternal,
+            )
         elif state_representation == "job_internal":
             return dynamic_model_information_from_py_type(self, self.py_type_internal, requires_value=True)
         elif state_representation == "job_runtime":

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -1154,6 +1154,10 @@ AdaptedDataCollectionRequestInternalTypeAdapter = TypeAdapter(
     AdaptedDataCollectionRequestInternal
 )  # type: ignore[var-annotated]
 
+DataCollectionJobInternal: Type = union_type(
+    [DataCollectionRequestInternal, AdaptedDataCollectionRequestInternal]
+)
+
 
 class DataCollectionParameterModel(BaseGalaxyToolParameterModelDefinition):
     parameter_type: Literal["gx_data_collection"] = "gx_data_collection"
@@ -1252,7 +1256,9 @@ class DataCollectionParameterModel(BaseGalaxyToolParameterModelDefinition):
                 BatchCollectionInstanceInternal,
             )
         elif state_representation == "job_internal":
-            return dynamic_model_information_from_py_type(self, self.py_type_internal, requires_value=True)
+            return dynamic_model_information_from_py_type(
+                self, optional_if_needed(DataCollectionJobInternal, self.optional), requires_value=True
+            )
         elif state_representation == "job_runtime":
             return dynamic_model_information_from_py_type(self, self.py_type_internal_json, requires_value=True)
         elif state_representation == "workflow_step":

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -469,21 +469,27 @@ def __expand_collection_parameter_async(
     # be "hdca_id|subcollection_type" else it will just be hdca_id
     try:
         src = incoming_val["src"]
-        if src != "hdca":
+        if src not in ("hdca", "dce"):
             raise exceptions.ToolMetaParameterException(f"Invalid dataset collection source type {src}")
-        hdc_id = incoming_val["id"]
+        item_id = incoming_val["id"]
         subcollection_type = incoming_val.get("map_over_type", None)
     except TypeError:
-        hdc_id = incoming_val
+        item_id = incoming_val
+        src = "hdca"
         subcollection_type = None
-    hdc = app.model.context.get(HistoryDatasetCollectionAssociation, hdc_id)
-    collections_to_match.add(input_key, hdc, subcollection_type=subcollection_type, linked=linked)
+    if src == "dce":
+        item = app.model.context.get(DatasetCollectionElement, item_id)
+        collection = item.child_collection
+    else:
+        item = app.model.context.get(HistoryDatasetCollectionAssociation, item_id)
+        collection = item.collection
+    collections_to_match.add(input_key, item, subcollection_type=subcollection_type, linked=linked)
     if subcollection_type is not None:
-        subcollection_elements = subcollections.split_dataset_collection_instance(hdc, subcollection_type)
+        subcollection_elements = subcollections._split_dataset_collection(collection, subcollection_type)
         return subcollection_elements
     else:
         hdas: list[DatasetInstance] = []
-        for element in hdc.collection.dataset_elements:
+        for element in collection.dataset_elements:
             hda = element.dataset_instance
             hda.element_identifier = element.element_identifier
             hdas.append(hda)

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -446,10 +446,11 @@ def __expand_collection_parameter(
     if src == "dce":
         item = trans.sa_session.get_one(DatasetCollectionElement, decoded_id)
         collection = item.child_collection
+        if not collection:
+            raise exceptions.ToolMetaParameterException(f"DCE {decoded_id} does not contain a child collection")
     else:
         item = trans.sa_session.get_one(HistoryDatasetCollectionAssociation, decoded_id)
         collection = item.collection
-    assert collection
     if not collection.populated_optimized:
         raise exceptions.ToolInputsNotReadyException("An input collection is not populated.")
     collections_to_match.add(input_key, item, subcollection_type=subcollection_type, linked=linked)
@@ -485,6 +486,8 @@ def __expand_collection_parameter_async(
     if src == "dce":
         item = app.model.context.get(DatasetCollectionElement, item_id)
         collection = item.child_collection
+        if not collection:
+            raise exceptions.ToolMetaParameterException(f"DCE {item_id} does not contain a child collection")
     else:
         item = app.model.context.get(HistoryDatasetCollectionAssociation, item_id)
         collection = item.collection

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -23,7 +23,10 @@ from galaxy.model.dataset_collections import (
     matching,
     subcollections,
 )
-from galaxy.model.dataset_collections.adapters import PromoteCollectionElementToCollectionAdapter
+from galaxy.model.dataset_collections.adapters import (
+    CollectionAdapter,
+    PromoteCollectionElementToCollectionAdapter,
+)
 from galaxy.tool_util.parameters import RequestInternalDereferencedToolState
 from galaxy.util.permutations import (
     build_combos,
@@ -399,6 +402,8 @@ def to_decoded_json(has_objects):
         return decoded_json
     elif isinstance(has_objects, list):
         return [to_decoded_json(o) for o in has_objects]
+    elif isinstance(has_objects, CollectionAdapter):
+        return has_objects.to_adapter_model().model_dump()
     elif isinstance(has_objects, DatasetCollectionElement):
         return {"src": "dce", "id": has_objects.id}
     elif isinstance(has_objects, HistoryDatasetAssociation):

--- a/lib/galaxy/tools/runtime.py
+++ b/lib/galaxy/tools/runtime.py
@@ -19,7 +19,8 @@ from galaxy.tool_util_models.parameters import (
     DataCollectionInternalJsonBase,
     DataCollectionRequestInternal,
     DataInternalJson,
-    DataRequestInternalDereferencedT,
+    DataJobInternalT,
+    DatasetCollectionElementReference,
     DataRequestInternalHda,
 )
 
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 
 
 # Type aliases for callbacks
-DatasetToRuntimeJson = Callable[[DataRequestInternalDereferencedT], DataInternalJson]
+DatasetToRuntimeJson = Callable[[DataJobInternalT], DataInternalJson]
 CollectionToRuntimeJson = Callable[[DataCollectionRequestInternal, Optional[str]], DataCollectionInternalJsonBase]
 
 # Input dataset collections dict type - values are HDCAs (from job.input_dataset_collections)
@@ -74,7 +75,15 @@ def setup_for_runtimeify(
             elif isinstance(value, DatasetCollectionElement):
                 dces_by_id[value.id] = value
 
-    def adapt_dataset(value: DataRequestInternalDereferencedT) -> DataInternalJson:
+    def adapt_dataset(value: DataJobInternalT) -> DataInternalJson:
+        if isinstance(value, DatasetCollectionElementReference):
+            dce = dces_by_id.get(value.id)
+            if not dce:
+                raise ValueError(f"DCE {value.id} not found")
+            hda = dce.hda
+            if not hda:
+                raise ValueError(f"DCE {value.id} does not reference an HDA")
+            return adapt_dataset(DataRequestInternalHda(src="hda", id=hda.id))
         hda_id = value.id
         if hda_id not in hdas_by_id:
             raise ValueError(f"Could not find HDA for dataset id {hda_id}")

--- a/lib/galaxy/tools/runtime.py
+++ b/lib/galaxy/tools/runtime.py
@@ -9,6 +9,7 @@ from typing import (
 from galaxy.model import (
     DatasetCollection,
     DatasetCollectionElement,
+    DatasetInstance,
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
     InpDataDictT,
@@ -62,7 +63,7 @@ def setup_for_runtimeify(
     hda_references: list[HistoryDatasetAssociation] = []
 
     # Build lookup for individual datasets
-    hdas_by_id: dict[int, tuple[HistoryDatasetAssociation, int]] = {d.id: (d, i) for (i, d) in enumerate(input_datasets.values()) if d is not None}
+    hdas_by_id: dict[int, tuple[DatasetInstance, int]] = {d.id: (d, i) for (i, d) in enumerate(input_datasets.values()) if d is not None}
 
     # Build separate lookups for HDCAs and DCEs
     hdcas_by_id: dict[int, HistoryDatasetCollectionAssociation] = {}
@@ -87,6 +88,7 @@ def setup_for_runtimeify(
         hda_id = value.id
         if hda_id not in hdas_by_id:
             raise ValueError(f"Could not find HDA for dataset id {hda_id}")
+        hda: DatasetInstance
         hda, index = hdas_by_id[hda_id]
         if not hda:
             raise ValueError(f"Could not find HDA for dataset id {hda_id}")

--- a/lib/galaxy/tools/runtime.py
+++ b/lib/galaxy/tools/runtime.py
@@ -62,7 +62,7 @@ def setup_for_runtimeify(
     hda_references: list[HistoryDatasetAssociation] = []
 
     # Build lookup for individual datasets
-    hdas_by_id = {d.id: (d, i) for (i, d) in enumerate(input_datasets.values()) if d is not None}
+    hdas_by_id: dict[int, tuple[HistoryDatasetAssociation, int]] = {d.id: (d, i) for (i, d) in enumerate(input_datasets.values()) if d is not None}
 
     # Build separate lookups for HDCAs and DCEs
     hdcas_by_id: dict[int, HistoryDatasetCollectionAssociation] = {}
@@ -91,7 +91,7 @@ def setup_for_runtimeify(
         if not hda:
             raise ValueError(f"Could not find HDA for dataset id {hda_id}")
         size = hda.dataset.get_size() if hda and hda.dataset else 0
-        properties = {
+        properties: dict[str, Any] = {
             "class": "File",
             "location": f"step_input://{index}",
             "format": hda.extension,

--- a/lib/galaxy/tools/runtime.py
+++ b/lib/galaxy/tools/runtime.py
@@ -21,8 +21,8 @@ from galaxy.tool_util_models.parameters import (
     DataCollectionRequestInternal,
     DataInternalJson,
     DataJobInternalT,
-    DatasetCollectionElementReference,
     DataRequestInternalHda,
+    DatasetCollectionElementReference,
 )
 
 if TYPE_CHECKING:
@@ -63,7 +63,9 @@ def setup_for_runtimeify(
     hda_references: list[HistoryDatasetAssociation] = []
 
     # Build lookup for individual datasets
-    hdas_by_id: dict[int, tuple[DatasetInstance, int]] = {d.id: (d, i) for (i, d) in enumerate(input_datasets.values()) if d is not None}
+    hdas_by_id: dict[int, tuple[DatasetInstance, int]] = {
+        d.id: (d, i) for (i, d) in enumerate(input_datasets.values()) if d is not None
+    }
 
     # Build separate lookups for HDCAs and DCEs
     hdcas_by_id: dict[int, HistoryDatasetCollectionAssociation] = {}
@@ -81,27 +83,34 @@ def setup_for_runtimeify(
             dce = dces_by_id.get(value.id)
             if not dce:
                 raise ValueError(f"DCE {value.id} not found")
-            hda = dce.hda
-            if not hda:
+            dce_hda = dce.hda
+            if not dce_hda:
                 raise ValueError(f"DCE {value.id} does not reference an HDA")
-            return adapt_dataset(DataRequestInternalHda(src="hda", id=hda.id))
+            # Resolve to HDA but preserve element_identifier for output naming
+            # and collection traceability
+            result = adapt_dataset(DataRequestInternalHda(src="hda", id=dce_hda.id))
+            return DataInternalJson(
+                **{**result.model_dump(by_alias=True), "element_identifier": dce.element_identifier}
+            )
         hda_id = value.id
         if hda_id not in hdas_by_id:
             raise ValueError(f"Could not find HDA for dataset id {hda_id}")
-        hda: DatasetInstance
-        hda, index = hdas_by_id[hda_id]
-        if not hda:
+        hda_entry: DatasetInstance
+        hda_entry, index = hdas_by_id[hda_id]
+        if not hda_entry:
             raise ValueError(f"Could not find HDA for dataset id {hda_id}")
-        size = hda.dataset.get_size() if hda and hda.dataset else 0
+        size = hda_entry.dataset.get_size() if hda_entry and hda_entry.dataset else 0
         properties: dict[str, Any] = {
             "class": "File",
             "location": f"step_input://{index}",
-            "format": hda.extension,
-            "path": compute_environment.input_path_rewrite(hda) if compute_environment else hda.get_file_name(),
+            "format": hda_entry.extension,
+            "path": (
+                compute_environment.input_path_rewrite(hda_entry) if compute_environment else hda_entry.get_file_name()
+            ),
             "size": int(size),
             "listing": [],
         }
-        set_basename_and_derived_properties(properties, hda.dataset.created_from_basename or hda.name)
+        set_basename_and_derived_properties(properties, hda_entry.dataset.created_from_basename or hda_entry.name)
         return DataInternalJson(**properties)
 
     def adapt_collection(
@@ -271,10 +280,7 @@ def _element_to_runtime(
         hda = element.element_object
         assert hda is not None
         request = DataRequestInternalHda(src="hda", id=hda.id)
-        result = adapt_dataset(request).model_dump()
-        # Rename class_ back to class for JSON output
-        if "class_" in result:
-            result["class"] = result.pop("class_")
+        result = adapt_dataset(request).model_dump(by_alias=True)
         result["element_identifier"] = element.element_identifier
         # Add columns for sample_sheet leaf elements
         if element.columns:

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -180,11 +180,17 @@ def test_map_over_with_output_format_actions(
 
 
 @requires_tool_id("output_action_change_format_paired")
-def test_map_over_with_nested_paired_output_format_actions(target_history: TargetHistory, required_tool: RequiredTool):
+def test_map_over_with_nested_paired_output_format_actions(
+    target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
     hdca = target_history.with_example_list_of_pairs()
-    execute = required_tool.execute().with_inputs(
-        {"input": {"batch": True, "values": [dict(map_over_type="paired", **hdca.src_dict)]}}
+    batch_val = dict(map_over_type="paired", **hdca.src_dict)
+    inputs = (
+        tool_input_format.when.flat({"input": {"batch": True, "values": [batch_val]}})
+        .when.nested({"input": {"batch": True, "values": [batch_val]}})
+        .when.request({"input": {"__class__": "Batch", "values": [batch_val]}})
     )
+    execute = required_tool.execute().with_inputs(inputs)
     execute.assert_has_n_jobs(2).assert_creates_n_implicit_collections(1)
     execute.assert_has_job(0).with_single_output.with_file_ext("txt")
     execute.assert_has_job(1).with_single_output.with_file_ext("txt")
@@ -502,11 +508,17 @@ def test_map_over_data_with_list_paired_or_unpaired(target_history: TargetHistor
 
 
 @requires_tool_id("collection_paired_or_unpaired")
-def test_map_over_paired_or_unpaired_with_list_paired(target_history: TargetHistory, required_tool: RequiredTool):
+def test_map_over_paired_or_unpaired_with_list_paired(
+    target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
     hdca = target_history.with_example_list_of_pairs()
-    execute = required_tool.execute().with_inputs(
-        {"f1": {"batch": True, "values": [{"map_over_type": "paired", **hdca.src_dict}]}}
+    batch_val = {"map_over_type": "paired", **hdca.src_dict}
+    inputs = (
+        tool_input_format.when.flat({"f1": {"batch": True, "values": [batch_val]}})
+        .when.nested({"f1": {"batch": True, "values": [batch_val]}})
+        .when.request({"f1": {"__class__": "Batch", "values": [batch_val]}})
     )
+    execute = required_tool.execute().with_inputs(inputs)
     execute.assert_has_n_jobs(2).assert_creates_n_implicit_collections(1)
     output_collection = execute.assert_creates_implicit_collection(0)
     output_collection.assert_has_dataset_element("test0").with_contents_stripped("123\n456")
@@ -514,12 +526,18 @@ def test_map_over_paired_or_unpaired_with_list_paired(target_history: TargetHist
 
 
 @requires_tool_id("collection_paired_or_unpaired")
-def test_map_over_paired_or_unpaired_with_list(target_history: TargetHistory, required_tool: RequiredTool):
+def test_map_over_paired_or_unpaired_with_list(
+    target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
     contents = [("foo", "text for foo element")]
     hdca = target_history.with_list(contents)
-    execute = required_tool.execute().with_inputs(
-        {"f1": {"batch": True, "values": [{"map_over_type": "single_datasets", **hdca.src_dict}]}}
+    batch_val = {"map_over_type": "single_datasets", **hdca.src_dict}
+    inputs = (
+        tool_input_format.when.flat({"f1": {"batch": True, "values": [batch_val]}})
+        .when.nested({"f1": {"batch": True, "values": [batch_val]}})
+        .when.request({"f1": {"__class__": "Batch", "values": [batch_val]}})
     )
+    execute = required_tool.execute().with_inputs(inputs)
     execute.assert_has_n_jobs(1).assert_creates_n_implicit_collections(1)
     output_collection = execute.assert_creates_implicit_collection(0)
     output_collection.assert_has_dataset_element("foo").with_contents_stripped("text for foo element")
@@ -549,6 +567,24 @@ def test_map_over_paired_or_unpaired_with_list_of_lists(target_history: TargetHi
     assert output_collection.details["collection_type"] == "list:list"
     as_dict_0 = output_collection.with_element_dict(0)
     assert len(as_dict_0["object"]["elements"]) == 3
+
+
+@requires_tool_id("collection_paired_test")
+def test_simple_subcollection_mapping(
+    target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
+    hdca = target_history.with_example_list_of_pairs()
+    batch_val = {"map_over_type": "paired", **hdca.src_dict}
+    inputs = (
+        tool_input_format.when.flat({"f1": {"batch": True, "values": [batch_val]}})
+        .when.nested({"f1": {"batch": True, "values": [batch_val]}})
+        .when.request({"f1": {"__class__": "Batch", "values": [batch_val]}})
+    )
+    execute = required_tool.execute().with_inputs(inputs)
+    execute.assert_has_n_jobs(2).assert_creates_n_implicit_collections(1)
+    output_collection = execute.assert_creates_implicit_collection(0)
+    output_collection.assert_has_dataset_element("test0").with_contents_stripped("123\n456")
+    output_collection.assert_has_dataset_element("test1").with_contents_stripped("789\n0ab")
 
 
 @requires_tool_id("collection_paired_or_unpaired")

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -13,6 +13,8 @@ import pytest
 
 from galaxy_test.base.decorators import requires_tool_id
 from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
+    DatasetPopulator,
     DescribeToolExecution,
     DescribeToolInputs,
     RequiredTool,
@@ -808,3 +810,55 @@ def test_deferred_multi_input(required_tool: RequiredTool, target_history: Targe
     output = required_tool.execute().with_inputs(inputs).assert_has_single_job.with_single_output
     output.assert_contains("chr1	147962192	147962580	CCDS989.1_cds_0_0_chr1_147962193_r	0	-")
     output.assert_contains("chr1    4225    19670")
+
+
+@requires_tool_id("collection_mixed_param")
+def test_combined_mapping_and_subcollection_mapping(
+    target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
+    hdca = target_history.with_example_list_of_pairs()
+    list_hdca = target_history.with_list(contents=["xxx\n", "yyy\n"])
+    f1_batch = {"map_over_type": "paired", **hdca.src_dict}
+    f2_batch = {**list_hdca.src_dict}
+    inputs = (
+        tool_input_format.when.flat(
+            {"f1": {"batch": True, "values": [f1_batch]}, "f2": {"batch": True, "values": [f2_batch]}}
+        )
+        .when.nested({"f1": {"batch": True, "values": [f1_batch]}, "f2": {"batch": True, "values": [f2_batch]}})
+        .when.request(
+            {
+                "f1": {"__class__": "Batch", "values": [f1_batch]},
+                "f2": {"__class__": "Batch", "values": [f2_batch]},
+            }
+        )
+    )
+    execute = required_tool.execute().with_inputs(inputs)
+    execute.assert_has_n_jobs(2).assert_creates_n_implicit_collections(1)
+    output_collection = execute.assert_creates_implicit_collection(0)
+    output_collection.assert_has_dataset_element("test0").with_contents_stripped("123\n456\nxxx")
+    output_collection.assert_has_dataset_element("test1").with_contents_stripped("789\n0ab\nyyy")
+
+
+@requires_tool_id("cat1")
+def test_map_over_dce_on_non_multiple_data_param(
+    target_history: TargetHistory,
+    required_tool: RequiredTool,
+    tool_input_format: DescribeToolInputs,
+    dataset_populator: DatasetPopulator,
+    dataset_collection_populator: DatasetCollectionPopulator,
+    history_id: str,
+):
+    hdca = target_history.with_example_list_of_pairs()
+    collection_details = dataset_populator.get_history_collection_details(history_id, content_id=hdca.id)
+    dce_id = collection_details["elements"][0]["id"]
+    dce_val = {"src": "dce", "id": dce_id}
+    inputs = (
+        tool_input_format.when.flat({"input1": {"batch": True, "values": [dce_val]}})
+        .when.nested({"input1": {"batch": True, "values": [dce_val]}})
+        .when.request({"input1": {"__class__": "Batch", "values": [dce_val]}})
+    )
+    execute = required_tool.execute().with_inputs(inputs)
+    execute.assert_has_n_jobs(2).assert_creates_n_implicit_collections(1)
+    output_collection = execute.assert_creates_implicit_collection(0)
+    output_collection.assert_has_dataset_element("test0").with_contents_stripped("123")
+    output_collection.assert_has_dataset_element("test1").with_contents_stripped("456")

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2633,30 +2633,6 @@ class TestToolsApi(ApiTestCase, TestsTools):
         assert len(response_object["jobs"]) == 2
         assert len(response_object["implicit_collections"]) == 1
 
-    @skip_without_tool("cat1")
-    def test_can_map_over_dce_on_non_multiple_data_param(self):
-        with self.dataset_populator.test_history() as history_id:
-            pair_id = self.dataset_collection_populator.create_pair_in_history(
-                history_id, contents=["0", "0"], wait=True
-            ).json()["outputs"][0]["id"]
-            ok_hdca = self.dataset_collection_populator.create_list_from_pairs(history_id, [pair_id])
-            assert ok_hdca.json()["elements"][0]["model_class"] == "DatasetCollectionElement"
-            dce_id = ok_hdca.json()["elements"][0]["id"]
-
-            inputs = {
-                "input1": {
-                    "batch": True,
-                    "values": [{"src": "dce", "id": dce_id, "map_over_type": None}],
-                },
-            }
-            response = self._run_cat1(history_id, inputs=inputs)
-            self._assert_status_code_is(response, 200)
-
-            response_object = response.json()
-            assert len(response_object["outputs"]) == 1
-            assert len(response_object["jobs"]) == 1
-            assert len(response_object["implicit_collections"]) == 1
-
     @skip_without_tool("identifier_source")
     def test_default_identifier_source_map_over(self):
         with self.dataset_populator.test_history() as history_id:
@@ -3017,37 +2993,6 @@ class TestToolsApi(ApiTestCase, TestsTools):
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
         assert output1_content.strip() == "123\n456", output1_content
         assert len(output2_content.strip().split("\n")) == 3, output2_content
-
-    @skip_without_tool("collection_mixed_param")
-    def test_combined_mapping_and_subcollection_mapping(self):
-        with self.dataset_populator.test_history() as history_id:
-            nested_list_id = self.__build_nested_list(history_id)
-            create_response = self.dataset_collection_populator.create_list_in_history(
-                history_id, contents=["xxx\n", "yyy\n"], wait=True
-            )
-            list_id = create_response.json()["output_collections"][0]["id"]
-            inputs = {
-                "f1": {
-                    "batch": True,
-                    "values": [{"src": "hdca", "map_over_type": "paired", "id": nested_list_id}],
-                },
-                "f2": {
-                    "batch": True,
-                    "values": [{"src": "hdca", "id": list_id}],
-                },
-            }
-            self._check_combined_mapping_and_subcollection_mapping(history_id, inputs)
-
-    def _check_combined_mapping_and_subcollection_mapping(self, history_id, inputs):
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        outputs = self._run_and_get_outputs("collection_mixed_param", history_id, inputs)
-        assert len(outputs), 2
-        output1 = outputs[0]
-        output2 = outputs[1]
-        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        assert output1_content.strip() == "123\n456\nxxx", output1_content
-        assert output2_content.strip() == "789\n0ab\nyyy", output2_content
 
     def _check_implicit_collection_populated(self, run_response):
         implicit_collections = run_response["implicit_collections"]

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -3018,31 +3018,6 @@ class TestToolsApi(ApiTestCase, TestsTools):
         assert output1_content.strip() == "123\n456", output1_content
         assert len(output2_content.strip().split("\n")) == 3, output2_content
 
-    @skip_without_tool("collection_paired_test")
-    def test_subcollection_mapping(self):
-        with self.dataset_populator.test_history() as history_id:
-            hdca_list_id = self.__build_nested_list(history_id)
-            inputs = {
-                "f1": {
-                    "batch": True,
-                    "values": [{"src": "hdca", "map_over_type": "paired", "id": hdca_list_id}],
-                }
-            }
-            self._check_simple_subcollection_mapping(history_id, inputs)
-
-    def _check_simple_subcollection_mapping(self, history_id, inputs):
-        # Following wait not really needed - just getting so many database
-        # locked errors with sqlite.
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        outputs = self._run_and_get_outputs("collection_paired_test", history_id, inputs)
-        assert len(outputs), 2
-        output1 = outputs[0]
-        output2 = outputs[1]
-        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        assert output1_content.strip() == "123\n456", output1_content
-        assert output2_content.strip() == "789\n0ab", output2_content
-
     @skip_without_tool("collection_mixed_param")
     def test_combined_mapping_and_subcollection_mapping(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1244,10 +1244,12 @@ gx_data:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd, map_over_type: paired}]}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd, map_over_type: "list:paired"}]}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd, map_over_type: null}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd, map_over_type: paired}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd, map_over_type: null}]}
   request_invalid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
-   - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd}]}
-   # map_over_type only valid on hdca, not hda/ldda
+   # map_over_type only valid on hdca/dce, not hda/ldda
    - parameter: {__class__: "Batch", values: [{src: hda, id: abcdabcd, map_over_type: paired}]}
    - parameter: {src: dce, id: abcdabcd}
    - parameter: {src: hda, id: 7}
@@ -1263,12 +1265,14 @@ gx_data:
   request_internal_valid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5, map_over_type: paired}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: 5}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: 5, map_over_type: paired}]}
    - parameter: {src: hda, id: 5}
    - parameter: {src: hda, id: 0}
    - parameter: {src: url, url: "https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt", ext: "txt"}
   request_internal_invalid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd}]}
-   # map_over_type only valid on hdca, not hda/ldda
+   # map_over_type only valid on hdca/dce, not hda/ldda
    - parameter: {__class__: "Batch", values: [{src: hda, id: 5, map_over_type: paired}]}
    - parameter: {src: hda, id: abcdabcd}
    - parameter: {}
@@ -1279,6 +1283,8 @@ gx_data:
   request_internal_dereferenced_valid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5, map_over_type: paired}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: 5}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: 5, map_over_type: paired}]}
    - parameter: {src: hda, id: 5}
    - parameter: {src: hda, id: 0}
   request_internal_dereferenced_invalid:
@@ -1321,6 +1327,10 @@ gx_data:
   job_runtime_valid:
    - parameter: {class: File, basename: "f.txt", location: "step_input://0",
       path: "/tmp/f.txt", nameroot: "f", nameext: ".txt", format: "txt", size: 100}
+   # DCE resolved to File preserves element_identifier for output naming
+   - parameter: {class: File, basename: "f.txt", location: "step_input://0",
+      path: "/tmp/f.txt", nameroot: "f", nameext: ".txt", format: "txt", size: 100,
+      element_identifier: "test0"}
   job_runtime_invalid:
    - parameter: {src: hda, id: 7}
    - parameter: null
@@ -1656,8 +1666,10 @@ gx_data_collection:
   - parameter: {class: Collection, elements: []}
   job_internal_valid:
     - parameter: {src: hdca, id: 5}
+    - parameter: {src: dce, id: 5}
   job_internal_invalid:
     - parameter: {src: hdca, id: abcdabcd}
+    - parameter: {src: dce, id: abcdabcd}
     - parameter: null
     - {}
   job_runtime_valid:

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1241,8 +1241,15 @@ gx_data:
    - parameter: {src: hda, id: abcdabcd}
    - parameter: {src: url, url: "https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt", "ext": "txt"}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd}]}
+   - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd, map_over_type: paired}]}
+   - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd, map_over_type: "list:paired"}]}
+   - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd, map_over_type: null}]}
   request_invalid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
+   - parameter: {__class__: "Batch", values: [{src: dce, id: abcdabcd}]}
+   # map_over_type only valid on hdca, not hda/ldda
+   - parameter: {__class__: "Batch", values: [{src: hda, id: abcdabcd, map_over_type: paired}]}
+   - parameter: {src: dce, id: abcdabcd}
    - parameter: {src: hda, id: 7}
    - parameter: {src: hdca, id: abcdabcd}
    - parameter: null
@@ -1255,11 +1262,14 @@ gx_data:
    - parameter: "5"
   request_internal_valid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
+   - parameter: {__class__: "Batch", values: [{src: hdca, id: 5, map_over_type: paired}]}
    - parameter: {src: hda, id: 5}
    - parameter: {src: hda, id: 0}
    - parameter: {src: url, url: "https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt", ext: "txt"}
   request_internal_invalid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd}]}
+   # map_over_type only valid on hdca, not hda/ldda
+   - parameter: {__class__: "Batch", values: [{src: hda, id: 5, map_over_type: paired}]}
    - parameter: {src: hda, id: abcdabcd}
    - parameter: {}
    - {}
@@ -1268,6 +1278,7 @@ gx_data:
    - parameter: "5"
   request_internal_dereferenced_valid:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
+   - parameter: {__class__: "Batch", values: [{src: hdca, id: 5, map_over_type: paired}]}
    - parameter: {src: hda, id: 5}
    - parameter: {src: hda, id: 0}
   request_internal_dereferenced_invalid:
@@ -1278,6 +1289,7 @@ gx_data:
    - parameter: {src: hda, id: abcdabcd}
    - parameter: {src: url, url: "https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt", "ext": "txt"}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd}]}
+   - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd, map_over_type: paired}]}
    - {}
    - parameter: {src: url, url: "https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt", "ext": "txt"}
   landing_request_invalid:
@@ -1294,11 +1306,15 @@ gx_data:
    - parameter: {__class__: "Batch", values: [{src: hdca, id: abcdabcd}]}
   job_internal_valid:
    - parameter: {src: hda, id: 7}
+   # subcollection mapping expansion produces DCE refs via to_decoded_json
+   - parameter: {src: dce, id: 5}
   job_internal_invalid:
    # valid request but after the job has been created, map/reduce concepts should have been
    # expanded out.
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    - parameter: {src: hda, id: abcdabcd}
+   # DCE with encoded string ID should fail
+   - parameter: {src: dce, id: abcdabcd}
    # url parameters should be dereferrenced into datasets by this point...
    - parameter: {src: url, url: "https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt", "ext": "txt"}
    - {}


### PR DESCRIPTION
## Summary

- Model `map_over_type` on batch data instances, restricted to `src:"hdca"` and `src:"dce"` via discriminated union — `map_over_type` is how clients express subcollection mapping intent and is meaningless on non-collection sources (`hda`/`ldda`)
- Model DCE (`src:"dce"`) properly across parameter schema layers: as a valid batch source in request/internal layers, and as a `job_internal` value produced when `meta.py` batch expansion resolves `DatasetCollectionElement` refs
- Fix `adapt_dataset` in `runtime.py` to handle DCE→HDA resolution while preserving `element_identifier` for output naming and collection traceability (previously lost immediately)
- Fix `__expand_collection_parameter_async` in `meta.py` to accept DCE src for job rerun scenarios, resolving the child collection from the DCE rather than assuming HDCA
- Fix `runtimeify` in `convert.py` to dispatch on `src` for DCE refs instead of blindly constructing `DataRequestInternalHda`
- Add `map_over_type` to `BatchCollectionInstance`/`BatchCollectionInstanceInternal` for `gx_data_collection` params
- Add `DataCollectionJobInternal` union type so `gx_data_collection` `job_internal` layer accepts both `DataCollectionRequestInternal` and `AdaptedDataCollectionRequestInternal`
- Add parameter specification tests covering `map_over_type` (request + internal), DCE batch values, `element_identifier` in job_runtime, and invalid combos (`map_over_type` on `hda` rejected)
- Migrate 3 legacy subcollection mapping tests from `test_tools.py` to `test_tool_execute.py` with `tool_input_format` fixture (covers flat, nested, request formats)
- Add new `test_simple_subcollection_mapping`, `test_combined_mapping_and_subcollection_mapping`, and `test_map_over_dce_on_non_multiple_data_param` API tests

Background context: [subcollection mapping docs](https://gist.github.com/jmchilton/18f0df38d3b66bf2342f739c09b16fb4), [DCE modeling plan](https://gist.github.com/jmchilton/ae2e7af5680f5b617b53dd5f083bd0d7)

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
