### PR TITLE
Migrate Workflow Components from BTable to GTable

### DIFF
--- a/client/src/components/JobStates/JobState.vue
+++ b/client/src/components/JobStates/JobState.vue
@@ -20,7 +20,7 @@ const stateIcon = computed(() => iconClasses[props.job.state] || null);
 </script>
 
 <template>
-    <span class="rounded px-2 py-1" :class="badgeClass">
+    <span class="rounded px-2 py-1 text-nowrap" :class="badgeClass">
         <FontAwesomeIcon v-if="stateIcon" :icon="stateIcon.icon" :spin="stateIcon.spin" />
         {{ props.job.state }}
     </span>

--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -217,8 +217,8 @@ defineExpose({ triggerImport });
 
                         <TrsTool
                             :trs-tool="item.data"
-                            @onImport="(versionId: string) => onVersionSelected(item.data, versionId)"
-                            @onSelect="(versionId: string) => onVersionSelected(item.data, versionId)" />
+                            @onImport="onVersionSelected(item.data, $event)"
+                            @onSelect="onVersionSelected(item.data, $event)" />
                     </BCard>
                 </template>
 

--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -2,7 +2,7 @@
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
-import { BAlert, BFormInput, BInputGroup, BInputGroupAppend } from "bootstrap-vue";
+import { BAlert, BCard, BFormInput, BInputGroup, BInputGroupAppend } from "bootstrap-vue";
 import { computed, type Ref, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 

--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -12,7 +12,7 @@ import { Services } from "@/components/Workflow/services";
 import { useMarkdown } from "@/composables/markdown";
 import { withPrefix } from "@/utils/redirect";
 
-import type { TrsSelection, TrsTool as TrsToolData } from "./types";
+import type { TrsSelection, TrsTool as TrsSearchData } from "./types";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GTable from "@/components/Common/GTable.vue";
@@ -24,8 +24,6 @@ import TrsTool from "@/components/Workflow/Import/TrsTool.vue";
 const emit = defineEmits<{
     (e: "input-valid", valid: boolean): void;
 }>();
-
-type TrsSearchData = TrsToolData;
 
 type TrsSearchRow = {
     id: string;

--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -2,10 +2,11 @@
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
-import { BAlert, BFormInput, BInputGroup, BInputGroupAppend, BTable } from "bootstrap-vue";
+import { BAlert, BFormInput, BInputGroup, BInputGroupAppend } from "bootstrap-vue";
 import { computed, type Ref, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
+import type { RowClickEvent, TableField } from "@/components/Common/GTable.types";
 import { getRedirectOnImportPath } from "@/components/Workflow/redirectPath";
 import { Services } from "@/components/Workflow/services";
 import { useMarkdown } from "@/composables/markdown";
@@ -14,6 +15,7 @@ import { withPrefix } from "@/utils/redirect";
 import type { TrsSelection } from "./types";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
+import GTable from "@/components/Common/GTable.vue";
 import HelpText from "@/components/Help/HelpText.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import TrsServerSelection from "@/components/Workflow/Import/TrsServerSelection.vue";
@@ -32,7 +34,7 @@ type TrsSearchData = {
 
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 
-const fields = [
+const fields: TableField[] = [
     { key: "name", label: "Name" },
     { key: "description", label: "Description" },
     { key: "organization", label: "Organization" },
@@ -99,23 +101,9 @@ function onTrsSelectionError(message: string) {
     errorMessage.value = message;
 }
 
-function showRowDetails(row: any, _index: number, e: MouseEvent) {
-    if ((e.target as Node | undefined)?.nodeName !== "A") {
-        // Collapse all other rows
-        itemsComputed.value.forEach((item) => {
-            if (item !== row) {
-                item._showDetails = false;
-            }
-        });
-        // Toggle the clicked row
-        const wasExpanded = row._showDetails;
-        row._showDetails = !row._showDetails;
-
-        // If collapsing the row, reset selection state
-        if (wasExpanded) {
-            selectedTool.value = null;
-            selectedVersion.value = undefined;
-        }
+function showRowDetails({ event, toggleDetails }: RowClickEvent<TrsSearchData>) {
+    if ((event.target as Node | undefined)?.nodeName !== "A") {
+        toggleDetails();
     }
 }
 
@@ -126,7 +114,6 @@ function computeItems(items: TrsSearchData[]) {
             name: item.name,
             description: item.description,
             data: item,
-            _showDetails: false,
         };
     });
 }
@@ -211,76 +198,59 @@ defineExpose({ triggerImport });
             <BAlert v-else-if="results.length == 0" variant="info" show>
                 No search results found, refine your search.
             </BAlert>
-            <BTable
+            <GTable
                 v-else
                 :fields="fields"
                 :items="itemsComputed"
                 hover
                 caption-top
-                :busy="loading"
-                tbody-tr-class="clickable-row"
-                @row-clicked="showRowDetails">
-                <template v-slot:row-details="row">
+                clickable-rows
+                :loading="loading"
+                @row-click="showRowDetails">
+                <template v-slot:row-details="{ item }">
                     <BCard>
                         <BAlert v-if="importing" variant="info" show>
                             <LoadingSpan message="Importing workflow" />
                         </BAlert>
 
                         <TrsTool
-                            :trs-tool="row.item.data"
-                            @onImport="(versionId) => onVersionSelected(row.item.data, versionId)"
-                            @onSelect="(versionId) => onVersionSelected(row.item.data, versionId)" />
+                            :trs-tool="item.data"
+                            @onImport="(versionId) => onVersionSelected(item.data, versionId)"
+                            @onSelect="(versionId) => onVersionSelected(item.data, versionId)" />
                     </BCard>
                 </template>
 
                 <template v-slot:cell(description)="row">
                     <span class="trs-description" v-html="renderMarkdown(row.item.data.description)" />
                 </template>
-            </BTable>
+            </GTable>
         </div>
     </div>
 </template>
 
 <style scoped lang="scss">
-.trs-description {
-    position: relative;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-}
-
-.trs-search-field {
-    display: flex;
-    gap: var(--spacing);
-    align-items: center;
-    margin-bottom: var(--spacing-4);
-
-    :deep(.popper-element) {
-        max-width: 30vw;
-    }
-}
-
 .vertical-scroll {
     max-height: 600px;
     overflow-y: auto;
-}
-.clickable-row:not(.b-table-details) {
-    cursor: pointer;
-}
-.clickable-row:not(:first-child) {
-    border-top: 1px double #ccc;
-}
-.clickable-row.b-table-has-details {
-    border: 2px solid var(--brand-primary, #007bff);
-    border-bottom: none;
-}
-.clickable-row.b-table-details {
-    border: 2px solid var(--brand-primary, #007bff);
-    border-top: none;
-}
-.clickable-row.b-table-details:hover {
-    background: unset;
+
+    .trs-description {
+        position: relative;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        line-clamp: 3;
+    }
+
+    .trs-search-field {
+        display: flex;
+        gap: var(--spacing);
+        align-items: center;
+        margin-bottom: var(--spacing-4);
+
+        :deep(.popper-element) {
+            max-width: 30vw;
+        }
+    }
 }
 </style>

--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -41,13 +41,13 @@ const fields: TableField[] = [
 ];
 
 const query = ref("");
-const results: Ref<TrsToolData[]> = ref([]);
+const results: Ref<TrsSearchData[]> = ref([]);
 const trsServer = ref("");
 const loading = ref(false);
 const importing = ref(false);
 const trsSelection: Ref<TrsSelection | null> = ref(null);
 const errorMessage: Ref<string | null> = ref(null);
-const selectedTool = ref<TrsToolData | null>(null);
+const selectedTool = ref<TrsSearchData | null>(null);
 const selectedVersion = ref<string | undefined>(undefined);
 
 const hasErrorMessage = computed(() => {
@@ -120,7 +120,7 @@ function computeItems(items: TrsSearchData[]) {
 
 const router = useRouter();
 
-function onVersionSelected(toolData: TrsToolData, versionId: string) {
+function onVersionSelected(toolData: TrsSearchData, versionId: string) {
     selectedTool.value = toolData;
     selectedVersion.value = versionId;
 }

--- a/client/src/components/Workflow/Import/TrsSearch.vue
+++ b/client/src/components/Workflow/Import/TrsSearch.vue
@@ -12,7 +12,7 @@ import { Services } from "@/components/Workflow/services";
 import { useMarkdown } from "@/composables/markdown";
 import { withPrefix } from "@/utils/redirect";
 
-import type { TrsSelection } from "./types";
+import type { TrsSelection, TrsTool as TrsToolData } from "./types";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GTable from "@/components/Common/GTable.vue";
@@ -25,11 +25,13 @@ const emit = defineEmits<{
     (e: "input-valid", valid: boolean): void;
 }>();
 
-type TrsSearchData = {
+type TrsSearchData = TrsToolData;
+
+type TrsSearchRow = {
     id: string;
     name: string;
     description: string;
-    [key: string]: unknown;
+    data: TrsSearchData;
 };
 
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
@@ -41,13 +43,13 @@ const fields: TableField[] = [
 ];
 
 const query = ref("");
-const results: Ref<TrsSearchData[]> = ref([]);
+const results: Ref<TrsToolData[]> = ref([]);
 const trsServer = ref("");
 const loading = ref(false);
 const importing = ref(false);
 const trsSelection: Ref<TrsSelection | null> = ref(null);
 const errorMessage: Ref<string | null> = ref(null);
-const selectedTool = ref<TrsSearchData | null>(null);
+const selectedTool = ref<TrsToolData | null>(null);
 const selectedVersion = ref<string | undefined>(undefined);
 
 const hasErrorMessage = computed(() => {
@@ -101,7 +103,7 @@ function onTrsSelectionError(message: string) {
     errorMessage.value = message;
 }
 
-function showRowDetails({ event, toggleDetails }: RowClickEvent<TrsSearchData>) {
+function showRowDetails({ event, toggleDetails }: RowClickEvent<TrsSearchRow>) {
     if ((event.target as Node | undefined)?.nodeName !== "A") {
         toggleDetails();
     }
@@ -120,7 +122,7 @@ function computeItems(items: TrsSearchData[]) {
 
 const router = useRouter();
 
-function onVersionSelected(toolData: TrsSearchData, versionId: string) {
+function onVersionSelected(toolData: TrsToolData, versionId: string) {
     selectedTool.value = toolData;
     selectedVersion.value = versionId;
 }
@@ -215,8 +217,8 @@ defineExpose({ triggerImport });
 
                         <TrsTool
                             :trs-tool="item.data"
-                            @onImport="(versionId) => onVersionSelected(item.data, versionId)"
-                            @onSelect="(versionId) => onVersionSelected(item.data, versionId)" />
+                            @onImport="(versionId: string) => onVersionSelected(item.data, versionId)"
+                            @onSelect="(versionId: string) => onVersionSelected(item.data, versionId)" />
                     </BCard>
                 </template>
 

--- a/client/src/components/WorkflowInvocationState/JobStep.test.ts
+++ b/client/src/components/WorkflowInvocationState/JobStep.test.ts
@@ -16,7 +16,7 @@ const SELECTORS = {
     JOB_STATE_BUTTON_NAV: "nav",
     JOB_STATE_BUTTON: ".g-button",
     JOBS_TABLE: ".job-step-jobs",
-    JOB_ROW: ".job-step-jobs > tbody > tr",
+    JOB_ROW: ".job-step-jobs .g-table tbody > tr:not(.g-table-details-row):not(.g-table-empty-row)",
     STUBBED_JOB_DETAILS: "anonymous-stub",
 };
 

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.test.ts
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.test.ts
@@ -21,7 +21,7 @@ const TEST_NEW_JOB_ID = "sample-job-NEW";
 
 const SELECTORS = {
     JOBS_TABLE: ".job-step-jobs",
-    JOB_ROW: ".job-step-jobs > tbody > tr",
+    JOB_ROW: ".job-step-jobs .g-table tbody > tr:not(.g-table-details-row):not(.g-table-empty-row)",
     JOB_CONTENT: ".g-modal-content",
     JOB_INFORMATION_TABLE: "table#job-information",
 };

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.vue
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { faArrowCircleLeft, faArrowCircleRight, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BTable } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import type { JobBaseModel } from "@/api/jobs";
+import type { TableField } from "@/components/Common/GTable.types";
 
 import { getJobDuration } from "../JobInformation/utilities";
 
@@ -15,6 +15,7 @@ import Heading from "../Common/Heading.vue";
 import JobDetails from "../JobInformation/JobDetails.vue";
 import JobState from "../JobStates/JobState.vue";
 import UtcDate from "../UtcDate.vue";
+import GTable from "@/components/Common/GTable.vue";
 
 const props = defineProps<{
     jobs: JobBaseModel[];
@@ -30,6 +31,14 @@ const emit = defineEmits<{
 }>();
 
 const showModal = ref(false);
+
+const fields: TableField[] = [
+    { key: "id", label: "Job ID" },
+    { key: "tool_id", label: "Tool" },
+    { key: "update_time", label: "Updated", sortable: true },
+    { key: "duration", label: "Time To Finish" },
+    { key: "state", label: "State" },
+];
 
 /** The job currently being viewed in the modal */
 const viewedJob = ref<JobBaseModel | null>(null);
@@ -55,20 +64,13 @@ const viewedJobIndex = computed<number | null>({
     },
 });
 
-function getTrClass(job: JobBaseModel) {
-    return {
-        "clickable-row": true,
-        "font-weight-bold": job.id === viewedJob.value?.id,
-    };
-}
-
 function jobClicked(job: JobBaseModel) {
     viewedJob.value = job;
     showModal.value = true;
 }
 
-function onSort(sortInfo: { sortDesc: boolean }) {
-    emit("update:sort-desc", sortInfo.sortDesc);
+function onSort(_sortBy: string, sortDesc: boolean) {
+    emit("update:sort-desc", sortDesc);
 }
 
 function navigateJob(direction: "previous" | "next") {
@@ -111,28 +113,24 @@ watch(
 
 <template>
     <div>
-        <BTable
+        <GTable
             class="job-step-jobs"
-            primary-key="id"
             :current-page="props.currentPage"
             :items="props.jobs"
+            :fields="fields"
             striped
-            no-sort-reset
-            no-local-sorting
             hover
+            clickable-rows
+            :sort-by="'update_time'"
+            :sort-desc="props.sortDesc"
+            :local-sorting="false"
             :per-page="props.perPage"
-            :fields="[
-                { key: 'id', label: 'Job ID' },
-                { key: 'tool_id', label: 'Tool' },
-                { key: 'update_time', label: 'Updated', sortable: true },
-                { key: 'duration', label: 'Time To Finish' },
-                { key: 'state', label: 'State' },
-            ]"
-            :tbody-tr-class="getTrClass"
-            @row-clicked="jobClicked"
+            @row-click="({ item }) => jobClicked(item)"
             @sort-changed="onSort">
             <template v-slot:cell(id)="data">
-                <div class="d-flex flex-gapx-1 align-items-center">
+                <div
+                    class="d-flex flex-gapx-1 align-items-center"
+                    :class="{ 'font-weight-bold': data.item.id === viewedJob?.id }">
                     <span>{{ data.item.id }}</span>
 
                     <GButton
@@ -158,7 +156,7 @@ watch(
             <template v-slot:cell(duration)="data">
                 {{ getJobDuration(data.item) }}
             </template>
-        </BTable>
+        </GTable>
 
         <GModal :show.sync="showModal" fixed-height size="medium" @close="viewedJob = null">
             <template v-slot:header>
@@ -195,7 +193,7 @@ watch(
 
 <style scoped lang="scss">
 .job-step-jobs {
-    :deep(.clickable-row) {
+    :deep(.g-table-row-clickable) {
         cursor: pointer;
         color: var(--color-blue-600);
         user-select: text;

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.vue
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.vue
@@ -5,25 +5,26 @@ import { computed, ref, watch } from "vue";
 
 import type { JobBaseModel } from "@/api/jobs";
 import type { TableField } from "@/components/Common/GTable.types";
+import { getJobDuration } from "@/components/JobInformation/utilities";
 
-import { getJobDuration } from "../JobInformation/utilities";
-
-import GButton from "../BaseComponents/GButton.vue";
-import GButtonGroup from "../BaseComponents/GButtonGroup.vue";
-import GModal from "../BaseComponents/GModal.vue";
-import Heading from "../Common/Heading.vue";
-import JobDetails from "../JobInformation/JobDetails.vue";
-import JobState from "../JobStates/JobState.vue";
-import UtcDate from "../UtcDate.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
+import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
+import GModal from "@/components/BaseComponents/GModal.vue";
 import GTable from "@/components/Common/GTable.vue";
+import Heading from "@/components/Common/Heading.vue";
+import JobDetails from "@/components/JobInformation/JobDetails.vue";
+import JobState from "@/components/JobStates/JobState.vue";
+import UtcDate from "@/components/UtcDate.vue";
 
-const props = defineProps<{
+interface Props {
     jobs: JobBaseModel[];
     invocationId: string;
     currentPage: number;
     sortDesc: boolean;
     perPage: number;
-}>();
+}
+
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
     (e: "update:current-page", value: number): void;
@@ -64,8 +65,8 @@ const viewedJobIndex = computed<number | null>({
     },
 });
 
-function jobClicked(job: JobBaseModel) {
-    viewedJob.value = job;
+function jobClicked(event: { item: JobBaseModel }) {
+    viewedJob.value = event.item;
     showModal.value = true;
 }
 
@@ -114,18 +115,18 @@ watch(
 <template>
     <div>
         <GTable
-            class="job-step-jobs"
-            :current-page="props.currentPage"
-            :items="props.jobs"
-            :fields="fields"
-            striped
-            hover
             clickable-rows
-            :sort-by="'update_time'"
-            :sort-desc="props.sortDesc"
+            hover
+            striped
+            class="job-step-jobs"
+            sort-by="update_time"
+            :current-page="props.currentPage"
+            :fields="fields"
+            :items="props.jobs"
             :local-sorting="false"
             :per-page="props.perPage"
-            @row-click="({ item }) => jobClicked(item)"
+            :sort-desc="props.sortDesc"
+            @row-click="jobClicked($event)"
             @sort-changed="onSort">
             <template v-slot:cell(id)="data">
                 <div
@@ -186,6 +187,7 @@ watch(
                     </div>
                 </div>
             </template>
+
             <JobDetails v-if="viewedJob" :job-id="viewedJob.id" :invocation-id="invocationId" />
         </GModal>
     </div>

--- a/client/src/components/WorkflowInvocationState/ParameterStep.vue
+++ b/client/src/components/WorkflowInvocationState/ParameterStep.vue
@@ -12,10 +12,12 @@ import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
 
 type InvocationStepTypes = InvocationInput | InvocationInputParameter | InvocationOutput | InvocationOutputCollection;
 
-const props = defineProps<{
+interface Props {
     parameters: InvocationStepTypes[];
     styledTable?: boolean;
-}>();
+}
+
+const props = defineProps<Props>();
 
 const fields: TableField[] = [
     { key: "label", label: "Label" },
@@ -25,11 +27,13 @@ const fields: TableField[] = [
 function isData(value: unknown): value is InvocationInput | InvocationOutput | InvocationOutputCollection {
     return typeof value === "object" && value !== null && "src" in value;
 }
+
 function hasValidId(
     value: InvocationInput | InvocationOutput | InvocationOutputCollection,
 ): value is typeof value & { id: string } {
     return value.id !== null && value.id !== undefined && typeof value.id === "string";
 }
+
 function dataStepLabel(input: InvocationStepTypes): string {
     if ("label" in input && input.label) {
         return input.label;

--- a/client/src/components/WorkflowInvocationState/ParameterStep.vue
+++ b/client/src/components/WorkflowInvocationState/ParameterStep.vue
@@ -34,6 +34,10 @@ function hasValidId(
     return value.id !== null && value.id !== undefined && typeof value.id === "string";
 }
 
+function isInputParameter(value: InvocationStepTypes): value is InvocationInputParameter {
+    return "parameter_value" in value;
+}
+
 function dataStepLabel(input: InvocationStepTypes): string {
     if ("label" in input && input.label) {
         return input.label;
@@ -59,12 +63,17 @@ function dataStepLabel(input: InvocationStepTypes): string {
                 :item-src="item.src"
                 :data-label="dataStepLabel(item)" />
             <div v-else-if="isData(item) && !hasValidId(item)" class="text-muted">Dataset with no ID</div>
-            <i v-else-if="item.parameter_value === null || item.parameter_value === undefined" class="text-muted">
+            <i
+                v-else-if="
+                    isInputParameter(item) && (item.parameter_value === null || item.parameter_value === undefined)
+                "
+                class="text-muted">
                 No value provided
             </i>
-            <span v-else>
+            <span v-else-if="isInputParameter(item)">
                 {{ item.parameter_value }}
             </span>
+            <span v-else class="text-muted">Unsupported input/output value</span>
         </template>
     </GTable>
 </template>

--- a/client/src/components/WorkflowInvocationState/ParameterStep.vue
+++ b/client/src/components/WorkflowInvocationState/ParameterStep.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { BTable } from "bootstrap-vue";
-
 import type {
     InvocationInput,
     InvocationInputParameter,
     InvocationOutput,
     InvocationOutputCollection,
 } from "@/api/invocations";
+import type { TableField } from "@/components/Common/GTable.types";
 
+import GTable from "@/components/Common/GTable.vue";
 import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
 
 type InvocationStepTypes = InvocationInput | InvocationInputParameter | InvocationOutput | InvocationOutputCollection;
@@ -16,6 +16,11 @@ const props = defineProps<{
     parameters: InvocationStepTypes[];
     styledTable?: boolean;
 }>();
+
+const fields: TableField[] = [
+    { key: "label", label: "Label" },
+    { key: "parameter_value", label: "Value" },
+];
 
 function isData(value: unknown): value is InvocationInput | InvocationOutput | InvocationOutputCollection {
     return typeof value === "object" && value !== null && "src" in value;
@@ -37,13 +42,12 @@ function dataStepLabel(input: InvocationStepTypes): string {
 </script>
 
 <template>
-    <BTable
-        small
-        :outlined="props.styledTable"
-        :striped="props.styledTable"
-        :borderless="props.styledTable"
-        :fields="['label', 'parameter_value']"
-        :items="props.parameters">
+    <GTable
+        compact
+        :bordered="props.styledTable"
+        :fields="fields"
+        :items="props.parameters"
+        :striped="props.styledTable">
         <template v-slot:cell(parameter_value)="{ item }">
             <GenericHistoryItem
                 v-if="isData(item) && hasValidId(item)"
@@ -58,5 +62,5 @@ function dataStepLabel(input: InvocationStepTypes): string {
                 {{ item.parameter_value }}
             </span>
         </template>
-    </BTable>
+    </GTable>
 </template>


### PR DESCRIPTION
This PR migrates workflow-related components (`Workflow/Import/TrsSearch.vue`, `WorkflowInvocationState/JobStepJobs.vue, and `WorkflowInvocationState/ParameterStep.vue`) from Bootstrap-Vue's components to our `GTable` as part of the ongoing effort tracked in #21703

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
