### PR TITLE
Fix mapOver terminology typo and minor polish

### DIFF
--- a/lib/galaxy/schema/terms.yml
+++ b/lib/galaxy/schema/terms.yml
@@ -128,14 +128,14 @@ galaxy:
       A flat list is just a simple dataset collection of type ``list`` that contains only datasets and not
       other collections.
     mapOver: |
-      When a tool consumes a dataset but is run with a collection, the collection *maps over* the collection.
+      When a tool consumes a dataset but is run with a collection, the tool *maps over* the collection.
       This means instead of just running the tool once - the tool will be run once for each element of the
       provided collection. Additionally, the outputs of the tool will be collected into a collection that
       matches the structure of the provided collection. This matching structure means the output collections
-      will have the same element identifiers as the provided collection and they will appear in the same order.
+      will have the same element identifiers as the provided collection and the elements will appear in the same order.
 
       It is easiest to visualize "mapping over" a collection in the context of a tool that consumes a dataset
-      and produces a dataset, but the semantics apply rather naturally to tools that consume collections or
+      and produces a dataset, but the semantics apply naturally to tools that consume collections or
       produce collections as well.
       
       For instance, consider a tool that consumes a ``paired`` collection and produces an output dataset.
@@ -145,7 +145,7 @@ galaxy:
 
       In the case of outputs, consider a tool that takes in a dataset and produces a flat list. If this tool
       is run over a flat list of datasets - that list will be "mapped over" and each element will produce a list.
-      These lists will be gathered together in a nested list structure (collection type ``list:list``) where
+      These lists will be gathered in a nested list structure (collection type ``list:list``) where
       the outer element count and structure matches that of the input and the inner list for each of those
       is just the outputs of the tool for the corresponding element of the input.
     collectionBuilder:


### PR DESCRIPTION


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
