### PR TITLE
Add test suite for running tool tests via Playwright using the tool form

### DIFF
--- a/.github/workflows/tool_form_harness.yaml
+++ b/.github/workflows/tool_form_harness.yaml
@@ -1,0 +1,114 @@
+name: Tool form harness tests
+on:
+  push:
+    paths:
+      - 'client/src/components/Form/**'
+      - 'client/src/components/Tool/**'
+      - 'client/src/utils/navigation/navigation.yml'
+      - 'lib/galaxy/navigation/navigation.yml'
+      - 'lib/galaxy/selenium/navigates_galaxy.py'
+      - 'lib/galaxy_test/selenium/framework.py'
+      - 'lib/galaxy_test/selenium/test_tool_form_harness.py'
+      - 'test/functional/tools/**'
+      - '.github/workflows/tool_form_harness.yaml'
+  pull_request:
+    paths:
+      - 'client/src/components/Form/**'
+      - 'client/src/components/Tool/**'
+      - 'client/src/utils/navigation/navigation.yml'
+      - 'lib/galaxy/navigation/navigation.yml'
+      - 'lib/galaxy/selenium/navigates_galaxy.py'
+      - 'lib/galaxy_test/selenium/framework.py'
+      - 'lib/galaxy_test/selenium/test_tool_form_harness.py'
+      - 'test/functional/tools/**'
+      - '.github/workflows/tool_form_harness.yaml'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
+env:
+  GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
+  GALAXY_TEST_E2E_TOOL_TESTS: '1'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+  GALAXY_TEST_SELENIUM_RETRIES: 1
+  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
+  GALAXY_TEST_SELENIUM_HEADLESS: 1
+  YARN_INSTALL_OPTS: --frozen-lockfile
+  GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build-client:
+    uses: ./.github/workflows/build_client.yaml
+  test:
+    name: Test
+    needs: [build-client]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - uses: actions/checkout@v6
+        with:
+          path: 'galaxy root'
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
+      - name: Cache galaxy venv
+        uses: actions/cache@v5
+        with:
+          path: 'galaxy root/.venv'
+          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-playwright
+      - name: Install dependencies
+        run: ./scripts/common_startup.sh --dev-wheels --skip-client-build
+        working-directory: 'galaxy root'
+      - name: Install Playwright
+        run: |
+          . .venv/bin/activate
+          playwright install chromium --with-deps
+        working-directory: 'galaxy root'
+      - name: Restore client cache
+        uses: actions/cache@v5
+        with:
+          fail-on-cache-miss: true
+          key: galaxy-static-${{ needs.build-client.outputs.commit-id }}
+          path: 'galaxy root/static'
+      - name: Run tests
+        run: ./run_tests.sh --coverage -playwright lib/galaxy_test/selenium/test_tool_form_harness.py
+        working-directory: 'galaxy root'
+      - uses: codecov/codecov-action@v5
+        with:
+          flags: tool-form-harness
+          working-directory: 'galaxy root'
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: Tool form harness test results (${{ matrix.python-version }})
+          path: 'galaxy root/run_playwright_tests.html'
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: Tool form harness debug info (${{ matrix.python-version }})
+          path: 'galaxy root/database/test_errors'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -669,9 +669,17 @@ tool_form:
     parameter_data_label: 'div.ui-form-element[id="form-element-${parameter}"] [data-description="form data label"]'
     parameter_data_select: 'div.ui-form-element[id="form-element-${parameter}"] .multiselect'
 
+    parameter_checkbox_input: 'div.ui-form-element[id="form-element-${parameter}"] input[type="checkbox"]'
+    parameter_color_input: 'div.ui-form-element[id="form-element-${parameter}"] input[type="color"]'
+    parameter_text_input: 'div.ui-form-element[id="form-element-${parameter}"] input'
+    parameter_form_selection: 'div.ui-form-element[id="form-element-${parameter}"] .form-selection'
+    parameter_multiselect_tag_close: 'div.ui-form-element[id="form-element-${parameter}"] i.multiselect__tag-icon'
+    parameter_drilldown_option: 'div.ui-form-element[id="form-element-${parameter}"] #drilldown-option-${value}'
+
     repeat_insert: '[data-description="repeat insert"]'
     repeat_move_up: '#${parameter}_up'
     repeat_move_down: '#${parameter}_down'
+    section_header: '.ui-portlet-section .portlet-header'
     reference: '.formatted-reference'
     about: '.tool-footer'
     storage_options: '.tool-storage'

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -2143,14 +2143,14 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         edit_button_element = rules_div_element.find_element(By.CSS_SELECTOR, ".form-rules-edit button")
         edit_button_element.click()
 
-    def tool_set_value(self, expanded_parameter_id, value, expected_type=None):
+    def tool_set_value(self, expanded_parameter_id, value, expected_type=None, multiple=False):
         div_element = self.tool_parameter_div(expanded_parameter_id)
         assert div_element
         if expected_type in ["select", "data", "data_collection"]:
             select_field = self.components.tool_form.parameter_data_select(
                 parameter=expanded_parameter_id
             ).wait_for_visible()
-            self.select_set_value(select_field, value)
+            self.select_set_value(select_field, value, multiple=multiple)
         else:
             input_element = div_element.find_element(By.CSS_SELECTOR, "input")
             # Clear default value

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -24,11 +24,16 @@ from gxformat2 import (
     ImporterGalaxyInterface,
 )
 from requests.models import Response
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 from galaxy.selenium import driver_factory
 from galaxy.selenium.axe_results import assert_baseline_accessible
 from galaxy.selenium.context import GalaxySeleniumContext
-from galaxy.selenium.has_driver import DEFAULT_AXE_SCRIPT_URL
+from galaxy.selenium.has_driver import (
+    DEFAULT_AXE_SCRIPT_URL,
+    SeleniumTimeoutException,
+)
 from galaxy.selenium.has_driver_protocol import (
     BackendType,
     HasDriverProtocol,
@@ -39,6 +44,7 @@ from galaxy.selenium.navigates_galaxy import (
     NavigatesGalaxy,
     retry_during_transitions,
 )
+from galaxy.tool_util.verify import verify
 from galaxy.tool_util.verify.interactor import prepare_request_params
 from galaxy.util import (
     asbool,
@@ -62,6 +68,7 @@ from galaxy_test.base.env import (
 )
 from galaxy_test.base.populators import (
     load_data_dict,
+    stage_inputs,
     YamlContentT,
 )
 from galaxy_test.base.testcase import FunctionalTestCase
@@ -701,6 +708,466 @@ class UsesHistoryItemAssertions(NavigatesGalaxyMixin):
         item_body = self.history_panel_item_component(hid=hid)
         hid_text = item_body.hid.wait_for_text()
         assert hid_text == f"{hid}:", hid_text
+
+
+class RunsToolTests(NavigatesGalaxyMixin):
+    """Mixin that drives tool execution through the browser form using tool test definitions."""
+
+    def run_tool_test(self, tool_id: str, test_index: int = 0, galaxy_interactor=None, dataset_populator=None):
+        """Top-level entry point: fetch test def, stage data, fill form, execute, verify."""
+        assert galaxy_interactor is not None, "galaxy_interactor is required"
+        assert dataset_populator is not None, "dataset_populator is required"
+        test_defs = galaxy_interactor.get_tool_tests(tool_id)
+        assert len(test_defs) > test_index, f"Tool {tool_id} has {len(test_defs)} tests, requested index {test_index}"
+        test_def = test_defs[test_index]
+        history_id = self.current_history_id()
+        self.home()
+        hid_map, required_filenames, collection_hid_map = self._stage_test_data(test_def, history_id, galaxy_interactor)
+        pre_job_ids = {j["id"] for j in dataset_populator.history_jobs_for_tool(history_id, tool_id)}
+        self.tool_open(tool_id)
+        self._fill_tool_test_inputs(test_def, hid_map, required_filenames, collection_hid_map)
+        self.tool_form_execute()
+        self._verify_tool_test_outputs(test_def, history_id, tool_id, pre_job_ids, dataset_populator)
+
+    # -- Data staging --
+
+    def _stage_test_data(
+        self, test_def: dict, history_id: str, galaxy_interactor
+    ) -> tuple[dict[str, int], set[str], dict[str, int]]:
+        """Stage test data files and collections using stage_inputs().
+
+        Returns (hid_map, required_filenames, collection_hid_map) where:
+        - hid_map maps filenames to HIDs for scalar data params
+        - required_filenames is the set of filenames from required_files
+        - collection_hid_map maps param keys to collection HIDs
+        """
+        required_files = test_def.get("required_files", [])
+        inputs = test_def.get("inputs", {})
+        required_filenames = {f[0] for f in required_files}
+
+        file_meta: dict[str, dict] = {}
+        for entry in required_files:
+            fname = entry[0]
+            if len(entry) > 1 and isinstance(entry[1], dict):
+                file_meta[fname] = entry[1]
+
+        job: dict = {}
+        filename_by_key: dict[str, str] = {}
+        collection_keys: set[str] = set()
+
+        for key, value in inputs.items():
+            raw = value[0] if isinstance(value, list) and len(value) == 1 else value
+            if isinstance(raw, dict) and raw.get("model_class") == "TestCollectionDef":
+                job[key] = self._convert_collection_def(raw, file_meta)
+                collection_keys.add(key)
+            elif isinstance(raw, str) and raw in required_filenames:
+                file_entry: dict = {"class": "File", "path": raw}
+                ftype = file_meta.get(raw, {}).get("ftype")
+                if ftype:
+                    file_entry["filetype"] = ftype
+                job[key] = file_entry
+                filename_by_key[key] = raw
+
+        if not job:
+            return {}, required_filenames, {}
+
+        staged_job, datasets = stage_inputs(
+            galaxy_interactor,
+            history_id,
+            job,
+            use_path_paste=False,
+            tool_or_workflow="tool",
+        )
+
+        dataset_id_to_hid = {ds["id"]: ds["hid"] for ds in datasets}
+        hid_map: dict[str, int] = {}
+        for key, ref in staged_job.items():
+            if key in collection_keys:
+                continue
+            filename = filename_by_key.get(key)
+            if filename and ref.get("id") in dataset_id_to_hid:
+                hid_map[filename] = dataset_id_to_hid[ref["id"]]
+
+        collection_hid_map: dict[str, int] = {}
+        if collection_keys:
+            contents = self.api_get(f"histories/{history_id}/contents?type=dataset_collection")
+            collection_id_to_hid = {item["id"]: item["hid"] for item in contents}
+            for key in collection_keys:
+                ref = staged_job.get(key, {})
+                if ref.get("id") in collection_id_to_hid:
+                    collection_hid_map[key] = collection_id_to_hid[ref["id"]]
+
+        for hid in hid_map.values():
+            self.history_panel_wait_for_hid_ok(hid)
+        for hid in collection_hid_map.values():
+            self.history_panel_wait_for_hid_ok(hid)
+
+        return hid_map, required_filenames, collection_hid_map
+
+    @staticmethod
+    def _convert_collection_def(coll_def: dict, file_meta: dict | None = None) -> dict:
+        """Convert a TestCollectionDef dict to a CWL-like collection job entry."""
+        file_meta = file_meta or {}
+        elements = []
+        for elem in coll_def["elements"]:
+            inner = elem["element_definition"]
+            if inner.get("model_class") == "TestCollectionDef":
+                converted = RunsToolTests._convert_collection_def(inner, file_meta)
+                converted["identifier"] = elem["element_identifier"]
+                elements.append(converted)
+            else:
+                file_entry: dict = {
+                    "identifier": elem["element_identifier"],
+                    "class": "File",
+                    "path": inner["value"],
+                }
+                ftype = file_meta.get(inner["value"], {}).get("ftype")
+                if ftype:
+                    file_entry["filetype"] = ftype
+                elements.append(file_entry)
+        result: dict = {
+            "class": "Collection",
+            "collection_type": coll_def["collection_type"],
+            "elements": elements,
+        }
+        if coll_def.get("name"):
+            result["name"] = coll_def["name"]
+        return result
+
+    # -- Form filling --
+
+    def _fill_tool_test_inputs(
+        self,
+        test_def: dict,
+        hid_map: dict,
+        required_filenames: set,
+        collection_hid_map: dict | None = None,
+    ):
+        """Fill tool form inputs from test definition.
+
+        Two-pass approach for conditionals: set shallow params first so
+        conditionals reveal nested params, then retry deferred ones.
+        Data/collection params set last.
+        """
+        inputs = test_def.get("inputs", {})
+        if not inputs:
+            return
+        collection_hid_map = collection_hid_map or {}
+
+        data_params = []
+        collection_params = []
+        non_data_params = []
+        repeat_counts: dict[str, int] = {}
+
+        for key, value in inputs.items():
+            raw_value = value[0] if isinstance(value, list) and len(value) == 1 else value
+
+            repeat_match = self._parse_repeat_key(key)
+            if repeat_match:
+                repeat_name, repeat_index, _child_key = repeat_match
+                if repeat_name not in repeat_counts:
+                    repeat_counts[repeat_name] = 0
+                repeat_counts[repeat_name] = max(repeat_counts[repeat_name], repeat_index + 1)
+
+            if isinstance(raw_value, dict) and raw_value.get("model_class") == "TestCollectionDef":
+                collection_params.append((key, raw_value))
+            elif isinstance(raw_value, str) and raw_value in required_filenames:
+                data_params.append((key, value))
+            else:
+                non_data_params.append((key, value))
+
+        for repeat_name, count in repeat_counts.items():
+            self._add_repeat_instances(repeat_name, count)
+
+        self._expand_collapsed_sections()
+
+        non_data_params.sort(key=lambda kv: kv[0].count("|"))
+
+        deferred = []
+        for key, value in non_data_params:
+            try:
+                self._set_tool_form_value(key, value, required_filenames)
+                self.sleep_for(self.wait_types.UX_RENDER)
+            except (NoSuchElementException, SeleniumTimeoutException, AssertionError):
+                deferred.append((key, value))
+
+        if deferred:
+            self.sleep_for(self.wait_types.UX_RENDER)
+            for key, value in deferred:
+                self._set_tool_form_value(key, value, required_filenames)
+
+        for key, value in data_params:
+            if isinstance(value, list) and len(value) == 1:
+                value = value[0]
+            hid = hid_map.get(value)
+            assert hid is not None, f"No staged file for data param {key}={value}"
+            is_multiple = self._is_multi_data_param(key)
+            if is_multiple:
+                self._clear_multiselect_tags(key)
+            self.tool_set_value(key, f"{hid}: {value}", expected_type="data", multiple=is_multiple)
+
+        for key, coll_def in collection_params:
+            hid = collection_hid_map.get(key)
+            assert hid is not None, f"No staged collection for param {key}"
+            coll_name = coll_def.get("name", "")
+            self.tool_set_value(key, f"{hid}: {coll_name}", expected_type="data")
+
+    def _is_multi_data_param(self, expanded_id: str) -> bool:
+        return not self.components.tool_form.parameter_form_selection(parameter=expanded_id).is_absent
+
+    def _clear_multiselect_tags(self, expanded_id: str):
+        tag_close = self.components.tool_form.parameter_multiselect_tag_close(parameter=expanded_id)
+        for _ in range(20):
+            close_buttons = tag_close.all()
+            if not close_buttons:
+                break
+            close_buttons[0].click()
+            self.sleep_for(self.wait_types.UX_RENDER)
+
+    @staticmethod
+    def _parse_repeat_key(key: str):
+        import re
+
+        match = re.match(r"^(.+?)_(\d+)\|(.+)$", key)
+        if match:
+            return match.group(1), int(match.group(2)), match.group(3)
+        return None
+
+    def _add_repeat_instances(self, repeat_name: str, count: int):
+        for _ in range(count):
+            self.components.tool_form.repeat_insert.wait_for_and_click()
+            self.sleep_for(self.wait_types.UX_RENDER)
+
+    def _expand_collapsed_sections(self):
+        self.components.tool_form.execute.wait_for_visible()
+        for header in self.components.tool_form.section_header.all():
+            header.click()
+            self.sleep_for(self.wait_types.UX_RENDER)
+
+    # -- Type detection and value setting --
+
+    def _detect_param_type(self, expanded_id: str) -> str:
+        """Inspect DOM to determine param type.
+
+        Detection order matters:
+        - drilldown before checkbox_select (drilldown also has checkboxes)
+        - checkbox_select before boolean (both have input[type='checkbox'])
+        """
+        tf = self.components.tool_form
+
+        param_div = tf.parameter_div(parameter=expanded_id).wait_for_visible()
+        if param_div.find_elements(By.CSS_SELECTOR, tf.drilldown_option.selector):
+            return "drilldown"
+
+        checkboxes = tf.parameter_checkbox_input(parameter=expanded_id).all()
+        if len(checkboxes) > 1:
+            return "checkbox_select"
+        if checkboxes:
+            return "boolean"
+
+        if not tf.parameter_color_input(parameter=expanded_id).is_absent:
+            return "color"
+        if not tf.parameter_select(parameter=expanded_id).is_absent:
+            return "select"
+
+        return "text"
+
+    def _set_tool_form_value(self, key: str, value, required_filenames: set):
+        if isinstance(value, list) and len(value) == 1:
+            value = value[0]
+        if isinstance(value, str) and value in required_filenames:
+            return
+
+        param_type = self._detect_param_type(key)
+
+        if param_type == "drilldown":
+            values = value if isinstance(value, list) else [value]
+            self._set_drilldown_value(key, values)
+        elif param_type == "checkbox_select":
+            values = value if isinstance(value, list) else [value]
+            self._set_checkbox_select_value(key, values)
+        elif param_type == "boolean":
+            self._set_boolean_value(key, value)
+        elif param_type == "color":
+            self._set_color_value(key, value)
+        elif param_type == "select":
+            self.tool_set_value(key, str(value), expected_type="select")
+        else:
+            self._set_text_value(key, str(value))
+
+    def _set_boolean_value(self, expanded_id: str, value):
+        checkbox = self.components.tool_form.parameter_checkbox_input(parameter=expanded_id).wait_for_present()
+        is_checked = checkbox.is_selected()
+        want_checked = str(value).lower() in ("true", "1", "yes")
+        if is_checked != want_checked:
+            self.execute_script("arguments[0].click();", checkbox)
+
+    def _set_checkbox_select_value(self, expanded_id: str, values: list):
+        all_checkboxes = self.components.tool_form.parameter_checkbox_input(parameter=expanded_id).all()
+        for val in values:
+            matched = [cb for cb in all_checkboxes if cb.get_attribute("value") == val]
+            assert matched, f"No checkbox with value '{val}' in param {expanded_id}"
+            if not matched[0].is_selected():
+                self.execute_script("arguments[0].click();", matched[0])
+
+    def _set_drilldown_value(self, expanded_id: str, values: list):
+        """Set drill-down param by clicking option checkboxes.
+
+        TODO: DOM id is ``drilldown-option-{option.name}`` but test API returns
+        option *values*. Works only when name == value. If a tool has
+        ``<option name="Label" value="key">``, the lookup will fail.
+        Fixing requires changing FormDrilldownOption.vue (breaks library export)
+        or adding a value->name mapping step here.
+        """
+        for val in values:
+            checkbox = self.components.tool_form.parameter_drilldown_option(
+                parameter=expanded_id, value=val
+            ).wait_for_present()
+            if not checkbox.is_selected():
+                self.execute_script("arguments[0].click();", checkbox)
+
+    def _set_color_value(self, expanded_id: str, value: str):
+        color_input = self.components.tool_form.parameter_color_input(parameter=expanded_id).wait_for_present()
+        self._set_input_value_via_js(color_input, value)
+
+    def _set_text_value(self, expanded_id: str, value: str):
+        input_element = self.components.tool_form.parameter_text_input(parameter=expanded_id).wait_for_present()
+        self._set_input_value_via_js(input_element, value)
+
+    def _set_input_value_via_js(self, element, value):
+        self.execute_script(
+            "arguments[0].value = arguments[1];"
+            "arguments[0].dispatchEvent(new Event('input', {bubbles: true}));"
+            "arguments[0].dispatchEvent(new Event('change', {bubbles: true}));",
+            element,
+            value,
+        )
+
+    # -- Output verification --
+
+    def _verify_tool_test_outputs(
+        self, test_def: dict, history_id: str, tool_id: str, pre_job_ids: set, dataset_populator
+    ):
+
+        outputs = test_def.get("outputs", [])
+        output_collections = test_def.get("output_collections", [])
+        if not outputs and not output_collections:
+            return
+
+        def _find_new_job(driver=None):
+            jobs = dataset_populator.history_jobs_for_tool(history_id, tool_id)
+            new_jobs = [j for j in jobs if j["id"] not in pre_job_ids]
+            if new_jobs:
+                return new_jobs[0]
+            return None
+
+        new_job = self._wait_on(_find_new_job, "tool job to appear in history")
+        assert new_job is not None
+        job_id = new_job["id"]
+        dataset_populator.wait_for_job(job_id, assert_ok=True)
+
+        all_job_outputs = dataset_populator.job_outputs(job_id)
+
+        if outputs:
+            output_id_by_name = {o["name"]: o["dataset"]["id"] for o in all_job_outputs if "dataset" in o}
+            for output_def in outputs:
+                output_name = output_def.get("name")
+                assert (
+                    output_name in output_id_by_name
+                ), f"Output '{output_name}' not found in job outputs: {list(output_id_by_name.keys())}"
+                dataset_id = output_id_by_name[output_name]
+                output_content = dataset_populator.get_history_dataset_content(
+                    history_id,
+                    dataset_id=dataset_id,
+                    type="bytes",
+                    wait=False,
+                )
+                verify(output_name, output_content, output_def.get("attributes", {}))
+
+        if output_collections:
+            collection_id_by_name = {
+                o["name"]: o["dataset_collection_instance"]["id"]
+                for o in all_job_outputs
+                if "dataset_collection_instance" in o
+            }
+            for oc_def in output_collections:
+                oc_name = oc_def["name"]
+                assert (
+                    oc_name in collection_id_by_name
+                ), f"Output collection '{oc_name}' not found in job outputs: {list(collection_id_by_name.keys())}"
+                self._verify_output_collection(oc_def, collection_id_by_name[oc_name], history_id, dataset_populator)
+
+    def _verify_output_collection(self, oc_def: dict, collection_id: str, history_id: str, dataset_populator):
+
+        data_collection = dataset_populator.get_history_collection_details(
+            history_id,
+            content_id=collection_id,
+            wait=False,
+        )
+
+        expected_type = oc_def.get("attributes", {}).get("type")
+        if expected_type:
+            actual_type = data_collection["collection_type"]
+            assert (
+                actual_type == expected_type
+            ), f"Collection '{oc_def['name']}': expected type '{expected_type}', got '{actual_type}'"
+
+        expected_count = oc_def.get("attributes", {}).get("count")
+        if expected_count is not None:
+            actual_count = len(data_collection["elements"])
+            assert actual_count == int(
+                expected_count
+            ), f"Collection '{oc_def['name']}': expected {expected_count} elements, got {actual_count}"
+
+        element_tests = oc_def.get("element_tests", {})
+        elements_by_id = {e["element_identifier"]: e for e in data_collection["elements"]}
+        for element_id, element_test in element_tests.items():
+            assert element_id in elements_by_id, f"Element '{element_id}' not found in collection '{oc_def['name']}'"
+            element = elements_by_id[element_id]
+            if isinstance(element_test, list):
+                _element_outfile, element_attrib = element_test
+            else:
+                element_attrib = element_test
+
+            if element.get("element_type") == "dataset_collection":
+                sub_elements = element["object"]["elements"]
+                sub_tests = element_attrib.get("elements", {})
+                sub_elements_by_id = {e["element_identifier"]: e for e in sub_elements}
+                for sub_id, sub_test in sub_tests.items():
+                    assert (
+                        sub_id in sub_elements_by_id
+                    ), f"Element '{sub_id}' not found in sub-collection '{element_id}'"
+                    sub_elem = sub_elements_by_id[sub_id]
+                    if isinstance(sub_test, list):
+                        _sub_outfile, sub_attrib = sub_test
+                    else:
+                        sub_attrib = sub_test
+                    if sub_elem.get("element_type") == "dataset_collection":
+                        sub_oc_def = {
+                            "name": f"{oc_def['name']}/{element_id}/{sub_id}",
+                            "attributes": {},
+                            "element_tests": sub_attrib.get("elements", {}),
+                        }
+                        self._verify_output_collection(
+                            sub_oc_def, sub_elem["object"]["id"], history_id, dataset_populator
+                        )
+                    else:
+                        content = dataset_populator.get_history_dataset_content(
+                            history_id,
+                            dataset_id=sub_elem["object"]["id"],
+                            type="bytes",
+                            wait=False,
+                        )
+                        verify(sub_id, content, sub_attrib if isinstance(sub_attrib, dict) else {})
+            else:
+                hda_id = element["object"]["id"]
+                content = dataset_populator.get_history_dataset_content(
+                    history_id,
+                    dataset_id=hda_id,
+                    type="bytes",
+                    wait=False,
+                )
+                verify(element_id, content, element_attrib if isinstance(element_attrib, dict) else {})
 
 
 EXAMPLE_WORKFLOW_URL_1 = (

--- a/lib/galaxy_test/selenium/test_tool_form_harness.py
+++ b/lib/galaxy_test/selenium/test_tool_form_harness.py
@@ -3,6 +3,7 @@ reusing tool test definitions (XML <tests> blocks) for inputs and output
 verification.
 """
 
+from galaxy.util.unittest_utils import skip_unless_environ
 from .framework import (
     managed_history,
     RunsToolTests,
@@ -11,6 +12,7 @@ from .framework import (
 )
 
 
+@skip_unless_environ("GALAXY_TEST_E2E_TOOL_TESTS")
 class TestToolFormHarness(SeleniumTestCase, RunsToolTests):
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_tool_form_harness.py
+++ b/lib/galaxy_test/selenium/test_tool_form_harness.py
@@ -1,0 +1,169 @@
+"""Selenium tests that drive tool execution through the browser tool form,
+reusing tool test definitions (XML <tests> blocks) for inputs and output
+verification.
+"""
+
+from .framework import (
+    managed_history,
+    RunsToolTests,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestToolFormHarness(SeleniumTestCase, RunsToolTests):
+    ensure_registered = True
+
+    def _run(self, tool_id, test_index=0):
+        interactor = self.api_interactor_for_logged_in_user()
+        self.run_tool_test(
+            tool_id,
+            test_index=test_index,
+            galaxy_interactor=interactor,
+            dataset_populator=self.dataset_populator,
+        )
+
+    @selenium_test
+    @managed_history
+    def test_environment_variables(self):
+        self._run("environment_variables", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_float(self):
+        self._run("gx_float", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_select(self):
+        self._run("gx_select", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_boolean(self):
+        self._run("gx_boolean", test_index=2)
+
+    @selenium_test
+    @managed_history
+    def test_gx_conditional_select(self):
+        self._run("gx_conditional_select", test_index=1)
+
+    @selenium_test
+    @managed_history
+    def test_gx_section_boolean(self):
+        self._run("gx_section_boolean", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_data(self):
+        self._run("gx_data", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_repeat_boolean(self):
+        self._run("gx_repeat_boolean", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_color(self):
+        self._run("gx_color", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_simple_constructs(self):
+        self._run("simple_constructs", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_conditional_boolean(self):
+        self._run("gx_conditional_boolean", test_index=2)
+
+    @selenium_test
+    @managed_history
+    def test_multi_output(self):
+        self._run("multi_output", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_data_optional(self):
+        self._run("data_optional", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_implicit_default_conds(self):
+        self._run("implicit_default_conds", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_column_param(self):
+        self._run("column_param", test_index=1)
+
+    @selenium_test
+    @managed_history
+    def test_multi_repeats(self):
+        self._run("multi_repeats", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_gx_repeat_data(self):
+        self._run("gx_repeat_data", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_multi_select(self):
+        self._run("multi_select", test_index=1)
+
+    @selenium_test
+    @managed_history
+    def test_multi_select_multiple(self):
+        self._run("multi_select", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_drill_down(self):
+        self._run("drill_down", test_index=2)
+
+    @selenium_test
+    @managed_history
+    def test_multi_data_param(self):
+        self._run("multi_data_param", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_collection_paired(self):
+        self._run("collection_paired_test", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_collection_nested(self):
+        self._run("collection_nested_test", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_collection_nested_paired(self):
+        self._run("collection_nested_test", test_index=1)
+
+    @selenium_test
+    @managed_history
+    def test_collection_list(self):
+        self._run("collection_creates_list", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_collection_mixed_param(self):
+        self._run("collection_mixed_param", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_collection_optional_absent(self):
+        self._run("collection_optional_param", test_index=1)
+
+    @selenium_test
+    @managed_history
+    def test_collection_creates_pair(self):
+        self._run("collection_creates_pair", test_index=0)
+
+    @selenium_test
+    @managed_history
+    def test_collection_creates_list_of_pairs(self):
+        self._run("collection_creates_list_of_pairs", test_index=0)

--- a/test/functional/tools/parameters/gx_data.xml
+++ b/test/functional/tools/parameters/gx_data.xml
@@ -9,5 +9,13 @@ cat '$parameter' >> '$output'
         <data name="output" format="data" />
     </outputs>
     <tests>
+        <test>
+            <param name="parameter" value="simple_line.txt" />
+            <output name="output">
+                <assert_contents>
+                    <has_line line="This is a line of text." />
+                </assert_contents>
+            </output>
+        </test>
     </tests>
 </tool>

--- a/test/functional/tools/parameters/gx_repeat_boolean.xml
+++ b/test/functional/tools/parameters/gx_repeat_boolean.xml
@@ -11,5 +11,15 @@ echo '$parameter[0].boolean_parameter' >> '$output'
         <data name="output" format="txt" />
     </outputs>
     <tests>
+        <test>
+            <repeat name="parameter">
+                <param name="boolean_parameter" value="true" />
+            </repeat>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="true" />
+                </assert_contents>
+            </output>
+        </test>
     </tests>
 </tool>

--- a/test/functional/tools/parameters/gx_repeat_data.xml
+++ b/test/functional/tools/parameters/gx_repeat_data.xml
@@ -15,7 +15,7 @@ cat '$parameter[0].data_parameter' >> '$output'
             <repeat name="parameter">
                 <param name="data_parameter" value="1.bed" />
             </repeat>
-            <output name="out_file1" file="1.bed" />
+            <output name="output" file="1.bed" />
         </test>
     </tests>
 </tool>


### PR DESCRIPTION
The tool form is a complex component and I think it would be great to validate the tool tests with it. This is too many new E2E tests for each PR though so I broke it out into its own suite and tried to limit when it runs. I'm tempted remove some of the paths that prompt it to run even more though (navigation.yml for instance changes a lot and most of those changes wouldn't affect this). I would like to expand the number of framework tests we're running here and limit the frequency/occurrence of the runs. 

This is work I promised on #21842.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
