### PR TITLE
[25.0] Fix legacy_expose_api error callable returning str instead of bytes

### DIFF
--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -20,6 +20,7 @@ from galaxy.exceptions.utils import (
 )
 from galaxy.util import (
     parse_non_hex_float,
+    smart_str,
     unicodify,
 )
 from galaxy.util.json import safe_dumps
@@ -154,7 +155,7 @@ def legacy_expose_api(func, to_json=True, user_required=True):
     def decorator(self, trans, *args, **kwargs):
         def error(environ, start_response):
             start_response(error_status, [("Content-type", "text/plain")])
-            return error_message
+            return [smart_str(error_message)]
 
         error_status = "403 Forbidden"
         if trans.error_message:


### PR DESCRIPTION
The error inner function was used as a WSGI sub-application but returned a bare string. WSGI requires response bodies to be iterables of byte strings. With a2wsgi converting to ASGI, h11 rejects the str, causing a TypeError in starlette's BaseHTTPMiddleware.

Fixes
```
ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/_utils.py", line 79, in collapse_excgroups
  |     yield
  |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 192, in __call__
  |     async with anyio.create_task_group() as task_group:
  |                ~~~~~~~~~~~~~~~~~~~~~~~^^
  |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/anyio/_backends/_asyncio.py", line 783, in __aexit__
  |     raise BaseExceptionGroup(
  |         "unhandled errors in a TaskGroup", self._exceptions
  |     ) from None
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 410, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         self.scope, self.receive, self.send
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     )
    |     ^
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    |     return await self.app(scope, receive, send)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/fastapi/applications.py", line 1135, in __call__
    |     await super().__call__(scope, receive, send)
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/applications.py", line 107, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
    |     raise exc
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette_context/middleware/raw_middleware.py", line 94, in __call__
    |     await self.app(scope, receive, send_wrapper)
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 191, in __call__
    |     with recv_stream, send_stream, collapse_excgroups():
    |                                    ~~~~~~~~~~~~~~~~~~^^
    |   File "/Users/mvandenb/.local/share/uv/python/cpython-3.13.7-macos-aarch64-none/lib/python3.13/contextlib.py", line 162, in __exit__
    |     self.gen.throw(value)
    |     ~~~~~~~~~~~~~~^^^^^^^
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/_utils.py", line 85, in collapse_excgroups
    |     raise exc
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 194, in __call__
    |     await response(scope, wrapped_receive, send)
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 238, in __call__
    |     await send({"type": "http.response.body", "body": chunk, "more_body": True})
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette_context/middleware/raw_middleware.py", line 83, in send_wrapper
    |     await send(message)
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 161, in _send
    |     await send(message)
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 507, in send
    |     output = self.conn.send(event=h11.Data(data=data))
    |   File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/h11/_connection.py", line 542, in send
    |     return b"".join(data_list)
    |            ~~~~~~~~^^^^^^^^^^^
    | TypeError: sequence item 1: expected a bytes-like object, str found
    +------------------------------------


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 410, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.scope, self.receive, self.send
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/fastapi/applications.py", line 1135, in __call__
    await super().__call__(scope, receive, send)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/applications.py", line 107, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette_context/middleware/raw_middleware.py", line 94, in __call__
    await self.app(scope, receive, send_wrapper)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 191, in __call__
    with recv_stream, send_stream, collapse_excgroups():
                                   ~~~~~~~~~~~~~~~~~~^^
  File "/Users/mvandenb/.local/share/uv/python/cpython-3.13.7-macos-aarch64-none/lib/python3.13/contextlib.py", line 162, in __exit__
    self.gen.throw(value)
    ~~~~~~~~~~~~~~^^^^^^^
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/_utils.py", line 85, in collapse_excgroups
    raise exc
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 194, in __call__
    await response(scope, wrapped_receive, send)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/base.py", line 238, in __call__
    await send({"type": "http.response.body", "body": chunk, "more_body": True})
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette_context/middleware/raw_middleware.py", line 83, in send_wrapper
    await send(message)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 161, in _send
    await send(message)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 507, in send
    output = self.conn.send(event=h11.Data(data=data))
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.13/site-packages/h11/_connection.py", line 542, in send
    return b"".join(data_list)
           ~~~~~~~~^^^^^^^^^^^
TypeError: sequence item 1: expected a bytes-like object, str found
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
