### PR TITLE
[26.0] Fix AttributeError when export_metadata is a string instead of dict

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -684,11 +684,12 @@ class HistoryExportManager:
         return self.export_tracker.create_export_association(object_id=history_id, object_type=self.export_object_type)
 
     def get_record_metadata(self, export: model.StoreExportAssociation) -> Optional[ExportObjectMetadata]:
-        metadata: Any = export.export_metadata
+        metadata: Union[dict, str, None] = export.export_metadata
         if not metadata:
             return None
         if isinstance(metadata, str):
             metadata = json.loads(metadata)
+        assert isinstance(metadata, dict)
         # Use model_construct to skip validation and avoid double-encoding of ID fields
         request_data_raw = metadata.get("request_data", {})
         result_data_raw = metadata.get("result_data")

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -5,6 +5,7 @@ Histories are containers for datasets or dataset collections
 created (or copied) by users over the course of an analysis.
 """
 
+import json
 import logging
 from typing import (
     Any,
@@ -683,9 +684,11 @@ class HistoryExportManager:
         return self.export_tracker.create_export_association(object_id=history_id, object_type=self.export_object_type)
 
     def get_record_metadata(self, export: model.StoreExportAssociation) -> Optional[ExportObjectMetadata]:
-        metadata = export.export_metadata
+        metadata: Any = export.export_metadata
         if not metadata:
             return None
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
         # Use model_construct to skip validation and avoid double-encoding of ID fields
         request_data_raw = metadata.get("request_data", {})
         result_data_raw = metadata.get("result_data")

--- a/lib/galaxy/webapps/galaxy/api/exports.py
+++ b/lib/galaxy/webapps/galaxy/api/exports.py
@@ -7,6 +7,7 @@ import logging
 from typing import (
     Annotated,
     Optional,
+    Union,
 )
 
 from fastapi import Query
@@ -91,7 +92,7 @@ class FastAPIExports:
 
         return ExportTaskListResponse(root=results)
 
-    def _parse_export_metadata(self, metadata) -> Optional[ExportObjectMetadata]:
+    def _parse_export_metadata(self, metadata: Union[dict, str]) -> Optional[ExportObjectMetadata]:
         """Parse export metadata dict without double-encoding ID fields.
 
         We use model_construct() to skip Pydantic validation because the ID fields
@@ -100,6 +101,7 @@ class FastAPIExports:
         """
         if isinstance(metadata, str):
             metadata = json.loads(metadata)
+        assert isinstance(metadata, dict)
         request_data_raw = metadata.get("request_data", {})
         result_data_raw = metadata.get("result_data")
 

--- a/lib/galaxy/webapps/galaxy/api/exports.py
+++ b/lib/galaxy/webapps/galaxy/api/exports.py
@@ -2,6 +2,7 @@
 API operations on user exports.
 """
 
+import json
 import logging
 from typing import (
     Annotated,
@@ -90,13 +91,15 @@ class FastAPIExports:
 
         return ExportTaskListResponse(root=results)
 
-    def _parse_export_metadata(self, metadata: dict) -> Optional[ExportObjectMetadata]:
+    def _parse_export_metadata(self, metadata) -> Optional[ExportObjectMetadata]:
         """Parse export metadata dict without double-encoding ID fields.
 
         We use model_construct() to skip Pydantic validation because the ID fields
         are stored as already-encoded strings, and the BeforeValidator on
         EncodedDatabaseIdField would encode them again.
         """
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
         request_data_raw = metadata.get("request_data", {})
         result_data_raw = metadata.get("result_data")
 


### PR DESCRIPTION
Old database records may store export_metadata as a JSON-encoded string rather than a native dict. Add isinstance guards to deserialize strings in get_record_metadata() and _parse_export_metadata(), matching the fix already applied in export_tracker.py.

Fixes https://github.com/galaxyproject/galaxy/issues/22019

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
