### PR TITLE
Migrate User CustomBuilds and ReviewCleanupDialog components from BTable to GTable

### DIFF
--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -4,7 +4,7 @@
 
         <b-row>
             <b-col>
-                <b-table small show-empty class="grid" :items="customBuilds" :fields="fields">
+                <GTable compact show-empty :items="customBuilds" :fields="fields" class="mb-3">
                     <template v-slot:cell(action)="row">
                         <a
                             v-b-tooltip.bottom.hover
@@ -14,7 +14,7 @@
                             <i class="icon fa fa-lg fa-trash-o" />
                         </a>
                     </template>
-                </b-table>
+                </GTable>
             </b-col>
         </b-row>
         <template v-if="installedBuilds.length > 0">
@@ -153,12 +153,14 @@ import { useHistoryStore } from "@/stores/historyStore";
 import { withPrefix } from "@/utils/redirect";
 
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 Vue.use(BootstrapVue);
 
 export default {
     components: {
         BreadcrumbHeading,
+        GTable,
         Multiselect,
     },
     data() {

--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -4,13 +4,9 @@
 
         <GTable compact show-empty :items="customBuilds" :fields="fields" class="mb-3">
             <template v-slot:cell(action)="row">
-                <a
-                    v-b-tooltip.bottom.hover
-                    href="javascript:void(0)"
-                    title="Delete build"
-                    @click="deleteBuild(row.item.id)">
-                    <i class="icon fa fa-lg fa-trash-o" />
-                </a>
+                <GLink tooltip title="Delete build" @click="deleteBuild(row.item.id)">
+                    <FontAwesomeIcon :icon="faTrash" />
+                </GLink>
             </template>
         </GTable>
 
@@ -105,7 +101,7 @@
                             type="submit"
                             variant="primary"
                             title="Create new build">
-                            <i class="icon fa fa-save" />
+                            <FontAwesomeIcon :icon="faSave" />
                             Save
                         </BButton>
                     </BForm>
@@ -151,6 +147,8 @@ chr5    152537259
 <script>
 import "vue-multiselect/dist/vue-multiselect.min.css";
 
+import { faSave, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
 import {
     BAlert,
@@ -172,6 +170,7 @@ import { getGalaxyInstance } from "@/app";
 import { useHistoryStore } from "@/stores/historyStore";
 import { withPrefix } from "@/utils/redirect";
 
+import GLink from "@/components/BaseComponents/GLink.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import GTable from "@/components/Common/GTable.vue";
 
@@ -190,12 +189,16 @@ export default {
         BProgress,
         BreadcrumbHeading,
         BRow,
+        FontAwesomeIcon,
+        GLink,
         GTable,
         Multiselect,
     },
     data() {
         const Galaxy = getGalaxyInstance();
         return {
+            faSave,
+            faTrash,
             breadcrumbItems: [{ title: "User Preferences", to: "/user" }, { title: "Current Custom Builds" }],
             customBuildsUrl: withPrefix(`/api/users/${Galaxy.user.id}/custom_builds`),
             selectedInstalledBuilds: [],

--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -359,9 +359,3 @@ export default {
     },
 };
 </script>
-
-<style scoped>
-.fa-trash-o {
-    color: initial;
-}
-</style>

--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -2,29 +2,27 @@
     <div>
         <BreadcrumbHeading :items="breadcrumbItems" />
 
-        <b-row>
-            <b-col>
-                <GTable compact show-empty :items="customBuilds" :fields="fields" class="mb-3">
-                    <template v-slot:cell(action)="row">
-                        <a
-                            v-b-tooltip.bottom.hover
-                            href="javascript:void(0)"
-                            title="Delete build"
-                            @click="deleteBuild(row.item.id)">
-                            <i class="icon fa fa-lg fa-trash-o" />
-                        </a>
-                    </template>
-                </GTable>
-            </b-col>
-        </b-row>
+        <GTable compact show-empty :items="customBuilds" :fields="fields" class="mb-3">
+            <template v-slot:cell(action)="row">
+                <a
+                    v-b-tooltip.bottom.hover
+                    href="javascript:void(0)"
+                    title="Delete build"
+                    @click="deleteBuild(row.item.id)">
+                    <i class="icon fa fa-lg fa-trash-o" />
+                </a>
+            </template>
+        </GTable>
+
         <template v-if="installedBuilds.length > 0">
-            <b-row class="mt-2">
-                <b-col>
+            <BRow class="mt-2">
+                <BCol>
                     <h2 class="h-sm">System Installed Builds</h2>
-                </b-col>
-            </b-row>
-            <b-row>
-                <b-col id="installed-builds" class="mb-4">
+                </BCol>
+            </BRow>
+
+            <BRow>
+                <BCol id="installed-builds" class="mb-4">
                     <Multiselect
                         v-model="selectedInstalledBuilds"
                         multiple
@@ -34,20 +32,21 @@
                         deselect-label=""
                         track-by="value"
                         :searchable="false"
-                        :options="installedBuilds">
-                    </Multiselect>
-                </b-col>
-            </b-row>
+                        :options="installedBuilds" />
+                </BCol>
+            </BRow>
         </template>
-        <b-row>
-            <b-col>
+
+        <BRow>
+            <BCol>
                 <h2 class="h-sm">Add a Custom Build</h2>
-            </b-col>
-        </b-row>
-        <b-row>
-            <b-col>
-                <b-card>
-                    <b-alert
+            </BCol>
+        </BRow>
+
+        <BRow>
+            <BCol>
+                <BCard>
+                    <BAlert
                         fade
                         dismissible
                         :variant="alertType"
@@ -55,57 +54,66 @@
                         @dismissed="dismissCountDown = 0"
                         @dismiss-count-down="countDownChanged">
                         {{ alertMessage }}
-                    </b-alert>
+                    </BAlert>
 
-                    <b-form @submit.prevent="save">
-                        <b-form-group label="Name" description="Specify a build name, e.g. Hamster." label-for="name">
-                            <b-form-input id="name" v-model="form.name" tour_id="name" required />
-                        </b-form-group>
-                        <b-form-group label="Key" description="Specify a build key, e.g. hamster_v1." label-for="id">
-                            <b-form-input id="id" v-model="form.id" tour_id="id" required />
-                        </b-form-group>
-                        <b-form-group label="Definition" description="Provide the data source." label-for="type">
-                            <b-form-select
+                    <BForm @submit.prevent="save">
+                        <BFormGroup label="Name" description="Specify a build name, e.g. Hamster." label-for="name">
+                            <BFormInput id="name" v-model="form.name" tour_id="name" required />
+                        </BFormGroup>
+
+                        <BFormGroup label="Key" description="Specify a build key, e.g. hamster_v1." label-for="id">
+                            <BFormInput id="id" v-model="form.id" tour_id="id" required />
+                        </BFormGroup>
+
+                        <BFormGroup label="Definition" description="Provide the data source." label-for="type">
+                            <BFormSelect
                                 id="type"
                                 v-model="selectedDataSource"
                                 tour_id="type"
-                                :options="dataSources"></b-form-select>
-                        </b-form-group>
+                                :options="dataSources"></BFormSelect>
+                        </BFormGroup>
+
                         <div>
-                            <b-form-group v-if="selectedDataSource === 'fasta'" label="FASTA-file">
-                                <b-form-select
+                            <BFormGroup v-if="selectedDataSource === 'fasta'" label="FASTA-file">
+                                <BFormSelect
                                     v-model="selectedFastaFile"
                                     :options="fastaFiles"
-                                    :disabled="fastaFilesSelectDisabled"></b-form-select>
-                            </b-form-group>
-                            <b-form-group v-if="selectedDataSource === 'file'" label="Len-file">
-                                <b-form-file placeholder="Choose a file..." @change="readFile" />
-                                <b-progress
+                                    :disabled="fastaFilesSelectDisabled"></BFormSelect>
+                            </BFormGroup>
+
+                            <BFormGroup v-if="selectedDataSource === 'file'" label="Len-file">
+                                <BFormFile placeholder="Choose a file..." @change="readFile" />
+
+                                <BProgress
                                     v-show="fileLoaded !== 0"
                                     animated
                                     show-progress
                                     :value="fileLoaded"
                                     :max="maxFileSize" />
-                                <b-form-textarea v-show="form.file" :value="form.file" />
-                            </b-form-group>
-                            <b-form-group v-if="selectedDataSource === 'text'" label="Edit/Paste">
-                                <b-form-textarea id="len-file-text-area" v-model="form.text" />
-                            </b-form-group>
+
+                                <BFormTextarea v-show="form.file" :value="form.file" />
+                            </BFormGroup>
+
+                            <BFormGroup v-if="selectedDataSource === 'text'" label="Edit/Paste">
+                                <BFormTextarea id="len-file-text-area" v-model="form.text" />
+                            </BFormGroup>
                         </div>
 
-                        <b-button
+                        <BButton
                             id="save"
                             v-b-tooltip.bottom.hover
                             type="submit"
                             variant="primary"
                             title="Create new build">
-                            <i class="icon fa fa-save" /> Save
-                        </b-button>
-                    </b-form>
-                </b-card>
-            </b-col>
-            <b-col>
-                <b-card v-if="selectedDataSource === 'fasta'" class="alert-info">
+                            <i class="icon fa fa-save" />
+                            Save
+                        </BButton>
+                    </BForm>
+                </BCard>
+            </BCol>
+
+            <BCol>
+                <BCard v-if="selectedDataSource === 'fasta'" class="alert-info">
                     <h2 class="h-sm">FASTA format</h2>
                     <p class="card-text">
                         This is a multi-fasta file from your current history that provides the genome sequences for each
@@ -119,10 +127,10 @@ ATTATATATAAGACCACAGAGAGAATATTTTGCCCGG...
 &gt;chr2
 GGCGGCCGCGGCGATATAGAACTACTCATTATATATA...
 
-...</pre
-                    >
-                </b-card>
-                <b-card v-else class="alert-info">
+...
+                    </pre>
+                </BCard>
+                <BCard v-else class="alert-info">
                     <h2 class="h-sm">Length Format</h2>
                     <p class="card-text">The length format is two-column, separated by whitespace, of the form:</p>
                     <pre class="card-text">chrom/contig   length of chrom/contig</pre>
@@ -132,11 +140,11 @@ chr1    197195432
 chr2    181748087
 chr3    159599783
 chr4    155630120
-chr5    152537259</pre
-                    >
-                </b-card>
-            </b-col>
-        </b-row>
+chr5    152537259
+                    </pre>
+                </BCard>
+            </BCol>
+        </BRow>
     </div>
 </template>
 
@@ -144,8 +152,20 @@ chr5    152537259</pre
 import "vue-multiselect/dist/vue-multiselect.min.css";
 
 import axios from "axios";
-import BootstrapVue from "bootstrap-vue";
-import Vue from "vue";
+import {
+    BAlert,
+    BButton,
+    BCard,
+    BCol,
+    BForm,
+    BFormFile,
+    BFormGroup,
+    BFormInput,
+    BFormSelect,
+    BFormTextarea,
+    BProgress,
+    BRow,
+} from "bootstrap-vue";
 import Multiselect from "vue-multiselect";
 
 import { getGalaxyInstance } from "@/app";
@@ -155,11 +175,21 @@ import { withPrefix } from "@/utils/redirect";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import GTable from "@/components/Common/GTable.vue";
 
-Vue.use(BootstrapVue);
-
 export default {
     components: {
+        BAlert,
+        BButton,
+        BCard,
+        BCol,
+        BForm,
+        BFormFile,
+        BFormGroup,
+        BFormInput,
+        BFormSelect,
+        BFormTextarea,
+        BProgress,
         BreadcrumbHeading,
+        BRow,
         GTable,
         Multiselect,
     },

--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.test.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.test.ts
@@ -44,7 +44,7 @@ const FAKE_OPERATION: CleanupOperation = {
 
 async function mountReviewCleanupDialogWith(operation: CleanupOperation, totalItems = EXPECTED_TOTAL_ITEMS) {
     const wrapper = mount(ReviewCleanupDialog as object, {
-        propsData: { operation, totalItems, show: true, modalStatic: true },
+        propsData: { operation, totalItems, modalStatic: true },
         localVue,
     });
     await flushPromises();
@@ -59,6 +59,9 @@ async function setAllItemsChecked(wrapper: Wrapper<any>) {
 describe("ReviewCleanupDialog.vue", () => {
     it("should display a table with items to review", async () => {
         const wrapper = await mountReviewCleanupDialogWith(FAKE_OPERATION);
+
+        (wrapper.vm as any).openModal();
+        await flushPromises();
 
         expect(wrapper.find(REVIEW_TABLE).exists()).toBe(true);
         expect(wrapper.findAll("tbody > tr").length).toBe(EXPECTED_TOTAL_ITEMS);

--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { BButton, BFormCheckbox, BModal, BPagination, BTable } from "bootstrap-vue";
+import { BButton, BFormCheckbox, BModal, BPagination } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import localize from "@/utils/localization";
 import { bytesToString } from "@/utils/utils";
 
 import { type CleanableItem, type CleanupOperation, PaginationOptions, type SortableKey } from "./model";
 
+import GTable from "@/components/Common/GTable.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
 interface ReviewCleanupDialogProps {
@@ -27,7 +29,7 @@ const emit = defineEmits<{
 const permanentlyDeleteText = localize("Permanently delete");
 const captionText = localize("To free up account space, review and select items to be permanently deleted here.");
 const agreementText = localize("I understand that once I delete the items, they cannot be recovered.");
-const fields = [
+const fields: TableField[] = [
     {
         key: "selected",
         label: "",
@@ -35,16 +37,18 @@ const fields = [
     },
     {
         key: "name",
+        label: localize("Name"),
         sortable: true,
     },
     {
         key: "size",
+        label: localize("Size"),
         sortable: true,
         formatter: toNiceSize,
     },
     {
-        label: "Updated",
         key: "update_time",
+        label: localize("Updated"),
         sortable: true,
     },
 ];
@@ -95,23 +99,28 @@ const confirmButtonVariant = computed(() => {
     return confirmChecked.value ? "danger" : "";
 });
 
-watch(props, (newVal) => {
-    currentPage.value = 1;
-    totalRows.value = newVal.totalItems;
-});
-
-watch(selectedItems, (newVal) => {
-    if (newVal.length === 0) {
-        indeterminate.value = false;
-        allSelected.value = false;
-    } else if (newVal.length === totalRows.value) {
-        indeterminate.value = false;
-        allSelected.value = true;
-    } else {
-        indeterminate.value = true;
-        allSelected.value = false;
+async function loadItems() {
+    if (!props.operation) {
+        items.value = [];
+        return;
     }
-});
+
+    try {
+        isBusy.value = true;
+        const page = currentPage.value > 0 ? currentPage.value - 1 : 0;
+        const offset = page * MAXIMUM_ITEMS_PER_PAGE;
+        const options = new PaginationOptions({
+            offset: offset,
+            limit: MAXIMUM_ITEMS_PER_PAGE,
+            sortBy: sortBy.value,
+            sortDesc: sortDesc.value,
+        });
+        const result = await props.operation.fetchItems(options);
+        items.value = result;
+    } finally {
+        isBusy.value = false;
+    }
+}
 
 function toNiceSize(sizeInBytes: number) {
     return bytesToString(sizeInBytes, true, undefined);
@@ -135,6 +144,7 @@ function hideModal() {
 
 function onShowModal() {
     resetModal();
+    loadItems();
 }
 
 function resetModal() {
@@ -150,9 +160,9 @@ function onConfirmCleanupSelectedItems() {
     hideModal();
 }
 
-function onSort(props: { sortBy: SortableKey; sortDesc: boolean }) {
-    sortBy.value = props.sortBy;
-    sortDesc.value = props.sortDesc;
+function onSort(sortByKey: string, sortDescending: boolean) {
+    sortBy.value = sortByKey as SortableKey;
+    sortDesc.value = sortDescending;
 }
 
 function isItemSelected(item: CleanableItem): boolean {
@@ -165,27 +175,6 @@ function toggleItemSelection(item: CleanableItem): void {
         selectedItems.value = [...selectedItems.value, item];
     } else {
         selectedItems.value = selectedItems.value.filter((selectedItem) => selectedItem.id !== item.id);
-    }
-}
-
-async function itemsProvider(ctx: { currentPage: number; perPage: number }) {
-    try {
-        const page = ctx.currentPage > 0 ? ctx.currentPage - 1 : 0;
-        const offset = page * ctx.perPage;
-        const options = new PaginationOptions({
-            offset: offset,
-            limit: ctx.perPage,
-            sortBy: sortBy.value,
-            sortDesc: sortDesc.value,
-        });
-        const operation = props.operation;
-        if (!operation) {
-            return [];
-        }
-        const result = await operation.fetchItems(options);
-        return result;
-    } catch (error) {
-        return [];
     }
 }
 
@@ -212,6 +201,38 @@ function unselectAllItems() {
     selectedItems.value = [];
 }
 
+watch(
+    () => props.totalItems,
+    (newVal) => {
+        currentPage.value = 1;
+        totalRows.value = newVal;
+    },
+);
+
+watch(
+    () => props.operation,
+    () => {
+        currentPage.value = 1;
+    },
+);
+
+watch([currentPage, sortBy, sortDesc], async () => {
+    await loadItems();
+});
+
+watch(selectedItems, (newVal) => {
+    if (newVal.length === 0) {
+        indeterminate.value = false;
+        allSelected.value = false;
+    } else if (newVal.length === totalRows.value) {
+        indeterminate.value = false;
+        allSelected.value = true;
+    } else {
+        indeterminate.value = true;
+        allSelected.value = false;
+    }
+});
+
 defineExpose({
     openModal,
     selectedItems,
@@ -227,18 +248,17 @@ defineExpose({
         <div>
             {{ captionText }}
         </div>
-        <BTable
+
+        <GTable
             v-if="operation"
-            v-model="items"
-            :fields="fields"
-            :items="itemsProvider"
-            :per-page="MAXIMUM_ITEMS_PER_PAGE"
-            :current-page="currentPage"
-            :busy="isBusy"
             hover
-            no-sort-reset
-            no-local-sorting
-            no-provider-filtering
+            :fields="fields"
+            :items="items"
+            :sort-by="sortBy"
+            :sort-desc="sortDesc"
+            :loading="isBusy"
+            :local-filtering="false"
+            :local-sorting="false"
             sticky-header="50vh"
             data-test-id="review-table"
             @sort-changed="onSort">
@@ -249,22 +269,26 @@ defineExpose({
                     data-test-id="select-all-checkbox"
                     @change="toggleSelectAll" />
             </template>
+
             <template v-slot:cell(selected)="data">
                 <BFormCheckbox
                     :key="data.index"
                     :checked="isItemSelected(data.item)"
                     @change="toggleItemSelection(data.item)" />
             </template>
+
             <template v-slot:cell(update_time)="data">
                 <UtcDate :date="data.value" mode="elapsed" />
             </template>
-        </BTable>
+        </GTable>
+
         <template v-slot:modal-footer>
             <BPagination
                 v-if="hasPages"
                 v-model="currentPage"
                 :total-rows="totalRows"
                 :per-page="MAXIMUM_ITEMS_PER_PAGE" />
+
             <BButton
                 v-b-modal.confirmation-modal
                 :disabled="!hasItemsSelected"

--- a/lib/galaxy_test/selenium/test_custom_builds.py
+++ b/lib/galaxy_test/selenium/test_custom_builds.py
@@ -59,12 +59,12 @@ class TestCustomBuilds(SharedStateSeleniumTestCase):
 
     def delete_custom_build(self, build_name):
         delete_button = None
-        grid = self.wait_for_selector("table.grid > tbody")
-        for row in grid.find_elements(By.TAG_NAME, "tr"):
+        custom_builds_table = self.wait_for_selector(".g-table > tbody")
+        for row in custom_builds_table.find_elements(By.TAG_NAME, "tr"):
             td = row.find_elements(By.TAG_NAME, "td")
             name = td[0].text
             if name == build_name:
-                delete_button = td[3].find_element(By.CSS_SELECTOR, ".fa-trash-o")
+                delete_button = td[3].find_element(By.CSS_SELECTOR, "button[data-title='Delete build']")
                 break
 
         if delete_button is None:
@@ -75,8 +75,8 @@ class TestCustomBuilds(SharedStateSeleniumTestCase):
     def get_custom_builds(self):
         self.sleep_for(self.wait_types.UX_RENDER)
         builds = []
-        grid = self.wait_for_selector("table.grid > tbody")
-        for row in grid.find_elements(By.TAG_NAME, "tr"):
+        custom_builds_table = self.wait_for_selector(".g-table > tbody")
+        for row in custom_builds_table.find_elements(By.TAG_NAME, "tr"):
             name = row.find_elements(By.TAG_NAME, "td")[0].text
             builds.append(name)
         return builds


### PR DESCRIPTION
This PR migrates `User/CustomBuilds.vue` and `User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue` from Bootstrap-Vue's components to our `GTable` as part of the ongoing effort tracked in #21703

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to `User preferences -> Custom builds`
  2. Go to `Storage Dashboard -> Manage your account storage -> Deleted datasets/histories`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
