### PR TITLE
Fix tag duplication when copying datasets/collections between histories

### DIFF
--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -255,9 +255,9 @@ class HistoryContentsManager(base.SortableManager):
                 if c.history_content_type == "dataset":
                     copy = c.copy(flush=False)
                     h.stage_addition(copy)
+                    copy.copy_tags_from(user, c)
                 else:
                     copy = c.copy(element_destination=h)
-                copy.copy_tags_from(user, c)
 
         for h in target_histories:
             h.add_pending_items()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -434,10 +434,12 @@ class HasTags:
         return tags_str_list
 
     def copy_tags_from(self, target_user, source):
+        existing = {(t.tag_id, t.value) for t in self.tags}
         for source_tag_assoc in source.tags:
-            new_tag_assoc = source_tag_assoc.copy()
-            new_tag_assoc.user = target_user
-            self.tags.append(new_tag_assoc)
+            if (source_tag_assoc.tag_id, source_tag_assoc.value) not in existing:
+                new_tag_assoc = source_tag_assoc.copy()
+                new_tag_assoc.user = target_user
+                self.tags.append(new_tag_assoc)
 
     @property
     def auto_propagated_tags(self):
@@ -2322,11 +2324,13 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     def set_final_state(self, final_state):
         self.set_state(final_state)
         # TODO: migrate to where-in subqueries?
-        statement = text("""
+        statement = text(
+            """
             UPDATE workflow_invocation_step
             SET update_time = :update_time
             WHERE job_id = :job_id;
-        """)
+        """
+        )
         sa_session = required_object_session(self)
         update_time = now()
         self.update_hdca_update_time_for_job(update_time=update_time, sa_session=sa_session)
@@ -2356,15 +2360,18 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     def update_output_states(self, supports_skip_locked):
         # TODO: migrate to where-in subqueries?
         statements = [
-            text("""
+            text(
+                """
             UPDATE dataset
             SET
                 state = :state,
                 update_time = :update_time
             WHERE
                 dataset.job_id = :job_id
-        """),
-            text("""
+        """
+            ),
+            text(
+                """
             UPDATE history_dataset_association
             SET
                 info = :info,
@@ -2373,8 +2380,10 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             WHERE
                 history_dataset_association.dataset_id = dataset.id
                 AND dataset.job_id = :job_id;
-        """),
-            text("""
+        """
+            ),
+            text(
+                """
             UPDATE library_dataset_dataset_association
             SET
                 info = :info,
@@ -2383,7 +2392,8 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             WHERE
                 library_dataset_dataset_association.dataset_id = dataset.id
                 AND dataset.job_id = :job_id;
-        """),
+        """
+            ),
         ]
         sa_session = required_object_session(self)
         update_time = now()
@@ -5919,9 +5929,12 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         if copy_tags is not None:
             if isinstance(copy_tags, dict):
                 copy_tags = copy_tags.values()
+            existing = {(t.tag_id, t.value) for t in self.tags}
             for tag in copy_tags:
-                copied_tag = tag.copy(cls=HistoryDatasetAssociationTagAssociation)
-                self.tags.append(copied_tag)
+                if (tag.tag_id, tag.value) not in existing:
+                    copied_tag = tag.copy(cls=HistoryDatasetAssociationTagAssociation)
+                    self.tags.append(copied_tag)
+                    existing.add((tag.tag_id, tag.value))
 
     def copy_attributes(self, new_dataset):
         if new_dataset.hid is None:
@@ -6474,8 +6487,10 @@ class LibraryDataset(Base, Serializable):
     )
     expired_datasets: Mapped[list["LibraryDatasetDatasetAssociation"]] = relationship(
         foreign_keys=[id, library_dataset_dataset_association_id],
-        primaryjoin=("and_(LibraryDataset.id == LibraryDatasetDatasetAssociation.library_dataset_id, \
-             not_(LibraryDataset.library_dataset_dataset_association_id == LibraryDatasetDatasetAssociation.id))"),
+        primaryjoin=(
+            "and_(LibraryDataset.id == LibraryDatasetDatasetAssociation.library_dataset_id, \
+             not_(LibraryDataset.library_dataset_dataset_association_id == LibraryDatasetDatasetAssociation.id))"
+        ),
         viewonly=True,
         uselist=True,
     )
@@ -6726,7 +6741,8 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         # sets the update_time for all continaing folders up the tree
         ldda = self
 
-        sql = text("""
+        sql = text(
+            """
                 WITH RECURSIVE parent_folders_of(folder_id) AS
                     (SELECT folder_id
                     FROM library_dataset
@@ -6742,7 +6758,8 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
                     WHERE id = :ldda_id)
                 WHERE exists (SELECT 1 FROM parent_folders_of
                     WHERE library_folder.id = parent_folders_of.folder_id)
-            """)
+            """
+        )
 
         with required_object_session(self).bind.connect() as conn, conn.begin():
             ret = conn.execute(sql, {"library_dataset_id": ldda.library_dataset_id, "ldda_id": ldda.id})

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2324,13 +2324,11 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     def set_final_state(self, final_state):
         self.set_state(final_state)
         # TODO: migrate to where-in subqueries?
-        statement = text(
-            """
+        statement = text("""
             UPDATE workflow_invocation_step
             SET update_time = :update_time
             WHERE job_id = :job_id;
-        """
-        )
+        """)
         sa_session = required_object_session(self)
         update_time = now()
         self.update_hdca_update_time_for_job(update_time=update_time, sa_session=sa_session)
@@ -2360,18 +2358,15 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     def update_output_states(self, supports_skip_locked):
         # TODO: migrate to where-in subqueries?
         statements = [
-            text(
-                """
+            text("""
             UPDATE dataset
             SET
                 state = :state,
                 update_time = :update_time
             WHERE
                 dataset.job_id = :job_id
-        """
-            ),
-            text(
-                """
+        """),
+            text("""
             UPDATE history_dataset_association
             SET
                 info = :info,
@@ -2380,10 +2375,8 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             WHERE
                 history_dataset_association.dataset_id = dataset.id
                 AND dataset.job_id = :job_id;
-        """
-            ),
-            text(
-                """
+        """),
+            text("""
             UPDATE library_dataset_dataset_association
             SET
                 info = :info,
@@ -2392,8 +2385,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             WHERE
                 library_dataset_dataset_association.dataset_id = dataset.id
                 AND dataset.job_id = :job_id;
-        """
-            ),
+        """),
         ]
         sa_session = required_object_session(self)
         update_time = now()
@@ -6487,10 +6479,8 @@ class LibraryDataset(Base, Serializable):
     )
     expired_datasets: Mapped[list["LibraryDatasetDatasetAssociation"]] = relationship(
         foreign_keys=[id, library_dataset_dataset_association_id],
-        primaryjoin=(
-            "and_(LibraryDataset.id == LibraryDatasetDatasetAssociation.library_dataset_id, \
-             not_(LibraryDataset.library_dataset_dataset_association_id == LibraryDatasetDatasetAssociation.id))"
-        ),
+        primaryjoin=("and_(LibraryDataset.id == LibraryDatasetDatasetAssociation.library_dataset_id, \
+             not_(LibraryDataset.library_dataset_dataset_association_id == LibraryDatasetDatasetAssociation.id))"),
         viewonly=True,
         uselist=True,
     )
@@ -6741,8 +6731,7 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         # sets the update_time for all continaing folders up the tree
         ldda = self
 
-        sql = text(
-            """
+        sql = text("""
                 WITH RECURSIVE parent_folders_of(folder_id) AS
                     (SELECT folder_id
                     FROM library_dataset
@@ -6758,8 +6747,7 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
                     WHERE id = :ldda_id)
                 WHERE exists (SELECT 1 FROM parent_folders_of
                     WHERE library_folder.id = parent_folders_of.folder_id)
-            """
-        )
+            """)
 
         with required_object_session(self).bind.connect() as conn, conn.begin():
             ret = conn.execute(sql, {"library_dataset_id": ldda.library_dataset_id, "ldda_id": ldda.id})

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -564,6 +564,58 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
         )
         assert copied_collection["tags"] == ["hdca_tag"], f"Expected ['hdca_tag'] but got {copied_collection['tags']}"
 
+    def test_copy_datasets_to_history_does_not_duplicate_tags(self):
+        source_history_id = self.dataset_populator.new_history()
+        target_history_id = self.dataset_populator.new_history()
+
+        # Create a tagged HDA
+        new_hda = self.dataset_populator.new_dataset(source_history_id, content="tagged dataset")
+        hda_id = new_hda["id"]
+        self.dataset_populator.tag_dataset(source_history_id, hda_id, tags=["hda_tag"])
+
+        # Create a tagged HDCA
+        fetch_response = self.dataset_collection_populator.create_list_in_history(
+            source_history_id, contents=["Hello", "World"], direct_upload=True
+        )
+        collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response.json())
+        hdca_id = collection["id"]
+        self._put(
+            f"histories/{source_history_id}/contents/dataset_collections/{hdca_id}",
+            data={"tags": ["hdca_tag"]},
+            json=True,
+        ).raise_for_status()
+
+        # Copy both to target history via copy_contents endpoint
+        payload = {
+            "source_content": [
+                {"id": hda_id, "type": "dataset"},
+                {"id": hdca_id, "type": "dataset_collection"},
+            ],
+            "target_history_ids": [target_history_id],
+        }
+        self._post(
+            f"histories/{source_history_id}/copy_contents",
+            data=payload,
+            json=True,
+        ).raise_for_status()
+
+        # Verify copied HDA tags are not duplicated
+        target_contents = self._get(f"histories/{target_history_id}/contents").json()
+        copied_hdas = [c for c in target_contents if c["history_content_type"] == "dataset" and c["visible"]]
+        assert len(copied_hdas) == 1
+        copied_hda_details = self.dataset_populator.get_history_dataset_details(
+            history_id=target_history_id, dataset_id=copied_hdas[0]["id"]
+        )
+        assert copied_hda_details["tags"] == ["hda_tag"], f"Expected ['hda_tag'] but got {copied_hda_details['tags']}"
+
+        # Verify copied HDCA tags are not duplicated
+        copied_hdcas = [c for c in target_contents if c["history_content_type"] == "dataset_collection"]
+        assert len(copied_hdcas) == 1
+        copied_collection = self.dataset_populator.get_history_collection_details(
+            history_id=target_history_id, history_content_type="dataset_collection"
+        )
+        assert copied_collection["tags"] == ["hdca_tag"], f"Expected ['hdca_tag'] but got {copied_collection['tags']}"
+
     # TODO: (CE) test_create_from_copy
     def test_import_from_model_store_dict(self):
         response = self.dataset_populator.create_from_store(store_dict=history_model_store_dict())


### PR DESCRIPTION
Fixes #21001

When copying datasets or collections between histories via "Copy Datasets and Collections" (or drag-and-drop), name tags were getting duplicated on the copies.

The root cause: `HDCA.copy()` already copies tags internally (added when the `target_user` parameter was introduced), but `copy_contents()` was also calling `copy_tags_from()` on the result for *all* content types — effectively doubling collection tags.

I moved the `copy_tags_from()` call into the HDA-only branch (since HDA.copy() doesn't copy tags when called without `copy_tags`), and added dedup guards to both `copy_tags_from()` and `copy_tags_to()` as a defensive measure so redundant callers can't create duplicate tag associations.

## Test plan
- New API test `test_copy_datasets_to_history_does_not_duplicate_tags` exercises the `copy_contents` endpoint with tagged HDAs and HDCAs
- Existing `test_copy_history_does_not_duplicate_tags` continues to pass