### PR TITLE
[26.0] Move history panel expand button to top

### DIFF
--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -120,18 +120,27 @@ defineExpose({
 
         <div v-if="isDragging" class="interaction-overlay" />
     </div>
-    <div v-else>
-        <button
-            class="collapse-button closed"
-            :class="{ ...sideClasses, show: true }"
-            title="Open panel"
-            @click="
-                show = true;
-                hoverToggle = false;
+    <div v-else class="flex-panel-closed" :class="{ ...sideClasses }">
+        <slot
+            name="closed-button"
+            :open="
+                () => {
+                    show = true;
+                    hoverToggle = false;
+                }
             ">
-            <FontAwesomeIcon v-if="side === 'right'" fixed-width :icon="faChevronLeft" />
-            <FontAwesomeIcon v-else :icon="faChevronRight" fixed-width />
-        </button>
+            <button
+                class="collapse-button closed"
+                :class="{ ...sideClasses, show: true }"
+                title="Open panel"
+                @click="
+                    show = true;
+                    hoverToggle = false;
+                ">
+                <FontAwesomeIcon v-if="side === 'right'" fixed-width :icon="faChevronLeft" />
+                <FontAwesomeIcon v-else :icon="faChevronRight" fixed-width />
+            </button>
+        </slot>
     </div>
 </template>
 
@@ -243,6 +252,10 @@ $border-width: 6px;
             left: 0;
         }
     }
+}
+
+.flex-panel-closed {
+    position: relative;
 }
 
 .interaction-overlay {

--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { faChevronLeft } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
 import { onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router/composables";
@@ -8,6 +10,7 @@ import { useUserStore } from "@/stores/userStore";
 
 import CenterFrame from "./CenterFrame.vue";
 import ActivityBar from "@/components/ActivityBar/ActivityBar.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
 import HistoryIndex from "@/components/History/Index.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
 import DragAndDropModal from "@/components/Upload/DragAndDropModal.vue";
@@ -57,8 +60,65 @@ onUnmounted(() => {
             </div>
         </div>
         <FlexPanel v-if="showPanels" ref="historyPanel" side="right" :reactive-width.sync="historyPanelWidth">
+            <template v-slot:closed-button="{ open }">
+                <GButton class="history-expand-button" size="small" @click="open">
+                    <FontAwesomeIcon fixed-width :icon="faChevronLeft" />
+                    <transition name="slide">
+                        <span>History</span>
+                    </transition>
+                </GButton>
+            </template>
             <HistoryIndex @show="onShow" />
         </FlexPanel>
         <DragAndDropModal />
     </div>
 </template>
+
+<style scoped lang="scss">
+.history-expand-button {
+    display: flex;
+    align-items: center;
+    height: 1.6rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 100;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    span {
+        opacity: 0;
+        max-width: 0;
+        overflow: hidden;
+        transition: all 0.3s ease;
+    }
+
+    &:hover span {
+        opacity: 1;
+        max-width: 100px;
+    }
+}
+
+// Slide transition for History text
+.slide-enter-active,
+.slide-leave-active {
+    transition: all 0.3s ease;
+    overflow: hidden;
+}
+
+.slide-enter-from,
+.slide-leave-to {
+    opacity: 0;
+    transform: translateX(10px);
+    max-width: 0;
+}
+
+.slide-enter-to,
+.slide-leave-from {
+    opacity: 1;
+    transform: translateX(0);
+    max-width: 100px;
+}
+</style>


### PR DESCRIPTION
The history panel hide button was made more obvious in https://github.com/galaxyproject/galaxy/pull/21207, but then there was a discrepancy in that the re-expand button was in the middle instead of on the top where the hide button was.

https://github.com/user-attachments/assets/f5275759-aa41-4428-ba8b-f67a04c699d5

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
