### PR TITLE
[26.0] Fix preferred_object_store_id not respected for discovered outputs

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -56,7 +56,10 @@ from galaxy.util import (
 )
 
 if TYPE_CHECKING:
-    from galaxy.model import LibraryFolder
+    from galaxy.model import (
+        Job,
+        LibraryFolder,
+    )
     from galaxy.model.store import (
         BaseDirectoryImportModelStore,
         DirectoryModelExportStore,
@@ -256,6 +259,7 @@ class SessionlessJobContext(SessionlessModelPersistenceContext, BaseJobContext):
         working_directory: str,
         final_job_state: "JobState",
         max_discovered_files: Optional[int],
+        job: Optional["Job"] = None,
     ):
         # TODO: use a metadata source provider... (pop from inputs and add parameter)
         super().__init__(object_store, export_store, working_directory)
@@ -265,6 +269,11 @@ class SessionlessJobContext(SessionlessModelPersistenceContext, BaseJobContext):
         self.final_job_state = final_job_state
         self.max_discovered_files = float("inf") if max_discovered_files is None else max_discovered_files
         self.discovered_file_count = 0
+        self._job = job
+
+    @property
+    def job(self):
+        return self._job
 
     @property
     def change_datatype_actions(self):

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -318,6 +318,7 @@ def set_metadata_portable(
         tool_job_working_directory / "working",
         final_job_state=final_job_state,
         max_discovered_files=max_discovered_files,
+        job=job,
     )
 
     if extended_metadata_collection:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2173,6 +2173,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         job_attrs["create_time"] = self.create_time.isoformat()
         job_attrs["update_time"] = self.update_time.isoformat()
         job_attrs["job_messages"] = self.job_messages
+        job_attrs["object_store_id"] = self.object_store_id
+        if self.object_store_id_overrides:
+            job_attrs["object_store_id_overrides"] = self.object_store_id_overrides
 
         # Get the job's parameters
         param_dict = self.raw_param_dict()

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1661,6 +1661,8 @@ class BaseDirectoryImportModelStore(ModelImportStore):
             "job_stdout",
             "job_stderr",
             "galaxy_version",
+            "object_store_id",
+            "object_store_id_overrides",
         )
         for attribute in ATTRIBUTES:
             value = job_attrs.get(attribute)

--- a/test/integration/objectstore/test_selection_with_user_preferred_object_store.py
+++ b/test/integration/objectstore/test_selection_with_user_preferred_object_store.py
@@ -494,3 +494,35 @@ class TestObjectStoreSelectionWithPreferredObjectStoresIntegration(BaseObjectSto
             select(Dataset).order_by(Dataset.table.c.id.desc()).limit(1)
         ).first()
         return latest_dataset
+
+
+class TestObjectStoreSelectionWithExtendedMetadataIntegration(
+    TestObjectStoreSelectionWithPreferredObjectStoresIntegration
+):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["metadata_strategy"] = "extended"
+        config["retry_metadata_internally"] = False
+
+    def test_objectstore_selection_dynamic_output_tools(self):
+        with self.dataset_populator.test_history() as history_id:
+            self._set_user_preferred_object_store_id("static")
+            response = self.dataset_populator.run_tool(
+                "collection_creates_dynamic_list_of_pairs",
+                {"foo": "bar"},
+                history_id,
+            )
+            self.dataset_populator.wait_for_job(response["jobs"][0]["id"], assert_ok=True)
+            output_collections = response["output_collections"]
+            assert len(output_collections) == 1
+            hdca = self.dataset_populator.get_history_collection_details(
+                history_id, content_id=output_collections[0]["id"]
+            )
+            # Check all leaf datasets in the collection use the preferred store
+            for outer_element in hdca["elements"]:
+                for inner_element in outer_element["object"]["elements"]:
+                    dataset = inner_element["object"]
+                    storage_dict = self._storage_info(dataset)
+                    assert_storage_name_is(storage_dict, "Static Storage")
+            self._reset_user_preferred_object_store_id()


### PR DESCRIPTION
Fixes #22035

## Summary
- Fix `preferred_object_store_id` not being respected for discovered outputs when using extended metadata

## Test plan
- [ ] Verify discovered outputs use the correct preferred object store