### PR TITLE
Disable undo/redo buttons in workflow editor when unavailable

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -174,13 +174,15 @@
 
                         <b-button
                             :title="undoRedoStore.undoText + ' (Ctrl + Z)'"
-                            :variant="undoRedoStore.hasUndo ? 'secondary' : 'muted'"
+                            variant="secondary"
+                            :disabled="!undoRedoStore.hasUndo"
                             @click="undoRedoStore.undo()">
                             <FontAwesomeIcon :icon="faArrowLeft" />
                         </b-button>
                         <b-button
                             :title="undoRedoStore.redoText + ' (Ctrl + Shift + Z)'"
-                            :variant="undoRedoStore.hasRedo ? 'secondary' : 'muted'"
+                            variant="secondary"
+                            :disabled="!undoRedoStore.hasRedo"
                             @click="undoRedoStore.redo()">
                             <FontAwesomeIcon :icon="faArrowRight" />
                         </b-button>


### PR DESCRIPTION
## Summary
- The undo/redo buttons in the workflow editor previously toggled between `secondary`/`muted` variants as a visual hint, but were never actually disabled — they remained clickable (though clicking did nothing).
- Replaces the variant toggle with a fixed variant and proper `:disabled` binding, matching the pattern already used by the nearby Save button.

## Test plan
- [ ] Open the workflow editor — confirm Undo and Redo buttons are greyed out and unclickable
- [ ] Make a change — confirm Undo becomes active
- [ ] Undo the change — confirm Redo becomes active and Undo becomes disabled again