### PR TITLE
Fix anonymous_user_concurrent_jobs to not allow jobs when 0

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1702,7 +1702,7 @@ class MinimalJobWrapper(HasResourceParameters):
                 )
                 conditions.append(destination_job_count < destination_user_limit)
 
-        elif anonymous_user_concurrent_jobs and job.galaxy_session and job.galaxy_session.id:
+        elif anonymous_user_concurrent_jobs is not None and job.galaxy_session and job.galaxy_session.id:
             anon_job_count = (
                 select(func.count(Job.id))
                 .where(

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -971,7 +971,7 @@ class JobHandlerQueue(BaseJobHandlerQueue):
                             return JOB_WAIT
         elif job.galaxy_session:
             # Anonymous users only get the hard limit
-            if self.app.job_config.limits.anonymous_user_concurrent_jobs:
+            if self.app.job_config.limits.anonymous_user_concurrent_jobs is not None:
                 count = (
                     self.sa_session.query(model.Job)
                     .enable_eagerloads(False)

--- a/test/unit/app/jobs/test_queue_limit.py
+++ b/test/unit/app/jobs/test_queue_limit.py
@@ -91,6 +91,11 @@ def test_anonymous_user_limit():
 
     create_mock_job(app, session_id=1, state="running")
 
+    # Test no jobs
+    app.job_config.limits.anonymous_user_concurrent_jobs = 0
+    result = job_wrapper.queue_with_limit(job, job_destination_mock)
+    assert result is False
+
     # Test below limit
     app.job_config.limits.anonymous_user_concurrent_jobs = 2
     result = job_wrapper.queue_with_limit(job, job_destination_mock)


### PR DESCRIPTION
When `anonymous_user_concurrent_jobs` is `0`, the condition is not evaluating, hence having infinite number of jobs.

Fix this, by checking if the value is defined, then use it to check.

Will fix https://github.com/galaxyproject/galaxy/issues/22089


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
