### PR TITLE
[26.0] Throw RequestAbortedError instead of returning undefined

### DIFF
--- a/client/src/app/addons/sentry.js
+++ b/client/src/app/addons/sentry.js
@@ -24,7 +24,7 @@ export async function initSentry(Galaxy, router) {
             release: release,
             beforeSend(event, hint) {
                 const error = hint.originalException;
-                if (["AdminRequired", "RegisteredUserRequired"].includes(error?.name)) {
+                if (["AdminRequired", "RegisteredUserRequired", "RequestAbortedError"].includes(error?.name)) {
                     // ignore these error events
                     return null;
                 }

--- a/client/src/utils/simple-error.ts
+++ b/client/src/utils/simple-error.ts
@@ -1,3 +1,11 @@
+/** Thrown when the browser aborts a request (e.g. page navigation, component unmount). */
+export class RequestAbortedError extends Error {
+    constructor() {
+        super("Request aborted");
+        this.name = "RequestAbortedError";
+    }
+}
+
 export function errorMessageAsString(e: any, defaultMessage = "Request failed.") {
     // Note that despite the name, this can actually currently return an object,
     // depending on what data.err_msg is (e.g. an object)
@@ -33,9 +41,7 @@ function isRequestAborted(e: any): boolean {
 
 export function rethrowSimple(e: any): never {
     if (isRequestAborted(e)) {
-        // Browser aborted the request (e.g. page navigation); swallow silently
-        // since no downstream consumer will handle the result anyway.
-        return undefined as never;
+        throw new RequestAbortedError();
     }
     if (process.env.NODE_ENV != "test") {
         console.debug(e);
@@ -52,6 +58,9 @@ export class ApiError extends Error {
 }
 
 export function rethrowSimpleWithStatus(e: any, response?: { status: number }): never {
+    if (isRequestAborted(e)) {
+        throw new RequestAbortedError();
+    }
     if (process.env.NODE_ENV != "test") {
         console.debug(e);
     }


### PR DESCRIPTION
The previous approach of `return undefined as never` breaks the `never` type contract — execution silently continues and callers that rely on control flow narrowing (e.g. `data.map(...)` after `rethrowSimple(error)`) get a TypeError on the undefined return value. This is especially problematic during SPA route changes where the app keeps running.

Instead, throw a dedicated RequestAbortedError that preserves the `never` contract while remaining distinguishable from real API errors. Filter it out in Sentry's beforeSend so it doesn't create noise.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
