### PR TITLE
[26.0] Fix OMERO temp directory handling

### DIFF
--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -142,7 +142,13 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             )
 
         try:
-            conn.c.enableKeepAlive(60)
+            client = conn.c
+            if client is None:
+                raise AuthenticationFailed(
+                    f"Connected to OMERO server at {context.config.host}:{context.config.port}, "
+                    "but no active OMERO client session was established."
+                )
+            client.enableKeepAlive(60)
             yield conn
         finally:
             conn.close()

--- a/lib/galaxy/files/sources/omero.py
+++ b/lib/galaxy/files/sources/omero.py
@@ -1,8 +1,11 @@
+import os
+import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from typing import (
     Optional,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -25,16 +28,22 @@ from galaxy.files.sources import (
 from galaxy.util.config_templates import TemplateExpansion
 
 try:
-    import omero.sys
-    from omero.gateway import BlitzGateway
-except ImportError:
-    omero = None
-    BlitzGateway = None
-
-try:
     import tifffile
 except ImportError:
     tifffile = None  # type: ignore[assignment,unused-ignore]
+
+# OMERO imports are deferred to avoid temp manager side effects at module import time.
+# At runtime these are populated by _ensure_omero_imported() before first use.
+if TYPE_CHECKING:
+    import omero
+    from omero.gateway import BlitzGateway
+else:
+    omero = None
+    BlitzGateway = None
+
+
+OMERO_TMPDIR_ENV_VAR = "OMERO_TMPDIR"
+OMERO_TMPDIR_FALLBACK = os.path.join(tempfile.gettempdir(), "galaxy", "file_sources", "omero")
 
 
 class OmeroFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
@@ -56,16 +65,14 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
     plugin_kind = PluginKind.rfs
     supports_pagination = True
     supports_search = True
-    required_module = BlitzGateway
     required_package = "omero-py (requires manual Zeroc IcePy installation)"
 
     template_config_class = OmeroFileSourceTemplateConfiguration
     resolved_config_class = OmeroFileSourceConfiguration
 
     def __init__(self, template_config: OmeroFileSourceTemplateConfiguration):
-        if self.required_module is None:
-            raise self.required_package_exception
         super().__init__(template_config)
+        self._configured_omero_tmpdir: Optional[str] = None
 
     @property
     def required_package_exception(self) -> Exception:
@@ -74,6 +81,43 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
             "Please see https://omero.readthedocs.io/en/stable/developers/Python.html for installation instructions."
         )
 
+    def _resolve_omero_tmpdir(self) -> str:
+        """Determine the OMERO temp directory to use, preferring Galaxy config and falling back to a safe default."""
+        configured_tmpdir = self._file_sources_config.tmp_dir if self._file_sources_config else None
+        if configured_tmpdir:
+            return configured_tmpdir
+        return OMERO_TMPDIR_FALLBACK
+
+    def _configure_omero_tmpdir(self) -> None:
+        """Set OMERO temp dir env var from Galaxy config or a Galaxy-scoped system tmp fallback."""
+        configured_tmpdir = self._resolve_omero_tmpdir()
+        if self._configured_omero_tmpdir == configured_tmpdir:
+            return
+
+        if configured_tmpdir == OMERO_TMPDIR_FALLBACK:
+            os.makedirs(configured_tmpdir, exist_ok=True)
+
+        os.environ[OMERO_TMPDIR_ENV_VAR] = configured_tmpdir
+        self._configured_omero_tmpdir = configured_tmpdir
+
+    def _ensure_omero_imported(self) -> None:
+        """Import OMERO modules if not already imported, and handle missing dependency."""
+        global omero
+        global BlitzGateway
+
+        if BlitzGateway is not None:
+            return
+
+        try:
+            import omero as omero_module
+            import omero.sys
+            from omero.gateway import BlitzGateway as blitz_gateway
+        except ImportError:
+            raise self.required_package_exception
+
+        omero = omero_module
+        BlitzGateway = blitz_gateway
+
     @contextmanager
     def _connection(self, context: FilesSourceRuntimeContext[OmeroFileSourceConfiguration]) -> Iterator[BlitzGateway]:
         """Context manager for OMERO connections with automatic cleanup.
@@ -81,8 +125,8 @@ class OmeroFileSource(BaseFilesSource[OmeroFileSourceTemplateConfiguration, Omer
         Establishes a connection to the OMERO server, enables keepalive for long-running
         operations, and ensures proper cleanup on exit.
         """
-        if BlitzGateway is None:
-            raise self.required_package_exception
+        self._configure_omero_tmpdir()
+        self._ensure_omero_imported()
 
         conn = BlitzGateway(
             username=context.config.username,


### PR DESCRIPTION
Fixes #22203

Galaxy loads all file sources on startup, so the only workaround Copilot and I could find is deferring the OMERO import until it is really used to avoid the import side effect of setting the temp directory to the default directory in the user's home dir before we can set the `OMERO_TMPDIR` to a sensible value.

This will now use the directory in `file_source_temp_dir` or try a sensible fallback with `tempfile.gettempdir()`.

Thanks again for noticing this @bernt-matthias! Can you give it a try?

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
