### PR TITLE
Skip X-Frame-Options header for published embed views

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -277,6 +277,10 @@ class WebApplication(base.WebApplication):
         return controller
 
 
+def _is_embed_request(path: str, query_string: str) -> bool:
+    return path.startswith("/published/") and "embed=true" in query_string
+
+
 def config_allows_origin(origin_raw, config):
     # boil origin header down to hostname
     origin = urlparse(origin_raw).hostname
@@ -323,7 +327,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         config = self.app.config
         self.debug = asbool(config.get("debug", False))
         if x_frame_options := getattr(config, "x_frame_options", None):
-            self.response.headers["X-Frame-Options"] = x_frame_options
+            if not _is_embed_request(self.request.path_info, self.environ.get("QUERY_STRING", "")):
+                self.response.headers["X-Frame-Options"] = x_frame_options
         # Flag indicating whether we are in workflow building mode (means
         # that the current history should not be used for parameter values
         # and such).

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -28,7 +28,10 @@ from galaxy.webapps.base.api import (
     GalaxyFileResponse,
     include_all_package_routers,
 )
-from galaxy.webapps.base.webapp import config_allows_origin
+from galaxy.webapps.base.webapp import (
+    _is_embed_request,
+    config_allows_origin,
+)
 from galaxy.webapps.openapi._compat.v2 import GenerateJsonSchema
 from galaxy.webapps.openapi.utils import get_openapi
 
@@ -129,7 +132,8 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
         @app.middleware("http")
         async def add_x_frame_options(request: Request, call_next):
             response = await call_next(request)
-            response.headers["X-Frame-Options"] = x_frame_options
+            if not _is_embed_request(request.url.path, str(request.url.query)):
+                response.headers["X-Frame-Options"] = x_frame_options
             return response
 
     GalaxyFileResponse.nginx_x_accel_redirect_base = gx_app.config.nginx_x_accel_redirect_base

--- a/lib/galaxy_test/api/test_framework.py
+++ b/lib/galaxy_test/api/test_framework.py
@@ -9,6 +9,10 @@ class TestApiFramework(ApiTestCase):
         get_response = self._get("licenses")
         assert get_response.headers["x-frame-options"] == "SAMEORIGIN"
 
+    def test_xframe_options_skipped_for_embed(self):
+        get_response = self._get("/published/page", data={"embed": "true"})
+        assert "x-frame-options" not in get_response.headers
+
     # Next several tests test the API's run_as functionality.
     def test_user_cannont_run_as(self):
         run_as_user = self._setup_user("for_run_as@bx.psu.edu")


### PR DESCRIPTION
## Summary

Fixes #21074 — the `X-Frame-Options: SAMEORIGIN` header was applied to all responses, blocking `/published/page?embed=true` and `/published/workflow?embed=true` from loading in external iframes.

I added a shared `_is_embed_request()` helper that checks for the `/published/` path prefix combined with `embed=true`, and use it to conditionally skip the header in both the FastAPI middleware (`fast_app.py`) and the WSGI transaction init (`webapp.py`).

## Test plan

- [x] `test_default_xframe_options` still passes (header present for normal requests)
- [x] New `test_xframe_options_skipped_for_embed` passes (header absent for embed requests)
- [x] Pre-commit hooks pass