### PR TITLE
[26.0] Show invalid tool error reasons in Tool Shed UI

### DIFF
--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -394,9 +394,7 @@ class BaseMetadataGenerator:
             invalid_tool_errors = {}
             for name, error_msg in self.invalid_file_tups:
                 if name in invalid_tool_configs:
-                    # Strip HTML tags from error messages for plain text display
-                    plain_msg = error_msg.replace("<br/>", " ").replace("<b>", "").replace("</b>", "")
-                    invalid_tool_errors[name] = plain_msg
+                    invalid_tool_errors[name] = error_msg
             metadata_dict["invalid_tool_errors"] = invalid_tool_errors
         self.metadata_dict = metadata_dict
         # Only remove work_dir if not resetting all metadata - in that case the caller handles cleanup

--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -391,6 +391,13 @@ class BaseMetadataGenerator:
                 self.invalid_file_tups.append((TOOL_DEPENDENCY_DEFINITION_FILENAME, error_message))
         if invalid_tool_configs:
             metadata_dict["invalid_tools"] = invalid_tool_configs
+            invalid_tool_errors = {}
+            for name, error_msg in self.invalid_file_tups:
+                if name in invalid_tool_configs:
+                    # Strip HTML tags from error messages for plain text display
+                    plain_msg = error_msg.replace("<br/>", " ").replace("<b>", "").replace("</b>", "")
+                    invalid_tool_errors[name] = plain_msg
+            metadata_dict["invalid_tool_errors"] = invalid_tool_errors
         self.metadata_dict = metadata_dict
         # Only remove work_dir if not resetting all metadata - in that case the caller handles cleanup
         if not self.resetting_all_metadata_on_repository:

--- a/lib/galaxy/tool_shed/tools/tool_validator.py
+++ b/lib/galaxy/tool_shed/tools/tool_validator.py
@@ -52,7 +52,7 @@ class ToolValidator:
                         else:
                             correction_msg = "This file requires an entry in the tool_data_table_conf.xml file.  "
                             correction_msg += "Upload a file named tool_data_table_conf.xml.sample to the repository "
-                            correction_msg += "that includes the required entry to correct this error.<br/>"
+                            correction_msg += "that includes the required entry to correct this error."
                             invalid_tup = (tool_config_name, correction_msg)
                             if invalid_tup not in invalid_files_and_errors_tups:
                                 invalid_files_and_errors_tups.append(invalid_tup)
@@ -71,8 +71,8 @@ class ToolValidator:
                                 break
                         if not sample_found:
                             correction_msg = (
-                                f"This file refers to a file named <b>{index_file_name}</b>.  "
-                                f"Upload a file named <b>{index_file_name}.sample</b> to the repository to correct this error."
+                                f"This file refers to a file named {index_file_name}.  "
+                                f"Upload a file named {index_file_name}.sample to the repository to correct this error."
                             )
                             invalid_files_and_errors_tups.append((tool_config_name, correction_msg))
         return invalid_files_and_errors_tups

--- a/lib/galaxy/tool_shed/util/tool_util.py
+++ b/lib/galaxy/tool_shed/util/tool_util.py
@@ -131,12 +131,7 @@ def generate_message_for_invalid_tools(
                 f"Upload a file named {bold_start}{sample_ext}{bold_end} to the repository to correct this error."
             )
         else:
-            if as_html:
-                correction_msg = exception_msg
-            else:
-                correction_msg = (
-                    exception_msg.replace("<br/>", new_line).replace("<b>", bold_start).replace("</b>", bold_end)
-                )
+            correction_msg = exception_msg
         message += f"{bold_start}{tool_file}{bold_end} - {correction_msg}{new_line}"
     return message
 

--- a/lib/tool_shed/managers/repositories.py
+++ b/lib/tool_shed/managers/repositories.py
@@ -45,6 +45,7 @@ from tool_shed.repository_types import util as rt_util
 from tool_shed.structured_app import ToolShedApp
 from tool_shed.util import hg_util
 from tool_shed.util.metadata_util import (
+    build_invalid_tools,
     get_all_dependencies,
     get_current_repository_metadata_for_changeset_revision,
     get_metadata_revisions,
@@ -447,20 +448,7 @@ def get_repository_revision_metadata_dict(
         metadata_dict["repository_dependencies"] = []
     if metadata.includes_tools:
         metadata_dict["tools"] = metadata.metadata["tools"]
-    raw_invalid_tools = metadata.metadata.get("invalid_tools", [])
-    invalid_tool_errors = metadata.metadata.get("invalid_tool_errors", {})
-    invalid_tools = []
-    for item in raw_invalid_tools:
-        if isinstance(item, str):
-            invalid_tools.append(
-                {
-                    "tool_config": item,
-                    "error_message": invalid_tool_errors.get(item, ""),
-                }
-            )
-        elif isinstance(item, dict):
-            invalid_tools.append(item)
-    metadata_dict["invalid_tools"] = invalid_tools
+    metadata_dict["invalid_tools"] = build_invalid_tools(metadata.metadata)
     return metadata_dict
 
 

--- a/lib/tool_shed/managers/repositories.py
+++ b/lib/tool_shed/managers/repositories.py
@@ -447,7 +447,20 @@ def get_repository_revision_metadata_dict(
         metadata_dict["repository_dependencies"] = []
     if metadata.includes_tools:
         metadata_dict["tools"] = metadata.metadata["tools"]
-    metadata_dict["invalid_tools"] = metadata.metadata.get("invalid_tools", [])
+    raw_invalid_tools = metadata.metadata.get("invalid_tools", [])
+    invalid_tool_errors = metadata.metadata.get("invalid_tool_errors", {})
+    invalid_tools = []
+    for item in raw_invalid_tools:
+        if isinstance(item, str):
+            invalid_tools.append(
+                {
+                    "tool_config": item,
+                    "error_message": invalid_tool_errors.get(item, ""),
+                }
+            )
+        elif isinstance(item, dict):
+            invalid_tools.append(item)
+    metadata_dict["invalid_tools"] = invalid_tools
     return metadata_dict
 
 

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -1118,7 +1118,7 @@ class ShedTwillTestCase(ShedApiTestCase):
             "tool_data_table_conf",
         ]
         self.add_file_to_repository(repository, "freebayes/freebayes.xml", strings_displayed=strings_displayed)
-        strings_displayed = ["Upload a file named <b>sam_fa_indices.loc.sample"]
+        strings_displayed = ["Upload a file named sam_fa_indices.loc.sample"]
         self.add_file_to_repository(
             repository, "freebayes/tool_data_table_conf.xml.sample", strings_displayed=strings_displayed
         )

--- a/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
@@ -70,7 +70,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
         Uploading the tool_data_table_conf.xml.sample alone should not make the tool valid, but the error message should change.
         """
         repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
-        strings_displayed = ["Upload a file named <b>sam_fa_indices.loc.sample"]
+        strings_displayed = ["Upload a file named sam_fa_indices.loc.sample"]
         self.add_file_to_repository(
             repository, "freebayes/tool_data_table_conf.xml.sample", strings_displayed=strings_displayed
         )

--- a/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
@@ -35,7 +35,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
                 "tool_data_table_conf",
             ]
             self.add_file_to_repository(repository, "freebayes/freebayes.xml", strings_displayed=strings_displayed)
-            strings_displayed = ["Upload a file named <b>sam_fa_indices.loc.sample"]
+            strings_displayed = ["Upload a file named sam_fa_indices.loc.sample"]
             self.add_file_to_repository(
                 repository, "freebayes/tool_data_table_conf.xml.sample", strings_displayed=strings_displayed
             )

--- a/lib/tool_shed/test/functional/test_frontend_invalid_tools.py
+++ b/lib/tool_shed/test/functional/test_frontend_invalid_tools.py
@@ -39,6 +39,7 @@ class TestFrontendInvalidTools(PlaywrightTestCase):
         assert invalid_tool.error_message
 
         # Navigate to the repository page in the frontend
+        assert not isinstance(repository, str)
         page = self._page
         page.goto(f"{self.url}/repositories/{repository.id}")
 

--- a/lib/tool_shed/test/functional/test_frontend_invalid_tools.py
+++ b/lib/tool_shed/test/functional/test_frontend_invalid_tools.py
@@ -1,0 +1,53 @@
+from playwright.sync_api import (
+    expect,
+    Page,
+)
+
+from ..base.api import skip_if_api_v1
+from ..base.playwrightbrowser import PlaywrightShedBrowser
+from ..base.twilltestcase import ShedTwillTestCase
+
+
+class PlaywrightTestCase(ShedTwillTestCase):
+    @property
+    def _playwright_browser(self) -> PlaywrightShedBrowser:
+        browser = self._browser
+        assert isinstance(browser, PlaywrightShedBrowser)
+        return browser
+
+    @property
+    def _page(self) -> Page:
+        return self._playwright_browser._page
+
+
+class TestFrontendInvalidTools(PlaywrightTestCase):
+    """Test that the Tool Shed frontend displays invalid tool error messages."""
+
+    @skip_if_api_v1
+    def test_invalid_tools_display_error_message(self):
+        """Navigate to a repository with invalid tools and verify the error reason is shown."""
+        populator = self.populator
+        repository = populator.setup_bismark_repo()
+        repository_metadata = populator.get_metadata(repository)
+        assert repository_metadata
+
+        # Verify the API returns error messages
+        revision = repository_metadata.latest_revision
+        assert revision.invalid_tools
+        invalid_tool = revision.invalid_tools[0]
+        assert invalid_tool.tool_config
+        assert invalid_tool.error_message
+
+        # Navigate to the repository page in the frontend
+        page = self._page
+        page.goto(f"{self.url}/repositories/{repository.id}")
+
+        # Wait for the page to load and the Invalid Tools section to appear
+        invalid_tools_header = page.locator("text=Invalid Tools")
+        expect(invalid_tools_header).to_be_visible(timeout=10000)
+
+        # Verify the tool config filename is displayed
+        expect(page.locator("body")).to_contain_text(invalid_tool.tool_config)
+
+        # Verify the error message is displayed (bismark tools reference missing .loc files)
+        expect(page.locator("body")).to_contain_text(invalid_tool.error_message)

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -109,6 +109,9 @@ class TestShedRepositoriesApi(ShedApiTestCase):
         assert repository_metadata
         for _, value in repository_metadata.root.items():
             assert value.invalid_tools
+            for invalid_tool in value.invalid_tools:
+                assert invalid_tool.tool_config
+                assert invalid_tool.error_message
 
     def test_index_simple(self):
         # Logic and typing is pretty different if given a tool id to search for - this should

--- a/lib/tool_shed/util/metadata_util.py
+++ b/lib/tool_shed/util/metadata_util.py
@@ -47,7 +47,20 @@ def get_all_dependencies(app: "ToolShedApp", metadata_entry, processed_dependenc
         dependency_dict["repository"] = repository.to_dict(value_mapper=value_mapper)
         if dependency_metadata.includes_tools:
             dependency_dict["tools"] = dependency_metadata.metadata["tools"]
-        dependency_dict["invalid_tools"] = dependency_metadata.metadata.get("invalid_tools", [])
+        raw_invalid_tools = dependency_metadata.metadata.get("invalid_tools", [])
+        invalid_tool_errors = dependency_metadata.metadata.get("invalid_tool_errors", {})
+        invalid_tools = []
+        for item in raw_invalid_tools:
+            if isinstance(item, str):
+                invalid_tools.append(
+                    {
+                        "tool_config": item,
+                        "error_message": invalid_tool_errors.get(item, ""),
+                    }
+                )
+            elif isinstance(item, dict):
+                invalid_tools.append(item)
+        dependency_dict["invalid_tools"] = invalid_tools
         dependency_dict["repository_dependencies"] = []
         if dependency_dict["includes_tool_dependencies"]:
             dependency_dict["tool_dependencies"] = repository.get_tool_dependencies(

--- a/lib/tool_shed/util/metadata_util.py
+++ b/lib/tool_shed/util/metadata_util.py
@@ -27,6 +27,24 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def build_invalid_tools(metadata: dict) -> list:
+    """Transform raw invalid_tools metadata into a list of dicts with tool_config and error_message."""
+    raw_invalid_tools = metadata.get("invalid_tools", [])
+    invalid_tool_errors = metadata.get("invalid_tool_errors", {})
+    invalid_tools = []
+    for item in raw_invalid_tools:
+        if isinstance(item, str):
+            invalid_tools.append(
+                {
+                    "tool_config": item,
+                    "error_message": invalid_tool_errors.get(item, ""),
+                }
+            )
+        elif isinstance(item, dict):
+            invalid_tools.append(item)
+    return invalid_tools
+
+
 def get_all_dependencies(app: "ToolShedApp", metadata_entry, processed_dependency_links=None):
     processed_dependency_links = processed_dependency_links or []
     encoder = app.security.encode_id
@@ -47,20 +65,7 @@ def get_all_dependencies(app: "ToolShedApp", metadata_entry, processed_dependenc
         dependency_dict["repository"] = repository.to_dict(value_mapper=value_mapper)
         if dependency_metadata.includes_tools:
             dependency_dict["tools"] = dependency_metadata.metadata["tools"]
-        raw_invalid_tools = dependency_metadata.metadata.get("invalid_tools", [])
-        invalid_tool_errors = dependency_metadata.metadata.get("invalid_tool_errors", {})
-        invalid_tools = []
-        for item in raw_invalid_tools:
-            if isinstance(item, str):
-                invalid_tools.append(
-                    {
-                        "tool_config": item,
-                        "error_message": invalid_tool_errors.get(item, ""),
-                    }
-                )
-            elif isinstance(item, dict):
-                invalid_tools.append(item)
-        dependency_dict["invalid_tools"] = invalid_tools
+        dependency_dict["invalid_tools"] = build_invalid_tools(dependency_metadata.metadata)
         dependency_dict["repository_dependencies"] = []
         if dependency_dict["includes_tool_dependencies"]:
             dependency_dict["tool_dependencies"] = repository.get_tool_dependencies(

--- a/lib/tool_shed/webapp/frontend/src/components/pages/RepositoryPage.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/pages/RepositoryPage.vue
@@ -276,8 +276,16 @@ const canPush = computed(() => repositoryPermissions.value?.can_push || false)
 
                     <q-list bordered class="rounded-borders q-mt-md" v-if="invalidTools && invalidTools.length > 0">
                         <q-item-label header>Invalid Tools</q-item-label>
-                        <q-item v-for="invalidTool in invalidTools" :key="invalidTool">
-                            <code>{{ invalidTool }}</code>
+                        <q-item v-for="invalidTool in invalidTools" :key="invalidTool.tool_config">
+                            <q-item-section>
+                                <q-item-label>
+                                    <q-icon name="error" color="negative" class="q-mr-xs" />
+                                    <code>{{ invalidTool.tool_config }}</code>
+                                </q-item-label>
+                                <q-item-label caption v-if="invalidTool.error_message">
+                                    {{ invalidTool.error_message }}
+                                </q-item-label>
+                            </q-item-section>
                         </q-item>
                     </q-list>
                 </div>

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -2171,6 +2171,13 @@ export interface components {
             /** value */
             value?: number | null
         }
+        /** InvalidTool */
+        InvalidTool: {
+            /** Error Message */
+            error_message: string
+            /** Tool Config */
+            tool_config: string
+        }
         /** LabelValue */
         LabelValue: {
             /** Label */
@@ -2441,7 +2448,7 @@ export interface components {
             /** Includes Workflows */
             includes_workflows?: boolean | null
             /** Invalid Tools */
-            invalid_tools: string[]
+            invalid_tools: components["schemas"]["InvalidTool"][]
             /** Malicious */
             malicious: boolean
             /** Missing Test Components */
@@ -2532,7 +2539,7 @@ export interface components {
             /** Includes Workflows */
             includes_workflows?: boolean | null
             /** Invalid Tools */
-            invalid_tools: string[]
+            invalid_tools: components["schemas"]["InvalidTool"][]
             /** Malicious */
             malicious: boolean
             /** Missing Test Components */

--- a/lib/tool_shed/webapp/frontend/src/schema/types.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/types.ts
@@ -3,4 +3,5 @@ import type { components } from "./schema"
 export type Repository = components["schemas"]["Repository"]
 export type RevisionMetadata = components["schemas"]["RepositoryRevisionMetadata"]
 export type RepositoryTool = components["schemas"]["RepositoryTool"]
+export type InvalidTool = components["schemas"]["InvalidTool"]
 export type ApiMessageException = components["schemas"]["MessageExceptionModel"]

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -168,12 +168,17 @@ class RepositoryTool(BaseModel):
     # version_string_cmd: Optional[str]
 
 
+class InvalidTool(BaseModel):
+    tool_config: str
+    error_message: str
+
+
 class RepositoryRevisionMetadata(BaseModel):
     id: str
     repository: Repository
     repository_dependencies: list["RepositoryDependency"]
     tools: Optional[list["RepositoryTool"]] = None
-    invalid_tools: list[str]  # added for rendering list of invalid tools in 2.0 frontend
+    invalid_tools: list[InvalidTool]
     repository_id: str
     numeric_revision: int
     changeset_revision: str


### PR DESCRIPTION
Previously, when tools were marked as "Invalid Tools" in the Tool Shed, only the tool config filename was displayed. Users had to click through to a separate detail page to understand why the tool was invalid. This change persists error messages alongside invalid tool filenames in the repository metadata and surfaces them directly in the Tool Shed 2.0 frontend, so tool authors can immediately see what needs to be fixed (e.g., missing tool_data_table_conf.xml.sample).

Fixes https://github.com/galaxyproject/galaxy/issues/22036

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
