### PR TITLE
[26.0] Don't fail on probable delete race

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4737,14 +4737,16 @@ class Dataset(Base, StorableObject, Serializable):
 
     def full_delete(self):
         """Remove the file and extra files, marks deleted and purged"""
-        # os.unlink( self.file_name )
         try:
             self.object_store.delete(self)
         except galaxy.exceptions.ObjectNotFound:
             pass
         if (rel_path := self._extra_files_rel_path) is not None:
             if self.object_store.exists(self, extra_dir=rel_path, dir_only=True):
-                self.object_store.delete(self, entire_dir=True, extra_dir=rel_path, dir_only=True)
+                try:
+                    self.object_store.delete(self, entire_dir=True, extra_dir=rel_path, dir_only=True)
+                except galaxy.exceptions.ObjectNotFound:
+                    pass
         # TODO: purge metadata files
         self.deleted = True
         self.purged = True


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/22182
extra files dir does indeed not exist anymore, and we just mirror what we do with the primary file.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
