### PR TITLE
[26.0] Include missing tools in stock_tool_paths.

### DIFF
--- a/lib/galaxy/tools/stock.py
+++ b/lib/galaxy/tools/stock.py
@@ -16,6 +16,7 @@ from galaxy.util.resources import files
 def stock_tool_paths():
     yield from _walk_directory_for_tools(files(galaxy.tools))
     yield from _walk_directory_for_tools(Path(galaxy_directory()) / "test" / "functional" / "tools")
+    yield from _walk_directory_for_tools(Path(galaxy_directory()) / "tools")
 
 
 def stock_tool_sources():

--- a/test/unit/app/tools/test_stock.py
+++ b/test/unit/app/tools/test_stock.py
@@ -9,6 +9,7 @@ def test_stock_tool_paths():
     assert "merge_collection.xml" in file_names
     assert "meme.xml" in file_names
     assert "output_auto_format.xml" in file_names
+    assert "parse_values_from_file.xml" in file_names
 
 
 def test_stock_tool_sources():


### PR DESCRIPTION
``stock_tool_paths()`` missed ``tools/expression_tools/`` (param_value_from_file, pick_value) — these are gaps in the API the tool shed is meant to be serving.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
