### PR TITLE
[26.0] Fix import order error from ESLint

### DIFF
--- a/client/src/components/admin/DataTables.vue
+++ b/client/src/components/admin/DataTables.vue
@@ -15,9 +15,8 @@
 <script>
 import axios from "axios";
 
-import { getAppRoot } from "@/onload/loadConfig";
-
 import { GalaxyApi } from "@/api";
+import { getAppRoot } from "@/onload/loadConfig";
 
 import Message from "../Message.vue";
 import DataManagerGrid from "./DataManagerGrid.vue";


### PR DESCRIPTION
Introduced when merging release_25.1 forward in commit 0881413e3e12222e9f1c5cbcd9557ae5e8b2bcb6 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
