### PR TITLE
[26.0] Fix HDCA shown as unavailable on tool form rerun

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2452,15 +2452,25 @@ class DataToolParameter(BaseDataToolParameter):
         # Route each to the correct options list by type so the client can
         # match them by id *and* src.
         for value in job_input_values:
-            if isinstance(value, (HistoryDatasetCollectionAssociation, HistoryDatasetAssociation)):
+            if isinstance(value, HistoryDatasetCollectionAssociation):
+                # HDCAs are handled by the dataset collections section below;
+                # only add here if not visible in the current history.
+                if value.deleted or not value.visible or value.history != history:
+                    if value.deleted:
+                        state = "deleted"
+                    elif not value.visible:
+                        state = "hidden"
+                    else:
+                        state = "not in current history"
+                    append(d["options"]["hdca"], value, f"({state}) {value.name}", "hdca", True)
+            elif isinstance(value, HistoryDatasetAssociation):
                 if value.deleted:
                     state = "deleted"
                 elif not value.visible:
                     state = "hidden"
                 else:
                     state = "not in current history"
-                src = "hdca" if isinstance(value, HistoryDatasetCollectionAssociation) else "hda"
-                append(d["options"][src], value, f"({state}) {value.name}", src, True)
+                append(d["options"]["hda"], value, f"({state}) {value.name}", "hda", True)
             elif isinstance(value, DatasetCollectionElement):
                 append_dce(value)
             elif isinstance(value, LibraryDatasetDatasetAssociation):


### PR DESCRIPTION
After 6a9323a79 (Fix HDCA lost in tool form on rerun), visible HDCAs in the current history were incorrectly added to the job_input_values fallback section with a "(not in current history)" label. This happened because active_visible_datasets_and_roles only iterates HDAs, so HDCAs were never removed from job_input_values during matching. The HDCA then appeared twice in the form: once correctly from the dataset collections section, and once as a "keep" option with wrong state.

Skip HDCAs in the fallback loop when they are active, visible, and in the current history — they are already properly handled by the active_visible_dataset_collections loop below.

Fixes `lib/galaxy_test/selenium/test_tool_form.py::TestToolForm::test_rerun_dataset_collection_element - selenium.common.exceptions.TimeoutException: Message: Timeout waiting on CSS selector [.dataset-collection-panel] to become present.`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
