### PR TITLE
[26.0] Skip WorkflowHub tests when workflowhub.eu is down

### DIFF
--- a/lib/galaxy/util/unittest_utils/__init__.py
+++ b/lib/galaxy/util/unittest_utils/__init__.py
@@ -41,6 +41,7 @@ def skip_if_site_down(url: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
 
 
 skip_if_github_down = skip_if_site_down("https://github.com/")
+skip_if_workflowhub_down = skip_if_site_down("https://workflowhub.eu/")
 
 
 def _identity(func: Callable[P, T]) -> Callable[P, T]:

--- a/test/integration_selenium/test_trs_import.py
+++ b/test/integration_selenium/test_trs_import.py
@@ -1,5 +1,6 @@
 import os
 
+from galaxy.util.unittest_utils import skip_if_workflowhub_down
 from .framework import SeleniumIntegrationTestCase
 
 TRS_API_URL_DOCKSTORE = "https://dockstore.org/api"
@@ -57,6 +58,7 @@ class TestTrsImport(SeleniumIntegrationTestCase):
         import_url = f"workflows/trs_import?trs_server=dockstore.org&trs_version={TRS_VERSION_DOCKSTORE}&trs_id=%23{TRS_ID_DOCKSTORE}"
         self._import_workflow_by_url(import_url)
 
+    @skip_if_workflowhub_down
     def test_import_workflow_by_url_workflowhub(self):
         import_url = f"workflows/trs_import?trs_server=workflowhub&trs_version={TRS_VERSION_WORKFLOWHUB}&trs_id={TRS_ID_WORKFLOWHUB}"
         self._import_workflow_by_url(import_url)
@@ -89,6 +91,7 @@ class TestTrsImport(SeleniumIntegrationTestCase):
         self.components.workflows.trs_icon.wait_for_visible()
         self.screenshot("workflow_imported_via_dockstore_search")
 
+    @skip_if_workflowhub_down
     def test_import_by_search_workflowhub(self):
         self.go_to_trs_search()
         self.components.trs_search.select_server_button.wait_for_and_click()
@@ -103,12 +106,14 @@ class TestTrsImport(SeleniumIntegrationTestCase):
     def test_import_by_id_dockstore(self):
         self._import_by_id(f"#{TRS_ID_DOCKSTORE}", server="dockstore")
 
+    @skip_if_workflowhub_down
     def test_import_by_id_workflowhub(self):
         self._import_by_id(TRS_ID_WORKFLOWHUB, server="workflowhub")
 
     def test_import_by_trs_url_dockstore(self):
         self._import_by_trs_url(TRS_URL_DOCKSTORE)
 
+    @skip_if_workflowhub_down
     def test_import_by_trs_url_workflowhub(self):
         self._import_by_trs_url(TRS_URL_WORKFLOWHUB)
 
@@ -116,6 +121,7 @@ class TestTrsImport(SeleniumIntegrationTestCase):
         import_url = f"workflows/trs_import?trs_url={TRS_URL_DOCKSTORE}"
         self._import_workflow_by_url(import_url)
 
+    @skip_if_workflowhub_down
     def test_auto_import_by_trs_url_workflowhub(self):
         import_url = f"workflows/trs_import?trs_url={TRS_URL_WORKFLOWHUB}"
         self._import_workflow_by_url(import_url)

--- a/test/unit/workflows/test_trs_proxy.py
+++ b/test/unit/workflows/test_trs_proxy.py
@@ -6,6 +6,7 @@ import yaml
 
 from galaxy.config import GalaxyAppConfiguration
 from galaxy.exceptions import ConfigDoesNotAllowException
+from galaxy.util.unittest_utils import skip_if_workflowhub_down
 from galaxy.workflow.trs_proxy import (
     GA4GH_GALAXY_DESCRIPTOR,
     parse_search_kwds,
@@ -119,6 +120,7 @@ def test_match_url():
     assert expected_exception, "matching url against localhost should fail"
 
 
+@skip_if_workflowhub_down
 def test_server_from_url():
     proxy = get_trs_proxy()
     server = proxy.server_from_url("https://workflowhub.eu")


### PR DESCRIPTION
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
