### PR TITLE
[26.0] Remove broken serialize_urls from HDASerializer

### DIFF
--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -614,7 +614,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                 id=self.app.security.encode_id(item.id),
                 context=context,
             ),
-            "urls": self.serialize_urls,
             # TODO: backwards compat: need to go away
             "download_url": lambda item, key, **context: self.url_for(
                 "history_contents_display",
@@ -701,30 +700,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                         display_apps.append(dict(label=display_label, links=app_links))
 
         return display_apps
-
-    def serialize_urls(self, item, key, **context):
-        """
-        Return web controller urls useful for this HDA.
-        """
-        hda = item
-        url_for = self.url_for
-        encoded_id = self.app.security.encode_id(hda.id)
-        urls = {
-            "purge": url_for(controller="dataset", action="purge_async", dataset_id=encoded_id),
-            "display": url_for(controller="dataset", action="display", dataset_id=encoded_id, preview=True),
-            "edit": url_for(controller="dataset", action="edit", dataset_id=encoded_id),
-            "download": url_for(controller="dataset", action="display", dataset_id=encoded_id, to_ext=hda.extension),
-            "report_error": url_for(controller="dataset", action="errors", id=encoded_id),
-            "rerun": url_for(controller="tool_runner", action="rerun", id=encoded_id),
-            "show_params": url_for(controller="dataset", action="details", dataset_id=encoded_id),
-            "visualization": url_for(
-                controller="visualization", action="index", id=encoded_id, model="HistoryDatasetAssociation"
-            ),
-            "meta_download": url_for(
-                controller="dataset", action="get_metadata_file", hda_id=encoded_id, metadata_name=""
-            ),
-        }
-        return urls
 
 
 class HDADeserializer(

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -446,7 +446,6 @@ class TestHDASerializer(HDATestCase):
         assert serialized["type"] == "file"
 
         assert isinstance(serialized["url"], str)
-        assert isinstance(serialized["urls"], dict)
         assert isinstance(serialized["download_url"], str)
 
         self.log("serialized should jsonify well")


### PR DESCRIPTION
The `serialize_urls` method has been broken in FastAPI context (raising NotImplementedError) because it used `self.url_for` without passing context. The client does not use these URLs — it hardcodes its own URL patterns in ContentItem.vue. The `urls` key was not included in any serializer view (summary, detailed, extended) and could only be fetched by explicitly requesting it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
