### PR TITLE
[25.1] Fix NoReplacement handling in workflow callback_helper

### DIFF
--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -33,7 +33,7 @@ from .grouping import (
 )
 from .workflow_utils import (
     is_runtime_value,
-    NO_REPLACEMENT,
+    NoReplacement,
     runtime_to_json,
 )
 from .wrapped import flat_to_nested_state
@@ -179,33 +179,33 @@ def visit_input_values(
         new_value = callback(**args)
 
         # is this good enough ? feels very ugh
-        if new_value == [no_replacement_value]:
+        if isinstance(new_value, list) and len(new_value) == 1 and isinstance(new_value[0], NoReplacement):
             # Single unspecified value in multiple="true" input with a single null input, pretend it's a singular value
             new_value = no_replacement_value
         if isinstance(new_value, list):
             # Maybe mixed input, I guess tool defaults don't really make sense here ?
             # Would e.g. be default dataset in multiple="true" input, you wouldn't expect the default to be inserted
             # if other inputs are connected and provided.
-            new_value = [item if not item == no_replacement_value else None for item in new_value]
+            new_value = [item if not isinstance(item, NoReplacement) else None for item in new_value]
 
         if no_replacement_value is REPLACE_ON_TRUTHY:
             replace = bool(new_value)
         else:
-            replace = new_value != no_replacement_value
+            replace = not isinstance(new_value, NoReplacement) and new_value != no_replacement_value
         if replace:
             input_values[input.name] = new_value
         elif replace_optional_connections:
-            # Only used in workflow context
-            has_default = hasattr(input, "value")
-            if new_value is value is NO_REPLACEMENT or is_runtime_value(value):
-                # NO_REPLACEMENT means value was connected but left unspecified
-                if has_default:
-                    # Use default if we have one
+            # Only used in workflow context.
+            # If we reach here the callback returned no_replacement_value,
+            # meaning the connected step did not produce a value (e.g. an
+            # omitted optional parameter_input).  Only replace sentinel
+            # values (ConnectedValue, RuntimeValue, NO_REPLACEMENT) with
+            # the tool parameter's own default — preserve valid tool-state
+            # values for unconnected inputs.
+            if isinstance(value, NoReplacement) or is_runtime_value(value):
+                if hasattr(input, "value"):
                     input_values[input.name] = input.value
                 else:
-                    # Should fail if input is not optional and does not have default value
-                    # Effectively however depends on parameter implementation.
-                    # We might want to raise an exception here, instead of depending on a tool parameter value error.
                     input_values[input.name] = None
 
     def get_current_case(input, input_values):

--- a/lib/galaxy_test/workflow/optional_text_to_bool.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_text_to_bool.gxwf-tests.yml
@@ -1,0 +1,27 @@
+- doc: |
+    Test that omitting an optional text parameter connected to an expression
+    tool that converts text to boolean produces false, correctly skipping
+    the conditional downstream step.
+  job:
+    required_input:
+      type: File
+      value: 1.fasta
+  outputs:
+    out:
+      asserts:
+        has_text:
+          text: "null"
+- doc: |
+    Test that providing an optional text parameter connected to an expression
+    tool that converts text to boolean produces true, so the conditional
+    downstream step runs.
+  job:
+    required_input:
+      type: File
+      value: 1.fasta
+    optional_text: some_value
+  outputs:
+    out:
+      asserts:
+        has_size:
+          min: 1

--- a/lib/galaxy_test/workflow/optional_text_to_bool.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_text_to_bool.gxwf.yml
@@ -1,0 +1,29 @@
+class: GalaxyWorkflow
+doc: |
+  Test that an omitted optional text parameter connected to an expression
+  tool (text→boolean conversion, like map_param_value) produces false,
+  allowing conditional (when) steps to be correctly skipped.
+  Regression test for https://github.com/galaxyproject/iwc/pull/1128
+inputs:
+  required_input:
+    type: data
+  optional_text:
+    type: text
+    optional: true
+outputs:
+  out:
+    outputSource: cat/out_file1
+steps:
+  text_to_bool:
+    tool_id: expression_text_to_bool
+    in:
+      text_input:
+        source: optional_text
+  cat:
+    tool_id: cat
+    in:
+      input1:
+        source: required_input
+      when:
+        source: text_to_bool/bool_out
+    when: $(inputs.when)

--- a/test/functional/tools/expression_text_to_bool.xml
+++ b/test/functional/tools/expression_text_to_bool.xml
@@ -1,0 +1,27 @@
+<tool name="expression_text_to_bool" id="expression_text_to_bool" version="0.1.0" tool_type="expression">
+    <expression type="ecma5.1">
+        {
+            var value = $job.text_input;
+            if (value == "false" || value == "False") {
+                return {'bool_out': false};
+            }
+            return {'bool_out': !!value};
+        }
+    </expression>
+    <inputs>
+        <param type="text" label="Text input." name="text_input" />
+    </inputs>
+    <outputs>
+        <output type="boolean" name="bool_out" from="bool_out" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="text_input" value="hello" />
+            <output name="bool_out" value_json="true" />
+        </test>
+        <test>
+            <param name="text_input" value="" />
+            <output name="bool_out" value_json="false" />
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -228,6 +228,7 @@
   <tool file="expression_null_handling_integer.xml" />
   <tool file="expression_null_handling_float.xml" />
   <tool file="expression_null_handling_text.xml" />
+  <tool file="expression_text_to_bool.xml" />
   <tool file="cheetah_casting.xml" />
   <tool file="cheetah_problem_unbound_var.xml" />
   <tool file="cheetah_problem_unbound_var_input.xml" />


### PR DESCRIPTION
When an optional text parameter is omitted from a workflow invocation and connected to an expression tool, the callback_helper in visit_input_values could fail to replace unresolved inputs with the tool parameter default.

Two issues contributed to this:

1. NoReplacement doesn't implement `__eq__`, so when the callback returns a different NoReplacement instance than the module-level NO_REPLACEMENT singleton, the equality comparison fails and the raw NoReplacement object gets stored as the input value.

2. The replace_optional_connections path needs to guard replacements with is_runtime_value(value) to avoid clobbering valid tool-state values for unconnected parameters (like select parameters with defaults).

Fix both by switching all NoReplacement comparisons to isinstance() checks and restoring the is_runtime_value guard. Add a framework workflow test that connects an optional text parameter to an expression tool converting text→boolean, then uses the boolean as a when condition.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
