### PR TITLE
Cap invocation graph zoom-to-fit at 100%

### DIFF
--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -79,7 +79,7 @@ onMounted(async () => {
     await nextTick();
 
     // @ts-ignore: TS2339 component method not exposed in template ref type
-    workflowGraph.value?.fitWorkflow(0.25, 1.5, 20.0);
+    workflowGraph.value?.fitWorkflow(0.25, 1.0, 20.0);
 });
 
 // Equivalent to onMounted; this is where the graph is initialized, and the polling is started


### PR DESCRIPTION
## Summary

When viewing a workflow invocation with only 1-2 nodes, the canvas auto-zooms past 100% (up to 150%), making it look like something has gone wrong. I lowered the `maximumFitZoom` argument to `fitWorkflow` from `1.5` to `1.0` so the invocation graph never zooms in past native scale. Large workflows still zoom out to fit as before.

## Test plan

- View an invocation of a 1-2 node workflow — canvas should no longer zoom past 100%
- View an invocation of a large workflow — should still zoom out to fit all nodes