### PR TITLE
[25.1] Fix ToolExpressionOutput.to_model() for boolean type.

### DIFF
--- a/lib/galaxy/tool_util/parser/output_objects.py
+++ b/lib/galaxy/tool_util/parser/output_objects.py
@@ -244,9 +244,8 @@ class ToolExpressionOutput(ToolOutputBase):
             model_class = ToolOutputIntegerModel
         elif self.output_type == "float":
             model_class = ToolOutputFloatModel
-        elif self.output_type == "bool":
+        elif self.output_type == "boolean":
             model_class = ToolOutputBooleanModel
-            model_type = "boolean"
         elif self.output_type == "text":
             model_class = ToolOutputTextModel
         assert model_class

--- a/test/functional/tools/expression_null_handling_boolean.xml
+++ b/test/functional/tools/expression_null_handling_boolean.xml
@@ -7,7 +7,7 @@
         <param type="boolean" label="Booelan input." name="bool_input" optional="true" />
     </inputs>
     <outputs>
-        <output type="bool" name="bool_out" from="bool_out" />
+        <output type="boolean" name="bool_out" from="bool_out" />
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
A release_25.1 version of #22007 


## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
