### PR TITLE
Fix test that transiently fails if GitHub rejects a request

### DIFF
--- a/doc/source/dev/writing_tests.md
+++ b/doc/source/dev/writing_tests.md
@@ -1602,6 +1602,30 @@ ping the Galaxy committers on the pull request and request a re-run. The
 GitHub actions workflow definition for these tests is located in
 ``.github/workflows/integration_selenium.yaml`` below Galaxy's root.
 
+{#avoiding_external_dependencies}
+## Avoiding External Dependencies in Tests
+
+Tests fetching from external services (GitHub, etc.) fail transiently due to
+network issues or rate limiting. Use ``DatasetPopulator``'s base64 URL helpers
+to encode local test data as ``base64://`` URLs instead — Galaxy's fetch API
+handles these identically to remote URLs.
+
+| Helper | Use Case |
+|--------|----------|
+| ``base64_url_for_test_file(filename)`` | Encode a file from ``test-data/`` |
+| ``base64_url_for_string(content)`` | Encode a string literal |
+| ``base64_url_for_bytes(content)`` | Encode raw bytes |
+
+```python
+# Instead of: "location": "https://github.com/.../1.fasta.gz?raw=true"
+base64_url = self.dataset_populator.base64_url_for_test_file("1.fasta.gz")
+job = {"input1": {"class": "File", "format": "fasta", "location": base64_url, "decompress": True}}
+```
+
+These work anywhere a URL is accepted: ``stage_inputs`` jobs, fetch API targets,
+deferred datasets, and workflow inputs. Only use real external URLs when the test
+specifically validates remote-fetch behavior.
+
 {#transient_failures}
 ## Handling Flaky Tests
 

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -307,13 +307,13 @@ class TestToolsUpload(ApiTestCase):
         details = self.dataset_populator.get_history_dataset_details(history_id=history_id, dataset=dataset)
         assert details["genome_build"] == "hg19"
 
-    @skip_if_github_down
     def test_stage_fetch_decompress_true(self, history_id: str) -> None:
+        base64_url = self.dataset_populator.base64_url_for_test_file("1.fasta.gz")
         job = {
             "input1": {
                 "class": "File",
                 "format": "fasta",
-                "location": "https://github.com/galaxyproject/galaxy/blob/dev/test-data/1.fasta.gz?raw=true",
+                "location": base64_url,
                 "decompress": True,
             }
         }
@@ -324,13 +324,13 @@ class TestToolsUpload(ApiTestCase):
         content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
         assert content.startswith(">hg17")
 
-    @skip_if_github_down
     def test_stage_fetch_decompress_false(self, history_id: str) -> None:
+        base64_url = self.dataset_populator.base64_url_for_test_file("1.fasta.gz")
         job = {
             "input1": {
                 "class": "File",
                 "format": "fasta",
-                "location": "https://github.com/galaxyproject/galaxy/blob/dev/test-data/1.fasta.gz?raw=true",
+                "location": base64_url,
                 "decompress": False,
             }
         }


### PR DESCRIPTION
... add a blurb to writing_tests.md to encourage use of base64 URIs during testing.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
