### PR TITLE
[26.0] Update fastmcp requirement to 3.0.2

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -4,6 +4,7 @@ a2wsgi==1.10.10
 adal==1.2.7
 ag-ui-protocol==0.1.10
 aiobotocore==3.1.1
+aiofile==3.9.0
 aiofiles==25.1.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.13.3
@@ -19,7 +20,7 @@ apispec==6.9.0
 appdirs==1.4.4
 arcp==0.2.1
 argcomplete==3.6.3
-async-timeout==5.0.1 ; python_full_version < '3.11.3'
+async-timeout==5.0.1 ; python_full_version < '3.11'
 attmap==0.13.2
 attrs==25.4.0
 authlib==1.6.6
@@ -41,6 +42,7 @@ botocore==1.42.30
 bx-python==0.14.0
 cachecontrol==0.14.4
 cachetools==6.2.4
+caio==0.9.25
 celery==5.6.2
 certifi==2026.1.4
 cffi==2.0.0 ; implementation_name == 'pypy' or platform_python_implementation != 'PyPy'
@@ -52,7 +54,6 @@ click-plugins==1.1.1.2
 click-repl==0.3.0
 cloudauthz==0.6.0
 cloudbridge==3.2.0
-cloudpickle==3.1.2
 cohere==5.20.2 ; sys_platform != 'emscripten'
 colorama==0.4.6
 coloredlogs==15.0.1
@@ -67,7 +68,6 @@ defusedxml==0.7.1
 deprecated==1.3.1
 deprecation==2.1.0
 dictobj==0.4
-diskcache==5.6.3
 distro==1.9.0
 dnspython==2.8.0
 docopt==0.6.2
@@ -81,10 +81,9 @@ et-xmlfile==2.0.0
 eval-type-backport==0.3.1
 exceptiongroup==1.3.1
 executing==2.2.1
-fakeredis==2.33.0
 fastapi==0.128.0
 fastavro==1.12.1 ; sys_platform != 'emscripten'
-fastmcp==2.14.4
+fastmcp==3.0.2
 filelock==3.20.3
 fissix==24.4.24
 frozenlist==1.8.0
@@ -140,7 +139,6 @@ legacy-cgi==2.6.4 ; python_full_version >= '3.13'
 limits==5.6.0
 logfire==4.19.0
 logfire-api==4.19.0
-lupa==2.6
 lxml==6.0.2
 mako==1.3.10
 markdown==3.10.1
@@ -173,7 +171,6 @@ openpyxl==3.1.5
 opentelemetry-api==1.39.1
 opentelemetry-exporter-otlp-proto-common==1.39.1
 opentelemetry-exporter-otlp-proto-http==1.39.1
-opentelemetry-exporter-prometheus==0.60b1
 opentelemetry-instrumentation==0.60b1
 opentelemetry-instrumentation-httpx==0.60b1
 opentelemetry-proto==1.39.1
@@ -188,11 +185,9 @@ parsley==1.3
 paste==3.10.1
 pastedeploy==3.1.0
 pathable==0.4.4
-pathvalidate==3.3.1
 pebble==5.1.3
 pillow==12.1.0
 platformdirs==4.5.1
-prometheus-client==0.24.1
 prompt-toolkit==3.0.52
 propcache==0.4.1
 proto-plus==1.27.0
@@ -200,8 +195,7 @@ protobuf==6.33.4
 prov==1.5.1
 psutil==7.2.1
 pulsar-galaxy-lib==0.15.14
-py-key-value-aio==0.3.0
-py-key-value-shared==0.3.0
+py-key-value-aio==0.4.4
 pyasn1==0.6.2
 pyasn1-modules==0.4.2
 pycparser==3.0 ; (implementation_name != 'PyPy' and platform_python_implementation != 'PyPy') or (implementation_name == 'pypy' and platform_python_implementation == 'PyPy')
@@ -215,7 +209,6 @@ pydantic-graph==1.44.0
 pydantic-settings==2.12.0
 pydantic-tes==0.2.0
 pydicom==3.0.1
-pydocket==0.16.6
 pydot==4.0.1
 pyeventsystem==0.1.0
 pyfaidx==0.9.0.3
@@ -231,7 +224,6 @@ pyreadline3==3.5.4 ; sys_platform == 'win32'
 pysam==0.23.3
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.1
-python-json-logger==4.0.0
 python-magic==0.4.27
 python-multipart==0.0.22
 python-slugify==8.0.4
@@ -242,7 +234,6 @@ pywin32-ctypes==0.2.3 ; sys_platform == 'win32'
 pyyaml==6.0.3
 pyzmq==27.1.0
 rdflib==7.5.0
-redis==7.1.0
 referencing==0.36.2
 refgenconf==0.12.2
 regex==2026.1.15
@@ -265,7 +256,6 @@ s3transfer==0.16.0
 schema-salad==8.9.20251102115403
 secretstorage==3.5.0 ; sys_platform == 'linux'
 setuptools==80.10.1
-shellingham==1.5.4
 six==1.17.0
 slowapi==0.1.9
 sniffio==1.3.1
@@ -292,7 +282,6 @@ tornado==6.5.4
 tqdm==4.67.1
 tuspy==1.1.0
 tuspyserver==4.2.3
-typer==0.21.1
 types-protobuf==6.32.1.20251210
 types-requests==2.32.4.20260107 ; sys_platform != 'emscripten'
 typing-extensions==4.15.0
@@ -304,6 +293,7 @@ urllib3==2.6.3
 uvicorn==0.40.0
 uvloop==0.22.1
 vine==5.1.0
+watchfiles==1.1.1
 wcwidth==0.3.2
 webencodings==0.5.1
 webob==1.8.9

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -88,11 +88,17 @@ class GalaxyFileResponse(FileResponse):
         background: Optional["BackgroundTask"] = None,
         filename: Optional[str] = None,
         stat_result: Optional[os.stat_result] = None,
-        method: Optional[str] = None,
         content_disposition_type: str = "attachment",
     ) -> None:
         super().__init__(
-            path, status_code, headers, media_type, background, filename, stat_result, method, content_disposition_type
+            path=path,
+            status_code=status_code,
+            headers=headers,
+            media_type=media_type,
+            background=background,
+            filename=filename,
+            stat_result=stat_result,
+            content_disposition_type=content_disposition_type,
         )
         self.headers["accept-ranges"] = "bytes"
         self.xsendfile = self.nginx_x_accel_redirect_base or self.apache_xsendfile

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -290,7 +290,7 @@ class FastAPIDatasets:
         assert isinstance(display_data, IOBase)
         file_name = getattr(display_data, "name", None)
         assert file_name
-        return GalaxyFileResponse(file_name, headers=headers, method=request.method)
+        return GalaxyFileResponse(file_name, headers=headers)
 
     @router.get(
         "/api/histories/{history_id}/contents/{history_content_id}/display",
@@ -374,7 +374,7 @@ class FastAPIDatasets:
         if isinstance(display_data, IOBase):
             file_name = getattr(display_data, "name", None)
             if file_name:
-                return GalaxyFileResponse(file_name, headers=headers, method=request.method)
+                return GalaxyFileResponse(file_name, headers=headers)
         elif isinstance(display_data, ZipstreamWrapper):
             return StreamingResponse(display_data.response(), headers=headers)
         elif isinstance(display_data, bytes):

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     cloudauthz==0.6.0
     cwl-utils
     dparse
-    gxformat2
+    gxformat2>=0.23.0
     kombu>=5.3
     lagom
     lxml!=4.2.2

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     galaxy-util
     bioblend
     cwltest>=2.5.20240906231108
-    gxformat2
+    gxformat2>=0.23.0
     pytest
     pytest-celery
     PyYAML

--- a/packages/test_selenium/setup.cfg
+++ b/packages/test_selenium/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     galaxy-selenium
     galaxy-test-base
     galaxy-util
-    gxformat2
+    gxformat2>=0.23.0
     pytest
     PyYAML
     requests

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     fastapi>=0.124.0
     gunicorn
     httpx
-    gxformat2
+    gxformat2>=0.23.0
     Mako
     MarkupSafe
     Paste


### PR DESCRIPTION
and update its dependencies. This is needed to drop the requirement on redis 7.1.0, which conflicts with our conditional requirement `redis>=5.3.0,<6` , which is needed for compatibility with celery 5.6.2 .

Fix https://github.com/galaxyproject/galaxy/issues/22201 .

Also:
- Sync gxformat2 in packages with pin in `pyproject.toml`
-  Drop use of deprecated method parameter of starlette ``FileResponse``

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
