### PR TITLE
[26.0] Fix AttributeError when anonymous user searches workflows with ``is:bookmarked``

### DIFF
--- a/client/src/components/Workflow/List/WorkflowList.vue
+++ b/client/src/components/Workflow/List/WorkflowList.vue
@@ -86,7 +86,7 @@ const bookmarkButtonTitle = computed(() =>
     showBookmarked.value ? "Hide bookmarked workflows" : "Show bookmarked workflows",
 );
 
-const workflowFilters = computed(() => getWorkflowFilters(props.activeList));
+const workflowFilters = computed(() => getWorkflowFilters(props.activeList, userStore.isAnonymous));
 const rawFilters = computed(() =>
     Object.fromEntries(workflowFilters.value.getFiltersForText(filterText.value, true, false)),
 );
@@ -425,7 +425,7 @@ onMounted(() => {
                 :show-advanced.sync="showAdvanced">
                 <template v-slot:menu-help-text>
                     <!-- eslint-disable-next-line vue/no-v-html -->
-                    <div v-html="helpHtml(activeList)"></div>
+                    <div v-html="helpHtml(activeList, userStore.isAnonymous)"></div>
                 </template>
             </FilterMenu>
 

--- a/client/src/components/Workflow/List/workflowFilters.ts
+++ b/client/src/components/Workflow/List/workflowFilters.ts
@@ -1,6 +1,6 @@
 import Filtering, { contains, equals, expandNameTag, toBool } from "@/utils/filtering";
 
-export function helpHtml(activeList = "my") {
+export function helpHtml(activeList = "my", isAnonymous = false) {
     let extra = "";
     if (activeList === "my") {
         extra = `<dt><code>is:published</code></dt>
@@ -30,11 +30,13 @@ export function helpHtml(activeList = "my") {
         extra = `<dt><code>user:____</code></dt>
         <dd>
             Shows workflows owned by the given user.
-        </dd>
-        <dt><code>is:shared_with_me</code></dt>
+        </dd>`;
+        if (!isAnonymous) {
+            extra += `<dt><code>is:shared_with_me</code></dt>
         <dd>
             Shows workflows shared by another user directly with you.
         </dd>`;
+        }
     }
 
     const conditionalHelpHtml = `<div>
@@ -71,7 +73,7 @@ export function helpHtml(activeList = "my") {
     return conditionalHelpHtml;
 }
 
-export function getWorkflowFilters(activeList = "my") {
+export function getWorkflowFilters(activeList = "my", isAnonymous = false) {
     const commonFilters = {
         name: { placeholder: "name", type: String, handler: contains("name"), menuItem: true },
         n: { handler: contains("n"), menuItem: false },
@@ -152,27 +154,25 @@ export function getWorkflowFilters(activeList = "my") {
             false,
         );
     } else {
-        return new Filtering(
-            {
-                ...commonFilters,
-                user: {
-                    placeholder: "owner",
-                    type: String,
-                    handler: contains("user"),
-                    menuItem: true,
-                },
-                u: { handler: contains("u"), menuItem: false },
-                shared_with_me: {
-                    placeholder: "Shared with me",
-                    type: Boolean,
-                    boolType: "is",
-                    handler: equals("shared_with_me", "shared_with_me", toBool),
-                    menuItem: true,
-                },
+        const publishedFilters: Record<string, any> = {
+            ...commonFilters,
+            user: {
+                placeholder: "owner",
+                type: String,
+                handler: contains("user"),
+                menuItem: true,
             },
-            undefined,
-            false,
-            false,
-        );
+            u: { handler: contains("u"), menuItem: false },
+        };
+        if (!isAnonymous) {
+            publishedFilters.shared_with_me = {
+                placeholder: "Shared with me",
+                type: Boolean,
+                boolType: "is",
+                handler: equals("shared_with_me", "shared_with_me", toBool),
+                menuItem: true,
+            };
+        }
+        return new Filtering(publishedFilters, undefined, false, false);
     }
 }

--- a/client/src/utils/filterConversion.test.js
+++ b/client/src/utils/filterConversion.test.js
@@ -28,6 +28,14 @@ describe("test filtering helpers to convert filters to filter text", () => {
         expect(HistoryFilters.containsDefaults(filters)).toBe(true);
     });
 
+    it("published filters exclude shared_with_me for anonymous users", async () => {
+        const loggedInFilters = getWorkflowFilters("published", false);
+        const anonFilters = getWorkflowFilters("published", true);
+        const filters = { shared_with_me: true };
+        expect(Object.keys(loggedInFilters.getValidFilters(filters).validFilters)).toContain("shared_with_me");
+        expect(Object.keys(anonFilters.getValidFilters(filters).validFilters)).not.toContain("shared_with_me");
+    });
+
     it("verify correct conversion of filters", async () => {
         const filters = {
             deleted: HistoryFilters.defaultFilters.deleted,

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -246,17 +246,19 @@ class WorkflowsManager(sharable.SharableModelManager[model.StoredWorkflow], dele
                                 message = "Can only use tag is:shared_with_me if show_shared parameter also true."
                                 raise exceptions.RequestParameterInvalidException(message)
                             if user is None:
-                                stmt = stmt.where(false())
-                            else:
-                                stmt = stmt.where(StoredWorkflowUserShareAssociation.user == user)
+                                raise exceptions.RequestParameterInvalidException(
+                                    "Can only use search filter is:shared_with_me when logged in."
+                                )
+                            stmt = stmt.where(StoredWorkflowUserShareAssociation.user == user)
                         elif q == "bookmarked":
                             if user is None:
-                                stmt = stmt.where(false())
-                            else:
-                                stmt = stmt.join(
-                                    model.StoredWorkflowMenuEntry,
-                                    model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id,
-                                ).where(model.StoredWorkflowMenuEntry.user_id == user.id)
+                                raise exceptions.RequestParameterInvalidException(
+                                    "Can only use search filter is:bookmarked when logged in."
+                                )
+                            stmt = stmt.join(
+                                model.StoredWorkflowMenuEntry,
+                                model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id,
+                            ).where(model.StoredWorkflowMenuEntry.user_id == user.id)
                 elif isinstance(term, RawTextTerm):
                     tf = w_tag_filter(term.text, False)
                     alias = aliased(User)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -245,12 +245,18 @@ class WorkflowsManager(sharable.SharableModelManager[model.StoredWorkflow], dele
                             if not show_shared:
                                 message = "Can only use tag is:shared_with_me if show_shared parameter also true."
                                 raise exceptions.RequestParameterInvalidException(message)
-                            stmt = stmt.where(StoredWorkflowUserShareAssociation.user == user)
+                            if user is None:
+                                stmt = stmt.where(false())
+                            else:
+                                stmt = stmt.where(StoredWorkflowUserShareAssociation.user == user)
                         elif q == "bookmarked":
-                            stmt = stmt.join(
-                                model.StoredWorkflowMenuEntry,
-                                model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id,
-                            ).where(model.StoredWorkflowMenuEntry.user_id == user.id)
+                            if user is None:
+                                stmt = stmt.where(false())
+                            else:
+                                stmt = stmt.join(
+                                    model.StoredWorkflowMenuEntry,
+                                    model.StoredWorkflowMenuEntry.stored_workflow_id == StoredWorkflow.id,
+                                ).where(model.StoredWorkflowMenuEntry.user_id == user.id)
                 elif isinstance(term, RawTextTerm):
                     tf = w_tag_filter(term.text, False)
                     alias = aliased(User)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1503,13 +1503,13 @@ steps:
 
     def test_anonymous_search_bookmarked(self):
         with self._different_user(anon=True):
-            index_ids = self.workflow_populator.index_ids(search="is:bookmarked", show_published=True)
-            assert index_ids == []
+            response = self._get("workflows?show_published=true&search=is:bookmarked")
+            self._assert_status_code_is(response, 400)
 
     def test_anonymous_search_shared_with_me(self):
         with self._different_user(anon=True):
-            index_ids = self.workflow_populator.index_ids(search="is:shared_with_me", show_shared=True)
-            assert index_ids == []
+            response = self._get("workflows?show_shared=true&search=is:shared_with_me")
+            self._assert_status_code_is(response, 400)
 
     def test_import_published(self):
         workflow_id = self.workflow_populator.simple_workflow("test_import_published", publish=True)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1501,6 +1501,16 @@ steps:
             ids = [w["id"] for w in workflow_index]
             assert workflow_id in ids
 
+    def test_anonymous_search_bookmarked(self):
+        with self._different_user(anon=True):
+            index_ids = self.workflow_populator.index_ids(search="is:bookmarked", show_published=True)
+            assert index_ids == []
+
+    def test_anonymous_search_shared_with_me(self):
+        with self._different_user(anon=True):
+            index_ids = self.workflow_populator.index_ids(search="is:shared_with_me", show_shared=True)
+            assert index_ids == []
+
     def test_import_published(self):
         workflow_id = self.workflow_populator.simple_workflow("test_import_published", publish=True)
         with self._different_user():


### PR DESCRIPTION
When an anonymous user queries the workflows API with `is:bookmarked` or `is:shared_with_me` search filters, `trans.user` is None, causing an AttributeError on `user.id`. Return empty results instead of crashing, since anonymous users have no bookmarks or shared workflows.

Fixes https://github.com/galaxyproject/galaxy/issues/22292

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
