### PR TITLE
[26.0] Fail early wehn no route match is found

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -220,7 +220,7 @@ class WebApplication:
         else:
             environ["is_api_request"] = False
             controllers = self.controllers
-        if map_match is None:
+        if not map_match:
             raise webob.exc.HTTPNotFound(f"No route for {path_info}")
         self.trace(path_info=path_info, map_match=map_match)
         # Setup routes
@@ -264,7 +264,10 @@ class WebApplication:
             f"{'api' if environ['is_api_request'] else 'web'}.{controller_name}.{action_tag}"
         )
         # Combine mapper args and query string / form args and call
-        kwargs = trans.request.params.mixed()
+        try:
+            kwargs = trans.request.params.mixed()
+        except UnicodeDecodeError:
+            raise webob.exc.HTTPBadRequest("Unable to decode request parameters.")
         kwargs.update(map_match)
         # Special key for AJAX debugging, remove to avoid confusing methods
         kwargs.pop("_", None)


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/22283 map_match must be a dict with a given structure, see
```
    def _resolve_map_match(self, map_match, path_info, controllers, use_default=True):
        # Get the controller class
        controller_name = map_match.pop("controller", None)
        controller = controllers.get(controller_name, None)
        if controller is None:
            raise webob.exc.HTTPNotFound(f"No controller for {path_info}")
```
just below. So let's fail early if the dict is empty. Also fail gracefully on non-unicode query params.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
