### PR TITLE
[26.0] Make sure origins for data landings are persisted

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -228,6 +228,7 @@ class ToolsService(ServiceBase):
             request_state=request_state,
             client_secret=file_landing_payload.client_secret,
             public=file_landing_payload.public,
+            origin=file_landing_payload.origin,
         )
 
     def data_landing_to_tool_landing(
@@ -250,6 +251,7 @@ class ToolsService(ServiceBase):
             request_state=request_state,
             client_secret=data_landing_payload.client_secret,
             public=data_landing_payload.public,
+            origin=data_landing_payload.origin,
         )
 
     def inputs(

--- a/lib/galaxy_test/api/test_landing.py
+++ b/lib/galaxy_test/api/test_landing.py
@@ -119,6 +119,34 @@ class TestLandingApi(ApiTestCase):
         assert target["elements"]
         assert len(target["elements"]) == 1
 
+    def test_data_landing_origin(self):
+        data_landing_request_state = DataLandingRequestState(
+            targets=[
+                {
+                    "destination": {"type": "hdas"},
+                    "items": [
+                        {
+                            "src": "url",
+                            "url": "base64://eyJ0ZXN0IjogInRlc3QifQ==",  # base64 encoded {"test": "test"}
+                            "ext": "txt",
+                            "deferred": False,
+                        }
+                    ],
+                }
+            ],
+        )
+        payload = CreateDataLandingPayload(
+            request_state=data_landing_request_state,
+            public=True,
+            origin=HttpUrl("http://example.localhost/"),
+        )
+        response = self.dataset_populator.create_data_landing(payload)
+        assert response.tool_id == "__DATA_FETCH__"
+        assert str(response.origin) == "http://example.localhost/"
+
+        tool_landing = self.dataset_populator.use_tool_landing(response.uuid)
+        assert str(tool_landing.origin) == "http://example.localhost/"
+
     def test_file_landing_with_sample_sheet(self):
         """Test that sample sheet metadata is preserved through landing request creation and claiming."""
         file_landing_request_state = FileOrCollectionRequestsAdapter.validate_python(
@@ -184,6 +212,29 @@ class TestLandingApi(ApiTestCase):
         assert target["rows"]["sample1"] == [1, "control"]
         assert "sample2" in target["rows"]
         assert target["rows"]["sample2"] == [2, "treatment"]
+
+    def test_file_landing_origin(self):
+        file_landing_request_state = FileOrCollectionRequestsAdapter.validate_python(
+            [
+                {
+                    "class": "File",
+                    "location": "base64://dGVzdCBmaWxl",  # base64 encoded "test file"
+                    "filetype": "txt",
+                    "deferred": False,
+                }
+            ],
+        )
+        payload = CreateFileLandingPayload(
+            request_state=file_landing_request_state,
+            public=True,
+            origin=HttpUrl("http://example.localhost/"),
+        )
+        response = self.dataset_populator.create_file_landing(payload)
+        assert response.tool_id == "__DATA_FETCH__"
+        assert str(response.origin) == "http://example.localhost/"
+
+        tool_landing = self.dataset_populator.use_tool_landing(response.uuid)
+        assert str(tool_landing.origin) == "http://example.localhost/"
 
     def test_file_landing_with_sample_sheet_invalid_collection_type(self):
         """Test that sample sheet metadata with non-sample_sheet collection_type is rejected."""


### PR DESCRIPTION
was trying to capture data landing metrics for brc, and found all origin 'unknown'. this is an attempt to understand and remedy that..

Changes:
- Add origin parameter to file_landing_to_tool_landing() conversion
- Add origin parameter to data_landing_to_tool_landing() conversion  
- Add unit tests to verify origin persistence for both request types

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
