### PR TITLE
Fix merge, tool shed metadata revision page uses new invalid_tools structure

### DIFF
--- a/lib/tool_shed/test/functional/test_frontend_invalid_tools.py
+++ b/lib/tool_shed/test/functional/test_frontend_invalid_tools.py
@@ -1,29 +1,11 @@
-from playwright.sync_api import (
-    expect,
-    Page,
-)
+from playwright.sync_api import expect
 
-from ..base.api import skip_if_api_v1
-from ..base.playwrightbrowser import PlaywrightShedBrowser
-from ..base.twilltestcase import ShedTwillTestCase
-
-
-class PlaywrightTestCase(ShedTwillTestCase):
-    @property
-    def _playwright_browser(self) -> PlaywrightShedBrowser:
-        browser = self._browser
-        assert isinstance(browser, PlaywrightShedBrowser)
-        return browser
-
-    @property
-    def _page(self) -> Page:
-        return self._playwright_browser._page
+from ..base.playwrighttestcase import PlaywrightTestCase
 
 
 class TestFrontendInvalidTools(PlaywrightTestCase):
     """Test that the Tool Shed frontend displays invalid tool error messages."""
 
-    @skip_if_api_v1
     def test_invalid_tools_display_error_message(self):
         """Navigate to a repository with invalid tools and verify the error reason is shown."""
         populator = self.populator

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/RevisionsTab.test.ts
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/RevisionsTab.test.ts
@@ -194,7 +194,13 @@ describe("RevisionsTab", () => {
                 [keys[0]]: makeRevision({
                     tools: [],
                     downloadable: false,
-                    invalid_tools: ["t1.xml", "t2.xml", "t3.xml", "t4.xml", "t5.xml"],
+                    invalid_tools: [
+                        { tool_config: "t1.xml", error_message: "error" },
+                        { tool_config: "t2.xml", error_message: "error" },
+                        { tool_config: "t3.xml", error_message: "error" },
+                        { tool_config: "t4.xml", error_message: "error" },
+                        { tool_config: "t5.xml", error_message: "error" },
+                    ],
                 }),
             }
 

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/RevisionsTab.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/RevisionsTab.vue
@@ -85,8 +85,8 @@ watch(
                     <q-card-section v-if="rev.data.invalid_tools?.length > 0">
                         <div class="text-subtitle2 text-negative">Invalid Tools:</div>
                         <ul class="q-my-none">
-                            <li v-for="path in rev.data.invalid_tools" :key="path">
-                                <code>{{ path }}</code>
+                            <li v-for="tool in rev.data.invalid_tools" :key="tool.tool_config">
+                                <code>{{ tool.tool_config }}</code>: {{ tool.error_message }}
                             </li>
                         </ul>
                     </q-card-section>

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/repository_metadata_bismark.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/repository_metadata_bismark.json
@@ -94,7 +94,7 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": ["bismark_bowtie_wrapper.xml"]
+        "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}]
     },
     "1:babbdbda7d7a": {
         "model_class": "RepositoryMetadata",
@@ -161,6 +161,6 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": ["bismark_bowtie_wrapper.xml", "bismark_bowtie2_wrapper.xml"]
+        "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}, {"tool_config": "bismark_bowtie2_wrapper.xml", "error_message": "Tool XML parsing error"}]
     }
 }

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/reset_metadata_bismark.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/reset_metadata_bismark.json
@@ -102,7 +102,7 @@
                     "version": "0.7.7.2"
                 }
             ],
-            "invalid_tools": ["bismark_bowtie_wrapper.xml"],
+            "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}],
             "repository_id": "529fd61ab1c6cc36",
             "numeric_revision": 0,
             "changeset_revision": "c35bbde3c5e0",
@@ -163,7 +163,7 @@
                     "version": "0.7.7.3"
                 }
             ],
-            "invalid_tools": ["bismark_bowtie_wrapper.xml", "bismark_bowtie2_wrapper.xml"],
+            "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}, {"tool_config": "bismark_bowtie2_wrapper.xml", "error_message": "Tool XML parsing error"}],
             "repository_id": "529fd61ab1c6cc36",
             "numeric_revision": 1,
             "changeset_revision": "babbdbda7d7a",
@@ -252,7 +252,7 @@
                     "version": "0.7.7.2"
                 }
             ],
-            "invalid_tools": ["bismark_bowtie_wrapper.xml"],
+            "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}],
             "repository_id": "529fd61ab1c6cc36",
             "numeric_revision": 0,
             "changeset_revision": "c35bbde3c5e0",
@@ -313,7 +313,7 @@
                     "version": "0.7.7.3"
                 }
             ],
-            "invalid_tools": ["bismark_bowtie_wrapper.xml", "bismark_bowtie2_wrapper.xml"],
+            "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}, {"tool_config": "bismark_bowtie2_wrapper.xml", "error_message": "Tool XML parsing error"}],
             "repository_id": "529fd61ab1c6cc36",
             "numeric_revision": 1,
             "changeset_revision": "babbdbda7d7a",

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_reset_warning.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_reset_warning.json
@@ -136,7 +136,7 @@
                     "version_string_cmd": null
                 }
             ],
-            "invalid_tools": ["broken_tool.xml"]
+            "invalid_tools": [{"tool_config": "broken_tool.xml", "error_message": "Tool XML parsing error"}]
         },
         "1:w1w1w1w1w1w1": {
             "id": "simwarn0000001",

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -2675,7 +2675,7 @@ export interface components {
              * Invalid Tools
              * @default []
              */
-            invalid_tools: string[]
+            invalid_tools: components["schemas"]["InvalidTool"][]
             /** Malicious */
             malicious: boolean
             /** Missing Test Components */

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -231,7 +231,7 @@ class RepositoryRevisionMetadataPreview(BaseModel):
     repository: Repository
     repository_dependencies: list["RepositoryDependency"]
     tools: Optional[list["RepositoryTool"]] = None
-    invalid_tools: list[str] = []
+    invalid_tools: list[InvalidTool] = []
     repository_id: Optional[str] = None
     numeric_revision: Optional[int] = None
     changeset_revision: str


### PR DESCRIPTION
Fallout from merging https://github.com/galaxyproject/galaxy/pull/22040 into dev

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
