### PR TITLE
Fix transient failure in test_workflow_with_deleted_dataset_step_parameter

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6082,6 +6082,10 @@ steps:
                 },
                 inputs_by="name",
             )
+            # Wait for the scheduler to hit the pause step (invocation state "new" → "ready")
+            # before deleting, otherwise the scheduler may detect the deleted dataset
+            # on step 2 during scheduling and fail the invocation before we can resume.
+            self._wait_for_invocation_state(workflow_id, invocation_id, "ready")
             # Invocation is paused — delete the dataset before resuming.
             self.dataset_populator.delete_dataset(history_id=history_id, content_id=to_delete_id, purge=False)
             # Resume the pause step. The cat step will now run and


### PR DESCRIPTION
Wait for invocation to reach "ready" (paused) state before deleting the dataset. Without this, the scheduler background thread could process the invocation and detect the deleted dataset parameter on step 2 during scheduling, failing the invocation before the test had a chance to resume the pause step.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
