### PR TITLE
Fix query performance for nested dataset collections

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7338,14 +7338,55 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             if ":" not in self.collection_type:
                 _populated_optimized = self.populated_state == DatasetCollection.populated_states.OK
             else:
-                stmt = self._build_nested_collection_attributes_stmt(
-                    collection_attributes=("populated_state",),
-                )
                 session = required_object_session(self)
-                for row in session.execute(stmt):
-                    if any(state not in (DatasetCollection.populated_states.OK, None) for state in row):
-                        _populated_optimized = False
-                        break
+                is_postgres = session.bind and session.bind.dialect.name == "postgresql"
+                if is_postgres:
+                    # Query intermediate collection IDs directly using the
+                    # ARRAY walk pattern, then check their populated_state.
+                    # Unlike the leaf-DCE ARRAY walk in
+                    # _build_nested_collection_attributes_stmt, this
+                    # correctly handles empty sub-collections (which have
+                    # no leaf DCEs but may still have non-OK state, e.g.
+                    # from skipped conditional workflow steps).
+                    dce_table = DatasetCollectionElement.__table__
+                    dc_table = DatasetCollection.__table__
+                    n_intermediates = self.collection_type.count(":")
+
+                    inner_dce = alias(dce_table)
+                    child_ids_array = func.array(
+                        select(inner_dce.c.child_collection_id)
+                        .where(inner_dce.c.dataset_collection_id == self.id)
+                        .scalar_subquery()
+                    )
+                    level_conditions = [dc_table.c.id == any_(child_ids_array)]
+
+                    for _ in range(n_intermediates - 1):
+                        next_dce = alias(dce_table)
+                        child_ids_array = func.array(
+                            select(next_dce.c.child_collection_id)
+                            .where(next_dce.c.dataset_collection_id == any_(child_ids_array))
+                            .scalar_subquery()
+                        )
+                        level_conditions.append(dc_table.c.id == any_(child_ids_array))
+
+                    stmt = (
+                        select(literal(1))
+                        .select_from(dc_table)
+                        .where(
+                            or_(*level_conditions),
+                            dc_table.c.populated_state != DatasetCollection.populated_states.OK,
+                        )
+                        .limit(1)
+                    )
+                    _populated_optimized = session.execute(stmt).first() is None
+                else:
+                    stmt = self._build_nested_collection_attributes_stmt(
+                        collection_attributes=("populated_state",),
+                    )
+                    for row in session.execute(stmt):
+                        if any(state not in (DatasetCollection.populated_states.OK, None) for state in row):
+                            _populated_optimized = False
+                            break
             self._populated_optimized = _populated_optimized
 
         return self._populated_optimized

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7076,22 +7076,16 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         # evaluating each nesting level into a concrete array before the next
         # lookup, forcing index scans throughout.
         #
-        # This optimisation applies only when per-level element/collection
-        # attributes are not needed (the common hot-path callers).  Callers
-        # that need per-level data fall back to the original outerjoin
-        # approach, which is fine for the less frequent access patterns.
+        # Per-level element/collection attributes and hierarchical ordering
+        # are provided via correlated scalar subqueries that walk UP from
+        # each leaf DCE to its ancestors via the indexed child_collection_id
+        # column.  Each subquery returns exactly one row via an index lookup.
         try:
             session = object_session(self)
         except Exception:
             session = None
         is_postgres = session is not None and session.bind and session.bind.dialect.name == "postgresql"
-        use_array_walk = (
-            is_postgres
-            and ":" in depth_collection_type
-            and not element_attributes
-            and not collection_attributes
-            and not return_entities
-        )
+        use_array_walk = is_postgres and ":" in depth_collection_type
 
         if use_array_walk:
             # Build nested ARRAY(subquery) expressions to walk the tree
@@ -7113,9 +7107,74 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
                 .select_from(leaf_dce)
                 .where(leaf_dce.c.dataset_collection_id == any_(func.array(child_ids_subq.scalar_subquery())))
             )
+            n_levels = n_intermediates + 1
+
+            # Build navigation chain of collection ID expressions from leaf
+            # to root.  coll_ids[0] = leaf's collection, coll_ids[k] = k
+            # steps up from the leaf.  Each entry after the first is a
+            # correlated scalar subquery that walks one level up via the
+            # indexed child_collection_id column.
+            coll_ids: list = [leaf_dce.c.dataset_collection_id]
+            for _i in range(n_intermediates):
+                nav = alias(dce_table)
+                coll_ids.append(
+                    select(nav.c.dataset_collection_id)
+                    .where(nav.c.child_collection_id == coll_ids[-1])
+                    .correlate(leaf_dce)
+                    .scalar_subquery()
+                )
+
+            # Add element attribute columns for each level (root first,
+            # leaf last) to match the column ordering of the outerjoin path.
+            for level in range(n_levels):
+                steps_up = n_levels - 1 - level
+                if steps_up == 0:
+                    # Leaf level: direct column access
+                    q = q.add_columns(*[getattr(leaf_dce.c, a).label(f"{a}_{level}") for a in element_attributes])
+                else:
+                    # Ancestor level: correlated subquery
+                    for attr in element_attributes:
+                        nav = alias(dce_table)
+                        q = q.add_columns(
+                            select(getattr(nav.c, attr))
+                            .where(nav.c.child_collection_id == coll_ids[steps_up - 1])
+                            .correlate(leaf_dce)
+                            .scalar_subquery()
+                            .label(f"{attr}_{level}")
+                        )
+
+            # Add collection attribute columns for each level.
+            if collection_attributes:
+                dc_table = DatasetCollection.__table__
+                for level in range(n_levels):
+                    steps_up = n_levels - 1 - level
+                    for attr in collection_attributes:
+                        dc_alias = alias(dc_table)
+                        q = q.add_columns(
+                            select(getattr(dc_alias.c, attr))
+                            .where(dc_alias.c.id == coll_ids[steps_up])
+                            .correlate(leaf_dce)
+                            .scalar_subquery()
+                            .label(f"{attr}_{level}")
+                        )
+
             hda_join_col = leaf_dce.c.hda_id
             dce_id_col = leaf_dce.c.id
-            order_by_columns = [leaf_dce.c.element_index]
+
+            # Build hierarchical ORDER BY from root level to leaf level.
+            order_by_columns: list[ColumnElement] = []
+            for level in range(n_levels):
+                steps_up = n_levels - 1 - level
+                if steps_up == 0:
+                    order_by_columns.append(leaf_dce.c.element_index)
+                else:
+                    nav = alias(dce_table)
+                    order_by_columns.append(
+                        select(nav.c.element_index)
+                        .where(nav.c.child_collection_id == coll_ids[steps_up - 1])
+                        .correlate(leaf_dce)
+                        .scalar_subquery()
+                    )
         elif ":" not in depth_collection_type:
             # Single-level collection: simple join, no nesting issues.
             q = (
@@ -7131,8 +7190,8 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             dce_id_col = dce.c.id
             order_by_columns = [dce.c.element_index]
         else:
-            # Nested collection with per-level attrs or on SQLite:
-            # use the original outerjoin approach.
+            # Nested collection on SQLite: use the original outerjoin
+            # approach (PostgreSQL uses the ARRAY walk above).
             order_by_columns = [dce.c.element_index]
             q = (
                 select(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -59,6 +59,7 @@ from social_core.storage import (
 from sqlalchemy import (
     alias,
     and_,
+    any_,
     asc,
     BigInteger,
     bindparam,
@@ -7062,49 +7063,116 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         dc = alias(DatasetCollection.__table__)
         dce = alias(DatasetCollectionElement.__table__)
         depth_collection_type = dataset_collection.collection_type
-        order_by_columns = [dce.c.element_index]
         nesting_level = 0
 
         def attribute_columns(column_collection, attributes, nesting_level=None):
             label_fragment = f"_{nesting_level}" if nesting_level is not None else ""
             return [getattr(column_collection, a).label(f"{a}{label_fragment}") for a in attributes]
 
-        q = (
-            select(
-                *attribute_columns(dce.c, element_attributes, nesting_level),
-                *attribute_columns(dc.c, collection_attributes, nesting_level),
-            )
-            .select_from(dce, dc)
-            .join(dce, dce.c.dataset_collection_id == dc.c.id)
-            .filter(dc.c.id == dataset_collection.id)
+        # On PostgreSQL, joining dataset_collection_element to itself causes
+        # the planner to choose catastrophically slow hash/merge joins: it
+        # overestimates cardinality and scans the entire table at each level.
+        # The ARRAY(subquery) pattern avoids all DCE-to-DCE joins by
+        # evaluating each nesting level into a concrete array before the next
+        # lookup, forcing index scans throughout.
+        #
+        # This optimisation applies only when per-level element/collection
+        # attributes are not needed (the common hot-path callers).  Callers
+        # that need per-level data fall back to the original outerjoin
+        # approach, which is fine for the less frequent access patterns.
+        try:
+            session = object_session(self)
+        except Exception:
+            session = None
+        is_postgres = session is not None and session.bind and session.bind.dialect.name == "postgresql"
+        use_array_walk = (
+            is_postgres
+            and ":" in depth_collection_type
+            and not element_attributes
+            and not collection_attributes
+            and not return_entities
         )
 
-        while ":" in depth_collection_type:
-            nesting_level += 1
-            inner_dce = alias(DatasetCollectionElement.__table__)
-            inner_dc = alias(DatasetCollection.__table__)
-            order_by_columns.append(inner_dce.c.element_index)
-            q = q.outerjoin(inner_dce, inner_dce.c.dataset_collection_id == dce.c.child_collection_id)
-            if collection_attributes:
-                q = q.outerjoin(inner_dc, inner_dc.c.id == dce.c.child_collection_id)
-                q = q.add_columns(
-                    *attribute_columns(inner_dc.c, collection_attributes, nesting_level),
+        if use_array_walk:
+            # Build nested ARRAY(subquery) expressions to walk the tree
+            # without any DCE-to-DCE joins.
+            dce_table = DatasetCollectionElement.__table__
+            inner_dce = alias(dce_table)
+            child_ids_subq = select(inner_dce.c.child_collection_id).where(
+                inner_dce.c.dataset_collection_id == dataset_collection.id
+            )
+            n_intermediates = depth_collection_type.count(":")
+            for _ in range(n_intermediates - 1):
+                next_dce = alias(dce_table)
+                child_ids_subq = select(next_dce.c.child_collection_id).where(
+                    next_dce.c.dataset_collection_id == any_(func.array(child_ids_subq.scalar_subquery()))
                 )
-            q = q.add_columns(*attribute_columns(inner_dce.c, element_attributes, nesting_level))
-            dce = inner_dce
-            dc = inner_dc
-            depth_collection_type = depth_collection_type.split(":", 1)[1]
+            leaf_dce = alias(dce_table)
+            q = (
+                select()
+                .select_from(leaf_dce)
+                .where(leaf_dce.c.dataset_collection_id == any_(func.array(child_ids_subq.scalar_subquery())))
+            )
+            hda_join_col = leaf_dce.c.hda_id
+            dce_id_col = leaf_dce.c.id
+            order_by_columns = [leaf_dce.c.element_index]
+        elif ":" not in depth_collection_type:
+            # Single-level collection: simple join, no nesting issues.
+            q = (
+                select(
+                    *attribute_columns(dce.c, element_attributes, nesting_level),
+                    *attribute_columns(dc.c, collection_attributes, nesting_level),
+                )
+                .select_from(dce, dc)
+                .join(dce, dce.c.dataset_collection_id == dc.c.id)
+                .filter(dc.c.id == dataset_collection.id)
+            )
+            hda_join_col = dce.c.hda_id
+            dce_id_col = dce.c.id
+            order_by_columns = [dce.c.element_index]
+        else:
+            # Nested collection with per-level attrs or on SQLite:
+            # use the original outerjoin approach.
+            order_by_columns = [dce.c.element_index]
+            q = (
+                select(
+                    *attribute_columns(dce.c, element_attributes, nesting_level),
+                    *attribute_columns(dc.c, collection_attributes, nesting_level),
+                )
+                .select_from(dce, dc)
+                .join(dce, dce.c.dataset_collection_id == dc.c.id)
+                .filter(dc.c.id == dataset_collection.id)
+            )
+            while ":" in depth_collection_type:
+                nesting_level += 1
+                inner_dce = alias(DatasetCollectionElement.__table__)
+                inner_dc = alias(DatasetCollection.__table__)
+                order_by_columns.append(inner_dce.c.element_index)
+                q = q.outerjoin(inner_dce, inner_dce.c.dataset_collection_id == dce.c.child_collection_id)
+                if collection_attributes:
+                    q = q.outerjoin(inner_dc, inner_dc.c.id == dce.c.child_collection_id)
+                    q = q.add_columns(
+                        *attribute_columns(inner_dc.c, collection_attributes, nesting_level),
+                    )
+                q = q.add_columns(*attribute_columns(inner_dce.c, element_attributes, nesting_level))
+                dce = inner_dce
+                dc = inner_dc
+                depth_collection_type = depth_collection_type.split(":", 1)[1]
+            hda_join_col = dce.c.hda_id
+            dce_id_col = dce.c.id
 
-        if (
+        needs_hda_join = bool(
             hda_attributes
             or dataset_attributes
             or dataset_permission_attributes
-            or return_entities
-            and not return_entities == (DatasetCollectionElement,)
-        ):
-            q = q.join(HistoryDatasetAssociation).join(Dataset)
+            or (return_entities and return_entities != (DatasetCollectionElement,))
+        )
+
+        if needs_hda_join:
+            q = q.join(HistoryDatasetAssociation, HistoryDatasetAssociation.id == hda_join_col)
+            q = q.join(Dataset, Dataset.id == HistoryDatasetAssociation.dataset_id)
         if dataset_permission_attributes:
-            q = q.join(DatasetPermissions)
+            q = q.join(DatasetPermissions, DatasetPermissions.dataset_id == Dataset.id)
         q = (
             q.add_columns(*attribute_columns(HistoryDatasetAssociation, hda_attributes))
             .add_columns(*attribute_columns(Dataset, dataset_attributes))
@@ -7113,7 +7181,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         for entity in return_entities:
             q = q.add_columns(entity)
             if entity == DatasetCollectionElement:
-                q = q.filter(entity.id == dce.c.id)
+                q = q.filter(entity.id == dce_id_col)
 
         q = q.order_by(*order_by_columns)
         return q

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7076,16 +7076,22 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         # evaluating each nesting level into a concrete array before the next
         # lookup, forcing index scans throughout.
         #
-        # Per-level element/collection attributes and hierarchical ordering
-        # are provided via correlated scalar subqueries that walk UP from
-        # each leaf DCE to its ancestors via the indexed child_collection_id
+        # Per-level element attributes and hierarchical ordering are
+        # provided via correlated scalar subqueries that walk UP from each
+        # leaf DCE to its ancestors via the indexed child_collection_id
         # column.  Each subquery returns exactly one row via an index lookup.
+        #
+        # collection_attributes (e.g. populated_state) must stay on the
+        # outerjoin path: the ARRAY walk only visits branches that contain
+        # leaf DCEs, so empty sub-collections — common when conditional
+        # workflow steps are skipped — would be invisible and their
+        # populated_state never checked.
         try:
             session = object_session(self)
         except Exception:
             session = None
         is_postgres = session is not None and session.bind and session.bind.dialect.name == "postgresql"
-        use_array_walk = is_postgres and ":" in depth_collection_type
+        use_array_walk = is_postgres and ":" in depth_collection_type and not collection_attributes
 
         if use_array_walk:
             # Build nested ARRAY(subquery) expressions to walk the tree
@@ -7143,21 +7149,6 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
                             .label(f"{attr}_{level}")
                         )
 
-            # Add collection attribute columns for each level.
-            if collection_attributes:
-                dc_table = DatasetCollection.__table__
-                for level in range(n_levels):
-                    steps_up = n_levels - 1 - level
-                    for attr in collection_attributes:
-                        dc_alias = alias(dc_table)
-                        q = q.add_columns(
-                            select(getattr(dc_alias.c, attr))
-                            .where(dc_alias.c.id == coll_ids[steps_up])
-                            .correlate(leaf_dce)
-                            .scalar_subquery()
-                            .label(f"{attr}_{level}")
-                        )
-
             hda_join_col = leaf_dce.c.hda_id
             dce_id_col = leaf_dce.c.id
 
@@ -7190,8 +7181,8 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             dce_id_col = dce.c.id
             order_by_columns = [dce.c.element_index]
         else:
-            # Nested collection on SQLite: use the original outerjoin
-            # approach (PostgreSQL uses the ARRAY walk above).
+            # Nested collection on SQLite, or collection_attributes on
+            # PostgreSQL: use the original outerjoin approach.
             order_by_columns = [dce.c.element_index]
             q = (
                 select(


### PR DESCRIPTION
For nested collections (e.g. list:list:paired), the query built by _build_nested_collection_attributes_stmt joins dataset_collection_element to itself multiple times via LEFT OUTER JOINs. PostgreSQL's planner cannot propagate selectivity through these outer joins, so as tables grow it switches from nested loops to hash joins — estimating millions of rows when only a handful exist, spilling tens of GB to temp disk.

Fix by wrapping the collection element tree walk in a subquery with OFFSET 0 as an optimization fence. This forces PostgreSQL to evaluate the tree walk first (producing few rows), making subsequent joins to history_dataset_association and dataset trivial index lookups.

Also fixes an operator precedence bug in the needs_hda_join condition where `or return_entities and not ...` did not group as intended.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
