### PR TITLE
[26.0] Raise MessageException instead of generic Exception in rules_dsl

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -51,6 +51,7 @@ from galaxy.short_term_storage import (
     storage_context,
 )
 from galaxy.util import validation
+from galaxy.util.rules_dsl import RulesDSLError
 
 if TYPE_CHECKING:
     from galaxy.model import (
@@ -740,7 +741,10 @@ class DatasetCollectionManager:
         elements = hdca_collection.elements
         collection_type_description = self.collection_type_descriptions.for_collection_type(collection_type)
         initial_data, initial_sources = self.__init_rule_data(elements, collection_type_description)
-        data, sources = rule_set.apply(initial_data, initial_sources)
+        try:
+            data, sources = rule_set.apply(initial_data, initial_sources)
+        except RulesDSLError as e:
+            raise MessageException(str(e)) from e
 
         collection_type = rule_set.collection_type
         collection_type_description = self.collection_type_descriptions.for_collection_type(collection_type)

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -11,6 +11,10 @@ import yaml
 from galaxy.util.resources import resource_string
 
 
+class RulesDSLError(Exception):
+    pass
+
+
 def get_rules_specification():
     return yaml.safe_load(resource_string(__name__, "rules_dsl_spec.yml"))
 
@@ -48,11 +52,11 @@ def apply_regex(regex, target, data, replacement=None, group_count=None, allow_u
                         new_columns = ["" for _ in range(group_count)]
                     result = row + new_columns
                 else:
-                    raise Exception(f"Problem applying regular expression [{regex}] to [{source}].")
+                    raise RulesDSLError(f"Problem applying regular expression [{regex}] to [{source}].")
             else:
                 if group_count:
                     if len(match.groups()) != group_count:
-                        raise Exception("Problem applying regular expression, wrong number of groups found.")
+                        raise RulesDSLError("Problem applying regular expression, wrong number of groups found.")
 
                     result = row + list(match.groups())
                 else:
@@ -65,7 +69,7 @@ def apply_regex(regex, target, data, replacement=None, group_count=None, allow_u
                 if allow_unmatched:
                     result = row + [""]
                 else:
-                    raise Exception(f"Problem applying regular expression [{regex}] to [{source}].")
+                    raise RulesDSLError(f"Problem applying regular expression [{regex}] to [{source}].")
 
         return result
 


### PR DESCRIPTION
Fixes #22100. When a regular expression fails to match in apply_regex(), the generic Exception was not caught by the API layer, resulting in an unhandled server error. Using MessageException ensures the error message is properly surfaced to users and matches error handling for other scenarios in lib/galaxy/util/rules_dsl.py.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
