### PR TITLE
[26.0] Fix FileNotFoundError when workflow references purged HDA

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -183,6 +183,12 @@ def to_cwl(
                         reason=FailureReason.dataset_failed, hda_id=value.id, workflow_step_id=step.id
                     )
                 )
+            if value.dataset.purged:
+                raise FailWorkflowEvaluation(
+                    why=InvocationFailureDatasetFailed(
+                        reason=FailureReason.dataset_failed, hda_id=value.id, workflow_step_id=step.id
+                    )
+                )
         if value.ext == "expression.json":
             with open(value.get_file_name()) as f:
                 # OUR safe_loads won't work, will not load numbers, etc...

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -249,6 +249,17 @@ def test_to_cwl():
     assert hda_references == hdas
 
 
+def test_to_cwl_purged_dataset():
+    hda = model.HistoryDatasetAssociation(create_dataset=True, flush=False)
+    hda.id = 1
+    hda.dataset.state = model.Dataset.states.OK
+    hda.dataset.purged = True
+    step = model.WorkflowStep()
+    step.id = 1
+    with pytest.raises(modules.FailWorkflowEvaluation):
+        modules.to_cwl(hda, [], step)
+
+
 def test_to_cwl_nested_collection():
     hda = model.HistoryDatasetAssociation(create_dataset=True, flush=False)
     hda.dataset.state = model.Dataset.states.OK


### PR DESCRIPTION
Add a check for purged datasets in to_cwl() before attempting to open the file. A purged dataset can have state=OK but no physical file, causing get_file_name() to return "" and open("") to raise an unhelpful FileNotFoundError. Now raises FailWorkflowEvaluation with a proper InvocationFailureDatasetFailed reason instead.

Fixes https://github.com/galaxyproject/galaxy/issues/22046

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
