### PR TITLE
[26.0] Fix unhandled exceptions in tool form model population

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1534,6 +1534,10 @@ class ColumnListParameter(SelectToolParameter):
         # otherwise read first row - assume is a header with tab separated names
         if self.usecolnames:
             dataset = other_values.get(self.data_ref, None)
+            if isinstance(dataset, HistoryDatasetCollectionAssociation):
+                dataset = dataset.to_hda_representative()
+            if isinstance(dataset, DatasetCollectionElement):
+                dataset = dataset.first_dataset_instance()
             column_names = getattr(dataset, "metadata", None) and dataset.metadata.get_if_set("column_names")
             if column_names:
                 try:

--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -1,12 +1,9 @@
-import logging
 from typing import (
     Any,
 )
 
 from galaxy.util.expressions import ExpressionContext
 from .basic import ImplicitConversionRequired
-
-log = logging.getLogger(__name__)
 
 
 def populate_model(request_context, inputs, state_inputs, group_inputs: list[dict[str, Any]], other_values=None):
@@ -50,6 +47,8 @@ def populate_model(request_context, inputs, state_inputs, group_inputs: list[dic
         elif input.type == "section":
             tool_dict = input.to_dict(request_context)
             populate_model(request_context, input.inputs, group_state, tool_dict["inputs"], other_values)
+        elif input.type == "upload_dataset":
+            tool_dict = input.to_dict(request_context)
         else:
             try:
                 initial_value = input.get_initial_value(request_context, other_values)
@@ -63,9 +62,6 @@ def populate_model(request_context, inputs, state_inputs, group_inputs: list[dic
                 tool_dict = input.to_dict(request_context, other_values=other_values)
                 # This hack leads client to display a text field
                 tool_dict["textable"] = True
-            except Exception:
-                tool_dict = input.to_dict(request_context, other_values=other_values)
-                log.exception("tools::to_json() - Skipping parameter expansion '%s'", input.name)
         if input_index >= len(group_inputs):
             group_inputs.append(tool_dict)
         else:

--- a/test/unit/app/tools/test_column_parameters.py
+++ b/test/unit/app/tools/test_column_parameters.py
@@ -57,6 +57,11 @@ class TestDataColumnParameter(BaseParameterTestCase):
         self.other_attributes = "value='c2'"
         assert "2" == self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()})
 
+    def test_get_options_hdca_with_usecolnames(self):
+        self.other_attributes = 'use_header_names="true"'
+        options = self.param.get_options(self.trans, {"input_tsv": self.build_ready_hdca()})
+        assert len(options) > 0
+
     def setUp(self):
         super().setUp()
         self.test_history = model.History()
@@ -88,6 +93,16 @@ class TestDataColumnParameter(BaseParameterTestCase):
         )
         ready_hda.state = "ok"
         return ready_hda
+
+    def build_ready_hdca(self):
+        hda = self.build_ready_hda()
+        session = self.app.model.context
+        c1 = model.DatasetCollection(collection_type="list")
+        model.DatasetCollectionElement(collection=c1, element=hda, element_identifier="sample1", element_index=0)
+        hdca = model.HistoryDatasetCollectionAssociation(collection=c1, name="test_collection")
+        session.add(hdca)
+        session.commit()
+        return hdca
 
     @property
     def param(self):


### PR DESCRIPTION
Fixes: #22131. The tool form builder had a generic exception handler that was covering two separate issues. One happened when rendering upload tools, where UploadDataset ended up in the wrong branch, and the other when rendering data_column parameters with use_header_names for collection inputs, where an HDCA was used without first resolving it to its HDA representative.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
