### PR TITLE
[26.0] AttributeError when history is None during tool execution

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -297,7 +297,7 @@ def _execute(
             history = execution_slice.history or history
             jobs_executed += 1
 
-    if execution_slice:
+    if execution_slice and history:
         history.add_pending_items()
     # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets
     trans.sa_session.commit()

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -321,7 +321,9 @@ class ToolsService(ServiceBase):
             history_id = trans.security.decode_id(history_id) if isinstance(history_id, str) else history_id
             target_history = self.history_manager.get_mutable(history_id, trans.user, current_history=trans.history)
         else:
-            target_history = None
+            if trans.history is None:
+                raise exceptions.RequestParameterMissingException("A valid history is required to execute tools.")
+            target_history = trans.history
 
         # Set up inputs.
         inputs = payload.get("inputs", {})


### PR DESCRIPTION
When executing tools via the API without a history_id and no active session history, the history variable is None, causing a crash at history.add_pending_items(). This raises a clear error early in the service layer and adds a defensive guard in execute.py.

Fixes https://github.com/galaxyproject/galaxy/issues/22018

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
