### PR TITLE
Set proxy_ssl_server_name for GTN proxy on CloudFlare due to SNI

### DIFF
--- a/doc/source/admin/special_topics/gtn.md
+++ b/doc/source/admin/special_topics/gtn.md
@@ -26,6 +26,7 @@ GTN, and your users can click on these to have that tool loaded in Galaxy.
 
 ```nginx
 location /training-material/ {
+    proxy_ssl_server_name on;
     proxy_pass https://training.galaxyproject.org/training-material/;
 }
 ```


### PR DESCRIPTION
this seems to be mandatory now? ping @natefoo 

source: https://github.com/galaxyproject/infrastructure-playbook/commit/262b572f21aa0ab06edd4af9961afc90618a19bb

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
