### PR TITLE
[26.0] Add optional dataset collection mode to harmonize tool

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -63,6 +63,7 @@ from galaxy.model import (
 )
 from galaxy.model.dataset_collections.matching import MatchingCollections
 from galaxy.model.dataset_collections.types.sample_sheet_workbook import _sample_sheet_to_list_collection_type
+from galaxy.objectstore import ObjectStorePopulator
 from galaxy.schema.credentials import CredentialsContext
 from galaxy.tool_shed.util.repository_util import get_installed_repository
 from galaxy.tool_shed.util.shed_util_common import set_image_paths
@@ -4490,11 +4491,14 @@ class HarmonizeTool(DatabaseOperationTool):
     require_dataset_ok = False
 
     def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
-        # Get the 2 input collections
         hdca1 = incoming["input1"]
-        hdca2 = incoming["input2"]
-        # Get the elements of both collections
+        hdca2 = incoming.get("input2")
         elements1 = hdca1.collection.elements
+
+        if hdca2 is None:
+            self._produce_outputs_with_optional_nulls(trans, output_collections, hdca1, elements1, history)
+            return
+
         elements2 = hdca2.collection.elements
         # Put elements in dictionary with identifiers:
         old_elements1_dict = {}
@@ -4544,6 +4548,75 @@ class HarmonizeTool(DatabaseOperationTool):
         # Create outputs:
         output_with_selected_identifiers(old_elements1_dict, "output1")
         output_with_selected_identifiers(old_elements2_dict, "output2")
+
+    def _produce_outputs_with_optional_nulls(self, trans, output_collections, hdca1, elements1, history):
+        """When input2 is not provided, output1 is a copy of input1 and output2
+        mirrors input1's structure but with expression.json null datasets."""
+        object_store_populator = ObjectStorePopulator(trans.app, trans.user)
+        collection_type = hdca1.collection.collection_type
+
+        # Build output1 as a copy of input1
+        new_elements1 = {}
+        new_rows1 = {}
+        for element in elements1:
+            dce_object = element.element_object
+            identifier = element.element_identifier
+            if element.is_collection:
+                copied_dataset = dce_object.copy(flush=False)
+            else:
+                copied_dataset = dce_object.copy(copy_tags=dce_object.tags, flush=False)
+            new_elements1[identifier] = copied_dataset
+            new_rows1[identifier] = element.columns
+        self._add_datasets_to_history(history, new_elements1.values())
+        output_collections.create_collection(
+            self.outputs["output1"],
+            "output1",
+            elements=new_elements1,
+            propagate_hda_tags=False,
+            rows=new_rows1,
+            column_definitions=hdca1.collection.column_definitions,
+        )
+
+        # Build output2 mirroring input1's structure with null expression.json datasets
+        null_hda = self._create_null_dataset(trans, history, object_store_populator)
+        new_elements2 = {}
+        for element in elements1:
+            identifier = element.element_identifier
+            dce_object = element.element_object
+            if element.is_collection:
+                # Sub-collection (e.g. paired) — create matching structure with null datasets
+                new_elements2[identifier] = self._create_null_subcollection(dce_object, null_hda)
+            else:
+                new_elements2[identifier] = null_hda
+        self._add_datasets_to_history(history, [null_hda])
+        output_collections.create_collection(
+            self.outputs["output2"],
+            "output2",
+            collection_type=collection_type,
+            elements=new_elements2,
+            propagate_hda_tags=False,
+        )
+
+    def _create_null_dataset(self, trans, history, object_store_populator):
+        """Create a new HDA with expression.json null content (skipped marker)."""
+        null_hda = HistoryDatasetAssociation(
+            extension="expression.json",
+            create_dataset=True,
+            sa_session=trans.sa_session,
+            history=history,
+        )
+        null_hda.set_skipped(object_store_populator, replace_dataset=False)
+        return null_hda
+
+    def _create_null_subcollection(self, source_collection, null_hda):
+        """Recursively create a sub-collection structure mirroring source_collection but with null datasets."""
+        sub_elements = {}
+        for dce in source_collection.elements:
+            if dce.is_collection:
+                sub_elements[dce.element_identifier] = self._create_null_subcollection(dce.element_object, null_hda)
+            else:
+                sub_elements[dce.element_identifier] = null_hda
+        return {"src": "new_collection", "collection_type": source_collection.collection_type, "elements": sub_elements}
 
 
 class RelabelFromFileTool(DatabaseOperationTool):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -4490,6 +4490,15 @@ class HarmonizeTool(DatabaseOperationTool):
     require_terminal_states = False
     require_dataset_ok = False
 
+    def check_inputs_ready(self, input_datasets, input_dataset_collections, security):
+        # input2 is optional — drop it from the collection check when not provided
+        filtered_collections = {
+            key: pairs
+            for key, pairs in input_dataset_collections.items()
+            if key != "input2" or any(hdca is not None for hdca, _ in pairs)
+        }
+        super().check_inputs_ready(input_datasets, filtered_collections, security)
+
     def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
         hdca1 = incoming["input1"]
         hdca2 = incoming.get("input2")

--- a/lib/galaxy/tools/harmonize_two_collections_list_1.0.0.xml
+++ b/lib/galaxy/tools/harmonize_two_collections_list_1.0.0.xml
@@ -2,8 +2,11 @@
       name="Harmonize two collections"
       version="1.0.0"
       tool_type="harmonize_list">
-    <description></description>
+    <description>to match identifiers and order</description>
     <type class="HarmonizeTool" module="galaxy.tools" />
+    <macros>
+        <import>model_operation_macros.xml</import>
+    </macros>
     <action module="galaxy.tools.actions.model_operations"
             class="ModelOperationToolAction"/>
     <edam_operations>
@@ -209,36 +212,70 @@
 Synopsis
 ========
 
-Harmonize 2 collections: Inputs are 2 collections. Outputs are 2 collections with:
-- Same identifiers (identifiers which are specific to one or the other are removed)
-- Identifiers are in the same order
+Harmonizes two collections so they contain the same element identifiers in the same order.
 
-=======
-Example
-=======
+===========
+Description
+===========
 
-If the inputs are::
+This tool takes two collections and produces two output collections that share exactly the same set of identifiers in the same order. It performs two operations:
 
- Collection1: [Horse123] 
-              [Donkey543] 
-              [Mule176]
+1. **Intersection** — any identifier that appears in only one of the two input collections is removed from both outputs.
+2. **Reordering** — the output elements follow the order of the **first** input collection.
 
- Collection2: [Horse] 
-              [Mule176] 
-              [Donkey543]
-The tool will output::
+This is useful when two collections were produced by independent analyses and you need to pair them element-wise for a downstream tool. Without harmonization, mismatched identifiers or different ordering would cause errors.
 
- Collection1: [Donkey543] 
-              [Mule176]
+The two input collections do not need to have the same collection type. For example, you can harmonize a ``list`` with a ``list:paired`` — each output preserves the type of its corresponding input.
 
- Collection2: [Donkey543] 
-              [Mule176]
+========
+Examples
+========
+
+**Keep only shared identifiers**
+
+Given two collections with partially overlapping identifiers::
+
+ Collection 1 (reference order):
+
+   sampleA  →  Dataset 1
+   sampleB  →  Dataset 2
+   sampleC  →  Dataset 3
+
+ Collection 2 (different order, extra element):
+
+   sampleD  →  Dataset 4
+   sampleC  →  Dataset 5
+   sampleA  →  Dataset 6
+
+Output 1 (from Collection 1, matching order preserved)::
+
+   sampleA  →  Dataset 1
+   sampleC  →  Dataset 3
+
+Output 2 (from Collection 2, reordered to match Collection 1)::
+
+   sampleA  →  Dataset 6
+   sampleC  →  Dataset 5
+
+``sampleB`` and ``sampleD`` are removed because they are not present in both collections.
+
+-------
+
+**No matching identifiers**
+
+If the two collections share no identifiers at all, both outputs will be empty collections.
+
+-------
+
+.. image:: ${static_path}/images/tools/collection_ops/harmonize.svg
+  :alt: Harmonize two collections to match identifiers and order
+  :width: 620
 
 -------
 
 .. class:: infomark
 
-This tool will create new history datasets from your collection but your quota usage will not increase.
+@QUOTA_USAGE_NOTE@
 
      ]]></help>
 </tool>

--- a/lib/galaxy/tools/harmonize_two_collections_list_1.0.0.xml
+++ b/lib/galaxy/tools/harmonize_two_collections_list_1.0.0.xml
@@ -1,12 +1,9 @@
 <tool id="__HARMONIZELISTS__"
       name="Harmonize two collections"
-      version="1.1.0"
+      version="1.0.0"
       tool_type="harmonize_list">
-    <description>to match identifiers and order</description>
+    <description></description>
     <type class="HarmonizeTool" module="galaxy.tools" />
-    <macros>
-        <import>model_operation_macros.xml</import>
-    </macros>
     <action module="galaxy.tools.actions.model_operations"
             class="ModelOperationToolAction"/>
     <edam_operations>
@@ -14,11 +11,11 @@
     </edam_operations>
     <inputs>
         <param type="data_collection" collection_type="list,list:paired" name="input1" label="Input Collection with good order" />
-        <param type="data_collection" collection_type="list,list:paired" name="input2" label="Input Collection to order" optional="true" />
+        <param type="data_collection" collection_type="list,list:paired" name="input2" label="Input Collection to order" />
     </inputs>
     <outputs>
-        <collection name="output1" format_source="input1" type_source="input1" label="${input1.name} (harmonized)" />
-        <collection name="output2" format_source="input2" type_source="input2" label="Harmonized output 2" />
+        <collection name="output1" format_source="input1" type_source="input1" label="${input1.name} (harmonized with ${input2.name})" />
+        <collection name="output2" format_source="input2" type_source="input2" label="${input2.name} (harmonized with ${input1.name})" />
     </outputs>
     <tests>
         <test>
@@ -205,72 +202,6 @@
                 </element>
             </output_collection>
         </test>
-        <!-- test optional input2 not provided with list type -->
-        <test>
-            <param name="input1">
-                <collection type="list">
-                    <element name="element_1" value="simple_line_alternative.txt" />
-                    <element name="element_2" value="simple_line.txt" />
-                </collection>
-            </param>
-            <output_collection name="output1" type="list" count="2">
-                <element name="element_1">
-                    <assert_contents>
-                        <has_text_matching expression="^This is a different line of text.\n$" />
-                    </assert_contents>
-                </element>
-                <element name="element_2">
-                    <assert_contents>
-                        <has_text_matching expression="^This is a line of text.\n$" />
-                    </assert_contents>
-                </element>
-            </output_collection>
-            <output_collection name="output2" type="list" count="2">
-                <element name="element_1" ftype="expression.json">
-                    <assert_contents>
-                        <has_text text="null" />
-                    </assert_contents>
-                </element>
-                <element name="element_2" ftype="expression.json">
-                    <assert_contents>
-                        <has_text text="null" />
-                    </assert_contents>
-                </element>
-            </output_collection>
-        </test>
-        <!-- test optional input2 not provided with list:paired type -->
-        <test>
-            <param name="input1">
-                <collection type="list:paired">
-                    <element name="sample_1">
-                        <collection type="paired">
-                            <element name="forward" value="1.fastqsanger" ftype="fastqsanger" />
-                            <element name="reverse" value="1.fastqsanger" ftype="fastqsanger" />
-                        </collection>
-                    </element>
-                </collection>
-            </param>
-            <output_collection name="output1" type="list:paired" count="1">
-                <element name="sample_1">
-                    <element name="forward" ftype="fastqsanger" />
-                    <element name="reverse" ftype="fastqsanger" />
-                </element>
-            </output_collection>
-            <output_collection name="output2" type="list:paired" count="1">
-                <element name="sample_1">
-                    <element name="forward" ftype="expression.json">
-                        <assert_contents>
-                            <has_text text="null" />
-                        </assert_contents>
-                    </element>
-                    <element name="reverse" ftype="expression.json">
-                        <assert_contents>
-                            <has_text text="null" />
-                        </assert_contents>
-                    </element>
-                </element>
-            </output_collection>
-        </test>
     </tests>
     <help><![CDATA[
 
@@ -278,97 +209,36 @@
 Synopsis
 ========
 
-Harmonizes two collections so they contain the same element identifiers in the same order.
+Harmonize 2 collections: Inputs are 2 collections. Outputs are 2 collections with:
+- Same identifiers (identifiers which are specific to one or the other are removed)
+- Identifiers are in the same order
 
-===========
-Description
-===========
+=======
+Example
+=======
 
-This tool takes two collections and produces two output collections that share exactly the same set of identifiers in the same order. It performs two operations:
+If the inputs are::
 
-1. **Intersection** — any identifier that appears in only one of the two input collections is removed from both outputs.
-2. **Reordering** — the output elements follow the order of the **first** input collection.
+ Collection1: [Horse123] 
+              [Donkey543] 
+              [Mule176]
 
-This is useful when two collections were produced by independent analyses and you need to pair them element-wise for a downstream tool. Without harmonization, mismatched identifiers or different ordering would cause errors.
-
-The two input collections do not need to have the same collection type. For example, you can harmonize a ``list`` with a ``list:paired`` — each output preserves the type of its corresponding input.
-
-**Optional second collection**
-
-If the second collection is not provided (optional), the tool will:
-
-- Output1: A copy of the first collection (all elements preserved)
-- Output2: Same structure and identifiers as the first collection, but all datasets are replaced with expression.json null datasets
-
-========
-Examples
-========
-
-**Keep only shared identifiers**
-
-Given two collections with partially overlapping identifiers::
-
- Collection 1 (reference order):
-
-   sampleA  →  Dataset 1
-   sampleB  →  Dataset 2
-   sampleC  →  Dataset 3
-
- Collection 2 (different order, extra element):
-
-   sampleD  →  Dataset 4
-   sampleC  →  Dataset 5
-   sampleA  →  Dataset 6
-
-Output 1 (from Collection 1, matching order preserved)::
-
-   sampleA  →  Dataset 1
-   sampleC  →  Dataset 3
-
-Output 2 (from Collection 2, reordered to match Collection 1)::
-
-   sampleA  →  Dataset 6
-   sampleC  →  Dataset 5
-
-``sampleB`` and ``sampleD`` are removed because they are not present in both collections.
-
--------
-
-**No matching identifiers**
-
-If the two collections share no identifiers at all, both outputs will be empty collections.
-
--------
-
-**Optional mode (no second collection)**
-
-If only Collection 1 is provided::
-
- Collection 1: [Horse123]
-               [Donkey543]
-               [Mule176]
-
+ Collection2: [Horse] 
+              [Mule176] 
+              [Donkey543]
 The tool will output::
 
- Output 1: [Horse123]
-           [Donkey543]
-           [Mule176]
+ Collection1: [Donkey543] 
+              [Mule176]
 
- Output 2: [Horse123] (null)
-           [Donkey543] (null)
-           [Mule176] (null)
-
--------
-
-.. image:: ${static_path}/images/tools/collection_ops/harmonize.svg
-  :alt: Harmonize two collections to match identifiers and order
-  :width: 620
+ Collection2: [Donkey543] 
+              [Mule176]
 
 -------
 
 .. class:: infomark
 
-@QUOTA_USAGE_NOTE@
+This tool will create new history datasets from your collection but your quota usage will not increase.
 
-    ]]></help>
+     ]]></help>
 </tool>

--- a/lib/galaxy_test/workflow/harmonize_optional_collection.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/harmonize_optional_collection.gxwf-tests.yml
@@ -1,0 +1,57 @@
+- doc: |
+    Test harmonize with both collections provided - should produce intersection.
+  job:
+    required_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: sample_a
+          class: File
+          contents: "content_a"
+        - identifier: sample_b
+          class: File
+          contents: "content_b"
+        - identifier: sample_c
+          class: File
+          contents: "content_c"
+    optional_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: sample_b
+          class: File
+          contents: "other_b"
+        - identifier: sample_a
+          class: File
+          contents: "other_a"
+  outputs:
+    nested_output1:
+      class: Collection
+      collection_type: list:list
+      element_count: 2
+    nested_output2:
+      class: Collection
+      collection_type: list:list
+      element_count: 2
+- doc: |
+    Test harmonize with optional collection not provided - output2 should have null datasets.
+  job:
+    required_collection:
+      class: Collection
+      collection_type: list
+      elements:
+        - identifier: sample_a
+          class: File
+          contents: "content_a"
+        - identifier: sample_b
+          class: File
+          contents: "content_b"
+  outputs:
+    nested_output1:
+      class: Collection
+      collection_type: list:list
+      element_count: 2
+    nested_output2:
+      class: Collection
+      collection_type: list:list
+      element_count: 2

--- a/lib/galaxy_test/workflow/harmonize_optional_collection.gxwf.yml
+++ b/lib/galaxy_test/workflow/harmonize_optional_collection.gxwf.yml
@@ -1,0 +1,33 @@
+class: GalaxyWorkflow
+doc: |
+  Test harmonize tool with optional second collection input.
+  When the optional input is not provided, output2 should contain
+  expression.json null datasets mirroring input1's structure.
+inputs:
+  required_collection:
+    type: data_collection
+    collection_type: list
+  optional_collection:
+    type: data_collection
+    collection_type: list
+    optional: true
+outputs:
+  nested_output1:
+    outputSource: nest_output1/output
+  nested_output2:
+    outputSource: nest_output2/output
+steps:
+  harmonize:
+    tool_id: '__HARMONIZELISTS__'
+    tool_version: '1.1.0'
+    in:
+      input1: required_collection
+      input2: optional_collection
+  nest_output1:
+    tool_id: '__NEST__'
+    in:
+      input: harmonize/output1
+  nest_output2:
+    tool_id: '__NEST__'
+    in:
+      input: harmonize/output2

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -330,6 +330,8 @@
   <tool file="${model_tools_path}/flatten_collection.xml" />
   <tool file="${model_tools_path}/sort_collection_list.xml" />
   <tool file="${model_tools_path}/harmonize_two_collections_list.xml" />
+  <tool file="${model_tools_path}/harmonize_two_collections_list_1.0.0.xml" />
+  <tool file="${model_tools_path}/nest_collection.xml" />
   <tool file="${model_tools_path}/merge_collection.xml" />
   <tool file="${model_tools_path}/relabel_from_file.xml" />
   <tool file="${model_tools_path}/filter_from_file.xml" />


### PR DESCRIPTION
When input2 is not provided, the tool produces:
- output1: a copy of input1 (all elements preserved)
- output2: same structure/identifiers as input1 but with expression.json null datasets

This enables workflows to use the harmonize tool with optional inputs, producing null-filled collections that can be filtered downstream with the Filter Null tool.

Bumps tool version to 1.1.0 and preserves 1.0.0 XML as backup. Closes https://github.com/galaxyproject/galaxy/issues/22080

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
