### PR TITLE
[26.0] Handle inaccessible history errors in route-level components

### DIFF
--- a/client/src/components/History/Archiving/HistoryArchiveWizard.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveWizard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faArchive } from "@fortawesome/free-solid-svg-icons";
 import { BAlert, BCard, BTab, BTabs } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
 
 import type { HistorySummary } from "@/api";
@@ -10,6 +10,7 @@ import { useFileSources } from "@/composables/fileSources";
 import { useToast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
 
+import Alert from "@/components/Alert.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import HistoryArchiveExportSelector from "@/components/History/Archiving/HistoryArchiveExportSelector.vue";
 import HistoryArchiveSimple from "@/components/History/Archiving/HistoryArchiveSimple.vue";
@@ -28,17 +29,26 @@ interface ArchiveHistoryWizardProps {
 const props = defineProps<ArchiveHistoryWizardProps>();
 
 const isArchiving = ref(false);
+const loadError = ref<string | null>(null);
 
 const history = computed<HistorySummary | null>(() => {
-    const history = historyStore.getHistoryById(props.historyId);
-    if (history === null) {
-        // It could be already an archived history, so we won't find it in the store
-        // as it's not in the active histories anymore.
-        historyStore.loadHistoryById(props.historyId);
-        return historyStore.getHistoryById(props.historyId);
-    }
-    return history;
+    return historyStore.getHistoryById(props.historyId, false);
 });
+
+watch(
+    () => props.historyId,
+    async (historyId) => {
+        loadError.value = null;
+        if (!historyStore.getHistoryById(historyId, false)) {
+            try {
+                await historyStore.loadHistoryById(historyId);
+            } catch (error) {
+                loadError.value = String(error);
+            }
+        }
+    },
+    { immediate: true },
+);
 
 const isHistoryAlreadyArchived = computed(() => {
     return history.value?.archived;
@@ -78,7 +88,8 @@ const breadcrumbItems = computed(() => [
     <div class="history-archive-wizard">
         <BreadcrumbHeading :items="breadcrumbItems" />
 
-        <BAlert v-if="!history" show>
+        <Alert v-if="loadError" :message="loadError" variant="error" />
+        <BAlert v-else-if="!history" show>
             <LoadingSpan spinner-only />
         </BAlert>
 

--- a/client/src/components/History/Archiving/HistoryArchiveWizard.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveWizard.vue
@@ -9,6 +9,7 @@ import { useConfig } from "@/composables/config";
 import { useFileSources } from "@/composables/fileSources";
 import { useToast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import Alert from "@/components/Alert.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
@@ -43,7 +44,7 @@ watch(
             try {
                 await historyStore.loadHistoryById(historyId);
             } catch (error) {
-                loadError.value = String(error);
+                loadError.value = errorMessageAsString(error);
             }
         }
     },

--- a/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
@@ -7,6 +7,7 @@ import { useRouter } from "vue-router/composables";
 import { useSelectableObjectStores } from "@/composables/useObjectStores";
 import { useHistoryStore } from "@/stores/historyStore";
 import localize from "@/utils/localization";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import type { DataValuePoint } from "./Charts";
 import { fetchHistoryContentsSizeSummary, type ItemSizeSummary } from "./service";
@@ -48,7 +49,7 @@ watch(
             try {
                 await historyStore.loadHistoryById(historyId);
             } catch (error) {
-                loadError.value = String(error);
+                loadError.value = errorMessageAsString(error);
             }
         }
     },

--- a/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoryStorageOverview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BButton, BForm, BFormGroup, BFormSelect, BInputGroup } from "bootstrap-vue";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { useSelectableObjectStores } from "@/composables/useObjectStores";
@@ -23,17 +23,37 @@ import OverviewPage from "./OverviewPage.vue";
 import RecoverableItemSizeTooltip from "./RecoverableItemSizeTooltip.vue";
 import SelectedItemActions from "./SelectedItemActions.vue";
 import WarnDeletedDatasets from "./WarnDeletedDatasets.vue";
+import Alert from "@/components/Alert.vue";
 import FilterObjectStoreLink from "@/components/Common/FilterObjectStoreLink.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const router = useRouter();
-const { getHistoryNameById, getHistoryById } = useHistoryStore();
+const historyStore = useHistoryStore();
 
 interface Props {
     historyId: string;
 }
 
 const props = defineProps<Props>();
+
+const loadError = ref<string | null>(null);
+
+const history = computed(() => historyStore.getHistoryById(props.historyId, false));
+
+watch(
+    () => props.historyId,
+    async (historyId) => {
+        loadError.value = null;
+        if (!historyStore.getHistoryById(historyId, false)) {
+            try {
+                await historyStore.loadHistoryById(historyId);
+            } catch (error) {
+                loadError.value = String(error);
+            }
+        }
+    },
+    { immediate: true },
+);
 
 const activeVsDeletedTotalSizeData = ref<DataValuePoint[] | null>(null);
 const {
@@ -54,8 +74,7 @@ const { selectableObjectStores, hasSelectableObjectStores } = useSelectableObjec
 const objectStore = ref<string>();
 
 const canEditHistory = computed(() => {
-    const history = getHistoryById(props.historyId);
-    return (history && !history.purged && !history.archived) ?? false;
+    return (history.value && !history.value.purged && !history.value.archived) ?? false;
 });
 
 function onChangeObjectStore(value?: string) {
@@ -127,119 +146,122 @@ function onUndelete(datasetId: string) {
 </script>
 <template>
     <OverviewPage class="history-storage-overview" title="History Storage Overview">
-        <p class="text-justify">
-            Here you will find some Graphs displaying the storage taken by datasets in your history:
-            <b>{{ getHistoryNameById(props.historyId) }}</b
-            >. You can use these graphs to identify the datasets that take the most space in your history. You can also
-            go to the
-            <router-link :to="{ name: 'HistoriesOverview' }"><b>Histories Storage Overview</b></router-link> page to see
-            the storage taken by <b>all your histories</b>.
-        </p>
-        <WarnDeletedDatasets />
-        <div v-if="isLoading" class="text-center">
-            <LoadingSpan class="mt-5" :message="localize('Loading your storage data. This may take a while...')" />
-        </div>
-        <div v-else>
-            <BarChart
-                v-if="topNDatasetsBySizeData"
-                data-description="chart history top datasets by size"
-                :description="
-                    localize(
-                        `These are the ${numberOfDatasetsToDisplay} datasets that take the most space in this history. Click on a bar to see more information about the dataset.`,
-                    )
-                "
-                :data="topNDatasetsBySizeData"
-                :enable-selection="true"
-                v-bind="byteFormattingForChart">
-                <template v-slot:title>
-                    <b>{{ localize(`Top ${numberOfDatasetsToDisplay} Datasets by Size`) }}</b>
-                    <BInputGroup size="sm" :class="inputGroupClasses">
-                        <BFormSelect
-                            v-if="!isAdvanced"
-                            v-model="numberOfDatasetsToDisplay"
-                            :options="numberOfDatasetsToDisplayOptions"
-                            :disabled="isLoading"
-                            title="Number of histories to show"
-                            size="sm"
-                            @change="buildGraphsData()">
-                        </BFormSelect>
-                        <BButton
-                            v-b-tooltip.hover.bottom.noninteractive
-                            aria-haspopup="true"
-                            size="sm"
-                            title="Toggle Advanced Filtering"
-                            data-description="wide toggle advanced filter"
-                            @click="toggleAdvanced">
-                            <FontAwesomeIcon :icon="isAdvanced ? faAngleDoubleUp : faAngleDoubleDown" />
-                        </BButton>
-                    </BInputGroup>
-                </template>
-                <template v-slot:options>
-                    <div v-if="isAdvanced" class="clear-fix">
-                        <BForm>
-                            <BFormGroup
-                                id="input-group-num-histories"
-                                label="Number of histories:"
-                                label-for="input-num-histories"
-                                description="This is the maximum number of histories that will be displayed.">
-                                <BFormSelect
-                                    v-model="numberOfDatasetsToDisplay"
-                                    :options="numberOfDatasetsToDisplayOptions"
-                                    :disabled="isLoading"
-                                    title="Number of histories to show"
-                                    @change="buildGraphsData()">
-                                </BFormSelect>
-                            </BFormGroup>
-                            <BFormGroup
-                                v-if="selectableObjectStores && hasSelectableObjectStores"
-                                id="input-group-object-store"
-                                label="Galaxy Storage:"
-                                label-for="input-object-store"
-                                description="This will constrain history size calculations to a particular Galaxy storage.">
-                                <FilterObjectStoreLink
-                                    :object-stores="selectableObjectStores"
-                                    :value="objectStore"
-                                    @change="onChangeObjectStore" />
-                            </BFormGroup>
-                        </BForm>
-                    </div>
-                </template>
-                <template v-slot:tooltip="{ data }">
-                    <RecoverableItemSizeTooltip
-                        v-if="data"
-                        :data="data"
-                        :is-recoverable="isRecoverableDataPoint(data)" />
-                </template>
-                <template v-slot:selection="{ data }">
-                    <SelectedItemActions
-                        :data="data"
-                        item-type="dataset"
-                        :is-recoverable="isRecoverableDataPoint(data)"
-                        :can-edit="canEditHistory"
-                        @view-item="onViewDataset"
-                        @undelete-item="onUndelete"
-                        @permanently-delete-item="onPermDelete" />
-                </template>
-            </BarChart>
+        <Alert v-if="loadError" :message="loadError" variant="error" />
+        <template v-else>
+            <p class="text-justify">
+                Here you will find some Graphs displaying the storage taken by datasets in your history:
+                <b>{{ history?.name ?? "..." }}</b
+                >. You can use these graphs to identify the datasets that take the most space in your history. You can
+                also go to the
+                <router-link :to="{ name: 'HistoriesOverview' }"><b>Histories Storage Overview</b></router-link> page to
+                see the storage taken by <b>all your histories</b>.
+            </p>
+            <WarnDeletedDatasets />
+            <div v-if="isLoading" class="text-center">
+                <LoadingSpan class="mt-5" :message="localize('Loading your storage data. This may take a while...')" />
+            </div>
+            <div v-else>
+                <BarChart
+                    v-if="topNDatasetsBySizeData"
+                    data-description="chart history top datasets by size"
+                    :description="
+                        localize(
+                            `These are the ${numberOfDatasetsToDisplay} datasets that take the most space in this history. Click on a bar to see more information about the dataset.`,
+                        )
+                    "
+                    :data="topNDatasetsBySizeData"
+                    :enable-selection="true"
+                    v-bind="byteFormattingForChart">
+                    <template v-slot:title>
+                        <b>{{ localize(`Top ${numberOfDatasetsToDisplay} Datasets by Size`) }}</b>
+                        <BInputGroup size="sm" :class="inputGroupClasses">
+                            <BFormSelect
+                                v-if="!isAdvanced"
+                                v-model="numberOfDatasetsToDisplay"
+                                :options="numberOfDatasetsToDisplayOptions"
+                                :disabled="isLoading"
+                                title="Number of histories to show"
+                                size="sm"
+                                @change="buildGraphsData()">
+                            </BFormSelect>
+                            <BButton
+                                v-b-tooltip.hover.bottom.noninteractive
+                                aria-haspopup="true"
+                                size="sm"
+                                title="Toggle Advanced Filtering"
+                                data-description="wide toggle advanced filter"
+                                @click="toggleAdvanced">
+                                <FontAwesomeIcon :icon="isAdvanced ? faAngleDoubleUp : faAngleDoubleDown" />
+                            </BButton>
+                        </BInputGroup>
+                    </template>
+                    <template v-slot:options>
+                        <div v-if="isAdvanced" class="clear-fix">
+                            <BForm>
+                                <BFormGroup
+                                    id="input-group-num-histories"
+                                    label="Number of histories:"
+                                    label-for="input-num-histories"
+                                    description="This is the maximum number of histories that will be displayed.">
+                                    <BFormSelect
+                                        v-model="numberOfDatasetsToDisplay"
+                                        :options="numberOfDatasetsToDisplayOptions"
+                                        :disabled="isLoading"
+                                        title="Number of histories to show"
+                                        @change="buildGraphsData()">
+                                    </BFormSelect>
+                                </BFormGroup>
+                                <BFormGroup
+                                    v-if="selectableObjectStores && hasSelectableObjectStores"
+                                    id="input-group-object-store"
+                                    label="Galaxy Storage:"
+                                    label-for="input-object-store"
+                                    description="This will constrain history size calculations to a particular Galaxy storage.">
+                                    <FilterObjectStoreLink
+                                        :object-stores="selectableObjectStores"
+                                        :value="objectStore"
+                                        @change="onChangeObjectStore" />
+                                </BFormGroup>
+                            </BForm>
+                        </div>
+                    </template>
+                    <template v-slot:tooltip="{ data }">
+                        <RecoverableItemSizeTooltip
+                            v-if="data"
+                            :data="data"
+                            :is-recoverable="isRecoverableDataPoint(data)" />
+                    </template>
+                    <template v-slot:selection="{ data }">
+                        <SelectedItemActions
+                            :data="data"
+                            item-type="dataset"
+                            :is-recoverable="isRecoverableDataPoint(data)"
+                            :can-edit="canEditHistory"
+                            @view-item="onViewDataset"
+                            @undelete-item="onUndelete"
+                            @permanently-delete-item="onPermDelete" />
+                    </template>
+                </BarChart>
 
-            <BarChart
-                v-if="activeVsDeletedTotalSizeData"
-                data-description="chart history datasets by active"
-                :title="localize('Active vs Deleted Total Size')"
-                :description="
-                    localize(
-                        'This graph shows the total size of your datasets in this history, split between active and deleted datasets.',
-                    )
-                "
-                :data="activeVsDeletedTotalSizeData"
-                v-bind="byteFormattingForChart">
-                <template v-slot:tooltip="{ data }">
-                    <RecoverableItemSizeTooltip
-                        v-if="data"
-                        :data="data"
-                        :is-recoverable="isRecoverableDataPoint(data)" />
-                </template>
-            </BarChart>
-        </div>
+                <BarChart
+                    v-if="activeVsDeletedTotalSizeData"
+                    data-description="chart history datasets by active"
+                    :title="localize('Active vs Deleted Total Size')"
+                    :description="
+                        localize(
+                            'This graph shows the total size of your datasets in this history, split between active and deleted datasets.',
+                        )
+                    "
+                    :data="activeVsDeletedTotalSizeData"
+                    v-bind="byteFormattingForChart">
+                    <template v-slot:tooltip="{ data }">
+                        <RecoverableItemSizeTooltip
+                            v-if="data"
+                            :data="data"
+                            :is-recoverable="isRecoverableDataPoint(data)" />
+                    </template>
+                </BarChart>
+            </div>
+        </template>
     </OverviewPage>
 </template>

--- a/client/src/components/Workflow/HistoryInvocations.vue
+++ b/client/src/components/Workflow/HistoryInvocations.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 
 import { useHistoryStore } from "@/stores/historyStore";
 
+import Alert from "@/components/Alert.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import GridInvocation from "@/components/Grid/GridInvocation.vue";
 
@@ -13,7 +14,25 @@ interface HistoryInvocationProps {
 const props = defineProps<HistoryInvocationProps>();
 
 const historyStore = useHistoryStore();
-const historyName = computed(() => historyStore.getHistoryNameById(props.historyId));
+const loadError = ref<string | null>(null);
+
+const history = computed(() => historyStore.getHistoryById(props.historyId, false));
+const historyName = computed(() => history.value?.name ?? "...");
+
+watch(
+    () => props.historyId,
+    async (historyId) => {
+        loadError.value = null;
+        if (!historyStore.getHistoryById(historyId, false)) {
+            try {
+                await historyStore.loadHistoryById(historyId);
+            } catch (error) {
+                loadError.value = String(error);
+            }
+        }
+    },
+    { immediate: true },
+);
 
 const breadcrumbItems = computed(() => [
     { title: "Histories", to: "/histories/list" },
@@ -30,6 +49,10 @@ const breadcrumbItems = computed(() => [
     <div>
         <BreadcrumbHeading :items="breadcrumbItems" />
 
-        <GridInvocation hide-heading :filtered-for="{ type: 'History', id: props.historyId, name: historyName }" />
+        <Alert v-if="loadError" :message="loadError" variant="error" />
+        <GridInvocation
+            v-else
+            hide-heading
+            :filtered-for="{ type: 'History', id: props.historyId, name: historyName }" />
     </div>
 </template>

--- a/client/src/components/Workflow/HistoryInvocations.vue
+++ b/client/src/components/Workflow/HistoryInvocations.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from "vue";
 
 import { useHistoryStore } from "@/stores/historyStore";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import Alert from "@/components/Alert.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
@@ -27,7 +28,7 @@ watch(
             try {
                 await historyStore.loadHistoryById(historyId);
             } catch (error) {
-                loadError.value = String(error);
+                loadError.value = errorMessageAsString(error);
             }
         }
     },


### PR DESCRIPTION
Catch errors from loadHistoryById in HistoryArchiveWizard, HistoryInvocations, and HistoryStorageOverview to show user-friendly error messages instead of generating unhandled promise rejections.

Fixes GALAXY-MAIN-4KSCZZZ0014Y1 / https://github.com/galaxyproject/galaxy/issues/22322

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
