### PR TITLE
[26.0] Use skip_locked also when updating collection 

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -159,6 +159,7 @@ from galaxy.model.custom_types import (
     UUIDType,
 )
 from galaxy.model.database_object_names import NAMING_CONVENTION
+from galaxy.model.database_utils import supports_skip_locked as _check_supports_skip_locked
 from galaxy.model.item_attrs import (
     get_item_annotation_str,
     UsesAnnotations,
@@ -4798,6 +4799,8 @@ class Dataset(Base, StorableObject, Serializable):
         dialect_name = session.bind.dialect.name
 
         if dialect_name in ("postgresql", "sqlite"):
+            if dialect_name == "postgresql" and supports_skip_locked is None:
+                supports_skip_locked = _check_supports_skip_locked(session.get_bind())
             self._touch_collection_update_time_cte(session, supports_skip_locked)
         else:
             # Fallback for other databases

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -1,15 +1,12 @@
 import sqlite3
 from contextlib import contextmanager
+from functools import lru_cache
 from typing import (
     NewType,
     Optional,
 )
 
-from sqlalchemy import (
-    create_engine,
-    select,
-    update,
-)
+from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import object_session
@@ -20,7 +17,6 @@ from sqlalchemy.sql.expression import (
 )
 
 from galaxy.exceptions import ConfigurationError
-from galaxy.model import Job
 
 DbUrl = NewType("DbUrl", str)
 
@@ -147,19 +143,21 @@ def is_one_database(db1_url: str, db2_url: Optional[str]):
     return not (db1_url and db2_url and db1_url != db2_url)
 
 
+@lru_cache(maxsize=1)
 def supports_returning(engine: Engine) -> bool:
     """
     Return True if the database bound to `engine` supports the `RETURNING` SQL clause.
     """
-    stmt = update(Job).where(Job.id == -1).values(create_time=None).returning(Job.id)
+    stmt = text("UPDATE job SET tool_id=abc WHERE false RETURNING id")
     return _statement_executed_without_error(stmt, engine)
 
 
+@lru_cache(maxsize=1)
 def supports_skip_locked(engine: Engine) -> bool:
     """
     Return True if the database bound to `engine` supports the `SKIP_LOCKED` parameter.
     """
-    stmt = select(Job).where(Job.id == -1).with_for_update(skip_locked=True)
+    stmt = text("SELECT 1 FROM job WHERE false FOR UPDATE SKIP LOCKED")
     return _statement_executed_without_error(stmt, engine)
 
 


### PR DESCRIPTION
via touch_collection_update_time

Should be more efficient than https://gist.github.com/natefoo/663d9b74b0e99ee57cac1a2cf0a2477f

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
