### PR TITLE
Update pre-commit black pin from 24.1.1 to 26.1.0

### DIFF
--- a/.pre-commit-config.yaml.sample
+++ b/.pre-commit-config.yaml.sample
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 26.1.0
     hooks:
     - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## Summary
- Aligns the sample pre-commit config with the black version from pyproject.toml dev deps (what CI uses via tox)
- The version mismatch can cause pre-commit to format code differently than CI expects, leading to spurious format check failures

## Test plan
- CI format check should pass