### PR TITLE
[26.0] Fix batch history purge not updating user's update_time

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -46,6 +46,7 @@ from galaxy.model import (
     Job,
     User,
 )
+from galaxy.model.orm.now import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.objectstore import BaseObjectStore
 from galaxy.objectstore.caching import check_caches
@@ -168,6 +169,9 @@ def purge_history_datasets(
     user = history.user
     if user:
         user.calculate_and_set_disk_usage(object_store)
+        if not request.preserve_owner_update_time:
+            user.update_time = now()
+            sa_session.commit()
     # Remove underlying dataset files from object store
     dataset_manager.purge_datasets(PurgeDatasetsTaskRequest(dataset_ids=dataset_ids))
 

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -296,7 +296,11 @@ class HistoryManager(sharable.SharableModelManager[model.History], deletable.Pur
         if self.app.config.enable_celery_tasks:
             from galaxy.celery.tasks import purge_history_datasets
 
-            request = PurgeHistoryDatasetsTaskRequest(history_id=item.id)
+            preserve_owner_update_time = kwargs.get("preserve_owner_update_time", False)
+            request = PurgeHistoryDatasetsTaskRequest(
+                history_id=item.id,
+                preserve_owner_update_time=preserve_owner_update_time,
+            )
             user = item.user
             result = purge_history_datasets.delay(request=request, task_user_id=user.id if user else None)
         else:

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -141,6 +141,7 @@ class PurgeDatasetsTaskRequest(Model):
 
 class PurgeHistoryDatasetsTaskRequest(Model):
     history_id: int
+    preserve_owner_update_time: bool = False
 
 
 class TaskState(str, Enum):


### PR DESCRIPTION
The batch `purge_history_datasets` celery task uses raw SQL for bulk operations, bypassing SQLAlchemy's `onupdate=now` trigger on `User.update_time`. This caused archiving with purge to leave the user's `update_time` stale, see https://github.com/galaxyproject/galaxy/pull/22180#issuecomment-4114374445 .

Also forwards `preserve_owner_update_time` through to the batch task so admin-initiated purges of other users' histories still preserve the owner's `update_time`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
