### PR TITLE
Try to create Rucio temp directory before writing rucio.cfg

### DIFF
--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -160,7 +160,8 @@ class RucioBroker:
             temp_directory = self.extra_dirs["temp"]
             key_for_pass = "password"
             os.makedirs(temp_directory, exist_ok=True)
-            with open(self.rucio_config_path, "w") as f:
+            rucio_config_path = os.path.join(temp_directory, "rucio.cfg")
+            with open(rucio_config_path, "w") as f:
                 f.write(f"""[client]
 rucio_host = {self.config['host']}
 auth_host = {self.config['auth_host']}
@@ -169,7 +170,7 @@ auth_type = {self.config['auth_type']}
 username = {self.config['username']}
 {key_for_pass} = {self.config[key_for_pass]}
 """)
-            self.rucio_config_path = os.path.join(temp_directory, "rucio.cfg")
+            self.rucio_config_path = rucio_config_path
         # We may have crossed a forkpool boundary. No harm setting the env var again.
         # Fixes rucio integration tests
         os.environ["RUCIO_CONFIG"] = self.rucio_config_path

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -158,8 +158,8 @@ class RucioBroker:
     def get_rucio_client(self):
         if not self.rucio_config_path:
             temp_directory = self.extra_dirs["temp"]
-            self.rucio_config_path = os.path.join(temp_directory, "rucio.cfg")
             key_for_pass = "password"
+            os.makedirs(temp_directory, exist_ok=True)
             with open(self.rucio_config_path, "w") as f:
                 f.write(f"""[client]
 rucio_host = {self.config['host']}
@@ -169,6 +169,7 @@ auth_type = {self.config['auth_type']}
 username = {self.config['username']}
 {key_for_pass} = {self.config[key_for_pass]}
 """)
+            self.rucio_config_path = os.path.join(temp_directory, "rucio.cfg")
         # We may have crossed a forkpool boundary. No harm setting the env var again.
         # Fixes rucio integration tests
         os.environ["RUCIO_CONFIG"] = self.rucio_config_path


### PR DESCRIPTION
I've added a line to `get_rucio_client` to attempt to create the temp directory where `rucio.cfg` will be written to in case it doesn't yet exist. I've also moved saving the rucio_config_path until after `rucio.cfg` is written so that if it fails `rucio_config_path` won't be saved with a non-existent path. This addresses https://github.com/galaxyproject/galaxy/issues/22085.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Configure Galaxy with a rucio-based object store using a temp extra directory that does not exist.
  2. Call `get_rucio_client` and confirm that it writes `rucio.cfg` successfully.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
