### PR TITLE
[26.0] Fix tool "Copy Link" generating broken /root?tool_id= URLs

### DIFF
--- a/client/src/components/Tool/ToolLink.vue
+++ b/client/src/components/Tool/ToolLink.vue
@@ -20,7 +20,7 @@ const toolName = computed(() => {
 });
 
 const toolLink = computed(() => {
-    return `/root?tool_id=${props.toolId}&tool_version=${props.toolVersion}`;
+    return `/?tool_id=${props.toolId}&tool_version=${props.toolVersion}`;
 });
 
 watch(

--- a/client/src/components/Tool/utilities.js
+++ b/client/src/components/Tool/utilities.js
@@ -2,7 +2,7 @@ import { getAppRoot } from "@/onload/loadConfig";
 import { copy } from "@/utils/clipboard";
 
 export function copyLink(toolId, message) {
-    const link = `${window.location.origin + getAppRoot()}root?tool_id=${toolId}`;
+    const link = `${window.location.origin + getAppRoot()}?tool_id=${toolId}`;
     // Encode the link to handle special characters in tool id
     copy(encodeURI(link), message);
 }

--- a/client/src/components/Tool/utilities.test.ts
+++ b/client/src/components/Tool/utilities.test.ts
@@ -23,6 +23,7 @@ describe("copyLink", () => {
         copyLink(toolId);
         expect(writeText).toHaveBeenCalledTimes(1);
         expect(writeText).toHaveBeenCalledWith(expect.stringContaining(toolId));
+        expect(writeText).toHaveBeenCalledWith(expect.not.stringContaining("/root?"));
     });
 
     it("should encode the tool id with spaces", () => {

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -194,6 +194,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     # The following routes don't bootstrap any information, simply provide the
     # base analysis interface at which point the application takes over.
     webapp.add_client_route("/")
+    webapp.add_client_route("/root")
     webapp.add_client_route("/index")
     webapp.add_client_route("/about")
     webapp.add_client_route("/admin")


### PR DESCRIPTION
Remove hardcoded `root` from the URL path in copyLink(), which caused 404s because /root was not a registered client route.

Also register /root as a client route for backward compatibility with existing bookmarks and shared links.

Fixes https://github.com/galaxyproject/galaxy/issues/22338

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
