### PR TITLE
[26.0] Fix AbortSignal being serialized as dataset view query parameter

### DIFF
--- a/client/src/api/datasets.ts
+++ b/client/src/api/datasets.ts
@@ -25,14 +25,15 @@ export async function fetchDatasetTextContentDetails(params: { id: string }): Pr
     return data;
 }
 
-export async function fetchDatasetDetails(params: { id: string }, view: string = "detailed"): Promise<HDADetailed> {
+export async function fetchDatasetDetails(params: { id: string }, signal?: AbortSignal): Promise<HDADetailed> {
     const { data, error, response } = await GalaxyApi().GET("/api/datasets/{dataset_id}", {
         params: {
             path: {
                 dataset_id: params.id,
             },
-            query: { view },
+            query: { view: "detailed" },
         },
+        signal,
     });
 
     if (error) {

--- a/client/src/composables/keyedCache.ts
+++ b/client/src/composables/keyedCache.ts
@@ -16,7 +16,7 @@ export interface FetchParams {
 /**
  * A function that fetches an item from the server.
  */
-type FetchHandler<T> = (params: FetchParams) => Promise<T>;
+type FetchHandler<T> = (params: FetchParams, signal?: AbortSignal) => Promise<T>;
 
 /**
  * A function that returns true if the item should be fetched.


### PR DESCRIPTION
LastQueue passes an AbortSignal as the second positional argument to fetch handlers, but fetchDatasetDetails had `view: string` as its second parameter. This caused the AbortSignal object to be serialized into the query string, producing URLs like:
/api/datasets/...?view[aborted]=false&view[throwIfAborted]=...

Move `view` into the params object and accept the signal as the second argument, passing it through to openapi-fetch so requests are properly cancellable. Also update the FetchHandler type in keyedCache to reflect that handlers may receive a signal.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
