### PR TITLE
Fix silently ignored <idphint> in oidc_backends_config.xml so kc_idp_hint reaches Keycloak

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -187,6 +187,12 @@ class AuthnzManager:
         if config_xml.find("checkin_env") is not None:
             rtv["checkin_env"] = config_xml.find("checkin_env").text
 
+        # Keycloak/CILogon IDP hint: tells Keycloak which federated IdP to redirect
+        # to directly (kc_idp_hint), bypassing the Keycloak login page.
+        # Corresponds to <idphint> in oidc_backends_config.xml (already in XSD).
+        if config_xml.find("idphint") is not None:
+            rtv["idphint"] = config_xml.find("idphint").text
+
         return rtv
 
     def _parse_custos_config(self, config_xml):

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -119,3 +119,82 @@ def test_psa_authnz_config(mock_app):
         app_config=mock_app.config,
     )
     assert psa_authnz.config[setting_name("USERNAME_KEY")] == config_values["username_key"]
+
+
+def _create_backend_config_with_idphint(idphint_value: str = None) -> tuple[str, str]:
+    """Create a Keycloak backend config, optionally including an <idphint> element."""
+    idphint_element = f"        <idphint>{idphint_value}</idphint>" if idphint_value else ""
+    contents = f"""<?xml version="1.0"?>
+<OIDC>
+    <provider name="keycloak">
+        <url>https://auth.example.org/realms/MyRealm/</url>
+        <client_id>galaxy-oidc</client_id>
+        <client_secret>secret</client_secret>
+        <redirect_uri>https://galaxy.example.org/authnz/keycloak/callback</redirect_uri>
+        <enable_idp_logout>true</enable_idp_logout>
+{idphint_element}
+    </provider>
+</OIDC>
+"""
+    file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".xml")
+    file.write(contents)
+    file.flush()
+    return contents, file.name
+
+
+def test_parse_idphint_from_xml(mock_app):
+    """
+    Regression test: <idphint> in oidc_backends_config.xml must be parsed into
+    the oidc_backend_config dict so that PSAAuthnz can forward it as IDPHINT to
+    the Keycloak/CILogon backends (which use it to set kc_idp_hint).
+
+    Previously, _parse_idp_config() had no branch for <idphint>, so the element
+    was silently ignored and oidc_backend_config.get("idphint") always returned
+    None, causing kc_idp_hint to never be sent to Keycloak.
+    """
+    _, oidc_path = create_oidc_config()
+    _, backend_path = _create_backend_config_with_idphint(idphint_value="my-switch-edu-id")
+    manager = AuthnzManager(app=mock_app, oidc_config_file=oidc_path, oidc_backends_config_file=backend_path)
+    parsed = manager.oidc_backends_config["keycloak"]
+    assert "idphint" in parsed, "<idphint> element must be parsed into oidc_backend_config dict"
+    assert parsed["idphint"] == "my-switch-edu-id"
+
+
+def test_idphint_propagated_to_psa_config(mock_app):
+    """
+    When <idphint> is configured, PSAAuthnz must expose it as IDPHINT in its
+    config so the Keycloak/CILogon PSA backend can add kc_idp_hint to the
+    authorization URL.
+    """
+    from galaxy.authnz.psa_authnz import PSAAuthnz
+
+    _, oidc_path = create_oidc_config()
+    _, backend_path = _create_backend_config_with_idphint(idphint_value="stage")
+    manager = AuthnzManager(app=mock_app, oidc_config_file=oidc_path, oidc_backends_config_file=backend_path)
+    psa = PSAAuthnz(
+        provider="keycloak",
+        oidc_config=manager.oidc_config,
+        oidc_backend_config=manager.oidc_backends_config["keycloak"],
+        app_config=mock_app.config,
+    )
+    assert psa.config.get("IDPHINT") == "stage", "IDPHINT must be 'stage' when <idphint>stage</idphint> is in XML"
+
+
+def test_missing_idphint_is_none(mock_app):
+    """
+    When <idphint> is absent from the XML, IDPHINT must be None (not a hardcoded
+    default string like 'oidc'), so the Keycloak backend omits kc_idp_hint
+    entirely rather than sending a wrong value.
+    """
+    from galaxy.authnz.psa_authnz import PSAAuthnz
+
+    _, oidc_path = create_oidc_config()
+    _, backend_path = _create_backend_config_with_idphint(idphint_value=None)
+    manager = AuthnzManager(app=mock_app, oidc_config_file=oidc_path, oidc_backends_config_file=backend_path)
+    psa = PSAAuthnz(
+        provider="keycloak",
+        oidc_config=manager.oidc_config,
+        oidc_backend_config=manager.oidc_backends_config["keycloak"],
+        app_config=mock_app.config,
+    )
+    assert psa.config.get("IDPHINT") is None, "IDPHINT must be None when <idphint> is absent from XML"

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -1,4 +1,5 @@
 import tempfile
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -121,7 +122,7 @@ def test_psa_authnz_config(mock_app):
     assert psa_authnz.config[setting_name("USERNAME_KEY")] == config_values["username_key"]
 
 
-def _create_backend_config_with_idphint(idphint_value: str = None) -> tuple[str, str]:
+def _create_backend_config_with_idphint(idphint_value: Optional[str] = None) -> tuple[str, str]:
     """Create a Keycloak backend config, optionally including an <idphint> element."""
     idphint_element = f"        <idphint>{idphint_value}</idphint>" if idphint_value else ""
     contents = f"""<?xml version="1.0"?>


### PR DESCRIPTION
## Summary

The `<idphint>` element in `oidc_backends_config.xml` was never parsed into the `oidc_backend_config` dict, causing `kc_idp_hint` to never be forwarded to Keycloak — even though the field is already defined in the XSD schema.

## Root Cause

`_parse_idp_config()` in `lib/galaxy/authnz/managers.py` explicitly parses each known XML child element into the returned dict (e.g. `label`, `url`, `pkce_support`, `checkin_env`…) but had **no branch for `<idphint>`**:

```python
# Before fix — idphint was never added to rtv:
if config_xml.find("checkin_env") is not None:
    rtv["checkin_env"] = config_xml.find("checkin_env").text

return rtv   # ← "idphint" missing from dict
```

As a result, `PSAAuthnz._setup_idp()` always set `IDPHINT=None`:

```python
# psa_authnz.py
self.config["IDPHINT"] = oidc_backend_config.get("idphint")  # → None
```

And the Keycloak backend silently skipped `kc_idp_hint`:

```python
# keycloak.py
if idphint := self.setting("IDPHINT", "oidc"):  # None → falsy → never executes
    params["kc_idp_hint"] = idphint              # ← never reached
```

The net effect: anyone configuring `<idphint>my-idp-alias</idphint>` in `oidc_backends_config.xml` to auto-redirect users to a federated IdP (Switch edu-ID, AAI, SWITCHaai, etc.) would see Keycloak's own login form instead, with no error or warning.

## Fix

One additional branch in `_parse_idp_config()`, matching the exact pattern used for every other optional element:

```python
if config_xml.find("idphint") is not None:
    rtv["idphint"] = config_xml.find("idphint").text
```

## Tests Added

Three new regression tests in `test/unit/authnz/test_authnz.py`:

- `test_parse_idphint_from_xml` — `<idphint>` is present in parsed dict
- `test_idphint_propagated_to_psa_config` — IDPHINT flows through to PSAAuthnz config
- `test_missing_idphint_is_none` — absent `<idphint>` → `IDPHINT=None` (no `kc_idp_hint` sent, correct behaviour)

## How to Reproduce

1. Configure `oidc_backends_config.xml` with `<idphint>my-alias</idphint>` inside a `<provider name="keycloak">` block  
2. Start Galaxy  
3. Click the Keycloak login button  
4. Observe: Keycloak shows its own login form (`kc_idp_hint` absent from redirect URL)

## Notes

- The `<idphint>` element is already in the XSD (`oidc_backends_config.xsd`, `minOccurs="0"`), so this is purely a parsing gap with no schema changes needed  
- Confirmed with Galaxy 25.1.0 / Helm chart 6.7.0 in a production Keycloak+SAML setup (Keycloak alias `stage`, federated IdP `https://eduid.ch/idp/shibboleth`)