### PR TITLE
[26.0] Fix subworkflow editing navigation and enable e2e test

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1072,8 +1072,10 @@ export default {
             this.onNavigate(`/workflows/run?id=${this.id}`, false, false, true);
         },
         async onNavigate(url, forceSave = false, ignoreChanges = false, appendVersion = false) {
+            let proceed = false;
             if (this.isNewTempWorkflow) {
                 await this.onCreate();
+                proceed = true;
             } else if (this.hasChanges && !forceSave && !ignoreChanges) {
                 // if there are changes, prompt user to save or discard or cancel
                 this.navUrl = url;
@@ -1081,7 +1083,13 @@ export default {
                 return;
             } else if (forceSave) {
                 // when forceSave is true, save the workflow before navigating
-                await this.onSave();
+                proceed = await this.onSave();
+            } else {
+                // no changes to save, proceed with navigation
+                proceed = true;
+            }
+            if (!proceed) {
+                return;
             }
 
             if (appendVersion && this.version !== undefined) {

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -44,7 +44,8 @@ export default {
                 this.skipNextReload = false;
             }
 
-            this.version = parseInt(Query.get("version"), 10);
+            const versionParam = Query.get("version");
+            this.version = versionParam !== undefined ? parseInt(versionParam, 10) : undefined;
             this.storedWorkflowId = Query.get("id");
             this.workflowId = Query.get("workflow_id");
             const workflowId = this.workflowId || this.storedWorkflowId;

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -4,7 +4,6 @@ from typing import (
     Optional,
 )
 
-import pytest
 import yaml
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -923,8 +922,6 @@ steps:
         self.workflow_editor_connect("nested_workflow#workflow_output", "metadata_bam#input_bam")
         self.assert_connected("nested_workflow#workflow_output", "metadata_bam#input_bam")
 
-    @pytest.mark.xfail
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_edit_subworkflow(self):
         self.open_in_workflow_editor("""
@@ -939,10 +936,13 @@ steps:
           - tool_id: create_2
             label: create_2
 """)
+        # Save after auto-layout so there are no unsaved changes
+        self.assert_workflow_has_changes_and_save()
         editor = self.components.workflow_editor
         node = editor.node._(label="nested_workflow")
         node.wait_for_and_click()
         editor.edit_subworkflow.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
         node = editor.node._(label="create_2")
         node.wait_for_and_click()
 


### PR DESCRIPTION
Two bugs prevented navigating to edit a subworkflow:

1. In `onNavigate`, when neither `isNewTempWorkflow`, `hasChanges`, nor `forceSave` conditions were met (e.g., no unsaved changes), `proceed` stayed `false` and navigation was silently blocked. This also broke the "Don't Save" path in the SaveChangesModal. Fix: add `else { proceed = true }` for the no-changes case.

2. In `WorkflowEditor.vue`, `parseInt(undefined, 10)` produced `NaN` when no version query parameter was present (e.g., navigating to `/workflows/edit?workflow_id=X`). This `NaN` was passed to the `getWorkflowInfo` API call, potentially causing validation errors. Fix: only parse version when the query parameter exists.

Also enables the existing `test_edit_subworkflow` e2e test by removing `@pytest.mark.xfail` and `@selenium_only` decorators, and adding a save step after auto-layout to clear unsaved changes before testing the edit subworkflow flow.

Fixes https://github.com/galaxyproject/galaxy/issues/21998

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
