### PR TITLE
Expanded workflow tests for semantic clarification.  

### DIFF
--- a/lib/galaxy/tool_util_models/__init__.py
+++ b/lib/galaxy/tool_util_models/__init__.py
@@ -196,6 +196,8 @@ class BaseTestOutputModel(StrictModel):
 
 class TestDataOutputAssertions(BaseTestOutputModel):
     class_: Optional[Literal["File"]] = Field("File", alias="class")
+    visible: Optional[bool] = None
+    deleted: Optional[bool] = None
 
 
 class TestCollectionCollectionElementAssertions(StrictModel):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -4650,6 +4650,55 @@ some_file:
             # Verify workflow_step_id points to the conditional_step (step 2 in the subworkflow)
             assert message["workflow_step_id"] == 2
 
+    def test_nested_subworkflow_error_includes_two_level_step_path(self):
+        """Test that errors from doubly-nested subworkflows include a 2-element step path."""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """
+class: GalaxyWorkflow
+inputs:
+  input_file: data
+steps:
+  outer_sub:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        mid_input: data
+      steps:
+        inner_sub:
+          run:
+            class: GalaxyWorkflow
+            inputs:
+              deep_input: data
+            steps:
+              failing_step:
+                tool_id: cat1
+                in:
+                  input1: deep_input
+                when: $("not_a_boolean")
+          in:
+            deep_input: mid_input
+    in:
+      mid_input: input_file
+""",
+                test_data="""
+input_file:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+                wait=True,
+                assert_ok=False,
+            )
+            invocation_details = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation_details["state"] == "failed"
+            assert len(invocation_details["messages"]) >= 1
+            message = invocation_details["messages"][0]
+            assert message["reason"] == "when_not_boolean"
+            assert message["details"] == "Type is: str"
+            # workflow_step_index_path should have 2 elements tracing through outer_sub and inner_sub
+            assert len(message["workflow_step_index_path"]) == 2
+
     def test_workflow_request(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_queue")
         workflow_request, history_id, workflow_id = self._setup_workflow_run(workflow)
@@ -9856,6 +9905,46 @@ should_run:
             job_details = self.dataset_populator.get_job_details(job["id"], full=True).json()
             assert job_details["state"] == "skipped"
             assert job_details["copied_from_job_id"]
+
+    def test_cache_miss_on_parameter_change(self):
+        """Changing a tool parameter causes cache miss even with use_cached_job=True."""
+        wf = """class: GalaxyWorkflow
+inputs: []
+steps:
+  create:
+    tool_id: create_2
+    state:
+      sleep_time: 0
+"""
+        wf_different = """class: GalaxyWorkflow
+inputs: []
+steps:
+  create:
+    tool_id: create_2
+    state:
+      sleep_time: 1
+"""
+        with self.dataset_populator.test_history() as history_id:
+            # Run 1: no cache, sleep_time=0
+            summary_1 = self._run_workflow(wf, history_id=history_id)
+            inv_1 = self.workflow_populator.get_invocation(summary_1.invocation_id, step_details=True)
+            job_1 = inv_1["steps"][0]["jobs"][0]
+            job_details_1 = self.dataset_populator.get_job_details(job_1["id"], full=True).json()
+            assert not job_details_1["copied_from_job_id"]
+
+            # Run 2: same params with cache -> cache HIT
+            summary_2 = self._run_workflow(wf, history_id=history_id, use_cached_job=True)
+            inv_2 = self.workflow_populator.get_invocation(summary_2.invocation_id, step_details=True)
+            job_2 = inv_2["steps"][0]["jobs"][0]
+            job_details_2 = self.dataset_populator.get_job_details(job_2["id"], full=True).json()
+            assert job_details_2["copied_from_job_id"], "Expected cache hit with same parameters"
+
+            # Run 3: different sleep_time with cache -> cache MISS
+            summary_3 = self._run_workflow(wf_different, history_id=history_id, use_cached_job=True)
+            inv_3 = self.workflow_populator.get_invocation(summary_3.invocation_id, step_details=True)
+            job_3 = inv_3["steps"][0]["jobs"][0]
+            job_details_3 = self.dataset_populator.get_job_details(job_3["id"], full=True).json()
+            assert not job_details_3["copied_from_job_id"], "Expected cache miss with changed parameter"
 
     def test_run_workflow_use_cached_job_format_source_pick_param(self):
         wf = """class: GalaxyWorkflow

--- a/lib/galaxy_test/workflow/format_source_inherits_input.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/format_source_inherits_input.gxwf-tests.yml
@@ -1,0 +1,23 @@
+- doc: |
+    Input is .bed format. Tool uses format_source="input1" on output.
+    Output should inherit .bed format, not the tool's default.
+  job:
+    input_file:
+      type: File
+      value: 1.bed
+      file_type: bed
+  outputs:
+    out:
+      class: File
+      ftype: bed
+- doc: |
+    Input is .fasta format. Output should inherit .fasta format.
+  job:
+    input_file:
+      type: File
+      value: 1.fasta
+      file_type: fasta
+  outputs:
+    out:
+      class: File
+      ftype: fasta

--- a/lib/galaxy_test/workflow/format_source_inherits_input.gxwf.yml
+++ b/lib/galaxy_test/workflow/format_source_inherits_input.gxwf.yml
@@ -1,0 +1,19 @@
+class: GalaxyWorkflow
+doc: |
+  Verify format_source on a tool output inherits the input file's format.
+  cat_data_and_sleep declares format_source="input1" on its output,
+  so the output format should match whatever format the input has.
+inputs:
+  input_file:
+    type: data
+outputs:
+  out:
+    outputSource: the_cat/out_file1
+steps:
+  the_cat:
+    tool_id: cat_data_and_sleep
+    state:
+      sleep_time: 0
+    in:
+      input1:
+        source: input_file

--- a/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf-tests.yml
@@ -1,0 +1,42 @@
+- doc: |
+    When should_run=false, conditional_cat skipped -> expression.json null.
+    Depends on 4a results: if skip propagates through pass_through_cat,
+    pick_value gets null first input and picks fallback_file.
+    If cat runs on null file literally, pick_value gets a real dataset
+    containing "null" text and picks that instead.
+    Initial assertion assumes skip propagates (pick_value picks fallback).
+  job:
+    input_file:
+      type: File
+      value: 1.fasta
+    fallback_file:
+      type: File
+      value: 1.bed
+    should_run:
+      type: raw
+      value: false
+  outputs:
+    pick_out:
+      class: File
+      asserts:
+      - that: has_text
+        text: "chr1"
+- doc: |
+    Control: should_run=true, conditional_cat runs, pass_through_cat
+    processes real output, pick_value picks the first (real) input.
+  job:
+    input_file:
+      type: File
+      value: 1.fasta
+    fallback_file:
+      type: File
+      value: 1.bed
+    should_run:
+      type: raw
+      value: true
+  outputs:
+    pick_out:
+      class: File
+      asserts:
+      - that: has_size
+        min: 1

--- a/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf-tests.yml
@@ -1,10 +1,6 @@
 - doc: |
-    When should_run=false, conditional_cat skipped -> expression.json null.
-    Depends on 4a results: if skip propagates through pass_through_cat,
-    pick_value gets null first input and picks fallback_file.
-    If cat runs on null file literally, pick_value gets a real dataset
-    containing "null" text and picks that instead.
-    Initial assertion assumes skip propagates (pick_value picks fallback).
+    Null propagates through intermediate cat step. pick_value receives
+    null as first input and selects fallback_file (1.bed with chr1).
   job:
     input_file:
       type: File
@@ -22,8 +18,7 @@
       - that: has_text
         text: "chr1"
 - doc: |
-    Control: should_run=true, conditional_cat runs, pass_through_cat
-    processes real output, pick_value picks the first (real) input.
+    All steps execute normally. pick_value picks the first (real) input.
   job:
     input_file:
       type: File

--- a/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf.yml
+++ b/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf.yml
@@ -1,7 +1,8 @@
 class: GalaxyWorkflow
 doc: |
-  Skipped step -> cat (data input) -> pick_value with fallback.
-  Tests whether pick_value sees the intermediate cat output as real or null.
+  Null propagation through data chain into pick_value. When skip state
+  propagates through an intermediate step, pick_value correctly
+  recognizes the propagated null and selects the fallback input.
 inputs:
   input_file:
     type: data

--- a/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf.yml
+++ b/lib/galaxy_test/workflow/null_propagation_data_chain_pick_value.gxwf.yml
@@ -1,0 +1,43 @@
+class: GalaxyWorkflow
+doc: |
+  Skipped step -> cat (data input) -> pick_value with fallback.
+  Tests whether pick_value sees the intermediate cat output as real or null.
+inputs:
+  input_file:
+    type: data
+  fallback_file:
+    type: data
+  should_run:
+    type: boolean
+outputs:
+  pick_out:
+    outputSource: pick_value/data_param
+steps:
+  conditional_cat:
+    tool_id: cat
+    in:
+      input1:
+        source: input_file
+      should_run:
+        source: should_run
+    when: $(inputs.should_run)
+  pass_through_cat:
+    tool_id: cat
+    in:
+      input1:
+        source: conditional_cat/out_file1
+  pick_value:
+    tool_id: pick_value
+    in:
+      style_cond|type_cond|pick_from_0|value:
+        source: pass_through_cat/out_file1
+      style_cond|type_cond|pick_from_1|value:
+        source: fallback_file
+    tool_state:
+      style_cond:
+        pick_style: first
+        type_cond:
+          param_type: data
+          pick_from:
+          - value: pass_through_cat/out_file1
+          - value: fallback_file

--- a/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf-tests.yml
@@ -1,0 +1,47 @@
+- doc: |
+    Omit optional text param. Step1 receives null via NoReplacement,
+    outputs expression.json with null. Step2 deserializes that null,
+    passes it through, outputs expression.json null. Step3 same.
+    All three outputs should be expression.json containing null.
+  job: {}
+  outputs:
+    out_step1:
+      class: File
+      ftype: expression.json
+      asserts:
+      - that: has_text
+        text: "null"
+    out_step2:
+      class: File
+      ftype: expression.json
+      asserts:
+      - that: has_text
+        text: "null"
+    out_step3:
+      class: File
+      ftype: expression.json
+      asserts:
+      - that: has_text
+        text: "null"
+- doc: |
+    Provide text param. All three steps pass it through unchanged.
+  job:
+    optional_text:
+      type: raw
+      value: hello_world
+  outputs:
+    out_step1:
+      class: File
+      asserts:
+      - that: has_text
+        text: "hello_world"
+    out_step2:
+      class: File
+      asserts:
+      - that: has_text
+        text: "hello_world"
+    out_step3:
+      class: File
+      asserts:
+      - that: has_text
+        text: "hello_world"

--- a/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf-tests.yml
@@ -1,8 +1,6 @@
 - doc: |
-    Omit optional text param. Step1 receives null via NoReplacement,
-    outputs expression.json with null. Step2 deserializes that null,
-    passes it through, outputs expression.json null. Step3 same.
-    All three outputs should be expression.json containing null.
+    Omitted optional text param produces null at every hop in a 3-step
+    expression tool chain. All outputs are expression.json null.
   job: {}
   outputs:
     out_step1:
@@ -24,7 +22,7 @@
       - that: has_text
         text: "null"
 - doc: |
-    Provide text param. All three steps pass it through unchanged.
+    Provided text param passes through all three steps unchanged.
   job:
     optional_text:
       type: raw

--- a/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf.yml
+++ b/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf.yml
@@ -1,9 +1,8 @@
 class: GalaxyWorkflow
 doc: |
-  Chain of 3 expression_null_handling_text steps where the first receives
-  an optional text param that is omitted. Tests whether null propagates
-  through expression tool parameter chains (expression.json deserialized
-  as JSON value at each hop).
+  Null propagates transitively through expression tool parameter chains.
+  Each step deserializes expression.json null as a JSON value and
+  produces expression.json null output, preserving null across all hops.
 inputs:
   optional_text:
     type: text

--- a/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf.yml
+++ b/lib/galaxy_test/workflow/null_propagation_param_chain.gxwf.yml
@@ -1,0 +1,33 @@
+class: GalaxyWorkflow
+doc: |
+  Chain of 3 expression_null_handling_text steps where the first receives
+  an optional text param that is omitted. Tests whether null propagates
+  through expression tool parameter chains (expression.json deserialized
+  as JSON value at each hop).
+inputs:
+  optional_text:
+    type: text
+    optional: true
+outputs:
+  out_step1:
+    outputSource: step1/text_out
+  out_step2:
+    outputSource: step2/text_out
+  out_step3:
+    outputSource: step3/text_out
+steps:
+  step1:
+    tool_id: expression_null_handling_text
+    in:
+      text_input:
+        source: optional_text
+  step2:
+    tool_id: expression_null_handling_text
+    in:
+      text_input:
+        source: step1/text_out
+  step3:
+    tool_id: expression_null_handling_text
+    in:
+      text_input:
+        source: step2/text_out

--- a/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf-tests.yml
@@ -1,10 +1,7 @@
 - doc: |
-    Discovery test: when should_run=false, step1 is skipped producing
-    expression.json null. Does skip propagate through step2 and step3?
-    Hypothesis A: skip propagates, all outputs are expression.json null.
-    Hypothesis B: cat processes the null file literally, step2/3 produce
-    regular files containing "null" text.
-    Starting with hypothesis A (all expression.json).
+    Skip propagates through a 3-step data chain. When step1 is skipped,
+    step2 and step3 also produce expression.json null — tools do not
+    process the null placeholder as a literal file.
   job:
     input_file:
       type: File
@@ -32,7 +29,7 @@
       - that: has_text
         text: "null"
 - doc: |
-    Control: when should_run=true, all steps run normally.
+    All steps execute normally when should_run=true.
   job:
     input_file:
       type: File

--- a/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf-tests.yml
@@ -1,0 +1,58 @@
+- doc: |
+    Discovery test: when should_run=false, step1 is skipped producing
+    expression.json null. Does skip propagate through step2 and step3?
+    Hypothesis A: skip propagates, all outputs are expression.json null.
+    Hypothesis B: cat processes the null file literally, step2/3 produce
+    regular files containing "null" text.
+    Starting with hypothesis A (all expression.json).
+  job:
+    input_file:
+      type: File
+      value: 1.fasta
+    should_run:
+      type: raw
+      value: false
+  outputs:
+    out_step1:
+      class: File
+      ftype: expression.json
+      asserts:
+      - that: has_text
+        text: "null"
+    out_step2:
+      class: File
+      ftype: expression.json
+      asserts:
+      - that: has_text
+        text: "null"
+    out_step3:
+      class: File
+      ftype: expression.json
+      asserts:
+      - that: has_text
+        text: "null"
+- doc: |
+    Control: when should_run=true, all steps run normally.
+  job:
+    input_file:
+      type: File
+      value: 1.fasta
+    should_run:
+      type: raw
+      value: true
+  outputs:
+    out_step1:
+      class: File
+      asserts:
+      - that: has_size
+        min: 1
+    out_step2:
+      class: File
+      asserts:
+      - that: has_size
+        min: 1
+    out_step3:
+      class: File
+      asserts:
+      - that: has_size
+        min: 1

--- a/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf.yml
+++ b/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf.yml
@@ -1,8 +1,8 @@
 class: GalaxyWorkflow
 doc: |
-  Chain of 3 cat steps where the first is conditionally skipped.
-  Discovery test: does null expression.json propagate skip through
-  downstream data-input steps, or do they process it as a literal file?
+  Null/skip state propagates transitively through data-input chains.
+  When the first step is skipped, all downstream steps that receive
+  its output as data input also produce expression.json null.
 inputs:
   input_file:
     type: data

--- a/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf.yml
+++ b/lib/galaxy_test/workflow/null_propagation_three_step_chain.gxwf.yml
@@ -1,0 +1,36 @@
+class: GalaxyWorkflow
+doc: |
+  Chain of 3 cat steps where the first is conditionally skipped.
+  Discovery test: does null expression.json propagate skip through
+  downstream data-input steps, or do they process it as a literal file?
+inputs:
+  input_file:
+    type: data
+  should_run:
+    type: boolean
+outputs:
+  out_step1:
+    outputSource: step1_cat/out_file1
+  out_step2:
+    outputSource: step2_cat/out_file1
+  out_step3:
+    outputSource: step3_cat/out_file1
+steps:
+  step1_cat:
+    tool_id: cat
+    in:
+      input1:
+        source: input_file
+      should_run:
+        source: should_run
+    when: $(inputs.should_run)
+  step2_cat:
+    tool_id: cat
+    in:
+      input1:
+        source: step1_cat/out_file1
+  step3_cat:
+    tool_id: cat
+    in:
+      input1:
+        source: step2_cat/out_file1

--- a/lib/galaxy_test/workflow/replacement_parameters_nested_two_levels.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_nested_two_levels.gxwf-tests.yml
@@ -1,0 +1,13 @@
+- doc: |
+    Text parameter "my_prefix" passes through parent -> level1 -> level2
+    where it's substituted in output rename PJA. Verifies parameter
+    substitution works across two subworkflow boundaries.
+  job:
+    rename_text:
+      value: my_prefix
+      type: raw
+  outputs:
+    out:
+      class: File
+      metadata:
+        name: 'my_prefix deep_output'

--- a/lib/galaxy_test/workflow/replacement_parameters_nested_two_levels.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_nested_two_levels.gxwf-tests.yml
@@ -1,7 +1,6 @@
 - doc: |
-    Text parameter "my_prefix" passes through parent -> level1 -> level2
-    where it's substituted in output rename PJA. Verifies parameter
-    substitution works across two subworkflow boundaries.
+    Text parameter substitution works across two subworkflow boundaries.
+    "my_prefix" flows parent -> level1 -> level2 into a rename PJA.
   job:
     rename_text:
       value: my_prefix

--- a/lib/galaxy_test/workflow/replacement_parameters_nested_two_levels.gxwf.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_nested_two_levels.gxwf.yml
@@ -1,0 +1,39 @@
+class: GalaxyWorkflow
+doc: |
+  Text parameter flows through TWO subworkflow boundaries and is
+  substituted in PJA RenameDatasetAction at the deepest level.
+inputs:
+  rename_text: text
+outputs:
+  out:
+    outputSource: subworkflow_level1/output
+steps:
+  subworkflow_level1:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        rename_text_l1: text
+      outputs:
+        output:
+          outputSource: subworkflow_level2/output
+      steps:
+        subworkflow_level2:
+          run:
+            class: GalaxyWorkflow
+            inputs:
+              rename_text_l2: text
+            outputs:
+              output:
+                outputSource: create_step/out_file1
+            steps:
+              create_step:
+                tool_id: create_2
+                state:
+                  sleep_time: 0
+                outputs:
+                  out_file1:
+                    rename: "${rename_text_l2} deep_output"
+          in:
+            rename_text_l2: rename_text_l1
+    in:
+      rename_text_l1: rename_text

--- a/lib/galaxy_test/workflow/skipped_mapped_output.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/skipped_mapped_output.gxwf-tests.yml
@@ -1,7 +1,6 @@
 - doc: |
-    Test that a mapped conditional step with mixed true/false boolean values
-    produces an output collection where executed elements have real content
-    and skipped elements have expression.json null content.
+    Mapped conditional with mixed true/false: executed elements have real
+    content, skipped elements are expression.json null placeholders.
   job:
     boolean_input_files:
       type: collection

--- a/lib/galaxy_test/workflow/skipped_mapped_output.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/skipped_mapped_output.gxwf-tests.yml
@@ -1,0 +1,27 @@
+- doc: |
+    Test that a mapped conditional step with mixed true/false boolean values
+    produces an output collection where executed elements have real content
+    and skipped elements have expression.json null content.
+  job:
+    boolean_input_files:
+      type: collection
+      collection_type: list
+      elements:
+        - identifier: run_me
+          content: "true"
+        - identifier: skip_me
+          content: "false"
+  outputs:
+    out:
+      class: Collection
+      collection_type: list
+      elements:
+        run_me:
+          asserts:
+          - that: has_text
+            text: "true"
+        skip_me:
+          ftype: expression.json
+          asserts:
+          - that: has_text
+            text: "null"

--- a/lib/galaxy_test/workflow/skipped_mapped_output.gxwf.yml
+++ b/lib/galaxy_test/workflow/skipped_mapped_output.gxwf.yml
@@ -1,8 +1,8 @@
 class: GalaxyWorkflow
 doc: |
-  Test workflow output from a mapped conditional step where some collection
-  elements are skipped and others execute. The output collection should
-  contain both real datasets and null expression.json placeholders.
+  Mapped conditional step with mixed skip/execute elements. Output
+  collection preserves element ordering with real datasets at executed
+  positions and expression.json null placeholders at skipped positions.
 inputs:
   boolean_input_files:
     type: collection

--- a/lib/galaxy_test/workflow/skipped_mapped_output.gxwf.yml
+++ b/lib/galaxy_test/workflow/skipped_mapped_output.gxwf.yml
@@ -1,0 +1,24 @@
+class: GalaxyWorkflow
+doc: |
+  Test workflow output from a mapped conditional step where some collection
+  elements are skipped and others execute. The output collection should
+  contain both real datasets and null expression.json placeholders.
+inputs:
+  boolean_input_files:
+    type: collection
+outputs:
+  out:
+    outputSource: the_cat/out_file1
+steps:
+  param_out:
+    tool_id: param_value_from_file
+    in:
+      input1: boolean_input_files
+    state:
+      param_type: boolean
+  the_cat:
+    tool_id: cat
+    in:
+      input1: boolean_input_files
+      should_run: param_out/boolean_param
+    when: $(inputs.should_run)

--- a/lib/galaxy_test/workflow/skipped_step_output.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/skipped_step_output.gxwf-tests.yml
@@ -1,0 +1,35 @@
+- doc: |
+    Test that a workflow output sourced from an always-skipped step (when=false)
+    produces a null expression.json dataset that is hidden.
+  job:
+    input_file:
+      type: File
+      value: 1.fasta
+    should_run:
+      type: raw
+      value: false
+  outputs:
+    out:
+      class: File
+      ftype: expression.json
+      visible: false
+      asserts:
+      - that: has_text
+        text: "null"
+- doc: |
+    Test that the same workflow with when=true executes the step and produces
+    real output with the original file type.
+  job:
+    input_file:
+      type: File
+      value: 1.fasta
+    should_run:
+      type: raw
+      value: true
+  outputs:
+    out:
+      class: File
+      visible: true
+      asserts:
+      - that: has_size
+        min: 1

--- a/lib/galaxy_test/workflow/skipped_step_output.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/skipped_step_output.gxwf-tests.yml
@@ -1,6 +1,6 @@
 - doc: |
-    Test that a workflow output sourced from an always-skipped step (when=false)
-    produces a null expression.json dataset that is hidden.
+    Skipped step (when=false) produces a hidden expression.json null dataset
+    as its workflow output.
   job:
     input_file:
       type: File
@@ -17,8 +17,7 @@
       - that: has_text
         text: "null"
 - doc: |
-    Test that the same workflow with when=true executes the step and produces
-    real output with the original file type.
+    Executed step (when=true) produces a visible dataset with real content.
   job:
     input_file:
       type: File

--- a/lib/galaxy_test/workflow/skipped_step_output.gxwf.yml
+++ b/lib/galaxy_test/workflow/skipped_step_output.gxwf.yml
@@ -1,0 +1,22 @@
+class: GalaxyWorkflow
+doc: |
+  Test workflow output behavior when sourced from a conditionally-skipped
+  step without pick_value. Verifies that skipped steps produce expression.json
+  null outputs that are correctly recorded as workflow outputs.
+inputs:
+  input_file:
+    type: data
+  should_run:
+    type: boolean
+outputs:
+  out:
+    outputSource: cat/out_file1
+steps:
+  cat:
+    tool_id: cat
+    in:
+      input1:
+        source: input_file
+      should_run:
+        source: should_run
+    when: $(inputs.should_run)

--- a/lib/galaxy_test/workflow/skipped_step_output.gxwf.yml
+++ b/lib/galaxy_test/workflow/skipped_step_output.gxwf.yml
@@ -1,8 +1,8 @@
 class: GalaxyWorkflow
 doc: |
-  Test workflow output behavior when sourced from a conditionally-skipped
-  step without pick_value. Verifies that skipped steps produce expression.json
-  null outputs that are correctly recorded as workflow outputs.
+  Workflow output sourced from a conditionally-skipped step (no pick_value).
+  Skipped steps produce hidden expression.json null outputs that are
+  recorded as workflow outputs without error.
 inputs:
   input_file:
     type: data

--- a/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf-tests.yml
@@ -1,12 +1,7 @@
 - doc: |
-    Parent sends list_a=[X,Y] into subworkflow's data input, triggering
-    parent-level map-over (2 invocations). Each invocation also receives
-    list_b=[P,Q] which triggers internal map-over of cat.
-    Discovery result: output is flat list (not list:list). The parent
-    mapping over list_a and the subworkflow's internal mapping over list_b
-    do NOT combine into nested output. The inner mapping produces list
-    output per subworkflow invocation, but the parent mapping doesn't
-    wrap that in an outer list.
+    Parent maps list_a over subworkflow data input, subworkflow maps
+    list_b internally. Output is flat list from the inner mapping axis,
+    not list:list. Two independent mapping sources do not stack.
   job:
     list_a:
       type: collection

--- a/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf-tests.yml
@@ -1,0 +1,39 @@
+- doc: |
+    Parent sends list_a=[X,Y] into subworkflow's data input, triggering
+    parent-level map-over (2 invocations). Each invocation also receives
+    list_b=[P,Q] which triggers internal map-over of cat.
+    Discovery result: output is flat list (not list:list). The parent
+    mapping over list_a and the subworkflow's internal mapping over list_b
+    do NOT combine into nested output. The inner mapping produces list
+    output per subworkflow invocation, but the parent mapping doesn't
+    wrap that in an outer list.
+  job:
+    list_a:
+      type: collection
+      collection_type: list
+      elements:
+        - identifier: X
+          content: "from_X"
+        - identifier: Y
+          content: "from_Y"
+    list_b:
+      type: collection
+      collection_type: list
+      elements:
+        - identifier: P
+          content: "P_content"
+        - identifier: Q
+          content: "Q_content"
+  outputs:
+    combined_out:
+      class: Collection
+      collection_type: list
+      elements:
+        P:
+          asserts:
+          - that: has_text
+            text: "P_content"
+        Q:
+          asserts:
+          - that: has_text
+            text: "Q_content"

--- a/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf.yml
@@ -1,9 +1,9 @@
 class: GalaxyWorkflow
 doc: |
-  Parent maps list_a over subworkflow (single_from_parent is data input,
-  receives one element per invocation). Subworkflow also receives list_b
-  as a collection and maps cat over it internally. Tests whether output
-  becomes list:list (outer=list_a, inner=list_b).
+  Parent-level mapping and subworkflow-internal mapping do not combine
+  into nested output. Consistent with collection_semantics.yml — implicit
+  mapping resolves the gap between provided and expected depth across
+  all inputs simultaneously, not per-input independently.
 inputs:
   list_a:
     type: collection

--- a/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf.yml
+++ b/lib/galaxy_test/workflow/subworkflow_mapping_combination.gxwf.yml
@@ -1,0 +1,42 @@
+class: GalaxyWorkflow
+doc: |
+  Parent maps list_a over subworkflow (single_from_parent is data input,
+  receives one element per invocation). Subworkflow also receives list_b
+  as a collection and maps cat over it internally. Tests whether output
+  becomes list:list (outer=list_a, inner=list_b).
+inputs:
+  list_a:
+    type: collection
+    collection_type: list
+  list_b:
+    type: collection
+    collection_type: list
+outputs:
+  combined_out:
+    outputSource: sub/sub_out
+steps:
+  sub:
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        single_from_parent: data
+        collection_to_map:
+          type: collection
+          collection_type: list
+      outputs:
+        sub_out:
+          outputSource: the_cat/out_file1
+      steps:
+        consume_parent:
+          tool_id: cat
+          in:
+            input1:
+              source: single_from_parent
+        the_cat:
+          tool_id: cat
+          in:
+            input1:
+              source: collection_to_map
+    in:
+      single_from_parent: list_a
+      collection_to_map: list_b

--- a/lib/galaxy_test/workflow/test_framework_workflows.py
+++ b/lib/galaxy_test/workflow/test_framework_workflows.py
@@ -102,11 +102,18 @@ class TestWorkflow(ApiTestCase):
             verify_file_contents_against_dict(get_filename, _get_location, item_label, output_content, test_properties)
             if isinstance(test_properties, dict):
                 metadata = get_metadata_to_test(test_properties)
-                if metadata:
+                top_level_properties = _get_top_level_properties(test_properties)
+                if metadata or top_level_properties:
                     dataset_details = self.dataset_populator.get_history_dataset_details(
                         run_summary.history_id, content_id=dataset["id"]
                     )
-                    compare_expected_metadata_to_api_response(metadata, dataset_details)
+                    if metadata:
+                        compare_expected_metadata_to_api_response(metadata, dataset_details)
+                    for prop, expected in top_level_properties.items():
+                        actual = dataset_details.get(prop)
+                        assert (
+                            actual == expected
+                        ), f"Expected {prop}={expected!r} but got {prop}={actual!r} for {item_label}"
 
         if is_collection_test:
             assert isinstance(test_properties, dict)
@@ -144,6 +151,13 @@ def _workflow_test_path(workflow_path: Path) -> Path:
     base_name = workflow_path.name[0 : -len(".gxwf.yml")]
     test_path = workflow_path.parent / f"{base_name}.gxwf-tests.yml"
     return test_path
+
+
+TOP_LEVEL_ASSERTION_PROPERTIES = {"visible", "deleted"}
+
+
+def _get_top_level_properties(test_properties: dict) -> dict:
+    return {k: test_properties[k] for k in TOP_LEVEL_ASSERTION_PROPERTIES if k in test_properties}
 
 
 def _get_location(location: str) -> str:


### PR DESCRIPTION
We were working on https://github.com/galaxyproject/galaxy/issues/22200 and I asked the agent to summarize everything that could be learned from existing tests - then we found gaps in what can be deduced and searched for tests that covered the gaps - we went through everything one fact at a time by this stage. I think the remaining gaps in the tests are real and implemented with fixes here. I think the resulting tests are useful for documentation and regression prevention (obviously there are no bug fixes here so we didn't find anything terrible but I think these are useful at preventing regressions nonetheless even if the purpose is more documentation). 

The final summary of what can be learned from the tests is here - https://gist.github.com/jmchilton/6f6dc82eacaececdc76367569ccb2a5b - augmented with some actual code analysis where tests would have been too messy or too noisy. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
