### PR TITLE
Remove unused enable_beta_workflow_modules config option

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4000,19 +4000,6 @@
 :Type: bool
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enable_beta_workflow_modules``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Enable beta workflow modules that should not yet be considered
-    part of Galaxy's stable API. (The module state definitions may
-    change and workflows built using these modules may not function in
-    the future.)
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~~~~~~
 ``edam_panel_views``
 ~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -202,6 +202,7 @@ OPTION_ACTIONS: dict[str, _OptionAction] = {
     "legacy_eager_objectstore_initialization": _DeprecatedAndDroppedAction(),
     "enable_openid": _DeprecatedAndDroppedAction(),
     "openid_consumer_cache_path": _DeprecatedAndDroppedAction(),
+    "enable_beta_workflow_modules": _DeprecatedAndDroppedAction(),
     "ga4gh_service_organization_name": _RenameAction("organization_name"),
     "ga4gh_service_organization_url": _RenameAction("organization_url"),
 }

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2236,11 +2236,6 @@ galaxy:
   # admin documentation.
   #enable_beta_gdpr: false
 
-  # Enable beta workflow modules that should not yet be considered part
-  # of Galaxy's stable API. (The module state definitions may change and
-  # workflows built using these modules may not function in the future.)
-  #enable_beta_workflow_modules: false
-
   # Comma-separated list of the EDAM panel views to load - choose from
   # merged, operations, topics. Set to empty string to disable EDAM all
   # together. Set default_panel_view to 'ontology:edam_topics' to

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2957,15 +2957,6 @@ mapping:
           Please read the GDPR section under the special topics area of the
           admin documentation.
 
-      enable_beta_workflow_modules:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          Enable beta workflow modules that should not yet be considered part of Galaxy's
-          stable API. (The module state definitions may change and workflows built using
-          these modules may not function in the future.)
-
       edam_panel_views:
         type: str
         default: 'operations,topics'

--- a/run.sh
+++ b/run.sh
@@ -37,7 +37,7 @@ setup_python
 if [ ! -z "$GALAXY_RUN_WITH_TEST_TOOLS" ];
 then
     export GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE="$(pwd)/test/functional/tools/sample_tool_conf.xml"
-    export GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_MODULES="true"
+
     export GALAXY_CONFIG_OVERRIDE_ENABLE_BETA_TOOL_FORMATS="true"
     export GALAXY_CONFIG_INTERACTIVETOOLS_ENABLE="true"
     export GALAXY_CONFIG_OVERRIDE_WEBHOOKS_DIR="test/functional/webhooks"


### PR DESCRIPTION
Dead option - nothing reads it, pause module always available regardless of setting. Add deprecation handler so existing configs don't error on upgrade.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. grep around the code and verify it is unused I guess

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
