### PR TITLE
[26.0] Wrap webhook scripts in IIFE to prevent redeclaration errors

### DIFF
--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -269,11 +269,13 @@ export function time(): string {
  * @param data object containing script and style strings
  */
 export function appendScriptStyle(data: Readonly<{ script?: string; styles?: string }>) {
-    // create a script tag inside head tag
+    // create a script tag inside head tag, wrapped in an IIFE to avoid
+    // "redeclaration of let" errors when the same webhook script is injected
+    // more than once (Firefox enforces this strictly in the global scope)
     if (data.script && data.script !== "") {
         const tag = document.createElement("script");
         tag.type = "text/javascript";
-        tag.textContent = data.script;
+        tag.textContent = `(function(){${data.script}})();`;
         document.head.appendChild(tag);
     }
     // create a style tag inside head tag

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -275,7 +275,7 @@ export function appendScriptStyle(data: Readonly<{ script?: string; styles?: str
     if (data.script && data.script !== "") {
         const tag = document.createElement("script");
         tag.type = "text/javascript";
-        tag.textContent = `(function(){${data.script}})();`;
+        tag.textContent = `(function(){\n${data.script}\n})();`;
         document.head.appendChild(tag);
     }
     // create a style tag inside head tag


### PR DESCRIPTION
Fixes SyntaxError: redeclaration of let tries in Firefox when webhook scripts are injected more than once via appendScriptStyle.

Fixes #22319 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
