### PR TITLE
Convert math.inf to None in JSON-serialized tool dicts

### DIFF
--- a/lib/galaxy/tool_util/parser/stdio.py
+++ b/lib/galaxy/tool_util/parser/stdio.py
@@ -48,8 +48,8 @@ class ToolStdioExitCode:
     def to_dict(self):
         return {
             "class": "ToolStdioExitCode",
-            "range_start": self.range_start,
-            "range_end": self.range_end,
+            "range_start": None if math.isinf(self.range_start) else self.range_start,
+            "range_end": None if math.isinf(self.range_end) else self.range_end,
             "error_level": self.error_level,
             "desc": self.desc,
         }

--- a/lib/galaxy/tool_util/parser/stdio.py
+++ b/lib/galaxy/tool_util/parser/stdio.py
@@ -48,8 +48,8 @@ class ToolStdioExitCode:
     def to_dict(self):
         return {
             "class": "ToolStdioExitCode",
-            "range_start": None if math.isinf(self.range_start) else self.range_start,
-            "range_end": None if math.isinf(self.range_end) else self.range_end,
+            "range_start": "-inf" if math.isinf(self.range_start) else self.range_start,
+            "range_end": "inf" if math.isinf(self.range_end) else self.range_end,
             "error_level": self.error_level,
             "desc": self.desc,
         }

--- a/lib/galaxy/tool_util/parser/stdio.py
+++ b/lib/galaxy/tool_util/parser/stdio.py
@@ -40,8 +40,8 @@ class ToolStdioExitCode:
 
     def __init__(self, as_dict=None):
         as_dict = as_dict or {}
-        self.range_start = as_dict.get("range_start", -math.inf)
-        self.range_end = as_dict.get("range_end", math.inf)
+        self.range_start = float(as_dict.get("range_start", -math.inf))
+        self.range_end = float(as_dict.get("range_end", math.inf))
         self.error_level = as_dict.get("error_level", StdioErrorLevel.FATAL)
         self.desc = as_dict.get("desc", "")
 

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -10,6 +10,7 @@ from collections.abc import (
     Callable,
     Mapping,
 )
+import math
 from math import inf
 from typing import (
     Any,
@@ -182,6 +183,8 @@ class Repeat(Group):
         if self.inputs is None:
             raise Exception("Must set 'inputs' attribute to use.")
         repeat_dict = super().to_dict(trans)
+        if math.isinf(repeat_dict.get("max", 0)):
+            repeat_dict["max"] = None
 
         def input_to_dict(input):
             return input.to_dict(trans)

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -4,13 +4,13 @@ Constructs for grouping tool parameters
 
 import io
 import logging
+import math
 import os
 import unicodedata
 from collections.abc import (
     Callable,
     Mapping,
 )
-import math
 from math import inf
 from typing import (
     Any,


### PR DESCRIPTION
## Summary
Fixes #22054 — Repeat.max and ToolStdioExitCode range fields default to `math.inf` which isn't JSON-serializable and causes ValueError in FastAPI responses. This converts inf values to None in the respective `to_dict` methods. The `/api/tools/{id}/build` path already handled this via `swap_inf_nan()`, but other serialization paths didn't.

Note: `ToolStdioExitCode.from_dict()` defaults to `float("-inf")`/`float("inf")`, so if these dicts ever round-trip through serialize→deserialize, the `None` would need to be handled in `from_dict` too. For the API response path (which is the reported bug), this is fine.