### PR TITLE
[26.0] Fix race condition in history list when rapidly changing search filters

### DIFF
--- a/client/src/components/History/HistoryList.vue
+++ b/client/src/components/History/HistoryList.vue
@@ -92,6 +92,7 @@ const limit = ref(24);
 const offset = ref(0);
 const loading = ref(true);
 const overlay = ref(false);
+let loadGeneration = 0;
 const filterText = ref("");
 const totalHistories = ref(0);
 const showAdvanced = ref(false);
@@ -219,6 +220,8 @@ function onToggleDeleted() {
  * @param {boolean} silent - Whether to skip loading indicators
  */
 async function load(overlayLoading: boolean = false, silent: boolean = false) {
+    const thisGeneration = ++loadGeneration;
+
     if (!silent) {
         if (overlayLoading) {
             overlay.value = true;
@@ -242,32 +245,37 @@ async function load(overlayLoading: boolean = false, silent: boolean = false) {
     };
 
     try {
+        let data;
+        let total;
+
         if (myView.value) {
-            const { data, total } = await getMyHistories(options);
-
-            historiesLoaded.value = data;
-            totalHistories.value = total;
+            ({ data, total } = await getMyHistories(options));
         } else if (sharedView.value) {
-            const { data, total } = await getSharedHistories(options);
-
-            historiesLoaded.value = data;
-            totalHistories.value = total;
+            ({ data, total } = await getSharedHistories(options));
         } else if (publishedView.value) {
-            const { data, total } = await getPublishedHistories(options);
-
-            historiesLoaded.value = data;
-            totalHistories.value = total;
+            ({ data, total } = await getPublishedHistories(options));
         } else if (archivedView.value) {
-            const { data, total } = await getArchivedHistories(options);
+            ({ data, total } = await getArchivedHistories(options));
+        }
 
+        if (thisGeneration !== loadGeneration) {
+            return;
+        }
+
+        if (data !== undefined) {
             historiesLoaded.value = data;
-            totalHistories.value = total;
+            totalHistories.value = total!;
         }
     } catch (error) {
+        if (thisGeneration !== loadGeneration) {
+            return;
+        }
         Toast.error(`Failed to load histories: ${errorMessageAsString(error)}`);
     } finally {
-        loading.value = false;
-        overlay.value = false;
+        if (thisGeneration === loadGeneration) {
+            loading.value = false;
+            overlay.value = false;
+        }
     }
 }
 


### PR DESCRIPTION
When a search reset and a new search triggered concurrent load() calls, a stale response from the reset could overwrite the correct search results. Use a generation counter to discard responses from superseded loads.

This fixes the flaky `test_advanced_search` test that fails consistently on https://github.com/galaxyproject/galaxy/pull/22210 (because it doesn't use the optimized psycopg[binary] dependency ...)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
