### PR TITLE
Handle upload_dataset type in populate_model

### DIFF
--- a/lib/galaxy/tools/parameters/populate_model.py
+++ b/lib/galaxy/tools/parameters/populate_model.py
@@ -50,6 +50,9 @@ def populate_model(request_context, inputs, state_inputs, group_inputs: list[dic
         elif input.type == "section":
             tool_dict = input.to_dict(request_context)
             populate_model(request_context, input.inputs, group_state, tool_dict["inputs"], other_values)
+        elif input.type == "upload_dataset":
+            tool_dict = input.to_dict(request_context)
+            populate_model(request_context, input.inputs, group_state, tool_dict["inputs"], other_values)
         else:
             try:
                 initial_value = input.get_initial_value(request_context, other_values)


### PR DESCRIPTION
## Summary
Fixes #22131 — UploadDataset inherits Group.to_dict which doesn't accept `other_values`, so it needs its own branch in `populate_model` like repeat/conditional/section instead of falling through to the else clause that passes `other_values` and crashes.