### PR TITLE
Prevent tag placeholder text wrapping in narrow columns

### DIFF
--- a/client/src/components/TagsMultiselect/HeadlessMultiselect.vue
+++ b/client/src/components/TagsMultiselect/HeadlessMultiselect.vue
@@ -431,6 +431,7 @@ onClickOutside(
         background: none;
         cursor: text;
         text-align: left;
+        white-space: nowrap;
         margin: 0;
         border: none;
         width: 100%;


### PR DESCRIPTION
The "Add Tags" toggle button in HeadlessMultiselect wraps its text and icon vertically when rendered in a narrow table column (e.g., the Tags column in the Dataset List). Adding `white-space: nowrap` to `.toggle-button` keeps "Add Tags" and the tag icon on a single line, letting the column width accommodate naturally.

Minor, but this prevents this jank:
<img width="649" height="466" alt="image" src="https://github.com/user-attachments/assets/cbddbf4d-d5fe-45e8-9ea4-88b4d0f00a02" />

After:
<img width="575" height="510" alt="image" src="https://github.com/user-attachments/assets/2393eff0-ea9e-4b80-a9f6-418701ce8b00" />

