### PR TITLE
Persist scratchbook windows across page reloads

### DIFF
--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -195,7 +195,9 @@ export default {
         if (!this.embedded) {
             this.Galaxy = getGalaxyInstance();
             this.Galaxy.frame = this.windowManager;
-            this.windowManager.restore();
+            if (this.showMasthead) {
+                this.windowManager.restore();
+            }
             if (this.Galaxy.config.interactivetools_enable) {
                 this.startWatchingEntryPoints();
             }

--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -195,6 +195,7 @@ export default {
         if (!this.embedded) {
             this.Galaxy = getGalaxyInstance();
             this.Galaxy.frame = this.windowManager;
+            this.windowManager.restore();
             if (this.Galaxy.config.interactivetools_enable) {
                 this.startWatchingEntryPoints();
             }

--- a/client/src/entry/analysis/window-manager.js
+++ b/client/src/entry/analysis/window-manager.js
@@ -7,12 +7,16 @@ import WinBox from "winbox/src/js/winbox.js";
 import _l from "@/utils/localization";
 import { withPrefix } from "@/utils/redirect";
 
+const STORAGE_KEY = "galaxy-scratchbook-windows";
+
 export class WindowManager {
     constructor(options) {
         options = options || {};
         this.counter = 0;
         this.active = false;
         this.zIndexInitialized = false;
+        this.windows = new Map();
+        this._saveTimeout = null;
     }
 
     /** Return window masthead tab props */
@@ -30,17 +34,39 @@ export class WindowManager {
 
     /** Add and display a new window based on options. */
     add(options, layout = 10, margin = 20) {
-        const url = this._build_url(withPrefix(options.url), { hide_panels: true, hide_masthead: true });
-        const x = this.counter * margin;
-        const y = (this.counter % layout) * margin;
+        const id = crypto.randomUUID();
+        const originalUrl = options.url;
+        const url = this._build_url(withPrefix(originalUrl), { hide_panels: true, hide_masthead: true });
+        const x = options.x ?? this.counter * margin;
+        const y = options.y ?? (this.counter % layout) * margin;
         this.counter++;
         const params = {
             title: options.title || "Window",
             url: url,
             x: x,
             y: y,
+            width: options.width,
+            height: options.height,
             onclose: () => {
                 this.counter--;
+                this.windows.delete(id);
+                this._saveWindows();
+            },
+            onmove: (newX, newY) => {
+                const entry = this.windows.get(id);
+                if (entry) {
+                    entry.x = newX;
+                    entry.y = newY;
+                    this._saveWindows();
+                }
+            },
+            onresize: (newW, newH) => {
+                const entry = this.windows.get(id);
+                if (entry) {
+                    entry.width = newW;
+                    entry.height = newH;
+                    this._saveWindows();
+                }
             },
         };
         // Set z-index floor on the first window only to position above
@@ -59,11 +85,61 @@ export class WindowManager {
         overlay.className = "iframe-focus-overlay";
         overlay.addEventListener("mousedown", () => win.focus());
         win.body.appendChild(overlay);
+
+        this.windows.set(id, {
+            id,
+            title: params.title,
+            url: originalUrl,
+            x: x,
+            y: y,
+            width: win.width,
+            height: win.height,
+        });
+        this._saveWindows();
+    }
+
+    /** Restore windows saved from a previous session. */
+    restore() {
+        const saved = this._loadWindows();
+        if (saved.length > 0) {
+            this.active = true;
+            for (const entry of saved) {
+                this.add({
+                    title: entry.title,
+                    url: entry.url,
+                    x: entry.x,
+                    y: entry.y,
+                    width: entry.width,
+                    height: entry.height,
+                });
+            }
+        }
     }
 
     /** Called before closing all windows. */
     beforeUnload() {
         return this.counter > 0;
+    }
+
+    _saveWindows() {
+        clearTimeout(this._saveTimeout);
+        this._saveTimeout = setTimeout(() => {
+            try {
+                const data = JSON.stringify([...this.windows.values()]);
+                localStorage.setItem(STORAGE_KEY, data);
+            } catch (e) {
+                // localStorage full or unavailable — silently ignore
+            }
+        }, 200);
+    }
+
+    _loadWindows() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? JSON.parse(raw) : [];
+        } catch (e) {
+            return [];
+        }
     }
 
     /** Url helper */

--- a/client/src/entry/analysis/window-manager.test.js
+++ b/client/src/entry/analysis/window-manager.test.js
@@ -1,0 +1,200 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture callbacks passed to WinBox so tests can invoke them
+let lastWinBoxParams = null;
+const mockWinBoxInstance = {
+    body: document.createElement("div"),
+    width: 400,
+    height: 300,
+    focus: vi.fn(),
+};
+
+vi.mock("winbox/src/js/winbox.js", () => ({
+    default: {
+        new: vi.fn((params) => {
+            lastWinBoxParams = params;
+            return { ...mockWinBoxInstance };
+        }),
+    },
+}));
+
+vi.mock("winbox/src/css/winbox.css", () => ({}));
+
+vi.mock("@/utils/redirect", () => ({
+    withPrefix: (url) => url,
+}));
+
+vi.mock("@/utils/localization", () => ({
+    default: (s) => s,
+}));
+
+const STORAGE_KEY = "galaxy-scratchbook-windows";
+
+// Dynamic import so mocks are in place before the module loads
+let WindowManager;
+
+describe("WindowManager persistence", () => {
+    beforeAll(async () => {
+        ({ WindowManager } = await import("./window-manager"));
+    });
+
+    beforeEach(() => {
+        localStorage.clear();
+        lastWinBoxParams = null;
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    function flushSave() {
+        vi.advanceTimersByTime(200);
+    }
+
+    it("saves window metadata to localStorage on add", () => {
+        const wm = new WindowManager();
+        wm.add({ title: "Chat", url: "/chat" });
+        flushSave();
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored).toHaveLength(1);
+        expect(stored[0].title).toBe("Chat");
+        expect(stored[0].url).toBe("/chat");
+    });
+
+    it("stores original url without hide_panels params", () => {
+        const wm = new WindowManager();
+        wm.add({ title: "Test", url: "/some/page" });
+        flushSave();
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored[0].url).toBe("/some/page");
+        expect(stored[0].url).not.toContain("hide_panels");
+    });
+
+    it("removes window from storage on close", () => {
+        const wm = new WindowManager();
+        wm.add({ title: "Win1", url: "/a" });
+        flushSave();
+
+        // Trigger the onclose callback WinBox would call
+        lastWinBoxParams.onclose();
+        flushSave();
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored).toHaveLength(0);
+    });
+
+    it("updates position on move", () => {
+        const wm = new WindowManager();
+        wm.add({ title: "Win", url: "/a" });
+        flushSave();
+
+        lastWinBoxParams.onmove(150, 250);
+        flushSave();
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored[0].x).toBe(150);
+        expect(stored[0].y).toBe(250);
+    });
+
+    it("updates size on resize", () => {
+        const wm = new WindowManager();
+        wm.add({ title: "Win", url: "/a" });
+        flushSave();
+
+        lastWinBoxParams.onresize(600, 500);
+        flushSave();
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored[0].width).toBe(600);
+        expect(stored[0].height).toBe(500);
+    });
+
+    it("restores windows from localStorage", () => {
+        const saved = [
+            { id: "abc", title: "Chat", url: "/chat", x: 100, y: 50, width: 500, height: 400 },
+            { id: "def", title: "Help", url: "/help", x: 200, y: 80, width: 300, height: 250 },
+        ];
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
+
+        const wm = new WindowManager();
+        wm.restore();
+
+        expect(wm.active).toBe(true);
+        expect(wm.counter).toBe(2);
+        expect(wm.windows.size).toBe(2);
+    });
+
+    it("passes saved position/size through to add on restore", () => {
+        const saved = [{ id: "abc", title: "Chat", url: "/chat", x: 100, y: 50, width: 500, height: 400 }];
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(saved));
+
+        const wm = new WindowManager();
+        wm.restore();
+
+        expect(lastWinBoxParams.x).toBe(100);
+        expect(lastWinBoxParams.y).toBe(50);
+        expect(lastWinBoxParams.width).toBe(500);
+        expect(lastWinBoxParams.height).toBe(400);
+    });
+
+    it("does not set active when nothing to restore", () => {
+        const wm = new WindowManager();
+        wm.restore();
+
+        expect(wm.active).toBe(false);
+        expect(wm.counter).toBe(0);
+    });
+
+    it("handles corrupt localStorage gracefully", () => {
+        localStorage.setItem(STORAGE_KEY, "not-valid-json{{{");
+
+        const wm = new WindowManager();
+        wm.restore();
+
+        expect(wm.active).toBe(false);
+        expect(wm.counter).toBe(0);
+    });
+
+    it("tracks multiple windows independently", () => {
+        const wm = new WindowManager();
+        wm.add({ title: "Win1", url: "/a" });
+        const firstClose = lastWinBoxParams.onclose;
+
+        wm.add({ title: "Win2", url: "/b" });
+        flushSave();
+
+        let stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored).toHaveLength(2);
+
+        // Close first window
+        firstClose();
+        flushSave();
+
+        stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored).toHaveLength(1);
+        expect(stored[0].title).toBe("Win2");
+    });
+
+    it("debounces rapid saves", () => {
+        const wm = new WindowManager();
+        wm.add({ title: "Win", url: "/a" });
+
+        // Multiple moves without flushing
+        lastWinBoxParams.onmove(10, 10);
+        lastWinBoxParams.onmove(20, 20);
+        lastWinBoxParams.onmove(30, 30);
+
+        // Nothing written yet
+        expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+        flushSave();
+
+        // Only final state persisted
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+        expect(stored[0].x).toBe(30);
+        expect(stored[0].y).toBe(30);
+    });
+});

--- a/lib/galaxy_test/selenium/test_window_manager_persistence.py
+++ b/lib/galaxy_test/selenium/test_window_manager_persistence.py
@@ -1,0 +1,131 @@
+"""E2E tests for scratchbook window persistence across page reloads."""
+
+from .framework import (
+    managed_history,
+    retry_assertion_during_transitions,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestWindowManagerPersistence(SeleniumTestCase):
+    ensure_registered = True
+
+    def setUp(self):
+        super().setUp()
+        # Clear persisted scratchbook state so tests don't leak into each other.
+        # Must happen before managed_history's home() call triggers restore().
+        self.execute_script("localStorage.removeItem('galaxy-scratchbook-windows');")
+
+    @selenium_test
+    @managed_history
+    def test_windows_persist_across_reload(self):
+        """Open a dataset in a scratchbook window, reload, and verify it's restored."""
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.history_panel_wait_for_hid_ok(1)
+
+        self.window_manager_enable()
+        item = self.history_panel_item_component(hid=1)
+        item.display_button.wait_for_and_click()
+        self.components.window_manager._.wait_for_visible()
+        assert self.window_manager_window_count() == 1
+        self.screenshot("persistence_before_reload")
+
+        self.home()
+
+        self.components.window_manager._.wait_for_visible()
+
+        @retry_assertion_during_transitions
+        def assert_window_restored():
+            assert self.window_manager_window_count() == 1
+
+        assert_window_restored()
+
+        titles = self.window_manager_get_titles()
+        assert len(titles) == 1
+        assert "1:" in titles[0]
+        self.screenshot("persistence_after_reload")
+
+    @selenium_test
+    @managed_history
+    def test_multiple_windows_persist(self):
+        """Multiple scratchbook windows should all restore after reload."""
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.perform_upload(self.get_filename("1.bed"))
+        self.history_panel_wait_for_hid_ok(2)
+
+        self.window_manager_enable()
+        for hid in [1, 2]:
+            item = self.history_panel_item_component(hid=hid)
+            self.clear_tooltips()
+            item.display_button.wait_for_and_click()
+
+        self.window_manager_wait_for_window_count(2)
+        self.screenshot("persistence_multi_before_reload")
+
+        self.home()
+
+        self.window_manager_wait_for_window_count(2)
+
+        titles = self.window_manager_get_titles()
+        assert len(titles) == 2
+        self.screenshot("persistence_multi_after_reload")
+
+    @selenium_test
+    @managed_history
+    def test_closed_windows_not_restored(self):
+        """Windows that were closed before reload should not come back."""
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.history_panel_wait_for_hid_ok(1)
+
+        self.window_manager_enable()
+        item = self.history_panel_item_component(hid=1)
+        item.display_button.wait_for_and_click()
+        self.components.window_manager._.wait_for_visible()
+        assert self.window_manager_window_count() == 1
+
+        self.window_manager_close_window(0)
+        self.window_manager_wait_for_window_count(0)
+
+        self.home()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        assert self.window_manager_window_count() == 0
+        self.screenshot("persistence_closed_not_restored")
+
+    @selenium_test
+    @managed_history
+    def test_close_one_of_many_persists_rest(self):
+        """Close one of two windows, reload, verify only the survivor restores."""
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.perform_upload(self.get_filename("1.bed"))
+        self.history_panel_wait_for_hid_ok(2)
+
+        self.window_manager_enable()
+        for hid in [1, 2]:
+            item = self.history_panel_item_component(hid=hid)
+            self.clear_tooltips()
+            item.display_button.wait_for_and_click()
+
+        self.window_manager_wait_for_window_count(2)
+
+        self.window_manager_close_window(0)
+        self.window_manager_wait_for_window_count(1)
+
+        surviving_title = self.window_manager_get_titles()[0]
+        # Wait for the debounced save (200ms) to flush to localStorage
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot("persistence_partial_close_before_reload")
+
+        self.home()
+
+        @retry_assertion_during_transitions
+        def assert_one_restored():
+            assert self.window_manager_window_count() == 1
+
+        assert_one_restored()
+
+        titles = self.window_manager_get_titles()
+        assert len(titles) == 1
+        assert titles[0] == surviving_title
+        self.screenshot("persistence_partial_close_after_reload")

--- a/lib/galaxy_test/selenium/test_window_manager_persistence.py
+++ b/lib/galaxy_test/selenium/test_window_manager_persistence.py
@@ -13,119 +13,79 @@ class TestWindowManagerPersistence(SeleniumTestCase):
 
     def setUp(self):
         super().setUp()
-        # Clear persisted scratchbook state so tests don't leak into each other.
-        # Must happen before managed_history's home() call triggers restore().
         self.execute_script("localStorage.removeItem('galaxy-scratchbook-windows');")
 
     @selenium_test
     @managed_history
-    def test_windows_persist_across_reload(self):
-        """Open a dataset in a scratchbook window, reload, and verify it's restored."""
+    def test_scratchbook_window_persistence(self):
+        """Progressive test: open, reload, multi-window, close, verify persistence at each step."""
         self.perform_upload(self.get_filename("1.fasta"))
-        self.history_panel_wait_for_hid_ok(1)
+        self.perform_upload(self.get_filename("1.bed"))
+        self.history_panel_wait_for_hid_ok(2)
 
         self.window_manager_enable()
-        item = self.history_panel_item_component(hid=1)
-        item.display_button.wait_for_and_click()
+
+        # Open dataset 1 in a window
+        item1 = self.history_panel_item_component(hid=1)
+        item1.display_button.wait_for_and_click()
         self.components.window_manager._.wait_for_visible()
         assert self.window_manager_window_count() == 1
-        self.screenshot("persistence_before_reload")
 
+        # Reload and verify 1 window restored with correct title
+        self.sleep_for(self.wait_types.UX_RENDER)
         self.home()
-
         self.components.window_manager._.wait_for_visible()
 
         @retry_assertion_during_transitions
-        def assert_window_restored():
+        def assert_one_window():
             assert self.window_manager_window_count() == 1
 
-        assert_window_restored()
-
+        assert_one_window()
         titles = self.window_manager_get_titles()
         assert len(titles) == 1
         assert "1:" in titles[0]
-        self.screenshot("persistence_after_reload")
+        self.screenshot("persistence_single_restored")
 
-    @selenium_test
-    @managed_history
-    def test_multiple_windows_persist(self):
-        """Multiple scratchbook windows should all restore after reload."""
-        self.perform_upload(self.get_filename("1.fasta"))
-        self.perform_upload(self.get_filename("1.bed"))
-        self.history_panel_wait_for_hid_ok(2)
-
-        self.window_manager_enable()
-        for hid in [1, 2]:
-            item = self.history_panel_item_component(hid=hid)
-            self.clear_tooltips()
-            item.display_button.wait_for_and_click()
-
+        # Open dataset 2 so we have 2 windows
+        item2 = self.history_panel_item_component(hid=2)
+        self.clear_tooltips()
+        item2.display_button.wait_for_and_click()
         self.window_manager_wait_for_window_count(2)
-        self.screenshot("persistence_multi_before_reload")
 
+        # Reload and verify both windows restored
+        self.sleep_for(self.wait_types.UX_RENDER)
         self.home()
-
         self.window_manager_wait_for_window_count(2)
-
         titles = self.window_manager_get_titles()
         assert len(titles) == 2
-        self.screenshot("persistence_multi_after_reload")
+        self.screenshot("persistence_multi_restored")
 
-    @selenium_test
-    @managed_history
-    def test_closed_windows_not_restored(self):
-        """Windows that were closed before reload should not come back."""
-        self.perform_upload(self.get_filename("1.fasta"))
-        self.history_panel_wait_for_hid_ok(1)
-
-        self.window_manager_enable()
-        item = self.history_panel_item_component(hid=1)
-        item.display_button.wait_for_and_click()
-        self.components.window_manager._.wait_for_visible()
-        assert self.window_manager_window_count() == 1
-
-        self.window_manager_close_window(0)
-        self.window_manager_wait_for_window_count(0)
-
-        self.home()
-        self.sleep_for(self.wait_types.UX_RENDER)
-
-        assert self.window_manager_window_count() == 0
-        self.screenshot("persistence_closed_not_restored")
-
-    @selenium_test
-    @managed_history
-    def test_close_one_of_many_persists_rest(self):
-        """Close one of two windows, reload, verify only the survivor restores."""
-        self.perform_upload(self.get_filename("1.fasta"))
-        self.perform_upload(self.get_filename("1.bed"))
-        self.history_panel_wait_for_hid_ok(2)
-
-        self.window_manager_enable()
-        for hid in [1, 2]:
-            item = self.history_panel_item_component(hid=hid)
-            self.clear_tooltips()
-            item.display_button.wait_for_and_click()
-
-        self.window_manager_wait_for_window_count(2)
-
+        # Close 1 of 2 windows, note the survivor
         self.window_manager_close_window(0)
         self.window_manager_wait_for_window_count(1)
-
         surviving_title = self.window_manager_get_titles()[0]
-        # Wait for the debounced save (200ms) to flush to localStorage
         self.sleep_for(self.wait_types.UX_RENDER)
-        self.screenshot("persistence_partial_close_before_reload")
 
+        # Reload and verify only the survivor restored
         self.home()
 
         @retry_assertion_during_transitions
-        def assert_one_restored():
+        def assert_survivor_restored():
             assert self.window_manager_window_count() == 1
 
-        assert_one_restored()
-
+        assert_survivor_restored()
         titles = self.window_manager_get_titles()
         assert len(titles) == 1
         assert titles[0] == surviving_title
-        self.screenshot("persistence_partial_close_after_reload")
+        self.screenshot("persistence_partial_close_restored")
+
+        # Close remaining window
+        self.window_manager_close_window(0)
+        self.window_manager_wait_for_window_count(0)
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # Reload and verify no windows restored
+        self.home()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        assert self.window_manager_window_count() == 0
+        self.screenshot("persistence_all_closed")


### PR DESCRIPTION
## Summary
- Scratchbook windows now survive page reloads by persisting their metadata (title, URL, position, size) to localStorage
- On startup, `WindowManager.restore()` re-opens any saved windows at their last position
- Saves are debounced (200ms) to avoid thrashing during drag/resize
- Original URLs are stored before `_build_url` appends query params, avoiding double-appending on restore

## Test plan
- [ ] Enable scratchbook, open a dataset in a window, reload the page — window should reappear
- [ ] Open multiple windows, reload — all should restore
- [ ] Close all windows, reload — nothing should restore
- [ ] Close one of several windows, reload — only survivors should restore
- [ ] Corrupt localStorage value manually — should degrade gracefully (no windows restored, no errors)
- [ ] Unit tests: `cd client && pnpm test window-manager` (11 tests)
- [ ] E2E tests: `GALAXY_TEST_DRIVER_BACKEND=playwright GALAXY_TEST_SELENIUM_HEADLESS=0 GALAXY_TEST_EXTERNAL=http://localhost:5173/ .venv/bin/pytest -xvs lib/galaxy_test/selenium/test_window_manager_persistence.py` (4 tests)