### PR TITLE
[26.0] Ignore aborted requests in rethrowSimple

### DIFF
--- a/client/src/utils/simple-error.ts
+++ b/client/src/utils/simple-error.ts
@@ -18,7 +18,25 @@ export function errorMessageAsString(e: any, defaultMessage = "Request failed.")
     return message;
 }
 
+function isRequestAborted(e: any): boolean {
+    // Only match genuine aborts (e.g. page navigation), not timeouts.
+    // ECONNABORTED is also used for timeouts when clarifyTimeoutError is false
+    // (the axios default), so check the message to distinguish.
+    if (e?.code === "ERR_CANCELED" && !e?.message?.includes("timeout")) {
+        return true;
+    }
+    if (e?.code === "ECONNABORTED" && e?.message === "Request aborted") {
+        return true;
+    }
+    return false;
+}
+
 export function rethrowSimple(e: any): never {
+    if (isRequestAborted(e)) {
+        // Browser aborted the request (e.g. page navigation); swallow silently
+        // since no downstream consumer will handle the result anyway.
+        return undefined as never;
+    }
     if (process.env.NODE_ENV != "test") {
         console.debug(e);
     }


### PR DESCRIPTION
When the browser aborts a request (e.g. during page navigation), silently return from rethrowSimple instead of throwing. No downstream consumer will handle the result when the page is being torn down.

Fixes GALAXY-MAIN-4KSCZZZ0014Z6 / https://github.com/galaxyproject/galaxy/issues/22324

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
