### PR TITLE
Fix ToolExpressionOutput.to_model() for boolean type

### DIFF
--- a/lib/galaxy/tool_util/parser/output_objects.py
+++ b/lib/galaxy/tool_util/parser/output_objects.py
@@ -244,9 +244,8 @@ class ToolExpressionOutput(ToolOutputBase):
             model_class = ToolOutputIntegerModel
         elif self.output_type == "float":
             model_class = ToolOutputFloatModel
-        elif self.output_type == "bool":
+        elif self.output_type == "boolean":
             model_class = ToolOutputBooleanModel
-            model_type = "boolean"
         elif self.output_type == "text":
             model_class = ToolOutputTextModel
         assert model_class

--- a/test/functional/tools/expression_null_handling_boolean.xml
+++ b/test/functional/tools/expression_null_handling_boolean.xml
@@ -7,7 +7,7 @@
         <param type="boolean" label="Booelan input." name="bool_input" optional="true" />
     </inputs>
     <outputs>
-        <output type="bool" name="bool_out" from="bool_out" />
+        <output type="boolean" name="bool_out" from="bool_out" />
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
to_model() checked "bool" but production expression tools (pick_value, param_value_from_file) declare type="boolean". Fix to_model() to match canonical "boolean" and fix lone test tool using non-canonical "bool".

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
