### PR TITLE
[26.0] Strip content-length and accept-ranges headers from proxied streaming responses

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/proxy.py
+++ b/lib/galaxy/webapps/galaxy/api/proxy.py
@@ -226,7 +226,8 @@ class FastAPIProxy:
         Removes:
         - Hop-by-hop headers (transfer-encoding, connection, keep-alive)
         - content-encoding: httpx auto-decompresses, so content is no longer encoded
-        - content-length: only if response was compressed (size changes after decompression)
+        - content-length: always removed because the actual streamed bytes may differ
+          from the upstream value (auto-decompression, stream size/time limits)
 
         Args:
             headers: The response headers from the upstream server
@@ -234,13 +235,19 @@ class FastAPIProxy:
         Returns:
             Filtered dictionary of headers safe to forward to the client
         """
-        had_content_encoding = "content-encoding" in headers
-
-        # Always exclude these hop-by-hop and encoding headers
-        excluded_headers = ["transfer-encoding", "connection", "keep-alive", "content-encoding"]
-
-        if had_content_encoding:
-            # If content was compressed, the content-length is now incorrect after decompression
-            excluded_headers.append("content-length")
+        # Always exclude these hop-by-hop and encoding headers.
+        # content-length is always excluded because:
+        # 1. httpx auto-decompresses, so compressed content-length is wrong after decompression
+        # 2. The stream may be truncated by MAX_STREAM_BYTES or MAX_STREAM_SECONDS limits
+        # StreamingResponse will use chunked transfer encoding instead.
+        # accept-ranges is excluded because range requests are not meaningful without content-length.
+        excluded_headers = [
+            "transfer-encoding",
+            "connection",
+            "keep-alive",
+            "content-encoding",
+            "content-length",
+            "accept-ranges",
+        ]
 
         return {key: value for key, value in headers.items() if key.lower() not in excluded_headers}

--- a/lib/galaxy_test/api/test_proxy.py
+++ b/lib/galaxy_test/api/test_proxy.py
@@ -1,6 +1,7 @@
 import pytest
 import requests
 
+from galaxy.webapps.galaxy.api.proxy import MAX_STREAM_BYTES
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
@@ -44,9 +45,11 @@ class TestProxyApi(ApiTestCase):
         url = self._get_zip_url(mock_http_server)
         response = self._get(f"proxy?url={url}")
         self._assert_status_code_is_ok(response)
-        assert response.headers["content-length"] == EXPECTED_HEADERS["content-length"]
+        # content-length and accept-ranges are stripped from GET responses
+        # (StreamingResponse uses chunked encoding, range requests not supported)
+        assert "content-length" not in response.headers
+        assert "accept-ranges" not in response.headers
         assert response.headers["content-type"] == EXPECTED_HEADERS["content-type"]
-        assert response.headers["accept-ranges"] == EXPECTED_HEADERS["accept-ranges"]
         assert len(response.content) == int(EXPECTED_HEADERS["content-length"])
 
     def test_proxy_get_request_with_range(self, mock_http_server):
@@ -54,8 +57,9 @@ class TestProxyApi(ApiTestCase):
         request_range = "bytes=0-3"
         response = self._get(f"proxy?url={url}", headers={"range": request_range})
         self._assert_status_code_is(response, 206)
-        assert response.headers["accept-ranges"] == "bytes"
-        assert response.headers["content-length"] == "4"
+        # content-length and accept-ranges are stripped from streamed responses
+        assert "content-length" not in response.headers
+        assert "accept-ranges" not in response.headers
         assert response.headers["content-range"].startswith("bytes 0-3/")
         assert response.content == ZIP_MAGIC_NUMBER
 
@@ -169,3 +173,23 @@ class TestProxyApi(ApiTestCase):
         response = self._get(f"proxy?url={url}")
         self._assert_status_code_is(response, 400)
         assert "Too many redirects" in response.json()["err_msg"]
+
+    def test_proxy_truncates_large_response(self, mock_http_server):
+        """Test that responses exceeding MAX_STREAM_BYTES are truncated without protocol errors.
+
+        The proxy must not forward the upstream content-length header, because the
+        stream may be cut short by the size limit. Using chunked transfer encoding
+        (no content-length) avoids 'Too little data for declared Content-Length'.
+        """
+        oversized_body = b"x" * (MAX_STREAM_BYTES + 1024)
+        url = mock_http_server.get_url(
+            remote_url="https://example.com/large-file",
+            body=oversized_body,
+            content_type="application/octet-stream",
+        )
+        response = self._get(f"proxy?url={url}")
+        self._assert_status_code_is_ok(response)
+        # content-length must not be forwarded for streamed responses
+        assert "content-length" not in response.headers
+        # Response should be truncated to at most MAX_STREAM_BYTES
+        assert len(response.content) <= MAX_STREAM_BYTES


### PR DESCRIPTION
The proxy endpoint can truncate responses via MAX_STREAM_BYTES or MAX_STREAM_SECONDS limits. When content-length from the upstream was forwarded but the stream was cut short, uvicorn raised "LocalProtocolError: Too little data for declared Content-Length".

Fix by always excluding content-length from forwarded headers. The StreamingResponse uses chunked transfer encoding instead, which tolerates early stream termination. Also strip accept-ranges since without content-length clients can't issue range requests anyway. HEAD responses still forward both headers unfiltered.

Fixes https://github.com/galaxyproject/galaxy/issues/22313

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
