### PR TITLE
[25.1] Use base64 URL instead of GitHub URL in test_stage_fetch_decompress_true

### DIFF
--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -307,13 +307,13 @@ class TestToolsUpload(ApiTestCase):
         details = self.dataset_populator.get_history_dataset_details(history_id=history_id, dataset=dataset)
         assert details["genome_build"] == "hg19"
 
-    @skip_if_github_down
     def test_stage_fetch_decompress_true(self, history_id: str) -> None:
+        base64_url = self.dataset_populator.base64_url_for_test_file("1.fasta.gz")
         job = {
             "input1": {
                 "class": "File",
                 "format": "fasta",
-                "location": "https://github.com/galaxyproject/galaxy/blob/dev/test-data/1.fasta.gz?raw=true",
+                "location": base64_url,
                 "decompress": True,
             }
         }
@@ -324,13 +324,13 @@ class TestToolsUpload(ApiTestCase):
         content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
         assert content.startswith(">hg17")
 
-    @skip_if_github_down
     def test_stage_fetch_decompress_false(self, history_id: str) -> None:
+        base64_url = self.dataset_populator.base64_url_for_test_file("1.fasta.gz")
         job = {
             "input1": {
                 "class": "File",
                 "format": "fasta",
-                "location": "https://github.com/galaxyproject/galaxy/blob/dev/test-data/1.fasta.gz?raw=true",
+                "location": base64_url,
                 "decompress": False,
             }
         }


### PR DESCRIPTION
Eliminates transient failures from GitHub being unreachable.
Partial backport of https://github.com/galaxyproject/galaxy/pull/22005/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
