### PR TITLE
Improve pairing wizard UX

### DIFF
--- a/client/src/components/Collections/ListWizard.vue
+++ b/client/src/components/Collections/ListWizard.vue
@@ -6,6 +6,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import type { CollectionElementIdentifiers, CreateNewCollectionPayload } from "@/api";
 import { createHistoryDatasetCollectionInstanceFull } from "@/api/datasetCollections";
 import { useWizard } from "@/components/Common/Wizard/useWizard";
+import { useHistoryBreadCrumbsToForProps } from "@/composables/historyBreadcrumbs";
 import { useCollectionBuilderItemSelection } from "@/stores/collectionBuilderItemsStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
@@ -19,6 +20,7 @@ import { showHid } from "./common/useCollectionCreator";
 import type { WhichListBuilder } from "./ListWizard/types";
 import { useAutoPairing } from "./usePairing";
 
+import BreadcrumbHeading from "../Common/BreadcrumbHeading.vue";
 import LoadingSpan from "../LoadingSpan.vue";
 import ListCollectionCreator from "./ListCollectionCreator.vue";
 import WhichBuilder from "./ListWizard/WhichBuilder.vue";
@@ -43,7 +45,15 @@ const collectionCreated = ref(false);
 
 type InferrableBuilder = "list" | "list:paired";
 const collectionCreator = ref<CollectionCreatorComponent>();
-const { selectedItems } = storeToRefs(store);
+const { selectedItems, historyId } = storeToRefs(store);
+
+const { breadcrumbItems } = useHistoryBreadCrumbsToForProps(
+    {
+        ...props,
+        historyId: historyId.value || "",
+    },
+    "Create List",
+);
 
 const inferredBuilder = ref<InferrableBuilder>("list");
 const builderInputsValid = ref(false);
@@ -198,7 +208,10 @@ function onRuleState(newRuleState: boolean) {
 </script>
 
 <template>
-    <div v-if="currentHistoryId">
+    <div v-if="currentHistoryId && historyId">
+        <BreadcrumbHeading :items="breadcrumbItems">
+            <i class="d-flex align-items-center"> {{ selectedItems.length }} datasets selected </i>
+        </BreadcrumbHeading>
         <div v-if="creationError">
             <BAlert variant="danger" show>
                 {{ creationError }}
@@ -273,5 +286,8 @@ function onRuleState(newRuleState: boolean) {
                     @validInput="onRuleState" />
             </div>
         </GenericWizard>
+    </div>
+    <div v-else>
+        <BAlert show> Select datasets from the history panel to use the Galaxy list building wizard. </BAlert>
     </div>
 </template>

--- a/client/src/components/Collections/ListWizard/WhichBuilder.vue
+++ b/client/src/components/Collections/ListWizard/WhichBuilder.vue
@@ -47,8 +47,7 @@ function toggleAdvanced() {
                     <b>List of Paired Datasets</b>
                 </BCardTitle>
                 <div>
-                    This option creates a uniform list of paired datasets, use this option if all of your data should be
-                    paired off.
+                    This option creates a list of paired datasets (e.g., paired-end data from Illumina and ElementBio), use this option if all of your data should be paired off.
                 </div>
             </BCard>
             <BCard

--- a/client/src/components/Collections/ListWizard/WhichBuilder.vue
+++ b/client/src/components/Collections/ListWizard/WhichBuilder.vue
@@ -47,7 +47,8 @@ function toggleAdvanced() {
                     <b>List of Paired Datasets</b>
                 </BCardTitle>
                 <div>
-                    This option creates a list of paired datasets (e.g., paired-end data from Illumina and ElementBio), use this option if all of your data should be paired off.
+                    This option creates a list of paired datasets (e.g., paired-end data from Illumina and ElementBio),
+                    use this option if all of your data should be paired off.
                 </div>
             </BCard>
             <BCard

--- a/client/src/components/Collections/common/AutoPairing.vue
+++ b/client/src/components/Collections/common/AutoPairing.vue
@@ -91,9 +91,8 @@ function onApply() {
             <div class="help-text mt-2">
                 Use the text boxes above to enter parts of file names that differentiate forward and reverse pairs.
                 These could be things like <code>_F</code> and <code>_R</code>, <code>_1</code> and <code>_2</code>, or
-                <code>.1</code> and <code>.2</code>. For example, if your files are named
-                <code>reads_F.fq.gz</code> and <code>reads_R.fq.gz</code>, then enter <code>_F</code> and
-                <code>_R</code>.
+                <code>.1</code> and <code>.2</code>. For example, if your files are named <code>reads_F.fq.gz</code> and
+                <code>reads_R.fq.gz</code>, then enter <code>_F</code> and <code>_R</code>.
             </div>
             <div class="summary-text mt-2">
                 {{ summaryText }}
@@ -106,12 +105,14 @@ function onApply() {
             <ol class="summary-list">
                 <li v-for="(pair, index) of currentSummary?.pairs" :key="`paired_${index}`">
                     <span v-if="index > 0">,</span>
-                    <span class="pair-name">{{ pair.name }}</span> (<span class="direction">FORWARD</span
-                    ><span v-if="showHid" class="dataset-hid">{{ getHid(pair.forward) }}: </span
-                    ><span class="dataset-name">{{ pair.forward.name }}</span> | <span class="direction">REVERSE</span
-                    ><span v-if="showHid" class="dataset-hid">{{ getHid(pair.reverse) }}: </span
-                    ><span class="dataset-name">{{ pair.reverse.name }}</span
-                    >)
+                    <span class="pair-name">{{ pair.name }}</span>
+                    (
+                    <span class="direction">FORWARD</span>
+                    <span v-if="showHid" class="dataset-hid">{{ getHid(pair.forward) }}: </span>
+                    <span class="dataset-name">{{ pair.forward.name }}</span> | <span class="direction">REVERSE</span>
+                    <span v-if="showHid" class="dataset-hid">{{ getHid(pair.reverse) }}: </span>
+                    <span class="dataset-name">{{ pair.reverse.name }}</span>
+                    )
                 </li>
             </ol>
             <span v-if="hasUnmatchedDatasets">
@@ -136,11 +137,9 @@ function onApply() {
                                 'extension' in unpairedDataset &&
                                 showElementExtension(unpairedDataset)
                             "
-                            class="dataset-extension-wrapper"
-                            >(
-                            <span class="dataset-extension">{{ unpairedDataset.extension }}</span>
-                            )</span
-                        >
+                            class="dataset-extension-wrapper">
+                            <span class="dataset-extension">({{ unpairedDataset.extension }})</span>
+                        </span>
                     </li>
                 </ul>
             </span>

--- a/client/src/components/Collections/common/AutoPairing.vue
+++ b/client/src/components/Collections/common/AutoPairing.vue
@@ -190,7 +190,6 @@ function onApply() {
             color: gray;
             font-size: var(--font-size-small);
             padding-right: 5px;
-            display: none;
         }
     }
 }

--- a/client/src/components/Collections/common/AutoPairing.vue
+++ b/client/src/components/Collections/common/AutoPairing.vue
@@ -166,13 +166,15 @@ function onApply() {
 </template>
 
 <style lang="scss" scoped>
+@import "@/style/scss/custom_theme_variables.scss";
+
 .help-text {
-    font-size: 0.9rem;
-    color: gray;
+    font-size: var(--font-size-medium);
+    color: var(--color-grey-400);
 }
 
 .summary-text {
-    font-size: 1rem;
+    font-size: var(--font-size-large);
 }
 
 .summary-list {
@@ -186,7 +188,7 @@ function onApply() {
             font-variant: small-caps;
             font-weight: normal;
             color: gray;
-            font-size: 0.8rem;
+            font-size: var(--font-size-small);
             padding-right: 5px;
             display: none;
         }
@@ -194,12 +196,12 @@ function onApply() {
 }
 
 .summary-list-header {
-    font-size: 1rem;
+    font-size: var(--font-size-large);
     font-weight: bold;
 }
 
 .summary-list-description {
-    font-size: 0.9rem;
+    font-size: var(--font-size-medium);
     font-style: italic;
 }
 
@@ -208,17 +210,17 @@ function onApply() {
 
     li {
         list-style-type: disc;
-        font-size: 0.9rem;
+        font-size: var(--font-size-medium);
     }
 }
 
 .pair-name {
     font-weight: bold;
-    font-size: 0.9rem;
+    font-size: var(--font-size-medium);
 }
 .unpaired-dataset-name {
     font-weight: bold;
-    font-size: 0.9rem;
+    font-size: var(--font-size-medium);
 }
 
 .dataset-extension-wrapper {

--- a/client/src/components/Collections/common/AutoPairing.vue
+++ b/client/src/components/Collections/common/AutoPairing.vue
@@ -88,6 +88,13 @@ function onApply() {
                 :forward-filter="currentForwardFilter"
                 :reverse-filter="currentReverseFilter"
                 @on-update="onUpdate" />
+            <div class="help-text mt-2">
+                Use the text boxes above to enter parts of file names that differentiate forward and reverse pairs.
+                These could be things like <code>_F</code> and <code>_R</code>, <code>_1</code> and <code>_2</code>, or
+                <code>.1</code> and <code>.2</code>. For example, if your files are named
+                <code>reads_F.fq.gz</code> and <code>reads_R.fq.gz</code>, then enter <code>_F</code> and
+                <code>_R</code>.
+            </div>
             <div class="summary-text mt-2">
                 {{ summaryText }}
             </div>
@@ -119,9 +126,8 @@ function onApply() {
                         Any of these datasets will be included in the final list if they are not discarded.
                     </span>
                 </div>
-                <ol class="summary-list">
+                <ul class="unmatched-list">
                     <li v-for="(unpairedDataset, index) of currentSummary?.unpaired" :key="`unpaired_${index}`">
-                        <span v-if="index > 0">,</span>
                         <span v-if="showHid" class="dataset-hid">{{ getHid(unpairedDataset) }}: </span>
                         <span class="unpaired-dataset-name dataset-name">{{ unpairedDataset.name }}</span>
                         <span
@@ -136,7 +142,7 @@ function onApply() {
                             )</span
                         >
                     </li>
-                </ol>
+                </ul>
             </span>
             <span v-else>
                 <div class="summary-list-header mt-2">No Un-matched Datasets</div>
@@ -161,6 +167,11 @@ function onApply() {
 </template>
 
 <style lang="scss" scoped>
+.help-text {
+    font-size: 0.9rem;
+    color: gray;
+}
+
 .summary-text {
     font-size: 1rem;
 }
@@ -191,6 +202,15 @@ function onApply() {
 .summary-list-description {
     font-size: 0.9rem;
     font-style: italic;
+}
+
+.unmatched-list {
+    margin-left: 20px;
+
+    li {
+        list-style-type: disc;
+        font-size: 0.9rem;
+    }
 }
 
 .pair-name {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -330,7 +330,7 @@ export default {
         listWizard(advanced) {
             const { setSelectedItems } = useCollectionBuilderItemSelection();
             const selection = Array.from(this.contentSelection.values());
-            setSelectedItems(selection);
+            setSelectedItems(this.history.id, selection);
 
             if (this.$route.path === "/collection/new_list") {
                 // vue-router 4 supports a native force push with clean URLs, but we're using a __vkey__

--- a/client/src/stores/collectionBuilderItemsStore.ts
+++ b/client/src/stores/collectionBuilderItemsStore.ts
@@ -9,12 +9,14 @@ import type { ShowElementExtensionFunction } from "@/components/Collections/comm
  */
 export const useCollectionBuilderItemSelection = defineStore("collectionBuilderItemSelection", () => {
     const selectedItems = ref<HistoryItemSummary[]>([]);
+    const historyId = ref<string | null>(null);
 
-    function setSelectedItems(newSelectedItems: HistoryItemSummary[]) {
+    function setSelectedItems(selectionHistoryId: string, newSelectedItems: HistoryItemSummary[]) {
+        historyId.value = selectionHistoryId;
         selectedItems.value = newSelectedItems;
     }
 
-    return { selectedItems, setSelectedItems };
+    return { selectedItems, historyId, setSelectedItems };
 });
 
 export const usePairingDatasetTargetsStore = defineStore("pairingDatasetTargets", {


### PR DESCRIPTION
## Summary
- Add help text under filter boxes explaining how to enter forward/reverse pair naming patterns
- Update paired datasets card description with Illumina/ElementBio examples
- Display unmatched datasets as a bulleted list instead of inline comma-separated text


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Navigate to `/collection/new_list?advanced=true` (by selecting a few datasets from your history, and choosing the "Advanced Build List" selection operation)
  2. Select "List of Paired Datasets" on the list builder
  3. Verify help text appears below filter boxes on auto-pairing step
  4. Verify unmatched datasets render as a bulleted list

🤖 Generated with [Claude Code](https://claude.com/claude-code)