### PR TITLE
Treat SVG datasets as images in dataset preview

### DIFF
--- a/client/src/components/Dataset/DatasetView.vue
+++ b/client/src/components/Dataset/DatasetView.vue
@@ -68,6 +68,11 @@ const isImageDataset = computed(() => {
     if (!dataset.value?.file_ext || !datatypesMapperStore.datatypesMapper) {
         return false;
     }
+    // SVG is not an image subclass, but should use DatasetAsImage for better
+    // user experience
+    if (dataset.value.file_ext === "svg") {
+        return true;
+    }
     return datatypesMapperStore.datatypesMapper.isSubTypeOfAny(dataset.value.file_ext, [
         "galaxy.datatypes.images.Image",
     ]);


### PR DESCRIPTION
## Summary

- SVG files are registered as `GenericXml` (not `Image`) in Galaxy's datatype hierarchy, so they get routed through the iframe-based `DatasetDisplay` which truncates content at 1 MB. This adds a special case in `isImageDataset` so SVGs use `DatasetAsImage` instead, rendering via `<img>` tags with no size truncation.
- Using `<img>` for SVGs is also safer than an iframe since browsers sandbox script execution in `<img src="...svg">`.

<img width="852" height="838" alt="image" src="https://github.com/user-attachments/assets/aae110c3-849d-4b1d-a4af-352c291bf0ad" />



Fixes #20741

## Test plan

- [ ] Upload an SVG > 1 MB, confirm it renders as an image in the preview tab instead of showing truncated XML
- [ ] Upload a small SVG, confirm it also renders correctly
- [ ] SVG with embedded `<script>` tags should not execute when rendered via `<img>`