### PR TITLE
[26.0] Validate replacement_params values are strings before storing

### DIFF
--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -589,6 +589,10 @@ def workflow_run_config_to_request(
 
     replacement_dict = run_config.replacement_dict
     for name, value in replacement_dict.items():
+        if not isinstance(value, str):
+            raise exceptions.RequestParameterInvalidException(
+                f"Replacement parameter '{name}' must be a string, got {type(value).__name__}"
+            )
         add_parameter(
             name=name,
             value=value,

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6937,6 +6937,20 @@ outer_input:
         request = self.workflow_populator.invocation_to_request(invocation_id)
         assert request["replacement_params"]["replaceme"] == "was replaced"
 
+    @skip_without_tool("cat1")
+    def test_run_with_non_string_replacement_params(self):
+        workflow = self.workflow_populator.load_workflow(name="test_for_pja_run", add_pja=True)
+        workflow_request, history_id, workflow_id = self._setup_workflow_run(workflow, inputs_by="step_index")
+        workflow_request["replacement_params"] = dumps(dict(replaceme={"nested_key": "was replaced"}))
+        run_workflow_response = self.workflow_populator.invoke_workflow_raw(
+            workflow_id, workflow_request, assert_ok=False
+        )
+        self._assert_status_code_is(run_workflow_response, 400)
+        self._assert_error_code_is(
+            run_workflow_response, error_codes.error_codes_by_name["USER_REQUEST_INVALID_PARAMETER"]
+        )
+        assert run_workflow_response.json()["err_msg"] == "Replacement parameter 'replaceme' must be a string, got dict"
+
     @skip_without_tool("hidden_param")
     def test_hidden_param_in_workflow(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
Non-string values (e.g. dicts) in replacement_params cause a ProgrammingError when inserting into the TEXT column of workflow_request_input_parameters.

Fixes #22247

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
