### PR TITLE
[26.0] Backport: Fix tool discovery help data race condition and stale results

### DIFF
--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { watchEffect } from "vue";
+import { computed } from "vue";
 
 import { type Tool, useToolStore } from "@/stores/toolStore";
 
@@ -42,18 +42,15 @@ async function loadTools(offset: number, limit: number): Promise<{ items: Tool[]
     return { items, total: props.tools.length };
 }
 
-// Watch for changes in tools array to preload initial help data
-watchEffect(() => {
-    if (props.tools.length > 0) {
-        const initialItems = props.tools.slice(0, FETCH_LIMIT + PREFETCH_AHEAD);
-        Promise.all(initialItems.map((tool) => toolStore.fetchHelpForId(tool.id)));
-    }
-});
+// Force ScrollList remount when tools change (e.g. after search),
+// ensuring loadTools is called again to await help data for new results.
+const toolsKey = computed(() => `${props.tools.length}-${props.tools[0]?.id}`);
 </script>
 
 <template>
     <ScrollList
         ref="root"
+        :key="toolsKey"
         :loader="loadTools"
         :limit="FETCH_LIMIT"
         :item-key="(tool) => tool.id"

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -95,7 +95,7 @@ export const useToolStore = defineStore("toolStore", () => {
     const toolsById = shallowRef<Record<string, Tool>>({});
     const toolResults = ref<Record<string, string[]>>({});
     const toolSections = ref<Record<string, Record<string, Tool | ToolSection>>>({});
-    const fetchedHelpIds = ref<Set<string>>(new Set());
+    const fetchedHelpIds = ref<Map<string, Promise<void>>>(new Map());
     const helpDataCached = ref<Record<string, ToolHelpData>>({});
 
     const currentToolSections = computed(() => {
@@ -245,10 +245,15 @@ export const useToolStore = defineStore("toolStore", () => {
     }
 
     async function fetchHelpForId(toolId: string) {
-        try {
-            if (!helpDataCached.value[toolId] && !fetchedHelpIds.value.has(toolId)) {
-                fetchedHelpIds.value.add(toolId);
-
+        if (helpDataCached.value[toolId]) {
+            return;
+        }
+        const existing = fetchedHelpIds.value.get(toolId);
+        if (existing) {
+            return existing;
+        }
+        const promise = (async () => {
+            try {
                 const toolHelpData: ToolHelpData = {};
 
                 const { data } = (await axios.get(
@@ -264,11 +269,13 @@ export const useToolStore = defineStore("toolStore", () => {
                 }
 
                 Vue.set(helpDataCached.value, toolId, toolHelpData);
+            } catch (error) {
+                console.error("Error fetching help:", error);
+                fetchedHelpIds.value.delete(toolId); // Allow retrying on next request
             }
-        } catch (error) {
-            console.error("Error fetching help:", error);
-            fetchedHelpIds.value.delete(toolId); // Allow retrying on next request
-        }
+        })();
+        fetchedHelpIds.value.set(toolId, promise);
+        return promise;
     }
 
     async function initializePanel() {

--- a/lib/galaxy_test/selenium/test_tool_discovery_view.py
+++ b/lib/galaxy_test/selenium/test_tool_discovery_view.py
@@ -16,7 +16,7 @@ class TestToolDiscoveryViewAnonymous(SeleniumTestCase):
     advanced search, and list vs grid view toggling.
     """
 
-    @transient_failure(issue=21225)
+    @transient_failure(issue=21225, potentially_fixed=True)
     @selenium_test
     def test_tool_discovery_landing(self):
         """Test navigation to the tool discovery view."""


### PR DESCRIPTION
Two issues caused flaky failures in test_tool_discovery_landing:

1. fetchHelpForId used a Set to guard against duplicate fetches. The watchEffect in ToolsListTable called fetchHelpForId fire-and-forget, adding tool IDs to the Set immediately. When loadTools subsequently called fetchHelpForId for the same IDs, the guard returned a resolved Promise before data was actually cached, so await Promise.all() resolved prematurely and help toggle links never appeared.

   Fix: change fetchedHelpIds from Set to Map<string, Promise<void>> so concurrent callers share the same in-flight Promise.

2. After a search, ScrollList kept stale items in localItems and considered allLoaded=true (old item count >= new total), so loadTools was never re-invoked for the filtered results. Help data was never awaited for the search results.

   Fix: replace the fire-and-forget watchEffect with a computed key on ScrollList that forces a remount when props.tools changes, ensuring loadTools runs again and awaits help data for new results.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
