### PR TITLE
Show node state colors in workflow invocation graph minimap

### DIFF
--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -371,20 +371,6 @@ useDraggable(canvas, {
         --selected-outline-color: #{$brand-primary};
         --view-color: #{fade-out($brand-dark, 0.8)};
         --view-outline-color: #{$brand-info};
-
-        // Invocation state colors
-        --state-color-new: #{$state-default-bg};
-        --state-color-waiting: #{$state-default-bg};
-        --state-color-queued: #{$state-default-bg};
-        --state-color-running: #{$state-running-bg};
-        --state-color-ok: #{$state-success-bg};
-        --state-color-error: #{$state-danger-bg};
-        --state-color-deleted: #{darken($state-default-bg, 30%)};
-        --state-color-setting-metadata: #{$state-warning-bg};
-        --state-color-paused: #{$state-info-bg};
-        --state-color-skipped: #{$state-default-bg};
-        --state-color-upload: #{$state-info-bg};
-        --state-color-undefined: #{$gray-200};
     }
 }
 </style>

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -385,6 +385,7 @@ useDraggable(canvas, {
         --state-color-skipped: #{$state-default-bg};
         --state-color-upload: #{$state-info-bg};
         --state-color-hidden: #{$state-default-bg};
+        --state-color-undefined: #{$gray-200};
     }
 }
 </style>

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -384,7 +384,6 @@ useDraggable(canvas, {
         --state-color-paused: #{$state-info-bg};
         --state-color-skipped: #{$state-default-bg};
         --state-color-upload: #{$state-info-bg};
-        --state-color-hidden: #{$state-default-bg};
         --state-color-undefined: #{$gray-200};
     }
 }

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -16,7 +16,14 @@ import type {
 import type { Step, Steps } from "@/stores/workflowStepStore";
 
 import { useWorkflowBoundingBox } from "./composables/workflowBoundingBox";
-import { drawBoxComments, drawFreehandComments, drawSteps } from "./modules/canvasDraw";
+import {
+    drawBoxComments,
+    drawFreehandComments,
+    drawStepBorders,
+    drawSteps,
+    getStepColor,
+    initStateColors,
+} from "./modules/canvasDraw";
 import { type AxisAlignedBoundingBox, Transform } from "./modules/geometry";
 
 const props = defineProps<{
@@ -108,6 +115,8 @@ onMounted(async () => {
     colors.view = style.getPropertyValue("--view-color");
     colors.viewOutline = style.getPropertyValue("--view-outline-color");
 
+    initStateColors(style);
+
     size.default = parseInt(style.getPropertyValue("--workflow-overview-size"));
     size.min = parseInt(style.getPropertyValue("--workflow-overview-min-size"));
     size.max = parseInt(style.getPropertyValue("--workflow-overview-max-size"));
@@ -162,22 +171,20 @@ function renderMinimap() {
         }
     });
 
-    // sort steps by error state
+    // group steps by their display color
     const allSteps = Object.values(props.steps);
-    const okSteps: Step[] = [];
-    const errorSteps: Step[] = [];
+    const stepsByColor = new Map<string, Step[]>();
     let selectedStep: Step | undefined;
 
     allSteps.forEach((step) => {
         if (stateStore.activeNodeId === step.id) {
             selectedStep = step;
         }
-
-        if (step.errors) {
-            errorSteps.push(step);
-        } else {
-            okSteps.push(step);
+        const color = getStepColor(step, colors.node, colors.error);
+        if (!stepsByColor.has(color)) {
+            stepsByColor.set(color, []);
         }
+        stepsByColor.get(color)?.push(step);
     });
 
     // draw rects
@@ -186,8 +193,10 @@ function renderMinimap() {
     drawBoxComments(ctx, markdownComments, 2 / canvasTransform.scaleX, colors.node);
     ctx.fillStyle = "rgba(0, 0, 0, 0)";
     drawBoxComments(ctx, textComments, 1 / canvasTransform.scaleX, colors.node);
-    drawSteps(ctx, okSteps, colors.node, stateStore);
-    drawSteps(ctx, errorSteps, colors.error, stateStore);
+    stepsByColor.forEach((stepsForColor, color) => {
+        drawSteps(ctx, stepsForColor, color, stateStore);
+    });
+    drawStepBorders(ctx, allSteps, colors.node, stateStore);
 
     drawFreehandComments(ctx, freehandComments, colors.node);
 
@@ -362,6 +371,20 @@ useDraggable(canvas, {
         --selected-outline-color: #{$brand-primary};
         --view-color: #{fade-out($brand-dark, 0.8)};
         --view-outline-color: #{$brand-info};
+
+        // Invocation state colors
+        --state-color-new: #{$state-default-bg};
+        --state-color-waiting: #{$state-default-bg};
+        --state-color-queued: #{$state-default-bg};
+        --state-color-running: #{$state-running-bg};
+        --state-color-ok: #{$state-success-bg};
+        --state-color-error: #{$state-danger-bg};
+        --state-color-deleted: #{darken($state-default-bg, 30%)};
+        --state-color-setting-metadata: #{$state-warning-bg};
+        --state-color-paused: #{$state-info-bg};
+        --state-color-skipped: #{$state-default-bg};
+        --state-color-upload: #{$state-info-bg};
+        --state-color-hidden: #{$state-default-bg};
     }
 }
 </style>

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.test.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.test.ts
@@ -6,18 +6,30 @@ import type { Step } from "@/stores/workflowStepStore";
 
 import { drawStepBorders, drawSteps, getStepColor, initStateColors } from "./canvasDraw";
 
+/**
+ * Makes a mock CSSStyleDeclaration whose `getPropertyValue` resolves CSS custom properties
+ * from a plain object. Simulates how `initStateColors` reads `--state-color-*` vars from
+ * a real element's computed style at mount time.
+ */
 function makeMockStyle(vars: Record<string, string>): CSSStyleDeclaration {
     return { getPropertyValue: (prop: string) => vars[prop] ?? "" } as unknown as CSSStyleDeclaration;
 }
 
+/** Makes a mock Step object provided with default values, allowing overrides. */
 function makeStep(overrides: Partial<Step> = {}): Step {
     return { id: 0, position: { left: 10, top: 20 }, errors: null, type: "tool", ...overrides } as unknown as Step;
 }
 
-function makeGraphStep(overrides: Partial<GraphStep> = {}): Step {
-    return makeStep(overrides as Partial<Step>);
+/** Makes a mock GraphStep object provided with default values, allowing overrides. */
+function makeGraphStep(overrides: Partial<GraphStep> = {}): GraphStep {
+    return makeStep(overrides as Partial<Step>) as unknown as GraphStep;
 }
 
+/**
+ * Makes a mock CanvasRenderingContext2D with spied drawing methods. Simulates the canvas
+ * context passed to `drawSteps`/`drawStepBorders` so tests can assert on draw calls
+ * without needing a real DOM canvas element.
+ */
 function makeCtx(): CanvasRenderingContext2D {
     return {
         beginPath: vi.fn(),
@@ -30,24 +42,22 @@ function makeCtx(): CanvasRenderingContext2D {
     } as unknown as CanvasRenderingContext2D;
 }
 
+/** Makes a mock workflow state store with specified step positions. */
 function makeStateStore(
     positions: Record<number, { width: number; height: number }>,
 ): ReturnType<typeof useWorkflowStateStore> {
     return { stepPosition: positions } as unknown as ReturnType<typeof useWorkflowStateStore>;
 }
 
-const STATE_COLORS = {
-    "--state-color-ok": "#d4edda",
-    "--state-color-error": "#f8d7da",
-    "--state-color-running": "#fff3cd",
-    "--state-color-new": "#e2e3e5",
-    "--state-color-waiting": "#e2e3e5",
-    "--state-color-queued": "#e2e3e5",
+const MOCK_COLORS: Record<string, string> = {
+    "--state-color-ok": "#ok-color",
+    "--state-color-error": "#error-color",
+    "--state-color-uninitialized": "#uninitialized-color",
 };
 
 describe("initStateColors + getStepColor", () => {
     beforeEach(() => {
-        initStateColors(makeMockStyle(STATE_COLORS));
+        initStateColors(makeMockStyle(MOCK_COLORS));
     });
 
     describe("plain editor steps (no headerClass)", () => {
@@ -56,41 +66,40 @@ describe("initStateColors + getStepColor", () => {
         });
 
         it("returns errorColor when step has errors", () => {
-            expect(getStepColor(makeStep({ errors: "something went wrong" } as any), "#node", "#error")).toBe("#error");
+            expect(getStepColor(makeStep({ errors: ["something went wrong"] }), "#node", "#error")).toBe("#error");
         });
     });
 
     describe("invocation steps (with headerClass)", () => {
-        it("returns the matching state color for an active header-* class", () => {
-            const step = makeGraphStep({ headerClass: { "node-header-invocation": true, "header-ok": true } } as any);
-            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-ok"]);
+        it("returns the CSS var color for an active header-* class", () => {
+            const step = makeGraphStep({ headerClass: { "node-header-invocation": true, "header-ok": true } });
+            expect(getStepColor(step, "#node", "#error")).toBe(MOCK_COLORS["--state-color-ok"]);
         });
 
-        it("returns the error state color for header-error", () => {
+        it("returns the CSS var color for header-error", () => {
             const step = makeGraphStep({
                 headerClass: { "node-header-invocation": true, "header-error": true },
-            } as any);
-            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-error"]);
+            });
+            expect(getStepColor(step, "#node", "#error")).toBe(MOCK_COLORS["--state-color-error"]);
         });
 
         it("ignores inactive header-* classes and falls back to nodeColor", () => {
             const step = makeGraphStep({
                 headerClass: { "node-header-invocation": true, "header-ok": false },
-            } as any);
+            });
             expect(getStepColor(step, "#node", "#error")).toBe("#node");
         });
 
         it("falls back to nodeColor when headerClass has no active header-* keys", () => {
-            const step = makeGraphStep({ headerClass: { "node-header-invocation": true } } as any);
+            const step = makeGraphStep({ headerClass: { "node-header-invocation": true } });
             expect(getStepColor(step, "#node", "#error")).toBe("#node");
         });
 
-        it("returns the uninitialized state color for header-uninitialized", () => {
-            initStateColors(makeMockStyle({ ...STATE_COLORS, "--state-color-uninitialized": "#dee2e6" }));
+        it("returns the CSS var color for header-uninitialized", () => {
             const step = makeGraphStep({
                 headerClass: { "node-header-invocation": true, "header-uninitialized": true },
-            } as any);
-            expect(getStepColor(step, "#node", "#error")).toBe("#dee2e6");
+            });
+            expect(getStepColor(step, "#node", "#error")).toBe(MOCK_COLORS["--state-color-uninitialized"]);
         });
     });
 });
@@ -98,7 +107,7 @@ describe("initStateColors + getStepColor", () => {
 describe("drawSteps", () => {
     it("fills each step rect using the provided color", () => {
         const ctx = makeCtx();
-        const steps = [makeStep({ id: 1, position: { left: 5, top: 10 } } as any)];
+        const steps = [makeStep({ id: 1, position: { left: 5, top: 10 } })];
         const stateStore = makeStateStore({ 1: { width: 100, height: 40 } });
 
         drawSteps(ctx, steps, "#ff0000", stateStore);
@@ -111,7 +120,7 @@ describe("drawSteps", () => {
 
     it("skips steps with no recorded position", () => {
         const ctx = makeCtx();
-        const steps = [makeStep({ id: 99 } as any)];
+        const steps = [makeStep({ id: 99 })];
         const stateStore = makeStateStore({});
 
         drawSteps(ctx, steps, "#ff0000", stateStore);
@@ -123,7 +132,7 @@ describe("drawSteps", () => {
 describe("drawStepBorders", () => {
     it("strokes each step rect using the provided border color", () => {
         const ctx = makeCtx();
-        const steps = [makeStep({ id: 1, position: { left: 5, top: 10 } } as any)];
+        const steps = [makeStep({ id: 1, position: { left: 5, top: 10 } })];
         const stateStore = makeStateStore({ 1: { width: 100, height: 40 } });
 
         drawStepBorders(ctx, steps, "#0000ff", stateStore);
@@ -136,7 +145,7 @@ describe("drawStepBorders", () => {
 
     it("skips steps with no recorded position", () => {
         const ctx = makeCtx();
-        const steps = [makeStep({ id: 99 } as any)];
+        const steps = [makeStep({ id: 99 })];
         const stateStore = makeStateStore({});
 
         drawStepBorders(ctx, steps, "#0000ff", stateStore);

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.test.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.test.ts
@@ -43,7 +43,6 @@ const STATE_COLORS = {
     "--state-color-new": "#e2e3e5",
     "--state-color-waiting": "#e2e3e5",
     "--state-color-queued": "#e2e3e5",
-    "--state-color-undefined": "#e9ecef",
 };
 
 describe("initStateColors + getStepColor", () => {
@@ -74,22 +73,24 @@ describe("initStateColors + getStepColor", () => {
             expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-error"]);
         });
 
-        it("ignores inactive header-* classes and falls back to the undefined color", () => {
+        it("ignores inactive header-* classes and falls back to nodeColor", () => {
             const step = makeGraphStep({
-                headerClass: { "node-header-invocation": true, "header-undefined": false },
+                headerClass: { "node-header-invocation": true, "header-ok": false },
             } as any);
-            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-undefined"]);
+            expect(getStepColor(step, "#node", "#error")).toBe("#node");
         });
 
-        it("falls back to undefined color when headerClass has no header-* keys", () => {
-            const step = makeGraphStep({ headerClass: { "node-header-invocation": true } } as any);
-            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-undefined"]);
-        });
-
-        it("falls back to nodeColor when undefined color is also unset", () => {
-            initStateColors(makeMockStyle({}));
+        it("falls back to nodeColor when headerClass has no active header-* keys", () => {
             const step = makeGraphStep({ headerClass: { "node-header-invocation": true } } as any);
             expect(getStepColor(step, "#node", "#error")).toBe("#node");
+        });
+
+        it("returns the uninitialized state color for header-uninitialized", () => {
+            initStateColors(makeMockStyle({ ...STATE_COLORS, "--state-color-uninitialized": "#dee2e6" }));
+            const step = makeGraphStep({
+                headerClass: { "node-header-invocation": true, "header-uninitialized": true },
+            } as any);
+            expect(getStepColor(step, "#node", "#error")).toBe("#dee2e6");
         });
     });
 });

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.test.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GraphStep } from "@/composables/useInvocationGraph";
+import type { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import type { Step } from "@/stores/workflowStepStore";
+
+import { drawStepBorders, drawSteps, getStepColor, initStateColors } from "./canvasDraw";
+
+function makeMockStyle(vars: Record<string, string>): CSSStyleDeclaration {
+    return { getPropertyValue: (prop: string) => vars[prop] ?? "" } as unknown as CSSStyleDeclaration;
+}
+
+function makeStep(overrides: Partial<Step> = {}): Step {
+    return { id: 0, position: { left: 10, top: 20 }, errors: null, type: "tool", ...overrides } as unknown as Step;
+}
+
+function makeGraphStep(overrides: Partial<GraphStep> = {}): Step {
+    return makeStep(overrides as Partial<Step>);
+}
+
+function makeCtx(): CanvasRenderingContext2D {
+    return {
+        beginPath: vi.fn(),
+        rect: vi.fn(),
+        fill: vi.fn(),
+        stroke: vi.fn(),
+        fillStyle: "",
+        strokeStyle: "",
+        lineWidth: 0,
+    } as unknown as CanvasRenderingContext2D;
+}
+
+function makeStateStore(
+    positions: Record<number, { width: number; height: number }>,
+): ReturnType<typeof useWorkflowStateStore> {
+    return { stepPosition: positions } as unknown as ReturnType<typeof useWorkflowStateStore>;
+}
+
+const STATE_COLORS = {
+    "--state-color-ok": "#d4edda",
+    "--state-color-error": "#f8d7da",
+    "--state-color-running": "#fff3cd",
+    "--state-color-new": "#e2e3e5",
+    "--state-color-waiting": "#e2e3e5",
+    "--state-color-queued": "#e2e3e5",
+    "--state-color-undefined": "#e9ecef",
+};
+
+describe("initStateColors + getStepColor", () => {
+    beforeEach(() => {
+        initStateColors(makeMockStyle(STATE_COLORS));
+    });
+
+    describe("plain editor steps (no headerClass)", () => {
+        it("returns nodeColor when no errors", () => {
+            expect(getStepColor(makeStep(), "#node", "#error")).toBe("#node");
+        });
+
+        it("returns errorColor when step has errors", () => {
+            expect(getStepColor(makeStep({ errors: "something went wrong" } as any), "#node", "#error")).toBe("#error");
+        });
+    });
+
+    describe("invocation steps (with headerClass)", () => {
+        it("returns the matching state color for an active header-* class", () => {
+            const step = makeGraphStep({ headerClass: { "node-header-invocation": true, "header-ok": true } } as any);
+            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-ok"]);
+        });
+
+        it("returns the error state color for header-error", () => {
+            const step = makeGraphStep({
+                headerClass: { "node-header-invocation": true, "header-error": true },
+            } as any);
+            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-error"]);
+        });
+
+        it("ignores inactive header-* classes and falls back to the undefined color", () => {
+            const step = makeGraphStep({
+                headerClass: { "node-header-invocation": true, "header-undefined": false },
+            } as any);
+            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-undefined"]);
+        });
+
+        it("falls back to undefined color when headerClass has no header-* keys", () => {
+            const step = makeGraphStep({ headerClass: { "node-header-invocation": true } } as any);
+            expect(getStepColor(step, "#node", "#error")).toBe(STATE_COLORS["--state-color-undefined"]);
+        });
+
+        it("falls back to nodeColor when undefined color is also unset", () => {
+            initStateColors(makeMockStyle({}));
+            const step = makeGraphStep({ headerClass: { "node-header-invocation": true } } as any);
+            expect(getStepColor(step, "#node", "#error")).toBe("#node");
+        });
+    });
+});
+
+describe("drawSteps", () => {
+    it("fills each step rect using the provided color", () => {
+        const ctx = makeCtx();
+        const steps = [makeStep({ id: 1, position: { left: 5, top: 10 } } as any)];
+        const stateStore = makeStateStore({ 1: { width: 100, height: 40 } });
+
+        drawSteps(ctx, steps, "#ff0000", stateStore);
+
+        expect(ctx.fillStyle).toBe("#ff0000");
+        expect(ctx.beginPath).toHaveBeenCalled();
+        expect(ctx.rect).toHaveBeenCalledWith(5, 10, 100, 40);
+        expect(ctx.fill).toHaveBeenCalled();
+    });
+
+    it("skips steps with no recorded position", () => {
+        const ctx = makeCtx();
+        const steps = [makeStep({ id: 99 } as any)];
+        const stateStore = makeStateStore({});
+
+        drawSteps(ctx, steps, "#ff0000", stateStore);
+
+        expect(ctx.rect).not.toHaveBeenCalled();
+    });
+});
+
+describe("drawStepBorders", () => {
+    it("strokes each step rect using the provided border color", () => {
+        const ctx = makeCtx();
+        const steps = [makeStep({ id: 1, position: { left: 5, top: 10 } } as any)];
+        const stateStore = makeStateStore({ 1: { width: 100, height: 40 } });
+
+        drawStepBorders(ctx, steps, "#0000ff", stateStore);
+
+        expect(ctx.strokeStyle).toBe("#0000ff");
+        expect(ctx.lineWidth).toBe(1);
+        expect(ctx.rect).toHaveBeenCalledWith(5, 10, 100, 40);
+        expect(ctx.stroke).toHaveBeenCalled();
+    });
+
+    it("skips steps with no recorded position", () => {
+        const ctx = makeCtx();
+        const steps = [makeStep({ id: 99 } as any)];
+        const stateStore = makeStateStore({});
+
+        drawStepBorders(ctx, steps, "#0000ff", stateStore);
+
+        expect(ctx.rect).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.ts
@@ -1,6 +1,7 @@
 import { curveCatmullRom, line } from "d3";
 
 import * as commentColors from "@/components/Workflow/Editor/Comments/colors";
+import type { GraphStep } from "@/composables/useInvocationGraph";
 import type {
     FrameWorkflowComment,
     FreehandWorkflowComment,
@@ -9,6 +10,48 @@ import type {
 } from "@/stores/workflowEditorCommentStore";
 import type { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 import type { Step } from "@/stores/workflowStepStore";
+
+const stateNames = [
+    "new",
+    "waiting",
+    "queued",
+    "running",
+    "ok",
+    "error",
+    "deleted",
+    "setting_metadata",
+    "paused",
+    "skipped",
+    "upload",
+    "hidden",
+] as const;
+
+const stateColors: Record<string, string> = {};
+
+/** Initialize the state colors for minimap nodes from CSS variables.
+ * This should be called once when the minimap is mounted. */
+export function initStateColors(style: CSSStyleDeclaration) {
+    for (const state of stateNames) {
+        const cssKey = state.replace("_", "-");
+        stateColors[state] = style.getPropertyValue(`--state-color-${cssKey}`);
+    }
+}
+
+/** Get the color for a minimap step based on its state (invocation view) and errors. */
+export function getStepColor(step: Step, nodeColor: string, errorColor: string): string {
+    const graphStep = step as GraphStep;
+    if (graphStep.headerClass) {
+        for (const [key, active] of Object.entries(graphStep.headerClass)) {
+            if (active && key.startsWith("header-")) {
+                const color = stateColors[key.slice(7)];
+                if (color) {
+                    return color;
+                }
+            }
+        }
+    }
+    return step.errors ? errorColor : nodeColor;
+}
 
 export function drawBoxComments(
     ctx: CanvasRenderingContext2D,
@@ -68,6 +111,27 @@ export function drawSteps(
         }
     });
     ctx.fill();
+}
+
+/** Draw borders around minimap steps. This is needed to make step boundaries visible when
+ * step colors are very light (in the invocation view where steps can have states). */
+export function drawStepBorders(
+    ctx: CanvasRenderingContext2D,
+    steps: Step[],
+    borderColor: string,
+    stateStore: ReturnType<typeof useWorkflowStateStore>,
+) {
+    ctx.beginPath();
+    ctx.strokeStyle = borderColor;
+    ctx.lineWidth = 1;
+    steps.forEach((step) => {
+        const rect = stateStore.stepPosition[step.id];
+
+        if (rect && step.position) {
+            ctx.rect(step.position.left, step.position.top, rect.width, rect.height);
+        }
+    });
+    ctx.stroke();
 }
 
 export function drawFreehandComments(

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.ts
@@ -24,6 +24,7 @@ const stateNames = [
     "skipped",
     "upload",
     "hidden",
+    "undefined",
 ] as const;
 
 const stateColors: Record<string, string> = {};
@@ -49,6 +50,7 @@ export function getStepColor(step: Step, nodeColor: string, errorColor: string):
                 }
             }
         }
+        return stateColors["undefined"] ?? nodeColor;
     }
     return step.errors ? errorColor : nodeColor;
 }

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.ts
@@ -1,7 +1,7 @@
 import { curveCatmullRom, line } from "d3";
 
 import * as commentColors from "@/components/Workflow/Editor/Comments/colors";
-import { type GraphStep, graphStepStates } from "@/composables/useInvocationGraph";
+import type { GraphStep } from "@/composables/useInvocationGraph";
 import type {
     FrameWorkflowComment,
     FreehandWorkflowComment,
@@ -11,19 +11,23 @@ import type {
 import type { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 import type { Step } from "@/stores/workflowStepStore";
 
-/** The names of all possible graph step states, including an undefined state
- * (for input parameters which do not have a graph step state). */
-const stateNames = [...graphStepStates, "undefined"] as const;
-
 const stateColors: Record<string, string> = {};
+let _style: CSSStyleDeclaration | null = null;
 
-/** Initialize the state colors for minimap nodes from CSS variables.
- * This should be called once when the minimap is mounted. */
+/** Initialize the state color cache from CSS variables. Call once when the minimap is mounted. */
 export function initStateColors(style: CSSStyleDeclaration) {
-    for (const state of stateNames) {
-        const cssKey = state.replace("_", "-");
-        stateColors[state] = style.getPropertyValue(`--state-color-${cssKey}`);
+    _style = style;
+    for (const key of Object.keys(stateColors)) {
+        delete stateColors[key];
     }
+}
+
+/** Returns the cached CSS `--state-color-{stateName}` value, looking it up on first use. */
+function lookupStateColor(stateName: string): string {
+    if (!(stateName in stateColors) && _style) {
+        stateColors[stateName] = _style.getPropertyValue(`--state-color-${stateName.replace(/_/g, "-")}`);
+    }
+    return stateColors[stateName] ?? "";
 }
 
 /** Get the color for a minimap step based on its state (invocation view) and errors. */
@@ -32,13 +36,13 @@ export function getStepColor(step: Step, nodeColor: string, errorColor: string):
     if (graphStep.headerClass) {
         for (const [key, active] of Object.entries(graphStep.headerClass)) {
             if (active && key.startsWith("header-")) {
-                const color = stateColors[key.slice(7)];
+                const color = lookupStateColor(key.slice(7));
                 if (color) {
                     return color;
                 }
             }
         }
-        return stateColors["undefined"] || nodeColor;
+        return lookupStateColor("undefined") || nodeColor;
     }
     return step.errors ? errorColor : nodeColor;
 }

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.ts
@@ -1,7 +1,7 @@
 import { curveCatmullRom, line } from "d3";
 
 import * as commentColors from "@/components/Workflow/Editor/Comments/colors";
-import type { GraphStep } from "@/composables/useInvocationGraph";
+import { type GraphStep, graphStepStates } from "@/composables/useInvocationGraph";
 import type {
     FrameWorkflowComment,
     FreehandWorkflowComment,
@@ -11,21 +11,9 @@ import type {
 import type { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 import type { Step } from "@/stores/workflowStepStore";
 
-const stateNames = [
-    "new",
-    "waiting",
-    "queued",
-    "running",
-    "ok",
-    "error",
-    "deleted",
-    "setting_metadata",
-    "paused",
-    "skipped",
-    "upload",
-    "hidden",
-    "undefined",
-] as const;
+/** The names of all possible graph step states, including an undefined state
+ * (for input parameters which do not have a graph step state). */
+const stateNames = [...graphStepStates, "undefined"] as const;
 
 const stateColors: Record<string, string> = {};
 

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.ts
@@ -42,7 +42,7 @@ export function getStepColor(step: Step, nodeColor: string, errorColor: string):
                 }
             }
         }
-        return lookupStateColor("undefined") || nodeColor;
+        return nodeColor;
     }
     return step.errors ? errorColor : nodeColor;
 }

--- a/client/src/components/Workflow/Editor/modules/canvasDraw.ts
+++ b/client/src/components/Workflow/Editor/modules/canvasDraw.ts
@@ -50,7 +50,7 @@ export function getStepColor(step: Step, nodeColor: string, errorColor: string):
                 }
             }
         }
-        return stateColors["undefined"] ?? nodeColor;
+        return stateColors["undefined"] || nodeColor;
     }
     return step.errors ? errorColor : nodeColor;
 }

--- a/client/src/composables/useInvocationGraph.test.ts
+++ b/client/src/composables/useInvocationGraph.test.ts
@@ -1,0 +1,145 @@
+import { createTestingPinia } from "@pinia/testing";
+import { setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import type { StepJobSummary, WorkflowInvocationElementView } from "@/api/invocations";
+
+import { useInvocationGraph } from "./useInvocationGraph";
+
+vi.mock("@/stores/workflowStore", () => ({
+    useWorkflowStore: () => ({
+        getFullWorkflowCached: vi.fn().mockResolvedValue({
+            steps: { 0: { id: 0, type: "tool", position: { left: 0, top: 0 } } },
+        }),
+    }),
+}));
+vi.mock("@/components/Workflow/Editor/modules/model", () => ({ fromSimple: vi.fn() }));
+vi.mock("./workflowStores", () => ({ provideScopedWorkflowStores: vi.fn() }));
+
+/** Sets up the invocation graph composable for testing.
+ * Initializes the composable and then loads it via its `loadInvocationGraph` function.
+ */
+function setupComposable(invStep?: object, summaries: object[] = []) {
+    const invocation = ref({
+        id: "inv1",
+        steps: invStep ? { 0: invStep } : {},
+        inputs: {},
+        input_step_parameters: {},
+    } as WorkflowInvocationElementView);
+    const { steps, loadInvocationGraph } = useInvocationGraph(
+        invocation,
+        ref(summaries as StepJobSummary[]),
+        ref("wf1"),
+        ref(0),
+    );
+    return { steps, load: () => loadInvocationGraph(false) };
+}
+
+/** Helper function to set up a a version of the composable with provided job states */
+function withJobStates(states: Record<string, number>, populated_state = "ok") {
+    return setupComposable({ job_id: "j1" }, [{ id: "j1", model: "Job", states, populated_state }]);
+}
+
+describe("useInvocationGraph — step state", () => {
+    beforeEach(() => {
+        setActivePinia(createTestingPinia({ createSpy: vi.fn }));
+    });
+
+    it("is queued — no invocation step for this workflow step", async () => {
+        const { steps, load } = setupComposable();
+        await load();
+        expect(steps.value[0]?.state).toBe("queued");
+    });
+
+    it("is waiting — invocation step present but no matching job summary", async () => {
+        const { steps, load } = setupComposable({ job_id: "j1" });
+        await load();
+        expect(steps.value[0]?.state).toBe("waiting");
+    });
+
+    describe("from job states (single-instance: any one job triggers it)", () => {
+        it("is error", async () => {
+            const { steps, load } = withJobStates({ error: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("error");
+        });
+
+        it("is running", async () => {
+            const { steps, load } = withJobStates({ running: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("running");
+        });
+
+        it("is paused", async () => {
+            const { steps, load } = withJobStates({ paused: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("paused");
+        });
+
+        it("is deleted — from deleting job state", async () => {
+            const { steps, load } = withJobStates({ deleting: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("deleted");
+        });
+    });
+
+    describe("from job states (all-instances: all jobs must be in that state)", () => {
+        it("is deleted", async () => {
+            const { steps, load } = withJobStates({ deleted: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("deleted");
+        });
+
+        it("is skipped", async () => {
+            const { steps, load } = withJobStates({ skipped: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("skipped");
+        });
+
+        it("is new", async () => {
+            const { steps, load } = withJobStates({ new: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("new");
+        });
+
+        it("is queued", async () => {
+            const { steps, load } = withJobStates({ queued: 1 });
+            await load();
+            expect(steps.value[0]?.state).toBe("queued");
+        });
+    });
+
+    describe("from populated_state fallback (when job states are inconclusive)", () => {
+        // use { ok: 1 } — not in any SINGLE or ALL_INSTANCES list, so falls through to populated_state
+        it("is queued — from scheduled populated_state", async () => {
+            const { steps, load } = withJobStates({ ok: 1 }, "scheduled");
+            await load();
+            expect(steps.value[0]?.state).toBe("queued");
+        });
+
+        it("is queued — from ready populated_state", async () => {
+            const { steps, load } = withJobStates({ ok: 1 }, "ready");
+            await load();
+            expect(steps.value[0]?.state).toBe("queued");
+        });
+
+        it("is new — from resubmitted populated_state", async () => {
+            const { steps, load } = withJobStates({ ok: 1 }, "resubmitted");
+            await load();
+            expect(steps.value[0]?.state).toBe("new");
+        });
+
+        it("is error — from failed populated_state", async () => {
+            const { steps, load } = withJobStates({ ok: 1 }, "failed");
+            await load();
+            expect(steps.value[0]?.state).toBe("error");
+        });
+
+        it("is deleted — from deleting populated_state", async () => {
+            const { steps, load } = withJobStates({ ok: 1 }, "deleting");
+            await load();
+            expect(steps.value[0]?.state).toBe("deleted");
+        });
+    });
+});

--- a/client/src/composables/useInvocationGraph.test.ts
+++ b/client/src/composables/useInvocationGraph.test.ts
@@ -110,6 +110,23 @@ describe("useInvocationGraph — step state", () => {
         });
     });
 
+    describe("uninitialized state", () => {
+        it("headerClass is set on a fresh step before state is determined", async () => {
+            const { steps, load } = setupComposable();
+            await load();
+            expect(steps.value[0]?.headerClass).toBeDefined();
+        });
+
+        it("stays uninitialized when job states are inconclusive and populated_state is excluded", async () => {
+            // "ok" not in SINGLE/ALL lists → getStepStateFromJobStates returns undefined
+            // "stop" is explicitly excluded from the populated_state fallback
+            // → newState stays undefined → preserves previous "uninitialized" state
+            const { steps, load } = withJobStates({ ok: 1 }, "stop");
+            await load();
+            expect(steps.value[0]?.state).toBe("uninitialized");
+        });
+    });
+
     describe("from populated_state fallback (when job states are inconclusive)", () => {
         // use { ok: 1 } — not in any SINGLE or ALL_INSTANCES list, so falls through to populated_state
         it("is queued — from scheduled populated_state", async () => {

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -6,6 +6,7 @@ import {
     faExclamationTriangle,
     faForward,
     faPause,
+    faQuestionCircle,
     faSpinner,
     faStopCircle,
     faTrash,
@@ -29,14 +30,16 @@ import { provideScopedWorkflowStores } from "./workflowStores";
 /** All possible states for an Invocation Graph step.
  * - `JobState`: for tool/collection steps (derived from job states and `populated_state`)
  * - `DatasetState`: for data input steps (derived from the dataset/collection state)
- * - `InvocationStepState`: for subworkflow steps (derived from the invocation step state) */
-type GraphStepState =
+ * - `InvocationStepState`: for subworkflow steps (derived from the invocation step state)
+ * - `"uninitialized"`: initial state before the step's actual state has been determined */
+export type GraphStepState =
     | components["schemas"]["JobState"]
     | components["schemas"]["DatasetState"]
-    | components["schemas"]["InvocationStepState"];
+    | components["schemas"]["InvocationStepState"]
+    | "uninitialized";
 
 export interface GraphStep extends Step {
-    state?: GraphStepState;
+    state: GraphStepState;
     jobs: StepJobSummary["states"];
     headerClass?: Record<string, boolean>;
     headerIcon?: IconDefinition;
@@ -78,6 +81,8 @@ export const iconClasses: Record<GraphStepState, { icon: IconDefinition; spin?: 
     deleting: { icon: faTrash, class: "text-danger" },
     stop: { icon: faStopCircle, class: "text-danger" },
     stopped: { icon: faStopCircle, class: "text-danger" },
+    // not yet determined
+    uninitialized: { icon: faQuestionCircle },
 };
 
 export const statePlaceholders: Record<string, string> = {
@@ -185,7 +190,8 @@ export function useInvocationGraph(
             /** An invocation graph step (initialized with the original workflow step) */
             let graphStepFromWfStep;
             if (!steps.value[i]) {
-                graphStepFromWfStep = { ...fullSteps[i] } as GraphStep;
+                graphStepFromWfStep = { ...fullSteps[i], state: "uninitialized" } as GraphStep;
+                setHeaderClass(graphStepFromWfStep);
             } else {
                 graphStepFromWfStep = steps.value[i] as GraphStep;
             }
@@ -235,8 +241,8 @@ export function useInvocationGraph(
         invocationStep: InvocationStep | undefined,
         invocationStepSummary: StepJobSummary | undefined,
     ) {
-        /** The new state for the graph step */
-        let newState = graphStep.state;
+        /** The resolved state for the graph step (undefined = not yet determined) */
+        let newState: GraphStepState | undefined = undefined;
 
         // there is an invocation step for this workflow step
         if (invocationStep) {
@@ -297,9 +303,10 @@ export function useInvocationGraph(
             newState = "queued";
         }
 
-        // if the state has changed, update the graph step
-        if (graphStep.state !== newState) {
-            graphStep.state = newState;
+        // preserve previous state if a new one couldn't be determined
+        const resolvedState = newState ?? graphStep.state;
+        if (graphStep.state !== resolvedState) {
+            graphStep.state = resolvedState;
             setHeaderClass(graphStep);
         }
     }

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -23,12 +23,8 @@ import { rethrowSimple } from "@/utils/simple-error";
 
 import { provideScopedWorkflowStores } from "./workflowStores";
 
-/** The names of all possible Invocation Graph step states.
- *
- * These are computed on the client, in the `updateStep` method,
- * by analyzing the `GraphStep.jobs` states for a given Invocation step, or by
- * examining other relevant step properties (subworkflow scheduling, etc.).
- */
+/** All possible states for an Invocation Graph step, derived from job states,
+ * input dataset states, and subworkflow scheduling states. */
 export const graphStepStates = [
     "new",
     "upload",
@@ -38,7 +34,6 @@ export const graphStepStates = [
     "ok",
     "error",
     "deleted",
-    "hidden",
     "setting_metadata",
     "paused",
     "skipped",

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -2,10 +2,12 @@ import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import {
     faCheckCircle,
     faClock,
+    faCloud,
     faExclamationTriangle,
     faForward,
     faPause,
     faSpinner,
+    faStopCircle,
     faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { computed, type Ref, ref, set } from "vue";
@@ -46,21 +48,45 @@ interface InvocationGraph extends Omit<StoredWorkflowDetailed, "steps"> {
 }
 
 /** Classes for states' icons */
-export const iconClasses: Record<string, { icon: IconDefinition; spin?: boolean; class?: string }> = {
+export const iconClasses: Record<GraphStepState, { icon: IconDefinition; spin?: boolean; class?: string }> = {
+    // terminal success
     ok: { icon: faCheckCircle, class: "text-success" },
-    error: { icon: faExclamationTriangle, class: "text-danger" },
-    paused: { icon: faPause, class: "text-primary" },
-    running: { icon: faSpinner, spin: true },
+    empty: { icon: faCheckCircle, class: "text-success" },
+    // transitional / waiting
     new: { icon: faClock },
     waiting: { icon: faClock },
     queued: { icon: faClock },
-    deleted: { icon: faTrash, class: "text-danger" },
+    resubmitted: { icon: faClock },
+    ready: { icon: faClock },
+    scheduled: { icon: faClock },
+    // active
+    running: { icon: faSpinner, spin: true },
+    upload: { icon: faSpinner, spin: true },
+    setting_metadata: { icon: faSpinner, spin: true },
+    // paused / info
+    paused: { icon: faPause, class: "text-primary" },
+    deferred: { icon: faCloud, class: "text-info" },
+    // skipped
     skipped: { icon: faForward, class: "text-warning" },
+    // errors / failures
+    error: { icon: faExclamationTriangle, class: "text-danger" },
+    failed: { icon: faExclamationTriangle, class: "text-danger" },
+    failed_metadata: { icon: faExclamationTriangle, class: "text-danger" },
+    discarded: { icon: faExclamationTriangle, class: "text-danger" },
+    // deleted / stopped
+    deleted: { icon: faTrash, class: "text-danger" },
+    deleting: { icon: faTrash, class: "text-danger" },
+    stop: { icon: faStopCircle, class: "text-danger" },
+    stopped: { icon: faStopCircle, class: "text-danger" },
 };
 
 export const statePlaceholders: Record<string, string> = {
     ok: "successful",
     error: "failed",
+    upload: "uploading",
+    setting_metadata: "setting metadata",
+    failed_metadata: "have metadata errors",
+    stop: "stopping",
 };
 
 /** Only one job needs to be in one of these states for the graph step to be in that state */
@@ -303,7 +329,7 @@ export function useInvocationGraph(
 
     function setHeaderClass(graphStep: GraphStep) {
         /** Setting the header class for the graph step */
-        graphStep.headerClass = getHeaderClass(graphStep.state as string);
+        graphStep.headerClass = getHeaderClass(graphStep.state);
 
         /** Setting the header icon for the graph step */
         if (graphStep.state) {
@@ -356,7 +382,7 @@ export function useInvocationGraph(
     };
 }
 
-export function getHeaderClass(state: string) {
+export function getHeaderClass(state: GraphStepState | undefined) {
     return {
         "node-header-invocation": true,
         [`header-${state}`]: !!state,

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -13,6 +13,7 @@ import { computed, type Ref, ref, set } from "vue";
 import { fetchCollectionSummary } from "@/api/datasetCollections";
 import { fetchDatasetDetails } from "@/api/datasets";
 import type { InvocationStep, StepJobSummary, WorkflowInvocationElementView } from "@/api/invocations";
+import type { components } from "@/api/schema";
 import type { StoredWorkflowDetailed } from "@/api/workflows";
 import { getContentItemState } from "@/components/History/Content/model/states";
 import { isWorkflowInput } from "@/components/Workflow/constants";
@@ -23,23 +24,14 @@ import { rethrowSimple } from "@/utils/simple-error";
 
 import { provideScopedWorkflowStores } from "./workflowStores";
 
-/** All possible states for an Invocation Graph step, derived from job states,
- * input dataset states, and subworkflow scheduling states. */
-export const graphStepStates = [
-    "new",
-    "upload",
-    "waiting",
-    "queued",
-    "running",
-    "ok",
-    "error",
-    "deleted",
-    "setting_metadata",
-    "paused",
-    "skipped",
-] as const;
-
-export type GraphStepState = (typeof graphStepStates)[number];
+/** All possible states for an Invocation Graph step.
+ * - `JobState`: for tool/collection steps (derived from job states and `populated_state`)
+ * - `DatasetState`: for data input steps (derived from the dataset/collection state)
+ * - `InvocationStepState`: for subworkflow steps (derived from the invocation step state) */
+type GraphStepState =
+    | components["schemas"]["JobState"]
+    | components["schemas"]["DatasetState"]
+    | components["schemas"]["InvocationStepState"];
 
 export interface GraphStep extends Step {
     state?: GraphStepState;
@@ -72,9 +64,9 @@ export const statePlaceholders: Record<string, string> = {
 };
 
 /** Only one job needs to be in one of these states for the graph step to be in that state */
-const SINGLE_INSTANCE_STATES = ["error", "running", "paused", "deleting"];
+const SINGLE_INSTANCE_STATES: GraphStepState[] = ["error", "running", "paused", "deleting"];
 /** All jobs need to be in one of these states for the graph step to be in that state */
-const ALL_INSTANCES_STATES = ["deleted", "skipped", "new", "queued"];
+const ALL_INSTANCES_STATES: GraphStepState[] = ["deleted", "skipped", "new", "queued"];
 
 /** Composable that creates a readonly invocation graph and loads it onto a workflow editor canvas for display.
  * @param invocation - The invocation to display in graph view
@@ -269,7 +261,7 @@ export function useInvocationGraph(
                 } else if (populatedState === "deleting") {
                     newState = "deleted";
                 } else if (populatedState && !["stop", "stopped"].includes(populatedState)) {
-                    newState = populatedState as GraphStep["state"];
+                    newState = populatedState;
                 }
             }
         }
@@ -292,18 +284,18 @@ export function useInvocationGraph(
      * @returns The state for the graph step or `undefined` if the states don't match any
      *          single instance state or all instances state
      * */
-    function getStepStateFromJobStates(jobStates: string[]): GraphStep["state"] | undefined {
+    function getStepStateFromJobStates(jobStates: string[]): GraphStepState | undefined {
         for (const state of SINGLE_INSTANCE_STATES) {
             if (jobStates.includes(state)) {
                 if (state === "deleting") {
                     return "deleted";
                 }
-                return state as GraphStep["state"];
+                return state;
             }
         }
         for (const state of ALL_INSTANCES_STATES) {
             if (jobStates.every((jobState) => jobState === state)) {
-                return state as GraphStep["state"];
+                return state;
             }
         }
         return undefined;

--- a/client/src/composables/useInvocationGraph.ts
+++ b/client/src/composables/useInvocationGraph.ts
@@ -23,20 +23,31 @@ import { rethrowSimple } from "@/utils/simple-error";
 
 import { provideScopedWorkflowStores } from "./workflowStores";
 
+/** The names of all possible Invocation Graph step states.
+ *
+ * These are computed on the client, in the `updateStep` method,
+ * by analyzing the `GraphStep.jobs` states for a given Invocation step, or by
+ * examining other relevant step properties (subworkflow scheduling, etc.).
+ */
+export const graphStepStates = [
+    "new",
+    "upload",
+    "waiting",
+    "queued",
+    "running",
+    "ok",
+    "error",
+    "deleted",
+    "hidden",
+    "setting_metadata",
+    "paused",
+    "skipped",
+] as const;
+
+export type GraphStepState = (typeof graphStepStates)[number];
+
 export interface GraphStep extends Step {
-    state?:
-        | "new"
-        | "upload"
-        | "waiting"
-        | "queued"
-        | "running"
-        | "ok"
-        | "error"
-        | "deleted"
-        | "hidden"
-        | "setting_metadata"
-        | "paused"
-        | "skipped";
+    state?: GraphStepState;
     jobs: StepJobSummary["states"];
     headerClass?: Record<string, boolean>;
     headerIcon?: IconDefinition;

--- a/client/src/composables/useWorkflowRunGraph.ts
+++ b/client/src/composables/useWorkflowRunGraph.ts
@@ -188,7 +188,7 @@ export function useWorkflowRunGraph(
     ): WorkflowRunStepInfo {
         // color variant for `paused` state works best for unpopulated inputs,
         // "" for optional inputs and `ok` for populated inputs
-        const headerClass = optional ? "" : !spin && populated ? "ok" : "paused";
+        const headerClass = optional ? undefined : !spin && populated ? "ok" : "paused";
         const headerIcon = spin ? faSpinner : populated ? faCheckCircle : faExclamationCircle;
 
         text = typeof text === "boolean" ? text : !optional ? text : `${text} (optional)`;

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -153,7 +153,28 @@ $galaxy-state-bg: (
     "hidden": $state-default-bg,
     "setting_metadata": $state-warning-bg,
     "inaccessible": darken($state-default-bg, 10%),
+    "paused": $state-info-bg,
+    "skipped": $state-default-bg,
+    "uninitialized": $gray-200,
 );
+
+// Replace all occurrences of $search in $string with $replace.
+@function str-replace($string, $search, $replace: "") {
+    $index: str-index($string, $search);
+    @if $index {
+        @return str-slice($string, 1, $index - 1) + $replace +
+            str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+    }
+    @return $string;
+}
+
+// Expose state background colors as CSS custom properties so canvas-based
+// rendering (e.g. the workflow minimap) can read them without duplicating values.
+:root {
+    @each $state, $color in $galaxy-state-bg {
+        --state-color-#{str-replace($state, "_", "-")}: #{$color};
+    }
+}
 
 @each $state in map-keys($galaxy-state-border) {
     .state-color-#{$state},
@@ -198,12 +219,6 @@ $galaxy-state-bg: (
         &.header-#{$state} {
             background-color: map-get($galaxy-state-bg, $state) !important;
         }
-    }
-    &.header-paused {
-        background-color: $state-info-bg !important;
-    }
-    &.header-skipped {
-        background-color: map-get($galaxy-state-bg, "hidden") !important;
     }
 }
 


### PR DESCRIPTION
In the invocation graph view, the minimap previously rendered all steps in a flat primary color regardless of their execution state.

Here, we've made the minimap reflect the same state-based colors used in the graph node headers.

- The state-to-color mapping is driven by CSS custom properties on the minimap canvas element.
- Also added borders to the minimap nodes since some of the state colors are very light and hence, hard to see.

https://github.com/user-attachments/assets/0e2ad8b2-9bdf-4ac0-a26c-9a302ab83ae7

Fixes #21086 (once the 3rd item there is also complete of course)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
