### PR TITLE
[26.0] Replace BaseHTTPMiddleware with pure ASGI middleware for X-Frame-Options

### DIFF
--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -15,6 +15,7 @@ from slowapi import (
 )
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
+from starlette.datastructures import MutableHeaders
 from starlette.middleware.cors import CORSMiddleware
 from tuspyserver import create_tus_router
 
@@ -116,14 +117,28 @@ class GalaxyCORSMiddleware(CORSMiddleware):
         return config_allows_origin(origin, self.config)
 
 
+class XFrameOptionsMiddleware:
+    def __init__(self, app, x_frame_options: str):
+        self.app = app
+        self.x_frame_options = x_frame_options
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers.append("X-Frame-Options", self.x_frame_options)
+            await send(message)
+
+        await self.app(scope, receive, send_with_header)
+
+
 def add_galaxy_middleware(app: FastAPI, gx_app):
     if x_frame_options := gx_app.config.x_frame_options:
-
-        @app.middleware("http")
-        async def add_x_frame_options(request: Request, call_next):
-            response = await call_next(request)
-            response.headers["X-Frame-Options"] = x_frame_options
-            return response
+        app.add_middleware(XFrameOptionsMiddleware, x_frame_options=x_frame_options)
 
     GalaxyFileResponse.nginx_x_accel_redirect_base = gx_app.config.nginx_x_accel_redirect_base
     GalaxyFileResponse.apache_xsendfile = gx_app.config.apache_xsendfile


### PR DESCRIPTION
The @app.middleware("http") decorator uses Starlette's BaseHTTPMiddleware which buffers the entire response body through an anyio memory channel between two tasks.

Replace with a pure ASGI middleware that injects the X-Frame-Options header directly into the response start message, avoiding the buffering entirely.

Before
```
❯ wrk --latency -t8 -c50 -d10s http://127.0.0.1:8080/api/configuration
Running 10s test @ http://127.0.0.1:8080/api/configuration
  8 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   104.75ms  211.07ms   1.21s    91.96%
    Req/Sec   134.29     26.12   181.00     83.59%
  Latency Distribution
     50%   42.98ms
     75%   49.55ms
     90%  105.43ms
     99%    1.11s
  9674 requests in 10.07s, 72.33MB read
Requests/sec:    961.03
Transfer/sec:      7.19MB
```

After
```
Last login: Wed Mar 25 12:06:06 on ttys018
❯ wrk --latency -t8 -c50 -d10s http://127.0.0.1:8080/api/configuration
Running 10s test @ http://127.0.0.1:8080/api/configuration
  8 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    39.29ms    7.78ms 136.97ms   94.58%
    Req/Sec   153.81     20.14   181.00     75.62%
  Latency Distribution
     50%   37.80ms
     75%   40.68ms
     90%   44.29ms
     99%   62.25ms
  12316 requests in 10.06s, 92.08MB read
Requests/sec:   1224.36
Transfer/sec:      9.15MB
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
