### PR TITLE
[26.0] Fix subworkflow input collection_type not enforced in editor.

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -762,7 +762,8 @@ class SubWorkflowModule(WorkflowModule):
                 )
                 step_type = step.type
                 if step_type == "data_collection_input":
-                    input["collection_type"] = step.tool_inputs.get("collection_type") if step.tool_inputs else None
+                    collection_type = step.tool_inputs.get("collection_type") if step.tool_inputs else None
+                    input["collection_types"] = listify(collection_type) if collection_type else None
                 if step_type == "parameter_input":
                     input["type"] = step.tool_inputs["parameter_type"]
                 input["optional"] = step.tool_inputs.get("optional", False)


### PR DESCRIPTION
SubWorkflowModule.get_all_inputs() returned collection_type (singular string) but the client expects collection_types (plural array), matching what ToolModule.get_all_inputs() returns. The mismatch caused the client InputCollectionTerminal to default to ANY_COLLECTION_TYPE_DESCRIPTION, accepting any collection and skipping type validation entirely.

e.g. a list→list:paired connection into a subworkflow was silently accepted when it should be rejected.

This has led to two technically invalid connections in the IWC https://github.com/galaxyproject/iwc/issues/1163. 

## How to test the changes?
- [ ] I mean the API test would be silly - this needs a Selenium test... I'd want to do that in dev. This bug is too permissive instead of too restrictive so maybe this doesn't even need to target release_26.0? 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
