### PR TITLE
Show step/tool form for any step in invocation graph

### DIFF
--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -241,7 +241,7 @@ function toggleDetailedView() {
             </div>
             <BCard v-if="activeNodeId !== null && activeStep" ref="stepCard" class="invocation-step-card mt-2" no-body>
                 <BCardHeader
-                    class="d-flex justify-content-between align-items-center px-3 py-1"
+                    class="invocation-step-header"
                     :class="activeNodeId !== null ? steps[activeNodeId]?.headerClass : ''">
                     <WorkflowInvocationStepHeader
                         class="w-100 pr-2"
@@ -339,5 +339,15 @@ function toggleDetailedView() {
     right: 1rem;
     z-index: 150;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.invocation-step-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--spacing) var(--spacing-4);
+    position: sticky;
+    top: 0;
+    z-index: 100;
 }
 </style>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -329,14 +329,13 @@ onUnmounted(() => {
                                         <BAlert v-if="loadingStepConfig" show>
                                             <LoadingSpan message="Loading step configuration" />
                                         </BAlert>
+                                        <fieldset v-else-if="activeStepWithConfig" disabled>
                                         <FormTool
-                                            v-else-if="workflowStepType === 'tool' && activeStepWithConfig"
+                                                v-if="workflowStepType === 'tool'"
                                             :step="activeStepWithConfig"
                                             :datatypes="datatypes" />
-                                        <FormDefault
-                                            v-else-if="workflowStepType !== 'tool' && activeStepWithConfig"
-                                            :step="activeStepWithConfig"
-                                            :datatypes="datatypes" />
+                                            <FormDefault v-else :step="activeStepWithConfig" :datatypes="datatypes" />
+                                        </fieldset>
                                     </GTab>
                                 </GTabs>
                             </div>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -213,6 +213,13 @@ onUnmounted(() => {
             </div>
 
             <div v-if="computedExpanded" class="portlet-content">
+                <div
+                    v-if="props.workflowStep.annotation"
+                    class="mb-2 bg-light rounded p-2"
+                    :class="{ 'mt-2': !props.inGraphView }">
+                    {{ props.workflowStep.annotation }}
+                </div>
+
                 <div v-if="isReady && invocationStepId !== undefined">
                     <div style="min-width: 1">
                         <BAlert v-if="loading" variant="info" show>
@@ -330,10 +337,10 @@ onUnmounted(() => {
                                             <LoadingSpan message="Loading step configuration" />
                                         </BAlert>
                                         <fieldset v-else-if="activeStepWithConfig" disabled>
-                                        <FormTool
+                                            <FormTool
                                                 v-if="workflowStepType === 'tool'"
-                                            :step="activeStepWithConfig"
-                                            :datatypes="datatypes" />
+                                                :step="activeStepWithConfig"
+                                                :datatypes="datatypes" />
                                             <FormDefault v-else :step="activeStepWithConfig" :datatypes="datatypes" />
                                         </fieldset>
                                     </GTab>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import { faTimesCircle } from "@fortawesome/free-regular-svg-icons";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import axios from "axios";
 import { BAlert } from "bootstrap-vue";
 import { computed, onUnmounted, ref, watch } from "vue";
 
 import type { WorkflowInvocationElementView } from "@/api/invocations";
 import type { WorkflowStepTyped } from "@/api/workflows";
+import { useDatatypesMapper } from "@/composables/datatypesMapper";
 import type { GraphStep } from "@/composables/useInvocationGraph";
+import { getAppRoot } from "@/onload/loadConfig";
 import { useInvocationStore } from "@/stores/invocationStore";
 
 import Heading from "../Common/Heading.vue";
@@ -20,6 +23,8 @@ import GTab from "@/components/BaseComponents/GTab.vue";
 import GTabs from "@/components/BaseComponents/GTabs.vue";
 import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
+import FormDefault from "@/components/Workflow/Editor/Forms/FormDefault.vue";
+import FormTool from "@/components/Workflow/Editor/Forms/FormTool.vue";
 
 const TERMINAL_JOB_STATES = ["ok", "error", "deleted", "paused"];
 
@@ -41,8 +46,11 @@ const emit = defineEmits<{
 }>();
 
 const invocationStore = useInvocationStore();
+const { datatypes } = useDatatypesMapper();
 
 const localExpanded = ref(Boolean(props.expanded));
+const stepConfigData = ref<Record<string, any> | null>(null);
+const loadingStepConfig = ref(false);
 const stepFetchInterval = ref<any>(undefined);
 
 const computedExpanded = computed({
@@ -142,6 +150,37 @@ const jobsTabTitle = computed(() => {
     }
     return "No jobs";
 });
+
+const activeStepWithConfig = computed(() => {
+    if (!stepConfigData.value) {
+        return null;
+    }
+    const step = props.workflowStep as any;
+    return {
+        ...step,
+        config_form: stepConfigData.value.config_form,
+        inputs: stepConfigData.value.inputs ?? step.inputs,
+        outputs: stepConfigData.value.outputs ?? step.outputs,
+    } as any;
+});
+
+async function fetchStepConfig() {
+    if (stepConfigData.value || loadingStepConfig.value) {
+        return;
+    }
+    loadingStepConfig.value = true;
+    try {
+        const step = props.workflowStep as any;
+        const { data } = await axios.post(`${getAppRoot()}api/workflows/build_module`, {
+            type: step.type,
+            content_id: step.content_id ?? step.tool_id,
+            tool_state: step.tool_state ?? "{}",
+        });
+        stepConfigData.value = data;
+    } finally {
+        loadingStepConfig.value = false;
+    }
+}
 
 function toggleStep() {
     computedExpanded.value = !computedExpanded.value;
@@ -278,6 +317,27 @@ onUnmounted(() => {
                                             </div>
                                         </div>
                                     </GTab>
+
+                                    <GTab
+                                        :class="{ 'invocation-view-step-config': props.inGraphView }"
+                                        lazy
+                                        @click="fetchStepConfig">
+                                        <template v-slot:title>
+                                            <FontAwesomeIcon :icon="faWrench" />
+                                            <span v-localize>Step Config</span>
+                                        </template>
+                                        <BAlert v-if="loadingStepConfig" show>
+                                            <LoadingSpan message="Loading step configuration" />
+                                        </BAlert>
+                                        <FormTool
+                                            v-else-if="workflowStepType === 'tool' && activeStepWithConfig"
+                                            :step="activeStepWithConfig"
+                                            :datatypes="datatypes" />
+                                        <FormDefault
+                                            v-else-if="workflowStepType !== 'tool' && activeStepWithConfig"
+                                            :step="activeStepWithConfig"
+                                            :datatypes="datatypes" />
+                                    </GTab>
                                 </GTabs>
                             </div>
                         </div>
@@ -300,6 +360,15 @@ onUnmounted(() => {
 .portlet-header {
     &:hover {
         opacity: 0.8;
+    }
+}
+
+.invocation-view-step-config {
+    :deep(.tool-header) {
+        position: unset;
+    }
+    :deep(.ui-form-header-underlay) {
+        display: none;
     }
 }
 </style>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -152,10 +152,15 @@ const jobsTabTitle = computed(() => {
 });
 
 const activeStepWithConfig = computed(() => {
+    // graphStep is the full editor-format step (already has config_form with correct values)
+    if (props.graphStep?.config_form) {
+        return props.graphStep as any;
+    }
+    // If the graphStep doesn't have config_form, we may be able to get it from stepConfigData (fetched when user clicks on Step Config tab)
     if (!stepConfigData.value) {
         return null;
     }
-    const step = props.workflowStep as any;
+    const step = props.graphStep ?? (props.workflowStep as any);
     return {
         ...step,
         config_form: stepConfigData.value.config_form,
@@ -165,16 +170,17 @@ const activeStepWithConfig = computed(() => {
 });
 
 async function fetchStepConfig() {
-    if (stepConfigData.value || loadingStepConfig.value) {
+    // graphStep already has config_form — no fetch needed
+    if (props.graphStep?.config_form || stepConfigData.value || loadingStepConfig.value) {
         return;
     }
     loadingStepConfig.value = true;
     try {
-        const step = props.workflowStep as any;
+        const step = props.graphStep ?? props.workflowStep;
         const { data } = await axios.post(`${getAppRoot()}api/workflows/build_module`, {
             type: step.type,
-            content_id: step.content_id ?? step.tool_id,
-            tool_state: step.tool_state ?? "{}",
+            content_id: "content_id" in step ? step.content_id : step.tool_id,
+            tool_state: "tool_state" in step ? step.tool_state : {},
         });
         stepConfigData.value = data;
     } finally {


### PR DESCRIPTION
When viewing an active step in the invocation graph, we see an additional `Step Config` tab next to the `Jobs` and `Outputs` tabs.

We see the exact same step form as shown in the workflow editor, except it is readonly.

https://github.com/user-attachments/assets/575aac2d-4f58-4609-95ef-ccd898274251

Fixes part of https://github.com/galaxyproject/galaxy/issues/21086

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. For a workflow invocation in the invocation view, click on a step (ideally a tool step)
  2. Scroll down to see the step's information, and click on the `Step Config` tab
  3. You will see the exact same form as would show up in the editor for that step (confirm by opening the same workflow in the editor and comparing the forms)
  4. The form should be readonly

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
