### PR TITLE
[26.0] Raise error when API client sends invalid parameter keys

### DIFF
--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -203,12 +203,7 @@ def process_key(incoming_key: str, incoming_value: Any, d: dict[str, Any]):
         input_name = key_parts[0]
         subdict = d.get(input_name, {})
         if not isinstance(subdict, dict):
-            raise RequestParameterInvalidException(
-                f"Parameter '{incoming_key}' uses prefix '{input_name}' as a nested group, "
-                f"but '{input_name}' was already assigned the plain value {subdict}. "
-                f"Use the full prefixed parameter name (e.g. '<conditional_name>|<input_name>') "
-                f"instead of the unprefixed input name."
-            )
+            raise RequestParameterInvalidException(f"Parameter '{incoming_key}' received conflicting value.")
         d[input_name] = subdict
         process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
 

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -7,6 +7,7 @@ from typing import (
     Union,
 )
 
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
     DataToolParameter,
@@ -201,6 +202,13 @@ def process_key(incoming_key: str, incoming_value: Any, d: dict[str, Any]):
         # Section / Conditional
         input_name = key_parts[0]
         subdict = d.get(input_name, {})
+        if not isinstance(subdict, dict):
+            raise RequestParameterInvalidException(
+                f"Parameter '{incoming_key}' uses prefix '{input_name}' as a nested group, "
+                f"but '{input_name}' was already assigned the plain value {subdict}. "
+                f"Use the full prefixed parameter name (e.g. '<conditional_name>|<input_name>') "
+                f"instead of the unprefixed input name."
+            )
         d[input_name] = subdict
         process_key("|".join(key_parts[1:]), incoming_value=incoming_value, d=subdict)
 


### PR DESCRIPTION
The Sentry crash (issue https://github.com/galaxyproject/galaxy/issues/22132) was triggered by a Python Requests 2.32
client sending an invalid payload.

In this case the input was
```json
{
  "in": "custom",

  "in|custom|mtx": {
    "id": "f9cad7b01a472135e9dd0bb539e2d0de",
    "src": "hda"
  },

  "in|custom|obs": {
    "id": "f9cad7b01a472135068f117b3249ac19",
    "src": "hda"
  },

  "in|custom|var": {
    "id": "f9cad7b01a472135e497326e87a7fa84",
    "src": "hda"
  }
}
```
where `in` is a conditional and `adata_format` is the tester select that
you can in fact set to `custom`.

Replace the opaque AttributeError with a RequestParameterInvalidException
that tells the caller exactly what went wrong and how to fix their
parameter naming.

Fixes https://github.com/galaxyproject/galaxy/issues/22132

Not adding tests here, I suppose that'll be fixed and covered once we validate against the tool state.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
