### PR TITLE
[26.0] Drop stored workflow menu entries from user serialization

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -40,7 +40,6 @@ from galaxy.model import (
     User,
     UserAddress,
     UserQuotaUsage,
-    UserWorkflowMenuEntry,
 )
 from galaxy.model.db.user import (
     _cleanup_nonprivate_user_roles,
@@ -671,7 +670,6 @@ class UserSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):
                 "quota",
                 "quota_bytes",
                 "quota_percent",
-                "stored_workflow_menu_entries",
                 "total_disk_usage",
             ],
             include_keys_from="summary",
@@ -693,7 +691,6 @@ class UserSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):
                 "quota_percent": lambda i, k, **c: self.user_manager.quota(i),
                 "quota": lambda i, k, **c: self.user_manager.quota(i, total=True),
                 "quota_bytes": lambda i, k, **c: self.user_manager.quota_bytes(i),
-                "stored_workflow_menu_entries": lambda i, k, **c: self.serialize_workflow_menu_entries(i),
             }
         )
 
@@ -729,22 +726,6 @@ class UserSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):
             quota=quota,
             quota_bytes=quota_bytes,
         )
-
-    def serialize_workflow_menu_entries(self, user: model.User) -> list[UserWorkflowMenuEntry]:
-        stored_workflow_menu_index = {}
-        stored_workflow_menu_entries: list[UserWorkflowMenuEntry] = []
-        for menu_item in getattr(user, "stored_workflow_menu_entries", []):
-            encoded_id = self.app.security.encode_id(menu_item.stored_workflow_id)
-            if encoded_id not in stored_workflow_menu_index:
-                stored_workflow_menu_index[encoded_id] = True
-                encoded_name = util.unicodify(menu_item.stored_workflow.name)
-                stored_workflow_menu_entries.append(
-                    UserWorkflowMenuEntry(
-                        id=encoded_id,
-                        name=encoded_name,
-                    )
-                )
-        return stored_workflow_menu_entries
 
 
 class UserDeserializer(base.ModelDeserializer):


### PR DESCRIPTION
No code consumes this, and we serialize it every time for client bootstrapping.

Moved into user serialization in https://github.com/galaxyproject/galaxy/commit/95465d0779eeb0084c92d95f0ebbe395fbe35838

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
