### PR TITLE
Fix S3 multipart upload to start all threads before waiting

### DIFF
--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -76,5 +76,5 @@ def multipart_upload(s3server, bucket, s3_key_name, tarball, mb_size):
         threads.append(t)
     for t in threads:
         t.join()
-        
+
     mp.complete_upload()

--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -69,9 +69,12 @@ def multipart_upload(s3server, bucket, s3_key_name, tarball, mb_size):
 
     mp = bucket.initiate_multipart_upload(s3_key_name, reduced_redundancy=s3server["use_rr"])
 
+    threads = []
     for i, part in enumerate(split_file(tarball, mb_size)):
         t = threading.Thread(target=transfer_part, args=(s3server, mp.id, mp.key_name, mp.bucket_name, i, part))
         t.start()
+        threads.append(t)
+    for t in threads:
         t.join()
-
+        
     mp.complete_upload()


### PR DESCRIPTION
start all planned threads before waiting for any

closes #22321

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
