### PR TITLE
Enrich tool parameter JSON Schema with Galaxy metadata via model methods

### DIFF
--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -8,6 +8,8 @@ from typing import (
     Union,
 )
 
+from typing_extensions import TypedDict
+
 from galaxy.tool_util.parser.interface import (
     InputSource,
     PageSource,
@@ -76,6 +78,23 @@ def get_color_value(input_source: InputSource) -> str:
     return input_source.get("value", "#000000")
 
 
+class _CommonParamKwargs(TypedDict, total=False):
+    label: str
+    help: str
+
+
+def _common_param_kwargs(input_source: InputSource) -> _CommonParamKwargs:
+    """Extract common metadata (label, help) from InputSource for parameter models."""
+    kwargs = _CommonParamKwargs()
+    label = input_source.parse_label()
+    if label:
+        kwargs["label"] = label
+    help_text = input_source.parse_help()
+    if help_text:
+        kwargs["help"] = help_text
+    return kwargs
+
+
 def _from_input_source_galaxy(input_source: InputSource, profile: float) -> ToolParameterT:
     input_type = input_source.parse_input_type()
     if input_type == "param":
@@ -110,6 +129,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 min=min_int,
                 max=max_int,
                 validators=int_validators,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "boolean":
             nullable = input_source.parse_optional()
@@ -119,6 +139,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 name=input_source.parse_name(),
                 optional=nullable,
                 value=value,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "text":
             optional, optionality_inferred = text_input_is_optional(input_source)
@@ -131,6 +152,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 optional=optional,
                 validators=text_validators,
                 value=default_value,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "float":
             optional = input_source.parse_optional()
@@ -162,6 +184,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 min=min_float,
                 max=max_float,
                 validators=float_validators,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "hidden":
             optional = input_source.parse_optional()
@@ -173,6 +196,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 optional=optional,
                 value=value,
                 validators=hidden_validators,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "color":
             optional = input_source.parse_optional()
@@ -181,11 +205,13 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 name=input_source.parse_name(),
                 optional=optional,
                 value=get_color_value(input_source),
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "rules":
             return RulesParameterModel(
                 type="rules",
                 name=input_source.parse_name(),
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "data":
             optional = input_source.parse_optional()
@@ -195,6 +221,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 name=input_source.parse_name(),
                 optional=optional,
                 multiple=multiple,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "data_collection":
             optional = input_source.parse_optional()
@@ -205,6 +232,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 name=input_source.parse_name(),
                 optional=optional,
                 value=default_value,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "select":
             # Function... example in devteam cummeRbund.
@@ -232,6 +260,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 options=options,
                 multiple=multiple,
                 validators=select_validators,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "drill_down":
             multiple = input_source.get_bool("multiple", False)
@@ -246,6 +275,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 multiple=multiple,
                 hierarchy=hierarchy,
                 options=static_options,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "data_column":
             multiple = input_source.get_bool("multiple", False)
@@ -269,6 +299,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 multiple=multiple,
                 optional=optional,
                 value=value,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "group_tag":
             multiple = input_source.get_bool("multiple", False)
@@ -278,11 +309,13 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 name=input_source.parse_name(),
                 optional=optional,
                 multiple=multiple,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "baseurl":
             return BaseUrlParameterModel(
                 type="baseurl",
                 name=input_source.parse_name(),
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "genomebuild":
             optional = input_source.parse_optional()
@@ -292,6 +325,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 name=input_source.parse_name(),
                 optional=optional,
                 multiple=multiple,
+                **_common_param_kwargs(input_source),
             )
         elif param_type == "directory_uri":
             directory_uri_validators: List[TextCompatiableValidators] = _text_validators(input_source)
@@ -299,6 +333,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 type="directory",
                 name=input_source.parse_name(),
                 validators=directory_uri_validators,
+                **_common_param_kwargs(input_source),
             )
         else:
             raise UnknownParameterTypeError(f"Unknown Galaxy parameter type {param_type}")
@@ -336,6 +371,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
             name=input_source.parse_name(),
             test_parameter=test_parameter,
             whens=whens,
+            **_common_param_kwargs(input_source),
         )
     elif input_type == "repeat":
         name = input_source.get("name")
@@ -353,6 +389,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
             parameters=instance_tool_parameter_models,
             min=min,
             max=max,
+            **_common_param_kwargs(input_source),
         )
     elif input_type == "section":
         name = input_source.get("name")
@@ -362,6 +399,7 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
             type="section",
             name=name,
             parameters=instance_tool_parameter_models,
+            **_common_param_kwargs(input_source),
         )
     else:
         raise Exception(

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -158,11 +158,19 @@ class ParamModel(Protocol):
         # input value MUST be specified.
         ...
 
+    def field_kwargs(self) -> Dict[str, Any]:
+        """Return kwargs for pydantic Field() including json_schema_extra metadata."""
+        ...
+
 
 def safe_field_name(name: str) -> str:
     if name.startswith("_"):
         return f"X{name}"
     return name
+
+
+def _label_value_dicts(options: List[Any]) -> List[Dict[str, Any]]:
+    return [{"label": o.label, "value": o.value, "selected": o.selected} for o in options]
 
 
 def dynamic_model_information_from_py_type(
@@ -177,9 +185,10 @@ def dynamic_model_information_from_py_type(
     if not py_type_is_optional and not requires_value:
         validators["not_null"] = field_validator(name)(Validators.validate_not_none)
 
+    field_kwargs = param_model.field_kwargs()
     return DynamicModelInformation(
         name,
-        (py_type, Field(initialize, alias=param_model.name if param_model.name != name else None)),
+        (py_type, Field(initialize, alias=param_model.name if param_model.name != name else None, **field_kwargs)),
         validators,
     )
 
@@ -197,6 +206,10 @@ class BaseToolParameterModelDefinition(ToolSourceBaseModel):
     @abstractmethod
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         """Return info needed to build Pydantic model at runtime for validation."""
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        """Return kwargs for pydantic Field() including json_schema_extra metadata."""
+        return {"json_schema_extra": {"gx_type": self.parameter_type}}
 
 
 class BaseGalaxyToolParameterModelDefinition(BaseToolParameterModelDefinition):
@@ -218,6 +231,20 @@ class BaseGalaxyToolParameterModelDefinition(BaseToolParameterModelDefinition):
     ] = None
     is_dynamic: bool = False
     optional: Annotated[bool, Field(description="If `false`, parameter must have a value.")] = False
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {}
+        if self.label:
+            kwargs["title"] = self.label
+        description_parts = []
+        if self.help:
+            description_parts.append(self.help)
+        if self.argument:
+            description_parts.append(f"({self.argument})")
+        if description_parts:
+            kwargs["description"] = " ".join(description_parts)
+        kwargs["json_schema_extra"] = {"gx_type": self.parameter_type}
+        return kwargs
 
 
 class LabelValue(BaseModel):
@@ -279,6 +306,14 @@ class TextParameterModel(BaseGalaxyToolParameterModelDefinition):
     default_options: List[LabelValue] = []
     validators: List[TextCompatiableValidators] = []
 
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        extra = kwargs["json_schema_extra"]
+        extra["gx_area"] = self.area
+        if self.default_options:
+            extra["gx_default_options"] = _label_value_dicts(self.default_options)
+        return kwargs
+
     @property
     def py_type(self) -> Type:
         return optional_if_needed(StrictStr, self.optional)
@@ -318,6 +353,15 @@ class IntegerParameterModel(BaseGalaxyToolParameterModelDefinition):
     max: Optional[int] = None
     validators: List[NumberCompatiableValidators] = []
 
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        extra = kwargs["json_schema_extra"]
+        if self.min is not None:
+            extra["gx_min"] = self.min
+        if self.max is not None:
+            extra["gx_max"] = self.max
+        return kwargs
+
     @property
     def py_type(self) -> Type:
         return optional_if_needed(StrictInt, self.optional)
@@ -349,6 +393,15 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
     min: Optional[float] = None
     max: Optional[float] = None
     validators: List[NumberCompatiableValidators] = []
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        extra = kwargs["json_schema_extra"]
+        if self.min is not None:
+            extra["gx_min"] = self.min
+        if self.max is not None:
+            extra["gx_max"] = self.max
+        return kwargs
 
     @property
     def py_type(self) -> Type:
@@ -919,6 +972,17 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
     min: Optional[int] = None
     max: Optional[int] = None
 
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        extra = kwargs["json_schema_extra"]
+        extra["gx_extensions"] = self.extensions
+        extra["gx_multiple"] = self.multiple
+        if self.min is not None:
+            extra["gx_min"] = self.min
+        if self.max is not None:
+            extra["gx_max"] = self.max
+        return kwargs
+
     @property
     def py_type(self) -> Type:
         base_model: Type
@@ -1111,6 +1175,11 @@ class DataCollectionParameterModel(BaseGalaxyToolParameterModelDefinition):
     extensions: List[str] = ["data"]
     value: Optional[Dict[str, Any]]
 
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        kwargs["json_schema_extra"]["gx_extensions"] = self.extensions
+        return kwargs
+
     @property
     def py_type(self) -> Type:
         return optional_if_needed(DataCollectionRequestOrCollectionUri, self.optional)
@@ -1294,9 +1363,10 @@ class ColorParameterModel(BaseGalaxyToolParameterModelDefinition):
             validators = {"color_format": field_validator(self.name)(ColorParameterModel.validate_color_str_if_value)}
         else:
             validators = {"color_format": field_validator(self.name)(ColorParameterModel.validate_color_str)}
+        field_kwargs = self.field_kwargs()
         return DynamicModelInformation(
             self.name,
-            (py_type, initialize),
+            (py_type, Field(initialize, **field_kwargs)),
             validators,
         )
 
@@ -1391,6 +1461,14 @@ class SelectParameterModel(BaseGalaxyToolParameterModelDefinition):
     options: Optional[List[LabelValue]] = None
     multiple: bool = False
     validators: List[SelectCompatiableValidators] = []
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        extra = kwargs["json_schema_extra"]
+        if self.options is not None and self.options:
+            extra["gx_options"] = _label_value_dicts(self.options)
+        extra["gx_multiple"] = self.multiple
+        return kwargs
 
     @staticmethod
     def split_str(cls, data: Any) -> Any:
@@ -1498,6 +1576,11 @@ class GenomeBuildParameterModel(BaseGalaxyToolParameterModelDefinition):
     type: Literal["genomebuild"]
     multiple: bool
 
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        kwargs["json_schema_extra"]["gx_multiple"] = self.multiple
+        return kwargs
+
     @property
     def py_type(self) -> Type:
         py_type: Type = StrictStr
@@ -1551,6 +1634,11 @@ class DrillDownParameterModel(BaseGalaxyToolParameterModelDefinition):
     options: Optional[List[DrillDownOptionsDict]] = None
     multiple: bool
     hierarchy: DrillDownHierarchyT
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        kwargs["json_schema_extra"]["gx_multiple"] = self.multiple
+        return kwargs
 
     @property
     def py_type(self) -> Type:
@@ -1645,6 +1733,11 @@ class DataColumnParameterModel(BaseGalaxyToolParameterModelDefinition):
     multiple: bool
     value: Optional[Union[int, List[int]]] = None
 
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        kwargs["json_schema_extra"]["gx_multiple"] = self.multiple
+        return kwargs
+
     @staticmethod
     def split_str(cls, data: Any) -> Any:
         if isinstance(data, str):
@@ -1694,6 +1787,11 @@ class GroupTagParameterModel(BaseGalaxyToolParameterModelDefinition):
     parameter_type: Literal["gx_group_tag"] = "gx_group_tag"
     type: Literal["group_tag"]
     multiple: bool
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        kwargs["json_schema_extra"]["gx_multiple"] = self.multiple
+        return kwargs
 
     @property
     def py_type(self) -> Type:
@@ -1756,6 +1854,18 @@ class ConditionalParameterModel(BaseGalaxyToolParameterModelDefinition):
     type: Literal["conditional"]
     test_parameter: Union[BooleanParameterModel, SelectParameterModel]
     whens: List[ConditionalWhen]
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        extra = kwargs["json_schema_extra"]
+        test_param = self.test_parameter
+        if isinstance(test_param, SelectParameterModel) and test_param.options:
+            extra["gx_options"] = _label_value_dicts(test_param.options)
+        if test_param.label:
+            extra["gx_test_label"] = test_param.label
+        if test_param.help:
+            extra["gx_test_help"] = test_param.help
+        return kwargs
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         is_boolean = isinstance(self.test_parameter, BooleanParameterModel)
@@ -1846,9 +1956,10 @@ class ConditionalParameterModel(BaseGalaxyToolParameterModelDefinition):
             else:
                 initialize_cond = None
 
+        field_kwargs = self.field_kwargs()
         return DynamicModelInformation(
             self.name,
-            (py_type, initialize_cond),
+            (py_type, Field(initialize_cond, **field_kwargs)),
             {},
         )
 
@@ -1863,6 +1974,15 @@ class RepeatParameterModel(BaseGalaxyToolParameterModelDefinition):
     parameters: List["ToolParameterT"]
     min: Optional[int] = None
     max: Optional[int] = None
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        extra = kwargs["json_schema_extra"]
+        if self.min is not None:
+            extra["gx_min"] = self.min
+        if self.max is not None:
+            extra["gx_max"] = self.max
+        return kwargs
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         # Maybe validators for min and max...
@@ -1887,9 +2007,10 @@ class RepeatParameterModel(BaseGalaxyToolParameterModelDefinition):
         class RepeatType(RootModel):
             root: List[instance_class] = Field(initialize_repeat, min_length=min_length, max_length=max_length)  # type: ignore[valid-type]
 
+        field_kwargs = self.field_kwargs()
         return DynamicModelInformation(
             self.name,
-            (RepeatType, initialize_repeat),
+            (RepeatType, Field(initialize_repeat, **field_kwargs)),
             {},
         )
 
@@ -1921,9 +2042,10 @@ class SectionParameterModel(BaseGalaxyToolParameterModelDefinition):
             initialize_section = ...
         else:
             initialize_section = None
+        field_kwargs = self.field_kwargs()
         return DynamicModelInformation(
             self.name,
-            (instance_class, initialize_section),
+            (instance_class, Field(initialize_section, **field_kwargs)),
             {},
         )
 

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -324,6 +324,46 @@ class TestToolsApi(ApiTestCase, TestsTools):
         with pytest.raises(ValidationError):
             validate(instance={"parameter": "Foobar"}, schema=landing_schema)
 
+    @skip_without_tool("cat_data_and_sleep")
+    def test_tool_schema_metadata(self):
+        """Test that tool parameter JSON schemas include Galaxy metadata attributes."""
+
+        # cat_data_and_sleep has an integer param with label and help
+        schema = self.dataset_populator.get_request_schema("cat_data_and_sleep")
+        props = schema["properties"]
+        sleep_prop = props["sleep_time"]
+        assert sleep_prop["title"] == "Sleep"
+        assert "Optionally simulates computation" in sleep_prop["description"]
+        assert sleep_prop["gx_type"] == "gx_integer"
+
+        # data param should have gx_type and gx_extensions
+        input1_prop = props["input1"]
+        assert input1_prop["title"] == "Concatenate Dataset"
+        assert input1_prop["gx_type"] == "gx_data"
+        assert "gx_extensions" in input1_prop
+
+        # repeat param should have gx_type
+        queries_prop = props["queries"]
+        assert queries_prop["gx_type"] == "gx_repeat"
+
+    @skip_without_tool("gx_int_min_max")
+    def test_tool_schema_min_max(self):
+        schema = self.dataset_populator.get_request_schema("gx_int_min_max")
+        param_prop = schema["properties"]["parameter"]
+        assert param_prop["gx_type"] == "gx_integer"
+        assert param_prop["gx_min"] == 0
+        assert param_prop["gx_max"] == 10
+
+    @skip_without_tool("gx_select")
+    def test_tool_schema_select_options(self):
+        schema = self.dataset_populator.get_request_schema("gx_select")
+        param_prop = schema["properties"]["parameter"]
+        assert param_prop["gx_type"] == "gx_select"
+        assert "gx_options" in param_prop
+        option_values = [o["value"] for o in param_prop["gx_options"]]
+        assert "--ex1" in option_values
+        assert "ex2" in option_values
+
     @skip_without_tool("test_data_source")
     @skip_if_github_down
     def test_data_source_ok_request(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1803,6 +1803,11 @@ class BaseDatasetPopulator(BasePopulator):
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
 
+    def get_request_schema(self, tool_id: str) -> dict[str, Any]:
+        response = self._get(f"tools/{tool_id}/parameter_request_schema")
+        api_asserts.assert_status_code_is_ok(response)
+        return response.json()
+
     def get_history_tool_requests(self, history_id: str) -> list[dict[str, Any]]:
         response = self._get(f"histories/{history_id}/tool_requests")
         api_asserts.assert_status_code_is_ok(response)

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -336,6 +336,7 @@
 
   <!-- Tools without tool test but useful for hand-crafted, artisanal test cases. -->
   <tool file="cat_data_and_sleep.xml" />
+  <tool file="parameters/gx_int_min_max.xml" />
 
   <!-- Load collection operation tools - I consider these part of the
        "framework" and they are used to in API tests to test the underlying


### PR DESCRIPTION
Add field_kwargs() methods to the pydantic parameter model hierarchy to expose label, help, argument, options, extensions, and other Galaxy metadata in generated JSON Schema. Each model class owns its own schema metadata rather than relying on a central hasattr/getattr function.

Add _common_param_kwargs helper to extract label/help from InputSource and pass them to all parameter model constructors in the factory.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
