### PR TITLE
[26.0] Fix atomicity issues when pulling files into object store cache

### DIFF
--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -285,14 +285,18 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             return cache_path
 
         # Check if the file exists in the cache first, always pull if file size in cache is zero
-        # For dir_only - the cache cleaning may have left empty directories so I think we need to
-        # always resync the cache. Gotta make sure we're being judicious in out data.extra_files_path
-        # calls I think.
         if not dir_only and self._in_cache(rel_path) and os.path.getsize(self._get_cache_path(rel_path)) > 0:
             return cache_path
 
+        # For directories: trust cache if it has files. Individual file accesses
+        # handle cache misses via _pull_into_cache, so a full re-download is only
+        # needed when the directory is empty (e.g. after cache cleaning removed
+        # all files but left the empty directory).
+        if dir_only and os.path.isdir(cache_path) and any(files for _, _, files in os.walk(cache_path)):
+            return cache_path
+
         # Check if the file exists in persistent storage and, if it does, pull it into cache
-        elif self._exists(obj, **kwargs):
+        if self._exists(obj, **kwargs):
             if dir_only:
                 self._download_directory_into_cache(rel_path, cache_path)
                 return cache_path
@@ -406,6 +410,10 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             yield tmp_path
             os.rename(tmp_path, cache_path)
         except BaseException:
+            # Catch BaseException (not just Exception) so that KeyboardInterrupt
+            # and SystemExit also trigger cleanup — we re-raise immediately, so
+            # propagation is not blocked. Without this, interrupted downloads
+            # leave .tmp files that poison the cache on next startup.
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
             raise

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+from contextlib import contextmanager
 from datetime import datetime
 from typing import (
     Any,
@@ -390,6 +391,24 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
     def _exists_remotely(self, rel_path: str) -> bool:
         raise NotImplementedError()
+
+    @contextmanager
+    def _atomic_download(self, cache_path):
+        """Download to a temp file then atomically rename to prevent serving partial files.
+
+        Usage::
+
+            with self._atomic_download(local_destination) as tmp_path:
+                do_download(tmp_path)
+        """
+        tmp_path = cache_path + ".tmp"
+        try:
+            yield tmp_path
+            os.rename(tmp_path, cache_path)
+        except BaseException:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
 
     def _download(self, rel_path: str) -> bool:
         raise NotImplementedError()

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -245,7 +245,8 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
             if not self._caching_allowed(rel_path):
                 return False
             else:
-                self._download_to_file(rel_path, local_destination)
+                with self._atomic_download(local_destination) as tmp:
+                    self._download_to_file(rel_path, tmp)
                 return True
         except AzureHttpError:
             log.exception("Problem downloading '%s' from Azure", rel_path)
@@ -266,12 +267,9 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
         for blob in blobs:
             key = blob.name
             local_file_path = os.path.join(cache_path, os.path.relpath(key, rel_path))
-
-            # Create directories if they don't exist
             os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-
-            # Download the file
-            self._download_to_file(key, local_file_path)
+            with self._atomic_download(local_file_path) as tmp:
+                self._download_to_file(key, tmp)
 
     def _push_string_to_path(self, rel_path: str, from_string: str) -> bool:
         try:

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -257,25 +257,21 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             if not self._caching_allowed(rel_path, remote_size):
                 return False
             log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
-            self._download_to(key, local_destination)
+            with self._atomic_download(local_destination) as tmp:
+                self._download_to(key, tmp)
             return True
         except Exception:
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self.bucket.name)
         return False
 
     def _download_directory_into_cache(self, rel_path, cache_path):
-        # List objects in the specified cloud folder
         objects = self.bucket.objects.list(prefix=rel_path)
-
         for obj in objects:
             remote_file_path = obj.name
             local_file_path = os.path.join(cache_path, os.path.relpath(remote_file_path, rel_path))
-
-            # Create directories if they don't exist
             os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-
-            # Download the file
-            self._download_to(obj, local_file_path)
+            with self._atomic_download(local_file_path) as tmp:
+                self._download_to(obj, tmp)
 
     def _download_to(self, key, local_destination):
         if self.use_axel:

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -432,7 +432,8 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         options = {kw.FORCE_FLAG_KW: "", kw.DEST_RESC_NAME_KW: self.resource}
 
         try:
-            self.session.data_objects.get(data_object_path, cache_path, **options)
+            with self._atomic_download(cache_path) as tmp:
+                self.session.data_objects.get(data_object_path, tmp, **options)
             log.debug("Pulled data object '%s' into cache to %s", rel_path, cache_path)
             return True
         except (DataObjectDoesNotExist, CollectionDoesNotExist):

--- a/lib/galaxy/objectstore/onedata.py
+++ b/lib/galaxy/objectstore/onedata.py
@@ -201,11 +201,12 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             if not self._caching_allowed(rel_path, file_size):
                 return False
 
-            with open(dst_path, "wb") as dst:
-                for chunk in self._client.iter_file_content(
-                    self.space_name, chunk_size=STREAM_CHUNK_SIZE, file_path=remote_path
-                ):
-                    dst.write(chunk)
+            with self._atomic_download(dst_path) as tmp:
+                with open(tmp, "wb") as dst:
+                    for chunk in self._client.iter_file_content(
+                        self.space_name, chunk_size=STREAM_CHUNK_SIZE, file_path=remote_path
+                    ):
+                        dst.write(chunk)
 
             log.debug("Pulled '%s' into cache to %s", rel_path, dst_path)
 

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -145,7 +145,8 @@ class PithosObjectStore(CachingConcreteObjectStore):
 
     def _download(self, rel_path):
         local_destination = self._get_cache_path(rel_path)
-        self.pithos.download_object(rel_path, local_destination)
+        with self._atomic_download(local_destination) as tmp:
+            self.pithos.download_object(rel_path, tmp)
 
     # No need to overwrite "shutdown"
 

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -35,18 +35,19 @@ logging.getLogger("boto").setLevel(logging.INFO)  # Otherwise boto is quite nois
 
 
 def download_directory(bucket, remote_folder, local_path):
-    # List objects in the specified S3 folder
     objects = bucket.list(prefix=remote_folder)
-
     for obj in objects:
         remote_file_path = obj.key
         local_file_path = os.path.join(local_path, os.path.relpath(remote_file_path, remote_folder))
-
-        # Create directories if they don't exist
         os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-
-        # Download the file
-        obj.get_contents_to_filename(local_file_path)
+        tmp_file_path = local_file_path + ".tmp"
+        try:
+            obj.get_contents_to_filename(tmp_file_path)
+            os.rename(tmp_file_path, local_file_path)
+        except Exception:
+            if os.path.exists(tmp_file_path):
+                os.remove(tmp_file_path)
+            raise
 
 
 def parse_config_xml(config_xml):
@@ -320,7 +321,8 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             else:
                 log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
                 self.transfer_progress = 0  # Reset transfer progress counter
-                key.get_contents_to_filename(local_destination, cb=self._transfer_cb, num_cb=10)
+                with self._atomic_download(local_destination) as tmp:
+                    key.get_contents_to_filename(tmp, cb=self._transfer_cb, num_cb=10)
                 return True
         except S3ResponseError:
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self._bucket.name)

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -320,7 +320,8 @@ class S3ObjectStore(CachingConcreteObjectStore):
             if not self._caching_allowed(rel_path):
                 return False
             config = self._transfer_config("download")
-            self._client.download_file(self.bucket, rel_path, local_destination, Config=config)
+            with self._atomic_download(local_destination) as tmp:
+                self._client.download_file(self.bucket, rel_path, tmp, Config=config)
             return True
         except ClientError:
             log.exception("Failed to download file from S3")
@@ -372,12 +373,9 @@ class S3ObjectStore(CachingConcreteObjectStore):
     def _download_directory_into_cache(self, rel_path, cache_path):
         for key in self._keys(rel_path):
             local_file_path = os.path.join(cache_path, os.path.relpath(key, rel_path))
-
-            # Create directories if they don't exist
             os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
-
-            # Download the file
-            self._client.download_file(self.bucket, key, local_file_path)
+            with self._atomic_download(local_file_path) as tmp:
+                self._client.download_file(self.bucket, key, tmp)
 
     def _get_object_url(self, obj, **kwargs):
         try:

--- a/test/integration/objectstore/test_swift_objectstore.py
+++ b/test/integration/objectstore/test_swift_objectstore.py
@@ -18,8 +18,6 @@ TEST_TOOL_IDS = [
     "tool_provided_metadata_10",
     "tool_provided_metadata_11",
     "tool_provided_metadata_12",
-    # Transiently fails - see issue #21226 - I'd love to mark this with the decorator but
-    # the test framework here doesn't support it yet.
     "composite_output",
     "composite_output_tests",
     "metadata",


### PR DESCRIPTION
All objectstore backends wrote downloads directly to the final cache path. If a download was interrupted, a partial file remained in cache and could be served on subsequent reads. This caused transient failures in `test_swift_objectstore::test_tools[composite_output]` (https://github.com/galaxyproject/galaxy/issues/21226) manifesting as IncompleteRead or content truncation.

Add `_atomic_download()` context manager to `CachingConcreteObjectStore` that writes to a .tmp file and atomically renames on success. Apply it to `_download()` and `_download_directory_into_cache()` across all backends (s3_boto3, s3, azure_blob, cloud, pithos, irods, onedata).

Root cause analysis: https://gist.github.com/mvdbeek/3c428a45d05c77838cb6762522b6504d
Fixes https://github.com/galaxyproject/galaxy/issues/21226

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
