### PR TITLE
[26.0] Fix oauth2 template validation

### DIFF
--- a/lib/galaxy/managers/_config_templates.py
+++ b/lib/galaxy/managers/_config_templates.py
@@ -15,6 +15,7 @@ from pydantic import (
 from typing_extensions import TypedDict
 
 from galaxy.exceptions import (
+    ConfigurationError,
     InconsistentDatabase,
     ObjectNotFound,
     RequestParameterInvalidException,
@@ -277,6 +278,10 @@ def prepare_environment_from_root(
             secret_value = vault.read_secret(template_secret.vault_key) or template_secret.default
             if secret_value:
                 environment[e_name] = secret_value
+            else:
+                raise ConfigurationError(
+                    f"Secret vault key {template_secret.vault_key} not found for environment entry {e_name} and no default provided. This secret is required to be set in the vault for the template to function. Please set this secret in the vault or provide a default value in the template definition."
+                )
         elif e_type == "variable":
             template_variable = cast(TemplateEnvironmentVariable, environment_entry)
             variable_value = os.environ.get(template_variable.variable)
@@ -284,6 +289,10 @@ def prepare_environment_from_root(
                 variable_value = template_variable.default
             if variable_value:
                 environment[e_name] = variable_value
+            else:
+                raise ConfigurationError(
+                    f"Environment variable {template_variable.variable} not found for environment entry {e_name} and no default provided. This variable is required to be set in the environment for the template to function. Please set this variable in the environment or provide a default value in the template definition."
+                )
         else:
             raise Exception(f"Unknown environment entry type detected [{e_type}]")
 

--- a/lib/galaxy/managers/_config_templates.py
+++ b/lib/galaxy/managers/_config_templates.py
@@ -15,8 +15,8 @@ from pydantic import (
 from typing_extensions import TypedDict
 
 from galaxy.exceptions import (
-    ConfigurationError,
     InconsistentDatabase,
+    InternalServerError,
     ObjectNotFound,
     RequestParameterInvalidException,
     RequestParameterMissingException,
@@ -279,9 +279,7 @@ def prepare_environment_from_root(
             if secret_value:
                 environment[e_name] = secret_value
             else:
-                raise ConfigurationError(
-                    f"Secret vault key {template_secret.vault_key} not found for environment entry {e_name} and no default provided. This secret is required to be set in the vault for the template to function. Please set this secret in the vault or provide a default value in the template definition."
-                )
+                raise InternalServerError(f"Failed to retrieve {template_secret.vault_key} from vault")
         elif e_type == "variable":
             template_variable = cast(TemplateEnvironmentVariable, environment_entry)
             variable_value = os.environ.get(template_variable.variable)
@@ -290,8 +288,8 @@ def prepare_environment_from_root(
             if variable_value:
                 environment[e_name] = variable_value
             else:
-                raise ConfigurationError(
-                    f"Environment variable {template_variable.variable} not found for environment entry {e_name} and no default provided. This variable is required to be set in the environment for the template to function. Please set this variable in the environment or provide a default value in the template definition."
+                raise InternalServerError(
+                    f"Environment variable {template_variable.variable} not found and no default provided. Please set this variable in the environment or provide a default value in the template definition."
                 )
         else:
             raise Exception(f"Unknown environment entry type detected [{e_type}]")

--- a/lib/galaxy/managers/file_source_instances.py
+++ b/lib/galaxy/managers/file_source_instances.py
@@ -15,8 +15,10 @@ from pydantic import (
 )
 
 from galaxy.exceptions import (
+    ConfigurationError,
     Conflict,
     ItemOwnershipException,
+    MessageException,
     ObjectNotFound,
     RequestParameterInvalidException,
     RequestParameterMissingException,
@@ -643,7 +645,13 @@ class UserDefinedFileSourcesImpl(UserDefinedFileSources):
         oauth2_configuration = get_oauth2_config_or_none(template)
         oauth2_scope = None
         if oauth2_configuration is not None:
-            environment = prepare_environment_from_root(template.environment, self._app_vault, self._app_config)
+            try:
+                environment = prepare_environment_from_root(template.environment, self._app_vault, self._app_config)
+            except ConfigurationError as e:
+                log.exception(
+                    f"Problem preparing environment for template {template_id} version {template_version} - Reason: {str(e)}"
+                )
+                raise MessageException("Problem with template configuration - Please contact your administrator.")
             user_details = user.config_template_details()
             oauth2_client_pair_obj, oauth2_scope = read_oauth2_info_from_configuration(
                 template.configuration, user_details, environment

--- a/lib/galaxy/managers/file_source_instances.py
+++ b/lib/galaxy/managers/file_source_instances.py
@@ -15,8 +15,8 @@ from pydantic import (
 )
 
 from galaxy.exceptions import (
-    ConfigurationError,
     Conflict,
+    InternalServerError,
     ItemOwnershipException,
     MessageException,
     ObjectNotFound,
@@ -647,7 +647,7 @@ class UserDefinedFileSourcesImpl(UserDefinedFileSources):
         if oauth2_configuration is not None:
             try:
                 environment = prepare_environment_from_root(template.environment, self._app_vault, self._app_config)
-            except ConfigurationError as e:
+            except InternalServerError as e:
                 log.exception(
                     f"Problem preparing environment for template {template_id} version {template_version} - Reason: {str(e)}"
                 )

--- a/test/unit/app/managers/test_user_file_sources.py
+++ b/test/unit/app/managers/test_user_file_sources.py
@@ -17,7 +17,7 @@ from requests.exceptions import HTTPError
 from yaml import safe_load
 
 from galaxy.exceptions import (
-    ConfigurationError,
+    InternalServerError,
     MessageException,
     RequestParameterInvalidException,
     RequestParameterMissingException,
@@ -800,7 +800,7 @@ class TestFileSourcesTestCase(BaseTestCase):
         entries: list[TemplateEnvironmentEntry] = [
             TemplateEnvironmentVariable(type="variable", name="myvar", variable=missing_var)
         ]
-        with pytest.raises(ConfigurationError) as exc_info:
+        with pytest.raises(InternalServerError) as exc_info:
             prepare_environment_from_root(entries, self.app.vault, self.app)
         assert missing_var in str(exc_info.value)
 
@@ -809,7 +809,7 @@ class TestFileSourcesTestCase(BaseTestCase):
         entries: list[TemplateEnvironmentEntry] = [
             TemplateEnvironmentSecret(type="secret", name="mysec", vault_key="nonexistent/missing_key")
         ]
-        with pytest.raises(ConfigurationError) as exc_info:
+        with pytest.raises(InternalServerError) as exc_info:
             prepare_environment_from_root(entries, self.app.vault, self.app)
         assert "nonexistent/missing_key" in str(exc_info.value)
 

--- a/test/unit/app/managers/test_user_file_sources.py
+++ b/test/unit/app/managers/test_user_file_sources.py
@@ -6,6 +6,7 @@ from typing import (
 from unittest import SkipTest
 from uuid import uuid4
 
+import pytest
 from fs.osfs import OSFS
 
 try:
@@ -16,6 +17,8 @@ from requests.exceptions import HTTPError
 from yaml import safe_load
 
 from galaxy.exceptions import (
+    ConfigurationError,
+    MessageException,
     RequestParameterInvalidException,
     RequestParameterMissingException,
 )
@@ -23,6 +26,7 @@ from galaxy.files import FileSourcesUserContext
 from galaxy.files.sources import dropbox
 from galaxy.files.templates import ConfiguredFileSourceTemplates
 from galaxy.files.templates.examples import get_example
+from galaxy.managers._config_templates import prepare_environment_from_root
 from galaxy.managers.file_source_instances import (
     CreateInstancePayload,
     FileSourceInstancesManager,
@@ -43,7 +47,12 @@ from galaxy.model import (
 )
 from galaxy.schema.schema import OAuth2State
 from galaxy.util import config_templates
-from galaxy.util.config_templates import RawTemplateConfig
+from galaxy.util.config_templates import (
+    RawTemplateConfig,
+    TemplateEnvironmentEntry,
+    TemplateEnvironmentSecret,
+    TemplateEnvironmentVariable,
+)
 from .base import BaseTestCase
 
 SIMPLE_FILE_SOURCE_NAME = "myfilesource"
@@ -783,6 +792,35 @@ class TestFileSourcesTestCase(BaseTestCase):
         assert status.template_settings.is_not_ok
         assert "Input should be a valid boolean" in status.template_settings.message
         assert status.connection is None
+
+    def test_environment_variable_missing_raises_configuration_error(self, tmp_path, monkeypatch):
+        self._init_managers(tmp_path)
+        missing_var = "GX_UNIT_TEST_SHOULD_NOT_BE_SET_XYZ123"
+        monkeypatch.delenv(missing_var, raising=False)
+        entries: list[TemplateEnvironmentEntry] = [
+            TemplateEnvironmentVariable(type="variable", name="myvar", variable=missing_var)
+        ]
+        with pytest.raises(ConfigurationError) as exc_info:
+            prepare_environment_from_root(entries, self.app.vault, self.app)
+        assert missing_var in str(exc_info.value)
+
+    def test_vault_secret_missing_raises_configuration_error(self, tmp_path):
+        self._init_managers(tmp_path)
+        entries: list[TemplateEnvironmentEntry] = [
+            TemplateEnvironmentSecret(type="secret", name="mysec", vault_key="nonexistent/missing_key")
+        ]
+        with pytest.raises(ConfigurationError) as exc_info:
+            prepare_environment_from_root(entries, self.app.vault, self.app)
+        assert "nonexistent/missing_key" in str(exc_info.value)
+
+    def test_oauth2_template_missing_env_raises_message_exception(self, tmp_path, monkeypatch):
+        self.init_user_in_database()
+        self._init_managers(tmp_path, safe_load(get_example("production_dropbox.yml")))
+        monkeypatch.delenv("GALAXY_DROPBOX_APP_CLIENT_ID", raising=False)
+        monkeypatch.delenv("GALAXY_DROPBOX_APP_CLIENT_SECRET", raising=False)
+        with pytest.raises(MessageException) as exc_info:
+            self.manager.template_oauth2(self.trans, "dropbox", 0)
+        assert "Please contact your administrator" in str(exc_info.value)
 
     def _init_invalid_upgrade_test_case(self, tmp_path) -> UserFileSourceModel:
         version_0 = home_directory_template(tmp_path)


### PR DESCRIPTION
Alternative to #22151 discussed in https://github.com/galaxyproject/galaxy/pull/22246#issuecomment-4120979105

Fixes #22041

The users now see:

<img width="991" height="558" alt="image" src="https://github.com/user-attachments/assets/05b6812e-c92f-48ab-8cc4-1d5f75a999c2" />

And the logged error is:

```
Traceback (most recent call last):
  File "/home/dlopez/dev/gx-version/26.0/lib/galaxy/managers/file_source_instances.py", line 649, in template_server_configuration
    environment = prepare_environment_from_root(template.environment, self._app_vault, self._app_config)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlopez/dev/gx-version/26.0/lib/galaxy/managers/_config_templates.py", line 293, in prepare_environment_from_root
    raise ConfigurationError(
galaxy.exceptions.ConfigurationError: Environment variable GALAXY_GOOGLE_DRIVE_APP_CLIENT_ID not found for environment entry oauth2_client_id and no default provided. This variable is required to be set in the environment for the template to function. Please set this variable in the environment or provide a default value in the template definition.
```

and for secrets, a similar exception:

```
galaxy.exceptions.ConfigurationError: Secret vault key file_source_secrets/google_drive/app_client_id not found for environment entry oauth2_client_id and no default provided. This secret is required to be set in the vault for the template to function. Please set this secret in the vault or provide a default value in the template definition.
```

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
