### PR TITLE
Add `pick_value` Workflow Module

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -46,7 +46,11 @@
             <FormPickValue
                 v-if="type == 'pick_value'"
                 :step="step"
-                @onChange="onChange" />
+                :datatypes="datatypes"
+                :node-inputs="stepInputs"
+                :post-job-actions="postJobActions"
+                @onChange="onChange"
+                @onChangePostJobActions="onChangePostJobActions" />
             <FormInputCollection
                 v-else-if="type == 'data_collection_input'"
                 :step="step"
@@ -104,9 +108,11 @@ const emit = defineEmits([
     "onEditSubworkflow",
     "onSetData",
     "onUpdateStep",
+    "onChangePostJobActions",
 ]);
 const stepRef = toRef(props, "step");
-const { stepId, contentId, annotation, label, name, type, configForm } = useStepProps(stepRef);
+const { stepId, contentId, annotation, label, name, type, configForm, stepInputs, postJobActions } =
+    useStepProps(stepRef);
 const { stepStore } = useWorkflowStores();
 const uniqueErrorLabel = useUniqueLabelError(stepStore, label.value);
 const stepTitle = computed(() => {
@@ -131,6 +137,9 @@ function onEditSubworkflow() {
 }
 function onUpgradeSubworkflow() {
     emit("onAttemptRefactor", [{ action_type: "upgrade_subworkflow", step: { order_index: stepId.value } }]);
+}
+function onChangePostJobActions(postJobActions: unknown) {
+    emit("onChangePostJobActions", stepId.value, postJobActions);
 }
 
 // keeps the component from emitting the onCreate change event

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -43,8 +43,12 @@
                 v-if="isSubworkflow"
                 :step="step"
                 @onUpdateStep="(id, step) => emit('onUpdateStep', id, step)" />
+            <FormPickValue
+                v-if="type == 'pick_value'"
+                :step="step"
+                @onChange="onChange" />
             <FormInputCollection
-                v-if="type == 'data_collection_input'"
+                v-else-if="type == 'data_collection_input'"
                 :step="step"
                 :datatypes="datatypes"
                 :inputs="configForm?.inputs"
@@ -87,6 +91,7 @@ import FormDisplay from "@/components/Form/FormDisplay.vue";
 import FormElement from "@/components/Form/FormElement.vue";
 import FormInputCollection from "@/components/Workflow/Editor/Forms/FormInputCollection.vue";
 import FormOutputLabel from "@/components/Workflow/Editor/Forms/FormOutputLabel.vue";
+import FormPickValue from "@/components/Workflow/Editor/Forms/FormPickValue.vue";
 
 const props = defineProps<{
     step: Step;

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
@@ -1,0 +1,157 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getLocalVue } from "@tests/vitest/helpers";
+import { shallowMount, type Wrapper } from "@vue/test-utils";
+import { PiniaVuePlugin } from "pinia";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Vue from "vue";
+
+import type { Step } from "@/stores/workflowStepStore";
+
+import FormElement from "@/components/Form/FormElement.vue";
+
+import FormPickValue from "./FormPickValue.vue";
+
+const localVue = getLocalVue();
+localVue.use(PiniaVuePlugin);
+
+interface EmittedState {
+    mode: string;
+    num_inputs: number;
+}
+
+function makeStep(overrides: Partial<Step> = {}): Step {
+    return {
+        id: 0,
+        name: "Pick Value",
+        type: "pick_value",
+        inputs: [],
+        outputs: [{ name: "output", extensions: ["input"], optional: false }],
+        input_connections: {},
+        position: { left: 0, top: 0 },
+        tool_state: { mode: "first_non_null", num_inputs: 2 },
+        workflow_outputs: [],
+        ...overrides,
+    } as Step;
+}
+
+function mountPickValue(step?: Step): Wrapper<Vue> {
+    return shallowMount(FormPickValue, {
+        propsData: {
+            step: step ?? makeStep(),
+        },
+        localVue,
+        pinia: createTestingPinia({ createSpy: vi.fn }),
+        provide: {
+            workflowId: "mock-workflow",
+        },
+    });
+}
+
+function getLastEmittedState(wrapper: Wrapper<Vue>): EmittedState {
+    const events = wrapper.emitted().onChange!;
+    return events[events.length - 1]![0] as EmittedState;
+}
+
+function getEmittedCount(wrapper: Wrapper<Vue>): number {
+    return wrapper.emitted().onChange!.length;
+}
+
+describe("FormPickValue", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("mode defaults", () => {
+        it("defaults to first_non_null when tool_state is empty", () => {
+            const wrapper = mountPickValue(makeStep({ tool_state: {} }));
+            const state = getLastEmittedState(wrapper);
+            expect(state.mode).toBe("first_non_null");
+            expect(state.num_inputs).toBe(2);
+        });
+
+        it("preserves mode from tool_state", () => {
+            const wrapper = mountPickValue(makeStep({ tool_state: { mode: "all_non_null", num_inputs: 3 } }));
+            const state = getLastEmittedState(wrapper);
+            expect(state.mode).toBe("all_non_null");
+            expect(state.num_inputs).toBe(3);
+        });
+    });
+
+    describe("mode changes", () => {
+        it("emits onChange with updated mode", () => {
+            const wrapper = mountPickValue();
+            const formElement = wrapper.findComponent(FormElement);
+            formElement.vm.$emit("input", "the_only_non_null");
+
+            const state = getLastEmittedState(wrapper);
+            expect(state.mode).toBe("the_only_non_null");
+            expect(state.num_inputs).toBe(2);
+        });
+
+        it("preserves num_inputs when changing mode", () => {
+            const wrapper = mountPickValue(makeStep({ tool_state: { mode: "first_non_null", num_inputs: 5 } }));
+            const formElement = wrapper.findComponent(FormElement);
+            formElement.vm.$emit("input", "all_non_null");
+
+            const state = getLastEmittedState(wrapper);
+            expect(state.mode).toBe("all_non_null");
+            expect(state.num_inputs).toBe(5);
+        });
+    });
+
+    describe("grow-on-connect", () => {
+        it("increments num_inputs when last terminal gets connected", async () => {
+            const step = makeStep({ tool_state: { mode: "first_non_null", num_inputs: 2 } });
+            const wrapper = mountPickValue(step);
+
+            // Simulate connecting to the last empty terminal (input_2, since num_inputs=2)
+            await wrapper.setProps({
+                step: {
+                    ...step,
+                    input_connections: {
+                        input_0: [{ id: 1, output_name: "output" }],
+                        input_1: [{ id: 2, output_name: "output" }],
+                        input_2: [{ id: 3, output_name: "output" }],
+                    },
+                },
+            });
+
+            expect(getLastEmittedState(wrapper).num_inputs).toBe(3);
+        });
+
+        it("does not increment when a non-last terminal gets connected", async () => {
+            const step = makeStep({ tool_state: { mode: "first_non_null", num_inputs: 3 } });
+            const wrapper = mountPickValue(step);
+            const countBefore = getEmittedCount(wrapper);
+
+            // Connect to input_1 (not the last terminal input_3)
+            await wrapper.setProps({
+                step: {
+                    ...step,
+                    input_connections: {
+                        input_1: [{ id: 2, output_name: "output" }],
+                    },
+                },
+            });
+
+            expect(getEmittedCount(wrapper)).toBe(countBefore);
+        });
+    });
+
+    describe("JSON-encoded tool_state", () => {
+        it("handles JSON-string-encoded values from API", () => {
+            // The build_module API may return tool_state values as JSON strings
+            const wrapper = mountPickValue(
+                makeStep({
+                    tool_state: {
+                        mode: JSON.stringify("the_only_non_null"),
+                        num_inputs: JSON.stringify(4),
+                    },
+                })
+            );
+            const state = getLastEmittedState(wrapper);
+            expect(state.mode).toBe("the_only_non_null");
+            expect(state.num_inputs).toBe(4);
+        });
+    });
+});

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
@@ -35,7 +35,7 @@ function makeStep(overrides: Partial<Step> = {}): Step {
 }
 
 function mountPickValue(step?: Step): Wrapper<Vue> {
-    return shallowMount(FormPickValue, {
+    return shallowMount(FormPickValue as any, {
         propsData: {
             step: step ?? makeStep(),
         },

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
@@ -3,13 +3,12 @@ import { getLocalVue } from "@tests/vitest/helpers";
 import { shallowMount, type Wrapper } from "@vue/test-utils";
 import { PiniaVuePlugin } from "pinia";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import Vue from "vue";
+import type Vue from "vue";
 
 import type { Step } from "@/stores/workflowStepStore";
 
-import FormElement from "@/components/Form/FormElement.vue";
-
 import FormPickValue from "./FormPickValue.vue";
+import FormElement from "@/components/Form/FormElement.vue";
 
 const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);
@@ -147,7 +146,7 @@ describe("FormPickValue", () => {
                         mode: JSON.stringify("the_only_non_null"),
                         num_inputs: JSON.stringify(4),
                     },
-                })
+                }),
             );
             const state = getLastEmittedState(wrapper);
             expect(state.mode).toBe("the_only_non_null");

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
@@ -119,21 +119,102 @@ describe("FormPickValue", () => {
         });
 
         it("does not increment when a non-last terminal gets connected", async () => {
-            const step = makeStep({ tool_state: { mode: "first_non_null", num_inputs: 3 } });
+            const step = makeStep({
+                tool_state: { mode: "first_non_null", num_inputs: 3 },
+                input_connections: {
+                    input_0: [{ id: 1, output_name: "output" }],
+                    input_1: [{ id: 2, output_name: "output" }],
+                },
+            });
             const wrapper = mountPickValue(step);
             const countBefore = getEmittedCount(wrapper);
 
-            // Connect to input_1 (not the last terminal input_3)
+            // Connect to input_2 (not the last terminal input_3)
             await wrapper.setProps({
                 step: {
                     ...step,
                     input_connections: {
+                        input_0: [{ id: 1, output_name: "output" }],
                         input_1: [{ id: 2, output_name: "output" }],
+                        input_2: [{ id: 3, output_name: "output" }],
                     },
                 },
             });
 
+            // num_inputs stays 3 since input_2 is not the last terminal (input_3)
             expect(getEmittedCount(wrapper)).toBe(countBefore);
+        });
+    });
+
+    describe("shrink-on-disconnect", () => {
+        it("decrements num_inputs when a connection is removed", async () => {
+            const step = makeStep({
+                tool_state: { mode: "first_non_null", num_inputs: 3 },
+                input_connections: {
+                    input_0: [{ id: 1, output_name: "output" }],
+                    input_1: [{ id: 2, output_name: "output" }],
+                    input_2: [{ id: 3, output_name: "output" }],
+                },
+            });
+            const wrapper = mountPickValue(step);
+
+            // Simulate disconnect of input_1 after compaction: input_2 renamed to input_1
+            await wrapper.setProps({
+                step: {
+                    ...step,
+                    input_connections: {
+                        input_0: [{ id: 1, output_name: "output" }],
+                        input_1: [{ id: 3, output_name: "output" }],
+                    },
+                },
+            });
+
+            expect(getLastEmittedState(wrapper).num_inputs).toBe(2);
+        });
+
+        it("does not shrink below minimum of 2", async () => {
+            const step = makeStep({
+                tool_state: { mode: "first_non_null", num_inputs: 2 },
+                input_connections: {
+                    input_0: [{ id: 1, output_name: "output" }],
+                },
+            });
+            const wrapper = mountPickValue(step);
+
+            // Disconnect all
+            await wrapper.setProps({
+                step: {
+                    ...step,
+                    input_connections: {},
+                },
+            });
+
+            expect(getLastEmittedState(wrapper).num_inputs).toBe(2);
+        });
+
+        it("increases num_inputs on undo-of-shrink", async () => {
+            const step = makeStep({
+                tool_state: { mode: "first_non_null", num_inputs: 2 },
+                input_connections: {
+                    input_0: [{ id: 1, output_name: "output" }],
+                },
+            });
+            const wrapper = mountPickValue(step);
+
+            // Simulate undo restoring connections
+            await wrapper.setProps({
+                step: {
+                    ...step,
+                    tool_state: { mode: "first_non_null", num_inputs: 2 },
+                    input_connections: {
+                        input_0: [{ id: 1, output_name: "output" }],
+                        input_1: [{ id: 2, output_name: "output" }],
+                        input_2: [{ id: 3, output_name: "output" }],
+                    },
+                },
+            });
+
+            expect(getLastEmittedState(wrapper).num_inputs).toBe(3);
         });
     });
 

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.test.ts
@@ -69,7 +69,16 @@ describe("FormPickValue", () => {
         });
 
         it("preserves mode from tool_state", () => {
-            const wrapper = mountPickValue(makeStep({ tool_state: { mode: "all_non_null", num_inputs: 3 } }));
+            const wrapper = mountPickValue(
+                makeStep({
+                    tool_state: { mode: "all_non_null", num_inputs: 3 },
+                    input_connections: {
+                        input_0: [{ id: 1, output_name: "output" }],
+                        input_1: [{ id: 2, output_name: "output" }],
+                        input_2: [{ id: 3, output_name: "output" }],
+                    },
+                }),
+            );
             const state = getLastEmittedState(wrapper);
             expect(state.mode).toBe("all_non_null");
             expect(state.num_inputs).toBe(3);
@@ -226,6 +235,12 @@ describe("FormPickValue", () => {
                     tool_state: {
                         mode: JSON.stringify("the_only_non_null"),
                         num_inputs: JSON.stringify(4),
+                    },
+                    input_connections: {
+                        input_0: [{ id: 1, output_name: "output" }],
+                        input_1: [{ id: 2, output_name: "output" }],
+                        input_2: [{ id: 3, output_name: "output" }],
+                        input_3: [{ id: 4, output_name: "output" }],
                     },
                 }),
             );

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
@@ -6,9 +6,9 @@ import type { InputTerminalSource, PostJobActions, Step } from "@/stores/workflo
 
 import { useToolState } from "../composables/useToolState";
 
+import Heading from "@/components/Common/Heading.vue";
 import FormElement from "@/components/Form/FormElement.vue";
 import FormSection from "@/components/Workflow/Editor/Forms/FormSection.vue";
-import Heading from "@/components/Common/Heading.vue";
 
 interface ToolState {
     mode: string;
@@ -26,7 +26,7 @@ const props = withDefaults(
         datatypes: undefined,
         nodeInputs: () => [],
         postJobActions: () => ({}),
-    }
+    },
 );
 
 const stepRef = toRef(props, "step");
@@ -77,7 +77,7 @@ watch(
             emit("onChange", state);
         }
     },
-    { deep: true }
+    { deep: true },
 );
 
 // Dummy initial emit (same pattern as FormInputCollection — resets initialChange guard)

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { toRef, watch } from "vue";
+
+import type { Step } from "@/stores/workflowStepStore";
+
+import { useToolState } from "../composables/useToolState";
+
+import FormElement from "@/components/Form/FormElement.vue";
+
+interface ToolState {
+    mode: string;
+    num_inputs: number;
+}
+
+const props = defineProps<{
+    step: Step;
+}>();
+
+const stepRef = toRef(props, "step");
+const { toolState } = useToolState(stepRef);
+
+function asToolState(ts: unknown): ToolState {
+    const raw = ts as Record<string, unknown>;
+    return {
+        mode: (raw.mode as string) ?? "first_non_null",
+        num_inputs: (raw.num_inputs as number) ?? 2,
+    };
+}
+
+function cleanToolState(): ToolState {
+    if (toolState.value) {
+        return asToolState({ ...toolState.value });
+    }
+    return { mode: "first_non_null", num_inputs: 2 };
+}
+
+const emit = defineEmits(["onChange"]);
+
+const modeOptions = [
+    { value: "first_non_null", label: "First non-null (error if all null)" },
+    { value: "first_or_skip", label: "First non-null (skip if all null)" },
+    { value: "the_only_non_null", label: "The only non-null (error if != 1)" },
+    { value: "all_non_null", label: "All non-null (as collection)" },
+];
+
+function onMode(newMode: string) {
+    const state = cleanToolState();
+    state.mode = newMode;
+    emit("onChange", state);
+}
+
+// Grow-on-connect: watch step connections, add terminal when last empty one gets connected
+watch(
+    () => props.step.input_connections,
+    (connections) => {
+        const state = cleanToolState();
+        const lastTerminalName = `input_${state.num_inputs}`;
+        if (connections && connections[lastTerminalName]) {
+            state.num_inputs = state.num_inputs + 1;
+            emit("onChange", state);
+        }
+    },
+    { deep: true }
+);
+
+// Dummy initial emit (same pattern as FormInputCollection — resets initialChange guard)
+emit("onChange", cleanToolState());
+</script>
+
+<template>
+    <div>
+        <FormElement
+            id="mode"
+            :value="asToolState(toolState).mode"
+            title="Selection Mode"
+            type="select"
+            :options="modeOptions"
+            help="How to select among the connected inputs."
+            @input="onMode" />
+    </div>
+</template>

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
@@ -37,10 +37,10 @@ function cleanToolState(): ToolState {
 const emit = defineEmits(["onChange"]);
 
 const modeOptions = [
-    { value: "first_non_null", label: "First non-null (error if all null)" },
-    { value: "first_or_skip", label: "First non-null (skip if all null)" },
-    { value: "the_only_non_null", label: "The only non-null (error if != 1)" },
-    { value: "all_non_null", label: "All non-null (as collection)" },
+    ["First non-null (error if all null)", "first_non_null"],
+    ["First non-null (skip if all null)", "first_or_skip"],
+    ["The only non-null (error if != 1)", "the_only_non_null"],
+    ["All non-null (as collection)", "all_non_null"],
 ];
 
 function onMode(newMode: string) {

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
@@ -1,20 +1,33 @@
 <script setup lang="ts">
 import { toRef, watch } from "vue";
 
-import type { Step } from "@/stores/workflowStepStore";
+import type { DatatypesMapperModel } from "@/components/Datatypes/model";
+import type { InputTerminalSource, PostJobActions, Step } from "@/stores/workflowStepStore";
 
 import { useToolState } from "../composables/useToolState";
 
 import FormElement from "@/components/Form/FormElement.vue";
+import FormSection from "@/components/Workflow/Editor/Forms/FormSection.vue";
+import Heading from "@/components/Common/Heading.vue";
 
 interface ToolState {
     mode: string;
     num_inputs: number;
 }
 
-const props = defineProps<{
-    step: Step;
-}>();
+const props = withDefaults(
+    defineProps<{
+        step: Step;
+        datatypes?: DatatypesMapperModel["datatypes"];
+        nodeInputs?: InputTerminalSource[];
+        postJobActions?: PostJobActions;
+    }>(),
+    {
+        datatypes: undefined,
+        nodeInputs: () => [],
+        postJobActions: () => ({}),
+    }
+);
 
 const stepRef = toRef(props, "step");
 const { toolState } = useToolState(stepRef);
@@ -34,7 +47,7 @@ function cleanToolState(): ToolState {
     return { mode: "first_non_null", num_inputs: 2 };
 }
 
-const emit = defineEmits(["onChange"]);
+const emit = defineEmits(["onChange", "onChangePostJobActions"]);
 
 const modeOptions = [
     ["First non-null (error if all null)", "first_non_null"],
@@ -47,6 +60,10 @@ function onMode(newMode: string) {
     const state = cleanToolState();
     state.mode = newMode;
     emit("onChange", state);
+}
+
+function onChangePostJobActions(postJobActions: PostJobActions) {
+    emit("onChangePostJobActions", postJobActions);
 }
 
 // Grow-on-connect: watch step connections, add terminal when last empty one gets connected
@@ -77,5 +94,16 @@ emit("onChange", cleanToolState());
             :options="modeOptions"
             help="How to select among the connected inputs."
             @input="onMode" />
+        <div v-if="datatypes && step.outputs && step.outputs.length > 0" class="mt-2 mb-4">
+            <Heading h2 separator bold size="sm"> Additional Options </Heading>
+            <FormSection
+                :id="step.id"
+                :node-inputs="nodeInputs ?? []"
+                :node-outputs="step.outputs"
+                :step="step"
+                :datatypes="datatypes"
+                :post-job-actions="postJobActions ?? {}"
+                @onChange="onChangePostJobActions" />
+        </div>
     </div>
 </template>

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
@@ -66,15 +66,33 @@ function onChangePostJobActions(postJobActions: PostJobActions) {
     emit("onChangePostJobActions", postJobActions);
 }
 
-// Grow-on-connect: watch step connections, add terminal when last empty one gets connected
+// Watch connections: grow on connect, shrink on disconnect
 watch(
     () => props.step.input_connections,
     (connections) => {
         const state = cleanToolState();
+
+        // Grow: last terminal got connected
         const lastTerminalName = `input_${state.num_inputs}`;
         if (connections && connections[lastTerminalName]) {
             state.num_inputs = state.num_inputs + 1;
             emit("onChange", state);
+            return;
+        }
+
+        // Shrink or undo-of-shrink: sync num_inputs with actual connections
+        if (connections) {
+            const connectedCount = Object.keys(connections).filter(
+                (k) =>
+                    k.startsWith("input_") &&
+                    connections[k] != null &&
+                    (!Array.isArray(connections[k]) || (connections[k] as unknown[]).length > 0),
+            ).length;
+            const desired = Math.max(2, connectedCount);
+            if (desired !== state.num_inputs) {
+                state.num_inputs = desired;
+                emit("onChange", state);
+            }
         }
     },
     { deep: true },

--- a/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormPickValue.vue
@@ -66,6 +66,15 @@ function onChangePostJobActions(postJobActions: PostJobActions) {
     emit("onChangePostJobActions", postJobActions);
 }
 
+function countConnectedInputs(connections: Record<string, unknown>): number {
+    return Object.keys(connections).filter(
+        (k) =>
+            k.startsWith("input_") &&
+            connections[k] != null &&
+            (!Array.isArray(connections[k]) || (connections[k] as unknown[]).length > 0),
+    ).length;
+}
+
 // Watch connections: grow on connect, shrink on disconnect
 watch(
     () => props.step.input_connections,
@@ -82,13 +91,7 @@ watch(
 
         // Shrink or undo-of-shrink: sync num_inputs with actual connections
         if (connections) {
-            const connectedCount = Object.keys(connections).filter(
-                (k) =>
-                    k.startsWith("input_") &&
-                    connections[k] != null &&
-                    (!Array.isArray(connections[k]) || (connections[k] as unknown[]).length > 0),
-            ).length;
-            const desired = Math.max(2, connectedCount);
+            const desired = Math.max(2, countConnectedInputs(connections));
             if (desired !== state.num_inputs) {
                 state.num_inputs = desired;
                 emit("onChange", state);
@@ -100,6 +103,17 @@ watch(
 
 // Dummy initial emit (same pattern as FormInputCollection — resets initialChange guard)
 emit("onChange", cleanToolState());
+
+// Correct num_inputs if connections don't match state (e.g., compaction happened while unmounted)
+const connections = props.step.input_connections;
+if (connections) {
+    const desired = Math.max(2, countConnectedInputs(connections));
+    const state = cleanToolState();
+    if (desired !== state.num_inputs) {
+        state.num_inputs = desired;
+        emit("onChange", state);
+    }
+}
 </script>
 
 <template>

--- a/client/src/components/Workflow/Editor/NodeInspector.vue
+++ b/client/src/components/Workflow/Editor/NodeInspector.vue
@@ -129,6 +129,7 @@ function updateStored(v: boolean) {
                     :datatypes="datatypes"
                     @onSetData="(id, d) => emit('dataChanged', id, d)"
                     @onUpdateStep="(id, s) => emit('stepUpdated', id, s)"
+                    @onChangePostJobActions="(id, a) => emit('postJobActionsChanged', id, a)"
                     @onAnnotation="(id, a) => emit('annotationChanged', id, a)"
                     @onLabel="(id, l) => emit('labelChanged', id, l)"
                     @onEditSubworkflow="(id) => emit('editSubworkflow', id)"

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -406,7 +406,7 @@ const removeTagsAction = computed(() => {
         <DraggableWrapper
             :id="id"
             ref="terminalComponent"
-            v-b-tooltip.hover="!props.blank ? outputDetails : ''"
+            v-b-tooltip.hover.noninteractive="!props.blank ? outputDetails : ''"
             class="output-terminal prevent-zoom"
             :class="{ 'mapped-over': isMultiple, 'blank-output': props.blank }"
             :output-name="output.name"

--- a/client/src/components/Workflow/Editor/modules/inputs.ts
+++ b/client/src/components/Workflow/Editor/modules/inputs.ts
@@ -1,5 +1,5 @@
 import { faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
-import { faPencilAlt } from "@fortawesome/free-solid-svg-icons";
+import { faCodeBranch, faPencilAlt } from "@fortawesome/free-solid-svg-icons";
 import type { IconDefinition } from "font-awesome-6";
 
 export interface WorkflowInput {
@@ -95,6 +95,12 @@ export function getWorkflowInputs(): WorkflowInput[] {
             stateOverwrites: {
                 parameter_type: "directory_uri",
             },
+        },
+        {
+            moduleId: "pick_value",
+            title: "Pick Value",
+            description: "Select among conditional branch outputs",
+            icon: faCodeBranch,
         },
     ];
 }

--- a/client/src/components/Workflow/Editor/modules/itemIcons.ts
+++ b/client/src/components/Workflow/Editor/modules/itemIcons.ts
@@ -1,6 +1,7 @@
 import {
     faArrowRightFromBracket,
     faArrowRightToBracket,
+    faCodeBranch,
     faComment,
     faFile,
     faFolderOpen,
@@ -22,6 +23,7 @@ export const iconForType = {
         parameter_input: faPen,
         subworkflow: faSitemap,
         pause: faPause,
+        pick_value: faCodeBranch,
     },
     input: faArrowRightToBracket,
     output: faArrowRightFromBracket,

--- a/client/src/components/Workflow/Editor/modules/pickValueCompact.test.ts
+++ b/client/src/components/Workflow/Editor/modules/pickValueCompact.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { computePickValueCompaction } from "./pickValueCompact";
+
+describe("computePickValueCompaction", () => {
+    it("no renames when disconnecting last of 3", () => {
+        const connections = {
+            input_0: { id: 1, output_name: "out" },
+            input_1: { id: 2, output_name: "out" },
+            input_2: { id: 3, output_name: "out" },
+        };
+        const result = computePickValueCompaction(connections, "input_2");
+        expect(result.renames).toEqual([]);
+    });
+
+    it("one rename when disconnecting middle of 3", () => {
+        const connections = {
+            input_0: { id: 1, output_name: "out" },
+            input_1: { id: 2, output_name: "out" },
+            input_2: { id: 3, output_name: "out" },
+        };
+        const result = computePickValueCompaction(connections, "input_1");
+        expect(result.renames).toEqual([{ from: "input_2", to: "input_1" }]);
+    });
+
+    it("three renames when disconnecting first of 4", () => {
+        const connections = {
+            input_0: { id: 1, output_name: "out" },
+            input_1: { id: 2, output_name: "out" },
+            input_2: { id: 3, output_name: "out" },
+            input_3: { id: 4, output_name: "out" },
+        };
+        const result = computePickValueCompaction(connections, "input_0");
+        expect(result.renames).toEqual([
+            { from: "input_1", to: "input_0" },
+            { from: "input_2", to: "input_1" },
+            { from: "input_3", to: "input_2" },
+        ]);
+    });
+
+    it("no renames when disconnecting only connection", () => {
+        const connections = {
+            input_0: { id: 1, output_name: "out" },
+        };
+        const result = computePickValueCompaction(connections, "input_0");
+        expect(result.renames).toEqual([]);
+    });
+
+    it("no renames with empty connections", () => {
+        const result = computePickValueCompaction({}, "input_0");
+        expect(result.renames).toEqual([]);
+    });
+
+    it("ignores non-input keys", () => {
+        const connections = {
+            input_0: { id: 1, output_name: "out" },
+            input_1: { id: 2, output_name: "out" },
+            input_2: { id: 3, output_name: "out" },
+            someOtherKey: { id: 99, output_name: "other" },
+        };
+        const result = computePickValueCompaction(connections, "input_1");
+        expect(result.renames).toEqual([{ from: "input_2", to: "input_1" }]);
+    });
+
+    it("ignores null/undefined connection values", () => {
+        const connections: Record<string, unknown> = {
+            input_0: { id: 1, output_name: "out" },
+            input_1: null,
+            input_2: { id: 3, output_name: "out" },
+        };
+        const result = computePickValueCompaction(connections, "input_1");
+        expect(result.renames).toEqual([{ from: "input_2", to: "input_1" }]);
+    });
+});

--- a/client/src/components/Workflow/Editor/modules/pickValueCompact.ts
+++ b/client/src/components/Workflow/Editor/modules/pickValueCompact.ts
@@ -1,0 +1,83 @@
+import type { WorkflowConnectionStore } from "@/stores/workflowConnectionStore";
+import { getTerminalId } from "@/stores/workflowConnectionStore";
+import type { Connection, InputTerminal } from "@/stores/workflowStoreTypes";
+
+export interface CompactRename {
+    from: string;
+    to: string;
+}
+
+export interface CompactResult {
+    renames: CompactRename[];
+}
+
+/**
+ * Compute which terminals need renaming after a disconnect.
+ * disconnectedName is excluded from the connected set.
+ */
+export function computePickValueCompaction(
+    inputConnections: Record<string, unknown>,
+    disconnectedName: string,
+): CompactResult {
+    const connected = Object.keys(inputConnections)
+        .filter((k) => k.startsWith("input_") && k !== disconnectedName && inputConnections[k] != null)
+        .map((k) => ({ name: k, index: parseInt(k.replace("input_", ""), 10) }))
+        .sort((a, b) => a.index - b.index);
+
+    const renames: CompactRename[] = [];
+    connected.forEach((entry, seqIndex) => {
+        if (entry.index !== seqIndex) {
+            renames.push({ from: entry.name, to: `input_${seqIndex}` });
+        }
+    });
+
+    return { renames };
+}
+
+/**
+ * Apply compaction: rename connections in stores (low to high order).
+ */
+export function applyCompaction(
+    stepId: number,
+    renames: CompactRename[],
+    connectionStore: WorkflowConnectionStore,
+): void {
+    for (const rename of renames) {
+        const terminalId = getTerminalId({ stepId, name: rename.from, connectorType: "input" });
+        const conns = [...connectionStore.getConnectionsForTerminal(terminalId)];
+
+        connectionStore.removeConnection({ stepId, name: rename.from, connectorType: "input" } as InputTerminal);
+
+        for (const conn of conns) {
+            const newConn: Connection = {
+                input: { stepId, name: rename.to, connectorType: "input" },
+                output: { ...conn.output },
+            };
+            connectionStore.addConnection(newConn);
+        }
+    }
+}
+
+/**
+ * Reverse compaction: rename connections back (high to low order).
+ */
+export function reverseCompaction(
+    stepId: number,
+    renames: CompactRename[],
+    connectionStore: WorkflowConnectionStore,
+): void {
+    for (const rename of [...renames].reverse()) {
+        const terminalId = getTerminalId({ stepId, name: rename.to, connectorType: "input" });
+        const conns = [...connectionStore.getConnectionsForTerminal(terminalId)];
+
+        connectionStore.removeConnection({ stepId, name: rename.to, connectorType: "input" } as InputTerminal);
+
+        for (const conn of conns) {
+            const newConn: Connection = {
+                input: { stepId, name: rename.from, connectorType: "input" },
+                output: { ...conn.output },
+            };
+            connectionStore.addConnection(newConn);
+        }
+    }
+}

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -435,7 +435,7 @@ describe("canAccept", () => {
         expect(step.input_connections["f1"]).toStrictEqual([{ id: dataOutOne.stepId, output_name: dataOutOne.name }]);
         multiDataIn.disconnect(dataOutOne);
         step = stepStore.getStep(multiDataIn.stepId)!;
-        expect(step.input_connections["f1"]).toStrictEqual([]);
+        expect(step.input_connections["f1"]).toBeUndefined();
         multiDataIn.connect(dataOutOne);
         multiDataIn.connect(dataOutTwo);
         step = stepStore.getStep(multiDataIn.stepId)!;

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -22,6 +22,7 @@ import {
     type CollectionTypeDescriptor,
     NULL_COLLECTION_TYPE_DESCRIPTION,
 } from "./collectionTypeDescription";
+import { applyCompaction, computePickValueCompaction, reverseCompaction } from "./pickValueCompact";
 
 export const NO_COLLECTION_TYPE_INFORMATION_MESSAGE =
     "No collection type or collection type source defined - this is fine but may lead to less intuitive connection logic.";
@@ -106,12 +107,35 @@ class Terminal extends EventEmitter {
         this.stores.connectionStore.addConnection(connection);
     }
     disconnect(other: Terminal | Connection) {
-        this.stores.undoRedoStore
-            .action()
-            .onRun(() => this.dropConnection(other))
-            .onUndo(() => this.makeConnection(other))
-            .setName("disconnect steps")
-            .apply();
+        const connection = this.buildConnection(other);
+        const step = this.stores.stepStore.getStep(connection.input.stepId);
+
+        if (step?.type === "pick_value") {
+            const compaction = computePickValueCompaction(step.input_connections, connection.input.name);
+            this.stores.undoRedoStore
+                .action()
+                .onRun(() => {
+                    this.dropConnection(other);
+                    if (compaction.renames.length > 0) {
+                        applyCompaction(step.id, compaction.renames, this.stores.connectionStore);
+                    }
+                })
+                .onUndo(() => {
+                    if (compaction.renames.length > 0) {
+                        reverseCompaction(step.id, compaction.renames, this.stores.connectionStore);
+                    }
+                    this.makeConnection(other);
+                })
+                .setName("disconnect steps")
+                .apply();
+        } else {
+            this.stores.undoRedoStore
+                .action()
+                .onRun(() => this.dropConnection(other))
+                .onUndo(() => this.makeConnection(other))
+                .setName("disconnect steps")
+                .apply();
+        }
     }
     dropConnection(other: Terminal | Connection) {
         const connection = this.buildConnection(other);

--- a/client/src/components/Workflow/icons.js
+++ b/client/src/components/Workflow/icons.js
@@ -5,4 +5,5 @@ export default {
     subworkflow: "fa-sitemap fa-rotate-270",
     parameter_input: "fa-pencil-alt", // fa-pencil for older FontAwesome, fa-pencil-alt for newer
     pause: "fa-pause",
+    pick_value: "fa-code-branch",
 };

--- a/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
@@ -5,7 +5,14 @@ import { computed } from "vue";
 import WorkflowIcons from "@/components/Workflow/icons";
 
 interface WorkflowStepIconProps {
-    stepType: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause" | "pick_value";
+    stepType:
+        | "tool"
+        | "data_input"
+        | "data_collection_input"
+        | "subworkflow"
+        | "parameter_input"
+        | "pause"
+        | "pick_value";
 }
 
 const props = defineProps<WorkflowStepIconProps>();

--- a/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepIcon.vue
@@ -5,7 +5,7 @@ import { computed } from "vue";
 import WorkflowIcons from "@/components/Workflow/icons";
 
 interface WorkflowStepIconProps {
-    stepType: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause";
+    stepType: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause" | "pick_value";
 }
 
 const props = defineProps<WorkflowStepIconProps>();

--- a/client/src/stores/workflowNodeInspectorStore.ts
+++ b/client/src/stores/workflowNodeInspectorStore.ts
@@ -21,6 +21,7 @@ function getContentId(step: Step) {
         data_input: () => "input",
         parameter_input: () => "input",
         pause: () => "pause",
+        pick_value: () => "pick_value",
     });
 }
 

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -363,9 +363,10 @@ export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (work
         );
 
         const inputConnections = inputStep.input_connections[connection.input.name];
+        const newInputConnections = { ...inputStep.input_connections };
 
         if (getStepExtraInputs.value(inputStep.id).find((input) => connection.input.name === input.name)) {
-            inputStep.input_connections[connection.input.name] = undefined;
+            newInputConnections[connection.input.name] = undefined;
         } else {
             if (Array.isArray(inputConnections)) {
                 const filtered = inputConnections.filter(
@@ -377,16 +378,16 @@ export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (work
                 );
 
                 if (filtered.length === 0) {
-                    del(inputStep.input_connections, connection.input.name);
+                    delete newInputConnections[connection.input.name];
                 } else {
-                    inputStep.input_connections[connection.input.name] = filtered;
+                    newInputConnections[connection.input.name] = filtered;
                 }
             } else {
-                del(inputStep.input_connections, connection.input.name);
+                delete newInputConnections[connection.input.name];
             }
         }
 
-        updateStep(inputStep);
+        updateStep({ ...inputStep, input_connections: newInputConnections });
     }
 
     const { deleteStepPosition, deleteStepTerminals } = useWorkflowStateStore(workflowId);

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -368,13 +368,19 @@ export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (work
             inputStep.input_connections[connection.input.name] = undefined;
         } else {
             if (Array.isArray(inputConnections)) {
-                inputStep.input_connections[connection.input.name] = inputConnections.filter(
+                const filtered = inputConnections.filter(
                     (outputLink) =>
                         !(
                             outputLink.id === connection.output.stepId &&
                             outputLink.output_name === connection.output.name
                         ),
                 );
+
+                if (filtered.length === 0) {
+                    del(inputStep.input_connections, connection.input.name);
+                } else {
+                    inputStep.input_connections[connection.input.name] = filtered;
+                }
             } else {
                 del(inputStep.input_connections, connection.input.name);
             }

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -370,8 +370,10 @@ export const useWorkflowStepStore = defineScopedStore("workflowStepStore", (work
             if (Array.isArray(inputConnections)) {
                 inputStep.input_connections[connection.input.name] = inputConnections.filter(
                     (outputLink) =>
-                        !(outputLink.id === connection.output.stepId,
-                        outputLink.output_name === connection.output.name),
+                        !(
+                            outputLink.id === connection.output.stepId &&
+                            outputLink.output_name === connection.output.name
+                        ),
                 );
             } else {
                 del(inputStep.input_connections, connection.input.name);

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -113,7 +113,7 @@ export interface NewStep {
     tool_state: Record<string, unknown>;
     tool_version?: string;
     tooltip?: string | null;
-    type: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause";
+    type: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause" | "pick_value";
     uuid?: string;
     when?: string | null;
     workflow_id?: string;

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -102,7 +102,7 @@ groq==1.1.1
 grpcio==1.78.0
 grpcio-status==1.78.0
 gunicorn==25.0.3
-gxformat2 @ git+https://github.com/galaxyproject/gxformat2.git@pick_value
+gxformat2==0.23.0
 h11==0.16.0
 h5grove==3.0.0
 h5py==3.16.0

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -102,7 +102,7 @@ groq==1.1.1
 grpcio==1.78.0
 grpcio-status==1.78.0
 gunicorn==25.0.3
-gxformat2==0.22.0
+gxformat2 @ git+https://github.com/galaxyproject/gxformat2.git@pick_value
 h11==0.16.0
 h5grove==3.0.0
 h5py==3.16.0

--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -108,6 +108,21 @@ class ChangeDatatypeAction(DefaultJobAction):
     verbose_name = "Change Datatype"
 
     @classmethod
+    def execute_on_mapped_over(
+        cls, trans, sa_session, action, step_inputs, step_outputs, replacement_dict, final_job_state=None
+    ):
+        if action.action_arguments and action.action_arguments.get("newtype"):
+            newtype = action.action_arguments["newtype"]
+            for name, step_output in step_outputs.items():
+                if action.output_name == "" or name == action.output_name:
+                    if hasattr(step_output, "dataset_instances"):
+                        for element in step_output.dataset_instances:
+                            if element:
+                                trans.app.datatypes_registry.change_datatype(element, newtype)
+                    else:
+                        trans.app.datatypes_registry.change_datatype(step_output, newtype)
+
+    @classmethod
     def execute(cls, app, sa_session, action, job, replacement_dict=None, final_job_state=None):
         if job.state == job.states.SKIPPED:
             # Don't change datatype, must remain expression.json
@@ -330,18 +345,30 @@ class ColumnSetAction(DefaultJobAction):
     verbose_name = "Assign Columns"
 
     @classmethod
+    def _apply_column_set(cls, dataset, action_arguments):
+        for k, v in action_arguments.items():
+            if v:
+                if not isinstance(v, int):
+                    if v[0] == "c":
+                        v = v[1:]
+                    v = int(v)
+                if v != 0:
+                    setattr(dataset.metadata, k, v)
+
+    @classmethod
+    def execute_on_mapped_over(
+        cls, trans, sa_session, action, step_inputs, step_outputs, replacement_dict, final_job_state=None
+    ):
+        if action.action_arguments:
+            for name, step_output in step_outputs.items():
+                if action.output_name == "" or name == action.output_name:
+                    cls._apply_column_set(step_output, action.action_arguments)
+
+    @classmethod
     def execute(cls, app, sa_session, action, job, replacement_dict=None, final_job_state=None):
         for dataset_assoc in job.output_datasets:
             if action.output_name == "" or dataset_assoc.name == action.output_name:
-                for k, v in action.action_arguments.items():
-                    if v:
-                        # Try to use both pure integer and 'cX' format.
-                        if not isinstance(v, int):
-                            if v[0] == "c":
-                                v = v[1:]
-                            v = int(v)
-                        if v != 0:
-                            setattr(dataset_assoc.dataset.metadata, k, v)
+                cls._apply_column_set(dataset_assoc.dataset, action.action_arguments)
 
     @classmethod
     def get_short_str(cls, pja):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -113,6 +113,7 @@ from galaxy.util.search import (
 from galaxy.work.context import WorkRequestContext
 from galaxy.workflow.modules import (
     module_factory,
+    PickValueModule,
     ToolModule,
     WorkflowModule,
     WorkflowModuleInjector,
@@ -597,6 +598,15 @@ class WorkflowSerializer(sharable.SharableModelSerializer):
     def add_serializers(self):
         super().add_serializers()
         self.serializers.update({})
+
+
+def _step_pja_dict(step):
+    pja_dict = {}
+    for pja in step.post_job_actions:
+        pja_dict[pja.action_type + pja.output_name] = dict(
+            action_type=pja.action_type, output_name=pja.output_name, action_arguments=pja.action_arguments
+        )
+    return pja_dict
 
 
 class WorkflowContentsManager(UsesAnnotations):
@@ -1372,12 +1382,10 @@ class WorkflowContentsManager(UsesAnnotations):
 
                 visit_input_values(module.tool.inputs, module.state.inputs, callback)
                 # post_job_actions
-                pja_dict = {}
-                for pja in step.post_job_actions:
-                    pja_dict[pja.action_type + pja.output_name] = dict(
-                        action_type=pja.action_type, output_name=pja.output_name, action_arguments=pja.action_arguments
-                    )
-                step_dict["post_job_actions"] = pja_dict
+                step_dict["post_job_actions"] = _step_pja_dict(step)
+
+            if isinstance(module, PickValueModule):
+                step_dict["post_job_actions"] = _step_pja_dict(step)
 
             # workflow outputs
             outputs = []
@@ -1640,12 +1648,10 @@ class WorkflowContentsManager(UsesAnnotations):
                         step_dict["tool_id"] = None
                         step_dict["tool_uuid"] = None
 
-                pja_dict = {}
-                for pja in step.post_job_actions:
-                    pja_dict[pja.action_type + pja.output_name] = dict(
-                        action_type=pja.action_type, output_name=pja.output_name, action_arguments=pja.action_arguments
-                    )
-                step_dict["post_job_actions"] = pja_dict
+                step_dict["post_job_actions"] = _step_pja_dict(step)
+
+            if isinstance(module, PickValueModule):
+                step_dict["post_job_actions"] = _step_pja_dict(step)
 
             if module.type == "subworkflow" and not internal:
                 del step_dict["errors"]

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -173,6 +173,10 @@ class HasDriver(TimeoutMessageMixin, WaitMethodsMixin, Generic[WaitTypeT]):
         """
         self.driver.get(url)
 
+    def refresh(self) -> None:
+        """Reload the current page."""
+        self.driver.refresh()
+
     def re_get_with_query_params(self, params_str: str):
         driver = self.driver
         new_url = driver.current_url

--- a/lib/galaxy/selenium/has_driver_protocol.py
+++ b/lib/galaxy/selenium/has_driver_protocol.py
@@ -118,6 +118,11 @@ class HasDriverProtocol(Protocol, Generic[WaitTypeT]):
         ...
 
     @abstractmethod
+    def refresh(self) -> None:
+        """Reload the current page."""
+        ...
+
+    @abstractmethod
     def re_get_with_query_params(self, params_str: str):
         """Navigate to current URL with additional query parameters."""
         ...

--- a/lib/galaxy/selenium/has_driver_proxy.py
+++ b/lib/galaxy/selenium/has_driver_proxy.py
@@ -108,6 +108,10 @@ class HasDriverProxy(ABC, Generic[WaitTypeT]):
         """Navigate to the specified URL."""
         self._driver_impl.navigate_to(url)
 
+    def refresh(self) -> None:
+        """Reload the current page."""
+        self._driver_impl.refresh()
+
     def re_get_with_query_params(self, params_str: str):
         """Navigate to current URL with additional query parameters."""
         return self._driver_impl.re_get_with_query_params(params_str)

--- a/lib/galaxy/selenium/has_playwright_driver.py
+++ b/lib/galaxy/selenium/has_playwright_driver.py
@@ -315,6 +315,10 @@ class HasPlaywrightDriver(TimeoutMessageMixin, WaitMethodsMixin, Generic[WaitTyp
         """
         self.page.goto(url)
 
+    def refresh(self) -> None:
+        """Reload the current page."""
+        self.page.reload()
+
     def re_get_with_query_params(self, params_str: str):
         """Add query parameters to current URL and reload."""
         current_url = self.page.url
@@ -773,7 +777,10 @@ class HasPlaywrightDriver(TimeoutMessageMixin, WaitMethodsMixin, Generic[WaitTyp
 
     def _hover(self, element: ElementHandle) -> None:
         """Internal implementation of hover."""
-        element.hover()
+        # force=True bypasses actionability checks that fail when overlapping
+        # UI elements (e.g. delete-terminal-button) intercept pointer events.
+        # Hover is non-destructive so this is safe.
+        element.hover(force=True)
 
     def move_to_and_click(self, element: WebElementProtocol) -> None:
         """
@@ -788,8 +795,8 @@ class HasPlaywrightDriver(TimeoutMessageMixin, WaitMethodsMixin, Generic[WaitTyp
 
     def _move_to_and_click(self, element: ElementHandle) -> None:
         """Internal implementation of move_to_and_click."""
-        element.hover()
-        element.click()
+        element.hover(force=True)
+        element.click(force=True)
 
     def drag_and_drop(self, source: WebElementProtocol, target: WebElementProtocol) -> None:
         """
@@ -807,23 +814,18 @@ class HasPlaywrightDriver(TimeoutMessageMixin, WaitMethodsMixin, Generic[WaitTyp
         """
         Internal implementation of drag and drop.
 
-        Uses JavaScript to simulate drag and drop events.
+        Creates a real DataTransfer via evaluate_handle so setData/getData
+        work across the full drag event sequence (unlike synthetic DragEvents
+        where Chrome restricts getData to return empty).
         """
-        self.page.evaluate(
-            """
-            (elements) => {
-                const [source, target] = elements;
-                const dataTransfer = new DataTransfer();
-                const dragstart = new DragEvent('dragstart', { dataTransfer, bubbles: true });
-                const dragover = new DragEvent('dragover', { dataTransfer, bubbles: true });
-                const drop = new DragEvent('drop', { dataTransfer, bubbles: true });
-                source.dispatchEvent(dragstart);
-                target.dispatchEvent(dragover);
-                target.dispatchEvent(drop);
-            }
-            """,
-            [source, target],
-        )
+        dt = self.page.evaluate_handle("() => new DataTransfer()")
+        source.dispatch_event("pointerdown")
+        source.dispatch_event("dragstart", {"dataTransfer": dt})
+        target.dispatch_event("dragenter", {"dataTransfer": dt})
+        target.dispatch_event("dragover", {"dataTransfer": dt})
+        target.dispatch_event("drop", {"dataTransfer": dt})
+        source.dispatch_event("dragend", {"dataTransfer": dt})
+        source.dispatch_event("pointerup")
 
     def action_chains(self):
         """

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1445,6 +1445,10 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
                 self.sleep_for(self.wait_types.UX_RENDER)
                 self.screenshot(screenshot_partial)
         self.drag_and_drop(source_element, sink_element)
+        if self._driver_impl.backend_type == "playwright":
+            # dispatch_event is synchronous but Vue reactivity (store updates,
+            # terminal type recalculation) runs in microtasks — wait for it.
+            self.sleep_for(self.wait_types.UX_RENDER)
 
     def workflow_editor_source_sink_terminal_ids(self, source, sink):
         editor = self.components.workflow_editor

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -3042,6 +3042,49 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         self.wait_for_and_click_selector(search_selector)
         self.wait_for_selector_visible("#gtn-screen")
 
+    def shift_click(self, element: WebElementProtocol) -> None:
+        """Shift-click an element. Works with both Selenium and Playwright."""
+        if self._driver_impl.backend_type == "playwright":
+            pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
+            pw_driver._unwrap_element(element).click(modifiers=["Shift"])
+        else:
+            self.action_chains().move_to_element(element).key_down(Keys.SHIFT).click().key_up(Keys.SHIFT).perform()
+
+    def send_keys_to_page(self, *value: str) -> None:
+        """Send keys to the currently focused element / page.
+
+        Replaces action_chains().send_keys(...).perform() with a backend-agnostic impl.
+        Accepts Selenium Keys constants and plain text, matching PlaywrightElement.send_keys semantics.
+        """
+        if self._driver_impl.backend_type == "playwright":
+            from galaxy.selenium.playwright_element import _SELENIUM_KEY_TO_PLAYWRIGHT, _SELENIUM_MODIFIERS
+
+            pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
+            page = pw_driver.page
+            all_chars = "".join(str(v) for v in value)
+            has_special = any(c in _SELENIUM_KEY_TO_PLAYWRIGHT for c in all_chars)
+            if not has_special:
+                page.keyboard.type(all_chars)
+            else:
+                modifiers: list[str] = []
+                for char in all_chars:
+                    pw_key = _SELENIUM_KEY_TO_PLAYWRIGHT.get(char)
+                    if pw_key and char in _SELENIUM_MODIFIERS:
+                        modifiers.append(pw_key)
+                    elif pw_key:
+                        combo = "+".join(modifiers + [pw_key])
+                        page.keyboard.press(combo)
+                        modifiers.clear()
+                    else:
+                        if modifiers:
+                            combo = "+".join(modifiers + [char])
+                            page.keyboard.press(combo)
+                            modifiers.clear()
+                        else:
+                            page.keyboard.type(char)
+        else:
+            self.action_chains().send_keys(*value).perform()
+
     def mouse_drag(
         self,
         from_element: WebElementProtocol,
@@ -3050,18 +3093,51 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         to_offset=(0, 0),
         via_offsets: Optional[list[tuple[int, int]]] = None,
     ):
-        chain = self.action_chains().move_to_element(from_element).move_by_offset(*from_offset)
-        chain = chain.click_and_hold().pause(self.wait_length(self.wait_types.UX_RENDER))
+        if self._driver_impl.backend_type == "playwright":
+            pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
+            page = pw_driver.page
+            pause_ms = int(self.wait_length(self.wait_types.UX_RENDER) * 1000)
 
-        if via_offsets is not None:
-            for offset in via_offsets:
-                chain = chain.move_by_offset(*offset).pause(self.wait_length(self.wait_types.UX_RENDER))
+            from_box = pw_driver._unwrap_element(from_element).bounding_box()
+            assert from_box is not None
+            cx = from_box["x"] + from_box["width"] / 2 + from_offset[0]
+            cy = from_box["y"] + from_box["height"] / 2 + from_offset[1]
 
-        if to_element is not None:
-            chain = chain.move_to_element(to_element)
+            page.mouse.move(cx, cy)
+            page.mouse.down()
+            page.wait_for_timeout(pause_ms)
 
-        chain = chain.move_by_offset(*to_offset).pause(self.wait_length(self.wait_types.UX_RENDER)).release()
-        chain.perform()
+            if via_offsets is not None:
+                for offset in via_offsets:
+                    cx += offset[0]
+                    cy += offset[1]
+                    page.mouse.move(cx, cy)
+                    page.wait_for_timeout(pause_ms)
+
+            if to_element is not None:
+                to_box = pw_driver._unwrap_element(to_element).bounding_box()
+                assert to_box is not None
+                cx = to_box["x"] + to_box["width"] / 2
+                cy = to_box["y"] + to_box["height"] / 2
+
+            cx += to_offset[0]
+            cy += to_offset[1]
+            page.mouse.move(cx, cy)
+            page.wait_for_timeout(pause_ms)
+            page.mouse.up()
+        else:
+            chain = self.action_chains().move_to_element(from_element).move_by_offset(*from_offset)
+            chain = chain.click_and_hold().pause(self.wait_length(self.wait_types.UX_RENDER))
+
+            if via_offsets is not None:
+                for offset in via_offsets:
+                    chain = chain.move_by_offset(*offset).pause(self.wait_length(self.wait_types.UX_RENDER))
+
+            if to_element is not None:
+                chain = chain.move_to_element(to_element)
+
+            chain = chain.move_by_offset(*to_offset).pause(self.wait_length(self.wait_types.UX_RENDER)).release()
+            chain.perform()
 
 
 class NotLoggedInException(SeleniumTimeoutException):

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -122,6 +122,15 @@ class NullTourCallback:
         pass
 
 
+def _exception_indicates_playwright_timeout(e):
+    try:
+        from playwright._impl._errors import TimeoutError as PlaywrightTimeoutError
+
+        return isinstance(e, PlaywrightTimeoutError)
+    except ImportError:
+        return False
+
+
 def exception_seems_to_indicate_transition(e):
     """True if exception seems to indicate the page state is transitioning.
 
@@ -132,14 +141,16 @@ def exception_seems_to_indicate_transition(e):
     cause of the exception. The methods that follow use it to allow retrying actions during
     transitions.
 
-    Currently the two kinds of exceptions that we say may indicate a transition are
-    StaleElement exceptions (a DOM element grabbed at one step is no longer available)
-    and "not clickable" exceptions (so perhaps a popup modal is blocking a click).
+    Currently the kinds of exceptions that we say may indicate a transition are
+    StaleElement exceptions (a DOM element grabbed at one step is no longer available),
+    "not clickable" exceptions (so perhaps a popup modal is blocking a click), and
+    Playwright TimeoutErrors (element not yet present/visible during a transition).
     """
     return (
         exception_indicates_stale_element(e)
         or exception_indicates_not_clickable(e)
         or exception_indicates_click_intercepted(e)
+        or _exception_indicates_playwright_timeout(e)
     )
 
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -34,6 +34,8 @@ from selenium.webdriver.common.keys import Keys
 if TYPE_CHECKING:
     from selenium.webdriver.remote.webdriver import WebDriver
 
+    from .has_playwright_driver import HasPlaywrightDriver
+
 from galaxy.navigation.components import (
     Component,
     HasText,
@@ -281,7 +283,7 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
             NotImplementedError: If using Selenium backend
         """
         if self._driver_impl.backend_type == "playwright":
-            return self._driver_impl.page  # type: ignore[attr-defined]
+            return cast("HasPlaywrightDriver", self._driver_impl).page
         else:
             raise NotImplementedError("Functionality cannot be run with Selenium yet.")
 
@@ -1415,13 +1417,33 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)
         source_element = self.find_element_by_selector(f"#{source_id}")
         sink_element = self.find_element_by_selector(f"#{sink_id}")
-        ac = self.action_chains()
-        ac = ac.move_to_element(source_element).click_and_hold()
+
         if screenshot_partial:
-            ac = ac.move_by_offset(10, 10)
-            ac.perform()
-            self.sleep_for(self.wait_types.UX_RENDER)
-            self.screenshot(screenshot_partial)
+            if self._driver_impl.backend_type == "playwright":
+                pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
+                page = pw_driver.page
+                source_handle = pw_driver._unwrap_element(source_element)
+                source_box = source_handle.bounding_box()
+                assert source_box is not None
+                page.mouse.move(
+                    source_box["x"] + source_box["width"] / 2,
+                    source_box["y"] + source_box["height"] / 2,
+                )
+                page.mouse.down()
+                page.mouse.move(
+                    source_box["x"] + source_box["width"] / 2 + 10,
+                    source_box["y"] + source_box["height"] / 2 + 10,
+                )
+                self.sleep_for(self.wait_types.UX_RENDER)
+                self.screenshot(screenshot_partial)
+                page.mouse.up()
+            else:
+                ac = self.action_chains()
+                ac = ac.move_to_element(source_element).click_and_hold()
+                ac = ac.move_by_offset(10, 10)
+                ac.perform()
+                self.sleep_for(self.wait_types.UX_RENDER)
+                self.screenshot(screenshot_partial)
         self.drag_and_drop(source_element, sink_element)
 
     def workflow_editor_source_sink_terminal_ids(self, source, sink):

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -3057,7 +3057,10 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         Accepts Selenium Keys constants and plain text, matching PlaywrightElement.send_keys semantics.
         """
         if self._driver_impl.backend_type == "playwright":
-            from galaxy.selenium.playwright_element import _SELENIUM_KEY_TO_PLAYWRIGHT, _SELENIUM_MODIFIERS
+            from galaxy.selenium.playwright_element import (
+                _SELENIUM_KEY_TO_PLAYWRIGHT,
+                _SELENIUM_MODIFIERS,
+            )
 
             pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
             page = pw_driver.page

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1445,10 +1445,6 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
                 self.sleep_for(self.wait_types.UX_RENDER)
                 self.screenshot(screenshot_partial)
         self.drag_and_drop(source_element, sink_element)
-        if self._driver_impl.backend_type == "playwright":
-            # dispatch_event is synchronous but Vue reactivity (store updates,
-            # terminal type recalculation) runs in microtasks — wait for it.
-            self.sleep_for(self.wait_types.UX_RENDER)
 
     def workflow_editor_source_sink_terminal_ids(self, source, sink):
         editor = self.components.workflow_editor

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -31,6 +31,11 @@ import yaml
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
+from .playwright_element import (
+    _SELENIUM_KEY_TO_PLAYWRIGHT,
+    _SELENIUM_MODIFIERS,
+)
+
 if TYPE_CHECKING:
     from selenium.webdriver.remote.webdriver import WebDriver
 
@@ -3057,11 +3062,6 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         Accepts Selenium Keys constants and plain text, matching PlaywrightElement.send_keys semantics.
         """
         if self._driver_impl.backend_type == "playwright":
-            from galaxy.selenium.playwright_element import (
-                _SELENIUM_KEY_TO_PLAYWRIGHT,
-                _SELENIUM_MODIFIERS,
-            )
-
             pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
             page = pw_driver.page
             all_chars = "".join(str(v) for v in value)

--- a/lib/galaxy/selenium/playwright_element.py
+++ b/lib/galaxy/selenium/playwright_element.py
@@ -14,6 +14,33 @@ from playwright.sync_api import (
     ElementHandle,
     JSHandle,
 )
+from selenium.webdriver.common.keys import Keys
+
+# Map Selenium Key unicode constants to Playwright key names
+_SELENIUM_KEY_TO_PLAYWRIGHT = {
+    Keys.CONTROL: "Control",
+    Keys.COMMAND: "Meta",
+    Keys.META: "Meta",
+    Keys.SHIFT: "Shift",
+    Keys.ALT: "Alt",
+    Keys.ENTER: "Enter",
+    Keys.RETURN: "Enter",
+    Keys.ESCAPE: "Escape",
+    Keys.BACKSPACE: "Backspace",
+    Keys.DELETE: "Delete",
+    Keys.TAB: "Tab",
+    Keys.SPACE: " ",
+    Keys.ARROW_DOWN: "ArrowDown",
+    Keys.ARROW_UP: "ArrowUp",
+    Keys.ARROW_LEFT: "ArrowLeft",
+    Keys.ARROW_RIGHT: "ArrowRight",
+    Keys.HOME: "Home",
+    Keys.END: "End",
+    Keys.PAGE_UP: "PageUp",
+    Keys.PAGE_DOWN: "PageDown",
+}
+
+_SELENIUM_MODIFIERS = {Keys.CONTROL, Keys.COMMAND, Keys.META, Keys.SHIFT, Keys.ALT}
 
 if TYPE_CHECKING:
     from .has_playwright_driver import HasPlaywrightDriver
@@ -69,23 +96,43 @@ class PlaywrightElement:
         """
         Send keys to the element (type text).
 
-        Uses focus() + cursor-to-end to match Selenium's send_keys behavior
-        of appending text. Playwright's click() positions cursor at click
-        point (center of element), which would insert text mid-content.
+        Translates Selenium Keys constants to Playwright keyboard actions.
+        Modifier keys (Control, Command, etc.) combine with the next key
+        as a keyboard shortcut (e.g. Keys.CONTROL, "a" -> "Control+a").
         """
-        text = "".join(str(v) for v in value)
         self._element.focus()
-        # setSelectionRange is not supported on email, number, date, etc. inputs
-        # per the HTML spec. For those types, use the End key to move cursor to end.
-        input_type = self._element.evaluate("el => (el.type || '').toLowerCase()")
-        no_selection_range_types = {"email", "number", "date", "month", "week", "time", "datetime-local"}
-        if input_type in no_selection_range_types:
-            self._element.press("End")
+        # Flatten all args into a single character stream
+        all_chars = "".join(str(v) for v in value)
+        has_special = any(c in _SELENIUM_KEY_TO_PLAYWRIGHT for c in all_chars)
+        if not has_special:
+            # setSelectionRange is not supported on email, number, date, etc. inputs
+            # per the HTML spec. For those types, use the End key to move cursor to end.
+            input_type = self._element.evaluate("el => (el.type || '').toLowerCase()")
+            no_selection_range_types = {"email", "number", "date", "month", "week", "time", "datetime-local"}
+            if input_type in no_selection_range_types:
+                self._element.press("End")
+            else:
+                self._element.evaluate(
+                    "el => { if (el.setSelectionRange) el.setSelectionRange(el.value.length, el.value.length) }"
+                )
+            self._element.type(all_chars)
         else:
-            self._element.evaluate(
-                "el => { if (el.setSelectionRange) el.setSelectionRange(el.value.length, el.value.length) }"
-            )
-        self._element.type(text)
+            modifiers: list[str] = []
+            for char in all_chars:
+                pw_key = _SELENIUM_KEY_TO_PLAYWRIGHT.get(char)
+                if pw_key and char in _SELENIUM_MODIFIERS:
+                    modifiers.append(pw_key)
+                elif pw_key:
+                    combo = "+".join(modifiers + [pw_key])
+                    self._element.press(combo)
+                    modifiers.clear()
+                else:
+                    if modifiers:
+                        combo = "+".join(modifiers + [char])
+                        self._element.press(combo)
+                        modifiers.clear()
+                    else:
+                        self._element.type(char)
 
     def clear(self) -> None:
         """

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -543,7 +543,7 @@ class WorkflowsAPIController(
         module_type = payload.get("type", "tool")
         inputs = payload.get("inputs", {})
         trans.workflow_building_mode = workflow_building_modes.ENABLED
-        from_tool_form = True if module_type != "data_collection_input" else False
+        from_tool_form = True if module_type not in ("data_collection_input", "pick_value") else False
         if not from_tool_form and "tool_state" not in payload and "inputs" in payload:
             # tool state not sent, use the manually constructed inputs
             payload["tool_state"] = payload["inputs"]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2127,10 +2127,10 @@ class PickValueModule(WorkflowModule):
         history = invocation.history
         hda = model.HistoryDatasetAssociation(
             name="Pick Value - skipped",
-            history=history,
             create_dataset=True,
             flush=False,
         )
+        history.add_dataset(hda)
         object_store_populator = ObjectStorePopulator(trans.app, trans.user)
         hda.set_skipped(object_store_populator, replace_dataset=False)
         trans.sa_session.add(hda)

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -41,6 +41,7 @@ from galaxy.model import (
     WorkflowStepConnection,
 )
 from galaxy.model.base import ensure_object_added_to_session
+from galaxy.objectstore import ObjectStorePopulator
 from galaxy.model.dataset_collections import matching
 from galaxy.model.dataset_collections.adapters import PromoteCollectionElementToCollectionAdapter
 from galaxy.model.dataset_collections.query import HistoryQuery
@@ -1947,6 +1948,197 @@ class PauseModule(WorkflowModule):
         return bool(action)
 
 
+class PickValueModule(WorkflowModule):
+    """Workflow module that selects among conditional branch outputs.
+
+    Accepts N inputs from conditional steps and produces a single output
+    based on the configured selection mode. Supports first_non_null,
+    first_or_skip, the_only_non_null, and all_non_null modes.
+    """
+
+    type = "pick_value"
+    name = "Pick Value"
+
+    MODES = ("first_non_null", "first_or_skip", "the_only_non_null", "all_non_null")
+
+    def get_inputs(self):
+        # State managed by frontend Vue component, not backend forms
+        return {}
+
+    def validate_state(self, inputs: dict[str, Any]) -> None:
+        mode = inputs.get("mode")
+        if mode and mode not in self.MODES:
+            raise ValueError(f"Invalid pick_value mode: {mode}")
+
+    def get_export_state(self):
+        return self._get_state_dict()
+
+    def _get_state_dict(self):
+        mode = self.state.inputs.get("mode", "first_non_null")
+        num_inputs = self.state.inputs.get("num_inputs", 2)
+        return {"mode": mode, "num_inputs": num_inputs}
+
+    def save_to_step(self, step, detached=False):
+        step.type = self.type
+        step.tool_inputs = self._get_state_dict()
+
+    @property
+    def _num_inputs(self):
+        """Number of input terminals — at least 2, grows with connections."""
+        num_from_state = self.state.inputs.get("num_inputs", 2)
+        num_from_connections = 0
+        if hasattr(self, "workflow_step") and self.workflow_step:
+            num_from_connections = len(self.workflow_step.input_connections_by_name)
+        return max(2, num_from_state, num_from_connections)
+
+    def get_all_inputs(self, data_only=False, connectable_only=False):
+        inputs = []
+        # N connected terminals + 1 empty terminal for grow-on-connect
+        for i in range(self._num_inputs + 1):
+            inputs.append(
+                dict(
+                    name=f"input_{i}",
+                    label=f"Input {i}",
+                    multiple=False,
+                    extensions=["input"],
+                    input_type="dataset",
+                    optional=True,
+                )
+            )
+        return inputs
+
+    def get_all_outputs(self, data_only=False):
+        mode = self.state.inputs.get("mode", "first_non_null")
+        if mode == "all_non_null":
+            return [
+                dict(
+                    name="output",
+                    label="Picked values",
+                    extensions=["input"],
+                    collection=True,
+                    collection_type="list",
+                )
+            ]
+        return [
+            dict(
+                name="output",
+                label="Picked value",
+                extensions=["input"],
+            )
+        ]
+
+    def get_runtime_state(self):
+        state = DefaultToolState()
+        state.inputs = {}
+        return state
+
+    @staticmethod
+    def _is_null_or_skipped(value) -> bool:
+        """Check if a replacement value represents a skipped/null output."""
+        if value is NO_REPLACEMENT:
+            return True
+        if isinstance(value, model.HistoryDatasetAssociation):
+            if value.extension == "expression.json" and value.blurb == "skipped":
+                return True
+        return False
+
+    def execute(
+        self, trans, progress: "WorkflowProgress", invocation_step, use_cached_job: bool = False
+    ) -> Optional[bool]:
+        step = invocation_step.workflow_step
+        mode = step.tool_inputs.get("mode", "first_non_null") if step.tool_inputs else "first_non_null"
+
+        # Gather replacements from each named input terminal, in order
+        replacements = []
+        for input_dict in self.get_all_inputs():
+            replacement = progress.replacement_for_input(trans, step, input_dict)
+            if replacement is not NO_REPLACEMENT:
+                replacements.append(replacement)
+
+        # Separate non-null from null/skipped, preserving order
+        non_null = [r for r in replacements if not self._is_null_or_skipped(r)]
+
+        if mode == "first_non_null":
+            if not non_null:
+                raise FailWorkflowEvaluation(
+                    why=InvocationFailureExpressionEvaluationFailed(
+                        reason=FailureReason.expression_evaluation_failed,
+                        workflow_step_id=step.id,
+                    )
+                )
+            output = non_null[0]
+
+        elif mode == "first_or_skip":
+            if not non_null:
+                output = self._create_skipped_output(trans, invocation_step)
+            else:
+                output = non_null[0]
+
+        elif mode == "the_only_non_null":
+            if len(non_null) != 1:
+                raise FailWorkflowEvaluation(
+                    why=InvocationFailureExpressionEvaluationFailed(
+                        reason=FailureReason.expression_evaluation_failed,
+                        workflow_step_id=step.id,
+                    )
+                )
+            output = non_null[0]
+
+        elif mode == "all_non_null":
+            if not non_null:
+                raise FailWorkflowEvaluation(
+                    why=InvocationFailureExpressionEvaluationFailed(
+                        reason=FailureReason.expression_evaluation_failed,
+                        workflow_step_id=step.id,
+                    )
+                )
+            output = self._create_collection_from_list(trans, invocation_step, non_null)
+
+        else:
+            raise ValueError(f"Unknown pick_value mode: {mode}")
+
+        progress.set_step_outputs(invocation_step, {"output": output})
+        return None
+
+    def _create_skipped_output(self, trans, invocation_step):
+        """Create a skipped HDA for first_or_skip when all inputs are null."""
+        invocation = invocation_step.workflow_invocation
+        history = invocation.history
+        hda = model.HistoryDatasetAssociation(
+            name="Pick Value - skipped",
+            history=history,
+            create_dataset=True,
+            flush=False,
+        )
+        object_store_populator = ObjectStorePopulator(trans.app, trans.user)
+        hda.set_skipped(object_store_populator, replace_dataset=False)
+        trans.sa_session.add(hda)
+        return hda
+
+    def _create_collection_from_list(self, trans, invocation_step, hdas):
+        """Create an HDCA from a list of non-null HDAs for all_non_null mode."""
+        invocation = invocation_step.workflow_invocation
+        history = invocation.history
+        elements = []
+        for i, hda in enumerate(hdas):
+            elements.append(
+                dict(
+                    name=str(i),
+                    src="hda",
+                    id=hda.id,
+                )
+            )
+        collection_manager = trans.app.dataset_collection_manager
+        hdca = collection_manager.create(
+            trans,
+            history,
+            name="Pick Value - all non-null",
+            collection_type="list",
+            element_identifiers=elements,
+        )
+        return hdca
+
+
 class ToolModule(WorkflowModule):
     type = "tool"
     name = "Tool"
@@ -2776,6 +2968,7 @@ module_types = dict(
     data_collection_input=InputDataCollectionModule,
     parameter_input=InputParameterModule,
     pause=PauseModule,
+    pick_value=PickValueModule,
     tool=ToolModule,
     subworkflow=SubWorkflowModule,
 )

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2178,10 +2178,14 @@ class PickValueModule(WorkflowModule):
     def _to_pja(key, value, step):
         if isinstance(value, PostJobAction):
             return value
-        output_name = value.get("output_name") if isinstance(value, dict) else None
-        action_arguments = value.get("action_arguments") if isinstance(value, dict) else None
-        action_type = value.get("action_type", key) if isinstance(value, dict) else key
-        return PostJobAction(action_type, step, output_name, action_arguments)
+        if not isinstance(value, dict):
+            raise TypeError(f"Expected PostJobAction or dict for PJA '{key}', got {type(value)}")
+        return PostJobAction(
+            value["action_type"],
+            step,
+            value.get("output_name"),
+            value.get("action_arguments"),
+        )
 
 
 class ToolModule(WorkflowModule):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2168,7 +2168,7 @@ class PickValueModule(WorkflowModule):
         if self._is_null_or_skipped(output):
             return
         step_outputs = {"output": output}
-        step_inputs = {}
+        step_inputs: dict[str, Any] = {}
         for pja in step.post_job_actions:
             ActionBox.execute_on_mapped_over(
                 trans, trans.sa_session, pja, step_inputs, step_outputs, replacement_dict

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2163,8 +2163,10 @@ class PickValueModule(WorkflowModule):
         """Apply post job actions directly to module output via ActionBox.
 
         Uses execute_on_mapped_over which operates on step_outputs dict
-        rather than requiring a Job object.
+        rather than requiring a Job object. Skipped outputs are left untouched.
         """
+        if self._is_null_or_skipped(output):
+            return
         step_outputs = {"output": output}
         step_inputs = {}
         for pja in step.post_job_actions:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1961,6 +1961,27 @@ class PickValueModule(WorkflowModule):
 
     MODES = ("first_non_null", "first_or_skip", "the_only_non_null", "all_non_null")
 
+    def __init__(self, trans, content_id=None, **kwds):
+        super().__init__(trans, content_id=content_id, **kwds)
+        self.post_job_actions: dict[str, Any] = {}
+
+    @classmethod
+    def from_dict(Class, trans, d, **kwds):
+        module = super().from_dict(trans, d, **kwds)
+        module.post_job_actions = d.get("post_job_actions", {})
+        return module
+
+    @classmethod
+    def from_workflow_step(Class, trans, step, **kwds):
+        module = super().from_workflow_step(trans, step, **kwds)
+        module.post_job_actions = {}
+        for pja in step.post_job_actions:
+            module.post_job_actions[pja.action_type + pja.output_name] = pja
+        return module
+
+    def get_post_job_actions(self, incoming):
+        return self.post_job_actions
+
     def get_inputs(self):
         # State managed by frontend Vue component, not backend forms
         return {}
@@ -1981,6 +2002,10 @@ class PickValueModule(WorkflowModule):
     def save_to_step(self, step, detached=False):
         step.type = self.type
         step.tool_inputs = self._get_state_dict()
+        if not detached:
+            for k, v in self.post_job_actions.items():
+                pja = self._to_pja(k, v, step)
+                self.trans.sa_session.add(pja)
 
     @property
     def _num_inputs(self):
@@ -2093,6 +2118,7 @@ class PickValueModule(WorkflowModule):
             raise ValueError(f"Unknown pick_value mode: {mode}")
 
         progress.set_step_outputs(invocation_step, {"output": output})
+        self._apply_post_job_actions(trans, step, output, progress.effective_replacement_dict())
         return None
 
     def _create_skipped_output(self, trans, invocation_step):
@@ -2132,6 +2158,28 @@ class PickValueModule(WorkflowModule):
             element_identifiers=elements,
         )
         return hdca
+
+    def _apply_post_job_actions(self, trans, step, output, replacement_dict):
+        """Apply post job actions directly to module output via ActionBox.
+
+        Uses execute_on_mapped_over which operates on step_outputs dict
+        rather than requiring a Job object.
+        """
+        step_outputs = {"output": output}
+        step_inputs = {}
+        for pja in step.post_job_actions:
+            ActionBox.execute_on_mapped_over(
+                trans, trans.sa_session, pja, step_inputs, step_outputs, replacement_dict
+            )
+
+    @staticmethod
+    def _to_pja(key, value, step):
+        if isinstance(value, PostJobAction):
+            return value
+        output_name = value.get("output_name") if isinstance(value, dict) else None
+        action_arguments = value.get("action_arguments") if isinstance(value, dict) else None
+        action_type = value.get("action_type", key) if isinstance(value, dict) else key
+        return PostJobAction(action_type, step, output_name, action_arguments)
 
 
 class ToolModule(WorkflowModule):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2127,6 +2127,7 @@ class PickValueModule(WorkflowModule):
         history = invocation.history
         hda = model.HistoryDatasetAssociation(
             name="Pick Value - skipped",
+            history=history,
             create_dataset=True,
             flush=False,
         )

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2067,20 +2067,9 @@ class PickValueModule(WorkflowModule):
                 return True
         return False
 
-    def execute(
-        self, trans, progress: "WorkflowProgress", invocation_step, use_cached_job: bool = False
-    ) -> Optional[bool]:
+    def _pick_from_replacements(self, trans, invocation_step, mode, replacements):
+        """Apply pick logic to a list of replacement values. Returns the picked output."""
         step = invocation_step.workflow_step
-        mode = step.tool_inputs.get("mode", "first_non_null") if step.tool_inputs else "first_non_null"
-
-        # Gather replacements from each named input terminal, in order
-        replacements = []
-        for input_dict in self.get_all_inputs():
-            replacement = progress.replacement_for_input(trans, step, input_dict)
-            if replacement is not NO_REPLACEMENT:
-                replacements.append(replacement)
-
-        # Separate non-null from null/skipped, preserving order
         non_null = [r for r in replacements if not self._is_null_or_skipped(r)]
 
         if mode == "first_non_null":
@@ -2091,13 +2080,12 @@ class PickValueModule(WorkflowModule):
                         workflow_step_id=step.id,
                     )
                 )
-            output = non_null[0]
+            return non_null[0]
 
         elif mode == "first_or_skip":
             if not non_null:
-                output = self._create_skipped_output(trans, invocation_step)
-            else:
-                output = non_null[0]
+                return self._create_skipped_output(trans, invocation_step)
+            return non_null[0]
 
         elif mode == "the_only_non_null":
             if len(non_null) != 1:
@@ -2107,19 +2095,76 @@ class PickValueModule(WorkflowModule):
                         workflow_step_id=step.id,
                     )
                 )
-            output = non_null[0]
+            return non_null[0]
 
         elif mode == "all_non_null":
-            # CWL spec: all_non_null returns list of non-null values,
-            # which may be empty if all inputs are null.
-            output = self._create_collection_from_list(trans, invocation_step, non_null)
+            return self._create_collection_from_list(trans, invocation_step, non_null)
 
         else:
             raise ValueError(f"Unknown pick_value mode: {mode}")
 
+    def execute(
+        self, trans, progress: "WorkflowProgress", invocation_step, use_cached_job: bool = False
+    ) -> Optional[bool]:
+        step = invocation_step.workflow_step
+        mode = step.tool_inputs.get("mode", "first_non_null") if step.tool_inputs else "first_non_null"
+        all_inputs = self.get_all_inputs()
+
+        collection_info = self.compute_collection_info(progress, step, all_inputs)
+
+        if collection_info:
+            output = self._execute_mapped(trans, invocation_step, mode, all_inputs, collection_info)
+        else:
+            # Gather replacements from each named input terminal, in order
+            replacements = []
+            for input_dict in all_inputs:
+                replacement = progress.replacement_for_input(trans, step, input_dict)
+                if replacement is not NO_REPLACEMENT:
+                    replacements.append(replacement)
+            output = self._pick_from_replacements(trans, invocation_step, mode, replacements)
+
         progress.set_step_outputs(invocation_step, {"output": output})
         self._apply_post_job_actions(trans, step, output, progress.effective_replacement_dict())
         return None
+
+    def _execute_mapped(self, trans, invocation_step, mode, all_inputs, collection_info):
+        """Execute pick_value mapped over collection inputs."""
+        invocation = invocation_step.workflow_invocation
+        history = invocation.history
+
+        # Build a map of input_name -> input_dict for quick lookup
+        input_names = {d["name"] for d in all_inputs}
+
+        per_element_outputs = []
+        for iteration_elements, _when_value in collection_info.slice_collections():
+            # For each slice, extract per-element replacements
+            replacements = []
+            for input_dict in all_inputs:
+                name = input_dict["name"]
+                if iteration_elements and name in iteration_elements:
+                    dce = iteration_elements[name]
+                    replacement = dce.hda if hasattr(dce, "hda") and dce.hda else dce.child_collection
+                else:
+                    # Input not part of the mapped collection — not connected
+                    replacement = NO_REPLACEMENT
+                if replacement is not NO_REPLACEMENT:
+                    replacements.append(replacement)
+
+            element_output = self._pick_from_replacements(trans, invocation_step, mode, replacements)
+            # Track the identifier from the first mapped input for naming
+            first_mapped = (
+                next(
+                    (iteration_elements[n] for n in sorted(iteration_elements) if n in input_names),
+                    None,
+                )
+                if iteration_elements
+                else None
+            )
+            identifier = first_mapped.element_identifier if first_mapped else str(len(per_element_outputs))
+            per_element_outputs.append((identifier, element_output))
+
+        # Build the output collection from per-element outputs
+        return self._create_mapped_output_collection(trans, history, mode, per_element_outputs)
 
     def _create_skipped_output(self, trans, invocation_step):
         """Create a skipped HDA for first_or_skip when all inputs are null."""
@@ -2159,6 +2204,50 @@ class PickValueModule(WorkflowModule):
             element_identifiers=elements,
         )
         return hdca
+
+    def _create_mapped_output_collection(self, trans, history, mode, per_element_outputs):
+        """Create an implicit output collection from per-element pick results.
+
+        For single-value modes (first_non_null, etc.), creates a flat list of HDAs.
+        For all_non_null mode, creates a list:list where each element is a sub-collection.
+        """
+        collection_manager = trans.app.dataset_collection_manager
+        if mode == "all_non_null":
+            # Each element is an HDCA — build list:list
+            elements = []
+            for identifier, hdca in per_element_outputs:
+                elements.append(
+                    dict(
+                        name=identifier,
+                        src="hdca",
+                        id=hdca.id,
+                    )
+                )
+            return collection_manager.create(
+                trans,
+                history,
+                name="Pick Value - mapped all non-null",
+                collection_type="list:list",
+                element_identifiers=elements,
+            )
+        else:
+            # Each element is an HDA — build flat list
+            elements = []
+            for identifier, hda in per_element_outputs:
+                elements.append(
+                    dict(
+                        name=identifier,
+                        src="hda",
+                        id=hda.id,
+                    )
+                )
+            return collection_manager.create(
+                trans,
+                history,
+                name="Pick Value - mapped",
+                collection_type="list",
+                element_identifiers=elements,
+            )
 
     def _apply_post_job_actions(self, trans, step, output, replacement_dict):
         """Apply post job actions directly to module output via ActionBox.

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2135,7 +2135,7 @@ class PickValueModule(WorkflowModule):
         # Build a map of input_name -> input_dict for quick lookup
         input_names = {d["name"] for d in all_inputs}
 
-        per_element_outputs = []
+        per_element_outputs: list[tuple[str, Any]] = []
         for iteration_elements, _when_value in collection_info.slice_collections():
             # For each slice, extract per-element replacements
             replacements = []

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2085,13 +2085,8 @@ class PickValueModule(WorkflowModule):
             output = non_null[0]
 
         elif mode == "all_non_null":
-            if not non_null:
-                raise FailWorkflowEvaluation(
-                    why=InvocationFailureExpressionEvaluationFailed(
-                        reason=FailureReason.expression_evaluation_failed,
-                        workflow_step_id=step.id,
-                    )
-                )
+            # CWL spec: all_non_null returns list of non-null values,
+            # which may be empty if all inputs are null.
             output = self._create_collection_from_list(trans, invocation_step, non_null)
 
         else:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -41,12 +41,12 @@ from galaxy.model import (
     WorkflowStepConnection,
 )
 from galaxy.model.base import ensure_object_added_to_session
-from galaxy.objectstore import ObjectStorePopulator
 from galaxy.model.dataset_collections import matching
 from galaxy.model.dataset_collections.adapters import PromoteCollectionElementToCollectionAdapter
 from galaxy.model.dataset_collections.query import HistoryQuery
 from galaxy.model.dataset_collections.type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 from galaxy.model.dataset_collections.types.sample_sheet_util import validate_column_definitions
+from galaxy.objectstore import ObjectStorePopulator
 from galaxy.schema.credentials import (
     CredentialsContext,
     SelectedGroup,
@@ -2170,9 +2170,7 @@ class PickValueModule(WorkflowModule):
         step_outputs = {"output": output}
         step_inputs: dict[str, Any] = {}
         for pja in step.post_job_actions:
-            ActionBox.execute_on_mapped_over(
-                trans, trans.sa_session, pja, step_inputs, step_outputs, replacement_dict
-            )
+            ActionBox.execute_on_mapped_over(trans, trans.sa_session, pja, step_inputs, step_outputs, replacement_dict)
 
     @staticmethod
     def _to_pja(key, value, step):

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -724,7 +724,13 @@ class WorkflowProgress:
         # Determine output value from inputs_by_step_id or default
         outputs = {}
         if step.id not in self.inputs_by_step_id:
-            outputs["output"] = step.get_input_default_value(NO_REPLACEMENT)
+            default_value = step.get_input_default_value(NO_REPLACEMENT)
+            # For parameter_input steps, unwrap {"src": "json", "value": X}
+            # dicts to just X — matching the unwrap logic in
+            # InputParameterModule.get_input_value().
+            if step.type == "parameter_input" and isinstance(default_value, dict):
+                default_value = default_value.get("value", default_value)
+            outputs["output"] = default_value
         else:
             outputs["output"] = self.inputs_by_step_id[step.id]
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3154,6 +3154,404 @@ test_data:
             )
             self.dataset_populator.wait_for_history(history_id=history_id, assert_ok=True)
 
+    def test_pick_value_first_non_null(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(true)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_data:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            output_details = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            assert output_details["state"] == "ok"
+
+    def test_pick_value_first_non_null_error_all_null(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_data:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation["state"] == "failed"
+
+    def test_pick_value_first_or_skip(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(true)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  pick:
+    type: pick_value
+    state:
+      mode: first_or_skip
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_data:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            output_details = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            assert output_details["state"] == "ok"
+
+    def test_pick_value_first_or_skip_all_null(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  pick:
+    type: pick_value
+    state:
+      mode: first_or_skip
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_data:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            output_details = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            assert output_details["extension"] == "expression.json"
+            assert output_details["misc_blurb"] == "skipped"
+
+    def test_pick_value_the_only_non_null(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(true)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  pick:
+    type: pick_value
+    state:
+      mode: the_only_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_data:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            output_details = self.dataset_populator.get_history_dataset_details(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            assert output_details["state"] == "ok"
+
+    def test_pick_value_the_only_non_null_error_multiple(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(true)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(true)
+  pick:
+    type: pick_value
+    state:
+      mode: the_only_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_data:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+                assert_ok=False,
+                wait=True,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            assert invocation["state"] == "failed"
+
+    def test_pick_value_all_non_null(self):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(true)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(true)
+  branch_c:
+    tool_id: cat1
+    in:
+      input1: input_data
+    when: $(false)
+  pick:
+    type: pick_value
+    state:
+      mode: all_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+      input_2: branch_c/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_data:
+  value: 1.bed
+  type: File
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            output_collection = self.dataset_populator.get_history_collection_details(
+                history_id, content_id=invocation["output_collections"]["picked"]["id"]
+            )
+            assert output_collection["collection_type"] == "list"
+            assert len(output_collection["elements"]) == 2
+
+    def test_pick_value_first_non_null_ordering(self):
+        """Verify first_non_null picks input_0 over input_1 when both are non-null."""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_a:
+    type: data
+  input_b:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_a
+    when: $(true)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_b
+    when: $(true)
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_a:
+  value: 1.bed
+  type: File
+input_b:
+  value: 2.bed
+  type: File
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            picked_content = self.dataset_populator.get_history_dataset_content(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            input_a_content = open(self.test_data_resolver.get_filename("1.bed")).read()
+            assert picked_content == input_a_content
+
+    def test_pick_value_first_non_null_ordering_skipped_first(self):
+        """Verify first_non_null skips null input_0 and picks input_1."""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """class: GalaxyWorkflow
+inputs:
+  input_a:
+    type: data
+  input_b:
+    type: data
+steps:
+  branch_a:
+    tool_id: cat1
+    in:
+      input1: input_a
+    when: $(false)
+  branch_b:
+    tool_id: cat1
+    in:
+      input1: input_b
+    when: $(true)
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+outputs:
+  picked:
+    outputSource: pick/output
+""",
+                test_data="""
+input_a:
+  value: 1.bed
+  type: File
+input_b:
+  value: 2.bed
+  type: File
+""",
+                history_id=history_id,
+            )
+            invocation = self.workflow_populator.get_invocation(summary.invocation_id, step_details=True)
+            picked_content = self.dataset_populator.get_history_dataset_content(
+                history_id, content_id=invocation["outputs"]["picked"]["id"]
+            )
+            input_b_content = open(self.test_data_resolver.get_filename("2.bed")).read()
+            assert picked_content == input_b_content
+
     def test_run_workflow_simple_conditional_step(self):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(

--- a/lib/galaxy_test/selenium/test_history_export.py
+++ b/lib/galaxy_test/selenium/test_history_export.py
@@ -1,0 +1,75 @@
+from .framework import (
+    managed_history,
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class TestHistoryExport(SeleniumTestCase):
+    """Test history export wizard (requires Celery + STS enabled, the default)."""
+
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_history_native_export_to_file(self):
+        self.perform_upload_of_pasted_content("my cool content")
+        self.history_panel_wait_for_hid_ok(1)
+
+        self.home()
+        self.click_history_option_export_to_file()
+        history_export_tasks = self.components.history_export_tasks
+        last_export_record = self.components.last_export_record
+
+        self.screenshot("history_export_formats")
+        # Step 1: Select export format (tar.gz)
+        history_export_tasks.select_format(format="tar.gz").wait_for_and_click()
+        history_export_tasks.next_button.wait_for_and_click()
+
+        # Step 2: Select download destination
+        history_export_tasks.select_destination(destination="download").wait_for_and_click()
+        self.screenshot("history_export_native_destinations")
+        history_export_tasks.next_button.wait_for_and_click()
+
+        # Step 3: Complete the export
+        self.screenshot("history_export_native_download_options")
+        history_export_tasks.export_button.wait_for_and_click()
+
+        # Wait for export to complete
+        last_export_record.preparing_export_badge.wait_for_visible()
+        self.screenshot("history_export_native_preparing_download")
+        last_export_record.preparing_export_badge.wait_for_absent(wait_type=self.wait_types.DATABASE_OPERATION)
+        last_export_record.download_btn.wait_for_visible()
+        self.screenshot("history_export_native_download_ready")
+
+    @selenium_test
+    @managed_history
+    def test_history_rocrate_export_to_file(self):
+        self.perform_upload_of_pasted_content("my cool content")
+        self.history_panel_wait_for_hid_ok(1)
+
+        self.home()
+        self.click_history_option_export_to_file()
+        history_export_tasks = self.components.history_export_tasks
+        last_export_record = self.components.last_export_record
+
+        self.screenshot("history_export_formats")
+        # Step 1: Select export format (rocrate)
+        history_export_tasks.select_format(format="rocrate.zip").wait_for_and_click()
+        history_export_tasks.next_button.wait_for_and_click()
+
+        # Step 2: Select download destination
+        history_export_tasks.select_destination(destination="download").wait_for_and_click()
+        self.screenshot("history_export_rocrate_destinations")
+        history_export_tasks.next_button.wait_for_and_click()
+
+        # Step 3: Complete the export
+        self.screenshot("history_export_rocrate_download_options")
+        history_export_tasks.export_button.wait_for_and_click()
+
+        # Wait for export to complete
+        last_export_record.preparing_export_badge.wait_for_visible()
+        self.screenshot("history_export_rocrate_preparing_download")
+        last_export_record.preparing_export_badge.wait_for_absent(wait_type=self.wait_types.DATABASE_OPERATION)
+        last_export_record.download_btn.wait_for_visible()
+        self.screenshot("history_export_rocrate_download_ready")

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1119,6 +1119,112 @@ steps:
         assert tool_state["mode"] == "all_non_null"
 
     @selenium_test
+    def test_pick_value_change_datatype_pja(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs:
+  input_data: data
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1: input_data
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+"""
+        )
+        editor = self.components.workflow_editor
+        pick_node = editor.node._(label="pick")
+        pick_node.wait_for_and_click()
+        # Expand the output card — PJA controls are inside a collapsed FormCard
+        editor.configure_output(output="output").wait_for_and_click()
+        editor.change_datatype.wait_for_and_click()
+        editor.select_datatype_text_search.wait_for_and_send_keys("bam")
+        editor.select_datatype(datatype="bam").wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.assert_workflow_has_changes_and_save()
+        workflow = self._download_current_workflow()
+        pick_step = [s for s in workflow["steps"].values() if s["type"] == "pick_value"][0]
+        pjas = pick_step["post_job_actions"]
+        assert "ChangeDatatypeActionoutput" in pjas
+        assert pjas["ChangeDatatypeActionoutput"]["action_arguments"]["newtype"] == "bam"
+
+    @selenium_test
+    def test_pick_value_rename_pja(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs:
+  input_data: data
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1: input_data
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+"""
+        )
+        editor = self.components.workflow_editor
+        pick_node = editor.node._(label="pick")
+        pick_node.wait_for_and_click()
+        editor.configure_output(output="output").wait_for_and_click()
+        editor.rename_output.wait_for_and_clear_and_send_keys("my_picked_output")
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.assert_workflow_has_changes_and_save()
+        workflow = self._download_current_workflow()
+        pick_step = [s for s in workflow["steps"].values() if s["type"] == "pick_value"][0]
+        pjas = pick_step["post_job_actions"]
+        assert "RenameDatasetActionoutput" in pjas
+        assert pjas["RenameDatasetActionoutput"]["action_arguments"]["newname"] == "my_picked_output"
+
+    @selenium_test
+    def test_pick_value_add_tags_pja(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs:
+  input_data: data
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1: input_data
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+"""
+        )
+        editor = self.components.workflow_editor
+        pick_node = editor.node._(label="pick")
+        pick_node.wait_for_and_click()
+        editor.configure_output(output="output").wait_for_and_click()
+        editor.add_tags_button.wait_for_and_click()
+        tag_input = editor.add_tags_input.wait_for_visible()
+        tag_input.send_keys("#picktag")
+        self.send_enter(tag_input)
+        self.send_escape(tag_input)
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.assert_workflow_has_changes_and_save()
+        workflow = self._download_current_workflow()
+        pick_step = [s for s in workflow["steps"].values() if s["type"] == "pick_value"][0]
+        pjas = pick_step["post_job_actions"]
+        assert "TagDatasetActionoutput" in pjas
+        assert "picktag" in pjas["TagDatasetActionoutput"]["action_arguments"]["tags"]
+
+    @selenium_test
     def test_editor_create_conditional_step(self):
         editor = self.components.workflow_editor
         self.workflow_create_new(annotation="simple when step definition")

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1213,6 +1213,62 @@ steps:
         assert "picktag" in pjas["TagDatasetActionoutput"]["action_arguments"]["tags"]
 
     @selenium_test
+    def test_pick_value_compact_on_disconnect(self):
+        self.open_in_workflow_editor("""
+class: GalaxyWorkflow
+inputs:
+  input_data: data
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1: input_data
+  branch_b:
+    tool_id: cat
+    in:
+      input1: input_data
+  branch_c:
+    tool_id: cat
+    in:
+      input1: input_data
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+      input_2: branch_c/out_file1
+""")
+        editor = self.components.workflow_editor
+        pick_node = editor.node._(label="pick")
+        # Verify initial state: 3 connected + 1 empty from grow-on-connect
+        self.assert_connected("branch_a#out_file1", "pick#input_0")
+        self.assert_connected("branch_b#out_file1", "pick#input_1")
+        self.assert_connected("branch_c#out_file1", "pick#input_2")
+        pick_node.input_terminal(name="input_3").wait_for_present()
+        # Disconnect middle input
+        self.workflow_editor_destroy_connection("pick#input_1")
+        self.sleep_for(self.wait_types.UX_RENDER)
+        # branch_b should no longer be connected
+        self.assert_not_connected("branch_b#out_file1", "pick#input_1")
+        # branch_c should have been compacted from input_2 to input_1
+        self.assert_connected("branch_a#out_file1", "pick#input_0")
+        self.assert_connected("branch_c#out_file1", "pick#input_1")
+        # Click pick node to mount FormPickValue watcher (triggers num_inputs shrink)
+        pick_node.wait_for_and_click()
+        pick_node.input_terminal(name="input_3").wait_for_absent_or_hidden()
+        # Save and verify connections and num_inputs were compacted
+        self.assert_workflow_has_changes_and_save()
+        workflow = self._download_current_workflow()
+        pick_step = [s for s in workflow["steps"].values() if s["type"] == "pick_value"][0]
+        tool_state = json.loads(pick_step["tool_state"])
+        assert tool_state["num_inputs"] == 2
+        assert len(pick_step["input_connections"]) == 2
+        assert "input_0" in pick_step["input_connections"]
+        assert "input_1" in pick_step["input_connections"]
+
+    @selenium_test
     def test_editor_create_conditional_step(self):
         editor = self.components.workflow_editor
         self.workflow_create_new(annotation="simple when step definition")

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1212,7 +1212,6 @@ steps:
         # should not show error
         editor.duplicate_label_error(output="out_file1").wait_for_absent()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_map_over_output_indicator(self):
         self.open_in_workflow_editor("""

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1515,11 +1515,14 @@ steps:
 
         return (int(width_stripped), int(height_stripped))
 
+    @retry_assertion_during_transitions
     def assert_node_output_is(self, label: str, output_type: str, subcollection_type: Optional[str] = None):
         editor = self.components.workflow_editor
         node_label, output_name = label.split("#")
         node = editor.node._(label=node_label)
         node.wait_for_present()
+        # Dismiss any stale tooltip before hovering so retry gets fresh text
+        self.click_center()
         output_element = node.output_terminal(name=output_name).wait_for_visible()
         self.hover_over(output_element)
         element = self.components._.tooltip_inner.wait_for_present()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1236,7 +1236,6 @@ steps:
         self.workflow_editor_destroy_connection("filter#how|filter_source")
         self.assert_node_output_is("filter#output_filtered", "list")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_place_comments(self):
         editor = self.components.workflow_editor
@@ -1252,12 +1251,12 @@ steps:
         editor.tool_bar.toggle_italic.wait_for_and_click()
         editor.tool_bar.color(color="pink").wait_for_and_click()
         editor.tool_bar.font_size.wait_for_and_click()
-        self.action_chains().send_keys(Keys.LEFT * 5).send_keys(Keys.RIGHT).perform()
+        self.send_keys_to_page(Keys.LEFT * 5 + Keys.RIGHT)
 
         # place text comment
         self.mouse_drag(from_element=canvas, from_offset=(-200, -200), to_offset=(400, 110))
 
-        self.action_chains().send_keys("Hello World").perform()
+        self.send_keys_to_page("Hello World")
 
         # check if all options were applied
         comment_content: WebElementProtocol = editor.comment.text_inner.wait_for_visible()
@@ -1281,7 +1280,7 @@ steps:
         editor.tool_bar.tool(tool="markdown_comment").wait_for_and_click()
         editor.tool_bar.color(color="lime").wait_for_and_click()
         self.mouse_drag(from_element=canvas, from_offset=(-100, -100), to_offset=(200, 220))
-        self.action_chains().send_keys("# Hello World").perform()
+        self.send_keys_to_page("# Hello World")
 
         editor.tool_bar.tool(tool="pointer").wait_for_and_click()
 
@@ -1302,7 +1301,7 @@ steps:
         editor.tool_bar.tool(tool="frame_comment").wait_for_and_click()
         editor.tool_bar.color(color="blue").wait_for_and_click()
         self.mouse_drag(from_element=canvas, from_offset=(-200, -150), to_offset=(400, 300))
-        self.action_chains().send_keys("My Frame").perform()
+        self.send_keys_to_page("My Frame")
 
         title: WebElementProtocol = editor.comment.frame_title.wait_for_visible()
         assert title.text == "My Frame"
@@ -1320,10 +1319,10 @@ steps:
         editor.tool_bar.tool(tool="freehand_pen").wait_for_and_click()
         editor.tool_bar.color(color="green").wait_for_and_click()
         editor.tool_bar.line_thickness.wait_for_and_click()
-        self.action_chains().send_keys(Keys.RIGHT * 20).perform()
+        self.send_keys_to_page(Keys.RIGHT * 20)
 
         editor.tool_bar.smoothing.wait_for_and_click()
-        self.action_chains().send_keys(Keys.RIGHT * 10).perform()
+        self.send_keys_to_page(Keys.RIGHT * 10)
 
         self.mouse_drag(from_element=canvas, from_offset=(-100, -100), to_offset=(200, 200))
 
@@ -1331,7 +1330,7 @@ steps:
 
         editor.tool_bar.color(color="black").wait_for_and_click()
         editor.tool_bar.line_thickness.wait_for_and_click()
-        self.action_chains().send_keys(Keys.LEFT * 20).perform()
+        self.send_keys_to_page(Keys.LEFT * 20)
         self.mouse_drag(from_element=canvas, from_offset=(-100, -100), via_offsets=[(100, 200)], to_offset=(-200, 30))
 
         # test bulk remove freehand
@@ -1340,7 +1339,7 @@ steps:
 
         # place another freehand comment and test eraser
         editor.tool_bar.line_thickness.wait_for_and_click()
-        self.action_chains().send_keys(Keys.RIGHT * 20).perform()
+        self.send_keys_to_page(Keys.RIGHT * 20)
         editor.tool_bar.color(color="orange").wait_for_and_click()
 
         self.mouse_drag(from_element=canvas, from_offset=(-100, -100), to_offset=(200, 200))
@@ -1349,7 +1348,7 @@ steps:
 
         # delete by clicking
         editor.tool_bar.tool(tool="freehand_eraser").wait_for_and_click()
-        self.action_chains().move_to_element(freehand_comment_a).click().perform()
+        self.move_to_and_click(freehand_comment_a)
 
         editor.comment.freehand_comment.wait_for_absent()
 
@@ -1368,7 +1367,6 @@ steps:
 
         editor.comment.freehand_comment.wait_for_absent()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_snapping(self):
         editor = self.components.workflow_editor
@@ -1382,11 +1380,11 @@ steps:
         # activate snapping and set it to max (200)
         editor.tool_bar.tool(tool="toggle_snap").wait_for_and_click()
         editor.tool_bar.snapping_distance.wait_for_and_click()
-        self.action_chains().send_keys(Keys.RIGHT * 10).perform()
+        self.send_keys_to_page(Keys.RIGHT * 10)
 
         # move the node a bit
         tool_node = editor.node._(label="tool_node").wait_for_present()
-        self.action_chains().move_to_element(tool_node).click_and_hold().move_by_offset(12, 3).release().perform()
+        self.mouse_drag(from_element=tool_node, to_offset=(12, 3))
 
         # check if editor position is snapped
         top, left = self.get_node_position("tool_node")
@@ -1396,7 +1394,7 @@ steps:
 
         # move the node a bit more
         tool_node = editor.node._(label="tool_node").wait_for_present()
-        self.action_chains().move_to_element(tool_node).click_and_hold().move_by_offset(207, -181).release().perform()
+        self.mouse_drag(from_element=tool_node, to_offset=(207, -181))
 
         # check if editor position is snapped
         top, left = self.get_node_position("tool_node")
@@ -1404,7 +1402,6 @@ steps:
         assert top % 200 == 0
         assert left % 200 == 0
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_selection(self):
         editor = self.components.workflow_editor
@@ -1422,7 +1419,7 @@ steps:
 
         # select the node
         editor.node_inspector_close.wait_for_and_click()
-        self.action_chains().move_to_element(tool_node).key_down(Keys.SHIFT).click().key_up(Keys.SHIFT).perform()
+        self.shift_click(tool_node)
         self.sleep_for(self.wait_types.UX_RENDER)
 
         assert editor.tool_bar.selection_count.wait_for_visible().text.find("1 step") != -1

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1018,8 +1018,7 @@ steps:
 
     @selenium_test
     def test_pick_value_grow_on_connect(self):
-        self.open_in_workflow_editor(
-            """
+        self.open_in_workflow_editor("""
 class: GalaxyWorkflow
 inputs:
   input_data: data
@@ -1039,8 +1038,7 @@ steps:
     in:
       input_0: branch_a/out_file1
       input_1: branch_b/out_file1
-"""
-        )
+""")
         editor = self.components.workflow_editor
         pick_node = editor.node._(label="pick")
         pick_node.input_terminal(name="input_0").wait_for_present()
@@ -1050,8 +1048,7 @@ steps:
 
     @selenium_test
     def test_pick_value_conditional_workflow_roundtrip(self):
-        self.open_in_workflow_editor(
-            """
+        self.open_in_workflow_editor("""
 class: GalaxyWorkflow
 inputs:
   input_data: data
@@ -1073,8 +1070,7 @@ steps:
     in:
       input_0: branch_a/out_file1
       input_1: branch_b/out_file1
-"""
-        )
+""")
         editor = self.components.workflow_editor
         pick_node = editor.node._(label="pick")
         pick_node.wait_for_present()
@@ -1089,8 +1085,7 @@ steps:
 
     @selenium_test
     def test_pick_value_output_type_changes_with_mode(self):
-        self.open_in_workflow_editor(
-            """
+        self.open_in_workflow_editor("""
 class: GalaxyWorkflow
 inputs:
   input_data: data
@@ -1105,8 +1100,7 @@ steps:
       mode: first_non_null
     in:
       input_0: branch_a/out_file1
-"""
-        )
+""")
         editor = self.components.workflow_editor
         pick_node = editor.node._(label="pick")
         pick_node.wait_for_and_click()
@@ -1120,8 +1114,7 @@ steps:
 
     @selenium_test
     def test_pick_value_change_datatype_pja(self):
-        self.open_in_workflow_editor(
-            """
+        self.open_in_workflow_editor("""
 class: GalaxyWorkflow
 inputs:
   input_data: data
@@ -1136,8 +1129,7 @@ steps:
       mode: first_non_null
     in:
       input_0: branch_a/out_file1
-"""
-        )
+""")
         editor = self.components.workflow_editor
         pick_node = editor.node._(label="pick")
         pick_node.wait_for_and_click()
@@ -1156,8 +1148,7 @@ steps:
 
     @selenium_test
     def test_pick_value_rename_pja(self):
-        self.open_in_workflow_editor(
-            """
+        self.open_in_workflow_editor("""
 class: GalaxyWorkflow
 inputs:
   input_data: data
@@ -1172,8 +1163,7 @@ steps:
       mode: first_non_null
     in:
       input_0: branch_a/out_file1
-"""
-        )
+""")
         editor = self.components.workflow_editor
         pick_node = editor.node._(label="pick")
         pick_node.wait_for_and_click()
@@ -1189,8 +1179,7 @@ steps:
 
     @selenium_test
     def test_pick_value_add_tags_pja(self):
-        self.open_in_workflow_editor(
-            """
+        self.open_in_workflow_editor("""
 class: GalaxyWorkflow
 inputs:
   input_data: data
@@ -1205,8 +1194,7 @@ steps:
       mode: first_non_null
     in:
       input_0: branch_a/out_file1
-"""
-        )
+""")
         editor = self.components.workflow_editor
         pick_node = editor.node._(label="pick")
         pick_node.wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -2,7 +2,11 @@ import json
 from typing import (
     cast,
     Optional,
+    TYPE_CHECKING,
 )
+
+if TYPE_CHECKING:
+    from galaxy.selenium.has_playwright_driver import HasPlaywrightDriver
 
 import yaml
 from selenium.webdriver.common.action_chains import ActionChains
@@ -58,7 +62,6 @@ CHIPSEQ_COLUMNS = [
 class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions):
     ensure_registered = True
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_basics(self):
         editor = self.components.workflow_editor
@@ -81,7 +84,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
 
         self.screenshot("workflow_editor_center_pane_maximized")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_edit_annotation(self):
         editor = self.components.workflow_editor
@@ -98,7 +100,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         self.workflow_index_open_with_name(name)
         self.assert_wf_annotation_is(new_annotation)
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_edit_name(self):
         name = self.create_and_wait_for_new_workflow_in_editor()
@@ -110,7 +111,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         self.workflow_index_open_with_name(new_name)
         self.assert_wf_name_is(name)
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_edit_license(self):
         editor = self.components.workflow_editor
@@ -124,7 +124,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         self.workflow_index_open_with_name(name)
         assert "MIT" in self.workflow_editor_license_text()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_parameter_regex_validation(self):
         editor = self.components.workflow_editor
@@ -154,7 +153,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         element = workflow_run.run_error.wait_for_present()
         assert "input must start with moocow" in element.text
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_int_parameter_minimum_validation(self):
         editor = self.components.workflow_editor
@@ -181,7 +179,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         # in parameter validators
         assert "Value ('3') must fulfill (4 <= value <= +infinity)" in element.text, element.text
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_float_parameter_maximum_validation(self):
         editor = self.components.workflow_editor
@@ -206,7 +203,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         # friendly.
         assert "Value ('3.2') must fulfill (-infinity <= value <= 3.14)" in element.text, element.text
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_optional_select_data_field(self):
         editor = self.components.workflow_editor
@@ -235,7 +231,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         tool_state = json.loads(workflow["steps"]["0"]["tool_state"])
         assert tool_state["select_single"] == ""
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_data_input(self):
         editor = self.components.workflow_editor
@@ -260,7 +255,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_data_input_deleted")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_collection_input(self):
         editor = self.components.workflow_editor
@@ -326,7 +320,6 @@ class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows, UsesWorkflowAssertions
         assert control["type"] == "element_identifier"
         assert control["optional"] is True
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_data_column_input_editing(self):
         self.open_in_workflow_editor("""
@@ -351,12 +344,11 @@ steps:
         self.set_text_element(columns, "4\n5\n6")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_workflow_has_changes_and_save()
-        self.driver.refresh()
+        self.refresh()
         node.title.wait_for_and_click()
         textarea_columns = columns.wait_for_visible()
         assert textarea_columns.get_attribute("value") == "4\n5\n6"
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_integer_input(self):
         editor = self.components.workflow_editor
@@ -382,7 +374,6 @@ steps:
         self.sleep_for(self.wait_types.UX_RENDER)
         self.screenshot("workflow_editor_parameter_input_deleted")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_non_data_connections(self):
         self.open_in_workflow_editor("""
@@ -436,7 +427,6 @@ steps:
         )
         self.assert_connected("input_int#output", "tool_exec#inttest")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_non_data_map_over_carried_through(self):
         # Use auto_layout=false, which prevents placing any
@@ -466,7 +456,6 @@ steps:
         self.workflow_editor_connect("text_input_step#out_file1", "collection_input#input1")
         self.assert_connected("text_input_step#out_file1", "collection_input#input1")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_connecting_display_in_upload_false_connections(self):
         self.open_in_workflow_editor("""
@@ -481,7 +470,6 @@ steps:
         self.workflow_editor_connect("step1#qname_input_sorted_bam_output", "step2#input5")
         self.assert_connected("step1#qname_input_sorted_bam_output", "step2#input5")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_existing_connections(self):
         self.open_in_workflow_editor(WORKFLOW_SIMPLE_CAT_TWICE)
@@ -504,7 +492,6 @@ steps:
         )
         self.assert_connected("input1#output", "first_cat#input1")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_reconnecting_nodes(self):
         name = self.open_in_workflow_editor(WORKFLOW_SIMPLE_CAT_TWICE)
@@ -518,14 +505,12 @@ steps:
         self.workflow_index_open_with_name(name)
         self.assert_connected("input1#output", "first_cat#input1")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_rendering_output_collection_connections(self):
         self.open_in_workflow_editor(WORKFLOW_WITH_OUTPUT_COLLECTION)
         self.workflow_editor_maximize_center_pane()
         self.screenshot("workflow_editor_output_collections")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_simple_mapping_connections(self):
         self.open_in_workflow_editor(WORKFLOW_SIMPLE_MAPPING)
@@ -539,14 +524,12 @@ steps:
         self.workflow_editor_connect("input1#output", "cat#input1")
         self.assert_input_mapped("cat#input1")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_rendering_simple_nested_workflow(self):
         self.open_in_workflow_editor(WORKFLOW_NESTED_SIMPLE)
         self.workflow_editor_maximize_center_pane()
         self.screenshot("workflow_editor_simple_nested")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_best_practices_input_label(self):
         editor = self.components.workflow_editor
@@ -596,7 +579,6 @@ steps:
         self.assert_connected(rule_output, random_lines_input)
         self.assert_input_mapped(random_lines_input)
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_rendering_rules_workflow_2(self):
         self.open_in_workflow_editor(WORKFLOW_WITH_RULES_2)
@@ -645,7 +627,6 @@ steps:
         # to a list:list, so there should be no mapping anymore even after connected.
         self.assert_input_not_mapped(copy_list_input)
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_save_as(self):
         name = self.workflow_upload_yaml_with_random_name(WORKFLOW_SIMPLE_CAT_TWICE)
@@ -656,7 +637,6 @@ steps:
 
         self.components.workflow_editor.save_as_activity.wait_for_and_click()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_tool_upgrade(self):
         workflow_populator = self.workflow_populator
@@ -690,7 +670,6 @@ steps:
         workflow = self.workflow_populator.download_workflow(workflow_id)
         assert workflow["steps"]["0"]["tool_version"] == "0.1+galaxy6"
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_tool_upgrade_all_tools(self):
         editor = self.components.workflow_editor
@@ -707,7 +686,6 @@ steps:
         version = node.get_attribute("data-version")
         assert version == "0.2"
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_tool_upgrade_message(self):
         workflow_populator = self.workflow_populator
@@ -719,7 +697,6 @@ steps:
         self.components.workflow_editor.modal_button_continue.wait_for_and_click()
         self.assert_workflow_has_changes_and_save()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_subworkflow_tool_upgrade_message(self):
         workflow_populator = self.workflow_populator
@@ -755,7 +732,6 @@ steps:
         element.wait_for_and_send_keys(Keys.BACKSPACE)
         element.wait_for_and_send_keys(value)
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_change_datatype(self):
         self.open_in_workflow_editor("""
@@ -791,7 +767,6 @@ steps:
         # Assert connection is valid
         self.assert_connected("create_2#out_file1", "checksum#input")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_change_datatype_post_job_action_lost_regression(self):
         self.open_in_workflow_editor("""
@@ -814,7 +789,6 @@ steps:
         node.wait_for_and_click()
         self.assert_connected("create_2#out_file1", "metadata_bam#input_bam")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_change_datatype_in_subworkflow(self):
         self.open_in_workflow_editor("""
@@ -870,7 +844,6 @@ steps:
         node = editor.node._(label="create_2")
         node.wait_for_and_click()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_duplicate_node(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
@@ -913,7 +886,6 @@ steps:
         assert len(source_step["post_job_actions"]) == len(cloned_step["post_job_actions"]) == 4
         assert source_step["post_job_actions"] == cloned_step["post_job_actions"]
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_embed_workflow(self):
         self.setup_subworkflow()
@@ -954,7 +926,6 @@ steps:
         assert subworkflow_step["input_connections"]["input1"]["input_subworkflow_step_id"] == 0
         return child_workflow_name
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_insert_steps(self):
         steps_to_insert = self.workflow_upload_yaml_with_random_name(WORKFLOW_SIMPLE_CAT_TWICE)
@@ -971,7 +942,7 @@ steps:
 
     def _download_current_workflow(self):
         self.sleep_for(self.wait_types.DATABASE_OPERATION)
-        workflow_id = self.driver.current_url.split("id=")[1]
+        workflow_id = self.current_url.split("id=")[1]
         workflow = self.workflow_populator.download_workflow(workflow_id)
         return workflow
 
@@ -1005,13 +976,13 @@ steps:
         # Assert no when input before making step conditional
         conditional_node.input_terminal(name="when").wait_for_absent()
         conditional_toggle = editor.step_when.wait_for_present()
-        self.action_chains().move_to_element(conditional_toggle).click().perform()
+        self.move_to_and_click(conditional_toggle)
         # Toggling conditional should cause when input to appear
         conditional_node.input_terminal(name="when").wait_for_present()
-        self.action_chains().move_to_element(conditional_toggle).click().perform()
+        self.move_to_and_click(conditional_toggle)
         # Toggling conditional should cause when input to disappear
         conditional_node.input_terminal(name="when").wait_for_absent()
-        self.action_chains().move_to_element(conditional_toggle).click().perform()
+        self.move_to_and_click(conditional_toggle)
         conditional_node.input_terminal(name="when").wait_for_present()
         # Output connection should be invalid, as output from conditional step is potentially null
         self.assert_connection_invalid("conditional_step#out_file1", "downstream_step#input1")
@@ -1057,11 +1028,18 @@ steps:
         self.assert_workflow_has_changes_and_save()
 
     def switch_param_type(self, element, param_type):
-        self.action_chains().move_to_element(element).click().pause(1).send_keys(param_type).pause(1).send_keys(
-            Keys.ENTER
-        ).perform()
+        if self.backend_type == "playwright":
+            pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
+            element.click()
+            self.sleep_for(self.wait_types.UX_RENDER)
+            pw_driver.page.keyboard.type(param_type)
+            self.sleep_for(self.wait_types.UX_RENDER)
+            pw_driver.page.keyboard.press("Enter")
+        else:
+            self.action_chains().move_to_element(element).click().pause(1).send_keys(param_type).pause(1).send_keys(
+                Keys.ENTER
+            ).perform()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_invalid_tool_state(self):
         workflow_populator = self.workflow_populator
@@ -1072,7 +1050,6 @@ steps:
         self.assert_modal_has_text("Using default: '1'")
         self.screenshot("workflow_editor_invalid_state")
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_missing_tools(self):
         workflow_populator = self.workflow_populator
@@ -1146,7 +1123,6 @@ steps:
         output_connector.send_keys(Keys.SPACE)
         assert self.driver.switch_to.active_element.text == "No compatible input found in workflow"
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_insert_input_handling(self):
         self.open_in_workflow_editor("""class: GalaxyWorkflow
@@ -1165,7 +1141,6 @@ steps:
         node.input_terminal(name="datasets_1|input").wait_for_present()
         self.assert_workflow_has_changes_and_save()
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_workflow_output_handling(self):
         self.open_in_workflow_editor(
@@ -1581,7 +1556,14 @@ steps:
 
     def assert_connected(self, source, sink):
         source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)
-        self.components.workflow_editor.connector_for(source_id=source_id, sink_id=sink_id).wait_for_visible()
+        # SVG <g> elements are considered "hidden" by Playwright even when
+        # rendered, so use wait_for_present instead of wait_for_visible
+        # with the Playwright backend.
+        connector = self.components.workflow_editor.connector_for(source_id=source_id, sink_id=sink_id)
+        if self._driver_impl.backend_type == "playwright":
+            connector.wait_for_present()
+        else:
+            connector.wait_for_visible()
 
     def assert_connection_invalid(self, source, sink):
         source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)
@@ -1595,10 +1577,24 @@ steps:
         name = self.workflow_upload_yaml_with_random_name(yaml_content)
         self.workflow_index_open()
         self.workflow_index_open_with_name(name)
+        self.workflow_editor_dismiss_state_upgrade_modal()
         if auto_layout:
             self.components.workflow_editor.tool_bar.auto_layout.wait_for_and_click()
             self.sleep_for(self.wait_types.UX_RENDER)
         return name
+
+    def workflow_editor_dismiss_state_upgrade_modal(self):
+        """Dismiss the StateUpgradeModal if it appears when opening a workflow.
+
+        This Bootstrap Vue modal intercepts pointer events and blocks clicks
+        on the workflow editor canvas. Wait briefly for it to potentially
+        appear, then dismiss if present.
+        """
+        editor = self.components.workflow_editor
+        self.sleep_for(self.wait_types.UX_RENDER)
+        if not editor.state_modal_body.is_absent:
+            editor.modal_button_continue.wait_for_and_click()
+            editor.state_modal_body.wait_for_absent()
 
     def workflow_editor_destroy_connection(self, sink):
         editor = self.components.workflow_editor
@@ -1637,7 +1633,19 @@ steps:
 
     def move_center_of_canvas(self, xoffset=0, yoffset=0):
         _canvas = self.find_element_by_id("canvas-container")
-        assert self.backend_type == "selenium"
-        canvas = cast(WebElement, _canvas)
-        chains = ActionChains(self.driver)
-        chains.click_and_hold(canvas).move_by_offset(xoffset=xoffset, yoffset=yoffset).release().perform()
+        if self.backend_type == "playwright":
+            pw_driver = cast("HasPlaywrightDriver", self._driver_impl)
+            page = pw_driver.page
+            handle = pw_driver._unwrap_element(_canvas)
+            box = handle.bounding_box()
+            assert box is not None
+            cx = box["x"] + box["width"] / 2
+            cy = box["y"] + box["height"] / 2
+            page.mouse.move(cx, cy)
+            page.mouse.down()
+            page.mouse.move(cx + xoffset, cy + yoffset)
+            page.mouse.up()
+        else:
+            canvas = cast(WebElement, _canvas)
+            chains = ActionChains(self.driver)
+            chains.click_and_hold(canvas).move_by_offset(xoffset=xoffset, yoffset=yoffset).release().perform()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -946,6 +946,178 @@ steps:
         workflow = self.workflow_populator.download_workflow(workflow_id)
         return workflow
 
+    def _pick_value_select_mode(self, label):
+        mode_selector = "div.ui-form-element[id='form-element-mode']"
+        container = self.wait_for_selector(mode_selector)
+        trigger = container.find_element(By.CSS_SELECTOR, ".multiselect__select")
+        trigger.click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        js = """
+            var label = arguments[0];
+            var container = document.querySelector('#form-element-mode');
+            var items = container.querySelectorAll('.multiselect__element');
+            for (var i = 0; i < items.length; i++) {
+                if (items[i].textContent.trim() === label) {
+                    items[i].querySelector('.multiselect__option').click();
+                    return true;
+                }
+            }
+            return false;
+        """
+        result = self.execute_script(js, label)
+        assert result, f"Mode option '{label}' not found"
+
+    @selenium_test
+    def test_pick_value_add_from_palette(self):
+        self.workflow_create_new(annotation="pick value test")
+        self.workflow_editor_add_input(item_name="pick_value")
+        editor = self.components.workflow_editor
+        editor.node._(label="Pick Value").wait_for_present()
+
+    @selenium_test
+    def test_pick_value_mode_selection(self):
+        self.workflow_create_new(annotation="pick value mode test")
+        self.workflow_editor_add_input(item_name="pick_value")
+        editor = self.components.workflow_editor
+        node = editor.node._(label="Pick Value")
+        node.wait_for_and_click()
+        self._pick_value_select_mode("All non-null (as collection)")
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.assert_workflow_has_changes_and_save()
+        workflow = self._download_current_workflow()
+        pick_step = [s for s in workflow["steps"].values() if s["type"] == "pick_value"][0]
+        tool_state = json.loads(pick_step["tool_state"])
+        assert tool_state["mode"] == "all_non_null"
+
+    @selenium_test
+    def test_pick_value_terminals(self):
+        self.workflow_create_new(annotation="pick value terminals test")
+        self.workflow_editor_add_input(item_name="pick_value")
+        editor = self.components.workflow_editor
+        node = editor.node._(label="Pick Value")
+        node.input_terminal(name="input_0").wait_for_present()
+        node.input_terminal(name="input_1").wait_for_present()
+        node.output_terminal(name="output").wait_for_present()
+
+    @selenium_test
+    def test_pick_value_connect_inputs(self):
+        self.workflow_create_new(annotation="pick value connections test")
+        self.workflow_editor_add_input(item_name="data_input")
+        editor = self.components.workflow_editor
+        editor.label_input.wait_for_and_send_keys("input_data")
+        self.tool_open("cat1")
+        self.sleep_for(self.wait_types.UX_RENDER)
+        editor.label_input.wait_for_and_send_keys("branch_a")
+        self.workflow_editor_add_input(item_name="pick_value")
+        editor.label_input.wait_for_and_send_keys("pick")
+        self.components.workflow_editor.tool_bar.auto_layout.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.workflow_editor_connect("input_data#output", "branch_a#input1")
+        self.workflow_editor_connect("branch_a#out_file1", "pick#input_0")
+        self.assert_connected("branch_a#out_file1", "pick#input_0")
+
+    @selenium_test
+    def test_pick_value_grow_on_connect(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs:
+  input_data: data
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1: input_data
+  branch_b:
+    tool_id: cat
+    in:
+      input1: input_data
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+"""
+        )
+        editor = self.components.workflow_editor
+        pick_node = editor.node._(label="pick")
+        pick_node.input_terminal(name="input_0").wait_for_present()
+        pick_node.input_terminal(name="input_1").wait_for_present()
+        # With 2 connections, grow-on-connect should have created a 3rd empty terminal
+        pick_node.input_terminal(name="input_2").wait_for_present()
+
+    @selenium_test
+    def test_pick_value_conditional_workflow_roundtrip(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs:
+  input_data: data
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1: input_data
+    when: $(true)
+  branch_b:
+    tool_id: cat
+    in:
+      input1: input_data
+    when: $(false)
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+      input_1: branch_b/out_file1
+"""
+        )
+        editor = self.components.workflow_editor
+        pick_node = editor.node._(label="pick")
+        pick_node.wait_for_present()
+        self.assert_connected("branch_a#out_file1", "pick#input_0")
+        self.assert_connected("branch_b#out_file1", "pick#input_1")
+        pick_node.output_terminal(name="output").wait_for_present()
+        workflow = self._download_current_workflow()
+        pick_step = [s for s in workflow["steps"].values() if s["type"] == "pick_value"][0]
+        tool_state = json.loads(pick_step["tool_state"])
+        assert tool_state["mode"] == "first_non_null"
+        assert len(pick_step["input_connections"]) == 2
+
+    @selenium_test
+    def test_pick_value_output_type_changes_with_mode(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs:
+  input_data: data
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1: input_data
+  pick:
+    type: pick_value
+    state:
+      mode: first_non_null
+    in:
+      input_0: branch_a/out_file1
+"""
+        )
+        editor = self.components.workflow_editor
+        pick_node = editor.node._(label="pick")
+        pick_node.wait_for_and_click()
+        self._pick_value_select_mode("All non-null (as collection)")
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.assert_workflow_has_changes_and_save()
+        workflow = self._download_current_workflow()
+        pick_step = [s for s in workflow["steps"].values() if s["type"] == "pick_value"][0]
+        tool_state = json.loads(pick_step["tool_state"])
+        assert tool_state["mode"] == "all_non_null"
+
     @selenium_test
     def test_editor_create_conditional_step(self):
         editor = self.components.workflow_editor

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -946,7 +946,6 @@ steps:
         workflow = self.workflow_populator.download_workflow(workflow_id)
         return workflow
 
-    @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
     def test_editor_create_conditional_step(self):
         editor = self.components.workflow_editor
@@ -997,6 +996,7 @@ steps:
         param_type_element = editor.param_type_form.wait_for_present()
         self.switch_param_type(param_type_element, "Text")
         self.assert_connection_invalid("param_input#output", "conditional_step#when")
+        editor.node_inspector_close.wait_for_and_click()
         self.workflow_editor_destroy_connection("conditional_step#when")
         # Make sure the when input is still shown
         conditional_node.input_terminal(name="when").wait_for_present()

--- a/lib/galaxy_test/workflow/pick_value_add_tag.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_add_tag.gxwf-tests.yml
@@ -1,0 +1,15 @@
+- doc: |
+    Test that TagDatasetAction on pick_value adds a tag to the output.
+  job:
+    input_data:
+      type: File
+      value: 1.bed
+      file_type: bed
+    when:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: File
+      metadata:
+        tags: "picktag"

--- a/lib/galaxy_test/workflow/pick_value_add_tag.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_add_tag.gxwf.yml
@@ -1,0 +1,29 @@
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+  when:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch:
+    tool_id: cat
+    in:
+      input1:
+        source: input_data
+      when:
+        source: when
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        add_tags:
+          - picktag

--- a/lib/galaxy_test/workflow/pick_value_all_non_null_mapped.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_all_non_null_mapped.gxwf-tests.yml
@@ -1,0 +1,55 @@
+- doc: |
+    Map over pick_value(all_non_null) with both branches active.
+    Each input element produces a 2-element inner list.
+    Output is list:list with 2 outer elements.
+  job:
+    input_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          contents: "line1"
+          filetype: bed
+        - identifier: el2
+          class: File
+          contents: "line2"
+          filetype: bed
+    when_a:
+      type: raw
+      value: true
+    when_b:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list:list
+      element_count: 2
+- doc: |
+    Map over pick_value(all_non_null) with one null branch.
+    Each element produces a 1-element inner list.
+  job:
+    input_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          contents: "line1"
+          filetype: bed
+        - identifier: el2
+          class: File
+          contents: "line2"
+          filetype: bed
+    when_a:
+      type: raw
+      value: true
+    when_b:
+      type: raw
+      value: false
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list:list
+      element_count: 2

--- a/lib/galaxy_test/workflow/pick_value_all_non_null_mapped.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_all_non_null_mapped.gxwf.yml
@@ -1,0 +1,38 @@
+class: GalaxyWorkflow
+inputs:
+  input_collection:
+    type: collection
+    collection_type: list
+  when_a:
+    type: boolean
+  when_b:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1:
+        source: input_collection
+      when:
+        source: when_a
+    when: $(inputs.when)
+  branch_b:
+    tool_id: cat
+    in:
+      input1:
+        source: input_collection
+      when:
+        source: when_b
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch_a/out_file1
+      input_1:
+        source: branch_b/out_file1
+    state:
+      mode: all_non_null

--- a/lib/galaxy_test/workflow/pick_value_all_non_null_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_all_non_null_pja.gxwf-tests.yml
@@ -1,0 +1,38 @@
+- doc: |
+    Test that PJAs work on all_non_null HDCA output. Both branches run,
+    pick collects both into a list, rename PJA sets collection name.
+  job:
+    input_data:
+      type: File
+      value: 1.bed
+      file_type: bed
+    when_a:
+      type: raw
+      value: true
+    when_b:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 2
+- doc: |
+    Test that all_non_null with one null branch collects only the
+    non-null output and applies the rename PJA.
+  job:
+    input_data:
+      type: File
+      value: 1.bed
+      file_type: bed
+    when_a:
+      type: raw
+      value: true
+    when_b:
+      type: raw
+      value: false
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 1

--- a/lib/galaxy_test/workflow/pick_value_all_non_null_pja.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_all_non_null_pja.gxwf.yml
@@ -1,0 +1,40 @@
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+  when_a:
+    type: boolean
+  when_b:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1:
+        source: input_data
+      when:
+        source: when_a
+    when: $(inputs.when)
+  branch_b:
+    tool_id: cat
+    in:
+      input1:
+        source: input_data
+      when:
+        source: when_b
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch_a/out_file1
+      input_1:
+        source: branch_b/out_file1
+    state:
+      mode: all_non_null
+    out:
+      output:
+        rename: "collected_picks"

--- a/lib/galaxy_test/workflow/pick_value_change_datatype.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_change_datatype.gxwf-tests.yml
@@ -1,0 +1,17 @@
+- doc: |
+    Test that ChangeDatatypeAction on pick_value changes output datatype.
+  job:
+    input_data:
+      type: File
+      value: 1.bed
+      file_type: bed
+    when:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: File
+      ftype: txt
+      asserts:
+        - that: has_text
+          text: chr1

--- a/lib/galaxy_test/workflow/pick_value_change_datatype.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_change_datatype.gxwf.yml
@@ -1,0 +1,28 @@
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+  when:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch:
+    tool_id: cat
+    in:
+      input1:
+        source: input_data
+      when:
+        source: when
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        change_datatype: txt

--- a/lib/galaxy_test/workflow/pick_value_first_non_null_mapped.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_first_non_null_mapped.gxwf-tests.yml
@@ -1,0 +1,73 @@
+- doc: |
+    Map over pick_value(first_non_null) with both branches active.
+    Each input element picks from branch_a, output is a list with same
+    element count as the input collection.
+  job:
+    input_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          contents: "line1"
+          filetype: bed
+        - identifier: el2
+          class: File
+          contents: "line2"
+          filetype: bed
+    when_a:
+      type: raw
+      value: true
+    when_b:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 2
+      elements:
+        el1:
+          asserts:
+            - that: has_text
+              text: "line1"
+        el2:
+          asserts:
+            - that: has_text
+              text: "line2"
+- doc: |
+    Map over pick_value(first_non_null) with only branch_b active.
+    Each element should pick from branch_b (branch_a is skipped).
+  job:
+    input_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: el1
+          class: File
+          contents: "line1"
+          filetype: bed
+        - identifier: el2
+          class: File
+          contents: "line2"
+          filetype: bed
+    when_a:
+      type: raw
+      value: false
+    when_b:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: Collection
+      collection_type: list
+      element_count: 2
+      elements:
+        el1:
+          asserts:
+            - that: has_text
+              text: "line1"
+        el2:
+          asserts:
+            - that: has_text
+              text: "line2"

--- a/lib/galaxy_test/workflow/pick_value_first_non_null_mapped.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_first_non_null_mapped.gxwf.yml
@@ -1,0 +1,38 @@
+class: GalaxyWorkflow
+inputs:
+  input_collection:
+    type: collection
+    collection_type: list
+  when_a:
+    type: boolean
+  when_b:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch_a:
+    tool_id: cat
+    in:
+      input1:
+        source: input_collection
+      when:
+        source: when_a
+    when: $(inputs.when)
+  branch_b:
+    tool_id: cat
+    in:
+      input1:
+        source: input_collection
+      when:
+        source: when_b
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch_a/out_file1
+      input_1:
+        source: branch_b/out_file1
+    state:
+      mode: first_non_null

--- a/lib/galaxy_test/workflow/pick_value_multi_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_multi_pja.gxwf-tests.yml
@@ -1,0 +1,17 @@
+- doc: |
+    Test multiple PJAs on pick_value: change datatype, rename, and add tag.
+  job:
+    input_data:
+      type: File
+      value: 1.bed
+      file_type: bed
+    when:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: File
+      ftype: txt
+      metadata:
+        name: "picked_and_typed"
+        tags: "pv_tag"

--- a/lib/galaxy_test/workflow/pick_value_multi_pja.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_multi_pja.gxwf.yml
@@ -1,0 +1,31 @@
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+  when:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch:
+    tool_id: cat
+    in:
+      input1:
+        source: input_data
+      when:
+        source: when
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        change_datatype: txt
+        rename: "picked_and_typed"
+        add_tags:
+          - pv_tag

--- a/lib/galaxy_test/workflow/pick_value_rename.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_rename.gxwf-tests.yml
@@ -1,0 +1,15 @@
+- doc: |
+    Test that RenameDatasetAction on pick_value renames the output.
+  job:
+    input_data:
+      type: File
+      value: 1.bed
+      file_type: bed
+    when:
+      type: raw
+      value: true
+  outputs:
+    picked:
+      class: File
+      metadata:
+        name: "picked_result"

--- a/lib/galaxy_test/workflow/pick_value_rename.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_rename.gxwf.yml
@@ -1,0 +1,28 @@
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+  when:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch:
+    tool_id: cat
+    in:
+      input1:
+        source: input_data
+      when:
+        source: when
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        rename: "picked_result"

--- a/lib/galaxy_test/workflow/pick_value_skip_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_skip_pja.gxwf-tests.yml
@@ -1,0 +1,16 @@
+- doc: |
+    Test that PJAs are NOT applied to skipped outputs. When all inputs are
+    null, first_or_skip produces a skipped HDA (expression.json). The
+    ChangeDatatypeAction should not corrupt it.
+  job:
+    input_data:
+      type: File
+      value: 1.bed
+      file_type: bed
+    when:
+      type: raw
+      value: false
+  outputs:
+    picked:
+      class: File
+      ftype: expression.json

--- a/lib/galaxy_test/workflow/pick_value_skip_pja.gxwf.yml
+++ b/lib/galaxy_test/workflow/pick_value_skip_pja.gxwf.yml
@@ -1,0 +1,28 @@
+class: GalaxyWorkflow
+inputs:
+  input_data:
+    type: data
+  when:
+    type: boolean
+outputs:
+  picked:
+    outputSource: pick/output
+steps:
+  branch:
+    tool_id: cat
+    in:
+      input1:
+        source: input_data
+      when:
+        source: when
+    when: $(inputs.when)
+  pick:
+    type: pick_value
+    in:
+      input_0:
+        source: branch/out_file1
+    state:
+      mode: first_or_skip
+    out:
+      output:
+        change_datatype: txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "future>=1.0.0",  # Python 3.12 support
     "gravity>=1.2.0",  # Python 3.14 support
     "gunicorn!=25.1.0",  # https://github.com/benoitc/gunicorn/discussions/3509
-    "gxformat2>=0.22.0",
+    "gxformat2 @ git+https://github.com/galaxyproject/gxformat2.git@pick_value",
     "h5grove>=1.2.1",
     "h5py>=3.12",  # Python 3.13 support
     "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "future>=1.0.0",  # Python 3.12 support
     "gravity>=1.2.0",  # Python 3.14 support
     "gunicorn!=25.1.0",  # https://github.com/benoitc/gunicorn/discussions/3509
-    "gxformat2 @ git+https://github.com/galaxyproject/gxformat2.git@pick_value",
+    "gxformat2>=0.23.0",
     "h5grove>=1.2.1",
     "h5py>=3.12",  # Python 3.13 support
     "httpx",

--- a/test/functional/tools/for_workflows/catWrapper.xml
+++ b/test/functional/tools/for_workflows/catWrapper.xml
@@ -1,0 +1,1 @@
+../../../../tools/filters/catWrapper.xml

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -288,6 +288,7 @@
   <tool file="for_workflows/count_multi_file.xml" />
   <tool file="for_workflows/create_input_collection.xml" />
   <tool file="for_workflows/randomlines.xml" />
+  <tool file="for_workflows/catWrapper.xml" />
   <tool file="create_directory_index.xml" />
   <tool file="use_directory_index.xml" />
 

--- a/test/integration_selenium/test_history_export_legacy.py
+++ b/test/integration_selenium/test_history_export_legacy.py
@@ -4,7 +4,16 @@ from .framework import (
 )
 
 
-class TestHistoryExport(SeleniumIntegrationTestCase):
+class TestLegacyHistoryExport(SeleniumIntegrationTestCase):
+    """Test legacy history export for when celery is disabled.
+
+    If Celery is enabled, a wizard will be setup and STS will serve downloads,
+    this is tested in test_history_export.py in the main selenium test suite.
+
+    This test needs to disable celery in order to work so it is an integration
+    test and we disable celery in handle_galaxy_config_kwds.
+    """
+
     ensure_registered = True
 
     @classmethod


### PR DESCRIPTION
Builds on #22164 for the workflow editor e2e abstractions.

## Overview

The `pick_value` module is a first-class workflow control-flow primitive that selects among outputs from conditional branches. It sits alongside `pause`, input modules, and `when` expressions in Galaxy's workflow module system. Users wire N conditional branch outputs as inputs, configure a selection mode, and get one output — no expression tools required.

The module is the Galaxy-native equivalent of CWL v1.2's `pickValue` on workflow outputs. Once CWL import integration is added, it will unblock 27+ CWL v1.2 conditional conformance tests.

## Architecture

### No Database Migration

The module uses existing Galaxy tables exclusively:

- `WorkflowStep` with `type = "pick_value"`
- `tool_state` JSON stores `{"mode": "first_non_null", "num_inputs": 2}`
- Input connections via `WorkflowStepConnection`
- Output via `WorkflowOutput`

### Selection Modes

| Mode | Behavior | Output Type |
|------|----------|-------------|
| `first_non_null` | First non-null input; **error** if all null | Single dataset |
| `first_or_skip` | First non-null input; **skip** if all null | Single dataset (or skipped HDA) |
| `the_only_non_null` | The single non-null input; **error** if count != 1 | Single dataset |
| `all_non_null` | All non-null inputs as collection (may be empty) | `list` HDCA |

### Null/Skip Detection

`_is_null_or_skipped()` checks two conditions:
1. `NO_REPLACEMENT` sentinel (no upstream output connected/available)
2. HDA with `extension == "expression.json"` and `blurb == "skipped"` (Galaxy's convention for skipped conditional outputs)


## Backend

### Module Class

**File:** `lib/galaxy/workflow/modules.py` — `PickValueModule(WorkflowModule)`

Registered in `module_types` dict (one line: `pick_value=PickValueModule`). The `module_factory` singleton picks it up automatically.

Key methods:

- **`get_all_inputs()`** — Returns N+1 input terminal dicts (`input_0` through `input_{N}`). The extra terminal enables grow-on-connect in the editor. Terminal count is `max(2, num_inputs from state, num connections)`.
- **`get_all_outputs()`** — Returns one output. For `all_non_null` mode: `collection=True, collection_type="list"`. For other modes: single dataset.
- **`execute()`** — Gathers replacements from input terminals, partitions into non-null vs null/skipped, applies mode logic, calls `progress.set_step_outputs()`.
- **`_create_skipped_output()`** — Creates a skipped HDA for `first_or_skip` when all inputs are null. Uses `hda.set_skipped()` with `ObjectStorePopulator`.
- **`_create_collection_from_list()`** — Creates an HDCA from non-null HDAs for `all_non_null` mode via `dataset_collection_manager.create()`.

### API Wiring

**File:** `lib/galaxy/webapps/galaxy/api/workflows.py`

One-line change: excludes `pick_value` from `from_tool_form` processing (same treatment as `data_collection_input`). State is managed by the frontend Vue component, not backend tool forms.

### Parameter Default Fix

**File:** `lib/galaxy/workflow/run.py`

Unwraps `parameter_input` default values from `{"src": "json", "value": X}` dict format to just `X`. This was a pre-existing bug exposed when testing pick_value with parameter inputs.

## Frontend

### Editor Form

**File:** `client/src/components/Workflow/Editor/Forms/FormPickValue.vue`

Single `<FormElement type="select">` for mode selection. Options use `[label, value]` tuple format (required by `FormSelection.vue`'s `currentOptions` computed).

**Grow-on-connect:** A `watch` on `step.input_connections` detects when the last empty terminal (`input_{num_inputs}`) gets connected, then increments `num_inputs` and emits `onChange`. This creates a new empty terminal — same UX pattern as input collection steps.

**Initial emit:** `emit("onChange", cleanToolState())` on mount resets the `initialChange` guard in the parent form (same pattern as `FormInputCollection`).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
