### PR TITLE
[25.1] Discard rest of line in chunks in iter_start_of_line

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -325,7 +325,7 @@ def iter_start_of_line(fh, chunk_size=None):
         if not data.endswith("\n"):
             # Discard the rest of the line without reading it all into memory
             while True:
-                line_rest = fh.readline(chunk_size)
+                line_rest = fh.readline(CHUNK_SIZE)
                 if not line_rest or line_rest.endswith("\n"):
                     break
         yield data

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -323,8 +323,11 @@ def iter_start_of_line(fh, chunk_size=None):
         if not data:
             break
         if not data.endswith("\n"):
-            # Discard the rest of the line
-            fh.readline()
+            # Discard the rest of the line without reading it all into memory
+            while True:
+                line_rest = fh.readline(chunk_size)
+                if not line_rest or line_rest.endswith("\n"):
+                    break
         yield data
 
 


### PR DESCRIPTION
Avoid reading the entire remainder of a line into memory when discarding, as some lines can be gigabytes in size.
Fixes #22331 

# How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
