### PR TITLE
[26.0] Fix purge for anon histories

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -94,14 +94,14 @@ class DatasetManager(
         They might not be removed if there are still un-purged associations to the dataset.
         """
         self.error_unless_dataset_purge_allowed()
-        with self.session().begin():
-            for dataset_id in request.dataset_ids:
-                dataset: Optional[Dataset] = self.session().get(Dataset, dataset_id)
-                if dataset and dataset.user_can_purge:
-                    try:
-                        dataset.full_delete()
-                    except Exception:
-                        log.exception(f"Unable to purge dataset ({dataset.id})")
+        for dataset_id in request.dataset_ids:
+            dataset: Optional[Dataset] = self.session().get(Dataset, dataset_id)
+            if dataset and dataset.user_can_purge:
+                try:
+                    dataset.full_delete()
+                except Exception:
+                    log.exception(f"Unable to purge dataset ({dataset.id})")
+        self.session().commit()
 
     # TODO: this may be more conv. somewhere else
     # TODO: how to allow admin bypass?

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -896,7 +896,7 @@ class TestDatasetsApi(ApiTestCase):
         self.dataset_populator.wait_for_history_jobs(history_id)
 
         # once we purge the history, it becomes immutable
-        self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        self.dataset_populator.purge_history(history_id)
 
         # now we can't update the datatype
         response = self._put(f"histories/{history_id}/contents/{hda_id}", data={"datatype": "tabular"}, json=True)

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -1,5 +1,4 @@
 import textwrap
-import urllib
 import zipfile
 from io import BytesIO
 from urllib.parse import quote
@@ -566,7 +565,7 @@ class TestDatasetsApi(ApiTestCase):
 
     def test_anon_tag_permissions(self):
         with self._different_user(anon=True):
-            history_id = self._get(urllib.parse.urljoin(self.url, "history/current_history_json")).json()["id"]
+            history_id = self._get_current_history_id()
             hda_id = self.dataset_populator.new_dataset(history_id, content="abc", wait=True)["id"]
             payload = {
                 "item_id": hda_id,

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -601,7 +601,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
         assert show_response["name"] == "Immutable Name"
 
         # once we purge the history, it becomes immutable
-        self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        self.dataset_populator.purge_history(history_id)
 
         # we cannot update the name anymore
         response = self._update(history_id, {"name": "New Name"})
@@ -617,7 +617,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
         self.dataset_populator.new_dataset(history_id, content="TestContents")
 
         # once we purge the history, it becomes immutable
-        self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        self.dataset_populator.purge_history(history_id)
 
         # we cannot add another dataset
         with self.assertRaisesRegex(AssertionError, "History is immutable"):
@@ -631,7 +631,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
         self._update(history_id, {"tags": ["FirstTag"]})
 
         # once we purge the history, it becomes immutable
-        self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        self.dataset_populator.purge_history(history_id)
 
         # we cannot add another tag
         response = self._update(history_id, {"tags": ["SecondTag"]})

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -595,7 +595,7 @@ class TestHistoryContentsApi(ApiTestCase):
 
     def test_delete_anon(self):
         with self._different_user(anon=True):
-            history_id = self._get(urllib.parse.urljoin(self.url, "history/current_history_json")).json()["id"]
+            history_id = self._get_current_history_id()
             hda1 = self.dataset_populator.new_dataset(history_id)
             self.dataset_populator.wait_for_history(history_id)
             assert str(self.__show(history_id, hda1).json()["deleted"]).lower() == "false"

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1052,7 +1052,7 @@ class TestHistoryContentsApi(ApiTestCase):
         }
 
         # once we purge the history, it becomes immutable
-        self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        self.dataset_populator.purge_history(history_id)
 
         with self.assertRaisesRegex(AssertionError, "History is immutable"):
             self.dataset_populator.run_tool("cat1", inputs=inputs, history_id=history_id)
@@ -1061,7 +1061,7 @@ class TestHistoryContentsApi(ApiTestCase):
         hdca = self._create_pair_collection(history_id)
 
         # once we purge the history, it becomes immutable
-        self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        self.dataset_populator.purge_history(history_id)
 
         body = dict(name="newnameforpair")
         update_response = self._put(
@@ -1074,7 +1074,7 @@ class TestHistoryContentsApi(ApiTestCase):
         hda1 = self._wait_for_new_hda(history_id)
 
         # once we purge the history, it becomes immutable
-        self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        self.dataset_populator.purge_history(history_id)
 
         update_response = self._update(history_id, hda1["id"], dict(name="Updated Name"))
         self._assert_status_code_is(update_response, 403)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import os
 import time
-import urllib.parse
 from operator import itemgetter
 from typing import Union
 from unittest import SkipTest
@@ -526,7 +525,7 @@ steps:
     @skip_without_tool("detect_errors_aggressive")
     def test_report_error_anon(self):
         with self._different_user(anon=True):
-            history_id = self._get(urllib.parse.urljoin(self.url, "history/current_history_json")).json()["id"]
+            history_id = self._get_current_history_id()
             self._run_error_report(history_id)
 
     def _run_error_report(self, history_id):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -9095,7 +9095,7 @@ outer_input:
     def test_cannot_run_workflow_on_immutable_history(self) -> None:
         with self.dataset_populator.test_history() as history_id:
             # once we purge the history, it becomes immutable
-            self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+            self.dataset_populator.purge_history(history_id)
 
             with self.assertRaisesRegex(AssertionError, "History is immutable"):
                 self.workflow_populator.run_workflow(

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -178,6 +178,10 @@ class UsesApiTestCaseMixin:
             self.galaxy_interactor.api_key = original_interactor_key
             self.galaxy_interactor.cookies = original_cookies
 
+    def _get_current_history_id(self) -> str:
+        """Return the current session's history ID (works for anonymous users)."""
+        return self._get(urljoin(self.url, "history/current_history_json")).json()["id"]
+
     def _get(self, *args, **kwds):
         return self.galaxy_interactor.get(*args, **kwds)
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -867,6 +867,14 @@ class BaseDatasetPopulator(BasePopulator):
         delete_response = self._delete(f"histories/{history_id}")
         delete_response.raise_for_status()
 
+    def purge_history(self, history_id: str) -> dict:
+        purge_response = self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+        purge_response.raise_for_status()
+        result = purge_response.json()
+        if purge_task := result.get("purge_task"):
+            self.wait_on_task_id(purge_task["id"])
+        return result
+
     def delete_dataset(
         self,
         history_id: str,

--- a/test/integration/test_purge_datasets.py
+++ b/test/integration/test_purge_datasets.py
@@ -113,6 +113,29 @@ class TestPurgeDatasetsIntegration(integration_util.IntegrationTestCase):
         assert not self._file_exists_on_disk(dataset_file1)
         assert not self._file_exists_on_disk(dataset_file2)
 
+    def test_purge_anonymous_history(self):
+        """Regression test for GALAXY-MAIN-4KSCZZZ00152B."""
+        with self._different_user(anon=True):
+            history_id = self._get_current_history_id()
+            hda = self.dataset_populator.new_dataset(history_id, wait=True)
+            hda_id = hda["id"]
+
+            dataset_file = self._get_underlying_dataset_on_disk(hda_id)
+            assert self._file_exists_on_disk(dataset_file)
+
+        # Purge via admin API (anonymous histories are only accessible to admins)
+        purge_response = self._delete(f"histories/{history_id}", data={"purge": True}, admin=True, json=True)
+        self._assert_status_code_is_ok(purge_response)
+        purge_result = purge_response.json()
+        assert purge_result["purged"]
+
+        # Wait for the celery purge task to finish
+        assert "purge_task" in purge_result
+        task_ok = self.dataset_populator.wait_on_task_id(purge_result["purge_task"]["id"])
+        assert task_ok
+
+        assert not self._file_exists_on_disk(dataset_file)
+
     def _get_underlying_dataset_on_disk(self, hda_id: str) -> Optional[str]:
         detailed_response = self._get(f"datasets/{hda_id}", admin=True).json()
         return detailed_response.get("file_name")

--- a/test/integration/test_purge_datasets.py
+++ b/test/integration/test_purge_datasets.py
@@ -89,27 +89,9 @@ class TestPurgeDatasetsIntegration(integration_util.IntegrationTestCase):
         assert self._file_exists_on_disk(dataset_file1)
         assert self._file_exists_on_disk(dataset_file2)
 
-        # Purge the entire history
-        purge_response = self._delete(f"histories/{self.test_history_id}", data={"purge": True}, json=True)
-        self._assert_status_code_is_ok(purge_response)
-        purge_result = purge_response.json()
-
-        # Verify history is purged
+        purge_result = self.dataset_populator.purge_history(self.test_history_id)
         assert purge_result["purged"]
         assert purge_result["deleted"]
-
-        # Verify the response contains a purge_task with an id
-        assert "purge_task" in purge_result
-        purge_task = purge_result["purge_task"]
-        assert "id" in purge_task
-        purge_task_id = purge_task["id"]
-
-        # Wait for the celery task to complete via the tasks API
-        self.dataset_populator.wait_on_task_id(purge_task_id)
-
-        # After task completion, HDAs should be purged and files deleted
-        self.dataset_populator.wait_for_purge(self.test_history_id, hda1_id)
-        self.dataset_populator.wait_for_purge(self.test_history_id, hda2_id)
         assert not self._file_exists_on_disk(dataset_file1)
         assert not self._file_exists_on_disk(dataset_file2)
 
@@ -123,16 +105,8 @@ class TestPurgeDatasetsIntegration(integration_util.IntegrationTestCase):
             dataset_file = self._get_underlying_dataset_on_disk(hda_id)
             assert self._file_exists_on_disk(dataset_file)
 
-        # Purge via admin API (anonymous histories are only accessible to admins)
-        purge_response = self._delete(f"histories/{history_id}", data={"purge": True}, admin=True, json=True)
-        self._assert_status_code_is_ok(purge_response)
-        purge_result = purge_response.json()
-        assert purge_result["purged"]
-
-        # Wait for the celery purge task to finish
-        assert "purge_task" in purge_result
-        task_ok = self.dataset_populator.wait_on_task_id(purge_result["purge_task"]["id"])
-        assert task_ok
+            purge_result = self.dataset_populator.purge_history(history_id)
+            assert purge_result["purged"]
 
         assert not self._file_exists_on_disk(dataset_file)
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/22269

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
