### PR TITLE
[26.0] Fix workflow search broken after auto layout

### DIFF
--- a/client/src/components/Workflow/Editor/Actions/stepActions.ts
+++ b/client/src/components/Workflow/Editor/Actions/stepActions.ts
@@ -2,7 +2,7 @@ import { replaceLabel } from "@/components/Markdown/parse";
 import { autoLayout } from "@/components/Workflow/Editor/modules/layout";
 import { useToast } from "@/composables/toast";
 import { useRefreshFromStore } from "@/stores/refreshFromStore";
-import { LazyUndoRedoAction, UndoRedoAction, type UndoRedoStore } from "@/stores/undoRedoStore";
+import { LazyUndoRedoAction, UndoRedoAction, type UndoRedoStore, useUndoRedoStore } from "@/stores/undoRedoStore";
 import type { WorkflowConnectionStore } from "@/stores/workflowConnectionStore";
 import { useWorkflowCommentStore } from "@/stores/workflowEditorCommentStore";
 import type { WorkflowStateStore } from "@/stores/workflowEditorStateStore";
@@ -506,6 +506,7 @@ export class AutoLayoutAction extends UndoRedoAction {
 
         if (this.ran) {
             this.mapPositionsToStore(this.positions);
+            useUndoRedoStore(this.workflowId).changeId += 1;
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix #21082: workflow search navigates to wrong positions after running auto layout
- `AutoLayoutAction.run()` is async — positions update after the promise resolves, but the search cache in `workflowSearchStore` only invalidates on `undoRedoStore.changeId`, which has already incremented by then (from the undo stack push). Bump `changeId` after the async positions are applied so the cache properly invalidates.

## Test plan

- Open workflow editor with a multi-step workflow
- Search for a step, confirm it navigates correctly
- Run auto layout
- Search again — results should navigate to the correct new positions (previously they pointed to pre-layout positions)