### PR TITLE
[26.0] Backport transient CI fixes from #22102 to release_26.0

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -265,6 +265,7 @@ function load() {
     if (urlTracker.isAtRoot.value || errorMessage.value) {
         itemsProvider.value = undefined;
         errorMessage.value = undefined;
+        isBusy.value = true;
         fetchFileSources(props.filterOptions)
             .then((results) => {
                 const convertedItems = results
@@ -274,13 +275,15 @@ function load() {
                 const sortedItems = convertedItems.sort(sortPrivateFileSourcesFirst);
                 items.value = sortedItems;
                 formatRows();
-                optionsShow.value = true;
                 showTime.value = false;
                 showDetails.value = true;
                 totalItems.value = convertedItems.length;
+                isBusy.value = false;
+                optionsShow.value = true;
             })
             .catch((error) => {
                 errorMessage.value = errorMessageAsString(error);
+                isBusy.value = false;
             });
     } else {
         if (!urlTracker.current.value) {
@@ -303,17 +306,20 @@ function load() {
             return;
         }
 
+        isBusy.value = true;
         browseRemoteFiles(urlTracker.current.value?.url, false, props.requireWritable)
             .then((result) => {
                 items.value = filterByMode(result.entries).map(entryToRecord);
                 totalItems.value = result.totalMatches;
                 formatRows();
-                optionsShow.value = true;
                 showTime.value = true;
                 showDetails.value = false;
+                isBusy.value = false;
+                optionsShow.value = true;
             })
             .catch((error) => {
                 errorMessage.value = errorMessageAsString(error);
+                isBusy.value = false;
             });
     }
 }

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -196,7 +196,7 @@ defineExpose({
             {{ errorMessage }}
         </BAlert>
         <div v-else>
-            <div v-if="optionsShow">
+            <div v-if="optionsShow" data-description="selection dialog options">
                 <BTable
                     small
                     hover

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -551,6 +551,7 @@ files_dialog:
     ftp_details: 'span[title="details-gxftp://"]'
     row: 'span[title="label-${uri}"]'
     back_btn: '#back-btn'
+    options_ready: '[data-description="selection dialog options"] .selection-dialog-table[aria-busy="false"]'
 
 history_export:
   selectors:

--- a/client/src/utils/navigation/schema.ts
+++ b/client/src/utils/navigation/schema.ts
@@ -301,6 +301,7 @@ interface Rootfiles_dialog extends Component {
     ftp_details: SelectorTemplate;
     row: SelectorTemplate;
     back_btn: SelectorTemplate;
+    options_ready: SelectorTemplate;
 }
 interface Roothistory_export extends Component {
     export_link: SelectorTemplate;

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2231,9 +2231,12 @@ class MinimalJobWrapper(HasResourceParameters):
                 dataset.full_delete()
                 collected_bytes = 0
 
-        # Calculate dataset hash
+        # Calculate dataset hash - only if the job completed successfully,
+        # otherwise dataset files may be missing/invalid (e.g. failed fetch from 404 URL).
         for dataset_assoc in output_dataset_associations:
             dataset = dataset_assoc.dataset.dataset
+            if final_job_state == job.states.ERROR:
+                continue
             if not dataset.purged and dataset.state == Dataset.states.OK and not dataset.hashes:
                 if self.app.config.calculate_dataset_hash == "always" or (
                     self.app.config.calculate_dataset_hash == "upload" and job.tool_id in ("upload1", "__DATA_FETCH__")

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2233,25 +2233,25 @@ class MinimalJobWrapper(HasResourceParameters):
 
         # Calculate dataset hash - only if the job completed successfully,
         # otherwise dataset files may be missing/invalid (e.g. failed fetch from 404 URL).
-        for dataset_assoc in output_dataset_associations:
-            dataset = dataset_assoc.dataset.dataset
-            if final_job_state == job.states.ERROR:
-                continue
-            if not dataset.purged and dataset.state == Dataset.states.OK and not dataset.hashes:
-                if self.app.config.calculate_dataset_hash == "always" or (
-                    self.app.config.calculate_dataset_hash == "upload" and job.tool_id in ("upload1", "__DATA_FETCH__")
-                ):
-                    # Calculate dataset hash via a celery task
-                    if self.app.config.enable_celery_tasks:
-                        from galaxy.celery.tasks import compute_dataset_hash
+        if final_job_state == job.states.OK:
+            for dataset_assoc in output_dataset_associations:
+                dataset = dataset_assoc.dataset.dataset
+                if not dataset.purged and dataset.state == Dataset.states.OK and not dataset.hashes:
+                    if self.app.config.calculate_dataset_hash == "always" or (
+                        self.app.config.calculate_dataset_hash == "upload"
+                        and job.tool_id in ("upload1", "__DATA_FETCH__")
+                    ):
+                        # Calculate dataset hash via a celery task
+                        if self.app.config.enable_celery_tasks:
+                            from galaxy.celery.tasks import compute_dataset_hash
 
-                        extra_files_path = dataset.extra_files_path if dataset.extra_files_path_exists() else None
-                        request = ComputeDatasetHashTaskRequest(
-                            dataset_id=dataset.id,
-                            extra_files_path=extra_files_path,
-                            hash_function=self.app.config.hash_function,
-                        )
-                        compute_dataset_hash.delay(request=request)
+                            extra_files_path = dataset.extra_files_path if dataset.extra_files_path_exists() else None
+                            request = ComputeDatasetHashTaskRequest(
+                                dataset_id=dataset.id,
+                                extra_files_path=extra_files_path,
+                                hash_function=self.app.config.hash_function,
+                            )
+                            compute_dataset_hash.delay(request=request)
 
         user = job.user
         if user and collected_bytes > 0 and quota_source_info is not None and quota_source_info.use:

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -18,6 +18,7 @@ from galaxy import (
     model,
 )
 from galaxy.datatypes import sniff
+from galaxy.exceptions import ObjectInvalid
 from galaxy.managers import (
     base,
     deletable,
@@ -164,11 +165,18 @@ class DatasetManager(
             return
         # For files in extra_files_path
         extra_files_path = request.extra_files_path
-        if extra_files_path:
-            extra_dir = dataset.extra_files_path_name
-            file_path = self.app.object_store.get_filename(dataset, extra_dir=extra_dir, alt_name=extra_files_path)
-        else:
-            file_path = dataset.get_file_name()
+        try:
+            if extra_files_path:
+                extra_dir = dataset.extra_files_path_name
+                file_path = self.app.object_store.get_filename(dataset, extra_dir=extra_dir, alt_name=extra_files_path)
+            else:
+                file_path = dataset.get_file_name()
+        except ObjectInvalid:
+            log.warning(
+                "Unable to calculate hash for dataset [%s]: object is invalid (dataset may have failed or been purged).",
+                dataset.id,
+            )
+            return
         hash_function = request.hash_function
         calculated_hash_value = memory_bound_hexdigest(hash_func_name=hash_function, path=file_path)
         dataset_hash = model.DatasetHash(

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -30,8 +30,13 @@ class TestHistoryImportExportFtpSeleniumIntegrationBase(SeleniumIntegrationTestC
         user_ftp_dir = os.path.join(self.ftp_dir(), email)
         os.makedirs(user_ftp_dir)
 
+    def _wait_for_files_dialog_ready(self):
+        """Wait for the files dialog to finish loading and display its options."""
+        self.components.files_dialog.options_ready.wait_for_visible()
+
     def _export_to_ftp_with_filename(self, filename: str):
         self.components.history_export.directory_input.wait_for_and_click()
+        self._wait_for_files_dialog_ready()
         self.components.files_dialog.ftp_label.wait_for_and_click()
         self.components.upload.file_dialog_ok.wait_for_and_click()
         self.components.history_export.name_input.wait_for_and_send_keys(filename)
@@ -72,6 +77,7 @@ class TestHistoryImportExportFtpSeleniumIntegration(TestHistoryImportExportFtpSe
         history_import = gx_selenium_context.components.history_import
         history_import.radio_button_remote_files.wait_for_and_click()
         history_import.open_files_dialog.wait_for_and_click()
+        self._wait_for_files_dialog_ready()
         files_dialog.ftp_label.wait_for_and_click()
         files_dialog.row(uri="gxftp://my_export.tar.gz").wait_for_and_click()
 
@@ -128,6 +134,7 @@ class TestHistoryImportExportFtpSeleniumIntegrationWithTasks(TestHistoryImportEx
 
         # Select FTP file source
         self.components.history_export.directory_input.wait_for_and_click()
+        self._wait_for_files_dialog_ready()
         self.components.files_dialog.ftp_label.wait_for_and_click()
         self.components.upload.file_dialog_ok.wait_for_and_click()
 


### PR DESCRIPTION
## Summary

Backports fixes from #22102 ("Fix transient CI failures") to `release_26.0`:

- **FilesDialog race condition fix**: Sets `isBusy=true` before async calls in `load()`, adds `data-description` marker to SelectionDialog, and adds `options_ready` navigation selector. Test helper `_wait_for_files_dialog_ready()` waits for the dialog to finish loading before interacting.
  - **Confirmed failing** on latest release_26.0 CI: `test_history_export_tracking` times out on `a[title="label-gxftp://"]`
- **Hash computation race on failed data fetch jobs**: Catches `ObjectInvalid` in `compute_hash()` and only schedules hash computation for successful jobs
  - Fixes `test_upload_from_404_url` (history stuck in "running" when fetching from 404 URL)

Excludes GTabs aria-controls/data-tab-title and admin allowlist XPATH→CSS changes which don't apply to 26.0 (uses BTabs).