### PR TITLE
[26.0] Fix event loop blocking in async API routes

### DIFF
--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -4,6 +4,7 @@ Error analysis agent for enhanced tool error diagnosis.
 
 import logging
 import re
+from functools import partial
 from pathlib import Path
 from typing import (
     Any,
@@ -11,6 +12,7 @@ from typing import (
     Optional,
 )
 
+import anyio
 from pydantic import BaseModel
 from pydantic_ai import Agent
 
@@ -94,7 +96,9 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
             if not self.deps.job_manager:
                 return {"error": "Job manager not available"}
 
-            job = self.deps.job_manager.get_accessible_job(self.deps.trans, job_id)
+            job = await anyio.to_thread.run_sync(
+                partial(self.deps.job_manager.get_accessible_job, self.deps.trans, job_id)
+            )
             if not job:
                 return {"error": f"Job {job_id} not found or not accessible"}
 

--- a/lib/galaxy/webapps/galaxy/api/agents.py
+++ b/lib/galaxy/webapps/galaxy/api/agents.py
@@ -2,11 +2,13 @@
 
 import logging
 import time
+from functools import partial
 from typing import (
     Any,
     Optional,
 )
 
+import anyio
 from fastapi import Body
 
 from galaxy.exceptions import ConfigurationError
@@ -160,16 +162,20 @@ class AgentAPI:
             # Save chat exchange for feedback tracking if requested or if job_id provided
             if bool(save_exchange) or job_id:
                 if job_id:
-                    job = self.job_manager.get_accessible_job(trans, job_id)
+                    job = await anyio.to_thread.run_sync(partial(self.job_manager.get_accessible_job, trans, job_id))
                     if job:
-                        existing = self.chat_manager.get(trans, job.id)
+                        existing = await anyio.to_thread.run_sync(partial(self.chat_manager.get, trans, job.id))
                         if not existing:
-                            exchange = self.chat_manager.create(trans, job.id, response.content)
+                            exchange = await anyio.to_thread.run_sync(
+                                partial(self.chat_manager.create, trans, job.id, response.content)
+                            )
                             response.metadata["exchange_id"] = exchange.id
                 elif trans.user:
                     # Create general chat exchange for non-job error analysis
                     result = {"response": response.content, "agent_response": response.model_dump()}
-                    exchange = self.chat_manager.create_general_chat(trans, query, result, "error_analysis")
+                    exchange = await anyio.to_thread.run_sync(
+                        partial(self.chat_manager.create_general_chat, trans, query, result, "error_analysis")
+                    )
                     response.metadata["exchange_id"] = exchange.id
 
             return response
@@ -206,7 +212,9 @@ class AgentAPI:
             # Save chat exchange for feedback tracking if requested
             if bool(save_exchange) and trans.user:
                 result = {"response": response.content, "agent_response": response.model_dump()}
-                exchange = self.chat_manager.create_general_chat(trans, query, result, "custom_tool")
+                exchange = await anyio.to_thread.run_sync(
+                    partial(self.chat_manager.create_general_chat, trans, query, result, "custom_tool")
+                )
                 response.metadata["exchange_id"] = exchange.id
 
             return response

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -5,6 +5,7 @@ API Controller providing Chat functionality
 import json
 import logging
 import time
+from functools import partial
 from typing import (
     Annotated,
     Any,
@@ -12,6 +13,7 @@ from typing import (
     Union,
 )
 
+import anyio
 from fastapi import (
     Body,
     Path,
@@ -59,8 +61,10 @@ from pydantic_ai.exceptions import UnexpectedModelBehavior
 # Keep OpenAI as a fallback option
 try:
     import openai
+    from openai import AsyncOpenAI
 except ImportError:
     openai = None  # type: ignore[assignment]
+    AsyncOpenAI = None  # type: ignore[assignment,misc]
 
 log = logging.getLogger(__name__)
 
@@ -152,9 +156,9 @@ class ChatAPI:
         job = None
         if job_id:
             # Job-based chat - check for existing responses (unless regenerate requested)
-            job = self.job_manager.get_accessible_job(trans, job_id)
+            job = await anyio.to_thread.run_sync(partial(self.job_manager.get_accessible_job, trans, job_id))
             if job and not regenerate:
-                existing_response = self.chat_manager.get(trans, job.id)
+                existing_response = await anyio.to_thread.run_sync(partial(self.chat_manager.get, trans, job.id))
                 if existing_response and existing_response.messages[0]:
                     return ChatResponse(
                         response=existing_response.messages[0].message,
@@ -176,7 +180,9 @@ class ChatAPI:
 
                 # If we have an exchange_id, ALWAYS load conversation history from database (source of truth)
                 if exchange_id:
-                    db_history = self.chat_manager.get_chat_history(trans, exchange_id, format_for_pydantic_ai=False)
+                    db_history = await anyio.to_thread.run_sync(
+                        partial(self.chat_manager.get_chat_history, trans, exchange_id, format_for_pydantic_ai=False)
+                    )
                     if db_history:
                         full_context["conversation_history"] = db_history
                     else:
@@ -197,13 +203,15 @@ class ChatAPI:
                 self._ensure_ai_configured()
                 # For legacy, use context_type from query_context if it exists
                 context_type = query_context.get("context_type") if isinstance(query_context, dict) else None
-                answer = self._get_ai_response(query_text, trans, context_type)
+                answer = await self._get_ai_response(query_text, trans, context_type)
                 result["response"] = answer
 
             # Save chat exchange to database
             if job:
                 # Job-based chat
-                exchange = self.chat_manager.create(trans, job.id, str(result["response"]))
+                exchange = await anyio.to_thread.run_sync(
+                    partial(self.chat_manager.create, trans, job.id, str(result["response"]))
+                )
                 result["exchange_id"] = exchange.id
             elif trans.user:
                 # Use the exchange_id we already extracted at the beginning
@@ -217,7 +225,9 @@ class ChatAPI:
                         "agent_response": agent_resp.model_dump() if agent_resp else None,
                     }
                     message_content = json.dumps(conversation_data)
-                    self.chat_manager.add_message(trans, exchange_id, message_content)
+                    await anyio.to_thread.run_sync(
+                        partial(self.chat_manager.add_message, trans, exchange_id, message_content)
+                    )
                     result["exchange_id"] = exchange_id
                 else:
                     # Create new exchange for first message
@@ -227,7 +237,9 @@ class ChatAPI:
                         "response": result.get("response", ""),
                         "agent_response": agent_resp.model_dump() if agent_resp else None,
                     }
-                    exchange = self.chat_manager.create_general_chat(trans, query_text, storable_result, agent_type)
+                    exchange = await anyio.to_thread.run_sync(
+                        partial(self.chat_manager.create_general_chat, trans, query_text, storable_result, agent_type)
+                    )
                     result["exchange_id"] = exchange.id
 
             result["processing_time"] = time.time() - start_time
@@ -421,7 +433,7 @@ class ChatAPI:
         if self.config.ai_api_key is None:
             raise ConfigurationError("AI API key is not configured for this instance.")
 
-    def _get_ai_response(self, query: str, trans: ProvidesUserContext, context_type: Optional[str] = None) -> str:
+    async def _get_ai_response(self, query: str, trans: ProvidesUserContext, context_type: Optional[str] = None) -> str:
         """Get response from AI using pydantic-ai Agent"""
         system_prompt = self._get_system_prompt()
         username = trans.user.username if trans.user else "Anonymous User"
@@ -432,8 +444,8 @@ class ChatAPI:
             full_system_prompt = f"{system_prompt}\n\nYou will address the user as {username}"
             agent: Agent[None, str] = Agent(model_name, system_prompt=full_system_prompt)
 
-            # Get response from the agent
-            result = agent.run_sync(query)
+            # Get response from the agent (async)
+            result = await agent.run(query)
             return result.output
         except UnexpectedModelBehavior as e:
             log.error(f"Unexpected model behavior: {e}")
@@ -442,10 +454,10 @@ class ChatAPI:
             log.error(f"Error using pydantic-ai Agent: {e}")
             # Try fallback to direct OpenAI if available
             if openai is not None:
-                return self._call_openai_directly(query, system_prompt, username)
+                return await self._call_openai_directly(query, system_prompt, username)
             raise
 
-    def _call_openai_directly(self, query: str, system_prompt: str, username: str) -> str:
+    async def _call_openai_directly(self, query: str, system_prompt: str, username: str) -> str:
         """Direct OpenAI API call as fallback"""
         try:
             messages: list[dict[str, str]] = [
@@ -456,7 +468,8 @@ class ChatAPI:
                 },
                 {"role": "user", "content": query},
             ]
-            response = openai.chat.completions.create(
+            client = AsyncOpenAI()
+            response = await client.chat.completions.create(
                 model=self.config.ai_model,
                 messages=messages,  # type: ignore[arg-type]
             )

--- a/lib/galaxy/webapps/galaxy/api/proxy.py
+++ b/lib/galaxy/webapps/galaxy/api/proxy.py
@@ -1,13 +1,15 @@
 """
-API Controller to handle remote zip operations.
+API Controller to proxy remote files.
 """
 
 import logging
+from functools import partial
 from urllib.parse import (
     urljoin,
     urlparse,
 )
 
+import anyio
 import httpx
 from fastapi import (
     Query,
@@ -71,7 +73,7 @@ class FastAPIProxy:
         if trans.anonymous:
             raise UserRequiredException("Anonymous users are not allowed to access this endpoint")
 
-        self._validate_url_and_access(url, trans)
+        await anyio.to_thread.run_sync(partial(self._validate_url_and_access, url, trans))
 
         headers: dict[str, str] = {}
         if "range" in request.headers:
@@ -151,7 +153,7 @@ class FastAPIProxy:
                 # Handle relative URLs by resolving them against the current URL
                 redirect_url = urljoin(current_url, redirect_location)
 
-                self._validate_url_and_access(redirect_url, trans)
+                await anyio.to_thread.run_sync(partial(self._validate_url_and_access, redirect_url, trans))
 
                 # Close current response and follow the validated redirect
                 await response.aclose()


### PR DESCRIPTION
Async def route handlers were calling synchronous DB queries, DNS lookups, and HTTP APIs directly on the event loop, blocking all concurrent requests on the same worker.

- chat.py: use await agent.run() instead of agent.run_sync(), use AsyncOpenAI instead of sync openai client, wrap all chat_manager and job_manager DB calls with anyio.to_thread.run_sync
- agents.py: wrap chat_manager/job_manager DB calls in analyze_error and create_custom_tool with anyio.to_thread.run_sync
- proxy.py: wrap _validate_url_and_access (blocking socket.getaddrinfo) with anyio.to_thread.run_sync
- error_analysis.py: wrap job_manager.get_accessible_job with anyio.to_thread.run_sync

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
