### PR TITLE
More precise ``metric_prefix()`` implementation

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1505,6 +1505,8 @@ def metric_prefix(number: Union[int, float], base: int) -> Tuple[float, str]:
     (1.001, 'K')
     >>> metric_prefix(1000000, 1000)
     (1.0, 'M')
+    >>> metric_prefix(10**26, 1000)
+    (100.0, 'Y')
     >>> metric_prefix(1000**10, 1000)
     (1.0, 'Q')
     >>> metric_prefix(1000**11, 1000)
@@ -1517,12 +1519,11 @@ def metric_prefix(number: Union[int, float], base: int) -> Tuple[float, str]:
     else:
         sign = 1
 
-    for prefix in prefixes:
-        if number < base:
-            return sign * float(number), prefix
-        number /= base
+    for i, prefix in enumerate(prefixes):
+        if number < base ** (i + 1):
+            return sign * number / (base**i), prefix
     else:
-        return sign * float(number) * base, prefix
+        return sign * number / (base**i), prefix
 
 
 def shorten_with_metric_prefix(amount: int) -> str:


### PR DESCRIPTION
Do only one division at the very end.

Fix this loss of precision:

```
>>> metric_prefix(10**26, 1000)
(99.99999999999999, 'Y')
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
