### PR TITLE
[25.1] Fix subworkflow editing navigation and enable e2e test

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1085,8 +1085,10 @@ export default {
             this.onNavigate(`/workflows/run?id=${this.id}`, false, false, true);
         },
         async onNavigate(url, forceSave = false, ignoreChanges = false, appendVersion = false) {
+            let proceed = false;
             if (this.isNewTempWorkflow) {
                 await this.onCreate();
+                proceed = true;
             } else if (this.hasChanges && !forceSave && !ignoreChanges) {
                 // if there are changes, prompt user to save or discard or cancel
                 this.navUrl = url;
@@ -1094,7 +1096,13 @@ export default {
                 return;
             } else if (forceSave) {
                 // when forceSave is true, save the workflow before navigating
-                await this.onSave();
+                proceed = await this.onSave();
+            } else {
+                // no changes to save, proceed with navigation
+                proceed = true;
+            }
+            if (!proceed) {
+                return;
             }
 
             if (appendVersion && this.version !== undefined) {

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -44,7 +44,8 @@ export default {
                 this.skipNextReload = false;
             }
 
-            this.version = parseInt(Query.get("version"), 10);
+            const versionParam = Query.get("version");
+            this.version = versionParam !== undefined ? parseInt(versionParam, 10) : undefined;
             this.storedWorkflowId = Query.get("id");
             this.workflowId = Query.get("workflow_id");
             const workflowId = this.workflowId || this.storedWorkflowId;

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1,7 +1,6 @@
 import json
 from typing import Optional
 
-import pytest
 import yaml
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -897,7 +896,6 @@ steps:
         self.workflow_editor_connect("nested_workflow#workflow_output", "metadata_bam#input_bam")
         self.assert_connected("nested_workflow#workflow_output", "metadata_bam#input_bam")
 
-    @pytest.mark.xfail
     @selenium_test
     def test_edit_subworkflow(self):
         self.open_in_workflow_editor(
@@ -914,10 +912,13 @@ steps:
             label: create_2
 """
         )
+        # Save after auto-layout so there are no unsaved changes
+        self.assert_workflow_has_changes_and_save()
         editor = self.components.workflow_editor
         node = editor.node._(label="nested_workflow")
         node.wait_for_and_click()
         editor.edit_subworkflow.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
         node = editor.node._(label="create_2")
         node.wait_for_and_click()
 


### PR DESCRIPTION
## Summary
- Backport of #22032 to release_25.1
- Fix navigation blocking when editing subworkflows with no unsaved changes
- Fix `parseInt(undefined, 10)` producing `NaN` for missing version query parameter
- Enable `test_edit_subworkflow` e2e test

Fixes https://github.com/galaxyproject/galaxy/issues/21998

🤖 Generated with [Claude Code](https://claude.com/claude-code)