### PR TITLE
[26.0] Fix toolshed "copy page link" copying relative URL instead of absolute

### DIFF
--- a/lib/tool_shed/webapp/frontend/src/components/RepositoryLinks.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RepositoryLinks.vue
@@ -13,7 +13,8 @@ interface RepositoryLinkProps {
 // why are the v-if's below not preventing needing undefined here typescript?
 function copyLink(link: string | undefined) {
     if (link) {
-        copyAndNotify(link, "Link copied to your clipboard")
+        const absoluteLink = link.startsWith("http") ? link : `${window.location.origin}${link}`
+        copyAndNotify(absoluteLink, "Link copied to your clipboard")
     }
 }
 


### PR DESCRIPTION
The copy link button on ToolShed repository pages was copying a relative path (e.g. /view/iuc/progressivemauve/ce795616bd9c) instead of a full absolute URL. Prepend window.location.origin for relative links while leaving already-absolute URLs (homepage, dev URL) unchanged.

Fixes https://github.com/galaxyproject/galaxy/issues/22008

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
