### PR TITLE
[26.0] Fix AttributeError serializing implicit output collections during job prep

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1838,7 +1838,8 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
                 if obj.name not in out_data:
                     out_collections[obj.name] = obj.dataset_collection_instance
                 # else this is a mapped over output
-        out_collections.update([(obj.name, obj.dataset_collection) for obj in self.output_dataset_collections])
+        if not exclude_implicit_outputs:
+            out_collections.update([(obj.name, obj.dataset_collection) for obj in self.output_dataset_collections])
         return IoDicts(inp_data, out_data, out_collections)
 
     # TODO: Add accessors for members defined in SQL Alchemy for the Job table and

--- a/test/unit/data/model/test_model.py
+++ b/test/unit/data/model/test_model.py
@@ -18,3 +18,27 @@ def test_get_uuid():
 def test_permitted_actions():
     actions = model.Dataset.permitted_actions
     assert actions and len(actions.values()) == 2
+
+
+def test_io_dicts_excludes_implicit_output_collections():
+    """Regression test for https://github.com/galaxyproject/galaxy/issues/22015
+
+    When a tool with an explicit collection output is mapped over a list,
+    each job gets a JobToImplicitOutputDatasetCollectionAssociation pointing
+    to a DatasetCollection with precreated (unpopulated) elements.
+    io_dicts(exclude_implicit_outputs=True) must exclude these to avoid
+    crashes during metadata serialization on unpopulated elements.
+    """
+    job = model.Job()
+    dc = model.DatasetCollection(collection_type="paired")
+    assoc = model.JobToImplicitOutputDatasetCollectionAssociation(name="paired_output", dataset_collection=dc)
+    job.output_dataset_collections.append(assoc)
+
+    # With exclude_implicit_outputs=True, output_dataset_collections must be excluded
+    io = job.io_dicts(exclude_implicit_outputs=True)
+    assert "paired_output" not in io.out_collections
+
+    # With exclude_implicit_outputs=False (default), they should be included
+    io = job.io_dicts(exclude_implicit_outputs=False)
+    assert "paired_output" in io.out_collections
+    assert io.out_collections["paired_output"] is dc


### PR DESCRIPTION
For map-over jobs, `io_dicts(exclude_implicit_outputs=True)` unconditionally included `output_dataset_collections` (JobToImplicitOutputDatasetCollectionAssociation). These are shared DatasetCollections with N precreated elements where only the current job's element has its HDA set. Serializing the full collection during metadata setup crashes on the N-1 unpopulated elements.

Exclude these implicit output collections when `exclude_implicit_outputs=True`, consistent with the existing exclusion of output_dataset_collection_instances.

Fixes https://github.com/galaxyproject/galaxy/issues/22015

Don't love the test but it's tricky to test in a real workflow, I think you'd have to be able to have discovered outputs be ready at different points. The unit test though make it really clear that we're dealing with an implicit output collection and that the change is correct.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
