### PR TITLE
[26.0] Batch-prefetch HDCA job_state_summary in history contents listing

### DIFF
--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -45,6 +45,7 @@ from galaxy.managers import (
     tools,
 )
 from galaxy.managers.job_connections import JobConnectionsManager
+from galaxy.model import batch_fetch_job_state_summaries
 from galaxy.schema import ValueFilterQueryParams
 from galaxy.schema.tasks import (
     CopyDatasetsPayload,
@@ -496,7 +497,12 @@ class HistoryContentsManager(base.SortableManager):
             .options(joinedload(component_class.annotations))
         )
         result = self._session().scalars(stmt).unique()
-        return {row.id: row for row in result}
+        id_map = {row.id: row for row in result}
+        if id_map and component_class is model.HistoryDatasetCollectionAssociation:
+            summaries = batch_fetch_job_state_summaries(self._session(), list(id_map.keys()))
+            for hdca_id, hdca in id_map.items():
+                hdca._job_state_summary = summaries.get(hdca_id)
+        return id_map
 
 
 class HistoryContentsSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -88,6 +88,7 @@ from sqlalchemy import (
     or_,
     PrimaryKeyConstraint,
     select,
+    Select,
     String,
     Table,
     TEXT,
@@ -13006,3 +13007,65 @@ def receive_init(target, args, kwargs):
 
 
 JobStateSummary = NamedTuple("JobStateSummary", [(value, int) for value in enum_values(Job.states)] + [("all_jobs", int)])  # type: ignore[misc]  # Ref https://github.com/python/mypy/issues/848#issuecomment-255237167
+
+_ZERO_JOB_STATE_SUMMARY = JobStateSummary._make([0] * (len(Job.states) + 1))
+
+
+def batch_fetch_job_state_summaries(session, hdca_ids: list[int]) -> dict[int, "JobStateSummary"]:
+    """Batch-fetch job state summaries for multiple HDCAs in a single query.
+
+    Returns a dict mapping hdca_id to JobStateSummary for every requested ID.
+    HDCAs with no associated jobs get a zero-filled summary.
+    """
+    if not hdca_ids:
+        return {}
+
+    hdca_id_label = "hdca_id"
+    state_label = "state"
+
+    # subq1: jobs via ImplicitCollectionJobs
+    subq1 = (
+        select(
+            HistoryDatasetCollectionAssociation.id.label(hdca_id_label),
+            Job.id,
+            Job.state.label(state_label),
+        )
+        .join(ImplicitCollectionJobsJobAssociation, ImplicitCollectionJobsJobAssociation.job_id == Job.id)
+        .join(
+            ImplicitCollectionJobs,
+            ImplicitCollectionJobs.id == ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id,
+        )
+        .join(
+            HistoryDatasetCollectionAssociation,
+            HistoryDatasetCollectionAssociation.implicit_collection_jobs_id == ImplicitCollectionJobs.id,
+        )
+        .where(HistoryDatasetCollectionAssociation.id.in_(hdca_ids))
+    )
+
+    # subq2: jobs directly on HDCA
+    subq2 = (
+        select(
+            HistoryDatasetCollectionAssociation.id.label(hdca_id_label),
+            Job.id,
+            Job.state.label(state_label),
+        )
+        .join(HistoryDatasetCollectionAssociation, HistoryDatasetCollectionAssociation.job_id == Job.id)
+        .where(HistoryDatasetCollectionAssociation.id.in_(hdca_ids))
+    )
+
+    subq = subq1.union(subq2).subquery()
+
+    # Aggregate per HDCA
+    stm: Select = select(subq.c[hdca_id_label]).select_from(subq).group_by(subq.c[hdca_id_label])
+    for state in enum_values(Job.states):
+        stm = stm.add_columns(func.sum(case((subq.c[state_label] == state, 1), else_=0)).label(state))
+    stm = stm.add_columns(func.count().label("all_jobs"))
+
+    result = {int(row[0]): JobStateSummary._make(row[1:]) for row in session.execute(stm)}
+
+    # Fill in zero summaries for HDCAs with no jobs
+    for hdca_id in hdca_ids:
+        if hdca_id not in result:
+            result[hdca_id] = _ZERO_JOB_STATE_SUMMARY
+
+    return result


### PR DESCRIPTION
When listing history contents, each HDCA triggered an individual SQL query to aggregate job states during serialization. This adds a batch query that prefetches all job state summaries in a single query before serialization begins, injecting results into the HDCA instances' cache.

Before:
  HDCA object loading:   1 query  (batch IN)
  Job state summaries:   N queries (one per HDCA)
  Total for HDCAs:       1 + N queries

After:
  HDCA object loading:   1 query  (batch IN)
  Job state summaries:   1 query  (batch IN + GROUP BY)
  Total for HDCAs:       2 queries

Benchmark test results:
- Old per-HDCA path emits at least N queries for N HDCAs
- batch_fetch_job_state_summaries emits exactly 1 query regardless of HDCA count
- Batch results are identical to per-HDCA results
- Injecting batch results into _job_state_summary cache prevents any further queries
- Wall-clock benchmark across 1/10/50/100 HDCAs confirms batch path uses fewer queries

Gist: https://gist.github.com/mvdbeek/6806938201eef20470285bc18267747d

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
