### PR TITLE
Bug fix and refactor of ChatGXY chat history component

### DIFF
--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -11,7 +11,7 @@ import { getGalaxyInstance } from "@/app";
 import { getAgentIcon } from "./agentTypes";
 import type { ChatHistoryItem } from "./chatTypes";
 
-import LoadingSpan from "@/components/LoadingSpan.vue";
+import SidebarList from "@/components/Common/SidebarList.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
@@ -46,9 +46,9 @@ async function loadHistory() {
 
 const lastClickedIndex = ref<number | null>(null);
 
-function handleItemClick(item: ChatHistoryItem, event: MouseEvent) {
+function handleItemClick(item: ChatHistoryItem, index: number, event: MouseEvent) {
     if (selectionMode.value) {
-        const currentIndex = chatHistory.value.findIndex((i) => i.id === item.id);
+        const currentIndex = index;
         if (event.shiftKey && lastClickedIndex.value !== null) {
             const start = Math.min(lastClickedIndex.value, currentIndex);
             const end = Math.max(lastClickedIndex.value, currentIndex);
@@ -147,52 +147,43 @@ async function deleteSelected() {
             </button>
         </template>
 
-        <div v-if="loading" class="text-center p-3">
-            <LoadingSpan message="Loading history..." />
+        <div v-if="selectionMode && chatHistory.length > 0" class="selection-toolbar">
+            <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
+            <span class="select-all-toggle" @click="toggleSelectAll">
+                <FontAwesomeIcon :icon="allSelected ? faCheckSquare : faSquare" fixed-width />
+                {{ allSelected ? "Deselect all" : "Select all" }}
+            </span>
+            <button class="btn btn-sm btn-danger" :disabled="selectedIds.size === 0" @click="deleteSelected">
+                Delete {{ selectedIds.size > 0 ? selectedIds.size : "" }}
+            </button>
         </div>
 
-        <div v-else-if="chatHistory.length === 0" class="text-muted p-3 text-center small">No chat history yet</div>
-
-        <template v-else>
-            <div v-if="selectionMode" class="selection-toolbar">
-                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
-                <span class="select-all-toggle" @click="toggleSelectAll">
-                    <FontAwesomeIcon :icon="allSelected ? faCheckSquare : faSquare" fixed-width />
-                    {{ allSelected ? "Deselect all" : "Select all" }}
+        <SidebarList
+            :items="chatHistory"
+            :is-loading="loading"
+            :item-key="(item: ChatHistoryItem) => item.id"
+            :item-class="(item: ChatHistoryItem) => ({ selected: selectedIds.has(item.id) })"
+            loading-message="Loading history..."
+            empty-message="No chat history yet"
+            @select="handleItemClick">
+            <template #item="{ item }">
+                <span v-if="selectionMode" class="history-checkbox">
+                    <FontAwesomeIcon :icon="selectedIds.has(item.id) ? faCheckSquare : faSquare" fixed-width />
                 </span>
-                <button class="btn btn-sm btn-danger" :disabled="selectedIds.size === 0" @click="deleteSelected">
-                    Delete {{ selectedIds.size > 0 ? selectedIds.size : "" }}
-                </button>
-            </div>
-
-            <div class="history-list">
-                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
-                <div
-                    v-for="item in chatHistory"
-                    :key="item.id"
-                    class="history-item"
-                    :class="{ selected: selectedIds.has(item.id) }"
-                    @click="handleItemClick(item, $event)">
-                    <div class="history-row">
-                        <span v-if="selectionMode" class="history-checkbox">
-                            <FontAwesomeIcon :icon="selectedIds.has(item.id) ? faCheckSquare : faSquare" fixed-width />
+                <div class="history-content">
+                    <div class="history-query">{{ item.query }}</div>
+                    <div class="history-meta">
+                        <span class="history-agent">
+                            <FontAwesomeIcon :icon="getAgentIcon(item.agent_type)" fixed-width />
                         </span>
-                        <div class="history-content">
-                            <div class="history-query">{{ item.query }}</div>
-                            <div class="history-meta">
-                                <span class="history-agent">
-                                    <FontAwesomeIcon :icon="getAgentIcon(item.agent_type)" fixed-width />
-                                </span>
-                                <span class="history-time">
-                                    <FontAwesomeIcon :icon="faClock" class="mr-1" />
-                                    <UtcDate :date="item.timestamp" mode="elapsed" />
-                                </span>
-                            </div>
-                        </div>
+                        <span class="history-time">
+                            <FontAwesomeIcon :icon="faClock" class="mr-1" />
+                            <UtcDate :date="item.timestamp" mode="elapsed" />
+                        </span>
                     </div>
                 </div>
-            </div>
-        </template>
+            </template>
+        </SidebarList>
     </ActivityPanel>
 </template>
 
@@ -220,68 +211,48 @@ async function deleteSelected() {
     }
 }
 
-.history-list {
-    flex: 1;
-    overflow-y: auto;
+// SidebarList provides base item hover/cursor styles.
+// .selected is applied via itemClass prop on the sidebar-item element,
+// which lives inside SidebarList's scoped styles, so we use :deep.
+:deep(.sidebar-item.selected) {
+    background: rgba($brand-primary, 0.06);
 }
 
-.history-item {
-    padding: 0.5rem 0.25rem;
-    border-bottom: 1px solid darken($panel-bg-color, 5%);
-    cursor: pointer;
-    transition: background-color 0.15s;
-    border-radius: $border-radius-base;
+.history-checkbox {
+    flex-shrink: 0;
+    color: $text-muted;
+    padding-top: 0.1rem;
+}
 
-    &:hover {
-        background: darken($panel-bg-color, 3%);
+.history-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.history-query {
+    font-size: 0.8rem;
+    color: $text-color;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-bottom: 0.2rem;
+}
+
+.history-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.7rem;
+    color: $text-light;
+
+    .history-agent {
+        color: $brand-primary;
     }
 
-    &.selected {
-        background: rgba($brand-primary, 0.06);
-    }
-
-    .history-row {
+    .history-time {
         display: flex;
-        align-items: flex-start;
-        gap: 0.375rem;
-    }
-
-    .history-checkbox {
-        flex-shrink: 0;
-        color: $text-muted;
-        padding-top: 0.1rem;
-    }
-
-    .history-content {
-        flex: 1;
-        min-width: 0;
-    }
-
-    .history-query {
-        font-size: 0.8rem;
-        color: $text-color;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        margin-bottom: 0.2rem;
-    }
-
-    .history-meta {
-        display: flex;
-        justify-content: space-between;
         align-items: center;
-        font-size: 0.7rem;
-        color: $text-light;
-
-        .history-agent {
-            color: $brand-primary;
-        }
-
-        .history-time {
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-        }
+        gap: 0.25rem;
     }
 }
 </style>

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -2,11 +2,12 @@
 import { faCheckSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
 import { faClock, faPlus, faTimes, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { computed, onMounted, ref } from "vue";
+import { onMounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { GalaxyApi } from "@/api";
 import { getGalaxyInstance } from "@/app";
+import { useSidebarSelection } from "@/composables/useSidebarSelection";
 
 import { getAgentIcon } from "./agentTypes";
 import type { ChatHistoryItem } from "./chatTypes";
@@ -19,10 +20,9 @@ const router = useRouter();
 
 const chatHistory = ref<ChatHistoryItem[]>([]);
 const loading = ref(false);
-const selectionMode = ref(false);
-const selectedIds = ref(new Set<string>());
 
-const allSelected = computed(() => chatHistory.value.length > 0 && selectedIds.value.size === chatHistory.value.length);
+const { selectionMode, selectedIds, allSelected, toggleSelectionMode, toggleSelectAll, handleSelectionClick, pruneAfterDelete } =
+    useSidebarSelection(chatHistory, (item) => item.id);
 
 onMounted(() => {
     loadHistory();
@@ -44,59 +44,16 @@ async function loadHistory() {
     }
 }
 
-const lastClickedIndex = ref<number | null>(null);
-
 function handleItemClick(item: ChatHistoryItem, index: number, event: MouseEvent) {
-    if (selectionMode.value) {
-        const currentIndex = index;
-        if (event.shiftKey && lastClickedIndex.value !== null) {
-            const start = Math.min(lastClickedIndex.value, currentIndex);
-            const end = Math.max(lastClickedIndex.value, currentIndex);
-            const next = new Set(selectedIds.value);
-            for (let i = start; i <= end; i++) {
-                const id = chatHistory.value[i]?.id;
-                if (id) {
-                    next.add(id);
-                }
-            }
-            selectedIds.value = next;
-        } else {
-            toggleSelection(item.id);
-        }
-        lastClickedIndex.value = currentIndex;
-    } else {
-        const Galaxy = getGalaxyInstance();
-        if (Galaxy?.frame?.active) {
-            // @ts-ignore - monkeypatched router, second arg is RouterPushOptions
-            router.push(`/chatgxy/${item.id}?compact=true`, { title: "ChatGXY" });
-        } else {
-            router.push(`/chatgxy/${item.id}`);
-        }
+    if (handleSelectionClick(item, index, event)) {
+        return;
     }
-}
-
-function toggleSelectionMode() {
-    selectionMode.value = !selectionMode.value;
-    if (!selectionMode.value) {
-        selectedIds.value.clear();
-    }
-}
-
-function toggleSelection(id: string) {
-    const next = new Set(selectedIds.value);
-    if (next.has(id)) {
-        next.delete(id);
+    const Galaxy = getGalaxyInstance();
+    if (Galaxy?.frame?.active) {
+        // @ts-ignore - monkeypatched router, second arg is RouterPushOptions
+        router.push(`/chatgxy/${item.id}?compact=true`, { title: "ChatGXY" });
     } else {
-        next.add(id);
-    }
-    selectedIds.value = next;
-}
-
-function toggleSelectAll() {
-    if (allSelected.value) {
-        selectedIds.value = new Set();
-    } else {
-        selectedIds.value = new Set(chatHistory.value.map((item) => item.id));
+        router.push(`/chatgxy/${item.id}`);
     }
 }
 
@@ -121,10 +78,7 @@ async function deleteSelected() {
         });
         if (!error) {
             chatHistory.value = chatHistory.value.filter((item) => !selectedIds.value.has(item.id));
-            selectedIds.value = new Set();
-            if (chatHistory.value.length === 0) {
-                selectionMode.value = false;
-            }
+            pruneAfterDelete();
         }
     } catch (e) {
         console.error("Failed to delete exchanges:", e);

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -21,8 +21,15 @@ const router = useRouter();
 const chatHistory = ref<ChatHistoryItem[]>([]);
 const loading = ref(false);
 
-const { selectionMode, selectedIds, allSelected, toggleSelectionMode, toggleSelectAll, handleSelectionClick, pruneAfterDelete } =
-    useSidebarSelection(chatHistory, (item) => item.id);
+const {
+    selectionMode,
+    selectedIds,
+    allSelected,
+    toggleSelectionMode,
+    toggleSelectAll,
+    handleSelectionClick,
+    pruneAfterDelete,
+} = useSidebarSelection(chatHistory, (item) => item.id);
 
 onMounted(() => {
     loadHistory();
@@ -120,7 +127,7 @@ async function deleteSelected() {
             loading-message="Loading history..."
             empty-message="No chat history yet"
             @select="handleItemClick">
-            <template #item="{ item }">
+            <template v-slot:item="{ item }">
                 <span v-if="selectionMode" class="history-checkbox">
                     <FontAwesomeIcon :icon="selectedIds.has(item.id) ? faCheckSquare : faSquare" fixed-width />
                 </span>

--- a/client/src/components/ChatGXY/ChatHistoryPanel.vue
+++ b/client/src/components/ChatGXY/ChatHistoryPanel.vue
@@ -122,8 +122,8 @@ async function deleteSelected() {
         <SidebarList
             :items="chatHistory"
             :is-loading="loading"
-            :item-key="(item: ChatHistoryItem) => item.id"
-            :item-class="(item: ChatHistoryItem) => ({ selected: selectedIds.has(item.id) })"
+            :item-key="(item) => item.id"
+            :item-class="(item) => ({ selected: selectedIds.has(item.id) })"
             loading-message="Loading history..."
             empty-message="No chat history yet"
             @select="handleItemClick">

--- a/client/src/components/Common/SidebarList.test.ts
+++ b/client/src/components/Common/SidebarList.test.ts
@@ -1,0 +1,181 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import SidebarList from "./SidebarList.vue";
+
+interface TestItem {
+    id: number;
+    label: string;
+}
+
+const ITEMS: TestItem[] = [
+    { id: 1, label: "Alpha" },
+    { id: 2, label: "Beta" },
+    { id: 3, label: "Gamma" },
+];
+
+function mountList(props: Record<string, unknown> = {}) {
+    return mount(SidebarList as any, {
+        propsData: {
+            items: ITEMS,
+            isLoading: false,
+            itemKey: (item: TestItem) => item.id,
+            ...props,
+        },
+        scopedSlots: {
+            item: '<div slot-scope="{ item, index }">{{ item.label }}-{{ index }}</div>',
+        },
+        stubs: {
+            FontAwesomeIcon: true,
+        },
+    });
+}
+
+describe("SidebarList", () => {
+    describe("loading state", () => {
+        it("shows loading indicator when isLoading is true", () => {
+            const wrapper = mountList({ isLoading: true });
+            expect(wrapper.find("[data-description='sidebar list loading']").exists()).toBe(true);
+        });
+
+        it("renders default loading message", () => {
+            const wrapper = mountList({ isLoading: true });
+            expect(wrapper.find("[data-description='sidebar list loading']").text()).toContain("Loading...");
+        });
+
+        it("renders custom loading message", () => {
+            const wrapper = mountList({ isLoading: true, loadingMessage: "Fetching data..." });
+            expect(wrapper.find("[data-description='sidebar list loading']").text()).toContain("Fetching data...");
+        });
+
+        it("does not render items when loading", () => {
+            const wrapper = mountList({ isLoading: true });
+            expect(wrapper.find(".sidebar-items").exists()).toBe(false);
+        });
+
+        it("does not render empty state when loading", () => {
+            const wrapper = mountList({ isLoading: true, items: [] });
+            expect(wrapper.find("[data-description='sidebar list empty']").exists()).toBe(false);
+        });
+    });
+
+    describe("empty state", () => {
+        it("shows empty message when items is empty", () => {
+            const wrapper = mountList({ items: [] });
+            expect(wrapper.find("[data-description='sidebar list empty']").exists()).toBe(true);
+        });
+
+        it("renders default empty message", () => {
+            const wrapper = mountList({ items: [] });
+            expect(wrapper.find("[data-description='sidebar list empty']").text()).toContain("No items found.");
+        });
+
+        it("renders custom empty message", () => {
+            const wrapper = mountList({ items: [], emptyMessage: "Nothing here" });
+            expect(wrapper.find("[data-description='sidebar list empty']").text()).toContain("Nothing here");
+        });
+
+        it("does not render items when empty", () => {
+            const wrapper = mountList({ items: [] });
+            expect(wrapper.find(".sidebar-items").exists()).toBe(false);
+        });
+
+        it("does not render loading state when empty", () => {
+            const wrapper = mountList({ items: [] });
+            expect(wrapper.find("[data-description='sidebar list loading']").exists()).toBe(false);
+        });
+    });
+
+    describe("items rendering", () => {
+        it("renders one sidebar-item per item", () => {
+            const wrapper = mountList();
+            expect(wrapper.findAll("[data-description='sidebar item']")).toHaveLength(3);
+        });
+
+        it("renders scoped slot content with correct item and index", () => {
+            const wrapper = mountList();
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            expect(items.at(0)!.text()).toContain("Alpha-0");
+            expect(items.at(1)!.text()).toContain("Beta-1");
+            expect(items.at(2)!.text()).toContain("Gamma-2");
+        });
+
+        it("does not render loading or empty states", () => {
+            const wrapper = mountList();
+            expect(wrapper.find("[data-description='sidebar list loading']").exists()).toBe(false);
+            expect(wrapper.find("[data-description='sidebar list empty']").exists()).toBe(false);
+        });
+    });
+
+    describe("interaction", () => {
+        it("emits select with item, index, and event on click", async () => {
+            const wrapper = mountList();
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            await items.at(1)!.trigger("click");
+
+            const emitted = wrapper.emitted("select")!;
+            expect(emitted).toHaveLength(1);
+            expect(emitted[0]![0]).toEqual(ITEMS[1]);
+            expect(emitted[0]![1]).toBe(1);
+            expect(emitted[0]![2]).toBeInstanceOf(MouseEvent);
+        });
+
+        it("emits select on Enter keydown", async () => {
+            const wrapper = mountList();
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            await items.at(0)!.trigger("keydown", { key: "Enter" });
+
+            const emitted = wrapper.emitted("select")!;
+            expect(emitted).toHaveLength(1);
+            expect(emitted[0]![0]).toEqual(ITEMS[0]);
+            expect(emitted[0]![1]).toBe(0);
+        });
+
+        it("does not emit select on non-Enter keydown", async () => {
+            const wrapper = mountList();
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            await items.at(0)!.trigger("keydown", { key: "Space" });
+            expect(wrapper.emitted("select")).toBeFalsy();
+        });
+    });
+
+    describe("accessibility", () => {
+        it("each item has role=button", () => {
+            const wrapper = mountList();
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            items.wrappers.forEach((item) => {
+                expect(item.attributes("role")).toBe("button");
+            });
+        });
+
+        it("each item has tabindex=0", () => {
+            const wrapper = mountList();
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            items.wrappers.forEach((item) => {
+                expect(item.attributes("tabindex")).toBe("0");
+            });
+        });
+    });
+
+    describe("itemClass prop", () => {
+        it("applies class from itemClass function", () => {
+            const wrapper = mountList({
+                itemClass: (_item: TestItem, index: number) => ({ active: index === 1 }),
+            });
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            expect(items.at(0)!.classes()).not.toContain("active");
+            expect(items.at(1)!.classes()).toContain("active");
+            expect(items.at(2)!.classes()).not.toContain("active");
+        });
+
+        it("applies string class from itemClass function", () => {
+            const wrapper = mountList({
+                itemClass: (_item: TestItem, index: number) => (index === 0 ? "first" : undefined),
+            });
+            const items = wrapper.findAll("[data-description='sidebar item']");
+            expect(items.at(0)!.classes()).toContain("first");
+            expect(items.at(1)!.classes()).not.toContain("first");
+        });
+    });
+
+});

--- a/client/src/components/Common/SidebarList.test.ts
+++ b/client/src/components/Common/SidebarList.test.ts
@@ -177,5 +177,4 @@ describe("SidebarList", () => {
             expect(items.at(1)!.classes()).not.toContain("first");
         });
     });
-
 });

--- a/client/src/components/Common/SidebarList.vue
+++ b/client/src/components/Common/SidebarList.vue
@@ -1,15 +1,15 @@
-<script setup lang="ts" generic="T">
+<script setup lang="ts">
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 const props = withDefaults(
     defineProps<{
-        items: T[];
+        items: any[];
         isLoading: boolean;
         loadingMessage?: string;
         emptyMessage?: string;
-        itemKey: (item: T) => string | number;
-        itemClass?: (item: T, index: number) => string | Record<string, boolean> | undefined;
+        itemKey: (item: any) => string | number;
+        itemClass?: (item: any, index: number) => string | Record<string, boolean> | undefined;
     }>(),
     {
         loadingMessage: "Loading...",
@@ -19,14 +19,14 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-    (e: "select", item: T, index: number, event: MouseEvent): void;
+    (e: "select", item: any, index: number, event: MouseEvent): void;
 }>();
 
-function onItemClick(item: T, index: number, event: MouseEvent) {
+function onItemClick(item: any, index: number, event: MouseEvent) {
     emit("select", item, index, event);
 }
 
-function onItemKeydown(item: T, index: number, event: KeyboardEvent) {
+function onItemKeydown(item: any, index: number, event: KeyboardEvent) {
     if (event.key === "Enter") {
         emit("select", item, index, event as unknown as MouseEvent);
     }

--- a/client/src/components/Common/SidebarList.vue
+++ b/client/src/components/Common/SidebarList.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts" generic="T">
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+const props = withDefaults(
+    defineProps<{
+        items: T[];
+        isLoading: boolean;
+        loadingMessage?: string;
+        emptyMessage?: string;
+        itemKey: (item: T) => string | number;
+        itemClass?: (item: T, index: number) => string | Record<string, boolean> | undefined;
+    }>(),
+    {
+        loadingMessage: "Loading...",
+        emptyMessage: "No items found.",
+        itemClass: undefined,
+    },
+);
+
+const emit = defineEmits<{
+    (e: "select", item: T, index: number, event: MouseEvent): void;
+}>();
+
+function onItemClick(item: T, index: number, event: MouseEvent) {
+    emit("select", item, index, event);
+}
+
+function onItemKeydown(item: T, index: number, event: KeyboardEvent) {
+    if (event.key === "Enter") {
+        emit("select", item, index, event as unknown as MouseEvent);
+    }
+}
+</script>
+
+<template>
+    <div class="sidebar-list" data-description="sidebar list">
+        <div v-if="isLoading" class="text-center p-3" data-description="sidebar list loading">
+            <FontAwesomeIcon :icon="faSpinner" spin />
+            {{ loadingMessage }}
+        </div>
+        <div v-else-if="items.length === 0" class="text-muted p-3 text-center" data-description="sidebar list empty">
+            {{ emptyMessage }}
+        </div>
+        <div v-else class="sidebar-items">
+            <div
+                v-for="(item, index) in items"
+                :key="itemKey(item)"
+                class="sidebar-item d-flex align-items-start p-2 border-bottom"
+                :class="props.itemClass?.(item, index)"
+                data-description="sidebar item"
+                role="button"
+                tabindex="0"
+                @click="onItemClick(item, index, $event)"
+                @keydown="onItemKeydown(item, index, $event)">
+                <slot name="item" :item="item" :index="index" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.sidebar-list {
+    max-height: 100%;
+    overflow-y: auto;
+}
+.sidebar-item:hover {
+    background: var(--gray-200);
+    cursor: pointer;
+}
+</style>

--- a/client/src/composables/useSidebarSelection.test.ts
+++ b/client/src/composables/useSidebarSelection.test.ts
@@ -1,0 +1,256 @@
+import { ref } from "vue";
+import { describe, expect, it } from "vitest";
+
+import { useSidebarSelection } from "./useSidebarSelection";
+
+interface TestItem {
+    id: string;
+    name: string;
+}
+
+function makeItems(...ids: string[]): TestItem[] {
+    return ids.map((id) => ({ id, name: `Item ${id}` }));
+}
+
+function mouseEvent(opts: Partial<MouseEvent> = {}): MouseEvent {
+    return { shiftKey: false, ...opts } as MouseEvent;
+}
+
+describe("useSidebarSelection", () => {
+    it("starts in non-selection mode with empty selection", () => {
+        const items = ref(makeItems("a", "b", "c"));
+        const { selectionMode, selectedIds, allSelected } = useSidebarSelection(items, (i) => i.id);
+
+        expect(selectionMode.value).toBe(false);
+        expect(selectedIds.value.size).toBe(0);
+        expect(allSelected.value).toBe(false);
+    });
+
+    describe("toggleSelectionMode", () => {
+        it("toggles selection mode on", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectionMode, toggleSelectionMode } = useSidebarSelection(items, (i) => i.id);
+
+            toggleSelectionMode();
+            expect(selectionMode.value).toBe(true);
+        });
+
+        it("clears selections when toggling off", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectionMode, selectedIds, toggleSelectionMode, toggleSelection } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            toggleSelection("a");
+            expect(selectedIds.value.has("a")).toBe(true);
+
+            toggleSelectionMode();
+            expect(selectionMode.value).toBe(false);
+            expect(selectedIds.value.size).toBe(0);
+        });
+    });
+
+    describe("toggleSelection", () => {
+        it("adds then removes an id", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectedIds, toggleSelection } = useSidebarSelection(items, (i) => i.id);
+
+            toggleSelection("a");
+            expect(selectedIds.value.has("a")).toBe(true);
+
+            toggleSelection("a");
+            expect(selectedIds.value.has("a")).toBe(false);
+        });
+
+        it("can select multiple ids", () => {
+            const items = ref(makeItems("a", "b", "c"));
+            const { selectedIds, toggleSelection } = useSidebarSelection(items, (i) => i.id);
+
+            toggleSelection("a");
+            toggleSelection("c");
+            expect(selectedIds.value.size).toBe(2);
+            expect(selectedIds.value.has("a")).toBe(true);
+            expect(selectedIds.value.has("c")).toBe(true);
+        });
+    });
+
+    describe("toggleSelectAll", () => {
+        it("selects all items", () => {
+            const items = ref(makeItems("a", "b", "c"));
+            const { selectedIds, allSelected, toggleSelectAll } = useSidebarSelection(items, (i) => i.id);
+
+            toggleSelectAll();
+            expect(selectedIds.value.size).toBe(3);
+            expect(allSelected.value).toBe(true);
+        });
+
+        it("deselects all when all are selected", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectedIds, allSelected, toggleSelectAll } = useSidebarSelection(items, (i) => i.id);
+
+            toggleSelectAll();
+            expect(allSelected.value).toBe(true);
+
+            toggleSelectAll();
+            expect(selectedIds.value.size).toBe(0);
+            expect(allSelected.value).toBe(false);
+        });
+    });
+
+    describe("allSelected", () => {
+        it("is false for empty items list", () => {
+            const items = ref<TestItem[]>([]);
+            const { allSelected } = useSidebarSelection(items, (i) => i.id);
+            expect(allSelected.value).toBe(false);
+        });
+
+        it("reacts to items changes", () => {
+            const items = ref(makeItems("a", "b"));
+            const { allSelected, toggleSelectAll } = useSidebarSelection(items, (i) => i.id);
+
+            toggleSelectAll();
+            expect(allSelected.value).toBe(true);
+
+            items.value = makeItems("a", "b", "c");
+            expect(allSelected.value).toBe(false);
+        });
+    });
+
+    describe("handleSelectionClick", () => {
+        it("returns false and does not mutate state when not in selection mode", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectedIds, handleSelectionClick } = useSidebarSelection(items, (i) => i.id);
+
+            const consumed = handleSelectionClick(items.value[0]!, 0, mouseEvent());
+            expect(consumed).toBe(false);
+            expect(selectedIds.value.size).toBe(0);
+        });
+
+        it("toggles item and returns true in selection mode", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            const consumed = handleSelectionClick(items.value[0]!, 0, mouseEvent());
+            expect(consumed).toBe(true);
+            expect(selectedIds.value.has("a")).toBe(true);
+
+            handleSelectionClick(items.value[0]!, 0, mouseEvent());
+            expect(selectedIds.value.has("a")).toBe(false);
+        });
+
+        it("shift-click selects range", () => {
+            const items = ref(makeItems("a", "b", "c", "d", "e"));
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            handleSelectionClick(items.value[1]!, 1, mouseEvent());
+            handleSelectionClick(items.value[3]!, 3, mouseEvent({ shiftKey: true }));
+
+            expect(selectedIds.value.size).toBe(3);
+            expect(selectedIds.value.has("b")).toBe(true);
+            expect(selectedIds.value.has("c")).toBe(true);
+            expect(selectedIds.value.has("d")).toBe(true);
+        });
+
+        it("shift-click backwards selects range", () => {
+            const items = ref(makeItems("a", "b", "c", "d"));
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            handleSelectionClick(items.value[3]!, 3, mouseEvent());
+            handleSelectionClick(items.value[0]!, 0, mouseEvent({ shiftKey: true }));
+
+            expect(selectedIds.value.size).toBe(4);
+        });
+
+        it("shift-click without prior click acts as normal click", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            handleSelectionClick(items.value[1]!, 1, mouseEvent({ shiftKey: true }));
+            expect(selectedIds.value.size).toBe(1);
+            expect(selectedIds.value.has("b")).toBe(true);
+        });
+
+        it("resets shift-click anchor when toggling mode off and back on", () => {
+            const items = ref(makeItems("a", "b", "c", "d"));
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            handleSelectionClick(items.value[0]!, 0, mouseEvent());
+            toggleSelectionMode();
+            toggleSelectionMode();
+            handleSelectionClick(items.value[3]!, 3, mouseEvent({ shiftKey: true }));
+            expect(selectedIds.value.size).toBe(1);
+            expect(selectedIds.value.has("d")).toBe(true);
+        });
+    });
+
+    describe("pruneAfterDelete", () => {
+        it("removes stale IDs after items are removed", () => {
+            const items = ref(makeItems("a", "b", "c"));
+            const { selectedIds, toggleSelection, pruneAfterDelete } = useSidebarSelection(items, (i) => i.id);
+
+            toggleSelection("a");
+            toggleSelection("b");
+            toggleSelection("c");
+
+            items.value = makeItems("b");
+            pruneAfterDelete();
+
+            expect(selectedIds.value.size).toBe(1);
+            expect(selectedIds.value.has("b")).toBe(true);
+        });
+
+        it("exits selection mode when list is empty", () => {
+            const items = ref(makeItems("a"));
+            const { selectionMode, toggleSelectionMode, toggleSelection, pruneAfterDelete } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            toggleSelection("a");
+
+            items.value = [];
+            pruneAfterDelete();
+
+            expect(selectionMode.value).toBe(false);
+        });
+
+        it("stays in selection mode when items remain", () => {
+            const items = ref(makeItems("a", "b"));
+            const { selectionMode, toggleSelectionMode, toggleSelection, pruneAfterDelete } = useSidebarSelection(
+                items,
+                (i) => i.id
+            );
+
+            toggleSelectionMode();
+            toggleSelection("a");
+
+            items.value = makeItems("b");
+            pruneAfterDelete();
+
+            expect(selectionMode.value).toBe(true);
+        });
+    });
+});

--- a/client/src/composables/useSidebarSelection.test.ts
+++ b/client/src/composables/useSidebarSelection.test.ts
@@ -1,5 +1,5 @@
-import { ref } from "vue";
 import { describe, expect, it } from "vitest";
+import { ref } from "vue";
 
 import { useSidebarSelection } from "./useSidebarSelection";
 
@@ -39,7 +39,7 @@ describe("useSidebarSelection", () => {
             const items = ref(makeItems("a", "b"));
             const { selectionMode, selectedIds, toggleSelectionMode, toggleSelection } = useSidebarSelection(
                 items,
-                (i) => i.id
+                (i) => i.id,
             );
 
             toggleSelectionMode();
@@ -130,10 +130,7 @@ describe("useSidebarSelection", () => {
 
         it("toggles item and returns true in selection mode", () => {
             const items = ref(makeItems("a", "b"));
-            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
-                items,
-                (i) => i.id
-            );
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(items, (i) => i.id);
 
             toggleSelectionMode();
             const consumed = handleSelectionClick(items.value[0]!, 0, mouseEvent());
@@ -146,10 +143,7 @@ describe("useSidebarSelection", () => {
 
         it("shift-click selects range", () => {
             const items = ref(makeItems("a", "b", "c", "d", "e"));
-            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
-                items,
-                (i) => i.id
-            );
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(items, (i) => i.id);
 
             toggleSelectionMode();
             handleSelectionClick(items.value[1]!, 1, mouseEvent());
@@ -163,10 +157,7 @@ describe("useSidebarSelection", () => {
 
         it("shift-click backwards selects range", () => {
             const items = ref(makeItems("a", "b", "c", "d"));
-            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
-                items,
-                (i) => i.id
-            );
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(items, (i) => i.id);
 
             toggleSelectionMode();
             handleSelectionClick(items.value[3]!, 3, mouseEvent());
@@ -177,10 +168,7 @@ describe("useSidebarSelection", () => {
 
         it("shift-click without prior click acts as normal click", () => {
             const items = ref(makeItems("a", "b"));
-            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
-                items,
-                (i) => i.id
-            );
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(items, (i) => i.id);
 
             toggleSelectionMode();
             handleSelectionClick(items.value[1]!, 1, mouseEvent({ shiftKey: true }));
@@ -190,10 +178,7 @@ describe("useSidebarSelection", () => {
 
         it("resets shift-click anchor when toggling mode off and back on", () => {
             const items = ref(makeItems("a", "b", "c", "d"));
-            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(
-                items,
-                (i) => i.id
-            );
+            const { selectedIds, toggleSelectionMode, handleSelectionClick } = useSidebarSelection(items, (i) => i.id);
 
             toggleSelectionMode();
             handleSelectionClick(items.value[0]!, 0, mouseEvent());
@@ -225,7 +210,7 @@ describe("useSidebarSelection", () => {
             const items = ref(makeItems("a"));
             const { selectionMode, toggleSelectionMode, toggleSelection, pruneAfterDelete } = useSidebarSelection(
                 items,
-                (i) => i.id
+                (i) => i.id,
             );
 
             toggleSelectionMode();
@@ -241,7 +226,7 @@ describe("useSidebarSelection", () => {
             const items = ref(makeItems("a", "b"));
             const { selectionMode, toggleSelectionMode, toggleSelection, pruneAfterDelete } = useSidebarSelection(
                 items,
-                (i) => i.id
+                (i) => i.id,
             );
 
             toggleSelectionMode();

--- a/client/src/composables/useSidebarSelection.ts
+++ b/client/src/composables/useSidebarSelection.ts
@@ -1,13 +1,11 @@
-import { computed, ref, unref, type ComputedRef, type Ref } from "vue";
+import { computed, type ComputedRef, type Ref, ref, unref } from "vue";
 
 export function useSidebarSelection<T>(items: Ref<T[]> | ComputedRef<T[]>, getId: (item: T) => string) {
     const selectionMode = ref(false);
     const selectedIds = ref(new Set<string>());
     const lastClickedIndex = ref<number | null>(null);
 
-    const allSelected = computed(
-        () => unref(items).length > 0 && selectedIds.value.size === unref(items).length
-    );
+    const allSelected = computed(() => unref(items).length > 0 && selectedIds.value.size === unref(items).length);
 
     function toggleSelectionMode() {
         selectionMode.value = !selectionMode.value;

--- a/client/src/composables/useSidebarSelection.ts
+++ b/client/src/composables/useSidebarSelection.ts
@@ -1,0 +1,85 @@
+import { computed, ref, unref, type ComputedRef, type Ref } from "vue";
+
+export function useSidebarSelection<T>(items: Ref<T[]> | ComputedRef<T[]>, getId: (item: T) => string) {
+    const selectionMode = ref(false);
+    const selectedIds = ref(new Set<string>());
+    const lastClickedIndex = ref<number | null>(null);
+
+    const allSelected = computed(
+        () => unref(items).length > 0 && selectedIds.value.size === unref(items).length
+    );
+
+    function toggleSelectionMode() {
+        selectionMode.value = !selectionMode.value;
+        if (!selectionMode.value) {
+            selectedIds.value = new Set();
+            lastClickedIndex.value = null;
+        }
+    }
+
+    function toggleSelection(id: string) {
+        const next = new Set(selectedIds.value);
+        if (next.has(id)) {
+            next.delete(id);
+        } else {
+            next.add(id);
+        }
+        selectedIds.value = next;
+    }
+
+    function toggleSelectAll() {
+        if (allSelected.value) {
+            selectedIds.value = new Set();
+        } else {
+            selectedIds.value = new Set(unref(items).map(getId));
+        }
+    }
+
+    /** Handle a click in the context of selection mode.
+     *  Returns true if the click was consumed (caller should not navigate). */
+    function handleSelectionClick(item: T, index: number, event: MouseEvent): boolean {
+        if (!selectionMode.value) {
+            return false;
+        }
+        if (event.shiftKey && lastClickedIndex.value !== null) {
+            const start = Math.min(lastClickedIndex.value, index);
+            const end = Math.max(lastClickedIndex.value, index);
+            const next = new Set(selectedIds.value);
+            for (let i = start; i <= end; i++) {
+                const el = unref(items)[i];
+                if (el) {
+                    const id = getId(el);
+                    if (id) {
+                        next.add(id);
+                    }
+                }
+            }
+            selectedIds.value = next;
+        } else {
+            toggleSelection(getId(item));
+        }
+        lastClickedIndex.value = index;
+        return true;
+    }
+
+    /** Call after items are removed (e.g. batch delete). Prunes stale
+     *  selections and exits selection mode if the list is now empty. */
+    function pruneAfterDelete() {
+        const currentIds = new Set(unref(items).map(getId));
+        selectedIds.value = new Set([...selectedIds.value].filter((id) => currentIds.has(id)));
+        if (unref(items).length === 0) {
+            selectionMode.value = false;
+        }
+    }
+
+    return {
+        selectionMode,
+        selectedIds,
+        allSelected,
+        toggleSelectionMode,
+        toggleSelection,
+        toggleSelectAll,
+        handleSelectionClick,
+        pruneAfterDelete,
+    };
+}


### PR DESCRIPTION
This refactors the ChatGXY chat history panel for reuse downstream in history_pages branch and fixes a bug I noticed during testing it (the new chat history button doesn't work in this panel even though an equivalent button in the main panel does work - issue research here https://gist.github.com/jmchilton/62f2a5b30bc7a4b4cc32ecd255fe07cf).

A lot of new Vite tests here - my review command thinks the quality of the potential slop is not sloppy but I'd be happy to remove some of the tests... https://gist.github.com/jmchilton/aba988aec7f0878a8bc9cd93252ed63b. I have some coals in the fire about getting E2E tests for all of this - I would clearly feel better with that in place.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
