### PR TITLE
[26.0] Fix uncaught `ImplicitConversionRequired`

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1528,7 +1528,10 @@ class ColumnListParameter(SelectToolParameter):
         Show column labels rather than c1..cn if use_header_names=True
         """
         options: Sequence[ParameterOption] = []
-        column_list = self.get_column_list(trans, other_values)
+        try:
+            column_list = self.get_column_list(trans, other_values)
+        except ImplicitConversionRequired:
+            return options
         if not column_list:
             return options
         # if available use column_names metadata for option names


### PR DESCRIPTION
When a ColumnListParameter references a dataset that needs format conversion but the converted dataset isn't available yet, get_column_list() raises ImplicitConversionRequired. This exception propagated through get_options() -> to_dict() and was caught in populate_model.py's except handler, which then called to_dict() again, raising the same uncaught exception a second time.

Handle ImplicitConversionRequired directly in get_options() by returning an empty options list, consistent with how get_initial_value() and _select_from_json() already handle this exception in sibling methods.

Fixes https://github.com/galaxyproject/galaxy/issues/22014

https://claude.ai/code/session_01PkQibjRiKGkkpUShH6nST1

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
