### PR TITLE
[26.0]  Fix validation of certain classes of text validators in tools.

### DIFF
--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -195,14 +195,14 @@ def strictify(relaxed_state: RelaxedRequestToolState, input_models: ToolParamete
                 if not parameter.optional:
                     # restore legacy behavior of allowing empty string implicit default
                     # for these non-optional inputs.
-                    tool_state[parameter_name] = ""
+                    tool_state[parameter_name] = parameter.default_value if parameter.default_value is not None else ""
                 else:
-                    tool_state[parameter_name] = None
+                    tool_state[parameter_name] = parameter.default_value
             else:
                 # legacy behavior of converting explicit None into implicit null. We should introduce
                 # a layer somewhere to deal with this behavior further up the stack and clean up these models.
                 if not parameter.optional and tool_state[parameter_name] is None:
-                    tool_state[parameter_name] = ""
+                    tool_state[parameter_name] = parameter.default_value if parameter.default_value is not None else ""
 
     def _strictify_parameters(tool_state: Dict[str, Any], input_models: ToolParameterBundle) -> None:
         for parameter in input_models.parameters:
@@ -399,14 +399,14 @@ def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT) -> 
             if not parameter.optional:
                 # restore legacy behavior of allowing empty string implicit default
                 # for these non-optional inputs.
-                tool_state[parameter_name] = parameter.default_value or ""
+                tool_state[parameter_name] = parameter.default_value if parameter.default_value is not None else ""
             else:
-                tool_state[parameter_name] = parameter.default_value or None
+                tool_state[parameter_name] = parameter.default_value
         else:
             # legacy behavior of converting explicit None into implicit null. We should introduce
             # a layer somewhere to deal with this behavior further up the stack and clean up these models.
             if not parameter.optional and tool_state[parameter_name] is None:
-                tool_state[parameter_name] = parameter.default_value or ""
+                tool_state[parameter_name] = parameter.default_value if parameter.default_value is not None else ""
 
 
 def _initialize_section_state(parameter: SectionParameterModel, tool_state: Dict[str, Any]) -> Dict[str, Any]:

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -241,8 +241,10 @@ def pydantic_to_galaxy_type(value: Any) -> Any:
 VT = TypeVar("VT", bound=StaticValidatorModel)
 
 
-def decorate_type_with_validators_if_needed(py_type: Type, static_validator_models: Sequence[VT]) -> Type:
-    pydantic_validator = pydantic_validator_for(static_validator_models)
+def decorate_type_with_validators_if_needed(
+    py_type: Type, static_validator_models: Sequence[VT], optional: bool = False
+) -> Type:
+    pydantic_validator = pydantic_validator_for(static_validator_models, optional=optional)
     if pydantic_validator:
         return expand_annotation(py_type, [pydantic_validator])
     else:
@@ -251,11 +253,14 @@ def decorate_type_with_validators_if_needed(py_type: Type, static_validator_mode
 
 # Looks like Annotated only work with one PlainValidator so condensing all static validators
 # into a single PlainValidator for pydantic.
-def pydantic_validator_for(static_validator_models: Sequence[VT]) -> Optional[AfterValidator]:
+def pydantic_validator_for(static_validator_models: Sequence[VT], optional: bool = False) -> Optional[AfterValidator]:
 
     if static_validator_models:
 
         def validator(v: Any) -> Any:
+            if optional and (v is None or v == ""):
+                return v
+
             gx_val = pydantic_to_galaxy_type(v)
 
             for static_validator_model in static_validator_models:
@@ -289,7 +294,7 @@ class TextParameterModel(BaseGalaxyToolParameterModelDefinition):
         py_type = self.py_type
         if state_representation == "relaxed_request":
             py_type = self.py_type_relaxed_request
-        py_type = decorate_type_with_validators_if_needed(py_type, self.validators)
+        py_type = decorate_type_with_validators_if_needed(py_type, self.validators, optional=self.optional)
         if state_representation == "workflow_step_linked":
             py_type = allow_connected_value(py_type)
         requires_value = self.request_requires_value

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -735,15 +735,58 @@ def test_null_to_text_tool_with_validation(required_tool: RequiredTool, tool_inp
     required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": ""})).assert_fails()
 
 
+@requires_tool_id("gx_text_optional_with_empty_default")
+def test_optional_text_with_empty_default(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    # absent — all formats resolve to value="" default
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": ""})
+
+    # explicit null
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": None}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": None})
+
+    # explicit empty string
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": ""}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": ""})
+
+    # provided value
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": "hello"}))
+    execute.assert_has_single_job.with_output("output").with_contents_stripped("hello")
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": "hello"})
+
+
 @requires_tool_id("gx_text_optional_regex_validation")
 def test_optional_text_with_regex_validation(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
-    # absent param — legacy/21.01 resolve to value="" default, runtime skips regex for empty optional
+    # absent — no value="" default so all formats treat as None
     execute = required_tool.execute().with_inputs(tool_input_format.when.any({}))
-    execute.assert_has_single_job.with_output("inputs_json").with_json(
-        {"parameter": None} if tool_input_format.is_request else {"parameter": ""}
-    )
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": None})
 
-    # explicit null — all formats treat as "not provided" for optional
+    # explicit null
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": None}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": None})
+
+    # explicit empty string — optional so skip regex validation, "" stays as ""
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": ""}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": ""})
+
+    # valid value
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": "0.5"}))
+    execute.assert_has_single_job.with_output("output").with_contents_stripped("0.5")
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": "0.5"})
+
+    # invalid value should fail regardless of format
+    required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": "abc"})).assert_fails()
+
+
+@requires_tool_id("gx_text_optional_with_empty_default_regex_validation")
+def test_optional_text_with_empty_default_with_regex_validation(
+    required_tool: RequiredTool, tool_input_format: DescribeToolInputs
+):
+    # absent — all formats resolve to value="" default
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": ""})
+
+    # explicit null
     execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": None}))
     execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": None})
 
@@ -751,7 +794,7 @@ def test_optional_text_with_regex_validation(required_tool: RequiredTool, tool_i
     execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": ""}))
     execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": ""})
 
-    # valid value should pass all formats
+    # valid value
     execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": "0.5"}))
     execute.assert_has_single_job.with_output("output").with_contents_stripped("0.5")
     execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": "0.5"})

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -735,6 +735,31 @@ def test_null_to_text_tool_with_validation(required_tool: RequiredTool, tool_inp
     required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": ""})).assert_fails()
 
 
+@requires_tool_id("gx_text_optional_regex_validation")
+def test_optional_text_with_regex_validation(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    # absent param — legacy/21.01 resolve to value="" default, runtime skips regex for empty optional
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json(
+        {"parameter": None} if tool_input_format.is_request else {"parameter": ""}
+    )
+
+    # explicit null — all formats treat as "not provided" for optional
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": None}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": None})
+
+    # explicit empty string — optional so runtime skips regex validation
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": ""}))
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": ""})
+
+    # valid value should pass all formats
+    execute = required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": "0.5"}))
+    execute.assert_has_single_job.with_output("output").with_contents_stripped("0.5")
+    execute.assert_has_single_job.with_output("inputs_json").with_json({"parameter": "0.5"})
+
+    # invalid value should fail regardless of format
+    required_tool.execute().with_inputs(tool_input_format.when.any({"parameter": "abc"})).assert_fails()
+
+
 @requires_tool_id("cat|cat1")
 def test_deferred_basic(required_tool: RequiredTool, target_history: TargetHistory):
     has_src_dict = target_history.with_deferred_dataset_for_test_file("1.bed", ext="bed")

--- a/test/functional/tools/parameters/gx_text_optional_regex_validation.xml
+++ b/test/functional/tools/parameters/gx_text_optional_regex_validation.xml
@@ -1,0 +1,20 @@
+<tool id="gx_text_optional_regex_validation" name="gx_text_optional_regex_validation" version="1.0.0">
+    <command><![CDATA[
+echo '$parameter' >> '$output';
+cat '$inputs' >> $inputs_json;
+    ]]></command>
+    <configfiles>
+        <inputs name="inputs" filename="inputs.json" />
+    </configfiles>
+    <inputs>
+        <param name="parameter" type="text" value="" optional="true">
+            <validator type="regex">[0-9.:]+</validator>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+        <data name="inputs_json" format="json" />
+    </outputs>
+    <tests>
+    </tests>
+</tool>

--- a/test/functional/tools/parameters/gx_text_optional_with_empty_default.xml
+++ b/test/functional/tools/parameters/gx_text_optional_with_empty_default.xml
@@ -1,4 +1,4 @@
-<tool id="gx_text_optional_regex_validation" name="gx_text_optional_regex_validation" version="1.0.0">
+<tool id="gx_text_optional_with_empty_default" name="gx_text_optional_with_empty_default" version="1.0.0">
     <command><![CDATA[
 echo '$parameter' >> '$output';
 cat '$inputs' >> $inputs_json;
@@ -7,9 +7,7 @@ cat '$inputs' >> $inputs_json;
         <inputs name="inputs" filename="inputs.json" />
     </configfiles>
     <inputs>
-        <param name="parameter" type="text" optional="true">
-            <validator type="regex">[0-9.:]+</validator>
-        </param>
+        <param name="parameter" type="text" value="" optional="true" />
     </inputs>
     <outputs>
         <data name="output" format="txt" />

--- a/test/functional/tools/parameters/gx_text_optional_with_empty_default_regex_validation.xml
+++ b/test/functional/tools/parameters/gx_text_optional_with_empty_default_regex_validation.xml
@@ -1,4 +1,4 @@
-<tool id="gx_text_optional_regex_validation" name="gx_text_optional_regex_validation" version="1.0.0">
+<tool id="gx_text_optional_with_empty_default_regex_validation" name="gx_text_optional_with_empty_default_regex_validation" version="1.0.0">
     <command><![CDATA[
 echo '$parameter' >> '$output';
 cat '$inputs' >> $inputs_json;
@@ -7,7 +7,7 @@ cat '$inputs' >> $inputs_json;
         <inputs name="inputs" filename="inputs.json" />
     </configfiles>
     <inputs>
-        <param name="parameter" type="text" optional="true">
+        <param name="parameter" type="text" value="" optional="true">
             <validator type="regex">[0-9.:]+</validator>
         </param>
     </inputs>


### PR DESCRIPTION
This is causing issues in the workflow work - a couple tools use this pattern that the tool request API was just rejecting:

```
        <param name="title" type="text" value="" optional="true" label="Report title" help="It is printed as page header">
            <sanitizer invalid_char="">
                <valid initial="string.letters,string.digits">
                    <add value=","/>
                    <add value=":"/>
                    <add value="-"/>
                    <add value="_"/>
                    <add value=" "/>
                    <add value="."/>
                </valid>
            </sanitizer>
            <validator type="regex">[0-9a-zA-Z,: _.-]+</validator>
        </param>
```

Rejecting empty values is the right thing to do with that regex - but Galaxy has a bug I guess that lets it through and so we just need to do that forever I think.

Random Claude Table:

| Input | optional (no default) | optional value="" | optional value="" + regex |
|-------|----------------------|-------------------|--------------------------|
| {}    | None                 | ""                | ""                        |
| None  | None                 | None              | None                      |
| ""    | ""                   | ""                | ""                        |
| valid | value                | value             | value                     |
| bad   | value                | value             | fails                     |

All rows now consistent across legacy, 21.01, and request formats.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
