### PR TITLE
Unify path adaptation for remote file sources

### DIFF
--- a/lib/galaxy/files/sources/_fsspec.py
+++ b/lib/galaxy/files/sources/_fsspec.py
@@ -142,15 +142,15 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         try:
             cache_options = self._get_cache_options(context.config)
             fs = self._open_fs(context, cache_options)
-            path = self._to_filesystem_path(path)
+            path = self._to_filesystem_path(path, context.config)
 
             if recursive:
-                return self._list_recursive(fs, path)
+                return self._list_recursive(fs, path, context.config)
 
             if query:
-                entries_list = self._list_with_query(fs, path, query)
+                entries_list = self._list_with_query(fs, path, query, context.config)
             else:
-                entries_list = self._list_directory(fs, path)
+                entries_list = self._list_directory(fs, path, context.config)
 
             total_count = len(entries_list)
 
@@ -184,7 +184,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         """Download a file from the fsspec filesystem to a local path."""
         cache_options = self._get_cache_options(context.config)
         fs = self._open_fs(context, cache_options)
-        source_path = self._to_filesystem_path(source_path)
+        source_path = self._to_filesystem_path(source_path, context.config)
         fs.get_file(source_path, native_path)
 
     def _write_from(
@@ -196,10 +196,10 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         """Upload a file from a local path to the fsspec filesystem."""
         cache_options = self._get_cache_options(context.config)
         fs = self._open_fs(context, cache_options)
-        target_path = self._to_filesystem_path(target_path)
+        target_path = self._to_filesystem_path(target_path, context.config)
         fs.put_file(native_path, target_path)
 
-    def _adapt_entry_path(self, filesystem_path: str) -> str:
+    def _adapt_entry_path(self, filesystem_path: str, config: FsspecResolvedConfigurationType) -> str:
         """Adapt the filesystem path to the desired entry path.
 
         Subclasses can override this to transform paths (e.g., filesystem to virtual paths).
@@ -207,7 +207,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         """
         return filesystem_path
 
-    def _to_filesystem_path(self, path: str) -> str:
+    def _to_filesystem_path(self, path: str, config: FsspecResolvedConfigurationType) -> str:
         """Convert an entry path to the filesystem path format.
 
         Subclasses can override this to transform paths (e.g., virtual to filesystem paths).
@@ -237,10 +237,10 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         """
         return None
 
-    def _info_to_entry(self, info: dict) -> AnyRemoteEntry:
+    def _info_to_entry(self, info: dict, config: FsspecResolvedConfigurationType) -> AnyRemoteEntry:
         """Convert fsspec file info to Galaxy's remote entry format."""
         filesystem_path = info["name"]
-        entry_path = self._adapt_entry_path(filesystem_path)
+        entry_path = self._adapt_entry_path(filesystem_path, config)
         name = os.path.basename(entry_path)
         uri = self.uri_from_path(entry_path)
 
@@ -252,7 +252,9 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
             hashes = self._get_file_hashes(info)
             return RemoteFile(name=name, size=size, ctime=ctime, uri=uri, path=entry_path, hashes=hashes)
 
-    def _list_recursive(self, fs: AbstractFileSystem, path: str) -> tuple[list[AnyRemoteEntry], int]:
+    def _list_recursive(
+        self, fs: AbstractFileSystem, path: str, config: FsspecResolvedConfigurationType
+    ) -> tuple[list[AnyRemoteEntry], int]:
         """Handle recursive directory listing with item limit."""
         # TODO: this is potentially inefficient for large directories.
         # We should consider dropping this option.
@@ -264,7 +266,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
             # so we can safely cast the result.
             dirs = cast(dict[str, dict], dirs)
             files = cast(dict[str, dict], files)
-            to_entry = functools.partial(self._info_to_entry)
+            to_entry = functools.partial(self._info_to_entry, config=config)
             res.extend(map(to_entry, dirs.values()))
             res.extend(map(to_entry, files.values()))
             count += len(dirs) + len(files)
@@ -281,7 +283,9 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
             MAX_ITEMS_LIMIT,
         )
 
-    def _list_with_query(self, fs: AbstractFileSystem, path: str, query: str) -> list[AnyRemoteEntry]:
+    def _list_with_query(
+        self, fs: AbstractFileSystem, path: str, query: str, config: FsspecResolvedConfigurationType
+    ) -> list[AnyRemoteEntry]:
         """Handle directory listing with query filtering using glob patterns."""
         entries_list = []
         glob_pattern = self._build_glob_pattern(path, query)
@@ -290,10 +294,12 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         matched_paths = cast(dict[str, dict], fs.glob(glob_pattern, detail=True))
         for entry_path, info in matched_paths.items():
             if entry_path:  # Only process entries with valid paths
-                entries_list.append(self._info_to_entry(info))
+                entries_list.append(self._info_to_entry(info, config))
         return entries_list
 
-    def _list_directory(self, fs: AbstractFileSystem, path: str) -> list[AnyRemoteEntry]:
+    def _list_directory(
+        self, fs: AbstractFileSystem, path: str, config: FsspecResolvedConfigurationType
+    ) -> list[AnyRemoteEntry]:
         """Handle standard directory listing without query filtering."""
         entries_list = []
         entries: list[dict] = fs.ls(path, detail=True)
@@ -304,7 +310,7 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
             # Skip entries that match the directory being listed (some fsspec implementations
             # include the directory itself in the listing results)
             if entry_path and entry_path.rstrip("/") != normalized_path:
-                entries_list.append(self._info_to_entry(entry))
+                entries_list.append(self._info_to_entry(entry, config))
         return entries_list
 
     def _apply_pagination(

--- a/lib/galaxy/files/sources/azureflat.py
+++ b/lib/galaxy/files/sources/azureflat.py
@@ -60,29 +60,24 @@ class AzureFlatFilesSource(
             fs = AzureBlobFileSystem(account_name=config.account_name, credential=config.account_key, **cache_options)
             return fs
 
-    def _to_container_path(self, path: str, config: AzureFlatFileSourceConfiguration) -> str:
-        result = ""
+    def _to_filesystem_path(self, path: str, config: AzureFlatFileSourceConfiguration) -> str:
+        """Convert an entry path to the Azure filesystem path format."""
         if path.startswith("az://"):
-            result = path.replace("az://", "", 1)
-        else:
-            container = config.container_name
-            if not container:
-                result = path.strip("/")
-            else:
-                result = self._container_path(container, path)
-        return result
+            return path.replace("az://", "", 1)
+        container = config.container_name
+        if not container:
+            return path.strip("/")
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{container}{path}"
 
-    def _adapt_entry_path(self, filesystem_path: str) -> str:
-        result = filesystem_path
-        if container_name := self.template_config.container_name:
+    def _adapt_entry_path(self, filesystem_path: str, config: AzureFlatFileSourceConfiguration) -> str:
+        """Remove the Azure container name from the filesystem path."""
+        if container_name := config.container_name:
             prefix = f"{container_name}/"
             if filesystem_path.startswith(prefix):
-                result = filesystem_path.replace(prefix, "", 1)
-            else:
-                result = filesystem_path
-        else:
-            result = filesystem_path
-        return result
+                return filesystem_path.replace(prefix, "", 1)
+        return filesystem_path
 
     def _list(
         self,
@@ -110,40 +105,15 @@ class AzureFlatFilesSource(
                     )
                 )
             return entries, len(entries)
-        container_path = self._to_container_path(path, context.config)
-        entries, count = super()._list(
+        return super()._list(
             context=context,
-            path=container_path,
+            path=path,
             recursive=recursive,
             limit=limit,
             offset=offset,
             query=query,
             sort_by=sort_by,
         )
-        return entries, count
-
-    def _realize_to(
-        self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[AzureFlatFileSourceConfiguration]
-    ):
-        container_path = self._to_container_path(source_path, context.config)
-        super()._realize_to(source_path=container_path, native_path=native_path, context=context)
-
-    def _write_from(
-        self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[AzureFlatFileSourceConfiguration]
-    ):
-        container_path = self._to_container_path(target_path, context.config)
-        super()._write_from(target_path=container_path, native_path=native_path, context=context)
-
-    def _container_path(self, container_name: str, path: str) -> str:
-        adjusted_path = path
-        if path.startswith("az://"):
-            adjusted_path = path.replace("az://", "", 1)
-        else:
-            if not path.startswith("/"):
-                adjusted_path = f"/{path}"
-            else:
-                adjusted_path = path
-        return f"{container_name}{adjusted_path}"
 
     def score_url_match(self, url: str):
         result = 0

--- a/lib/galaxy/files/sources/googlecloudstorage.py
+++ b/lib/galaxy/files/sources/googlecloudstorage.py
@@ -4,10 +4,7 @@ from typing import (
     Union,
 )
 
-from galaxy.files.models import (
-    AnyRemoteEntry,
-    FilesSourceRuntimeContext,
-)
+from galaxy.files.models import FilesSourceRuntimeContext
 from galaxy.files.sources._fsspec import (
     CacheOptionsDictType,
     FsspecBaseFileSourceConfiguration,
@@ -102,13 +99,12 @@ class GoogleCloudStorageFilesSource(
         )
         return fs
 
-    def _to_bucket_path(self, path: str, config: GoogleCloudStorageFileSourceConfiguration) -> str:
-        """Adapt the path to the GCS bucket format, including root_path if configured."""
+    def _to_filesystem_path(self, path: str, config: GoogleCloudStorageFileSourceConfiguration) -> str:
+        """Convert an entry path to the GCS filesystem path format."""
         bucket = config.bucket_name
         root = (config.root_path or "").strip("/")
         if path.startswith("/"):
             path = path[1:]
-        # Build path: bucket / root_path / path
         if root and path:
             return f"{bucket}/{root}/{path}"
         elif root:
@@ -117,56 +113,16 @@ class GoogleCloudStorageFilesSource(
             return f"{bucket}/{path}"
         return bucket
 
-    def _adapt_entry_path(self, filesystem_path: str) -> str:
+    def _adapt_entry_path(self, filesystem_path: str, config: GoogleCloudStorageFileSourceConfiguration) -> str:
         """Remove the GCS bucket name and root_path from the filesystem path."""
-        if self.template_config.bucket_name:
-            bucket = self.template_config.bucket_name
-            root = (self.template_config.root_path or "").strip("/")
+        if config.bucket_name:
+            bucket = config.bucket_name
+            root = (config.root_path or "").strip("/")
             full_prefix = f"{bucket}/{root}" if root else bucket
             if filesystem_path == full_prefix:
                 return "/"
             return "/" + filesystem_path.removeprefix(f"{full_prefix}/")
         return "/" + filesystem_path
-
-    def _list(
-        self,
-        context: FilesSourceRuntimeContext[GoogleCloudStorageFileSourceConfiguration],
-        path="/",
-        recursive=False,
-        write_intent: bool = False,
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
-        query: Optional[str] = None,
-        sort_by: Optional[str] = None,
-    ) -> tuple[list[AnyRemoteEntry], int]:
-        bucket_path = self._to_bucket_path(path, context.config)
-        return super()._list(
-            context=context,
-            path=bucket_path,
-            recursive=recursive,
-            limit=limit,
-            offset=offset,
-            query=query,
-            sort_by=sort_by,
-        )
-
-    def _realize_to(
-        self,
-        source_path: str,
-        native_path: str,
-        context: FilesSourceRuntimeContext[GoogleCloudStorageFileSourceConfiguration],
-    ):
-        bucket_path = self._to_bucket_path(source_path, context.config)
-        super()._realize_to(source_path=bucket_path, native_path=native_path, context=context)
-
-    def _write_from(
-        self,
-        target_path: str,
-        native_path: str,
-        context: FilesSourceRuntimeContext[GoogleCloudStorageFileSourceConfiguration],
-    ):
-        bucket_path = self._to_bucket_path(target_path, context.config)
-        super()._write_from(target_path=bucket_path, native_path=native_path, context=context)
 
     def score_url_match(self, url: str):
         bucket_name = self.template_config.bucket_name

--- a/lib/galaxy/files/sources/huggingface.py
+++ b/lib/galaxy/files/sources/huggingface.py
@@ -94,7 +94,7 @@ class HuggingFaceFilesSource(
             **cache_options,
         )
 
-    def _to_filesystem_path(self, path: str) -> str:
+    def _to_filesystem_path(self, path: str, config: HuggingFaceFileSourceConfiguration) -> str:
         """Transform entry path to Hugging Face filesystem path."""
         if path == "/":
             # Hugging Face does not implement access to the repositories root

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -5,10 +5,7 @@ from typing import (
 )
 
 from galaxy import exceptions
-from galaxy.files.models import (
-    AnyRemoteEntry,
-    FilesSourceRuntimeContext,
-)
+from galaxy.files.models import FilesSourceRuntimeContext
 from galaxy.files.sources._fsspec import (
     CacheOptionsDictType,
     FsspecBaseFileSourceConfiguration,
@@ -73,62 +70,23 @@ class S3FsFilesSource(FsspecFilesSource[S3FSFileSourceTemplateConfiguration, S3F
         )
         return fs
 
-    def _to_bucket_path(self, path: str, config: S3FSFileSourceConfiguration) -> str:
-        """Adapt the path to the S3 bucket format."""
+    def _to_filesystem_path(self, path: str, config: S3FSFileSourceConfiguration) -> str:
+        """Convert an entry path to the S3 filesystem path format."""
         if path.startswith("s3://"):
             return path.replace("s3://", "")
         bucket = config.bucket
-        if not bucket and not path.startswith("s3://"):
+        if not bucket:
             raise exceptions.MessageException("Bucket name is required for S3FsFilesSource.")
-        return self._bucket_path(bucket or "", path)
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{bucket}{path}"
 
-    def _adapt_entry_path(self, filesystem_path: str) -> str:
+    def _adapt_entry_path(self, filesystem_path: str, config: S3FSFileSourceConfiguration) -> str:
         """Remove the S3 bucket name from the filesystem path."""
-        if self.template_config.bucket:
-            bucket_prefix = f"{self.template_config.bucket}/"
+        if config.bucket:
+            bucket_prefix = f"{config.bucket}/"
             return filesystem_path.replace(bucket_prefix, "", 1)
         return filesystem_path
-
-    def _list(
-        self,
-        context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration],
-        path="/",
-        recursive=False,
-        write_intent: bool = False,
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
-        query: Optional[str] = None,
-        sort_by: Optional[str] = None,
-    ) -> tuple[list[AnyRemoteEntry], int]:
-        bucket_path = self._to_bucket_path(path, context.config)
-        return super()._list(
-            context=context,
-            path=bucket_path,
-            recursive=recursive,
-            limit=limit,
-            offset=offset,
-            query=query,
-            sort_by=sort_by,
-        )
-
-    def _realize_to(
-        self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration]
-    ):
-        bucket_path = self._to_bucket_path(source_path, context.config)
-        super()._realize_to(source_path=bucket_path, native_path=native_path, context=context)
-
-    def _write_from(
-        self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[S3FSFileSourceConfiguration]
-    ):
-        bucket_path = self._to_bucket_path(target_path, context.config)
-        super()._write_from(target_path=bucket_path, native_path=native_path, context=context)
-
-    def _bucket_path(self, bucket_name: str, path: str):
-        if path.startswith("s3://"):
-            return path.replace("s3://", "")
-        elif not path.startswith("/"):
-            path = f"/{path}"
-        return f"{bucket_name}{path}"
 
     def score_url_match(self, url: str):
         # We need to use template_config here because this is called before the template is expanded.

--- a/lib/galaxy/files/sources/ssh.py
+++ b/lib/galaxy/files/sources/ssh.py
@@ -64,9 +64,25 @@ class SshFilesSource(PyFilesystem2FilesSource[SshFileSourceTemplateConfiguration
             compress=config.compress,
             config_path=config.config_path,
         )
-        if config.path:
-            return handle.opendir(config.path)
         return handle
+
+    def _to_filesystem_path(self, path: str, config: SshFileSourceConfiguration) -> str:
+        base = config.path.rstrip("/")
+        relative = path.lstrip("/")
+        if not relative:
+            return base or "/"
+        return f"{base}/{relative}"
+
+    def _adapt_entry_path(self, filesystem_path: str, config: SshFileSourceConfiguration) -> str:
+        base = config.path.rstrip("/")
+        if base and filesystem_path.startswith(base):
+            virtual_path = filesystem_path[len(base) :]
+            if not virtual_path:
+                return "/"
+            if not virtual_path.startswith("/"):
+                virtual_path = f"/{virtual_path}"
+            return virtual_path
+        return filesystem_path
 
 
 __all__ = ("SshFilesSource",)

--- a/lib/galaxy/files/sources/temp.py
+++ b/lib/galaxy/files/sources/temp.py
@@ -1,7 +1,6 @@
 import os
 from typing import (
     Annotated,
-    Optional,
     Union,
 )
 
@@ -9,7 +8,6 @@ from fsspec.implementations.local import LocalFileSystem
 from pydantic import Field
 
 from galaxy.files.models import (
-    AnyRemoteEntry,
     FilesSourceRuntimeContext,
     StrictModel,
 )
@@ -56,91 +54,35 @@ class TempFilesSource(FsspecFilesSource[TempFileSourceTemplateConfiguration, Tem
 
     def __init__(self, template_config: TempFileSourceTemplateConfiguration):
         super().__init__(template_config)
-        self._root_path = self.template_config.root_path
 
     def _open_fs(
         self,
         context: FilesSourceRuntimeContext[TempFileSourceConfiguration],
         cache_options: CacheOptionsDictType,
     ):
-        self._root_path = context.config.root_path
         return LocalFileSystem(
             auto_mkdir=context.config.auto_mkdir,
             **cache_options,
         )
 
-    def _to_temp_path(self, path: str) -> str:
-        """Convert a virtual temp path to an actual filesystem path.
-
-        i.e. /a/b/c -> /{root_path}/a/b/c
-        """
+    def _to_filesystem_path(self, path: str, config: TempFileSourceConfiguration) -> str:
+        """Convert a virtual temp path to an actual filesystem path."""
         relative_path = path.lstrip("/")
         if not relative_path:
-            return self._root_path
-        return os.path.join(self._root_path, relative_path)
+            return config.root_path
+        return os.path.join(config.root_path, relative_path)
 
-    def _from_temp_path(self, native_path: str) -> str:
-        """Convert an actual filesystem path back to virtual temp path.
-
-        i.e. /{root_path}/a/b/c -> /a/b/c
-        """
-        # Remove the root path prefix
-        if native_path.startswith(self._root_path):
-            virtual_path = native_path[len(self._root_path) :]
-            # Ensure the path starts with a single forward slash
+    def _adapt_entry_path(self, filesystem_path: str, config: TempFileSourceConfiguration) -> str:
+        """Convert an actual filesystem path back to virtual temp path."""
+        root_path = config.root_path
+        if filesystem_path.startswith(root_path):
+            virtual_path = filesystem_path[len(root_path) :]
             if not virtual_path.startswith("/"):
                 virtual_path = f"/{virtual_path}"
             elif virtual_path.startswith("//"):
-                # Remove extra leading slash if present
                 virtual_path = virtual_path[1:]
             return virtual_path
-        return native_path
-
-    def _list(
-        self,
-        context: FilesSourceRuntimeContext[TempFileSourceConfiguration],
-        path="/",
-        recursive=False,
-        write_intent: bool = False,
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
-        query: Optional[str] = None,
-        sort_by: Optional[str] = None,
-    ) -> tuple[list[AnyRemoteEntry], int]:
-        native_path = self._to_temp_path(path)
-        entries, total = super()._list(
-            context=context,
-            path=native_path,
-            recursive=recursive,
-            write_intent=write_intent,
-            limit=limit,
-            offset=offset,
-            query=query,
-            sort_by=sort_by,
-        )
-        return entries, total
-
-    def _adapt_entry_path(self, filesystem_path: str) -> str:
-        """Convert filesystem path to virtual temp path."""
-        return self._from_temp_path(filesystem_path)
-
-    def _realize_to(
-        self,
-        source_path: str,
-        native_path: str,
-        context: FilesSourceRuntimeContext[TempFileSourceConfiguration],
-    ):
-        temp_path = self._to_temp_path(source_path)
-        return super()._realize_to(temp_path, native_path, context)
-
-    def _write_from(
-        self,
-        target_path: str,
-        native_path: str,
-        context: FilesSourceRuntimeContext[TempFileSourceConfiguration],
-    ):
-        temp_path = self._to_temp_path(target_path)
-        return super()._write_from(temp_path, native_path, context)
+        return filesystem_path
 
     def get_scheme(self) -> str:
         return "temp"


### PR DESCRIPTION
Refactors the remote file source adapters to consistently handle translation between virtual entry paths and physical filesystem paths. Introduces and standardizes methods to convert between virtual and storage-specific paths. Removes redundant or duplicate code, eliminates unnecessary intermediate path conversion helpers, and ensures that path adaptation logic always receives the **resolved configuration context** with resolved templates for configuration values (addressing https://github.com/galaxyproject/galaxy/pull/21646#discussion_r3006093098).


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
