### PR TITLE
Fix broken log format string in validate_non_local

### DIFF
--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -135,7 +135,7 @@ def validate_non_local(uri: str, ip_allowlist: list[IpAllowedListEntryT]) -> str
     try:
         addrinfo = socket.getaddrinfo(parsed_url, port)
     except socket.gaierror as e:
-        log.debug("Could not resolve url '%': %'", url, e)
+        log.debug(f"Could not resolve url '{url}': {e}")
         raise RequestParameterInvalidException(f"Could not verify url '{url}'.")
     # Get the IP addresses that this entry resolves to (uniquely)
     # We drop:


### PR DESCRIPTION
The log.debug call used '%' instead of '%s' for format specifiers, causing a ValueError that masked the actual gaierror.

See https://github.com/galaxyproject/galaxy/actions/runs/22767902867/job/66040607721

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
