### PR TITLE
Propagate `start()` to backends in `DistributedObjectStore`

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1482,6 +1482,10 @@ class DistributedObjectStore(NestedObjectStore):
         as_dict["backends"] = backends
         return as_dict
 
+    def start(self):
+        for backend in self.backends.values():
+            backend.start()
+
     def shutdown(self):
         """Shut down. Kill the free space monitor if there is one."""
         super().shutdown()

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -6,7 +6,10 @@ from tempfile import (
     mkdtemp,
     mkstemp,
 )
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 from uuid import uuid4
 
 import pytest
@@ -512,6 +515,15 @@ def test_distributed_store_with_cache_targets():
     for config_str in [get_example("distributed_s3.yml")]:
         with TestConfig(config_str) as (_, object_store):
             assert len(object_store.cache_targets()) == 2
+
+
+def test_distributed_store_start_propagates_to_backends():
+    with TestConfig(DISTRIBUTED_TEST_CONFIG) as (_, object_store):
+        for backend in object_store.backends.values():
+            backend.start = MagicMock()
+        object_store.start()
+        for backend in object_store.backends.values():
+            backend.start.assert_called_once()
 
 
 HIERARCHICAL_MUST_HAVE_UNIFIED_QUOTA_SOURCE = """<?xml version="1.0"?>


### PR DESCRIPTION
Fixes #22219.

`DistributedObjectStore` inherited the placeholder base `ObjectStore.start()`, so `IRODSObjectStore.start()` (which starts the `ConnectionPoolMonitorThread`) was never called after Gunicorn forks workers.

The fix mirrors the existing `shutdown()` pattern — iterate backends and delegate:

```python
def start(self):
    for backend in self.backends.values():
        backend.start()
```

Also adds `test_distributed_store_start_propagates_to_backends` to verify the delegation, using `MagicMock` to assert `start()` is called on each backend.