### PR TITLE
Add request_checksum_calculation support for s3fs

### DIFF
--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -66,7 +66,7 @@ class S3FsFilesSource(FsspecFilesSource[S3FSFileSourceTemplateConfiguration, S3F
 
         config = context.config
         client_kwargs = {"endpoint_url": config.endpoint_url} if config.endpoint_url else None
-        config_kwargs={'request_checksum_calculation': config.request_checksum_calculation} if config.request_checksum_calculation else None
+        config_kwargs = {'request_checksum_calculation': config.request_checksum_calculation} if config.request_checksum_calculation else None
         fs = S3FileSystem(
             anon=config.anon,
             key=config.key,

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -66,7 +66,11 @@ class S3FsFilesSource(FsspecFilesSource[S3FSFileSourceTemplateConfiguration, S3F
 
         config = context.config
         client_kwargs = {"endpoint_url": config.endpoint_url} if config.endpoint_url else None
-        config_kwargs = {'request_checksum_calculation': config.request_checksum_calculation} if config.request_checksum_calculation else None
+        config_kwargs = (
+            {"request_checksum_calculation": config.request_checksum_calculation}
+            if config.request_checksum_calculation
+            else None
+        )
         fs = S3FileSystem(
             anon=config.anon,
             key=config.key,

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -36,6 +36,7 @@ class S3FSFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfigurat
     bucket: Union[str, TemplateExpansion, None] = None
     secret: Union[str, TemplateExpansion, None] = None
     key: Union[str, TemplateExpansion, None] = None
+    request_checksum_calculation: Union[str, TemplateExpansion, None] = None
 
 
 class S3FSFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
@@ -44,6 +45,7 @@ class S3FSFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
     bucket: Optional[str] = None
     secret: Optional[str] = None
     key: Optional[str] = None
+    request_checksum_calculation: Optional[str] = None
 
 
 class S3FsFilesSource(FsspecFilesSource[S3FSFileSourceTemplateConfiguration, S3FSFileSourceConfiguration]):
@@ -64,11 +66,13 @@ class S3FsFilesSource(FsspecFilesSource[S3FSFileSourceTemplateConfiguration, S3F
 
         config = context.config
         client_kwargs = {"endpoint_url": config.endpoint_url} if config.endpoint_url else None
+        config_kwargs={'request_checksum_calculation': config.request_checksum_calculation} if config.request_checksum_calculation else None
         fs = S3FileSystem(
             anon=config.anon,
             key=config.key,
             secret=config.secret,
             client_kwargs=client_kwargs,
+            config_kwargs=config_kwargs,
             **cache_options,
         )
         return fs

--- a/lib/galaxy/files/templates/examples/production_s3fs.yml
+++ b/lib/galaxy/files/templates/examples/production_s3fs.yml
@@ -122,3 +122,78 @@
     secret: '{{ secrets.secret_key }}'
     bucket: '{{ variables.bucket }}'
     writable: '{{ variables.writable }}'
+
+- id: s3fs
+  version: 2
+  name: S3 Compatible repositories with Credentials
+  description: |
+    The APIs used to connect to Amazon's S3 (Simple Storage Service) have become something
+    of an unofficial standard for cloud storage across a variety of vendors and services.
+    Many vendors offer storage APIs compatible with S3. Here, you can configure any S3 based repository
+    as long as you have the relevant credentials.
+  variables:
+    access_key:
+      label: Access Key ID
+      type: string
+      help: |
+        The less secure part of your access tokens or access keys that describe the user
+        that is accessing the data. The [Amazon documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html)
+        calls these an "access key ID", the [CloudFlare documentation](https://developers.cloudflare.com/r2/examples/aws/boto3/)
+        describes these as ``aws_access_key_id``.
+    bucket:
+      label: Bucket
+      type: string
+      help: |
+        The [bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html) to
+        store your datasets in. How to setup buckets for your storage will vary from service to service
+        but all S3 compatible storage services should have the concept of a bucket to namespace
+        a grouping of your data together with.
+      validators:
+        - type: regex
+          expression: '^(?!\s)(?!.*\s$).*$'
+          message: "Bucket name cannot have leading or trailing whitespace"
+        - type: regex
+          expression: '^.*[^/]$'
+          message: "Bucket name cannot end with a slash"
+    endpoint_url:
+      label: S3-Compatible API Endpoint
+      type: string
+      help: |
+        If the documentation for your storage service has something called an ``endpoint_url``,
+        For instance, the CloudFlare documentation describes its endpoints as ``https://<accountid>.r2.cloudflarestorage.com``. Here
+        you would substitute your CloudFlare account ID into the endpoint url and use that value.
+        So if your account ID was ``galactian``, you would enter ``galactian.r2.cloudflarestorage.com``.
+        The [MinIO](https://min.io/docs/minio/linux/integrations/aws-cli-with-minio.html)
+        documentation describes the endpoint URL for its Play service as ``https://play.min.io:9000``,
+        this value would be entered here.
+    writable:
+      label: Writable?
+      type: boolean
+      optional: true
+      default: false
+      help: Is this a bucket you have permission to write to?
+    request_checksum_calculation:
+      label: Request Checksum Calculation
+      type: string
+      optional: true
+      default: None
+      help: |
+        By default, users are opted-in to calculating a request checksum when sending a request. However some non AWS S3-compatible endpoint do not support this option. If you get errors like `An error occurred (MissingContentLength) when calling the PutObject operation: You must provide the Content-Length HTTP header.` when you try uploading data. Set this to `when_required`.
+  secrets:
+    secret_key:
+      label: Secret Access Key
+      help: |
+        The secret key used to connect to the S3 compatible storage with for the given access key.
+
+        The [Amazon documentation] calls these an "secret access key" and
+        the [CloudFlare documentation](https://developers.cloudflare.com/r2/examples/aws/boto3/)
+        describes these as ``aws_secret_access_key``. Internally to Galaxy, we often just call
+        this the ``secret_key``.
+  configuration:
+    type: s3fs
+    endpoint_url: '{{ variables.endpoint_url }}'
+    key: '{{ variables.access_key }}'
+    secret: '{{ secrets.secret_key }}'
+    bucket: '{{ variables.bucket }}'
+    writable: '{{ variables.writable }}'
+    request_checksum_calculation: '{{ variables.request_checksum_calculation }}'

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -123,6 +123,7 @@ class S3FSFileSourceTemplateConfiguration(StrictModel):
     writable: Union[bool, TemplateExpansion] = False
     template_start: Optional[str] = None
     template_end: Optional[str] = None
+    request_checksum_calculation: Optional[Union[str, TemplateExpansion, None]] = None
 
 
 class S3FSFileSourceConfiguration(StrictModel):
@@ -133,6 +134,7 @@ class S3FSFileSourceConfiguration(StrictModel):
     key: Optional[str] = None
     bucket: Optional[str] = None
     writable: bool = False
+    request_checksum_calculation: Optional[str] = None
 
 
 class FtpFileSourceTemplateConfiguration(StrictModel):


### PR DESCRIPTION
Hi,
I try to fix the bug I described on matrix: https://matrix.to/#/!rfLDbcWEWZapZrujix:gitter.im/$9aabuSTmCGn2W2i5k5LyLQns5z-lhoxU4K7tgKA4xBk?via=gitter.im&via=matrix.org&via=private.coffee

The bug seems to be linked to boto > 1.36.0

I am absolutely not an expert in s3. The links that helped me to write this are:

https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html

https://github.com/fsspec/s3fs/issues/931

Code in boto:

https://github.com/boto/botocore/blob/9ae78f127eeb06c2bf4e0e0a8bd4e3116430e9db/botocore/config.py#L244-L258

Release: https://github.com/boto/botocore/blob/9ae78f127eeb06c2bf4e0e0a8bd4e3116430e9db/.changes/1.36.0.json#L64

I don't know how to test this.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
