### PR TITLE
[26.0] Use ParameterValueError for dataset count validation to reduce Sentry noise

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -48,6 +48,7 @@ from galaxy.tool_util.deps.dependencies import (
     ToolInfo,
 )
 from galaxy.tool_util.output_checker import DETECTED_JOB_STATE
+from galaxy.tools.parameters.basic import ParameterValueError
 from galaxy.util import (
     asbool,
     DATABASE_MAX_STRING_SIZE,
@@ -308,6 +309,10 @@ class BaseJobRunner:
                 modify_command_for_container=modify_command_for_container,
                 stream_stdout_stderr=stream_stdout_stderr,
             )
+        except ParameterValueError as e:
+            log.info("(%s) parameter validation error preparing job: %s", job_id, unicodify(e))
+            job_wrapper.fail(unicodify(e), exception=False)
+            return False
         except Exception as e:
             log.exception("(%s) Failure preparing job", job_id)
             job_wrapper.fail(unicodify(e), exception=True)

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -57,6 +57,7 @@ from galaxy.model.base import check_database_connection
 from galaxy.tool_util.deps import dependencies
 from galaxy.tool_util.parser.output_collection_def import FilePatternDatasetCollectionDescription
 from galaxy.tool_util.parser.output_objects import ToolOutput
+from galaxy.tools.parameters.basic import ParameterValueError
 from galaxy.util import (
     galaxy_directory,
     specs,
@@ -542,8 +543,10 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             try:
                 job_prepare_ret = job_wrapper.prepare(**prepare_kwds)
             except Exception as e:
-                # If we fail here the error isn't recoverable and we fail the job.
-                log.exception("failure preparing job %d", job_wrapper.job_id)
+                if isinstance(e, ParameterValueError):
+                    log.info("parameter validation error preparing job %d: %s", job_wrapper.job_id, unicodify(e))
+                else:
+                    log.exception("failure preparing job %d", job_wrapper.job_id)
                 job_state = self._job_state(job_wrapper.get_job(), job_wrapper)
                 job_state.fail_message = str(e)
                 self.work_queue.put((self.fail_job, job_state))

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2025,10 +2025,10 @@ class BaseDataToolParameter(ToolParameter):
 
         if self.min is not None:
             if self.min > dataset_count:
-                raise ValueError(f"At least {self.min} datasets are required for {self.name}")
+                raise ParameterValueError(f"at least {self.min} datasets are required", self.name)
         if self.max is not None:
             if self.max < dataset_count:
-                raise ValueError(f"At most {self.max} datasets are required for {self.name}")
+                raise ParameterValueError(f"at most {self.max} datasets are required", self.name)
 
 
 ItemFromSrcAny = Union[


### PR DESCRIPTION
The min/max dataset count checks in BaseDataToolParameter.validate() raised raw ValueError, which propagated to job runners and was logged at error level via log.exception. Since these are user input validation errors, not system errors, change them to ParameterValueError and catch them specifically in job runners to log at info level instead.

Fixes #22043

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
