### PR TITLE
Add type guard in process_key for non-dict intermediate values

### DIFF
--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -201,6 +201,8 @@ def process_key(incoming_key: str, incoming_value: Any, d: dict[str, Any]):
         # Section / Conditional
         input_name = key_parts[0]
         subdict = d.get(input_name, {})
+        if not isinstance(subdict, dict):
+            subdict = {}
         d[input_name] = subdict
         process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
 


### PR DESCRIPTION
## Summary
Fixes #22132 — when flat pipe-delimited tool parameters get converted to nested dicts, a prior iteration can store a string at a key that a later iteration tries to recurse into. This adds an isinstance check so we don't crash calling .get() on a string.

One-line change in `lib/galaxy/tools/parameters/wrapped.py`.