### PR TITLE
Fix text alignment in invocation grid rows

### DIFF
--- a/client/src/components/History/SwitchToHistoryLink.vue
+++ b/client/src/components/History/SwitchToHistoryLink.vue
@@ -131,7 +131,10 @@ const linkClass = computed(() => {
 .history-link {
     display: flex;
     gap: 1px;
-    align-items: center;
-    justify-content: space-between;
+    align-items: baseline;
+}
+
+.history-link :deep(.g-link) {
+    text-align: start;
 }
 </style>


### PR DESCRIPTION
Fixes #21143.

The history name in SwitchToHistoryLink had two alignment issues when wrapping to multiple lines:

1. The flex container used `justify-content: space-between` and `align-items: center`, which pushed the archive/purge icon to the far right and vertically centered it against multi-line text. Switched to `baseline` and dropped `space-between`.

2. GLink renders as a `<button>` when no `href`/`to` prop is provided, and browsers default buttons to `text-align: center`. On single-line text this is invisible, but wrapped text center-aligns each line. Used a scoped `:deep()` selector to override this on the history link.