### PR TITLE
Migrate Some components from BTable to GTable and GTable header variant

### DIFF
--- a/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
+++ b/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
@@ -33,6 +33,10 @@ const fields: TableField[] = [
     },
 ];
 
+function optionalString(value: string | null | undefined): string | undefined {
+    return value ?? undefined;
+}
+
 const edamLink = (edamIRI: string) => `https://edamontology.github.io/edam-browser/#${edamIRI}`;
 </script>
 
@@ -52,25 +56,37 @@ const edamLink = (edamIRI: string) => `https://edamontology.github.io/edam-brows
                     v-if="item.descriptionUrl"
                     tooltip
                     target="_blank"
-                    :title="item.description"
+                    :title="optionalString(item.description)"
                     :href="item.descriptionUrl">
                     {{ item.extension }}
                 </GLink>
-                <span v-else v-b-tooltip.hover :title="item.description">
+                <span v-else v-b-tooltip.hover :title="optionalString(item.description)">
                     {{ item.extension }}
                 </span>
             </template>
 
             <template v-slot:cell(edamFormatLabel)="{ item }">
-                <GLink tooltip target="_blank" :href="edamLink(item.edamFormat)" :title="item.edamFormatDefinition">
+                <GLink
+                    v-if="item.edamFormat"
+                    tooltip
+                    target="_blank"
+                    :href="edamLink(item.edamFormat)"
+                    :title="optionalString(item.edamFormatDefinition)">
                     {{ item.edamFormatLabel }}
                 </GLink>
+                <span v-else>{{ item.edamFormatLabel }}</span>
             </template>
 
             <template v-slot:cell(edamDataLabel)="{ item }">
-                <GLink tooltip target="_blank" :href="edamLink(item.edamData)" :title="item.edamDataDefinition">
+                <GLink
+                    v-if="item.edamData"
+                    tooltip
+                    target="_blank"
+                    :href="edamLink(item.edamData)"
+                    :title="optionalString(item.edamDataDefinition)">
                     {{ item.edamDataLabel }}
                 </GLink>
+                <span v-else>{{ item.edamDataLabel }}</span>
             </template>
         </GTable>
     </div>

--- a/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
+++ b/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
@@ -5,6 +5,7 @@ import type { TableField } from "@/components/Common/GTable.types";
 import { type DetailedDatatypes, useDetailedDatatypes } from "@/composables/datatypes";
 import { useFilterObjectArray } from "@/composables/filter";
 
+import GLink from "@/components/BaseComponents/GLink.vue";
 import DelayedInput from "@/components/Common/DelayedInput.vue";
 import GTable from "@/components/Common/GTable.vue";
 
@@ -42,37 +43,34 @@ const edamLink = (edamIRI: string) => `https://edamontology.github.io/edam-brows
             All Datatypes supported by this Galaxy instance. Hover over an item for more information. These extensions
             can be filtered by in the History, by expanding "search datasets".
         </p>
+
         <DelayedInput placeholder="filter extensions" class="mb-3" :delay="200" @change="(val) => (filter = val)" />
 
         <GTable compact show-empty striped sort-by="extension" :fields="fields" :items="filteredDatatypes">
             <template v-slot:cell(extension)="{ item }">
-                <a
+                <GLink
                     v-if="item.descriptionUrl"
-                    v-b-tooltip.hover
+                    tooltip
                     target="_blank"
                     :title="item.description"
                     :href="item.descriptionUrl">
                     {{ item.extension }}
-                </a>
+                </GLink>
                 <span v-else v-b-tooltip.hover :title="item.description">
                     {{ item.extension }}
                 </span>
             </template>
 
             <template v-slot:cell(edamFormatLabel)="{ item }">
-                <a
-                    v-b-tooltip.hover
-                    target="_blank"
-                    :href="edamLink(item.edamFormat)"
-                    :title="item.edamFormatDefinition">
+                <GLink tooltip target="_blank" :href="edamLink(item.edamFormat)" :title="item.edamFormatDefinition">
                     {{ item.edamFormatLabel }}
-                </a>
+                </GLink>
             </template>
 
             <template v-slot:cell(edamDataLabel)="{ item }">
-                <a v-b-tooltip.hover target="_blank" :href="edamLink(item.edamData)" :title="item.edamDataDefinition">
+                <GLink tooltip target="_blank" :href="edamLink(item.edamData)" :title="item.edamDataDefinition">
                     {{ item.edamDataLabel }}
-                </a>
+                </GLink>
             </template>
         </GTable>
     </div>

--- a/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
+++ b/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import { type DetailedDatatypes, useDetailedDatatypes } from "@/composables/datatypes";
 import { useFilterObjectArray } from "@/composables/filter";
 
 import DelayedInput from "@/components/Common/DelayedInput.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 const filter = ref("");
 const filterFields: Array<keyof DetailedDatatypes> = ["extension"];
@@ -12,9 +14,10 @@ const filterFields: Array<keyof DetailedDatatypes> = ["extension"];
 const { datatypes } = useDetailedDatatypes();
 const filteredDatatypes = useFilterObjectArray(datatypes, filter, filterFields);
 
-const fields = [
+const fields: TableField[] = [
     {
         key: "extension",
+        label: "Extension",
         sortable: true,
     },
     {
@@ -40,46 +43,37 @@ const edamLink = (edamIRI: string) => `https://edamontology.github.io/edam-brows
             can be filtered by in the History, by expanding "search datasets".
         </p>
         <DelayedInput placeholder="filter extensions" class="mb-3" :delay="200" @change="(val) => (filter = val)" />
-        <b-table striped small sort-icon-left sort-by="extension" :items="filteredDatatypes" :fields="fields">
-            <template v-slot:cell(extension)="row">
+
+        <GTable compact show-empty striped sort-by="extension" :fields="fields" :items="filteredDatatypes">
+            <template v-slot:cell(extension)="{ item }">
                 <a
-                    v-if="row.item.descriptionUrl"
+                    v-if="item.descriptionUrl"
                     v-b-tooltip.hover
                     target="_blank"
-                    :title="row.item.description"
-                    :href="row.item.descriptionUrl">
-                    {{ row.item.extension }}
+                    :title="item.description"
+                    :href="item.descriptionUrl">
+                    {{ item.extension }}
                 </a>
-                <span v-else v-b-tooltip.hover :title="row.item.description">
-                    {{ row.item.extension }}
+                <span v-else v-b-tooltip.hover :title="item.description">
+                    {{ item.extension }}
                 </span>
             </template>
 
-            <template v-slot:cell(edamFormatLabel)="row">
+            <template v-slot:cell(edamFormatLabel)="{ item }">
                 <a
                     v-b-tooltip.hover
                     target="_blank"
-                    :href="edamLink(row.item.edamFormat)"
-                    :title="row.item.edamFormatDefinition">
-                    {{ row.item.edamFormatLabel }}
+                    :href="edamLink(item.edamFormat)"
+                    :title="item.edamFormatDefinition">
+                    {{ item.edamFormatLabel }}
                 </a>
             </template>
 
-            <template v-slot:cell(edamDataLabel)="row">
-                <a
-                    v-b-tooltip.hover
-                    target="_blank"
-                    :href="edamLink(row.item.edamData)"
-                    :title="row.item.edamDataDefinition">
-                    {{ row.item.edamDataLabel }}
+            <template v-slot:cell(edamDataLabel)="{ item }">
+                <a v-b-tooltip.hover target="_blank" :href="edamLink(item.edamData)" :title="item.edamDataDefinition">
+                    {{ item.edamDataLabel }}
                 </a>
             </template>
-        </b-table>
+        </GTable>
     </div>
 </template>
-
-<style scoped>
-table {
-    cursor: default;
-}
-</style>

--- a/client/src/components/Common/GTable.vue
+++ b/client/src/components/Common/GTable.vue
@@ -113,6 +113,12 @@ interface Props {
     hover?: boolean;
 
     /**
+     * Header variant style for the table header
+     * @default light
+     */
+    headVariant?: "light" | "dark";
+
+    /**
      * Whether to hide the table header
      * @default false
      */
@@ -264,6 +270,7 @@ const props = withDefaults(defineProps<Props>(), {
     filterIncludedFields: undefined,
     fixed: false,
     hover: true,
+    headVariant: "light",
     hideHeader: false,
     items: () => [],
     loading: false,
@@ -342,6 +349,10 @@ const stickyHeaderMaxHeight = computed(() => {
         return undefined;
     }
     return props.stickyHeader === true ? "300px" : props.stickyHeader;
+});
+
+const headerVariantClass = computed(() => {
+    return props.headVariant === "dark" ? "g-header-dark" : undefined;
 });
 
 const paginatedLocalItems = computed(() => {
@@ -668,7 +679,7 @@ defineExpose({
 
                     <thead v-if="!props.hideHeader">
                         <tr>
-                            <th v-if="selectable" class="g-table-select-column">
+                            <th v-if="selectable" class="g-table-select-column" :class="headerVariantClass">
                                 <slot name="head-select">
                                     <BFormCheckbox
                                         v-if="showSelectAll"
@@ -690,6 +701,7 @@ defineExpose({
                                 :key="field.key"
                                 :class="[
                                     field.headerClass,
+                                    headerVariantClass,
                                     { 'g-table-sortable': field.sortable },
                                     { 'g-table-sorted': sortBy === field.key },
                                     { 'hide-on-small': field.hideOnSmall },
@@ -954,6 +966,11 @@ defineExpose({
             border-bottom: 2px solid $brand-secondary;
             font-weight: 600;
             padding: 0.75rem;
+
+            &.g-header-dark {
+                background-color: $brand-primary;
+                color: $body-bg;
+            }
 
             &.g-table-sortable {
                 cursor: pointer;

--- a/client/src/components/Dataset/Tabular/TabularChunkedView.vue
+++ b/client/src/components/Dataset/Tabular/TabularChunkedView.vue
@@ -5,7 +5,10 @@ import { parse } from "csv-parse/sync";
 import { computed, onMounted, reactive, ref, watch } from "vue";
 
 import type { HDADetailed } from "@/api";
+import type { TableField } from "@/components/Common/GTable.types";
 import { getAppRoot } from "@/onload/loadConfig";
+
+import GTable from "@/components/Common/GTable.vue";
 
 interface TabularChunk {
     ck_data: string;
@@ -49,10 +52,31 @@ const columnStyle = computed(() => {
     const columnStyle = Array(props.options.metadata_columns);
     if (props.options.metadata_column_types && props.options.metadata_column_types?.length > 0) {
         props.options.metadata_column_types.forEach((column_type, index) => {
-            columnStyle[index] = column_type === "str" || column_type === "list" ? "string-align" : "number-align";
+            columnStyle[index] = column_type === "str" || column_type === "list" ? "text-left" : "text-right";
         });
     }
     return columnStyle;
+});
+
+const fieldKeys = computed(() => {
+    return Array.from({ length: columns.value.length }, (_, index) => `column_${index}`);
+});
+
+const fields = computed<TableField[]>(() => {
+    return fieldKeys.value.map((key, index) => ({
+        key,
+        label: columns.value[index] || `Column ${index + 1}`,
+        cellClass: columnStyle.value[index],
+    }));
+});
+
+const tableRows = computed(() => {
+    return tabularData.rows.map((row) => {
+        const paddedRow =
+            row.length < columns.value.length ? row.concat(Array(columns.value.length - row.length).fill("")) : row;
+
+        return Object.fromEntries(fieldKeys.value.map((key, index) => [key, paddedRow[index] ?? ""]));
+    });
 });
 
 const delimiter = computed(() => {
@@ -65,6 +89,7 @@ const chunkUrl = computed(() => {
 
 // Loading more data on user scroll to (near) bottom.
 const { y } = useWindowScroll();
+
 watch(y, (newY) => {
     if (
         atEOF.value !== true &&
@@ -169,34 +194,13 @@ onMounted(() => {
 <template>
     <div>
         <!-- TODO loading spinner locked to top right -->
-        <b-table-simple hover small striped>
-            <b-thead head-variant="dark">
-                <b-tr>
-                    <b-th v-for="(column, index) in columns" :key="column">{{ column || `Column ${index + 1}` }}</b-th>
-                </b-tr>
-            </b-thead>
-            <b-tbody>
-                <b-tr v-for="(row, index) in tabularData.rows" :key="index">
-                    <b-td
-                        v-for="(element, elementIndex) in row.slice(0, -1)"
-                        :key="elementIndex"
-                        :class="columnStyle[elementIndex]">
-                        {{ element }}
-                    </b-td>
-                    <b-td :class="columnStyle[row.length - 1]" :colspan="1 + columns.length - row.length">
-                        {{ row.slice(-1)[0] }}
-                    </b-td>
-                </b-tr>
-            </b-tbody>
-        </b-table-simple>
+        <GTable
+            compact
+            hover
+            striped
+            head-variant="dark"
+            :fields="fields"
+            :items="tableRows"
+            :load-more-loading="loading" />
     </div>
 </template>
-
-<style lang="scss" scoped>
-.string-align {
-    text-align: left;
-}
-.number-align {
-    text-align: right;
-}
-</style>

--- a/client/src/components/FileSources/Instances/ManageIndex.vue
+++ b/client/src/components/FileSources/Instances/ManageIndex.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { TableField } from "@/components/Common/GTable.types";
@@ -42,8 +43,8 @@ const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testi
 <template>
     <div>
         <ConfigurationTestSummaryModal v-model="showTestResults" :error="testingError" :test-results="testResults" />
-        <ManageIndexHeader header="My Repositories" :message="message" create-route="/file_source_instances/create">
-        </ManageIndexHeader>
+
+        <ManageIndexHeader header="My Repositories" :message="message" create-route="/file_source_instances/create" />
 
         <GTable
             id="user-file-sources-index"
@@ -56,18 +57,19 @@ const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testi
             :items="activeInstances">
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading your user's file source instances" />
-                <b-alert v-else id="no-file-source-instances" variant="info" show>
-                    <div>
-                        No file source instances found for your users, click the create button to configure a new one.
-                    </div>
-                </b-alert>
+                <BAlert v-else id="no-file-source-instances" variant="info" show>
+                    No file source instances found for your users, click the create button to configure a new one.
+                </BAlert>
             </template>
+
             <template v-slot:cell(name)="{ item }">
                 <InstanceDropdown :file-source="item" @entryRemoved="reload" @test="test(item)" />
             </template>
+
             <template v-slot:cell(type)="{ item }">
                 <FileSourceTypeSpan :type="item.type" />
             </template>
+
             <template v-slot:cell(template)="{ item }">
                 <TemplateSummarySpan :template-version="item.template_version ?? 0" :template-id="item.template_id" />
             </template>

--- a/client/src/components/FileSources/Instances/ManageIndex.vue
+++ b/client/src/components/FileSources/Instances/ManageIndex.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { BTable } from "bootstrap-vue";
 import { computed } from "vue";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import { DESCRIPTION_FIELD, NAME_FIELD, TEMPLATE_FIELD, TYPE_FIELD } from "@/components/ConfigTemplates/fields";
 import { useInstanceTesting } from "@/components/ConfigTemplates/useConfigurationTesting";
 import { useFiltering } from "@/components/ConfigTemplates/useInstanceFiltering";
 import { useFileSourceInstancesStore } from "@/stores/fileSourceInstancesStore";
 
+import GTable from "@/components/Common/GTable.vue";
 import ManageIndexHeader from "@/components/ConfigTemplates/ManageIndexHeader.vue";
 import FileSourceTypeSpan from "@/components/FileSources/FileSourceTypeSpan.vue";
 import InstanceDropdown from "@/components/FileSources/Instances/InstanceDropdown.vue";
@@ -21,7 +22,7 @@ interface Props {
 
 defineProps<Props>();
 
-const fields = [NAME_FIELD, DESCRIPTION_FIELD, TYPE_FIELD, TEMPLATE_FIELD];
+const fields: TableField[] = [NAME_FIELD, DESCRIPTION_FIELD, TYPE_FIELD, TEMPLATE_FIELD];
 
 const allItems = computed(() => fileSourceInstancesStore.getInstances);
 const { activeInstances } = useFiltering(allItems);
@@ -43,16 +44,16 @@ const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testi
         <ConfigurationTestSummaryModal v-model="showTestResults" :error="testingError" :test-results="testResults" />
         <ManageIndexHeader header="My Repositories" :message="message" create-route="/file_source_instances/create">
         </ManageIndexHeader>
-        <BTable
+
+        <GTable
             id="user-file-sources-index"
-            no-sort-reset
+            caption-top
+            fixed
+            hover
+            show-empty
+            striped
             :fields="fields"
-            :items="activeInstances"
-            :hover="true"
-            :striped="true"
-            :caption-top="true"
-            :fixed="true"
-            :show-empty="true">
+            :items="activeInstances">
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading your user's file source instances" />
                 <b-alert v-else id="no-file-source-instances" variant="info" show>
@@ -61,17 +62,15 @@ const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testi
                     </div>
                 </b-alert>
             </template>
-            <template v-slot:cell(name)="row">
-                <InstanceDropdown :file-source="row.item" @entryRemoved="reload" @test="test(row.item)" />
+            <template v-slot:cell(name)="{ item }">
+                <InstanceDropdown :file-source="item" @entryRemoved="reload" @test="test(item)" />
             </template>
-            <template v-slot:cell(type)="row">
-                <FileSourceTypeSpan :type="row.item.type" />
+            <template v-slot:cell(type)="{ item }">
+                <FileSourceTypeSpan :type="item.type" />
             </template>
-            <template v-slot:cell(template)="row">
-                <TemplateSummarySpan
-                    :template-version="row.item.template_version ?? 0"
-                    :template-id="row.item.template_id" />
+            <template v-slot:cell(template)="{ item }">
+                <TemplateSummarySpan :template-version="item.template_version ?? 0" :template-id="item.template_id" />
             </template>
-        </BTable>
+        </GTable>
     </div>
 </template>

--- a/client/src/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/src/components/InteractiveTools/InteractiveTools.test.js
@@ -67,9 +67,10 @@ describe("InteractiveTools/InteractiveTools.vue", () => {
     });
 
     it("renders table with interactive tools", async () => {
-        expect(wrapper.get("#interactive-tool-table").exists()).toBeTruthy();
-        // Each entry has 2 links: one to open inline and one to open in new tab
-        expect(wrapper.findAll("td > a").length).toBe(4);
+        expect(wrapper.find("#g-table-interactive-tool-table").exists()).toBeTruthy();
+        // Each entry has 2 links: one to open inline (rendered as button) and one to open in new tab (rendered as anchor)
+        expect(wrapper.findAll("td > button.g-link").length).toBe(2);
+        expect(wrapper.findAll("td > a").length).toBe(2);
     });
 
     it("displays interactive tool information correctly", async () => {

--- a/client/src/components/InteractiveTools/InteractiveTools.vue
+++ b/client/src/components/InteractiveTools/InteractiveTools.vue
@@ -9,7 +9,7 @@ import { useRouter } from "vue-router/composables";
 import type { TableField } from "@/components/Common/GTable.types";
 import { useInteractiveToolsStore } from "@/stores/interactiveToolsStore";
 
-import GLink from "../BaseComponents/GLink.vue";
+import GLink from "@/components/BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import Heading from "@/components/Common/Heading.vue";
 import UtcDate from "@/components/UtcDate.vue";
@@ -106,6 +106,7 @@ onMounted(() => {
     filter.value = "";
 });
 </script>
+
 <template>
     <div aria-labelledby="interactive-tools-heading">
         <BAlert v-for="(message, index) in messages" :key="index" :show="3" variant="danger">
@@ -123,66 +124,64 @@ onMounted(() => {
             autocomplete="off"
             type="text" />
 
-        <div id="interactive-tool-table">
-            <GTable id="interactive-tool-table" show-empty striped :fields="fields" :items="filteredTools">
-                <template v-slot:empty>
-                    <BAlert variant="info" show class="mb-0">
-                        <div v-if="isActiveToolsListEmpty">You do not have active interactive tools yet</div>
-                        <div v-else-if="showNotFound">
-                            No matching entries found for:
-                            <span class="font-weight-bold"> {{ filter }} </span>.
-                        </div>
-                    </BAlert>
-                </template>
+        <GTable id="interactive-tool-table" show-empty striped :fields="fields" :items="filteredTools">
+            <template v-slot:empty>
+                <BAlert variant="info" show class="mb-0">
+                    <div v-if="isActiveToolsListEmpty">You do not have active interactive tools yet</div>
+                    <div v-else-if="showNotFound">
+                        No matching entries found for:
+                        <span class="font-weight-bold"> {{ filter }} </span>.
+                    </div>
+                </BAlert>
+            </template>
 
-                <template v-slot:cell(actions)="{ item }">
-                    <BButton
-                        :id="createId('stop', item.id)"
-                        v-b-tooltip.hover
-                        variant="link"
-                        class="p-0"
-                        title="Stop this interactive tool"
-                        @click.stop="stopInteractiveTool(item.id, item.name)">
-                        <FontAwesomeIcon :icon="faStop" />
-                    </BButton>
-                </template>
+            <template v-slot:cell(actions)="{ item }">
+                <BButton
+                    :id="createId('stop', item.id)"
+                    v-b-tooltip.hover
+                    variant="link"
+                    class="p-0"
+                    title="Stop this interactive tool"
+                    @click.stop="stopInteractiveTool(item.id, item.name)">
+                    <FontAwesomeIcon :icon="faStop" />
+                </BButton>
+            </template>
 
-                <template v-slot:cell(name)="{ item, index }">
-                    <GLink
-                        :id="createId('link', item.id)"
-                        tooltip
-                        title="Open Interactive Tool"
-                        :index="index"
-                        :name="item.name"
-                        @click.prevent="openInteractiveTool(item.id)">
-                        {{ item.name }}
-                    </GLink>
+            <template v-slot:cell(name)="{ item, index }">
+                <GLink
+                    :id="createId('link', item.id)"
+                    tooltip
+                    title="Open Interactive Tool"
+                    :index="index"
+                    :name="item.name"
+                    @click.prevent="openInteractiveTool(item.id)">
+                    {{ item.name }}
+                </GLink>
 
-                    <GLink
-                        v-if="item.target"
-                        :id="createId('external-link', item.id)"
-                        tooltip
-                        class="ml-2"
-                        target="_blank"
-                        title="Open in new tab"
-                        :href="item.target">
-                        <FontAwesomeIcon :icon="faExternalLinkAlt" />
-                    </GLink>
-                </template>
+                <GLink
+                    v-if="item.target"
+                    :id="createId('external-link', item.id)"
+                    tooltip
+                    class="ml-2"
+                    target="_blank"
+                    title="Open in new tab"
+                    :href="item.target">
+                    <FontAwesomeIcon :icon="faExternalLinkAlt" />
+                </GLink>
+            </template>
 
-                <template v-slot:cell(job_info)="{ item }">
-                    <span v-if="item.active"> Running </span>
-                    <span v-else> Starting </span>
-                </template>
+            <template v-slot:cell(job_info)="{ item }">
+                <span v-if="item.active"> Running </span>
+                <span v-else> Starting </span>
+            </template>
 
-                <template v-slot:cell(created_time)="{ item }">
-                    <UtcDate :date="item.created_time" mode="elapsed" />
-                </template>
+            <template v-slot:cell(created_time)="{ item }">
+                <UtcDate :date="item.created_time" mode="elapsed" />
+            </template>
 
-                <template v-slot:cell(modified_time)="{ item }">
-                    <UtcDate :date="item.modified_time" mode="elapsed" />
-                </template>
-            </GTable>
-        </div>
+            <template v-slot:cell(modified_time)="{ item }">
+                <UtcDate :date="item.modified_time" mode="elapsed" />
+            </template>
+        </GTable>
     </div>
 </template>

--- a/client/src/components/InteractiveTools/InteractiveTools.vue
+++ b/client/src/components/InteractiveTools/InteractiveTools.vue
@@ -5,13 +5,24 @@ import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
+import type { TableField } from "@/components/Common/GTable.types";
 import { useInteractiveToolsStore } from "@/stores/interactiveToolsStore";
 
+import GTable from "@/components/Common/GTable.vue";
 import Heading from "@/components/Common/Heading.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
+interface InteractiveToolRow {
+    id: string;
+    name: string;
+    active: boolean;
+    created_time: string;
+    modified_time: string;
+    target?: string;
+    job_info: string;
+}
+
 const filter = ref("");
-const nInteractiveTools = ref(0);
 const router = useRouter();
 
 // Use the stores
@@ -20,49 +31,61 @@ const interactiveToolsStore = useInteractiveToolsStore();
 // Get reactive refs from stores
 const { messages, activeTools } = storeToRefs(interactiveToolsStore);
 
-const fields = [
+const fields: TableField[] = [
     {
-        label: "",
         key: "actions",
-        class: "text-center",
+        label: "",
+        align: "center",
     },
     {
-        label: "Name",
         key: "name",
+        label: "Name",
         sortable: true,
     },
     {
-        label: "Job Info",
         key: "job_info",
+        label: "Job Info",
         sortable: true,
     },
     {
-        label: "Created",
         key: "created_time",
+        label: "Created",
         sortable: true,
     },
     {
+        key: "modified_time",
         label: "Last Updated",
-        key: "last_updated",
         sortable: true,
     },
 ];
 
+const tableItems = computed<InteractiveToolRow[]>(() => {
+    return activeTools.value.map((tool) => ({
+        ...tool,
+        job_info: tool.active ? "Running" : "Starting",
+    }));
+});
+
+const filteredTools = computed<InteractiveToolRow[]>(() => {
+    const query = filter.value.trim().toLowerCase();
+    if (!query) {
+        return tableItems.value;
+    }
+
+    return tableItems.value.filter((tool) => {
+        return [tool.name, tool.job_info, tool.created_time, tool.modified_time, tool.target]
+            .filter((value): value is string => Boolean(value))
+            .some((value) => value.toLowerCase().includes(query));
+    });
+});
+
 const showNotFound = computed(() => {
-    return nInteractiveTools.value === 0 && filter.value !== "" && !isActiveToolsListEmpty.value;
+    return filteredTools.value.length === 0 && filter.value !== "" && !isActiveToolsListEmpty.value;
 });
 
 const isActiveToolsListEmpty = computed(() => {
     return activeTools.value.length === 0;
 });
-
-const load = () => {
-    filter.value = "";
-};
-
-const filtered = (items: any[]) => {
-    nInteractiveTools.value = items.length;
-};
 
 const stopInteractiveTool = (toolId: string, toolName: string) => {
     interactiveToolsStore.stopInteractiveTool(toolId, toolName);
@@ -78,7 +101,7 @@ const openInteractiveTool = (toolId: string) => {
 
 onMounted(() => {
     interactiveToolsStore.getActiveTools();
-    load();
+    filter.value = "";
 });
 </script>
 <template>
@@ -97,61 +120,61 @@ onMounted(() => {
                     type="text" />
             </b-col>
         </b-row>
-        <b-table
-            id="interactive-tool-table"
-            striped
-            :fields="fields"
-            :items="activeTools"
-            :filter="filter"
-            @filtered="filtered">
-            <template v-slot:cell(actions)="row">
-                <b-button
-                    :id="createId('stop', row.item.id)"
-                    v-b-tooltip.hover
-                    variant="link"
-                    class="p-0"
-                    title="Stop this interactive tool"
-                    @click.stop="stopInteractiveTool(row.item.id, row.item.name)">
-                    <FontAwesomeIcon :icon="faStop" />
-                </b-button>
-            </template>
-            <template v-slot:cell(name)="row">
-                <a
-                    :id="createId('link', row.item.id)"
-                    v-b-tooltip
-                    title="Open Interactive Tool"
-                    :index="row.index"
-                    href="#"
-                    :name="row.item.name"
-                    @click.prevent="openInteractiveTool(row.item.id)"
-                    >{{ row.item.name }}
-                </a>
-                <a
-                    v-if="row.item.target"
-                    :id="createId('external-link', row.item.id)"
-                    v-b-tooltip
-                    class="ml-2"
-                    title="Open in new tab"
-                    :href="row.item.target"
-                    target="_blank">
-                    <FontAwesomeIcon :icon="faExternalLinkAlt" />
-                </a>
-            </template>
-            <template v-slot:cell(job_info)="row">
-                <label v-if="row.item.active"> Running </label>
-                <label v-else> Starting </label>
-            </template>
-            <template v-slot:cell(created_time)="row">
-                <UtcDate :date="row.item.created_time" mode="elapsed" />
-            </template>
-            <template v-slot:cell(last_updated)="row">
-                <UtcDate :date="row.item.modified_time" mode="elapsed" />
-            </template>
-        </b-table>
-        <label v-if="isActiveToolsListEmpty">You do not have active interactive tools yet </label>
-        <div v-if="showNotFound">
-            No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
-            >.
+        <div id="interactive-tool-table">
+            <GTable id="interactive-tool-table" show-empty striped :fields="fields" :items="filteredTools">
+                <template v-slot:empty>
+                    <b-alert variant="info" show class="mb-0">
+                        <div v-if="isActiveToolsListEmpty">You do not have active interactive tools yet</div>
+                        <div v-else-if="showNotFound">
+                            No matching entries found for:
+                            <span class="font-weight-bold"> {{ filter }} </span>.
+                        </div>
+                    </b-alert>
+                </template>
+                <template v-slot:cell(actions)="{ item }">
+                    <b-button
+                        :id="createId('stop', item.id)"
+                        v-b-tooltip.hover
+                        variant="link"
+                        class="p-0"
+                        title="Stop this interactive tool"
+                        @click.stop="stopInteractiveTool(item.id, item.name)">
+                        <FontAwesomeIcon :icon="faStop" />
+                    </b-button>
+                </template>
+                <template v-slot:cell(name)="{ item, index }">
+                    <a
+                        :id="createId('link', item.id)"
+                        v-b-tooltip
+                        title="Open Interactive Tool"
+                        :index="index"
+                        href="#"
+                        :name="item.name"
+                        @click.prevent="openInteractiveTool(item.id)"
+                        >{{ item.name }}
+                    </a>
+                    <a
+                        v-if="item.target"
+                        :id="createId('external-link', item.id)"
+                        v-b-tooltip
+                        class="ml-2"
+                        title="Open in new tab"
+                        :href="item.target"
+                        target="_blank">
+                        <FontAwesomeIcon :icon="faExternalLinkAlt" />
+                    </a>
+                </template>
+                <template v-slot:cell(job_info)="{ item }">
+                    <label v-if="item.active"> Running </label>
+                    <label v-else> Starting </label>
+                </template>
+                <template v-slot:cell(created_time)="{ item }">
+                    <UtcDate :date="item.created_time" mode="elapsed" />
+                </template>
+                <template v-slot:cell(modified_time)="{ item }">
+                    <UtcDate :date="item.modified_time" mode="elapsed" />
+                </template>
+            </GTable>
         </div>
     </div>
 </template>

--- a/client/src/components/InteractiveTools/InteractiveTools.vue
+++ b/client/src/components/InteractiveTools/InteractiveTools.vue
@@ -9,6 +9,7 @@ import { useRouter } from "vue-router/composables";
 import type { TableField } from "@/components/Common/GTable.types";
 import { useInteractiveToolsStore } from "@/stores/interactiveToolsStore";
 
+import GLink from "../BaseComponents/GLink.vue";
 import GTable from "@/components/Common/GTable.vue";
 import Heading from "@/components/Common/Heading.vue";
 import UtcDate from "@/components/UtcDate.vue";
@@ -147,27 +148,26 @@ onMounted(() => {
                 </template>
 
                 <template v-slot:cell(name)="{ item, index }">
-                    <a
+                    <GLink
                         :id="createId('link', item.id)"
-                        v-b-tooltip
+                        tooltip
                         title="Open Interactive Tool"
                         :index="index"
-                        href="#"
                         :name="item.name"
                         @click.prevent="openInteractiveTool(item.id)">
                         {{ item.name }}
-                    </a>
+                    </GLink>
 
-                    <a
+                    <GLink
                         v-if="item.target"
                         :id="createId('external-link', item.id)"
-                        v-b-tooltip
+                        tooltip
                         class="ml-2"
+                        target="_blank"
                         title="Open in new tab"
-                        :href="item.target"
-                        target="_blank">
+                        :href="item.target">
                         <FontAwesomeIcon :icon="faExternalLinkAlt" />
-                    </a>
+                    </GLink>
                 </template>
 
                 <template v-slot:cell(job_info)="{ item }">

--- a/client/src/components/InteractiveTools/InteractiveTools.vue
+++ b/client/src/components/InteractiveTools/InteractiveTools.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { faExternalLinkAlt, faStop } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert, BButton, BFormInput } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
@@ -106,33 +107,35 @@ onMounted(() => {
 </script>
 <template>
     <div aria-labelledby="interactive-tools-heading">
-        <b-alert v-for="(message, index) in messages" :key="index" :show="3" variant="danger">{{ message }}</b-alert>
-        <Heading id="interactive-tools-heading" h1 separator inline size="lg">Active Interactive Tools</Heading>
-        <b-row class="mb-3">
-            <b-col cols="6">
-                <b-input
-                    id="interactivetool-search"
-                    v-model="filter"
-                    class="m-1"
-                    name="query"
-                    placeholder="Search Interactive Tool"
-                    autocomplete="off"
-                    type="text" />
-            </b-col>
-        </b-row>
+        <BAlert v-for="(message, index) in messages" :key="index" :show="3" variant="danger">
+            {{ message }}
+        </BAlert>
+
+        <Heading id="interactive-tools-heading" h1 separator inline size="lg"> Active Interactive Tools </Heading>
+
+        <BFormInput
+            id="interactivetool-search"
+            v-model="filter"
+            class="m-1"
+            name="query"
+            placeholder="Search Interactive Tool"
+            autocomplete="off"
+            type="text" />
+
         <div id="interactive-tool-table">
             <GTable id="interactive-tool-table" show-empty striped :fields="fields" :items="filteredTools">
                 <template v-slot:empty>
-                    <b-alert variant="info" show class="mb-0">
+                    <BAlert variant="info" show class="mb-0">
                         <div v-if="isActiveToolsListEmpty">You do not have active interactive tools yet</div>
                         <div v-else-if="showNotFound">
                             No matching entries found for:
                             <span class="font-weight-bold"> {{ filter }} </span>.
                         </div>
-                    </b-alert>
+                    </BAlert>
                 </template>
+
                 <template v-slot:cell(actions)="{ item }">
-                    <b-button
+                    <BButton
                         :id="createId('stop', item.id)"
                         v-b-tooltip.hover
                         variant="link"
@@ -140,8 +143,9 @@ onMounted(() => {
                         title="Stop this interactive tool"
                         @click.stop="stopInteractiveTool(item.id, item.name)">
                         <FontAwesomeIcon :icon="faStop" />
-                    </b-button>
+                    </BButton>
                 </template>
+
                 <template v-slot:cell(name)="{ item, index }">
                     <a
                         :id="createId('link', item.id)"
@@ -150,9 +154,10 @@ onMounted(() => {
                         :index="index"
                         href="#"
                         :name="item.name"
-                        @click.prevent="openInteractiveTool(item.id)"
-                        >{{ item.name }}
+                        @click.prevent="openInteractiveTool(item.id)">
+                        {{ item.name }}
                     </a>
+
                     <a
                         v-if="item.target"
                         :id="createId('external-link', item.id)"
@@ -164,13 +169,16 @@ onMounted(() => {
                         <FontAwesomeIcon :icon="faExternalLinkAlt" />
                     </a>
                 </template>
+
                 <template v-slot:cell(job_info)="{ item }">
-                    <label v-if="item.active"> Running </label>
-                    <label v-else> Starting </label>
+                    <span v-if="item.active"> Running </span>
+                    <span v-else> Starting </span>
                 </template>
+
                 <template v-slot:cell(created_time)="{ item }">
                     <UtcDate :date="item.created_time" mode="elapsed" />
                 </template>
+
                 <template v-slot:cell(modified_time)="{ item }">
                     <UtcDate :date="item.modified_time" mode="elapsed" />
                 </template>

--- a/client/src/components/ObjectStore/Instances/ManageIndex.vue
+++ b/client/src/components/ObjectStore/Instances/ManageIndex.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { BTable } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { UserConcreteObjectStore } from "@/api/objectStores";
+import type { TableField } from "@/components/Common/GTable.types";
 import { DESCRIPTION_FIELD, NAME_FIELD, TEMPLATE_FIELD, TYPE_FIELD } from "@/components/ConfigTemplates/fields";
 import { useInstanceTesting } from "@/components/ConfigTemplates/useConfigurationTesting";
 import { useFiltering } from "@/components/ConfigTemplates/useInstanceFiltering";
@@ -10,6 +10,7 @@ import { useObjectStoreInstancesStore } from "@/stores/objectStoreInstancesStore
 import _l from "@/utils/localization";
 
 import InstanceDropdown from "./InstanceDropdown.vue";
+import GTable from "@/components/Common/GTable.vue";
 import ManageIndexHeader from "@/components/ConfigTemplates/ManageIndexHeader.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ObjectStoreBadges from "@/components/ObjectStore/ObjectStoreBadges.vue";
@@ -24,13 +25,13 @@ interface Props {
 
 defineProps<Props>();
 
-const BADGE_FIELD = {
+const BADGE_FIELD: TableField = {
     key: "badges",
     label: _l(" "),
     sortable: false,
 };
 
-const fields = [NAME_FIELD, DESCRIPTION_FIELD, TYPE_FIELD, TEMPLATE_FIELD, BADGE_FIELD];
+const fields: TableField[] = [NAME_FIELD, DESCRIPTION_FIELD, TYPE_FIELD, TEMPLATE_FIELD, BADGE_FIELD];
 
 const allItems = computed<UserConcreteObjectStore[]>(() => objectStoreInstancesStore.getInstances);
 const { activeInstances } = useFiltering(allItems);
@@ -52,36 +53,34 @@ const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testi
         <ManageIndexHeader header="Galaxy Storage" :message="message" create-route="/object_store_instances/create">
         </ManageIndexHeader>
         <ConfigurationTestSummaryModal v-model="showTestResults" :error="testingError" :test-results="testResults" />
-        <BTable
+
+        <GTable
             id="user-object-stores-index"
-            no-sort-reset
+            caption-top
+            fixed
+            hover
+            show-empty
+            striped
             :fields="fields"
-            :items="activeInstances"
-            :hover="true"
-            :striped="true"
-            :caption-top="true"
-            :fixed="true"
-            :show-empty="true">
+            :items="activeInstances">
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading Galaxy storage instances" />
                 <b-alert v-else id="no-object-store-instances" variant="info" show>
                     <div>No Galaxy storage instances found, click the create button to configure a new one.</div>
                 </b-alert>
             </template>
-            <template v-slot:cell(badges)="row">
-                <ObjectStoreBadges size="1x" :badges="row.item.badges" />
+            <template v-slot:cell(badges)="{ item }">
+                <ObjectStoreBadges size="1x" :badges="item.badges" />
             </template>
-            <template v-slot:cell(name)="row">
-                <InstanceDropdown :object-store="row.item" @entryRemoved="reload" @test="test(row.item)" />
+            <template v-slot:cell(name)="{ item }">
+                <InstanceDropdown :object-store="item" @entryRemoved="reload" @test="test(item)" />
             </template>
-            <template v-slot:cell(type)="row">
-                <ObjectStoreTypeSpan :type="row.item.type" />
+            <template v-slot:cell(type)="{ item }">
+                <ObjectStoreTypeSpan :type="item.type" />
             </template>
-            <template v-slot:cell(template)="row">
-                <TemplateSummarySpan
-                    :template-version="row.item.template_version ?? 0"
-                    :template-id="row.item.template_id" />
+            <template v-slot:cell(template)="{ item }">
+                <TemplateSummarySpan :template-version="item.template_version ?? 0" :template-id="item.template_id" />
             </template>
-        </BTable>
+        </GTable>
     </div>
 </template>

--- a/client/src/components/ObjectStore/Instances/ManageIndex.vue
+++ b/client/src/components/ObjectStore/Instances/ManageIndex.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
 import { computed } from "vue";
 
 import type { UserConcreteObjectStore } from "@/api/objectStores";
@@ -50,9 +51,9 @@ const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testi
 
 <template>
     <div>
-        <ManageIndexHeader header="Galaxy Storage" :message="message" create-route="/object_store_instances/create">
-        </ManageIndexHeader>
         <ConfigurationTestSummaryModal v-model="showTestResults" :error="testingError" :test-results="testResults" />
+
+        <ManageIndexHeader header="Galaxy Storage" :message="message" create-route="/object_store_instances/create" />
 
         <GTable
             id="user-object-stores-index"
@@ -65,19 +66,23 @@ const { ConfigurationTestSummaryModal, showTestResults, testResults, test, testi
             :items="activeInstances">
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading Galaxy storage instances" />
-                <b-alert v-else id="no-object-store-instances" variant="info" show>
-                    <div>No Galaxy storage instances found, click the create button to configure a new one.</div>
-                </b-alert>
+                <BAlert v-else id="no-object-store-instances" variant="info" show>
+                    No Galaxy storage instances found, click the create button to configure a new one.
+                </BAlert>
             </template>
+
             <template v-slot:cell(badges)="{ item }">
                 <ObjectStoreBadges size="1x" :badges="item.badges" />
             </template>
+
             <template v-slot:cell(name)="{ item }">
                 <InstanceDropdown :object-store="item" @entryRemoved="reload" @test="test(item)" />
             </template>
+
             <template v-slot:cell(type)="{ item }">
                 <ObjectStoreTypeSpan :type="item.type" />
             </template>
+
             <template v-slot:cell(template)="{ item }">
                 <TemplateSummarySpan :template-version="item.template_version ?? 0" :template-id="item.template_id" />
             </template>

--- a/client/src/components/PageEditor/ObjectPermissions.vue
+++ b/client/src/components/PageEditor/ObjectPermissions.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import axios from "axios";
+import { BAlert } from "bootstrap-vue";
 import Vue, { computed, type Ref, ref, watch } from "vue";
 
 import { GalaxyApi, type MessageException } from "@/api";
@@ -341,16 +342,17 @@ async function makeAccessible(item: ItemInterface) {
         <GTable show-empty :items="tableItems" :fields="tableFields">
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading objects" />
-                <b-alert v-else variant="info" show>
-                    <div>No objects found in referenced Galaxy markdown content.</div>
-                </b-alert>
+                <BAlert v-else show variant="info"> No objects found in referenced Galaxy markdown content. </BAlert>
             </template>
+
             <template v-slot:cell(name)="{ item }">
                 {{ item.name }}
             </template>
+
             <template v-slot:cell(accessible)="{ item }">
                 <SharingIndicator :accessible="item.accessible" @makeAccessible="makeAccessible(item)" />
             </template>
+
             <template v-slot:cell(type)="{ item }">
                 <PermissionObjectType :type="item.type" />
             </template>

--- a/client/src/components/PageEditor/ObjectPermissions.vue
+++ b/client/src/components/PageEditor/ObjectPermissions.vue
@@ -4,6 +4,7 @@ import Vue, { computed, type Ref, ref, watch } from "vue";
 
 import { GalaxyApi, type MessageException } from "@/api";
 import { fetchCollectionSummary } from "@/api/datasetCollections";
+import type { TableField } from "@/components/Common/GTable.types";
 import { useToast } from "@/composables/toast";
 import { useDatasetStore } from "@/stores/datasetStore";
 import { useHistoryStore } from "@/stores/historyStore";
@@ -20,6 +21,7 @@ import {
 
 import PermissionObjectType from "./PermissionObjectType.vue";
 import SharingIndicator from "./SharingIndicator.vue";
+import GTable from "@/components/Common/GTable.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const { getHistoryNameById, loadHistoryById } = useHistoryStore();
@@ -49,8 +51,8 @@ const { jobsToHistories, invocationsToHistories, historyDatasetCollectionsToHist
     initializeObjectToHistoryRefs(referencedObjects);
 
 type ErrorString = string;
-type AccessibleState = Boolean | null | ErrorString;
-type AccessibleMapRef = Ref<{ [key: string]: AccessibleState }>;
+type AccessibleState = boolean | null | ErrorString;
+type AccessibleMapRef = Ref<Record<string, AccessibleState>>;
 const historyAccessible: AccessibleMapRef = ref({});
 const workflowAccessible: AccessibleMapRef = ref({});
 const historyDatasetAccessible: AccessibleMapRef = ref({});
@@ -135,7 +137,7 @@ watch(referencedHistoryDatasetCollectionIds, async () => {
 
 interface ItemInterface {
     id: string;
-    accessible: Boolean | null;
+    accessible: AccessibleState;
     name: string;
     type: string;
 }
@@ -175,11 +177,25 @@ const datasets = computed<ItemInterface[]>(() => {
 
 const loading = ref(false);
 
-const SHARING_FIELD = { key: "accessible", label: _l("Accessible"), sortable: false, thStyle: { width: "10%" } };
-const NAME_FIELD = { key: "name", label: _l("Name"), sortable: true };
-const TYPE_FIELD = { key: "type", label: _l("Type"), sortable: true, thStyle: { width: "10%" } };
-
-const tableFields = [SHARING_FIELD, TYPE_FIELD, NAME_FIELD];
+const tableFields: TableField[] = [
+    {
+        key: "accessible",
+        label: _l("Accessible"),
+        sortable: false,
+        width: "10%",
+    },
+    {
+        key: "type",
+        label: _l("Type"),
+        sortable: true,
+        width: "10%",
+    },
+    {
+        key: "name",
+        label: _l("Name"),
+        sortable: true,
+    },
+];
 
 watch(
     props,
@@ -322,22 +338,22 @@ async function makeAccessible(item: ItemInterface) {
 
 <template>
     <div>
-        <b-table :items="tableItems" show-empty :fields="tableFields">
+        <GTable show-empty :items="tableItems" :fields="tableFields">
             <template v-slot:empty>
                 <LoadingSpan v-if="loading" message="Loading objects" />
                 <b-alert v-else variant="info" show>
                     <div>No objects found in referenced Galaxy markdown content.</div>
                 </b-alert>
             </template>
-            <template v-slot:cell(name)="row">
-                {{ row.item.name }}
+            <template v-slot:cell(name)="{ item }">
+                {{ item.name }}
             </template>
-            <template v-slot:cell(accessible)="row">
-                <SharingIndicator :accessible="row.item.accessible" @makeAccessible="makeAccessible(row.item)" />
+            <template v-slot:cell(accessible)="{ item }">
+                <SharingIndicator :accessible="item.accessible" @makeAccessible="makeAccessible(item)" />
             </template>
-            <template v-slot:cell(type)="row">
-                <PermissionObjectType :type="row.item.type" />
+            <template v-slot:cell(type)="{ item }">
+                <PermissionObjectType :type="item.type" />
             </template>
-        </b-table>
+        </GTable>
     </div>
 </template>

--- a/client/src/components/PageEditor/ObjectPermissions.vue
+++ b/client/src/components/PageEditor/ObjectPermissions.vue
@@ -54,6 +54,8 @@ const { jobsToHistories, invocationsToHistories, historyDatasetCollectionsToHist
 type ErrorString = string;
 type AccessibleState = boolean | null | ErrorString;
 type AccessibleMapRef = Ref<Record<string, AccessibleState>>;
+type PermissionObjectTypeValue = "history" | "historyDataset" | "workflow";
+
 const historyAccessible: AccessibleMapRef = ref({});
 const workflowAccessible: AccessibleMapRef = ref({});
 const historyDatasetAccessible: AccessibleMapRef = ref({});
@@ -140,7 +142,7 @@ interface ItemInterface {
     id: string;
     accessible: AccessibleState;
     name: string;
-    type: string;
+    type: PermissionObjectTypeValue;
 }
 
 const histories = computed<ItemInterface[]>(() => {
@@ -149,8 +151,8 @@ const histories = computed<ItemInterface[]>(() => {
             id: historyId,
             type: "history",
             name: getHistoryNameById(historyId),
-            accessible: historyAccessible.value[historyId],
-        } as ItemInterface;
+            accessible: historyAccessible.value[historyId] ?? null,
+        };
     });
 });
 
@@ -160,8 +162,8 @@ const workflows = computed<ItemInterface[]>(() => {
             id: workflowId,
             type: "workflow",
             name: getStoredWorkflowNameByInstanceId(workflowId),
-            accessible: workflowAccessible.value[workflowId],
-        } as ItemInterface;
+            accessible: workflowAccessible.value[workflowId] ?? null,
+        };
     });
 });
 
@@ -171,8 +173,8 @@ const datasets = computed<ItemInterface[]>(() => {
             id: historyDatasetId,
             type: "historyDataset",
             name: getDataset(historyDatasetId)?.name || "Fetching dataset name...",
-            accessible: historyDatasetAccessible.value[historyDatasetId],
-        } as ItemInterface;
+            accessible: historyDatasetAccessible.value[historyDatasetId] ?? null,
+        };
     });
 });
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -96,7 +96,7 @@ object_store_instances:
   index:
     selectors:
       create_button: '#create-button-galaxy-storage'
-      _: '#user-object-stores-index'
+      _: '#g-table-user-object-stores-index'
 
   create:
     selectors:
@@ -108,7 +108,7 @@ file_source_instances:
   index:
     selectors:
       create_button: '#create-button-my-repositories'
-      _: '#user-file-sources-index'
+      _: '#g-table-user-file-sources-index'
 
   create:
     selectors:


### PR DESCRIPTION
This PR migrates `AvailableDatatypes/AvailableDatatypes.vue`, `Dataset/Tabular/TabularChunkedView.vue`, `FileSources/Instances/ManageIndex.vue`, `InteractiveTools/InteractiveTools.vue`, `ObjectStore/Instances/ManageIndex.vue`, and `PageEditor/ObjectPermissions.vue` components from Bootstrap-Vue's table component to `GTable` and `a` tags to `GLink` as part of the ongoing effort tracked in #21703, and also adds `dark-variant` prop to `GTable`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
