### PR TITLE
Restore the #22116 fixes that only apply to dev

### DIFF
--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1399,11 +1399,11 @@ gx_data_optional:
    - parameter: {src: hda, id: 5}
   job_internal_invalid: &data_optional_job_internal_invalid
    - {}
-  job_runtime_valid:
+  job_runtime_valid: &data_optional_job_runtime_valid
    - parameter: {class: File, basename: "f.txt", location: "step_input://0",
       path: "/tmp/f.txt", nameroot: "f", nameext: ".txt", format: "txt", size: 100}
    - parameter: null
-  job_runtime_invalid:
+  job_runtime_invalid: &data_optional_job_runtime_invalid
    - parameter: {src: hda, id: 7}
    - parameter: {class: File}
    - {}
@@ -1435,6 +1435,8 @@ gx_hidden_data:
   request_internal_invalid: *data_optional_request_internal_invalid
   job_internal_valid: *data_optional_job_internal_valid
   job_internal_invalid: *data_optional_job_internal_invalid
+  job_runtime_valid: *data_optional_job_runtime_valid
+  job_runtime_invalid: *data_optional_job_runtime_invalid
   workflow_step_valid: *data_optional_workflow_step_valid
   workflow_step_invalid: *data_optional_workflow_step_invalid
   workflow_step_linked_valid: *data_optional_workflow_step_linked_valid


### PR DESCRIPTION
These were stripped out when I adjust this work for 26.0.

xref #22116

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
