### PR TITLE
Implement more tool validation APIs in Galaxy to mirror the Tool Shed. 

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -5379,6 +5379,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/tools/{tool_id}/parsed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return Galaxy's meta model description of the tool's inputs and outputs. */
+        get: operations["tools__parsed"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tools/{tool_id}/versions/{tool_version}/parameter_landing_request_schema": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return a JSON schema description of the tool's inputs for the tool landing request API. */
+        get: operations["tools__versioned_parameter_landing_request_schema"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tools/{tool_id}/versions/{tool_version}/parameter_request_schema": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return a JSON schema description of the tool's inputs for the tool request API. */
+        get: operations["tools__versioned_parameter_request_schema"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tools/{tool_id}/versions/{tool_version}/parameter_test_case_xml_schema": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return a JSON schema description of the tool's inputs for test case construction. */
+        get: operations["tools__versioned_parameter_test_case_xml_schema"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tools/{tool_id}/versions/{tool_version}/parsed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return Galaxy's meta model description of the tool's inputs and outputs. */
+        get: operations["tools__versioned_parsed"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tours": {
         parameters: {
             query?: never;
@@ -19986,6 +20071,70 @@ export interface components {
              */
             workbook_type: "datasets" | "collection" | "collections";
         };
+        /** ParsedTool */
+        ParsedTool: {
+            /** citations */
+            citations: components["schemas"]["Citation"][];
+            /** description */
+            description: string | null;
+            /** edam_operations */
+            edam_operations: string[];
+            /** edam_topics */
+            edam_topics: string[];
+            /** help */
+            help: components["schemas"]["HelpContent"] | null;
+            /** id */
+            id: string;
+            /** inputs */
+            inputs: (
+                | components["schemas"]["CwlIntegerParameterModel"]
+                | components["schemas"]["CwlFloatParameterModel"]
+                | components["schemas"]["CwlStringParameterModel"]
+                | components["schemas"]["CwlBooleanParameterModel"]
+                | components["schemas"]["CwlNullParameterModel"]
+                | components["schemas"]["CwlFileParameterModel"]
+                | components["schemas"]["CwlDirectoryParameterModel"]
+                | components["schemas"]["CwlUnionParameterModel-Output"]
+                | components["schemas"]["TextParameterModel"]
+                | components["schemas"]["IntegerParameterModel"]
+                | components["schemas"]["FloatParameterModel"]
+                | components["schemas"]["BooleanParameterModel"]
+                | components["schemas"]["HiddenParameterModel"]
+                | components["schemas"]["SelectParameterModel"]
+                | components["schemas"]["DataParameterModel"]
+                | components["schemas"]["DataCollectionParameterModel"]
+                | components["schemas"]["DataColumnParameterModel"]
+                | components["schemas"]["DirectoryUriParameterModel"]
+                | components["schemas"]["RulesParameterModel"]
+                | components["schemas"]["DrillDownParameterModel-Output"]
+                | components["schemas"]["GroupTagParameterModel"]
+                | components["schemas"]["BaseUrlParameterModel"]
+                | components["schemas"]["GenomeBuildParameterModel"]
+                | components["schemas"]["ColorParameterModel"]
+                | components["schemas"]["ConditionalParameterModel-Output"]
+                | components["schemas"]["RepeatParameterModel-Output"]
+                | components["schemas"]["SectionParameterModel-Output"]
+            )[];
+            /** license */
+            license: string | null;
+            /** name */
+            name: string;
+            /** outputs */
+            outputs: (
+                | components["schemas"]["ToolOutputDataset"]
+                | components["schemas"]["ToolOutputCollection"]
+                | components["schemas"]["ToolOutputText"]
+                | components["schemas"]["ToolOutputInteger"]
+                | components["schemas"]["ToolOutputFloat"]
+                | components["schemas"]["ToolOutputBoolean"]
+            )[];
+            /** profile */
+            profile: string | null;
+            /** version */
+            version: string | null;
+            /** xrefs */
+            xrefs: components["schemas"]["XrefDict"][];
+        };
         /** ParsedWorkbook */
         ParsedWorkbook: {
             /** Extra Columns */
@@ -23408,6 +23557,31 @@ export interface components {
              */
             type: "boolean";
         };
+        /** ToolOutputCollection */
+        ToolOutputCollection: {
+            /**
+             * hidden
+             * @description If true, the output will not be shown in the history.
+             */
+            hidden: boolean;
+            /**
+             * label
+             * @description Output label. Will be used as dataset name in history.
+             */
+            label?: string | null;
+            /**
+             * name
+             * @description Parameter name. Used when referencing parameter in workflows.
+             */
+            name: string;
+            /** structure */
+            structure: components["schemas"]["ToolOutputCollectionStructure"];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "collection";
+        };
         /** ToolOutputCollectionStructure */
         ToolOutputCollectionStructure: {
             /** collection_type */
@@ -23425,6 +23599,61 @@ export interface components {
                 | null;
             /** structured_like */
             structured_like?: string | null;
+        };
+        /** ToolOutputDataset */
+        ToolOutputDataset: {
+            /** discover_datasets */
+            discover_datasets?:
+                | (
+                      | components["schemas"]["FilePatternDatasetCollectionDescription"]
+                      | components["schemas"]["ToolProvidedMetadataDatasetCollection"]
+                  )[]
+                | null;
+            /**
+             * format
+             * @description The short name for the output datatype.
+             */
+            format: string;
+            /**
+             * format_source
+             * @description This sets the data type of the output dataset(s) to be the same format as that of the specified tool input.
+             */
+            format_source?: string | null;
+            /**
+             * from_work_dir
+             * @description Relative path to a file produced by the tool in its working directory. Output’s contents are set to this file’s contents.
+             */
+            from_work_dir?: string | null;
+            /**
+             * hidden
+             * @description If true, the output will not be shown in the history.
+             */
+            hidden: boolean;
+            /**
+             * label
+             * @description Output label. Will be used as dataset name in history.
+             */
+            label?: string | null;
+            /**
+             * metadata_source
+             * @description This copies the metadata information from the tool’s input dataset to serve as default for information that cannot be detected from the output. One prominent use case is interval data with a non-standard column order that cannot be deduced from a header line, but which is known to be identical in the input and output datasets.
+             */
+            metadata_source?: string | null;
+            /**
+             * name
+             * @description Parameter name. Used when referencing parameter in workflows.
+             */
+            name: string;
+            /**
+             * precreate_directory
+             * @default false
+             */
+            precreate_directory: boolean | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "data";
         };
         /** ToolOutputFloat */
         ToolOutputFloat: {
@@ -42962,6 +43191,236 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    tools__parsed: {
+        parameters: {
+            query?: {
+                tool_version?: string | null;
+            };
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The tool ID for the lineage stored in Galaxy's toolbox. */
+                tool_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ParsedTool"];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    tools__versioned_parameter_landing_request_schema: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The tool ID for the lineage stored in Galaxy's toolbox. */
+                tool_id: string;
+                /** @description The full version string defined on the Galaxy tool wrapper. */
+                tool_version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    tools__versioned_parameter_request_schema: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The tool ID for the lineage stored in Galaxy's toolbox. */
+                tool_id: string;
+                /** @description The full version string defined on the Galaxy tool wrapper. */
+                tool_version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    tools__versioned_parameter_test_case_xml_schema: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The tool ID for the lineage stored in Galaxy's toolbox. */
+                tool_id: string;
+                /** @description The full version string defined on the Galaxy tool wrapper. */
+                tool_version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    tools__versioned_parsed: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path: {
+                /** @description The tool ID for the lineage stored in Galaxy's toolbox. */
+                tool_id: string;
+                /** @description The full version string defined on the Galaxy tool wrapper. */
+                tool_version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ParsedTool"];
                 };
             };
             /** @description Request Error */

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -80,6 +80,7 @@ from galaxy.tool_util.loader import (
     template_macro_params,
 )
 from galaxy.tool_util.loader_directory import looks_like_a_tool
+from galaxy.tool_util.model_factory import parse_tool
 from galaxy.tool_util.ontologies.ontology_data import (
     biotools_reference,
     expand_ontology_data,
@@ -126,6 +127,7 @@ from galaxy.tool_util.version import (
     LegacyVersion,
     parse_version,
 )
+from galaxy.tool_util_models import ParsedTool
 from galaxy.tool_util_models.parameters import (
     MaybeToolParameterBundle,
     ToolParameterBundleModel,
@@ -197,6 +199,7 @@ from galaxy.util import (
     listify,
     Params,
     parse_xml_string,
+    parse_xml_string_to_etree,
     rst_to_html,
     string_as_bool,
     unicodify,
@@ -1145,6 +1148,18 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
     @property
     def history_manager(self):
         return self.app.history_manager
+
+    @property
+    def parsed_tool(self) -> ParsedTool:
+        """Return a ParsedTool model for this tool.
+
+        After tool loading, mem_optimize destroys the XML tree to save memory.
+        When that has happened, re-parse from the stored string representation.
+        """
+        tool_source = self.tool_source
+        if getattr(tool_source, "root", None) is None:
+            tool_source = get_tool_source(xml_tree=parse_xml_string_to_etree(tool_source.to_string()))
+        return parse_tool(tool_source)
 
     @property
     def _view(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1149,7 +1149,6 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
     def history_manager(self):
         return self.app.history_manager
 
-    @property
     def parsed_tool(self) -> ParsedTool:
         """Return a ParsedTool model for this tool.
 

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -63,7 +63,10 @@ from galaxy.tool_util.parameters import (
     ToolParameterT,
 )
 from galaxy.tool_util.verify import ToolTestDescriptionDict
-from galaxy.tool_util_models import UserToolSource
+from galaxy.tool_util_models import (
+    ParsedTool,
+    UserToolSource,
+)
 from galaxy.tools.evaluation import global_tool_errors
 from galaxy.tools.fetch.workbooks import (
     FetchWorkbookCollectionType,
@@ -89,7 +92,10 @@ from galaxy.webapps.base.controller import UsesVisualizationMixin
 from galaxy.webapps.base.webapp import GalaxyWebTransaction
 from galaxy.webapps.galaxy.api.common import serve_workbook
 from galaxy.webapps.galaxy.services.base import tool_request_detailed_to_model
-from galaxy.webapps.galaxy.services.tools import ToolsService
+from galaxy.webapps.galaxy.services.tools import (
+    get_tool,
+    ToolsService,
+)
 from . import (
     APIContentTypeRoute,
     as_form,
@@ -148,6 +154,11 @@ ToolIDPathParam: str = Path(
     ...,
     title="Tool ID",
     description="The tool ID for the lineage stored in Galaxy's toolbox.",
+)
+ToolVersionPathParam: str = Path(
+    ...,
+    title="Tool Version",
+    description="The full version string defined on the Galaxy tool wrapper.",
 )
 ToolVersionQueryParam: Optional[str] = Query(default=None, title="Tool Version", description="")
 
@@ -421,6 +432,87 @@ class FetchTools:
             TestCaseToolState,
             inputs,
         )
+
+    @router.get(
+        "/api/tools/{tool_id}/parsed",
+        operation_id="tools__parsed",
+        summary="Return Galaxy's meta model description of the tool's inputs and outputs.",
+    )
+    def parsed_tool(
+        self,
+        tool_id: str = ToolIDPathParam,
+        tool_version: Optional[str] = ToolVersionQueryParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> ParsedTool:
+        return self._parsed_tool(trans, tool_id, tool_version)
+
+    @router.get(
+        "/api/tools/{tool_id}/versions/{tool_version}/parsed",
+        operation_id="tools__versioned_parsed",
+        summary="Return Galaxy's meta model description of the tool's inputs and outputs.",
+    )
+    def parsed_tool_versioned(
+        self,
+        tool_id: str = ToolIDPathParam,
+        tool_version: str = ToolVersionPathParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> ParsedTool:
+        return self._parsed_tool(trans, tool_id, tool_version)
+
+    @router.get(
+        "/api/tools/{tool_id}/versions/{tool_version}/parameter_request_schema",
+        operation_id="tools__versioned_parameter_request_schema",
+        summary="Return a JSON schema description of the tool's inputs for the tool request API.",
+    )
+    def tool_state_request_versioned(
+        self,
+        tool_id: str = ToolIDPathParam,
+        tool_version: str = ToolVersionPathParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> Response:
+        tool_run_ref = ToolRunReference(tool_id=tool_id, tool_version=tool_version, tool_uuid=None)
+        inputs = self.service.inputs(trans, tool_run_ref)
+        return json_schema_response_for_tool_state_model(RequestToolState, inputs)
+
+    @router.get(
+        "/api/tools/{tool_id}/versions/{tool_version}/parameter_landing_request_schema",
+        operation_id="tools__versioned_parameter_landing_request_schema",
+        summary="Return a JSON schema description of the tool's inputs for the tool landing request API.",
+    )
+    def tool_state_landing_request_versioned(
+        self,
+        tool_id: str = ToolIDPathParam,
+        tool_version: str = ToolVersionPathParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> Response:
+        tool_run_ref = ToolRunReference(tool_id=tool_id, tool_version=tool_version, tool_uuid=None)
+        inputs = self.service.inputs(trans, tool_run_ref)
+        return json_schema_response_for_tool_state_model(LandingRequestToolState, inputs)
+
+    @router.get(
+        "/api/tools/{tool_id}/versions/{tool_version}/parameter_test_case_xml_schema",
+        operation_id="tools__versioned_parameter_test_case_xml_schema",
+        summary="Return a JSON schema description of the tool's inputs for test case construction.",
+    )
+    def tool_state_test_case_xml_versioned(
+        self,
+        tool_id: str = ToolIDPathParam,
+        tool_version: str = ToolVersionPathParam,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> Response:
+        tool_run_ref = ToolRunReference(tool_id=tool_id, tool_version=tool_version, tool_uuid=None)
+        inputs = self.service.inputs(trans, tool_run_ref)
+        return json_schema_response_for_tool_state_model(TestCaseToolState, inputs)
+
+    def _parsed_tool(
+        self,
+        trans: ProvidesHistoryContext,
+        tool_id: str,
+        tool_version: Optional[str],
+    ) -> ParsedTool:
+        tool_run_ref = ToolRunReference(tool_id=tool_id, tool_version=tool_version, tool_uuid=None)
+        tool = get_tool(trans, tool_run_ref)
+        return tool.parsed_tool
 
 
 class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -434,9 +434,9 @@ class FetchTools:
         )
 
     @router.get(
-        "/api/tools/{tool_id}/parsed",
-        operation_id="tools__parsed",
-        summary="Return Galaxy's meta model description of the tool's inputs and outputs.",
+        "/api/tools/{tool_id}/interop",
+        operation_id="tools__interop",
+        summary="Return Galaxy's meta model description of the tool's metadata, inputs, and outputs.",
     )
     def parsed_tool(
         self,
@@ -447,9 +447,9 @@ class FetchTools:
         return self._parsed_tool(trans, tool_id, tool_version)
 
     @router.get(
-        "/api/tools/{tool_id}/versions/{tool_version}/parsed",
-        operation_id="tools__versioned_parsed",
-        summary="Return Galaxy's meta model description of the tool's inputs and outputs.",
+        "/api/tools/{tool_id}/versions/{tool_version}/interop",
+        operation_id="tools__versioned_interop",
+        summary="Return Galaxy's meta model description of the tool's metadata, inputs, and outputs.",
     )
     def parsed_tool_versioned(
         self,
@@ -512,7 +512,7 @@ class FetchTools:
     ) -> ParsedTool:
         tool_run_ref = ToolRunReference(tool_id=tool_id, tool_version=tool_version, tool_uuid=None)
         tool = get_tool(trans, tool_run_ref)
-        return tool.parsed_tool
+        return tool.parsed_tool()
 
 
 class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -384,31 +384,31 @@ class TestToolsApi(ApiTestCase, TestsTools):
         assert "ex2" in option_values
 
     @skip_without_tool("gx_int")
-    def test_parsed_tool(self):
-        """GET /api/tools/{tool_id}/parsed returns ParsedTool JSON."""
-        response = self._get("tools/gx_int/parsed")
+    def test_tool_interop(self):
+        """GET /api/tools/{tool_id}/interop returns ParsedTool JSON."""
+        response = self._get("tools/gx_int/interop")
         self._assert_status_code_is(response, 200)
-        parsed = response.json()
-        assert parsed["id"] == "gx_int"
-        assert "inputs" in parsed
-        assert "outputs" in parsed
-        assert len(parsed["inputs"]) > 0
+        interop = response.json()
+        assert interop["id"] == "gx_int"
+        assert "inputs" in interop
+        assert "outputs" in interop
+        assert len(interop["inputs"]) > 0
 
     @skip_without_tool("gx_int")
-    def test_parsed_tool_versioned(self):
-        """GET /api/tools/{tool_id}/versions/{version}/parsed returns same result."""
+    def test_tool_interop_versioned(self):
+        """GET /api/tools/{tool_id}/versions/{version}/interop returns same result."""
         # Get version from the unversioned endpoint first
-        response = self._get("tools/gx_int/parsed")
+        response = self._get("tools/gx_int/interop")
         self._assert_status_code_is(response, 200)
-        parsed = response.json()
-        version = parsed["version"]
+        interop = response.json()
+        version = interop["version"]
 
-        versioned_response = self._get(f"tools/gx_int/versions/{version}/parsed")
+        versioned_response = self._get(f"tools/gx_int/versions/{version}/interop")
         self._assert_status_code_is(versioned_response, 200)
-        versioned_parsed = versioned_response.json()
-        assert versioned_parsed["id"] == parsed["id"]
-        assert versioned_parsed["version"] == version
-        assert len(versioned_parsed["inputs"]) == len(parsed["inputs"])
+        versioned_interop = versioned_response.json()
+        assert versioned_interop["id"] == interop["id"]
+        assert versioned_interop["version"] == version
+        assert len(versioned_interop["inputs"]) == len(interop["inputs"])
 
     @skip_without_tool("gx_int")
     def test_versioned_schema_endpoints(self):

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -383,6 +383,47 @@ class TestToolsApi(ApiTestCase, TestsTools):
         assert "--ex1" in option_values
         assert "ex2" in option_values
 
+    @skip_without_tool("gx_int")
+    def test_parsed_tool(self):
+        """GET /api/tools/{tool_id}/parsed returns ParsedTool JSON."""
+        response = self._get("tools/gx_int/parsed")
+        self._assert_status_code_is(response, 200)
+        parsed = response.json()
+        assert parsed["id"] == "gx_int"
+        assert "inputs" in parsed
+        assert "outputs" in parsed
+        assert len(parsed["inputs"]) > 0
+
+    @skip_without_tool("gx_int")
+    def test_parsed_tool_versioned(self):
+        """GET /api/tools/{tool_id}/versions/{version}/parsed returns same result."""
+        # Get version from the unversioned endpoint first
+        response = self._get("tools/gx_int/parsed")
+        self._assert_status_code_is(response, 200)
+        parsed = response.json()
+        version = parsed["version"]
+
+        versioned_response = self._get(f"tools/gx_int/versions/{version}/parsed")
+        self._assert_status_code_is(versioned_response, 200)
+        versioned_parsed = versioned_response.json()
+        assert versioned_parsed["id"] == parsed["id"]
+        assert versioned_parsed["version"] == version
+        assert len(versioned_parsed["inputs"]) == len(parsed["inputs"])
+
+    @skip_without_tool("gx_int")
+    def test_versioned_schema_endpoints(self):
+        """Versioned /versions/{v}/parameter_*_schema endpoints mirror unversioned ones."""
+        response = self._get("tools/gx_int/parsed")
+        version = response.json()["version"]
+
+        for schema_type in ["request", "landing_request", "test_case_xml"]:
+            unversioned = self._get(f"tools/gx_int/parameter_{schema_type}_schema")
+            self._assert_status_code_is(unversioned, 200)
+
+            versioned = self._get(f"tools/gx_int/versions/{version}/parameter_{schema_type}_schema")
+            self._assert_status_code_is(versioned, 200)
+            assert unversioned.json() == versioned.json()
+
     @skip_without_tool("test_data_source")
     def test_data_source_ok_request(self, mock_http_server):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
Add /parsed and versioned schema endpoints to Galaxy tools API.

Mirror ToolShed tool endpoints on Galaxy's API:

- GET /api/tools/{id}/parsed — ParsedTool JSON (inputs + outputs)
- GET /api/tools/{id}/versions/{v}/parsed — versioned variant
- GET /api/tools/{id}/versions/{v}/parameter_request_schema
- GET /api/tools/{id}/versions/{v}/parameter_landing_request_schema
- GET /api/tools/{id}/versions/{v}/parameter_test_case_xml_schema

Enables galaxy-tool-cache to fetch tool metadata from a running Galaxy instance in addition to ToolShed - it will make it easier to work around various bugs in the tool shed (#22181 , https://github.com/galaxyproject/galaxy/pull/22007) found during development and is needed longer term for custom Galaxy tools not deployed to the Tool Shed at private Galaxy instances.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
