### PR TITLE
[26.0] Fix TypeError in ExternalIdentities by always including provider_label in authnz response

### DIFF
--- a/client/src/utils/strings.test.ts
+++ b/client/src/utils/strings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { capitalizeFirstLetter } from "./strings";
+
+describe("capitalizeFirstLetter", () => {
+    it("capitalizes a normal string", () => {
+        expect(capitalizeFirstLetter("google")).toBe("Google");
+    });
+
+    it("trims whitespace", () => {
+        expect(capitalizeFirstLetter("  google  ")).toBe("Google");
+    });
+
+    it("returns empty string for undefined input", () => {
+        expect(capitalizeFirstLetter(undefined as unknown as string)).toBe("");
+    });
+
+    it("returns empty string for null input", () => {
+        expect(capitalizeFirstLetter(null as unknown as string)).toBe("");
+    });
+
+    it("returns empty string for empty string", () => {
+        expect(capitalizeFirstLetter("")).toBe("");
+    });
+});

--- a/client/src/utils/strings.test.ts
+++ b/client/src/utils/strings.test.ts
@@ -12,7 +12,7 @@ describe("capitalizeFirstLetter", () => {
     });
 
     it("returns empty string for undefined input", () => {
-        expect(capitalizeFirstLetter(undefined as unknown as string)).toBe("");
+        expect(capitalizeFirstLetter(undefined)).toBe("");
     });
 
     it("returns empty string for null input", () => {

--- a/client/src/utils/strings.ts
+++ b/client/src/utils/strings.ts
@@ -45,7 +45,7 @@ export function snakeCaseToTitleCase(str: string): string {
 /**
  * Capitalize the first letter of a string
  */
-export function capitalizeFirstLetter(str: string): string {
+export function capitalizeFirstLetter(str?: string): string {
     if (!str) {
         return "";
     }

--- a/client/src/utils/strings.ts
+++ b/client/src/utils/strings.ts
@@ -46,6 +46,9 @@ export function snakeCaseToTitleCase(str: string): string {
  * Capitalize the first letter of a string
  */
 export function capitalizeFirstLetter(str: string): string {
+    if (!str) {
+        return "";
+    }
     str = str.trim();
     return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -53,8 +53,7 @@ class OIDC(BaseUIController):
             provider_label = trans.app.authnz_manager.oidc_backends_config.get(authnz.provider, {}).get(
                 "label", authnz.provider
             )
-            if provider_label != authnz.provider:
-                token_info["provider_label"] = provider_label
+            token_info["provider_label"] = provider_label
 
             # Try to extract expiration from id_token if available
             if authnz.extra_data and "id_token" in authnz.extra_data:


### PR DESCRIPTION
Resolves #22230.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
