### PR TITLE
Show change stack count on workflow editor changes activity

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -287,6 +287,8 @@ defineExpose({
                                 :key="activity.id"
                                 :activity-bar-id="props.activityBarId"
                                 :icon="activity.icon"
+                                :indicator="activity.indicator"
+                                :indicator-variant="activity.indicatorVariant"
                                 :is-active="panelActivityIsActive(activity)"
                                 :title="activity.title"
                                 :tooltip="activity.tooltip"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -93,6 +93,13 @@ watchImmediate(
     },
 );
 
+watchImmediate(
+    () => props.specialActivities,
+    (specials) => {
+        activityStore.setSpecialPanelActivityIds(specials.filter((a) => a.panel).map((a) => a.id));
+    },
+);
+
 const { isAdmin, isAnonymous } = storeToRefs(userStore);
 
 const emit = defineEmits<{

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import { faQuestion } from "@fortawesome/free-solid-svg-icons";
+import { faExclamation, faQuestion } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { Placement } from "@popperjs/core";
 import { computed } from "vue";
@@ -27,7 +27,7 @@ export interface Props {
     activityBarId: string;
     title?: string;
     icon?: IconDefinition;
-    indicator?: number | IconDefinition;
+    indicator?: number | boolean;
     indicatorVariant?: ActivityVariant;
     isActive?: boolean;
     tooltip?: string;
@@ -109,11 +109,11 @@ const meta = computed(() => store.metaForId(props.id));
                         {{ Math.min(indicator, 99) }}
                     </span>
                     <span
-                        v-else-if="typeof indicator !== 'number'"
+                        v-else-if="indicator === true"
                         class="nav-indicator"
                         :class="`${indicatorVariant}-indicator`"
                         data-description="activity indicator">
-                        <FontAwesomeIcon :icon="indicator" />
+                        <FontAwesomeIcon :icon="faExclamation" />
                     </span>
                     <FontAwesomeIcon :icon="icon" />
                 </div>

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -271,7 +271,7 @@ import { InsertStepAction, useStepActions } from "./Actions/stepActions";
 import { CopyIntoWorkflowAction, SetValueActionHandler } from "./Actions/workflowActions";
 import { defaultPosition } from "./composables/useDefaultStepPosition";
 import { useWorkflowBoundingBox } from "./composables/workflowBoundingBox";
-import { useActivityLogic, useSpecialWorkflowActivities, workflowEditorActivities } from "./modules/activities";
+import { useSpecialWorkflowActivities, useWorkflowActivities } from "./modules/activities";
 import { getWorkflowInputs } from "./modules/inputs";
 import { fromSteps } from "./modules/labels";
 import { fromSimple } from "./modules/model";
@@ -349,6 +349,7 @@ export default {
             useWorkflowBoundingBox(id);
 
         const { undo, redo } = undoRedoStore;
+        const { undoStackLength } = storeToRefs(undoRedoStore);
         const { ctrl_z, ctrl_shift_z, meta_z, meta_shift_z } = useMagicKeys();
 
         const undoKeys = logicOr(ctrl_z, meta_z);
@@ -610,13 +611,6 @@ export default {
             hasInvalidConnections.value ? `${errorText.value}, review and remove workflow errors.` : "Save Workflow",
         );
 
-        useActivityLogic(
-            computed(() => ({
-                activityBarId: "workflow-editor",
-                isNewTempWorkflow: isNewTempWorkflow.value,
-            })),
-        );
-
         const { confirm } = useConfirmDialog();
         const inputs = getWorkflowInputs();
 
@@ -628,10 +622,12 @@ export default {
 
         const unprivilegedToolStore = useUnprivilegedToolStore();
         const { canUseUnprivilegedTools } = storeToRefs(unprivilegedToolStore);
-        const workflowActivities = computed(() =>
-            workflowEditorActivities.filter(
-                (activity) => activity.id !== "workflow-editor-user-defined-tools" || canUseUnprivilegedTools.value,
-            ),
+        const workflowActivities = useWorkflowActivities(
+            "workflow-editor",
+            isNewTempWorkflow,
+            hasChanges,
+            undoStackLength,
+            canUseUnprivilegedTools,
         );
 
         const scrollToId = ref(null);

--- a/client/src/components/Workflow/Editor/modules/activities.test.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.test.ts
@@ -1,9 +1,20 @@
+import { faExclamation } from "@fortawesome/free-solid-svg-icons";
 import { createTestingPinia } from "@pinia/testing";
 import { setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ref } from "vue";
+import { ref, shallowRef } from "vue";
 
-import { useWorkflowActivities } from "./activities";
+import { useSpecialWorkflowActivities, useWorkflowActivities } from "./activities";
+import type { LintData } from "./useLinting";
+
+function makeLintData(totalPriority = 0, resolvedPriority = 0, totalAttribute = 0, resolvedAttribute = 0): LintData {
+    return {
+        totalPriorityIssues: ref(totalPriority),
+        resolvedPriorityIssues: ref(resolvedPriority),
+        totalAttributeIssues: ref(totalAttribute),
+        resolvedAttributeIssues: ref(resolvedAttribute),
+    } as unknown as LintData;
+}
 
 describe("useWorkflowActivities", () => {
     beforeEach(() => {
@@ -45,5 +56,76 @@ describe("useWorkflowActivities", () => {
         expect(saveTooltip()).toBe("No changes to save");
         hasChanges.value = true;
         expect(saveTooltip()).toBe("Save current changes");
+    });
+});
+
+describe("useSpecialWorkflowActivities", () => {
+    function setUpBestPractices(hasInvalidConnections = false, lintData = makeLintData()) {
+        const { specialWorkflowActivities, exitWorkflowActivity } = useSpecialWorkflowActivities(
+            shallowRef({ hasInvalidConnections, lintData }),
+        );
+        const bestPracticesActivity = specialWorkflowActivities.value.find((a) => a.id === "workflow-best-practices")!;
+        return { bestPracticesActivity, exitWorkflowActivity };
+    }
+
+    describe("Best Practices indicator", () => {
+        it("is undefined when there are no issues", () => {
+            expect(setUpBestPractices().bestPracticesActivity.indicator).toBeUndefined();
+        });
+
+        it("shows remaining critical count when priority issues are unresolved", () => {
+            expect(setUpBestPractices(false, makeLintData(3, 1)).bestPracticesActivity.indicator).toBe(2);
+        });
+
+        it("shows faExclamation icon when only minor issues remain", () => {
+            expect(setUpBestPractices(false, makeLintData(0, 0, 2, 0)).bestPracticesActivity.indicator).toBe(
+                faExclamation,
+            );
+        });
+
+        it("uses danger variant for numeric indicator and primary for icon indicator", () => {
+            expect(setUpBestPractices(false, makeLintData(1, 0)).bestPracticesActivity.indicatorVariant).toBe("danger");
+            expect(setUpBestPractices(false, makeLintData(0, 0, 1, 0)).bestPracticesActivity.indicatorVariant).toBe(
+                "primary",
+            );
+        });
+    });
+
+    describe("Best Practices tooltip", () => {
+        it("shows default tooltip when no issues remain", () => {
+            expect(setUpBestPractices().bestPracticesActivity.tooltip).toBe("Test workflow for best practices");
+        });
+
+        it("uses singular wording for exactly 1 critical issue", () => {
+            expect(setUpBestPractices(false, makeLintData(1, 0)).bestPracticesActivity.tooltip).toBe(
+                "1 critical best practice issue remains",
+            );
+        });
+
+        it("uses plural wording for multiple critical issues", () => {
+            expect(setUpBestPractices(false, makeLintData(3, 1)).bestPracticesActivity.tooltip).toBe(
+                "2 critical best practice issues remain",
+            );
+        });
+
+        it("shows minor issue count when only minor issues remain", () => {
+            expect(setUpBestPractices(false, makeLintData(0, 0, 2, 1)).bestPracticesActivity.tooltip).toBe(
+                "1 minor best practice issue remains",
+            );
+        });
+    });
+
+    describe("exitWorkflowActivity tooltip", () => {
+        it("shows save and exit message when connections are valid", () => {
+            const { exitWorkflowActivity } = setUpBestPractices(false);
+            expect(exitWorkflowActivity.value.tooltip).toBe("Save this workflow, then exit the workflow editor");
+        });
+
+        it("shows invalid connections warning when hasInvalidConnections is true", () => {
+            const { exitWorkflowActivity } = setUpBestPractices(true);
+            expect(exitWorkflowActivity.value.tooltip).toBe(
+                "Workflow has invalid connections, review and remove invalid connections",
+            );
+        });
     });
 });

--- a/client/src/components/Workflow/Editor/modules/activities.test.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.test.ts
@@ -1,4 +1,3 @@
-import { faExclamation } from "@fortawesome/free-solid-svg-icons";
 import { createTestingPinia } from "@pinia/testing";
 import { setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -77,10 +76,8 @@ describe("useSpecialWorkflowActivities", () => {
             expect(setUpBestPractices(false, makeLintData(3, 1)).bestPracticesActivity.indicator).toBe(2);
         });
 
-        it("shows faExclamation icon when only minor issues remain", () => {
-            expect(setUpBestPractices(false, makeLintData(0, 0, 2, 0)).bestPracticesActivity.indicator).toBe(
-                faExclamation,
-            );
+        it("shows true when only minor issues remain", () => {
+            expect(setUpBestPractices(false, makeLintData(0, 0, 2, 0)).bestPracticesActivity.indicator).toBe(true);
         });
 
         it("uses danger variant for numeric indicator and primary for icon indicator", () => {

--- a/client/src/components/Workflow/Editor/modules/activities.test.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.test.ts
@@ -1,0 +1,49 @@
+import { createTestingPinia } from "@pinia/testing";
+import { setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import { useWorkflowActivities } from "./activities";
+
+describe("useWorkflowActivities", () => {
+    beforeEach(() => {
+        const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
+        setActivePinia(pinia);
+    });
+
+    it("excludes custom tools when canUseUnprivilegedTools is false", () => {
+        const activities = useWorkflowActivities("workflow-editor", ref(false), ref(false), ref(0), ref(false));
+        expect(activities.value.map((a) => a.id)).not.toContain("workflow-editor-user-defined-tools");
+    });
+
+    it("includes custom tools when canUseUnprivilegedTools is true", () => {
+        const activities = useWorkflowActivities("workflow-editor", ref(false), ref(false), ref(0), ref(true));
+        expect(activities.value.map((a) => a.id)).toContain("workflow-editor-user-defined-tools");
+    });
+
+    it("reflects undoStackLength reactively as the Changes activity indicator", () => {
+        const undoStackLength = ref(5);
+        const activities = useWorkflowActivities(
+            "workflow-editor",
+            ref(false),
+            ref(false),
+            undoStackLength,
+            ref(false),
+        );
+        const changesActivity = () => activities.value.find((a) => a.id === "workflow-undo-redo");
+
+        expect(changesActivity()?.indicator).toBe(5);
+        undoStackLength.value = 10;
+        expect(changesActivity()?.indicator).toBe(10);
+    });
+
+    it("reflects hasChanges reactively as the Save activity tooltip", () => {
+        const hasChanges = ref(false);
+        const activities = useWorkflowActivities("workflow-editor", ref(false), hasChanges, ref(0), ref(false));
+        const saveTooltip = () => activities.value.find((a) => a.id === "save-workflow")?.tooltip;
+
+        expect(saveTooltip()).toBe("No changes to save");
+        hasChanges.value = true;
+        expect(saveTooltip()).toBe("Save current changes");
+    });
+});

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -16,178 +16,200 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { watchImmediate } from "@vueuse/core";
 import { faDiagramNext, faSearch, type IconDefinition } from "font-awesome-6";
-import { computed, type Ref } from "vue";
+import { computed, type ComputedRef, type Ref } from "vue";
 
 import { useActivityStore } from "@/stores/activityStore";
 import type { Activity } from "@/stores/activityStoreTypes";
 
 import type { LintData } from "./useLinting";
 
-export const workflowEditorActivities = [
-    {
-        title: "Attributes",
-        id: "workflow-editor-attributes",
-        tooltip: "Edit workflow attributes",
-        description: "View and edit the attributes of this workflow.",
-        panel: true,
-        icon: faPencilAlt,
-        visible: true,
-    },
-    {
-        title: "Search",
-        id: "workflow-editor-search",
-        tooltip: "Search the contents of this workflow",
-        description: "Search the contents of this workflow.",
-        panel: true,
-        icon: faSearch,
-        visible: true,
-    },
-    {
-        title: "Inputs",
-        id: "workflow-editor-inputs",
-        tooltip: "Add input steps to your workflow",
-        description: "Add input steps to your workflow.",
-        icon: faDiagramNext,
-        panel: true,
-        visible: true,
-    },
-    {
-        title: "Tools",
-        id: "workflow-editor-tools",
-        description: "Displays the tool panel to search and place all available tools.",
-        icon: faWrench,
-        panel: true,
-        tooltip: "Search tools to use in your workflow",
-        visible: true,
-    },
-    {
-        title: "Workflows",
-        id: "workflow-editor-workflows",
-        description: "Browse other workflows and add them as sub-workflows.",
-        tooltip: "Search workflows to use in your workflow",
-        icon: faSitemap,
-        panel: true,
-        visible: true,
-        optional: true,
-    },
-    {
-        title: "Report",
-        id: "workflow-editor-report",
-        description: "Edit the report for this workflow.",
-        tooltip: "Edit workflow report",
-        icon: faEdit,
-        panel: true,
-        visible: true,
-        optional: true,
-    },
+export function useWorkflowActivities(
+    /** The ID of the activity bar these activities belong to (set to "workflow-editor" for now) */
+    activityBarId: string,
+    /** Whether the workflow being edited is a new workflow that has not been created/saved yet */
+    isNewTempWorkflow: Ref<boolean>,
+    /** Whether the workflow has unsaved changes */
+    hasChanges: Ref<boolean>,
+    /** How many changes before we get back to the last saved state */
+    undoStackLength: Ref<number>,
+    /** Whether the user can use custom tools */
+    canUseUnprivilegedTools: Ref<boolean>,
+): ComputedRef<Activity[]> {
+    const store = useActivityStore(activityBarId);
 
-    {
-        title: "Changes",
-        id: "workflow-undo-redo",
-        description: "View, undo, and redo your latest changes.",
-        tooltip: "Show and manage latest changes",
-        icon: faHistory,
-        panel: true,
-        visible: true,
-        optional: true,
-    },
-    {
-        title: "Run",
-        id: "workflow-run",
-        description: "Run this workflow with specific parameters.",
-        tooltip: "Run workflow",
-        icon: faPlay,
-        visible: true,
-        click: true,
-        optional: true,
-    },
-    {
-        description: "Save this workflow.",
-        icon: faSave,
-        id: "save-workflow",
-        title: "Save",
-        tooltip: "Save current changes",
-        visible: true,
-        click: true,
-        optional: true,
-    },
-    {
-        description: "Save this workflow with a different name and annotation.",
-        icon: farSave,
-        id: "save-workflow-as",
-        title: "Save as",
-        tooltip: "Save a copy of this workflow",
-        visible: true,
-        click: true,
-        optional: true,
-    },
-    {
-        title: "Upgrade",
-        id: "workflow-upgrade",
-        description: "Update all tools used in this workflow.",
-        tooltip: "Update all tools",
-        icon: faRecycle,
-        visible: true,
-        click: true,
-        optional: true,
-    },
-    {
-        description: "Insert custom tools.",
-        icon: faWrench,
-        id: "workflow-editor-user-defined-tools",
-        optional: true,
-        panel: true,
-        title: "Custom Tools",
-        to: null,
-        tooltip: "List and create user-defined tools",
-        visible: true,
-    },
-    {
-        title: "Download",
-        id: "workflow-download",
-        description: "Download this workflow in '.ga' format.",
-        tooltip: "Download workflow",
-        icon: faDownload,
-        visible: true,
-        click: true,
-        optional: true,
-    },
-    {
-        description: "Save this workflow and create a new workflow.",
-        icon: faPlus,
-        title: "Create new",
-        id: "workflow-create",
-        tooltip: "Save this workflow and create a new one",
-        visible: true,
-        click: true,
-        optional: true,
-    },
-    {
-        description: "Exit the workflow editor and return to the start screen.",
-        icon: faSignOutAlt,
-        id: "exit",
-        title: "Exit",
-        tooltip: "Exit workflow editor",
-        visible: false,
-        click: true,
-        optional: true,
-    },
-] as const satisfies Readonly<Activity[]>;
-
-interface ActivityLogicOptions {
-    activityBarId: string;
-    isNewTempWorkflow: boolean;
-}
-
-export function useActivityLogic(options: Ref<ActivityLogicOptions>) {
-    const store = useActivityStore(options.value.activityBarId);
-
+    // Disable running the workflow if it is new and has not been created
     watchImmediate(
-        () => options.value.isNewTempWorkflow,
+        () => isNewTempWorkflow.value,
         (value) => {
             store.setMeta("workflow-run", "disabled", value);
         },
     );
+
+    // Disable saving the workflow if there are no changes to save
+    watchImmediate(
+        () => hasChanges.value,
+        (value) => {
+            store.setMeta("save-workflow", "disabled", !value);
+        },
+    );
+
+    // Return a computed list of workflow editor activities
+    return computed(() => [
+        {
+            title: "Attributes",
+            id: "workflow-editor-attributes",
+            tooltip: "Edit workflow attributes",
+            description: "View and edit the attributes of this workflow.",
+            panel: true,
+            icon: faPencilAlt,
+            visible: true,
+        },
+        {
+            title: "Search",
+            id: "workflow-editor-search",
+            tooltip: "Search the contents of this workflow",
+            description: "Search the contents of this workflow.",
+            panel: true,
+            icon: faSearch,
+            visible: true,
+        },
+        {
+            title: "Inputs",
+            id: "workflow-editor-inputs",
+            tooltip: "Add input steps to your workflow",
+            description: "Add input steps to your workflow.",
+            icon: faDiagramNext,
+            panel: true,
+            visible: true,
+        },
+        {
+            title: "Tools",
+            id: "workflow-editor-tools",
+            description: "Displays the tool panel to search and place all available tools.",
+            icon: faWrench,
+            panel: true,
+            tooltip: "Search tools to use in your workflow",
+            visible: true,
+        },
+        {
+            title: "Workflows",
+            id: "workflow-editor-workflows",
+            description: "Browse other workflows and add them as sub-workflows.",
+            tooltip: "Search workflows to use in your workflow",
+            icon: faSitemap,
+            panel: true,
+            visible: true,
+            optional: true,
+        },
+        {
+            title: "Report",
+            id: "workflow-editor-report",
+            description: "Edit the report for this workflow.",
+            tooltip: "Edit workflow report",
+            icon: faEdit,
+            panel: true,
+            visible: true,
+            optional: true,
+        },
+
+        {
+            title: "Changes",
+            id: "workflow-undo-redo",
+            description: "View, undo, and redo your latest changes.",
+            tooltip: "Show and manage latest changes",
+            icon: faHistory,
+            panel: true,
+            visible: true,
+            optional: true,
+            indicator: undoStackLength.value,
+            indicatorVariant: "primary",
+        },
+        {
+            title: "Run",
+            id: "workflow-run",
+            description: "Run this workflow with specific parameters.",
+            tooltip: "Run workflow",
+            icon: faPlay,
+            visible: true,
+            click: true,
+            optional: true,
+        },
+        {
+            description: "Save this workflow.",
+            icon: faSave,
+            id: "save-workflow",
+            title: "Save",
+            tooltip: hasChanges.value ? "Save current changes" : "No changes to save",
+            visible: true,
+            click: true,
+            optional: true,
+        },
+        {
+            description: "Save this workflow with a different name and annotation.",
+            icon: farSave,
+            id: "save-workflow-as",
+            title: "Save as",
+            tooltip: "Save a copy of this workflow",
+            visible: true,
+            click: true,
+            optional: true,
+        },
+        {
+            title: "Upgrade",
+            id: "workflow-upgrade",
+            description: "Update all tools used in this workflow.",
+            tooltip: "Update all tools",
+            icon: faRecycle,
+            visible: true,
+            click: true,
+            optional: true,
+        },
+        ...(canUseUnprivilegedTools.value
+            ? [
+                  {
+                      description: "Insert custom tools.",
+                      icon: faWrench,
+                      id: "workflow-editor-user-defined-tools",
+                      optional: true,
+                      panel: true,
+                      title: "Custom Tools",
+                      to: null,
+                      tooltip: "List and create user-defined tools",
+                      visible: true,
+                  },
+              ]
+            : []),
+        {
+            title: "Download",
+            id: "workflow-download",
+            description: "Download this workflow in '.ga' format.",
+            tooltip: "Download workflow",
+            icon: faDownload,
+            visible: true,
+            click: true,
+            optional: true,
+        },
+        {
+            description: "Save this workflow and create a new workflow.",
+            icon: faPlus,
+            title: "Create new",
+            id: "workflow-create",
+            tooltip: "Save this workflow and create a new one",
+            visible: true,
+            click: true,
+            optional: true,
+        },
+        {
+            description: "Exit the workflow editor and return to the start screen.",
+            icon: faSignOutAlt,
+            id: "exit",
+            title: "Exit",
+            tooltip: "Exit workflow editor",
+            visible: false,
+            click: true,
+            optional: true,
+        },
+    ]);
 }
 
 interface SpecialActivityOptions {

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -2,7 +2,6 @@ import { faSave as farSave } from "@fortawesome/free-regular-svg-icons";
 import {
     faDownload,
     faEdit,
-    faExclamation,
     faHistory,
     faMagic,
     faPencilAlt,
@@ -15,7 +14,7 @@ import {
     faWrench,
 } from "@fortawesome/free-solid-svg-icons";
 import { watchImmediate } from "@vueuse/core";
-import { faDiagramNext, faSearch, type IconDefinition } from "font-awesome-6";
+import { faDiagramNext, faSearch } from "font-awesome-6";
 import { computed, type ComputedRef, type Ref } from "vue";
 
 import { useActivityStore } from "@/stores/activityStore";
@@ -229,16 +228,16 @@ export function useSpecialWorkflowActivities(options: Ref<SpecialActivityOptions
     /** Indicator for best practices activity
      * @returns
      * - `number`: count of critical issues remaining
-     * - `faInfoCircle`: non-critical issues remaining
+     * - `true`: non-critical issues remaining (renders exclamation icon)
      * - `undefined`: no issues remaining
      */
-    const bestPracticesIndicator = computed<number | IconDefinition | undefined>(() => {
+    const bestPracticesIndicator = computed<number | true | undefined>(() => {
         const { resolvedPriorityIssues, totalPriorityIssues, resolvedAttributeIssues, totalAttributeIssues } =
             options.value.lintData;
         if (totalPriorityIssues.value > resolvedPriorityIssues.value) {
             return totalPriorityIssues.value - resolvedPriorityIssues.value;
         } else if (totalAttributeIssues.value > resolvedAttributeIssues.value) {
-            return faExclamation;
+            return true;
         }
         return undefined;
     });

--- a/client/src/stores/activityStore.test.ts
+++ b/client/src/stores/activityStore.test.ts
@@ -167,6 +167,46 @@ describe("Activity Store", () => {
         });
     });
 
+    describe("setSpecialPanelActivityIds", () => {
+        it("prevents sync from resetting toggledSideBar when set to a registered special panel activity", async () => {
+            const activityStore = useActivityStore("default");
+            await activityStore.sync();
+
+            activityStore.setSpecialPanelActivityIds(["special-panel-id"]);
+            activityStore.toggledSideBar = "special-panel-id";
+
+            await activityStore.sync();
+
+            expect(activityStore.toggledSideBar).toBe("special-panel-id");
+        });
+
+        it("still resets toggledSideBar when it is not in defaults or registered special activities", async () => {
+            const activityStore = useActivityStore("default");
+            await activityStore.sync();
+
+            activityStore.setSpecialPanelActivityIds([]);
+            activityStore.toggledSideBar = "unknown-panel-id";
+
+            await activityStore.sync();
+
+            expect(activityStore.toggledSideBar).toBe("a-id");
+        });
+
+        it("resets toggledSideBar after special activity is unregistered", async () => {
+            const activityStore = useActivityStore("default");
+            await activityStore.sync();
+
+            activityStore.setSpecialPanelActivityIds(["special-panel-id"]);
+            activityStore.toggledSideBar = "special-panel-id";
+            await activityStore.sync();
+            expect(activityStore.toggledSideBar).toBe("special-panel-id");
+
+            activityStore.setSpecialPanelActivityIds([]);
+            await activityStore.sync();
+            expect(activityStore.toggledSideBar).toBe("a-id");
+        });
+    });
+
     describe("ensureVisible", () => {
         it("marks an existing activity as visible", async () => {
             const activityStore = useActivityStore("default");

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -32,6 +32,12 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
     const currentDefaultActivities = computed(() => customDefaultActivities.value ?? defaultActivities);
     const isSideBarOpen = computed(() => toggledSideBar.value !== "" && toggledSideBar.value !== "closed");
 
+    const specialPanelActivityIds = ref<Set<string>>(new Set());
+
+    function setSpecialPanelActivityIds(ids: string[]) {
+        specialPanelActivityIds.value = new Set(ids);
+    }
+
     const toggledSideBar = useUserLocalStorage(`activity-store-current-side-bar-${scope}`, "tools");
     const sidePanelWidth = useUserLocalStorage(`activity-store-side-panel-width-${scope}`, 300);
 
@@ -115,7 +121,7 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
                 }
             });
 
-            const allSideBarsSet = new Set(allSideBars);
+            const allSideBarsSet = new Set([...allSideBars, ...specialPanelActivityIds.value]);
             const firstSideBar = allSideBars[0];
 
             if (firstSideBar && !allSideBarsSet.has(toggledSideBar.value)) {
@@ -229,5 +235,6 @@ export const useActivityStore = defineScopedStore("activityStore", (scope) => {
         currentDefaultActivities,
         overrideDefaultActivities,
         resetDefaultActivities,
+        setSpecialPanelActivityIds,
     };
 });

--- a/client/src/stores/activityStoreTypes.ts
+++ b/client/src/stores/activityStoreTypes.ts
@@ -25,8 +25,8 @@ export interface Activity {
     tooltip: string;
     // indicate wether the activity should be visible by default
     visible?: boolean;
-    /** Activity indicator; a number or an icon */
-    indicator?: number | IconDefinition;
+    /** Activity indicator; a number, or true to show an exclamation icon */
+    indicator?: number | boolean;
     /** Variant for the activity indicator */
     indicatorVariant?: ActivityVariant;
     // if activity should cause a click event

--- a/client/src/stores/undoRedoStore/index.ts
+++ b/client/src/stores/undoRedoStore/index.ts
@@ -34,6 +34,8 @@ export const useUndoRedoStore = defineScopedStore("undoRedoStore", () => {
 
     const changeId = ref(0);
 
+    const undoStackLength = computed(() => undoActionStack.value.length);
+
     watch(
         () => [undoActionStack.value.length, deletedActions.value.length],
         () => (changeId.value += 1),
@@ -204,6 +206,7 @@ export const useUndoRedoStore = defineScopedStore("undoRedoStore", () => {
         maxUndoActions,
         savedUndoActions,
         deletedActions,
+        undoStackLength,
         undo,
         redo,
         applyAction,


### PR DESCRIPTION

![firefox_B4jiPLoael](https://github.com/user-attachments/assets/0ab37f4b-893b-47bb-9c91-36fca1152a93)


### Changes:

- Replace the static `workflowEditorActivities` array and the separate `useActivityLogic` composable with a unified `useWorkflowActivities(...)` composable that returns a `ComputedRef<Activity[]>`, keeping all activity-bar logic in one place.
- The Changes activity now carries a reactive `indicator` badge showing the current undo-stack depth, powered by a new `undoStackLength` computed ref exposed from `useUndoRedoStore`.
- The Save activity's tooltip and disabled state now update reactively based on `hasChanges`.
- Custom Tools is included/excluded inline via a conditional spread inside the computed, removing the external filter in Index.vue.

Fixes https://github.com/galaxyproject/galaxy/issues/21123

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
