### PR TITLE
Fix long history names pushing items off panel

### DIFF
--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -67,9 +67,9 @@ function checkClamped() {
 
 const clampTooltip = computed(() => {
     if (isClamped.value) {
-        return headingRef.value?.textContent?.trim();
+        return headingRef.value?.textContent?.trim() ?? "";
     }
-    return undefined;
+    return "";
 });
 
 const clampStyle = computed(() => {

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faAngleDoubleDown, faAngleDoubleUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { computed } from "vue";
+import { computed, nextTick, onMounted, onUpdated, ref } from "vue";
 
 import type { IconLike } from "@/components/icons/galaxyIcons";
 
@@ -21,6 +21,7 @@ interface Props {
     size?: "xs" | "sm" | "md" | "lg" | "xl" | "text";
     icon?: IconLike;
     truncate?: boolean;
+    clamp?: number;
     collapse?: "open" | "closed" | "none";
 }
 
@@ -52,6 +53,34 @@ const element = computed(() => {
     }
     return "h1";
 });
+
+const headingRef = ref<HTMLElement | null>(null);
+const isClamped = ref(false);
+
+function checkClamped() {
+    if (headingRef.value && props.clamp) {
+        isClamped.value = headingRef.value.scrollHeight > headingRef.value.clientHeight;
+    } else {
+        isClamped.value = false;
+    }
+}
+
+const clampTooltip = computed(() => {
+    if (isClamped.value) {
+        return headingRef.value?.textContent?.trim();
+    }
+    return undefined;
+});
+
+const clampStyle = computed(() => {
+    if (props.clamp) {
+        return { webkitLineClamp: props.clamp };
+    }
+    return undefined;
+});
+
+onMounted(checkClamped);
+onUpdated(() => nextTick(checkClamped));
 </script>
 
 <template>
@@ -63,12 +92,16 @@ const element = computed(() => {
         <div v-else class="stripe"></div>
         <component
             :is="element"
+            ref="headingRef"
+            v-b-tooltip.hover="clampTooltip"
             :class="[
                 sizeClass,
                 props.bold ? 'font-weight-bold' : '',
                 collapsible ? 'collapsible' : '',
                 props.truncate ? 'truncate' : '',
+                props.clamp ? 'clamp' : '',
             ]"
+            :style="clampStyle"
             @click="$emit('click')">
             <slot />
         </component>
@@ -77,6 +110,8 @@ const element = computed(() => {
     <component
         :is="element"
         v-else
+        ref="headingRef"
+        v-b-tooltip.hover="clampTooltip"
         class="heading word-wrap-break"
         :class="[
             sizeClass,
@@ -84,7 +119,9 @@ const element = computed(() => {
             props.inline ? 'inline' : '',
             collapsible ? 'collapsible' : '',
             props.truncate ? 'truncate' : '',
+            props.clamp ? 'clamp' : '',
         ]"
+        :style="clampStyle"
         @click="$emit('click')">
         <GButton v-if="collapsible" transparent size="small" icon-only inline>
             <FontAwesomeIcon v-if="collapsed" fixed-width :icon="faAngleDoubleDown" />
@@ -100,7 +137,7 @@ const element = computed(() => {
 
 // prettier-ignore
 h1, h2, h3, h4, h5, h6 {
-    &:not(.truncate) {
+    &:not(.truncate):not(.clamp) {
         display: flex;
     }
     align-items: center;
@@ -115,6 +152,12 @@ h1, h2, h3, h4, h5, h6 {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+    }
+
+    &.clamp {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
     }
 }
 

--- a/client/src/components/Common/Heading.vue
+++ b/client/src/components/Common/Heading.vue
@@ -67,9 +67,9 @@ function checkClamped() {
 
 const clampTooltip = computed(() => {
     if (isClamped.value) {
-        return headingRef.value?.textContent?.trim() ?? "";
+        return headingRef.value?.textContent?.trim() ?? null;
     }
-    return "";
+    return null;
 });
 
 const clampStyle = computed(() => {
@@ -93,7 +93,7 @@ onUpdated(() => nextTick(checkClamped));
         <component
             :is="element"
             ref="headingRef"
-            v-b-tooltip.hover="clampTooltip"
+            :title="clampTooltip"
             :class="[
                 sizeClass,
                 props.bold ? 'font-weight-bold' : '',
@@ -111,7 +111,7 @@ onUpdated(() => nextTick(checkClamped));
         :is="element"
         v-else
         ref="headingRef"
-        v-b-tooltip.hover="clampTooltip"
+        :title="clampTooltip"
         class="heading word-wrap-break"
         :class="[
             sizeClass,

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -131,7 +131,7 @@ function selectText() {
                     {{ props.name || "..." }}
                 </h3>
             </template>
-            <div v-else style="max-width: 80%">
+            <div v-else class="overflow-hidden" style="max-width: 80%">
                 <TextSummary
                     :description="name"
                     data-description="name display"

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -11,6 +11,7 @@ import l from "@/utils/localization";
 import type { DetailsLayoutSummarized } from "./types";
 
 import ClickToEdit from "@/components/Collections/common/ClickToEdit.vue";
+import Heading from "@/components/Common/Heading.vue";
 import TextSummary from "@/components/Common/TextSummary.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
@@ -40,8 +41,8 @@ const userStore = useUserStore();
 const { isAnonymous } = storeToRefs(userStore);
 
 const nameRef = ref<HTMLInputElement | null>(null);
-const nameDisplayRef = ref<InstanceType<typeof ClickToEdit> | HTMLElement | null>(null);
-const nameClamped = ref(false);
+const clickToEditRef = ref<InstanceType<typeof ClickToEdit> | null>(null);
+const clickToEditClamped = ref(false);
 
 const editing = ref(false);
 const textSelected = ref(false);
@@ -106,17 +107,17 @@ function onToggle() {
     }
 }
 
-function checkNameClamped() {
-    const el = nameDisplayRef.value instanceof HTMLElement ? nameDisplayRef.value : nameDisplayRef.value?.$el;
+function checkClickToEditClamped() {
+    const el = clickToEditRef.value?.$el;
     if (el) {
-        nameClamped.value = el.scrollHeight > el.clientHeight;
+        clickToEditClamped.value = el.scrollHeight > el.clientHeight;
     }
 }
 
-onMounted(checkNameClamped);
+onMounted(checkClickToEditClamped);
 watch(
     () => props.name,
-    () => nextTick(checkNameClamped),
+    () => nextTick(checkClickToEditClamped),
 );
 
 function selectText() {
@@ -136,22 +137,17 @@ function selectText() {
             <template v-if="!summarized && !editing">
                 <ClickToEdit
                     v-if="renameable"
-                    ref="nameDisplayRef"
+                    ref="clickToEditRef"
                     v-model="clickToEditName"
-                    v-b-tooltip.hover="nameClamped ? name : undefined"
+                    v-b-tooltip.hover="clickToEditClamped ? name : undefined"
                     component="h3"
                     title="..."
                     data-description="name display"
                     no-save-on-blur
                     class="name-display my-2 w-100" />
-                <h3
-                    v-else
-                    ref="nameDisplayRef"
-                    v-b-tooltip.hover
-                    :title="nameClamped ? name : undefined"
-                    class="name-display my-2 w-100">
+                <Heading v-else h3 :clamp="2" class="my-2 w-100">
                     {{ props.name || "..." }}
-                </h3>
+                </Heading>
             </template>
             <div v-else class="overflow-hidden" style="max-width: 80%">
                 <TextSummary

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -139,7 +139,7 @@ function selectText() {
                     v-if="renameable"
                     ref="clickToEditRef"
                     v-model="clickToEditName"
-                    v-b-tooltip.hover="clickToEditClamped ? name : undefined"
+                    v-b-tooltip.hover="clickToEditClamped ? name : ''"
                     component="h3"
                     title="..."
                     data-description="name display"

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -3,7 +3,7 @@ import { faPen, faSave, faUndo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BFormInput, BFormTextarea } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import { useUserStore } from "@/stores/userStore";
 import l from "@/utils/localization";
@@ -40,6 +40,8 @@ const userStore = useUserStore();
 const { isAnonymous } = storeToRefs(userStore);
 
 const nameRef = ref<HTMLInputElement | null>(null);
+const nameDisplayRef = ref<InstanceType<typeof ClickToEdit> | HTMLElement | null>(null);
+const nameClamped = ref(false);
 
 const editing = ref(false);
 const textSelected = ref(false);
@@ -104,6 +106,19 @@ function onToggle() {
     }
 }
 
+function checkNameClamped() {
+    const el = nameDisplayRef.value instanceof HTMLElement ? nameDisplayRef.value : nameDisplayRef.value?.$el;
+    if (el) {
+        nameClamped.value = el.scrollHeight > el.clientHeight;
+    }
+}
+
+onMounted(checkNameClamped);
+watch(
+    () => props.name,
+    () => nextTick(checkNameClamped),
+);
+
 function selectText() {
     if (!textSelected.value) {
         nameRef.value?.select();
@@ -121,13 +136,20 @@ function selectText() {
             <template v-if="!summarized && !editing">
                 <ClickToEdit
                     v-if="renameable"
+                    ref="nameDisplayRef"
                     v-model="clickToEditName"
+                    v-b-tooltip.hover="nameClamped ? name : undefined"
                     component="h3"
                     title="..."
                     data-description="name display"
                     no-save-on-blur
-                    class="my-2 w-100" />
-                <h3 v-else class="my-2 w-100">
+                    class="name-display my-2 w-100" />
+                <h3
+                    v-else
+                    ref="nameDisplayRef"
+                    v-b-tooltip.hover
+                    :title="nameClamped ? name : undefined"
+                    class="name-display my-2 w-100">
                     {{ props.name || "..." }}
                 </h3>
             </template>
@@ -233,6 +255,14 @@ function selectText() {
 </template>
 
 <style lang="scss" scoped>
+.name-display :deep(h3),
+h3.name-display {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+}
+
 .summarized-details {
     margin-left: 0.5rem;
     max-width: 15rem;


### PR DESCRIPTION
## Summary
- Clamp history name display to 2 lines in expanded panel view using `-webkit-line-clamp`, preventing long names from pushing datasets off-screen
- Add tooltip on hover showing the full name when truncated
- Add `overflow: hidden` on the summarized view name container to fix flex item min-width issue that prevented existing TextSummary truncation from working

Fixes #20572