### PR TITLE
Add configurable tooltip hover timing delay

### DIFF
--- a/client/src/components/BaseComponents/GTooltip.vue
+++ b/client/src/components/BaseComponents/GTooltip.vue
@@ -20,6 +20,7 @@ import { computed, onBeforeUnmount, ref, watch } from "vue";
 
 import { useAccessibleHover } from "@/composables/accessibleHover";
 import { useUid } from "@/composables/utils/uid";
+import { DEFAULT_TOOLTIP_HOVER_DELAY_MS } from "@/utils/tooltipTiming";
 
 const props = defineProps<{
     /** Optional id override. Will auto generate an id if none is provided */
@@ -126,7 +127,10 @@ watch(
     },
 );
 
-useAccessibleHover(() => props.reference, show, hide);
+useAccessibleHover(() => props.reference, show, hide, {
+    showDelayMs: DEFAULT_TOOLTIP_HOVER_DELAY_MS,
+    delayFocusEnter: false,
+});
 
 defineExpose({
     show,

--- a/client/src/components/Popper/Popper.test.js
+++ b/client/src/components/Popper/Popper.test.js
@@ -1,11 +1,15 @@
 import { createPopper } from "@popperjs/core";
+import {
+    advanceToJustBeforeTooltipHoverDelay,
+    advanceTooltipHoverDelay,
+    runPendingTimersAndFlush,
+} from "@tests/vitest/tooltipTestUtils";
 import { mount } from "@vue/test-utils";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { DEFAULT_TOOLTIP_HOVER_DELAY_MS, INTERACTIVE_POPOVER_CLOSE_DELAY_MS } from "@/utils/tooltipTiming";
 
 import PopperComponent from "./Popper.vue";
-
-// value from usePopper.ts
-const DELAY_CLOSE = 50;
 
 vi.mock("@popperjs/core", () => ({
     createPopper: vi.fn(() => ({
@@ -30,7 +34,13 @@ function mountTarget(trigger = "click", interactive = false) {
 }
 
 describe("PopperComponent.vue", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
     afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
         vi.clearAllMocks();
     });
 
@@ -106,9 +116,13 @@ describe("PopperComponent.vue", () => {
         const popperElement = wrapper.find(".popper-element");
         expect(popperElement.isVisible()).toBe(false);
         await reference.trigger("mouseover");
+        expect(popperElement.isVisible()).toBe(false);
+        advanceToJustBeforeTooltipHoverDelay();
+        expect(popperElement.isVisible()).toBe(false);
+        await advanceTooltipHoverDelay();
         expect(popperElement.isVisible()).toBe(true);
         await reference.trigger("mouseout");
-        await new Promise((r) => setTimeout(r, 0));
+        await runPendingTimersAndFlush();
         expect(popperElement.isVisible()).toBe(false);
     });
 
@@ -118,14 +132,15 @@ describe("PopperComponent.vue", () => {
         const popperElement = wrapper.find(".popper-element");
         expect(popperElement.isVisible()).toBe(false);
         await reference.trigger("mouseover");
+        await advanceTooltipHoverDelay(DEFAULT_TOOLTIP_HOVER_DELAY_MS);
         expect(popperElement.isVisible()).toBe(true);
         await reference.trigger("mouseout");
-        await new Promise((r) => setTimeout(r, DELAY_CLOSE / 2));
+        await advanceTooltipHoverDelay(INTERACTIVE_POPOVER_CLOSE_DELAY_MS / 2);
         expect(popperElement.isVisible()).toBe(true);
         await popperElement.trigger("mouseover");
-        await new Promise((r) => setTimeout(r, DELAY_CLOSE * 2));
+        await advanceTooltipHoverDelay(INTERACTIVE_POPOVER_CLOSE_DELAY_MS * 2);
         await popperElement.trigger("mouseout");
-        await new Promise((r) => setTimeout(r, DELAY_CLOSE * 2));
+        await advanceTooltipHoverDelay(INTERACTIVE_POPOVER_CLOSE_DELAY_MS * 2);
         expect(popperElement.isVisible()).toBe(false);
     });
 

--- a/client/src/components/Popper/Popper.vue
+++ b/client/src/components/Popper/Popper.vue
@@ -20,20 +20,34 @@
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { Placement } from "@popperjs/core";
-import type { PropType } from "vue";
 import { ref } from "vue";
+
+import { DEFAULT_TOOLTIP_HOVER_DELAY_MS } from "@/utils/tooltipTiming";
 
 import { type Trigger, usePopper } from "./usePopper";
 
-const props = defineProps({
-    arrow: { type: Boolean, default: true },
-    disabled: { type: Boolean, default: false },
-    interactive: { type: Boolean, default: false },
-    mode: { type: String, default: "dark" },
-    placement: String as PropType<Placement>,
-    referenceEl: HTMLElement,
-    title: String,
-    trigger: String as PropType<Trigger>,
+interface Props {
+    arrow?: boolean;
+    disabled?: boolean;
+    hoverDelay?: number;
+    interactive?: boolean;
+    mode?: string;
+    placement?: Placement;
+    referenceEl?: HTMLElement;
+    title?: string;
+    trigger?: Trigger;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    arrow: true,
+    disabled: false,
+    hoverDelay: DEFAULT_TOOLTIP_HOVER_DELAY_MS,
+    interactive: false,
+    mode: "dark",
+    placement: "bottom",
+    referenceEl: undefined,
+    title: undefined,
+    trigger: "hover",
 });
 
 const reference = props.referenceEl ? ref(props.referenceEl) : ref();
@@ -41,6 +55,7 @@ const reference = props.referenceEl ? ref(props.referenceEl) : ref();
 const popper = ref();
 
 const { visible } = usePopper(reference, popper, {
+    hoverDelay: props.hoverDelay,
     interactive: props.interactive,
     placement: props.placement,
     trigger: props.trigger,

--- a/client/src/components/Popper/usePopper.ts
+++ b/client/src/components/Popper/usePopper.ts
@@ -1,46 +1,68 @@
 import { createPopper, type Placement } from "@popperjs/core";
 import { onMounted, onUnmounted, type Ref, ref, watch } from "vue";
 
+import {
+    DEFAULT_TOOLTIP_HOVER_DELAY_MS,
+    INTERACTIVE_POPOVER_CLOSE_DELAY_MS,
+    useDelayedAction,
+} from "@/utils/tooltipTiming";
+
 export type Trigger = "click" | "hover" | "none";
 
 const defaultTrigger: Trigger = "hover";
 
-const DELAY_CLOSE = 50;
-
 export function usePopper(
     reference: Ref<HTMLElement>,
     popper: Ref<HTMLElement>,
-    options: { interactive?: boolean; placement?: Placement; trigger?: Trigger },
+    options: { interactive?: boolean; placement?: Placement; trigger?: Trigger; hoverDelay?: number },
 ) {
     const instance = ref<ReturnType<typeof createPopper>>();
     const visible = ref(false);
     const listeners: Array<{ target: EventTarget; event: string; handler: EventListener }> = [];
 
-    let closeHandler: ReturnType<typeof setTimeout> | undefined;
+    const openDelay = useDelayedAction(options.hoverDelay ?? DEFAULT_TOOLTIP_HOVER_DELAY_MS);
+    const closeDelay = useDelayedAction(options.interactive ? INTERACTIVE_POPOVER_CLOSE_DELAY_MS : 0);
 
-    const doOpen = () => {
-        closeHandler && clearTimeout(closeHandler);
+    const doOpenImmediately = () => {
+        openDelay.clear();
+        closeDelay.clear();
         visible.value = true;
     };
+    const doOpen = () => {
+        closeDelay.clear();
+        if (visible.value || openDelay.isScheduled()) {
+            return;
+        }
+        openDelay.schedule(() => {
+            visible.value = true;
+        });
+    };
     const doClose = () => {
-        const delay = options.interactive ? DELAY_CLOSE : 0;
-        closeHandler && clearTimeout(closeHandler);
-        closeHandler = setTimeout(() => (visible.value = false), delay);
+        openDelay.clear();
+        closeDelay.schedule(() => {
+            visible.value = false;
+        });
     };
     const doCloseDocument = (e: Event) => {
         if (!reference.value?.contains(e.target as Node) && !popper.value?.contains(e.target as Node)) {
+            openDelay.clear();
+            closeDelay.clear();
             visible.value = false;
         }
     };
     const doCloseElement = (event: Event) => {
         const target = event.target as Element;
         if (target && target.closest(".popper-close")) {
+            openDelay.clear();
+            closeDelay.clear();
             visible.value = false;
         }
     };
     const doCloseEscape = (event: Event) => {
         const keyboardEvent = event as KeyboardEvent;
         if (keyboardEvent.key === "Escape") {
+            openDelay.clear();
+            closeDelay.clear();
             visible.value = false;
         }
     };
@@ -66,7 +88,7 @@ export function usePopper(
 
         const trigger = options.trigger ?? defaultTrigger;
         if (trigger === "click") {
-            addEventListener(reference.value, "click", doOpen);
+            addEventListener(reference.value, "click", doOpenImmediately);
             addEventListener(popper.value, "click", doCloseElement);
             addEventListener(document, "click", doCloseDocument);
             addEventListener(document, "keydown", doCloseEscape);
@@ -79,6 +101,8 @@ export function usePopper(
     });
 
     onUnmounted(() => {
+        openDelay.clear();
+        closeDelay.clear();
         instance.value?.destroy();
         listeners.forEach(({ target, event, handler }) => target.removeEventListener(event, handler));
         listeners.length = 0;

--- a/client/src/composables/accessibleHover.test.ts
+++ b/client/src/composables/accessibleHover.test.ts
@@ -1,0 +1,86 @@
+import { advanceToJustBeforeTooltipHoverDelay, advanceTooltipHoverDelay } from "@tests/vitest/tooltipTestUtils";
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ref } from "vue";
+
+import { DEFAULT_TOOLTIP_HOVER_DELAY_MS } from "@/utils/tooltipTiming";
+
+import { useAccessibleHover } from "./accessibleHover";
+
+describe("useAccessibleHover", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        vi.clearAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    function mountWithElement(element: HTMLElement, onEnter?: () => void, onExit?: () => void) {
+        const elementRef = ref<HTMLElement | null>(element);
+
+        return mount({
+            template: "<div />",
+            setup() {
+                useAccessibleHover(() => elementRef.value, onEnter, onExit, {
+                    showDelayMs: DEFAULT_TOOLTIP_HOVER_DELAY_MS,
+                    delayFocusEnter: false,
+                });
+            },
+        });
+    }
+
+    test("delays hover enter", async () => {
+        const element = document.createElement("button");
+        document.body.appendChild(element);
+
+        const onEnter = vi.fn();
+        const wrapper = mountWithElement(element, onEnter);
+
+        element.dispatchEvent(new Event("mouseenter"));
+        expect(onEnter).not.toHaveBeenCalled();
+
+        advanceToJustBeforeTooltipHoverDelay();
+        expect(onEnter).not.toHaveBeenCalled();
+
+        await advanceTooltipHoverDelay();
+        expect(onEnter).toHaveBeenCalledTimes(1);
+
+        wrapper.destroy();
+    });
+
+    test("cancels delayed hover enter on mouseleave", async () => {
+        const element = document.createElement("button");
+        document.body.appendChild(element);
+
+        const onEnter = vi.fn();
+        const onExit = vi.fn();
+        const wrapper = mountWithElement(element, onEnter, onExit);
+
+        element.dispatchEvent(new Event("mouseenter"));
+        await advanceTooltipHoverDelay(100);
+        element.dispatchEvent(new Event("mouseleave"));
+        await advanceTooltipHoverDelay(500);
+
+        expect(onEnter).not.toHaveBeenCalled();
+        expect(onExit).not.toHaveBeenCalled();
+
+        wrapper.destroy();
+    });
+
+    test("shows immediately on focus", () => {
+        const element = document.createElement("button");
+        document.body.appendChild(element);
+
+        const onEnter = vi.fn();
+        const wrapper = mountWithElement(element, onEnter);
+
+        element.dispatchEvent(new Event("focus"));
+        expect(onEnter).toHaveBeenCalledTimes(1);
+
+        wrapper.destroy();
+    });
+});

--- a/client/src/composables/accessibleHover.ts
+++ b/client/src/composables/accessibleHover.ts
@@ -17,6 +17,7 @@ export function useAccessibleHover(
     const isHovering = ref(false);
     let previousElement: HTMLElement | null = null;
     const enterDelay = useDelayedAction(options?.showDelayMs ?? DEFAULT_TOOLTIP_HOVER_DELAY_MS);
+    const focusHandler = options?.delayFocusEnter ? enterWithDelay : enter;
 
     function enter() {
         enterDelay.clear();
@@ -53,7 +54,7 @@ export function useAccessibleHover(
             if (previousElement) {
                 exit();
                 previousElement.removeEventListener("mouseenter", enterWithDelay);
-                previousElement.removeEventListener("focus", enter);
+                previousElement.removeEventListener("focus", focusHandler);
                 previousElement.removeEventListener("mouseleave", exit);
                 previousElement.removeEventListener("blur", exit);
                 previousElement.removeEventListener("keydown", keydown);
@@ -61,7 +62,7 @@ export function useAccessibleHover(
 
             if (element) {
                 element.addEventListener("mouseenter", enterWithDelay);
-                element.addEventListener("focus", options?.delayFocusEnter ? enterWithDelay : enter);
+                element.addEventListener("focus", focusHandler);
                 element.addEventListener("mouseleave", exit);
                 element.addEventListener("blur", exit);
                 element.addEventListener("keydown", keydown);

--- a/client/src/composables/accessibleHover.ts
+++ b/client/src/composables/accessibleHover.ts
@@ -1,22 +1,40 @@
 import { type MaybeRefOrGetter, toValue } from "@vueuse/core";
 import { ref, watch } from "vue";
 
+import { DEFAULT_TOOLTIP_HOVER_DELAY_MS, useDelayedAction } from "@/utils/tooltipTiming";
+
+interface AccessibleHoverOptions {
+    showDelayMs?: number;
+    delayFocusEnter?: boolean;
+}
+
 export function useAccessibleHover(
     elementRef: MaybeRefOrGetter<HTMLElement | null>,
     onHoverEnter?: () => void,
     onHoverExit?: () => void,
+    options?: AccessibleHoverOptions,
 ) {
     const isHovering = ref(false);
     let previousElement: HTMLElement | null = null;
+    const enterDelay = useDelayedAction(options?.showDelayMs ?? DEFAULT_TOOLTIP_HOVER_DELAY_MS);
 
     function enter() {
+        enterDelay.clear();
         if (!isHovering.value) {
             onHoverEnter?.();
             isHovering.value = true;
         }
     }
 
+    function enterWithDelay() {
+        if (isHovering.value || enterDelay.isScheduled()) {
+            return;
+        }
+        enterDelay.schedule(() => enter());
+    }
+
     function exit() {
+        enterDelay.clear();
         if (isHovering.value) {
             onHoverExit?.();
             isHovering.value = false;
@@ -34,7 +52,7 @@ export function useAccessibleHover(
         (element) => {
             if (previousElement) {
                 exit();
-                previousElement.removeEventListener("mouseenter", enter);
+                previousElement.removeEventListener("mouseenter", enterWithDelay);
                 previousElement.removeEventListener("focus", enter);
                 previousElement.removeEventListener("mouseleave", exit);
                 previousElement.removeEventListener("blur", exit);
@@ -42,8 +60,8 @@ export function useAccessibleHover(
             }
 
             if (element) {
-                element.addEventListener("mouseenter", enter);
-                element.addEventListener("focus", enter);
+                element.addEventListener("mouseenter", enterWithDelay);
+                element.addEventListener("focus", options?.delayFocusEnter ? enterWithDelay : enter);
                 element.addEventListener("mouseleave", exit);
                 element.addEventListener("blur", exit);
                 element.addEventListener("keydown", keydown);

--- a/client/src/directives/vGTooltip.test.ts
+++ b/client/src/directives/vGTooltip.test.ts
@@ -1,0 +1,97 @@
+import { advanceToJustBeforeTooltipHoverDelay, advanceTooltipHoverDelay } from "@tests/vitest/tooltipTestUtils";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { DirectiveBinding, VNode } from "vue";
+
+import { vGTooltip } from "./vGTooltip";
+
+describe("vGTooltip", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        vi.clearAllMocks();
+        document.body.innerHTML = "";
+    });
+
+    function createTooltipTarget(title = "Tooltip text") {
+        const element = document.createElement("button");
+        element.setAttribute("title", title);
+        document.body.appendChild(element);
+
+        const binding = {
+            modifiers: { hover: true },
+            value: undefined,
+            arg: undefined,
+        } as unknown as DirectiveBinding<unknown>;
+
+        vGTooltip.inserted?.(element, binding, undefined as unknown as VNode, undefined as unknown as VNode);
+
+        return element;
+    }
+
+    function getRenderedTooltip() {
+        return document.body.querySelector(".g-tooltip-d");
+    }
+
+    test("shows on hover after delay", async () => {
+        const element = createTooltipTarget();
+
+        element.dispatchEvent(new Event("mouseenter"));
+        expect(getRenderedTooltip()).toBeNull();
+
+        advanceToJustBeforeTooltipHoverDelay();
+        expect(getRenderedTooltip()).toBeNull();
+
+        await advanceTooltipHoverDelay();
+        expect(getRenderedTooltip()).not.toBeNull();
+
+        vGTooltip.unbind?.(element, bindingForCleanup(), undefined as unknown as VNode, undefined as unknown as VNode);
+    });
+
+    test("cancels delayed show when hover leaves early", async () => {
+        const element = createTooltipTarget();
+
+        element.dispatchEvent(new Event("mouseenter"));
+        await advanceTooltipHoverDelay(100);
+        element.dispatchEvent(new Event("mouseleave"));
+        await advanceTooltipHoverDelay(500);
+
+        expect(getRenderedTooltip()).toBeNull();
+
+        vGTooltip.unbind?.(element, bindingForCleanup(), undefined as unknown as VNode, undefined as unknown as VNode);
+    });
+
+    test("suppresses native title during delayed hover and restores it on leave", async () => {
+        const element = createTooltipTarget("Native title");
+
+        element.dispatchEvent(new Event("mouseenter"));
+        expect(element.getAttribute("title")).toBe("");
+
+        await advanceTooltipHoverDelay(100);
+        element.dispatchEvent(new Event("mouseleave"));
+
+        expect(element.getAttribute("title")).toBe("Native title");
+
+        vGTooltip.unbind?.(element, bindingForCleanup(), undefined as unknown as VNode, undefined as unknown as VNode);
+    });
+
+    test("shows immediately on focusin", () => {
+        const element = createTooltipTarget();
+
+        element.dispatchEvent(new Event("focusin"));
+        expect(getRenderedTooltip()).not.toBeNull();
+
+        vGTooltip.unbind?.(element, bindingForCleanup(), undefined as unknown as VNode, undefined as unknown as VNode);
+    });
+});
+
+function bindingForCleanup() {
+    return {
+        modifiers: { hover: true },
+        value: undefined,
+        arg: undefined,
+    } as unknown as DirectiveBinding<unknown>;
+}

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -24,7 +24,7 @@ import {
     shift,
 } from "@floating-ui/dom";
 import purify from "dompurify";
-import type { DirectiveOptions, VNode } from "vue";
+import type { ObjectDirective, VNode } from "vue";
 
 import { DEFAULT_TOOLTIP_HOVER_DELAY_MS, useDelayedAction } from "@/utils/tooltipTiming";
 
@@ -334,7 +334,7 @@ function updateContent(el: HTMLElement, bindingValue: unknown, state: TooltipSta
     }
 }
 
-export const vGTooltip: DirectiveOptions = {
+export const vGTooltip: ObjectDirective<HTMLElement> = {
     inserted(el, binding, vnode) {
         const modifiers = binding.modifiers || {};
         const isDanger = !!modifiers["v-danger"];

--- a/client/src/directives/vGTooltip.ts
+++ b/client/src/directives/vGTooltip.ts
@@ -26,6 +26,8 @@ import {
 import purify from "dompurify";
 import type { DirectiveOptions, VNode } from "vue";
 
+import { DEFAULT_TOOLTIP_HOVER_DELAY_MS, useDelayedAction } from "@/utils/tooltipTiming";
+
 interface TooltipState {
     tooltipEl: HTMLElement;
     arrowEl: HTMLElement;
@@ -34,6 +36,7 @@ interface TooltipState {
     cleanupListeners: () => void;
     placement: Placement;
     isHtml: boolean;
+    showDelay: ReturnType<typeof useDelayedAction>;
 }
 
 const stateMap = new WeakMap<HTMLElement, TooltipState>();
@@ -216,10 +219,7 @@ function showTooltip(el: HTMLElement) {
         return;
     }
 
-    // Suppress native tooltip while ours is visible
-    if (el.hasAttribute("title")) {
-        el.setAttribute("title", "");
-    }
+    suppressNativeTooltip(el);
 
     if (!state.tooltipEl.isConnected) {
         document.body.appendChild(state.tooltipEl);
@@ -229,19 +229,52 @@ function showTooltip(el: HTMLElement) {
     state.cleanupAutoUpdate = autoUpdate(el, state.tooltipEl, () => updatePosition(el, state));
 }
 
+function suppressNativeTooltip(el: HTMLElement) {
+    if (el.hasAttribute("title")) {
+        el.setAttribute("title", "");
+    }
+}
+
+function restoreNativeTooltip(el: HTMLElement) {
+    if (el.dataset.gTooltipTitle) {
+        el.setAttribute("title", el.dataset.gTooltipTitle);
+    }
+}
+
+function clearPendingShow(el: HTMLElement) {
+    const state = stateMap.get(el);
+    if (!state) {
+        return;
+    }
+
+    state.showDelay.clear();
+}
+
+function scheduleShowTooltip(el: HTMLElement) {
+    const state = stateMap.get(el);
+    if (!state) {
+        return;
+    }
+
+    clearPendingShow(el);
+    suppressNativeTooltip(el);
+    state.showDelay.schedule(() => {
+        showTooltip(el);
+    });
+}
+
 function hideTooltip(el: HTMLElement) {
     const state = stateMap.get(el);
     if (!state) {
         return;
     }
 
+    clearPendingShow(el);
+
     state.cleanupAutoUpdate?.();
     state.cleanupAutoUpdate = null;
 
-    // Restore native title attribute
-    if (el.dataset.gTooltipTitle) {
-        el.setAttribute("title", el.dataset.gTooltipTitle);
-    }
+    restoreNativeTooltip(el);
 
     if (state.tooltipEl.isConnected) {
         state.tooltipEl.remove();
@@ -257,7 +290,11 @@ function setupListeners(el: HTMLElement, modifiers: Record<string, boolean>, arg
     }
 
     const focusOnly = (modifiers.focus || arg === "focus") && !modifiers.hover && arg !== "hover";
-    const showHandler = () => showTooltip(el);
+    const hoverShowHandler = () => scheduleShowTooltip(el);
+    const focusShowHandler = () => {
+        clearPendingShow(el);
+        showTooltip(el);
+    };
     const hideHandler = () => hideTooltip(el);
     const keyHandler = (e: Event) => {
         if ((e as KeyboardEvent).key === "Escape") {
@@ -266,10 +303,10 @@ function setupListeners(el: HTMLElement, modifiers: Record<string, boolean>, arg
     };
 
     if (!focusOnly) {
-        addListener("mouseenter", showHandler);
+        addListener("mouseenter", hoverShowHandler);
         addListener("mouseleave", hideHandler);
     }
-    addListener("focusin", showHandler);
+    addListener("focusin", focusShowHandler);
     addListener("focusout", hideHandler);
     addListener("keydown", keyHandler);
 
@@ -319,6 +356,7 @@ export const vGTooltip: DirectiveOptions = {
             cleanupListeners,
             placement,
             isHtml,
+            showDelay: useDelayedAction(DEFAULT_TOOLTIP_HOVER_DELAY_MS),
         };
 
         stateMap.set(el, state);
@@ -346,8 +384,10 @@ export const vGTooltip: DirectiveOptions = {
             return;
         }
         state.cleanupListeners();
+        clearPendingShow(el);
         state.cleanupAutoUpdate?.();
         state.tooltipEl.remove();
+        restoreNativeTooltip(el);
         el.removeAttribute("aria-describedby");
         if (el.dataset.gTooltipAriaLabel) {
             el.removeAttribute("aria-label");

--- a/client/src/utils/tooltipTiming.ts
+++ b/client/src/utils/tooltipTiming.ts
@@ -1,0 +1,25 @@
+export const DEFAULT_TOOLTIP_HOVER_DELAY_MS = 300;
+export const INTERACTIVE_POPOVER_CLOSE_DELAY_MS = 50;
+
+export function useDelayedAction(delayMs: number) {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    return {
+        schedule: (callback: () => void) => {
+            if (timer !== null) {
+                clearTimeout(timer);
+            }
+            timer = setTimeout(() => {
+                timer = null;
+                callback();
+            }, delayMs);
+        },
+        clear: () => {
+            if (timer !== null) {
+                clearTimeout(timer);
+                timer = null;
+            }
+        },
+        isScheduled: () => timer !== null,
+    };
+}

--- a/client/tests/vitest/tooltipTestUtils.ts
+++ b/client/tests/vitest/tooltipTestUtils.ts
@@ -1,0 +1,18 @@
+import { vi } from "vitest";
+import { nextTick } from "vue";
+
+import { DEFAULT_TOOLTIP_HOVER_DELAY_MS } from "@/utils/tooltipTiming";
+
+export function advanceToJustBeforeTooltipHoverDelay(delayMs = DEFAULT_TOOLTIP_HOVER_DELAY_MS) {
+    vi.advanceTimersByTime(delayMs - 1);
+}
+
+export async function advanceTooltipHoverDelay(delayMs = 1) {
+    vi.advanceTimersByTime(delayMs);
+    await nextTick();
+}
+
+export async function runPendingTimersAndFlush() {
+    vi.runOnlyPendingTimers();
+    await nextTick();
+}


### PR DESCRIPTION
Follow up to #21962

Currently, tooltips are displayed instantly, and sometimes they get in the way when moving the cursor rapidly. This adds a configurable delay (currently 300 ms) to avoid that, while keeping the tooltip instant for keyboard navigation, so accessibility is preserved.

## Before
https://github.com/user-attachments/assets/081f0543-22f9-4ddd-a3e8-378f8f565b87

## After
https://github.com/user-attachments/assets/8c56cb6b-c204-4e27-a72b-0cd9fb6dc44f






## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
