### PR TITLE
Prevent card images from overflowing container

### DIFF
--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -748,6 +748,12 @@ function onKeyDown(event: KeyboardEvent) {
         background-color: $body-bg;
         border: 1px solid $brand-secondary;
         border-radius: 0.5rem;
+        overflow: hidden;
+
+        .g-card-description :deep(img) {
+            max-width: 100%;
+            height: auto;
+        }
 
         .g-card-title-truncate {
             display: -webkit-box;


### PR DESCRIPTION
## Summary
Fixes #22067 — adds overflow constraint and max-width rule for images rendered inside GCard descriptions so they don't bleed past the card border.

CSS-only change in `GCard.vue`: `overflow: hidden` on `.g-card-content` and a `:deep(img)` rule constraining images to card width.