### PR TITLE
Add toggle to invocation graph for viewing step inputs/outputs like in the editor

### DIFF
--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -41,6 +41,7 @@ const props = defineProps({
     fixedHeight: { type: Number, default: undefined },
     populatedInputs: { type: Boolean, default: false },
     loading: { type: Boolean, default: false },
+    detailedView: { type: Boolean, default: false },
 });
 
 const { stateStore, stepStore } = useWorkflowStores();
@@ -224,7 +225,7 @@ defineExpose({
                     :scroll="scroll"
                     :scale="scale"
                     :readonly="readonly"
-                    :is-invocation="props.isInvocation"
+                    :is-invocation="props.isInvocation && (!props.detailedView || activeNodeId !== step.id)"
                     :populated-inputs="props.populatedInputs"
                     @pan-by="panBy"
                     @stopDragging="onStopDragging"

--- a/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
+++ b/client/src/components/Workflow/Invocation/Graph/InvocationGraph.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faArrowCircleLeft, faArrowCircleRight, faArrowDown, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faArrowCircleLeft, faArrowCircleRight, faArrowDown, faEye, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { until } from "@vueuse/core";
 import { BAlert, BCard, BCardBody, BCardHeader } from "bootstrap-vue";
@@ -60,6 +60,7 @@ const pollTimeout = ref<any>(null);
 const showSideOverlay = ref(false);
 const stepCard = ref<BCard | null>(null);
 const loadedJobInfo = ref<typeof WorkflowInvocationStep | null>(null);
+const detailedViewEnabled = ref(false);
 const workflowGraph = ref<InstanceType<typeof WorkflowGraph> | null>(null);
 
 const { datatypesMapper } = useDatatypesMapper();
@@ -171,6 +172,10 @@ function stepClicked(nodeId: number | null) {
         scrollStepToView();
     }
 }
+
+function toggleDetailedView() {
+    detailedViewEnabled.value = !detailedViewEnabled.value;
+}
 </script>
 
 <template>
@@ -204,6 +209,7 @@ function stepClicked(nodeId: number | null) {
                             :scroll-to-id="activeNodeId"
                             :show-minimap="props.showMinimap"
                             :show-zoom-controls="props.showZoomControls"
+                            :detailed-view="detailedViewEnabled"
                             :fixed-height="60"
                             is-invocation
                             readonly
@@ -212,6 +218,25 @@ function stepClicked(nodeId: number | null) {
                             v-if="activeNodeId !== null && showSideOverlay"
                             class="graph-scroll-overlay overlay-right" />
                     </BCard>
+
+                    <GButton
+                        v-if="activeNodeId !== null"
+                        class="detailed-view-button"
+                        tooltip
+                        :title="
+                            detailedViewEnabled
+                                ? 'Hide step connections'
+                                : 'Show the inputs and outputs of the selected step, including all connections leading in and out'
+                        "
+                        data-description="toggle step connections button"
+                        size="small"
+                        color="blue"
+                        outline
+                        :pressed="detailedViewEnabled"
+                        @click="toggleDetailedView">
+                        <FontAwesomeIcon :icon="faEye" fixed-width />
+                        Show Connections
+                    </GButton>
                 </div>
             </div>
             <BCard v-if="activeNodeId !== null && activeStep" ref="stepCard" class="invocation-step-card mt-2" no-body>
@@ -306,5 +331,13 @@ function stepClicked(nodeId: number | null) {
 
 .invocation-step-card {
     min-height: 500px;
+}
+
+.detailed-view-button {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 150;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 </style>


### PR DESCRIPTION
When this is toggled, we see the step just like it would appear in the editor.

https://github.com/user-attachments/assets/4f5c3437-392e-4da5-9e0d-cfd7ccbc69e0

Fixes part of https://github.com/galaxyproject/galaxy/issues/21086

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
