### PR TITLE
[26.0] Downgrade authnz OAuth callback errors from ERROR/EXCEPTION to WARNING

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -1,6 +1,13 @@
 import builtins
 import logging
 
+import jwt as pyjwt
+from social_core.exceptions import (
+    AuthAlreadyAssociated,
+    AuthCanceled,
+    AuthTokenError,
+)
+
 from galaxy import (
     exceptions,
     model,
@@ -321,6 +328,26 @@ class AuthnzManager:
             return success, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
         except exceptions.AuthenticationFailed:
             raise
+        except AuthCanceled:
+            msg = f"Authentication with `{provider}` was canceled or the authorization code has expired. Please try logging in again."
+            log.warning(msg)
+            return False, msg, (None, None)
+        except AuthAlreadyAssociated:
+            msg = (
+                f"The account from `{provider}` is already linked to a different Galaxy user. "
+                "Please log in to the Galaxy account that is already linked to this identity, "
+                "or use a different identity provider account."
+            )
+            log.warning(msg)
+            return False, msg, (None, None)
+        except AuthTokenError:
+            msg = (
+                f"Authentication session with `{provider}` has expired or is invalid. "
+                "This can happen when using multiple browser tabs during login. "
+                "Please close other login tabs and try again."
+            )
+            log.warning(msg)
+            return False, msg, (None, None)
         except Exception:
             msg = f"An error occurred when handling callback from `{provider}` identity provider.  Please contact an administrator for assistance."
             log.exception(msg)
@@ -365,6 +392,9 @@ class AuthnzManager:
             user, jwt = None, None
             try:
                 user, jwt = backend.decode_user_access_token(sa_session, access_token)
+            except pyjwt.exceptions.InvalidTokenError as e:
+                log.warning("Could not decode access token: %s", e)
+                raise exceptions.AuthenticationFailed(err_msg="Invalid access token.")
             except Exception:
                 log.exception("Could not decode access token")
                 raise exceptions.AuthenticationFailed(err_msg="Invalid access token or an unexpected error occurred.")

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -107,7 +107,7 @@ class OIDC(BaseUIController):
             # Fallback to default redirect if no login_next cookie is found.
             login_next = url_for("/")
         if not bool(kwargs):
-            log.error(f"OIDC callback received no data for provider `{provider}` and user `{user}`")
+            log.warning(f"OIDC callback received no data for provider `{provider}` and user `{user}`")
             return trans.show_error_message(
                 f"Did not receive any information from the `{provider}` identity provider to complete user `{user}` authentication "
                 "flow. Please try again, and if the problem persists, contact the Galaxy instance admin. Also note "
@@ -115,7 +115,7 @@ class OIDC(BaseUIController):
                 "a user."
             )
         if "error" in kwargs:
-            log.error(
+            log.warning(
                 "Error handling authentication callback from `{}` identity provider for user `{}` login request."
                 " Error message: {}".format(provider, user, kwargs.get("error", "None"))
             )


### PR DESCRIPTION
These errors represent expected client-initiated OAuth failures, not server-side bugs. Logging them as ERROR/EXCEPTION generates ~1,200+ noisy Sentry events per week and creates false urgency on dashboards. The authentication handling itself is correct in all cases.

Changes in controllers/authnz.py:
- access_denied from provider (850 events/wk): user denied consent or Google blocked login. Not actionable on our side.
- OIDC callback with no data (1 event/wk): crawler or manual URL hit.

Changes in authnz/managers.py callback():
- AuthCanceled (91 events/wk): expired auth code from back button, slow user, or double-click. Now returns actionable user message instead of generic "contact administrator".
- AuthAlreadyAssociated (86 events/wk): Google account linked to a different Galaxy user. Now returns specific guidance without revealing which Galaxy user holds the link (privacy).
- AuthTokenError nonce mismatch (59 events/wk): multiple tabs or session expiry. Now explains the likely cause to the user.

Changes in authnz/managers.py _match_access_token_to_user_in_provider():
- JWT DecodeError (2 events/wk): API client sent non-JWT Bearer token. Now catches InvalidTokenError specifically at WARNING level.

The generic `except Exception` with log.exception() is preserved as a fallback for truly unexpected errors in all locations.

Fixes https://github.com/galaxyproject/galaxy/issues/22299

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
