### PR TITLE
[26.0] Fix DOMPurify sanitize TypeError in Library components

### DIFF
--- a/client/src/components/Libraries/LibraryEditField.vue
+++ b/client/src/components/Libraries/LibraryEditField.vue
@@ -60,13 +60,15 @@ export default {
             type: Boolean,
         },
     },
+    setup() {
+        return { purify };
+    },
     data() {
         return {
             maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
         };
     },
     methods: {
-        purify,
         updateValue(value) {
             this.$emit("update:changedValue", value);
         },

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -330,6 +330,9 @@ export default {
             required: false,
         },
     },
+    setup() {
+        return { purify };
+    },
     data() {
         return {
             ...initialFolderState(),
@@ -349,8 +352,6 @@ export default {
                 faTimes,
                 faUnlock,
                 faUsers,
-                // Utilities
-                purify,
                 // Data
                 currentPage: 1,
                 sortBy: "name",
@@ -396,7 +397,6 @@ export default {
         this.getFolder(this.folder_id, this.page);
     },
     methods: {
-        purify,
         getFolder(folder_id, page) {
             this.currentFolderId = folder_id;
             this.currentPage = page;


### PR DESCRIPTION
## Summary

- Fix `TypeError: e.purify.sanitize is not a function` (#22239) in Library components
- Vue 2's `initMethods` calls `.bind(vm)` on every method, which strips custom properties from the DOMPurify callable -- `.sanitize()` disappears at runtime
- Move `purify` from `methods`/`data()` into `setup()` which returns values to the template without binding

## Test plan

- [x] `pnpm test LibraryFolder` passes
- [x] Production build succeeds and bundle no longer routes `purify.sanitize` through a bound method
- [x] Verified all 8 DOMPurify consumers -- only these two options-API components were affected