### PR TITLE
[26.0] Pass tool_uuid as proper query parameter instead of reusing URL path id

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -352,7 +352,13 @@ export default {
             this.disabled = true;
             this.loading = true;
 
-            return getToolFormData(this.id || this.toolUuid, this.currentVersion, this.job_id, this.history_id)
+            return getToolFormData(
+                this.id || this.toolUuid,
+                this.currentVersion,
+                this.job_id,
+                this.history_id,
+                this.toolUuid,
+            )
                 .then((data) => {
                     this.currentVersion = data.version;
                     this.formConfig = data;

--- a/client/src/components/Tool/services.js
+++ b/client/src/components/Tool/services.js
@@ -11,7 +11,7 @@ export async function updateToolFormData(tool_id, tool_uuid, tool_version, histo
         inputs: inputs,
         history_id: history_id,
     };
-    const url = `${getAppRoot()}api/tools/${tool_uuid || tool_id}/build`;
+    const url = `${getAppRoot()}api/tools/${tool_id || tool_uuid}/build`;
     try {
         const { data } = await axios.post(url, current_state);
         return data;
@@ -21,7 +21,7 @@ export async function updateToolFormData(tool_id, tool_uuid, tool_version, histo
 }
 
 /** Tools data request helper **/
-export async function getToolFormData(tool_id, tool_version, job_id, history_id) {
+export async function getToolFormData(tool_id, tool_version, job_id, history_id, tool_uuid) {
     let url = "";
     const data = {};
 
@@ -40,6 +40,7 @@ export async function getToolFormData(tool_id, tool_version, job_id, history_id)
     }
     history_id && (data["history_id"] = history_id);
     tool_version && (data["tool_version"] = tool_version);
+    tool_uuid && (data["tool_uuid"] = tool_uuid);
 
     // attach data to request url
     if (Object.entries(data).length != 0) {

--- a/client/src/components/providers/ToolSourceProvider.js
+++ b/client/src/components/providers/ToolSourceProvider.js
@@ -7,7 +7,10 @@ import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
 
 async function toolSource({ id, uuid }) {
-    const url = `${getAppRoot()}api/tools/${uuid || id}/raw_tool_source`;
+    let url = `${getAppRoot()}api/tools/${id || uuid}/raw_tool_source`;
+    if (uuid) {
+        url += `?tool_uuid=${uuid}`;
+    }
     try {
         const { data, headers } = await axios.get(url);
         const result = {};

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -539,7 +539,8 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         io_details = util.string_as_bool(kwd.get("io_details", False))
         link_details = util.string_as_bool(kwd.get("link_details", False))
         tool_version = kwd.get("tool_version")
-        tool = self.service._get_tool(trans, id, user=trans.user, tool_version=tool_version, tool_uuid=id)
+        tool_uuid = kwd.get("tool_uuid")
+        tool = self.service._get_tool(trans, id, user=trans.user, tool_version=tool_version, tool_uuid=tool_uuid)
         return tool.to_dict(trans, io_details=io_details, link_details=link_details)
 
     @expose_api_anonymous
@@ -870,7 +871,10 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
             raise exceptions.InsufficientPermissionsException(
                 "Only administrators may display tool sources on this Galaxy server."
             )
-        tool = self.service._get_tool(trans, id, user=trans.user, tool_version=kwds.get("tool_version"), tool_uuid=id)
+        tool_uuid = kwds.get("tool_uuid")
+        tool = self.service._get_tool(
+            trans, id, user=trans.user, tool_version=kwds.get("tool_version"), tool_uuid=tool_uuid
+        )
         trans.response.headers["language"] = tool.tool_source.language
         if dynamic_tool := getattr(tool, "dynamic_tool", None):
             if dynamic_tool.value.get("class") == "GalaxyUserTool":

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Union,
 )
+from uuid import UUID
 
 from starlette.datastructures import UploadFile
 
@@ -496,12 +497,14 @@ class ToolsService(ServiceBase):
     def _get_tool(
         self, trans: ProvidesUserContext, id, tool_version=None, tool_uuid=None, user: Optional[User] = None
     ) -> Tool:
+        if tool_uuid:
+            try:
+                UUID(tool_uuid)
+            except ValueError:
+                raise exceptions.RequestParameterInvalidException(f"Invalid tool_uuid '{tool_uuid}'.")
         tool = trans.app.toolbox.get_tool(id, tool_version)
         if not tool:
-            if user:
-                # FIXME: id as tool_uuid is for raw_tool_source endpoint, port to fastapi and fix
-                if id == tool_uuid:
-                    id = None
+            if user and (id or tool_uuid):
                 tool = trans.app.toolbox.get_tool(user=user, tool_id=id, tool_uuid=tool_uuid)
                 if tool:
                     return tool


### PR DESCRIPTION
Fixes #22260. The show() and raw_tool_source() endpoints passed the URL path `id` as both tool_id and tool_uuid to _get_tool(), causing a ValueError when a non-UUID tool ID fell through to UUID parsing.

Now tool_uuid is passed as a separate query parameter (matching the pattern already used by the build endpoint), and the frontend sends it accordingly.

Also validates tool_uuid is a valid UUID before attempting lookup.

- [x] I want to do some manual checks in the editor, invocation, tool form etc before merging.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
