### PR TITLE
Show file size for CRAM datasets and in download tooltip

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetDownload.test.ts
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.test.ts
@@ -8,8 +8,8 @@ import DatasetDownload from "./DatasetDownload.vue";
 const localVue = getLocalVue();
 
 const items = [
-    { id: "item_id", extension: "ext", meta_files: [{ file_type: "a" }, { file_type: "b" }] },
-    { id: "item_id", extension: "ext", meta_files: [] },
+    { id: "item_id", extension: "ext", file_size: 1024, meta_files: [{ file_type: "a" }, { file_type: "b" }] },
+    { id: "item_id", extension: "ext", file_size: 0, meta_files: [] },
 ];
 
 describe("DatasetDownload", () => {

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -6,6 +6,7 @@ import { computed } from "vue";
 
 import type { HDADetailed } from "@/api";
 import { prependPath } from "@/utils/redirect";
+import { bytesToString } from "@/utils/utils";
 
 interface Props {
     item: HDADetailed;
@@ -27,6 +28,13 @@ const metaDownloadUrl = computed(() => {
 const downloadUrl = computed(() => {
     return prependPath(`api/datasets/${props.item.id}/display?to_ext=${props.item.extension}`);
 });
+const downloadTitle = computed(() => {
+    const size = props.item.file_size;
+    if (size) {
+        return `Download (${bytesToString(size)})`;
+    }
+    return "Download";
+});
 
 function onDownload(resource: string, extension = "") {
     emit("on-download", `${resource}${extension}`);
@@ -43,7 +51,7 @@ function onDownload(resource: string, extension = "") {
         size="sm"
         variant="link"
         toggle-class="text-decoration-none"
-        title="Download"
+        :title="downloadTitle"
         class="download-btn"
         data-description="dataset download">
         <template v-slot:button-content>
@@ -68,7 +76,7 @@ function onDownload(resource: string, extension = "") {
         v-else
         v-g-tooltip.hover
         class="download-btn px-1"
-        title="Download"
+        :title="downloadTitle"
         size="sm"
         variant="link"
         :href="downloadUrl"

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1139,7 +1139,7 @@ class CRAM(Binary):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             dataset.peek = "CRAM binary alignment file"
-            dataset.blurb = "binary data"
+            dataset.blurb = nice_size(dataset.get_size())
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"


### PR DESCRIPTION
CRAM's `set_peek` was hardcoding its blurb as "binary data" instead of calling `nice_size()` like every other binary datatype, so CRAM datasets didn't show their file size in the history panel. This came up when someone uploaded a CRAM that was unexpectedly small and there was no visible indication.

Also adds the dataset file size to the download button tooltip -- hovering now shows "Download (1.5 GB)" instead of just "Download". This surfaces size information without adding clutter to the history UI. Follows the same pattern already used in `DownloadWorkbookButton.vue`.