### PR TITLE
[26.0] Fix slow get_private_role_user_emails_dict query

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -460,11 +460,18 @@ class DatasetAssociationManager(
             library_dataset = None
             dataset = dataset_assoc.dataset
 
-        private_role_emails = get_private_role_user_emails_dict(self.session())
-
         # Omit duplicated roles by converting to set
         access_roles = set(dataset.get_access_roles(self.app.security_agent))
         manage_roles = set(dataset.get_manage_permissions_roles(self.app.security_agent))
+        modify_roles = set()
+        if library_dataset is not None:
+            modify_roles = set(
+                self.app.security_agent.get_roles_for_action(
+                    library_dataset, self.app.security_agent.permitted_actions.LIBRARY_MODIFY
+                )
+            )
+        all_role_ids = {r.id for r in access_roles | manage_roles | modify_roles}
+        private_role_emails = get_private_role_user_emails_dict(self.session(), role_ids=all_role_ids)
 
         def make_tuples(roles: set):
             tuples = []
@@ -480,11 +487,6 @@ class DatasetAssociationManager(
 
         rval = dict(access_dataset_roles=access_dataset_role_list, manage_dataset_roles=manage_dataset_role_list)
         if library_dataset is not None:
-            modify_roles = set(
-                self.app.security_agent.get_roles_for_action(
-                    library_dataset, self.app.security_agent.permitted_actions.LIBRARY_MODIFY
-                )
-            )
             modify_item_role_list = make_tuples(modify_roles)
             rval["modify_item_roles"] = modify_item_role_list
         return rval

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -306,8 +306,6 @@ class FolderManager:
         :returns:   dict of current roles for all available permission types
         :rtype:     dictionary
         """
-        private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
-
         # Omit duplicated roles by converting to set
         modify_roles = set(
             trans.app.security_agent.get_roles_for_action(
@@ -324,6 +322,8 @@ class FolderManager:
                 folder, trans.app.security_agent.permitted_actions.LIBRARY_ADD
             )
         )
+        all_role_ids = {r.id for r in modify_roles | manage_roles | add_roles}
+        private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=all_role_ids)
 
         def make_tuples(roles: set):
             tuples = []

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -272,11 +272,12 @@ class LibraryManager:
         :rtype:     dictionary
         :returns:   dict of current roles for all available permission types
         """
-        private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
         access_roles = self.get_access_roles(trans, library)
         modify_roles = self.get_modify_roles(trans, library)
         manage_roles = self.get_manage_roles(trans, library)
         add_roles = self.get_add_roles(trans, library)
+        all_role_ids = {r.id for r in access_roles | modify_roles | manage_roles | add_roles}
+        private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=all_role_ids)
 
         def make_tuples(roles: set):
             tuples = []

--- a/lib/galaxy/model/db/role.py
+++ b/lib/galaxy/model/db/role.py
@@ -59,6 +59,8 @@ def get_private_role_user_emails_dict(session, role_ids: set[int] | None = None)
     If role_ids is provided, only return mappings for roles in that set,
     avoiding a full table scan on large instances.
     """
+    if role_ids is not None and not role_ids:
+        return {}
     stmt = select(UserRoleAssociation.role_id, User.email).join(Role).join(User).where(Role.type == Role.types.PRIVATE)
     if role_ids is not None:
         stmt = stmt.where(UserRoleAssociation.role_id.in_(role_ids))

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -52,7 +52,8 @@ class FastAPIGroupRoles:
         trans: ProvidesAppContext = DependsOnTrans,
     ) -> GroupRoleListResponse:
         group_roles = self.manager.index(trans, group_id)
-        private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+        role_ids = {gr.role.id for gr in group_roles}
+        private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=role_ids)
         data = []
         for group in group_roles:
             role = group.role

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -151,7 +151,8 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
                 page_limit = 10
             query = kwd.get("q", None)
             roles, total_roles = trans.app.security_agent.get_valid_roles(trans, dataset, query, page, page_limit)
-            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+            role_ids = {r.id for r in roles}
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=role_ids)
             return_roles = []
             for role in roles:
                 role_id = trans.security.encode_id(role.id)

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -1094,9 +1094,11 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         user = self._get_user(trans, id)
 
         def get_role_tuples():
-            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+            roles = user.all_roles()
+            role_ids = {r.id for r in roles}
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=role_ids)
             role_tuples = set()
-            for role in user.all_roles():
+            for role in roles:
                 displayed_name = private_role_emails.get(role.id, role.name)
                 role_tuples.add((displayed_name, role.id))
             return list(role_tuples)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -140,7 +140,8 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         if trans.request.method == "GET":
             inputs = []
             all_roles = set(trans.user.all_roles())
-            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+            role_ids = {r.id for r in all_roles}
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=role_ids)
             current_actions = history.default_permissions
             for action_key, action in Dataset.permitted_actions.items():
                 in_roles = set()

--- a/lib/galaxy/webapps/galaxy/services/libraries.py
+++ b/lib/galaxy/webapps/galaxy/services/libraries.py
@@ -172,7 +172,8 @@ class LibrariesService(ServiceBase, ConsumesModelStores):
                 trans, library, query, page, page_limit, is_library_access
             )
 
-            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+            role_ids = {r.id for r in roles}
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=role_ids)
             return_roles = []
             for role in roles:
                 displayed_name = private_role_emails.get(role.id, role.name)

--- a/lib/galaxy/webapps/galaxy/services/library_folders.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folders.py
@@ -116,7 +116,8 @@ class LibraryFoldersService(ServiceBase):
         elif scope == LibraryPermissionScope.available:
             roles, total_roles = trans.app.security_agent.get_valid_roles(trans, folder, query, page, page_limit)
 
-            private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+            role_ids = {r.id for r in roles}
+            private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=role_ids)
             return_roles = []
             for role in roles:
                 displayed_name = private_role_emails.get(role.id, role.name)

--- a/lib/galaxy/webapps/galaxy/services/roles.py
+++ b/lib/galaxy/webapps/galaxy/services/roles.py
@@ -40,7 +40,8 @@ class RolesService(ServiceBase):
 
     def get_index(self, trans: ProvidesUserContext) -> RoleListResponse:
         roles = self.role_manager.list_displayable_roles(trans)
-        private_role_emails = get_private_role_user_emails_dict(trans.sa_session)
+        role_ids = {r.id for r in roles}
+        private_role_emails = get_private_role_user_emails_dict(trans.sa_session, role_ids=role_ids)
         data = []
         for role in roles:
             displayed_name = private_role_emails.get(role.id, role.name)

--- a/test/unit/data/model/db/test_role.py
+++ b/test/unit/data/model/db/test_role.py
@@ -168,11 +168,28 @@ def test_get_private_role_user_emails_dict(session, make_role, make_user_and_rol
     user2, private_role2 = make_user_and_role(email="user2@example.com")
     user3, private_role3 = make_user_and_role(email="user3@example.com")
     # make 2 non-private roles
-    make_role(type="admin", name="admin-role-1", description="Description of admin-role1")
+    admin_role1 = make_role(type="admin", name="admin-role-1", description="Description of admin-role1")
     make_role(type="admin", name="admin-role-2", description="Description of admin-role2")
 
-    data = get_private_role_user_emails_dict(session)
-    assert len(data) == 3  # only private role mappings are returned
+    # all private role ids
+    all_ids = {private_role1.id, private_role2.id, private_role3.id}
+    data = get_private_role_user_emails_dict(session, role_ids=all_ids)
+    assert len(data) == 3
     assert data[private_role1.id] == "user1@example.com"
     assert data[private_role2.id] == "user2@example.com"
     assert data[private_role3.id] == "user3@example.com"
+
+    # subset of role ids
+    subset_ids = {private_role1.id, private_role3.id}
+    data = get_private_role_user_emails_dict(session, role_ids=subset_ids)
+    assert len(data) == 2
+    assert data[private_role1.id] == "user1@example.com"
+    assert data[private_role3.id] == "user3@example.com"
+
+    # empty set returns empty dict without hitting the database
+    data = get_private_role_user_emails_dict(session, role_ids=set())
+    assert len(data) == 0
+
+    # non-private role ids return empty (filtered by type=PRIVATE)
+    data = get_private_role_user_emails_dict(session, role_ids={admin_role1.id})
+    assert len(data) == 0


### PR DESCRIPTION
by passing role_ids filter

The function was doing a full table scan of all private role-to-email mappings on every call, even though each caller only needs a small subset. On large instances like usegalaxy.org this scans hundreds of thousands of rows unnecessarily.

Pass role_ids at all non-admin call sites so the query uses an IN clause instead of scanning the entire user_role_association table.

Fixes https://github.com/galaxyproject/galaxy/issues/20469

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
