### PR TITLE
Move celery metadata to an asychronous task monitored by a queued on a dedicated thread

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -11,6 +11,8 @@ import threading
 import time
 import traceback
 import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
 from queue import (
     Empty,
     Queue,
@@ -96,10 +98,17 @@ class RunnerParams(ParamsWithSpecs):
         raise Exception(JOB_RUNNER_PARAMETER_VALIDATION_FAILED_MESSAGE % name)
 
 
+@dataclass
+class CeleryMetadataMonitorItem:
+    job_id: int
+    async_result: Any  # celery AsyncResult
+    on_complete: Callable[[], None]
+
+
 class BaseJobRunner:
     runner_name = "BaseJobRunner"
 
-    start_methods = ["_init_monitor_thread", "_init_worker_threads"]
+    start_methods = ["_init_monitor_thread", "_init_worker_threads", "_init_celery_metadata_monitor"]
     DEFAULT_SPECS = dict(recheck_missing_job_retries=dict(map=int, valid=lambda x: int(x) >= 0, default=0))
 
     def __init__(self, app: "GalaxyManagerApplication", nworkers: int, **kwargs) -> None:
@@ -441,10 +450,66 @@ class BaseJobRunner:
                 "Celery backend not set. Please set `result_backend` on the `celery_conf` config option."
             )
 
-    def _handle_metadata_externally(self, job_wrapper: "MinimalJobWrapper", resolve_requirements: bool = False):
+    def _init_celery_metadata_monitor(self):
+        """Start a daemon thread that monitors async celery metadata tasks."""
+        self._celery_metadata_queue: Queue = Queue()
+        self._celery_metadata_watched: list[CeleryMetadataMonitorItem] = []
+        if not self.app.config.enable_celery_tasks:
+            return
+        thread = threading.Thread(
+            name=f"{self.runner_name}.celery_metadata_monitor",
+            target=self._celery_metadata_monitor,
+            daemon=True,
+        )
+        thread.start()
+
+    def _celery_metadata_monitor(self):
+        """Monitor loop for async celery metadata tasks."""
+        while not self._should_stop:
+            # Drain queue into watched list
+            try:
+                while True:
+                    item = self._celery_metadata_queue.get_nowait()
+                    self._celery_metadata_watched.append(item)
+            except Empty:
+                pass
+            # Check each watched item
+            self._celery_metadata_watched = [
+                item for item in self._celery_metadata_watched if self._check_celery_metadata_item(item)
+            ]
+            time.sleep(self.app.config.job_runner_monitor_sleep)
+
+    def _check_celery_metadata_item(self, item: CeleryMetadataMonitorItem) -> bool:
+        """Check a celery metadata item. Returns True if still pending."""
+        if not item.async_result.ready():
+            return True
+        try:
+            if item.async_result.failed():
+                log.error("Celery metadata task failed for job %d: %s", item.job_id, item.async_result.result)
+            else:
+                log.debug("Celery metadata task completed for job %d", item.job_id)
+            item.on_complete()
+        except Exception:
+            log.exception("Error in celery metadata on_complete callback for job %d", item.job_id)
+        return False
+
+    def _make_work_queue_callback(self, method: Callable, arg: Any) -> Callable[[], None]:
+        """Create a callback that puts (method, arg) on the work queue."""
+
+        def on_complete() -> None:
+            self.work_queue.put((method, arg))
+
+        return on_complete
+
+    def _handle_metadata_externally(
+        self, job_wrapper: "MinimalJobWrapper", resolve_requirements: bool = False
+    ) -> Optional[Any]:
         """
         Set metadata externally. Used by the Pulsar job runner where this
         shouldn't be attached to command line to execute.
+
+        Returns a celery AsyncResult if metadata is dispatched asynchronously,
+        or None if handled synchronously or skipped.
         """
         # run the metadata setting script here
         # this is terminate-able when output dataset/job is deleted
@@ -462,17 +527,14 @@ class BaseJobRunner:
                 self._verify_celery_config()
                 from galaxy.celery.tasks import set_job_metadata
 
-                # We're synchronously waiting for a task here. This means we have to have a result backend.
-                # That is bad practice and also means this can never become part of another task.
-                try:
-                    set_job_metadata.delay(
-                        tool_job_working_directory=job_wrapper.working_directory,
-                        job_id=job_wrapper.job_id,
-                        extended_metadata_collection="extended" in metadata_strategy,
-                    ).get()
-                except Exception:
-                    log.exception("Metadata task failed")
-                    return
+                job_wrapper.change_state(model.Job.states.FINISHING)
+                log.debug("Dispatching external metadata execution to celery for job: %d", job_wrapper.job_id)
+                async_result = set_job_metadata.delay(
+                    tool_job_working_directory=job_wrapper.working_directory,
+                    job_id=job_wrapper.job_id,
+                    extended_metadata_collection="extended" in metadata_strategy,
+                )
+                return async_result
             else:
                 lib_adjust = GALAXY_LIB_ADJUST_TEMPLATE % job_wrapper.galaxy_lib_dir
                 venv = GALAXY_VENV_TEMPLATE % job_wrapper.galaxy_virtual_env
@@ -498,6 +560,7 @@ class BaseJobRunner:
                     preexec_fn=os.setpgrp,
                 )
             log.debug("execution of external set_meta for job %d finished", job_wrapper.job_id)
+        return None
 
     def get_job_file(self, job_wrapper: "MinimalJobWrapper", **kwds) -> str:
         job_metrics = job_wrapper.app.job_metrics
@@ -965,9 +1028,26 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
         return collect_output_success, stdout, stderr
 
     def finish_job(self, job_state: T) -> None:
+        """Handle external metadata (if needed), then call _finish_job."""
+        external_metadata = not asbool(job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
+        if external_metadata:
+            async_result = self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
+            if async_result is not None:
+                self._celery_metadata_queue.put(
+                    CeleryMetadataMonitorItem(
+                        job_id=job_state.job_wrapper.job_id,
+                        async_result=async_result,
+                        on_complete=self._make_work_queue_callback(self._finish_job, job_state),
+                    )
+                )
+                return
+        self._finish_job(job_state)
+
+    def _finish_job(self, job_state: T) -> None:
         """
         Get the output/error for a finished job, pass to `job_wrapper.finish`
         and cleanup all the job's temporary files.
+        Subclasses override this for post-metadata work.
         """
         galaxy_id_tag = job_state.job_wrapper.get_id_tag()
         external_job_id = job_state.job_id

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -253,8 +253,8 @@ class ChronosJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         return None
 
     @handle_exception_call
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         self._chronos_client.delete(job_state.job_id)
 
     def parse_destination_params(self, params):

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -200,20 +200,12 @@ class ShellJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 ajs.running = True
             ajs.old_state = state
             if state == model.Job.states.OK or job_state == model.Job.states.STOPPED:
-                external_metadata = not asbool(
-                    ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB)
-                )
-                if external_metadata:
-                    self.work_queue.put((self.handle_metadata_externally, ajs))
                 log.debug(f"({id_tag}/{external_job_id}) job execution finished, running job wrapper finish method")
                 self.work_queue.put((self.finish_job, ajs))
             else:
                 new_watched.append(ajs)
         # Replace the watch list with the updated version
         self.watched = new_watched
-
-    def handle_metadata_externally(self, ajs):
-        self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
 
     def __handle_job_failure_reasons(self, ajs, external_job_id):
         shell_params, job_params = self.parse_destination_params(ajs.job_destination.params)

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -234,11 +234,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
             job_state = cjs.job_wrapper.get_state()
             if job_complete or job_state == model.Job.states.STOPPED:
                 if job_state != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{job_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
                 continue
@@ -272,11 +267,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
                 self._stop_container(job_wrapper)
                 # self.watched.append(cjs)
                 if cjs.job_wrapper.get_state() != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{external_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
             except Exception as e:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -270,10 +270,6 @@ class DRMAAJobRunner(AsynchronousJobRunner[DRMAAJobState]):
                 ajs.fail_message = "The cluster DRM system terminated this job"
                 self.work_queue.put((self.fail_job, ajs))
         elif drmaa_state == drmaa.JobState.DONE or job_state == model.Job.states.STOPPED:
-            # External metadata processing for external runjobs
-            external_metadata = not asbool(ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
-            if external_metadata:
-                self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
             if job_state != model.Job.states.DELETED:
                 self.work_queue.put((self.finish_job, ajs))
         return None

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -1141,9 +1141,8 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         # run super method
         super().fail_job(job_state, exception, message, full_status)
 
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         jobs = find_job_object_by_name(self._pykube_api, job_state.job_id, self.runner_params["k8s_namespace"])
         if len(jobs.response["items"]) > 1:
             log.warning(

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -19,6 +19,7 @@ from galaxy.util import asbool
 from galaxy.util.commands import new_clean_env
 from . import (
     BaseJobRunner,
+    CeleryMetadataMonitorItem,
     JobState,
 )
 from .util.process_groups import (
@@ -148,7 +149,21 @@ class LocalJobRunner(BaseJobRunner):
             self._fail_job_local(job_wrapper, "failure running job")
             return
 
-        self._handle_metadata_if_needed(job_wrapper)
+        async_result = self._handle_metadata_if_needed(job_wrapper)
+        if async_result is not None:
+            job_destination = job_wrapper.job_destination
+            job_state = JobState(job_wrapper, job_destination)
+            job_state.stop_job = False
+            self._celery_metadata_queue.put(
+                CeleryMetadataMonitorItem(
+                    job_id=job_wrapper.job_id,
+                    async_result=async_result,
+                    on_complete=lambda: self.work_queue.put(
+                        (lambda js: self._finish_or_resubmit_job(js, stdout, stderr, job_id=job_id), job_state)
+                    ),
+                )
+            )
+            return
 
         job_destination = job_wrapper.job_destination
         job_state = JobState(job_wrapper, job_destination)
@@ -199,8 +214,10 @@ class LocalJobRunner(BaseJobRunner):
         self.fail_job(job_state, exception=True)
 
     def _handle_metadata_if_needed(self, job_wrapper):
+        """Returns an AsyncResult if celery metadata was dispatched, None otherwise."""
         if not self._embed_metadata(job_wrapper):
-            self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
+            return self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
+        return None
 
     def _embed_metadata(self, job_wrapper):
         job_destination = job_wrapper.job_destination

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from time import sleep
 from typing import (
     Any,
@@ -51,6 +52,7 @@ from galaxy.jobs.job_destination import JobDestination
 from galaxy.jobs.runners import (
     AsynchronousJobRunner,
     AsynchronousJobState,
+    CeleryMetadataMonitorItem,
     JobState,
 )
 from galaxy.model.base import check_database_connection
@@ -221,6 +223,17 @@ PULSAR_PARAM_SPECS = dict(
 
 PARAMETER_SPECIFICATION_REQUIRED = object()
 PARAMETER_SPECIFICATION_IGNORED = object()
+
+
+@dataclass
+class PulsarFinishJobResult:
+    tool_stdout: Optional[str]
+    tool_stderr: Optional[str]
+    exit_code: Optional[int]
+    job_stdout: Optional[str]
+    job_stderr: Optional[str]
+    remote_metadata_directory: Optional[str]
+    job_metrics_directory: str
 
 
 class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
@@ -748,28 +761,52 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             self.fail_job(job_state, message=GENERIC_REMOTE_ERROR, exception=True)
             log.exception("failure finishing job %d", job_wrapper.job_id)
             return
+        result = PulsarFinishJobResult(
+            tool_stdout=tool_stdout,
+            tool_stderr=tool_stderr,
+            exit_code=exit_code,
+            job_stdout=job_stdout,
+            job_stderr=job_stderr,
+            remote_metadata_directory=remote_metadata_directory,
+            job_metrics_directory=os.path.join(job_wrapper.working_directory, "metadata"),
+        )
         if not PulsarJobRunner.__remote_metadata(client):
             # we need an actual exit code file in the job working directory to detect job errors in the metadata script
             with open(
                 os.path.join(job_wrapper.working_directory, f"galaxy_{job_wrapper.job_id}.ec"), "w"
             ) as exit_code_file:
                 exit_code_file.write(str(exit_code))
-            self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
-        job_metrics_directory = os.path.join(job_wrapper.working_directory, "metadata")
-        # Finish the job
+            async_result = self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
+            if async_result is not None:
+                self._celery_metadata_queue.put(
+                    CeleryMetadataMonitorItem(
+                        job_id=job_wrapper.job_id,
+                        async_result=async_result,
+                        on_complete=lambda: self.work_queue.put(
+                            (
+                                lambda _jw: self._finish_pulsar_job(_jw, result),
+                                job_wrapper,
+                            )
+                        ),
+                    )
+                )
+                return
+        self._finish_pulsar_job(job_wrapper, result)
+
+    def _finish_pulsar_job(self, job_wrapper, result: PulsarFinishJobResult):
         try:
             job_wrapper.finish(
-                tool_stdout,
-                tool_stderr,
-                exit_code,
-                job_stdout=job_stdout,
-                job_stderr=job_stderr,
-                remote_metadata_directory=remote_metadata_directory,
-                job_metrics_directory=job_metrics_directory,
+                result.tool_stdout,
+                result.tool_stderr,
+                result.exit_code,
+                job_stdout=result.job_stdout,
+                job_stderr=result.job_stderr,
+                remote_metadata_directory=result.remote_metadata_directory,
+                job_metrics_directory=result.job_metrics_directory,
             )
         except Exception:
             log.exception("Job wrapper finish method failed")
-            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=job_metrics_directory)
+            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=result.job_metrics_directory)
 
     def check_pid(self, pid):
         try:
@@ -833,11 +870,14 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             client.kill()
 
     def recover(self, job: model.Job, job_wrapper: "MinimalJobWrapper") -> None:
-        """Recover jobs stuck in the queued/running state when Galaxy started."""
+        """Recover jobs stuck in the queued/running/finishing state when Galaxy started."""
         job_state = self._job_state(job, job_wrapper)
         job_wrapper.command_line = job.get_command_line()
         state = job.get_state()
-        if state in [model.Job.states.RUNNING, model.Job.states.QUEUED, model.Job.states.STOPPED]:
+        if state == model.Job.states.FINISHING:
+            log.debug(f"(Pulsar/{job.id}) is in FINISHING state, re-running finish_job for recovery")
+            self.mark_as_finished(job_state)
+        elif state in [model.Job.states.RUNNING, model.Job.states.QUEUED, model.Job.states.STOPPED]:
             log.debug(f"(Pulsar/{job.id}) is still in {state} state, adding to the Pulsar queue")
             job_state.old_state = state if state != model.Job.states.STOPPED else model.Job.states.RUNNING
             job_state.running = state != model.Job.states.QUEUED
@@ -1099,6 +1139,8 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 galaxy_job_id = remote_job_id
             assert isinstance(self.app.job_manager.job_handler.job_queue, JobHandlerQueue)
             job, job_wrapper = self.app.job_manager.job_handler.job_queue.job_pair_for_id(galaxy_job_id)
+            if full_status["status"] in ("complete", "cancelled"):
+                job.handler = self.app.config.server_name
             job_state = self._job_state(job, job_wrapper)
             self._update_job_state_for_status(job_state, full_status["status"], full_status=full_status)
         except Exception:

--- a/lib/galaxy/jobs/runners/tasks.py
+++ b/lib/galaxy/jobs/runners/tasks.py
@@ -9,7 +9,10 @@ from galaxy.jobs import (
     JobWrapper,
     TaskWrapper,
 )
-from galaxy.jobs.runners import BaseJobRunner
+from galaxy.jobs.runners import (
+    BaseJobRunner,
+    CeleryMetadataMonitorItem,
+)
 
 if TYPE_CHECKING:
     from galaxy.app import GalaxyManagerApplication
@@ -131,8 +134,21 @@ class TaskedJobRunner(BaseJobRunner):
         # run the metadata setting script here
         # this is terminate-able when output dataset/job is deleted
         # so that long running set_meta()s can be canceled without having to reboot the server
-        self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
-        # Finish the job
+        async_result = self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
+        if async_result is not None:
+            self._celery_metadata_queue.put(
+                CeleryMetadataMonitorItem(
+                    job_id=job_wrapper.job_id,
+                    async_result=async_result,
+                    on_complete=lambda: self.work_queue.put(
+                        (lambda jw: self._finish_job_after_metadata(jw, stdout, stderr, job_exit_code), job_wrapper)
+                    ),
+                )
+            )
+            return
+        self._finish_job_after_metadata(job_wrapper, stdout, stderr, job_exit_code)
+
+    def _finish_job_after_metadata(self, job_wrapper, stdout, stderr, job_exit_code):
         try:
             job_wrapper.finish(stdout, stderr, job_exit_code)
         except Exception:

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -2076,9 +2076,9 @@ def summarize_job_outputs(job: model.Job, tool, params):
 
 def get_jobs_to_check_at_startup(session: galaxy_scoped_session, track_jobs_in_database: bool, config):
     if track_jobs_in_database:
-        in_list = (Job.states.QUEUED, Job.states.RUNNING, Job.states.STOPPED)
+        in_list = (Job.states.QUEUED, Job.states.RUNNING, Job.states.STOPPED, Job.states.FINISHING)
     else:
-        in_list = (Job.states.NEW, Job.states.QUEUED, Job.states.RUNNING)
+        in_list = (Job.states.NEW, Job.states.QUEUED, Job.states.RUNNING, Job.states.FINISHING)
 
     stmt = (
         select(Job)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1716,6 +1716,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         states.WAITING,
         states.QUEUED,
         states.RUNNING,
+        states.FINISHING,
     ]
 
     # Please include an accessor (get/set pair) for any new columns/members.

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -130,6 +130,7 @@ class JobState(str, Enum):
     WAITING = "waiting"
     QUEUED = "queued"
     RUNNING = "running"
+    FINISHING = "finishing"
     OK = "ok"
     ERROR = "error"
     FAILED = "failed"

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -4195,6 +4195,7 @@ def wait_on_state(
             "stop",
             "stopped",
             "setting_metadata",
+            "finishing",
             "waiting",
             "cancelling",
             "deleting",


### PR DESCRIPTION
On usegalaxy.org we're regularly seeing two issues:

1. handler worker pool threads blocking on waiting for a response from celery metadata jobs. This can be due to celery being busy, or in worse cases, celery being down, and
2. jobs stuck permanently non-terminal due to celery or handler restarts.

This should help with both cases.

- Make external metadata celery waits asynchronous via a new monitor thread
- Move external metadata handling from individual runner monitor threads into the base `AsynchronousJobRunner.finish_job()`, so it always runs on a worker thread instead of blocking the monitor.
- Some refactoring

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
