### PR TITLE
[26.0] Model hidden_data params as optional data in tool meta-models.

### DIFF
--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -184,8 +184,10 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
                 type="rules",
                 name=input_source.parse_name(),
             )
-        elif param_type == "data":
-            optional = input_source.parse_optional()
+        elif param_type in ("data", "hidden_data"):
+            # hidden_data is broken without optional="true" (job runner rejects
+            # missing datasets); only known user is cufflinks which sets it.
+            optional = input_source.parse_optional() if param_type == "data" else True
             multiple = input_source.get_bool("multiple", False)
             return DataParameterModel(
                 type="data",

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -303,7 +303,7 @@ def _process_raw_inputs(
                 location = param_extra.get("location")
                 if param_type != "text":
                     param_value = split_if_str(param_value)
-                if param_type == "data":
+                if param_type in ("data", "hidden_data"):
                     if location and input_source.get_bool("multiple", False):
                         # We get the input/s from the location which can be a list of urls separated by commas
                         locations = split_if_str(location)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2711,6 +2711,14 @@ class HiddenDataToolParameter(HiddenToolParameter, DataToolParameter):
         self.value = "None"
         self.type = "hidden_data"
         self.hidden = True
+        # hidden_data params are broken without optional="true" - the job runner's
+        # parameter validation rejects them when no dataset is provided. The only
+        # known tool using hidden_data (cufflinks) sets optional="true".
+        if not self.optional:
+            raise ParameterValueError(
+                'hidden_data parameters must declare optional="true" to function correctly',
+                self.name,
+            )
 
 
 class BaseJsonToolParameter(ToolParameter):

--- a/test/functional/tools/parameters/gx_hidden_data.xml
+++ b/test/functional/tools/parameters/gx_hidden_data.xml
@@ -1,0 +1,28 @@
+<tool id="gx_hidden_data" name="gx_hidden_data" version="1.0.0">
+    <command><![CDATA[
+#if $parameter
+cat '$parameter' >> '$output'
+#else
+echo 'NO_DATA' >> '$output'
+#end if
+    ]]></command>
+    <inputs>
+        <param name="parameter" type="hidden_data" ext="data" optional="true" />
+    </inputs>
+    <outputs>
+        <data name="output" format="data" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="NO_DATA" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="parameter" value="1.bed" />
+            <output name="output" file="1.bed" />
+        </test>
+    </tests>
+</tool>

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1145,11 +1145,11 @@ gx_data:
 
 
 gx_data_optional:
-  request_valid:
+  request_valid: &data_optional_request_valid
    - parameter: {src: hda, id: abcdabcd}
    - parameter: null
    - {}
-  request_invalid:
+  request_invalid: &data_optional_request_invalid
    - parameter: {src: hda, id: 5}
    - parameter: {src: hdca, id: abcdabcd}
    - parameter: {src: fooda, id: abcdabcd}
@@ -1158,11 +1158,11 @@ gx_data_optional:
    - parameter: true
    - parameter: 5
    - parameter: "5"
-  request_internal_valid:
+  request_internal_valid: &data_optional_request_internal_valid
    - parameter: {src: hda, id: 5}
    - parameter: null
    - {}
-  request_internal_invalid:
+  request_internal_invalid: &data_optional_request_internal_invalid
    - parameter: {src: hda, id: abcdabcd}
    - parameter: {src: hdca, id: abcdabcd}
    - parameter: {src: fooda, id: abcdabcd}
@@ -1171,31 +1171,45 @@ gx_data_optional:
    - parameter: true
    - parameter: 5
    - parameter: "5"
-  job_internal_valid:
+  job_internal_valid: &data_optional_job_internal_valid
    - parameter: null
    - parameter: {src: hda, id: 5}
-  job_internal_invalid:
+  job_internal_invalid: &data_optional_job_internal_invalid
    - {}
-  workflow_step_valid:
+  workflow_step_valid: &data_optional_workflow_step_valid
    - {}
-  workflow_step_invalid:
+  workflow_step_invalid: &data_optional_workflow_step_invalid
    - {src: hda, id: abcdabcd}
    - {src: hda, id: 7}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    - parameter: {__class__: 'ConnectedValue'}
-  workflow_step_linked_valid:
+  workflow_step_linked_valid: &data_optional_workflow_step_linked_valid
    - {}
    - parameter: {__class__: 'ConnectedValue'}
-  workflow_step_linked_invalid:
+  workflow_step_linked_invalid: &data_optional_workflow_step_linked_invalid
    - {src: hda, id: abcdabcd}
    - {src: hda, id: 7}
    - parameter: {__class__: "Batch", values: [{src: hdca, id: 5}]}
    - parameter: {__class__: 'ConnectedValueX'}
-  test_case_xml_valid:
+  test_case_xml_valid: &data_optional_test_case_xml_valid
   - {}
   - parameter: {class: "File", path: "1.bed"}
-  test_case_xml_invalid:
+  test_case_xml_invalid: &data_optional_test_case_xml_invalid
   - parameter: {class: "NotAFile", path: "1.bed"}
+
+gx_hidden_data:
+  request_valid: *data_optional_request_valid
+  request_invalid: *data_optional_request_invalid
+  request_internal_valid: *data_optional_request_internal_valid
+  request_internal_invalid: *data_optional_request_internal_invalid
+  job_internal_valid: *data_optional_job_internal_valid
+  job_internal_invalid: *data_optional_job_internal_invalid
+  workflow_step_valid: *data_optional_workflow_step_valid
+  workflow_step_invalid: *data_optional_workflow_step_invalid
+  workflow_step_linked_valid: *data_optional_workflow_step_linked_valid
+  workflow_step_linked_invalid: *data_optional_workflow_step_linked_invalid
+  test_case_xml_valid: *data_optional_test_case_xml_valid
+  test_case_xml_invalid: *data_optional_test_case_xml_invalid
 
 gx_data_multiple:
   request_valid:


### PR DESCRIPTION
Map hidden_data to DataParameterModel(optional=True) in factory, treat hidden_data as data in test definition parser for file uploads, add gx_hidden_data test tool and parameter specs (anchored to gx_data_optional).

Fixes cufflinks parameter parsing.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
