### PR TITLE
[26.0] Improve timeout and error handling in ``/api/proxy`` endpoint

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -308,6 +308,16 @@ class ServerNotConfiguredForRequest(MessageException):
     err_code = error_codes_by_name["SERVER_NOT_CONFIGURED_FOR_REQUEST"]
 
 
+class UpstreamProxyError(MessageException):
+    status_code = 502
+    err_code = error_codes_by_name["UPSTREAM_PROXY_ERROR"]
+
+
+class GatewayTimeoutException(MessageException):
+    status_code = 504
+    err_code = error_codes_by_name["UPSTREAM_PROXY_TIMEOUT"]
+
+
 class HandlerAssignmentError(Exception):
     def __init__(self, msg=None, obj=None, **kwargs):
         super().__init__(msg)

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -218,5 +218,15 @@
         "name": "SERVER_NOT_CONFIGURED_FOR_REQUEST",
         "code": 501002,
         "message": "Server not configured for the request. The Galaxy admin may be able to resolve the problem by installing additional dependencies or setting up new infrastructure."
+    },
+    {
+        "name": "UPSTREAM_PROXY_ERROR",
+        "code": 502001,
+        "message": "An error occurred while proxying a request to an upstream server."
+    },
+    {
+        "name": "UPSTREAM_PROXY_TIMEOUT",
+        "code": 504001,
+        "message": "The upstream server did not respond in time."
     }
 ]

--- a/lib/galaxy/webapps/galaxy/api/proxy.py
+++ b/lib/galaxy/webapps/galaxy/api/proxy.py
@@ -3,6 +3,7 @@ API Controller to proxy remote files.
 """
 
 import logging
+import time
 from functools import partial
 from urllib.parse import (
     urljoin,
@@ -21,7 +22,9 @@ from starlette.responses import (
 )
 
 from galaxy.exceptions import (
+    GatewayTimeoutException,
     RequestParameterInvalidException,
+    UpstreamProxyError,
     UserRequiredException,
 )
 from galaxy.files.uris import validate_uri_access
@@ -42,6 +45,8 @@ URLQueryParam: str = Query(
 
 ALLOWED_SCHEMES = ("https", "http")
 MAX_REDIRECTS = 5
+MAX_STREAM_BYTES = 1 * 1024 * 1024  # 1 MB
+MAX_STREAM_SECONDS = 10
 
 
 def is_valid_url(url: str) -> bool:
@@ -83,7 +88,9 @@ class FastAPIProxy:
         # This is to prevent the server from hanging indefinitely
         timeout = httpx.Timeout(10.0, connect=60.0)
 
+        response = None
         client = httpx.AsyncClient(timeout=timeout)
+        streaming = False
         try:
             response = await self._handle_redirects_validation(request, url, trans, headers, client)
 
@@ -93,13 +100,32 @@ class FastAPIProxy:
 
                 async def stream_with_cleanup():
                     """Stream response chunks and ensure cleanup on completion or error."""
+                    total_bytes = 0
+                    start_time = time.monotonic()
                     try:
                         async for chunk in response.aiter_bytes():
+                            total_bytes += len(chunk)
+                            if total_bytes > MAX_STREAM_BYTES:
+                                log.warning(
+                                    "Proxy stream to %s exceeded max size of %d bytes",
+                                    url,
+                                    MAX_STREAM_BYTES,
+                                )
+                                break
+                            elapsed = time.monotonic() - start_time
+                            if elapsed > MAX_STREAM_SECONDS:
+                                log.warning(
+                                    "Proxy stream to %s exceeded max time of %d seconds",
+                                    url,
+                                    MAX_STREAM_SECONDS,
+                                )
+                                break
                             yield chunk
                     finally:
                         await response.aclose()
                         await client.aclose()
 
+                streaming = True
                 # StreamingResponse will handle chunked transfer encoding automatically
                 return StreamingResponse(
                     stream_with_cleanup(),
@@ -116,11 +142,13 @@ class FastAPIProxy:
         except httpx.InvalidURL as e:
             # Catch any URL validation errors that slip through our pre-validation
             raise RequestParameterInvalidException(f"Invalid URL format: {e}")
+        except httpx.TimeoutException as e:
+            raise GatewayTimeoutException(f"Timeout proxying request to {url}: {type(e).__name__}")
         except httpx.RequestError as e:
-            raise Exception(f"Request error: {e}")
+            raise UpstreamProxyError(f"Error proxying request to {url}: {type(e).__name__}: {e}")
         finally:
-            # Only cleanup for non-GET requests (GET cleanup happens in the stream generator)
-            if request.method != "GET":
+            # Only cleanup if we're NOT handing off to the stream generator
+            if not streaming:
                 if response is not None:
                     await response.aclose()
                 await client.aclose()
@@ -139,9 +167,12 @@ class FastAPIProxy:
         redirect_count = 0
 
         while redirect_count <= MAX_REDIRECTS:
-            response = await client.request(
-                method=request.method, url=current_url, headers=headers, follow_redirects=False
+            req = client.build_request(
+                method=request.method,
+                url=current_url,
+                headers=headers,
             )
+            response = await client.send(req, follow_redirects=False, stream=True)
 
             if self._is_redirect_response(response):
                 redirect_count += 1

--- a/lib/galaxy_test/api/test_proxy.py
+++ b/lib/galaxy_test/api/test_proxy.py
@@ -148,7 +148,8 @@ class TestProxyApi(ApiTestCase):
 
         # Setup mock client
         mock_client = MagicMock()
-        mock_client.request = AsyncMock(return_value=redirect_response)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=redirect_response)
         mock_client.aclose = AsyncMock()
         mock_client_class.return_value = mock_client
 
@@ -181,7 +182,8 @@ class TestProxyApi(ApiTestCase):
 
         # Setup mock client to return redirect first, then final response
         mock_client = MagicMock()
-        mock_client.request = AsyncMock(side_effect=[redirect_response, final_response])
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(side_effect=[redirect_response, final_response])
         mock_client.aclose = AsyncMock()
         mock_client_class.return_value = mock_client
 
@@ -203,7 +205,8 @@ class TestProxyApi(ApiTestCase):
 
         # Setup mock client
         mock_client = MagicMock()
-        mock_client.request = AsyncMock(return_value=redirect_response)
+        mock_client.build_request = MagicMock(return_value=MagicMock())
+        mock_client.send = AsyncMock(return_value=redirect_response)
         mock_client.aclose = AsyncMock()
         mock_client_class.return_value = mock_client
 

--- a/lib/galaxy_test/api/test_proxy.py
+++ b/lib/galaxy_test/api/test_proxy.py
@@ -1,9 +1,3 @@
-from unittest.mock import (
-    AsyncMock,
-    MagicMock,
-    patch,
-)
-
 import pytest
 import requests
 
@@ -137,82 +131,41 @@ class TestProxyApi(ApiTestCase):
         # Verify content-encoding header was properly filtered out (no double decompression)
         assert "content-encoding" not in response.headers
 
-    @patch("galaxy.webapps.galaxy.api.proxy.httpx.AsyncClient")
-    def test_proxy_validates_redirects(self, mock_client_class):
-        """Test that redirects are validated."""
-        # Create mock responses - redirect to a local file (invalid scheme)
-        redirect_response = MagicMock()
-        redirect_response.status_code = 302
-        redirect_response.headers = {"location": "file://internal-server/secret-files"}
-        redirect_response.aclose = AsyncMock()
-
-        # Setup mock client
-        mock_client = MagicMock()
-        mock_client.build_request = MagicMock(return_value=MagicMock())
-        mock_client.send = AsyncMock(return_value=redirect_response)
-        mock_client.aclose = AsyncMock()
-        mock_client_class.return_value = mock_client
-
-        # Attempt to proxy a URL that redirects to file:// (should be blocked)
-        response = self._get("proxy?url=https://evil.com/redirect")
-
-        # Should fail with 400 Bad Request due to invalid redirect URL scheme
+    def test_proxy_validates_redirects(self, mock_http_server):
+        """Test that redirects to invalid schemes are blocked."""
+        url = mock_http_server.get_url(
+            remote_url="https://evil.com/redirect",
+            status=302,
+            response_headers={"Location": "file://internal-server/secret-files"},
+        )
+        response = self._get(f"proxy?url={url}")
         self._assert_status_code_is(response, 400)
         assert "Invalid URL format" in response.json()["err_msg"]
 
-    @patch("galaxy.webapps.galaxy.api.proxy.httpx.AsyncClient")
-    def test_proxy_follows_valid_redirects(self, mock_client_class):
+    def test_proxy_follows_valid_redirects(self, mock_http_server):
         """Test that valid redirects are followed after validation."""
-        # Create mock responses
-        redirect_response = MagicMock()
-        redirect_response.status_code = 301
-        redirect_response.headers = {"location": "https://example.com/final"}
-        redirect_response.aclose = AsyncMock()
-
-        final_response = MagicMock()
-        final_response.status_code = 200
-        final_response.headers = {"content-type": "text/plain"}
-        final_response.aclose = AsyncMock()
-
-        # Create async generator for streaming
-        async def mock_stream():
-            yield b"test content"
-
-        final_response.aiter_bytes = mock_stream
-
-        # Setup mock client to return redirect first, then final response
-        mock_client = MagicMock()
-        mock_client.build_request = MagicMock(return_value=MagicMock())
-        mock_client.send = AsyncMock(side_effect=[redirect_response, final_response])
-        mock_client.aclose = AsyncMock()
-        mock_client_class.return_value = mock_client
-
-        # Proxy a URL that redirects to a valid external URL
-        response = self._get("proxy?url=https://example.com/redirect")
-
-        # Should succeed and follow the redirect
+        final_url = mock_http_server.get_url(
+            remote_url="https://example.com/final",
+            status=200,
+            body="test content",
+            content_type="text/plain",
+        )
+        redirect_url = mock_http_server.get_url(
+            remote_url="https://example.com/redirect",
+            status=301,
+            response_headers={"Location": final_url},
+        )
+        response = self._get(f"proxy?url={redirect_url}")
         self._assert_status_code_is_ok(response)
         assert b"test content" in response.content
 
-    @patch("galaxy.webapps.galaxy.api.proxy.httpx.AsyncClient")
-    def test_proxy_blocks_too_many_redirects(self, mock_client_class):
+    def test_proxy_blocks_too_many_redirects(self, mock_http_server):
         """Test that excessive redirects are blocked to prevent redirect loops."""
-        # Create a mock response that always redirects
-        redirect_response = MagicMock()
-        redirect_response.status_code = 302
-        redirect_response.headers = {"location": "https://example.com/loop"}
-        redirect_response.aclose = AsyncMock()
-
-        # Setup mock client
-        mock_client = MagicMock()
-        mock_client.build_request = MagicMock(return_value=MagicMock())
-        mock_client.send = AsyncMock(return_value=redirect_response)
-        mock_client.aclose = AsyncMock()
-        mock_client_class.return_value = mock_client
-
-        # Attempt to proxy a URL that loops redirects
-        response = self._get("proxy?url=https://example.com/loop")
-
-        # Should fail with 400 Bad Request due to too many redirects
+        url = mock_http_server.get_url(
+            remote_url="https://example.com/loop",
+            status=302,
+            redirect_to_self=True,
+        )
+        response = self._get(f"proxy?url={url}")
         self._assert_status_code_is(response, 400)
         assert "Too many redirects" in response.json()["err_msg"]

--- a/lib/galaxy_test/base/mock_http_server.py
+++ b/lib/galaxy_test/base/mock_http_server.py
@@ -141,6 +141,7 @@ class MockHttpServer:
         request_method: str = "GET",
         support_head: bool = False,
         support_ranges: bool = False,
+        redirect_to_self: bool = False,
     ) -> str:
         """Register a mock endpoint and return its URL, or return remote_url with skip-if-down.
 
@@ -155,6 +156,7 @@ class MockHttpServer:
             request_method: HTTP method to match (GET, POST, etc.).
             support_head: Whether to also respond to HEAD requests.
             support_ranges: Whether to support Range request headers (HTTP 206).
+            redirect_to_self: Whether to add a Location header pointing to this route's own URL.
         """
         if self.is_remote:
             if not is_site_up(remote_url):
@@ -194,7 +196,10 @@ class MockHttpServer:
             support_head=support_head,
             support_ranges=support_ranges,
         )
-        return f"{self.base_url}{path}"
+        url = f"{self.base_url}{path}"
+        if redirect_to_self:
+            headers["Location"] = url
+        return url
 
 
 def start_mock_http_server(host: str = "127.0.0.1", port: int = 0) -> tuple[HTTPServer, str]:


### PR DESCRIPTION
- Use streaming responses (client.send with stream=True) to avoid buffering
  entire response body before proxying
- Replace generic Exception with UpstreamProxyError and GatewayTimeoutException using proper HTTP status
  codes
- Include exception type and URL in error messages for better diagnostics
- Replace mock-based proxy redirect tests with integration tests

Fixes https://github.com/galaxyproject/galaxy/issues/22293

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
