### PR TITLE
[26.0] Fix nested DatasetCollectionElement in dynamic options

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -1079,10 +1079,10 @@ def _get_ref_data(other_values, ref_name):
         if is_runtime_value(ref):
             return []
         raise ValueError
-    if isinstance(ref, DatasetCollectionElement) and ref.hda:
-        ref = ref.hda
+    if isinstance(ref, DatasetCollectionElement):
+        return ref.dataset_instances
     if isinstance(ref, (DatasetFilenameWrapper, HistoryDatasetAssociation, LibraryDatasetDatasetAssociation)):
-        ref = [ref]
+        return [ref]
     elif isinstance(ref, HistoryDatasetCollectionAssociation):
-        ref = ref.to_hda_representative(multiple=True)
+        return ref.to_hda_representative(multiple=True)
     return ref

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -286,6 +286,26 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert "hg18_value" in option_values
             assert "mm10_value" in option_values
 
+    @skip_without_tool("dbkey_filter_collection_input")
+    def test_run_dbkey_filter_nested_collection_dce(self):
+        with self.dataset_populator.test_history() as history_id:
+            list_list = self.dataset_collection_populator.create_list_of_list_in_history(history_id, wait=True).json()
+            # Set dbkey on the datasets in the inner list
+            for outer_element in list_list["elements"]:
+                for inner_element in outer_element["object"]["elements"]:
+                    hda_id = inner_element["object"]["id"]
+                    self.dataset_populator._put(
+                        f"histories/{history_id}/contents/{hda_id}", {"genome_build": "hg19"}, json=True
+                    )
+            # Get DCE ID of the inner list element - this is a DatasetCollectionElement
+            # wrapping a child collection (not an HDA)
+            dce_id = list_list["elements"][0]["id"]
+            inputs = {
+                "inputs": {"src": "dce", "id": dce_id},
+                "index": "hg19_value",
+            }
+            self._run("dbkey_filter_collection_input", history_id, inputs, assert_ok=True)
+
     @skip_without_tool("cheetah_problem_unbound_var_input")
     def test_legacy_biotools_xref_injection(self):
         url = self._api_url("tools/cheetah_problem_unbound_var_input")


### PR DESCRIPTION
When a `DatasetCollectionElement` containing an LDDA or nested child collection (rather than an HDA) was used as a reference for dynamic option filtering, `_get_ref_data()` failed to normalize it into a list, causing "TypeError: 'DatasetCollectionElement' object is not iterable".

Use `DatasetCollectionElement.dataset_instances` which correctly returns a list of dataset instances for all element types (HDA, LDDA, or nested collections).

Fixes https://github.com/galaxyproject/galaxy/issues/22099

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
