### PR TITLE
[25.1] Fix flaky job search for HDCA inputs on PostgreSQL

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     or_,
     true,
 )
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import select
 from typing_extensions import TypedDict
@@ -798,7 +799,7 @@ class JobSearch:
         if self.dialect_name == "sqlite":
             return func.group_concat(column)
         else:
-            return func.array_agg(column, order_by=column)
+            return func.array_agg(aggregate_order_by(column, column.asc()))
 
     def _build_stmt_for_hdca(
         self, stmt, data_conditions, used_ids, k, v, user_id, value_index, require_name_match=True


### PR DESCRIPTION
The job search HDCA signature comparison was non-deterministic because `func.array_agg(column, order_by=column)` silently drops the `order_by` keyword argument in SQLAlchemy, generating `array_agg(col)` instead of `array_agg(col ORDER BY col)`.

This meant both the reference and candidate HDCA signatures were aggregated in whatever scan order PostgreSQL happened to use. When the query planner chose different scan orders for the reference and candidate CTEs (which depends on table statistics and query plan), the resulting arrays had different element orderings, causing the equality comparison to fail — even for the exact same HDCA.

The fix uses `aggregate_order_by` from SQLAlchemy's PostgreSQL dialect, which correctly generates `array_agg(col ORDER BY col ASC)`.

Diagnostic output from CI confirming the root cause:

  reference full signature=['data0;251', 'data1;252', 'data2;253']
  candidate full signatures=[(75, ['data2;253', 'data1;252', 'data0;251'])]
  equivalent HDCA ids=[]

Same HDCA (id=75), same elements, different array ordering → no match.

Investigation details: https://gist.github.com/mvdbeek/a3bd1528be0985e4a7d36e929a502bd2

Fixes #21230

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
