### PR TITLE
[26.0] Do not render hide button on non-optional activities in activity bar

### DIFF
--- a/client/src/components/ActivityBar/ActivitySettings.vue
+++ b/client/src/components/ActivityBar/ActivitySettings.vue
@@ -110,28 +110,30 @@ function executeActivity(activity: Activity) {
                                 @click.stop="onRemove(activity)">
                                 <FontAwesomeIcon :icon="faTrash" fa-fw />
                             </GButton>
-                            <GButton
-                                v-if="activity.visible"
-                                tooltip
-                                size="small"
-                                transparent
-                                icon-only
-                                color="blue"
-                                title="Hide in Activity Bar"
-                                @click.stop="onFavorite(activity)">
-                                <FontAwesomeIcon :icon="faStar" fa-fw />
-                            </GButton>
-                            <GButton
-                                v-else
-                                tooltip
-                                transparent
-                                icon-only
-                                color="blue"
-                                size="small"
-                                title="Show in Activity Bar"
-                                @click.stop="onFavorite(activity)">
-                                <FontAwesomeIcon :icon="faStarRegular" fa-fw />
-                            </GButton>
+                            <template v-if="activity.optional">
+                                <GButton
+                                    v-if="activity.visible"
+                                    tooltip
+                                    size="small"
+                                    transparent
+                                    icon-only
+                                    color="blue"
+                                    title="Hide in Activity Bar"
+                                    @click.stop="onFavorite(activity)">
+                                    <FontAwesomeIcon :icon="faStar" fa-fw />
+                                </GButton>
+                                <GButton
+                                    v-else
+                                    tooltip
+                                    transparent
+                                    icon-only
+                                    color="blue"
+                                    size="small"
+                                    title="Show in Activity Bar"
+                                    @click.stop="onFavorite(activity)">
+                                    <FontAwesomeIcon :icon="faStarRegular" fa-fw />
+                                </GButton>
+                            </template>
                         </div>
                     </span>
                 </div>


### PR DESCRIPTION
The ⭐ button was being rendered even though the activity can never be hidden (is not `optional`).

| Before | After |
| ---- | ---- |
| <img width="377" height="648" alt="hkx7MbnTKE" src="https://github.com/user-attachments/assets/9fefd607-5d66-4b10-afc8-2f5005e9e009" /> | <img width="377" height="648" alt="firefox_1raqdl6b3l" src="https://github.com/user-attachments/assets/f2bda356-cf93-43ce-b44a-ee35b673610a" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
