### PR TITLE
[26.0] Fix AttributeError when fetching citations for missing tools

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7785,6 +7785,16 @@ export interface components {
              */
             type: string;
         };
+        /** BibtexCitationResponse */
+        BibtexCitationResponse: {
+            /** Content */
+            content: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            format: "bibtex";
+        };
         /** Body_analyze_error_api_ai_agents_error_analysis_post */
         Body_analyze_error_api_ai_agents_error_analysis_post: {
             /**
@@ -8372,6 +8382,18 @@ export interface components {
             content: string;
             /** type */
             type: string;
+        };
+        /** CitationErrorResponse */
+        CitationErrorResponse: {
+            /** Error */
+            error: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            format: "error";
+            /** Tool Id */
+            tool_id: string;
         };
         /** ClaimLandingPayload */
         ClaimLandingPayload: {
@@ -32581,7 +32603,10 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown[];
+                    "application/json": (
+                        | components["schemas"]["BibtexCitationResponse"]
+                        | components["schemas"]["CitationErrorResponse"]
+                    )[];
                 };
             };
             /** @description Request Error */

--- a/client/src/components/Citation/CitationsList.test.ts
+++ b/client/src/components/Citation/CitationsList.test.ts
@@ -23,17 +23,20 @@ setMockConfig({
 
 vi.mock("@/components/Citation/services", () => ({
     getCitations: vi.fn(() =>
-        Promise.resolve([
-            {
-                raw: "@article{Hourahine_2020,\n\tdoi = {10.1063/1.5143190},\n\turl = {https://doi.org/10.1063%2F1.5143190},\n\tyear = 2020,\n\tmonth = {mar},\n\tpublisher = {{AIP} Publishing},\n\tvolume = {152},\n\tnumber = {12},\n\tpages = {124101},\n\tauthor = {B. Hourahine and B. Aradi and V. Blum and F. Bonaf{\\'{e}} and A. Buccheri and C. Camacho and C. Cevallos and M. Y. Deshaye and T. Dumitric{\\u{a}} and A. Dominguez and S. Ehlert and M. Elstner and T. van der Heide and J. Hermann and S. Irle and J. J. Kranz and C. K\u00f6hler and T. Kowalczyk and T. Kuba{\\v{r}} and I. S. Lee and V. Lutsker and R. J. Maurer and S. K. Min and I. Mitchell and C. Negre and T. A. Niehaus and A. M. N. Niklasson and A. J. Page and A. Pecchia and G. Penazzi and M. P. Persson and J. {\\v{R}}ez{\\'{a}}{\\v{c}} and C. G. S{\\'{a}}nchez and M. Sternberg and M. St\u00f6hr and F. Stuckenberg and A. Tkatchenko and V. W.-z. Yu and T. Frauenheim},\n\ttitle = {{DFTB}$\\mathplus$, a software package for efficient approximate density functional theory based atomistic simulations},\n\tjournal = {The Journal of Chemical Physics}\n}",
-                cite: {
-                    format: vi.fn(
-                        () =>
-                            '<div class="csl-bib-body"><div data-csl-entry-id="Hourahine_2020" class="csl-entry">Hourahine, B. (2020). DFTB$\\mathplus$, a software package for efficient approximate density functional theory based atomistic simulations. The Journal of Chemical Physics, 152(12), 124101. https://doi.org/10.1063/1.5143190</div></div>',
-                    ),
+        Promise.resolve({
+            citations: [
+                {
+                    raw: "@article{Hourahine_2020,\n\tdoi = {10.1063/1.5143190},\n\turl = {https://doi.org/10.1063%2F1.5143190},\n\tyear = 2020,\n\tmonth = {mar},\n\tpublisher = {{AIP} Publishing},\n\tvolume = {152},\n\tnumber = {12},\n\tpages = {124101},\n\tauthor = {B. Hourahine and B. Aradi and V. Blum and F. Bonaf{\\'{e}} and A. Buccheri and C. Camacho and C. Cevallos and M. Y. Deshaye and T. Dumitric{\\u{a}} and A. Dominguez and S. Ehlert and M. Elstner and T. van der Heide and J. Hermann and S. Irle and J. J. Kranz and C. K\u00f6hler and T. Kowalczyk and T. Kuba{\\v{r}} and I. S. Lee and V. Lutsker and R. J. Maurer and S. K. Min and I. Mitchell and C. Negre and T. A. Niehaus and A. M. N. Niklasson and A. J. Page and A. Pecchia and G. Penazzi and M. P. Persson and J. {\\v{R}}ez{\\'{a}}{\\v{c}} and C. G. S{\\'{a}}nchez and M. Sternberg and M. St\u00f6hr and F. Stuckenberg and A. Tkatchenko and V. W.-z. Yu and T. Frauenheim},\n\ttitle = {{DFTB}$\\mathplus$, a software package for efficient approximate density functional theory based atomistic simulations},\n\tjournal = {The Journal of Chemical Physics}\n}",
+                    cite: {
+                        format: vi.fn(
+                            () =>
+                                '<div class="csl-bib-body"><div data-csl-entry-id="Hourahine_2020" class="csl-entry">Hourahine, B. (2020). DFTB$\\mathplus$, a software package for efficient approximate density functional theory based atomistic simulations. The Journal of Chemical Physics, 152(12), 124101. https://doi.org/10.1063/1.5143190</div></div>',
+                        ),
+                    },
                 },
-            },
-        ]),
+            ],
+            warnings: [],
+        }),
     ),
 }));
 

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faCopy, faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BCard, BCollapse, BNav, BNavItem, BSpinner } from "bootstrap-vue";
+import { BAlert, BButton, BCard, BCollapse, BNav, BNavItem, BSpinner } from "bootstrap-vue";
 import { computed, onMounted, onUpdated, ref, toRef } from "vue";
 
 import { getCitations } from "@/components/Citation/services";
@@ -37,6 +37,7 @@ const emit = defineEmits(["rendered", "show", "shown", "hide", "hidden"]);
 
 const outputFormat = ref<string>(outputFormats.CITATION);
 const fetchedCitations = ref<Citation[]>([]);
+const warnings = ref<string[]>([]);
 const isLoading = ref<boolean>(false);
 
 onUpdated(() => {
@@ -46,7 +47,9 @@ onUpdated(() => {
 onMounted(async () => {
     try {
         isLoading.value = true;
-        fetchedCitations.value = await getCitations(props.source, props.id);
+        const result = await getCitations(props.source, props.id);
+        fetchedCitations.value = result.citations;
+        warnings.value = result.warnings;
     } catch (e) {
         console.error(e);
     } finally {
@@ -181,6 +184,12 @@ function citationsToBibtexAsText() {
                 <div v-if="source === 'histories'" class="infomessage">
                     <div v-html="config?.citations_export_message_html"></div>
                 </div>
+
+                <BAlert v-if="warnings.length > 0" variant="warning" show>
+                    <ul class="mb-0">
+                        <li v-for="(warning, idx) in warnings" :key="idx">{{ warning }}</li>
+                    </ul>
+                </BAlert>
 
                 <div class="citations-formatted">
                     <CitationItem

--- a/client/src/components/Citation/index.ts
+++ b/client/src/components/Citation/index.ts
@@ -14,3 +14,8 @@ export interface Citation {
         ) => string;
     };
 }
+
+export interface CitationsResult {
+    citations: Citation[];
+    warnings: string[];
+}

--- a/client/src/components/Citation/services.test.ts
+++ b/client/src/components/Citation/services.test.ts
@@ -24,14 +24,35 @@ describe("Citation", () => {
                     return HttpResponse.json(mockCitationResponseJson);
                 }),
             );
-            const citations = await getCitations("tools", "random_lines1");
-            const formattedCitation = citations?.[0]?.cite.format("bibliography", {
+            const result = await getCitations("tools", "random_lines1");
+            expect(result.warnings).toHaveLength(0);
+            const formattedCitation = result.citations?.[0]?.cite.format("bibliography", {
                 format: "html",
                 template: "apa",
                 lang: "en-US",
             });
             expect(formattedCitation).toContain("Hourahine");
             // TODO: actually test formatting here, too.
+        });
+
+        it("Should separate error entries into warnings", async () => {
+            const mockResponseWithErrors = [
+                ...mockCitationResponseJson,
+                {
+                    format: "error",
+                    error: "Tool 'missing_tool' not found. Citations for this tool may be missing.",
+                    tool_id: "missing_tool",
+                },
+            ];
+            server.use(
+                http.untyped.get("/api/histories/test-history/citations", () => {
+                    return HttpResponse.json(mockResponseWithErrors);
+                }),
+            );
+            const result = await getCitations("histories", "test-history");
+            expect(result.citations).toHaveLength(1);
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0]).toContain("missing_tool");
         });
     });
 });

--- a/client/src/components/Citation/services.ts
+++ b/client/src/components/Citation/services.ts
@@ -3,15 +3,20 @@ import axios from "axios";
 import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
-import type { Citation } from ".";
+import type { CitationsResult } from ".";
 
-export async function getCitations(source: string, id: string): Promise<Citation[]> {
+export async function getCitations(source: string, id: string): Promise<CitationsResult> {
     try {
         const request = await axios.get(`${getAppRoot()}api/${source}/${id}/citations`);
         const rawCitations = request.data;
         const citations = [];
+        const warnings: string[] = [];
         const { Cite } = await import("./cite");
         for (const rawCitation of rawCitations) {
+            if (rawCitation.format === "error") {
+                warnings.push(rawCitation.error);
+                continue;
+            }
             try {
                 const cite = new Cite(rawCitation.content);
                 citations.push({ raw: rawCitation.content, cite: cite });
@@ -19,7 +24,7 @@ export async function getCitations(source: string, id: string): Promise<Citation
                 console.warn(`Error parsing bibtex: ${err}`);
             }
         }
-        return citations;
+        return { citations, warnings };
     } catch (e) {
         rethrowSimple(e);
     }

--- a/client/src/components/Tool/ToolFooter.test.js
+++ b/client/src/components/Tool/ToolFooter.test.js
@@ -36,11 +36,11 @@ const citationsB = [
 vi.mock("@/components/Citation/services", () => ({
     getCitations: vi.fn((source, id) => {
         if (id === "tool_a") {
-            return Promise.resolve(citationsA);
+            return Promise.resolve({ citations: citationsA, warnings: [] });
         } else if (id === "tool_b") {
-            return Promise.resolve(citationsB);
+            return Promise.resolve({ citations: citationsB, warnings: [] });
         }
-        return Promise.resolve([]);
+        return Promise.resolve({ citations: [], warnings: [] });
     }),
 }));
 

--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -145,8 +145,8 @@ export default {
         loadCitations() {
             if (this.hasCitations) {
                 getCitations("tools", this.id)
-                    .then((citations) => {
-                        this.citations = citations;
+                    .then((result) => {
+                        this.citations = result.citations;
                     })
                     .catch((e) => {
                         console.error(e);

--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -8,6 +8,10 @@ from typing import (
 from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
 
+from galaxy.schema.citations import (
+    BibtexCitationResponse,
+    CitationErrorResponse,
+)
 from galaxy.structured_app import BasicSharedApp
 from galaxy.tool_util_models.tool_source import Citation
 from galaxy.util import (
@@ -31,11 +35,21 @@ class CitationsManager:
 
     def citations_for_tool_ids(self, tool_ids):
         citation_collection = CitationCollection()
+        errors: list[CitationErrorResponse] = []
         for tool_id in tool_ids:
             tool = self._get_tool(tool_id)
+            if not tool:
+                log.warning("Tool '%s' not found, citations may be missing.", tool_id)
+                errors.append(
+                    CitationErrorResponse(
+                        error=f"Tool '{tool_id}' not found. Citations for this tool may be missing.",
+                        tool_id=tool_id,
+                    )
+                )
+                continue
             for citation in self.citations_for_tool(tool):
                 citation_collection.add(citation)
-        return citation_collection.citations
+        return citation_collection.citations, errors
 
     def parse_citation(self, citation_model: Citation) -> OptionalCitationT:
         return parse_citation(citation_model, self)
@@ -115,10 +129,7 @@ class CitationCollection:
 class BaseCitation:
     def to_dict(self, citation_format):
         if citation_format == "bibtex":
-            return dict(
-                format="bibtex",
-                content=self.to_bibtex(),
-            )
+            return BibtexCitationResponse(content=self.to_bibtex())
         else:
             raise Exception(f"Unknown citation format {citation_format}")
 

--- a/lib/galaxy/schema/citations.py
+++ b/lib/galaxy/schema/citations.py
@@ -1,0 +1,24 @@
+from typing import (
+    Annotated,
+    Literal,
+    Union,
+)
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+
+class BibtexCitationResponse(BaseModel):
+    format: Literal["bibtex"] = "bibtex"
+    content: str
+
+
+class CitationErrorResponse(BaseModel):
+    format: Literal["error"] = "error"
+    error: str
+    tool_id: str
+
+
+CitationItem = Annotated[Union[BibtexCitationResponse, CitationErrorResponse], Field(discriminator="format")]

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -33,6 +33,9 @@ from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
 )
+from galaxy.schema.citations import (
+    CitationItem,
+)
 from galaxy.schema.fields import (
     AcceptHeaderValidator,
     DecodedDatabaseIdField,
@@ -371,7 +374,7 @@ class FastAPIHistories:
         self,
         history_id: HistoryIDPathParam,
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> list[Any]:
+    ) -> list[CitationItem]:
         return self.service.citations(trans, history_id)
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -31,6 +31,7 @@ from galaxy import (
     web,
 )
 from galaxy.datatypes.data import get_params_and_input_name
+from galaxy.managers.citations import CitationsManager
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.context import (
     ProvidesHistoryContext,
@@ -427,6 +428,7 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
     RESTful controller for interactions with tools.
     """
 
+    citations_manager: CitationsManager = depends(CitationsManager)
     history_manager: HistoryManager = depends(HistoryManager)
     hda_manager: HDAManager = depends(HDAManager)
     hdca_manager: DatasetCollectionManager = depends(DatasetCollectionManager)
@@ -792,11 +794,10 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
     @expose_api_anonymous_and_sessionless
     def citations(self, trans: GalaxyWebTransaction, id, **kwds):
-        tool = self.service._get_tool(trans, id, user=trans.user)
-        rval = []
-        for citation in tool.citations:
-            rval.append(citation.to_dict("bibtex"))
-        return rval
+        citations, errors = self.citations_manager.citations_for_tool_ids([id])
+        return [citation.to_dict("bibtex").model_dump() for citation in citations] + [
+            error.model_dump() for error in errors
+        ]
 
     @expose_api
     def conversion(self, trans: GalaxyWebTransaction, tool_id, payload, **kwd):

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -560,7 +560,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             if not tool_id:
                 continue
             tool_ids.add(tool_id)
-        return [citation.to_dict("bibtex") for citation in self.citations_manager.citations_for_tool_ids(tool_ids)]
+        citations, errors = self.citations_manager.citations_for_tool_ids(tool_ids)
+        return [citation.to_dict("bibtex") for citation in citations] + errors
 
     def index_exports(
         self,


### PR DESCRIPTION
When a history contains datasets created by tools that are no longer installed, the citations endpoint crashes accessing tool.citations on None. Instead of crashing, return error entries in the API response for missing tools and render them as warnings in the frontend.

Fixes https://github.com/galaxyproject/galaxy/issues/22017

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
