### PR TITLE
Move metadata handling into finish_job on the work queue

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -965,9 +965,17 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors, Generic[T]):
         return collect_output_success, stdout, stderr
 
     def finish_job(self, job_state: T) -> None:
+        """Handle external metadata (if needed), then call _finish_job."""
+        external_metadata = not asbool(job_state.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
+        if external_metadata:
+            self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
+        self._finish_job(job_state)
+
+    def _finish_job(self, job_state: T) -> None:
         """
         Get the output/error for a finished job, pass to `job_wrapper.finish`
         and cleanup all the job's temporary files.
+        Subclasses override this for post-metadata work.
         """
         galaxy_id_tag = job_state.job_wrapper.get_id_tag()
         external_job_id = job_state.job_id

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -253,8 +253,8 @@ class ChronosJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         return None
 
     @handle_exception_call
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         self._chronos_client.delete(job_state.job_id)
 
     def parse_destination_params(self, params):

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -200,20 +200,12 @@ class ShellJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 ajs.running = True
             ajs.old_state = state
             if state == model.Job.states.OK or job_state == model.Job.states.STOPPED:
-                external_metadata = not asbool(
-                    ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", DEFAULT_EMBED_METADATA_IN_JOB)
-                )
-                if external_metadata:
-                    self.work_queue.put((self.handle_metadata_externally, ajs))
                 log.debug(f"({id_tag}/{external_job_id}) job execution finished, running job wrapper finish method")
                 self.work_queue.put((self.finish_job, ajs))
             else:
                 new_watched.append(ajs)
         # Replace the watch list with the updated version
         self.watched = new_watched
-
-    def handle_metadata_externally(self, ajs):
-        self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
 
     def __handle_job_failure_reasons(self, ajs, external_job_id):
         shell_params, job_params = self.parse_destination_params(ajs.job_destination.params)

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -234,11 +234,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
             job_state = cjs.job_wrapper.get_state()
             if job_complete or job_state == model.Job.states.STOPPED:
                 if job_state != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{job_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
                 continue
@@ -272,11 +267,6 @@ class CondorJobRunner(AsynchronousJobRunner[CondorJobState]):
                 self._stop_container(job_wrapper)
                 # self.watched.append(cjs)
                 if cjs.job_wrapper.get_state() != model.Job.states.DELETED:
-                    external_metadata = not asbool(
-                        cjs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True)
-                    )
-                    if external_metadata:
-                        self._handle_metadata_externally(cjs.job_wrapper, resolve_requirements=True)
                     log.debug(f"({galaxy_id_tag}/{external_id}) job has completed")
                     self.work_queue.put((self.finish_job, cjs))
             except Exception as e:

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -270,10 +270,6 @@ class DRMAAJobRunner(AsynchronousJobRunner[DRMAAJobState]):
                 ajs.fail_message = "The cluster DRM system terminated this job"
                 self.work_queue.put((self.fail_job, ajs))
         elif drmaa_state == drmaa.JobState.DONE or job_state == model.Job.states.STOPPED:
-            # External metadata processing for external runjobs
-            external_metadata = not asbool(ajs.job_wrapper.job_destination.params.get("embed_metadata_in_job", True))
-            if external_metadata:
-                self._handle_metadata_externally(ajs.job_wrapper, resolve_requirements=True)
             if job_state != model.Job.states.DELETED:
                 self.work_queue.put((self.finish_job, ajs))
         return None

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -1141,9 +1141,8 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         # run super method
         super().fail_job(job_state, exception, message, full_status)
 
-    def finish_job(self, job_state: AsynchronousJobState) -> None:
-        self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)
-        super().finish_job(job_state)
+    def _finish_job(self, job_state: AsynchronousJobState) -> None:
+        super()._finish_job(job_state)
         jobs = find_job_object_by_name(self._pykube_api, job_state.job_id, self.runner_params["k8s_namespace"])
         if len(jobs.response["items"]) > 1:
             log.warning(

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from time import sleep
 from typing import (
     Any,
@@ -221,6 +222,17 @@ PULSAR_PARAM_SPECS = dict(
 
 PARAMETER_SPECIFICATION_REQUIRED = object()
 PARAMETER_SPECIFICATION_IGNORED = object()
+
+
+@dataclass
+class PulsarFinishJobResult:
+    tool_stdout: Optional[str]
+    tool_stderr: Optional[str]
+    exit_code: Optional[int]
+    job_stdout: Optional[str]
+    job_stderr: Optional[str]
+    remote_metadata_directory: Optional[str]
+    job_metrics_directory: str
 
 
 class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
@@ -748,6 +760,15 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             self.fail_job(job_state, message=GENERIC_REMOTE_ERROR, exception=True)
             log.exception("failure finishing job %d", job_wrapper.job_id)
             return
+        result = PulsarFinishJobResult(
+            tool_stdout=tool_stdout,
+            tool_stderr=tool_stderr,
+            exit_code=exit_code,
+            job_stdout=job_stdout,
+            job_stderr=job_stderr,
+            remote_metadata_directory=remote_metadata_directory,
+            job_metrics_directory=os.path.join(job_wrapper.working_directory, "metadata"),
+        )
         if not PulsarJobRunner.__remote_metadata(client):
             # we need an actual exit code file in the job working directory to detect job errors in the metadata script
             with open(
@@ -755,21 +776,22 @@ class PulsarJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             ) as exit_code_file:
                 exit_code_file.write(str(exit_code))
             self._handle_metadata_externally(job_wrapper, resolve_requirements=True)
-        job_metrics_directory = os.path.join(job_wrapper.working_directory, "metadata")
-        # Finish the job
+        self._finish_pulsar_job(job_wrapper, result)
+
+    def _finish_pulsar_job(self, job_wrapper, result: PulsarFinishJobResult):
         try:
             job_wrapper.finish(
-                tool_stdout,
-                tool_stderr,
-                exit_code,
-                job_stdout=job_stdout,
-                job_stderr=job_stderr,
-                remote_metadata_directory=remote_metadata_directory,
-                job_metrics_directory=job_metrics_directory,
+                result.tool_stdout,
+                result.tool_stderr,
+                result.exit_code,
+                job_stdout=result.job_stdout,
+                job_stderr=result.job_stderr,
+                remote_metadata_directory=result.remote_metadata_directory,
+                job_metrics_directory=result.job_metrics_directory,
             )
         except Exception:
             log.exception("Job wrapper finish method failed")
-            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=job_metrics_directory)
+            job_wrapper.fail("Unable to finish job", exception=True, job_metrics_directory=result.job_metrics_directory)
 
     def check_pid(self, pid):
         try:


### PR DESCRIPTION
Split AsynchronousJobRunner.finish_job into finish_job (metadata) and _finish_job (output collection). Metadata now runs on worker threads instead of blocking the monitor thread. Removes duplicated metadata handling from cli, condor, drmaa, and kubernetes runners.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
