### PR TITLE
More Complete, Robust, and Tested JSON-Schema for Tool State Models

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -8506,8 +8506,6 @@ export interface components {
             identifier: string;
             /** Info */
             info?: string | null;
-            /** Location */
-            location: string;
             /** Name */
             name?: string | null;
             /**
@@ -8524,6 +8522,8 @@ export interface components {
              * @default false
              */
             to_posix_lines: boolean;
+            /** Url */
+            url: string;
         };
         /** CollectionElementIdentifier */
         CollectionElementIdentifier: {
@@ -12789,8 +12789,6 @@ export interface components {
             hashes?: components["schemas"]["FileHash"][] | null;
             /** Info */
             info?: string | null;
-            /** Location */
-            location: string;
             /** Name */
             name?: string | null;
             /**
@@ -12807,6 +12805,8 @@ export interface components {
              * @default false
              */
             to_posix_lines: boolean;
+            /** Url */
+            url: string;
         };
         /** FileSourceTemplateSummaries */
         FileSourceTemplateSummaries: components["schemas"]["FileSourceTemplateSummary"][];

--- a/lib/galaxy/tool_util/parameters/json.py
+++ b/lib/galaxy/tool_util/parameters/json.py
@@ -23,6 +23,27 @@ class CustomGenerateJsonSchema(GenerateJsonSchema):
         return json_schema
 
 
+def _absent_test_params(defs: Dict[str, Any]) -> Dict[str, str]:
+    """Map test parameter names to their absent branch def names, longest name first."""
+    result: Dict[str, str] = {}
+    for def_name in defs:
+        m = WHEN_ABSENT_RE.match(def_name)
+        if m:
+            result[m.group(1)] = def_name
+    return dict(sorted(result.items(), key=lambda item: len(item[0]), reverse=True))
+
+
+def _match_when_branch(def_name: str, absent_test_params: Dict[str, str]) -> Any:
+    """Return (test_param_name, value_suffix) for an explicit When branch, or None."""
+    if not def_name.startswith("When_") or "___absent" in def_name:
+        return None
+    for test_param_name in absent_test_params:
+        prefix = f"When_{test_param_name}_"
+        if def_name.startswith(prefix):
+            return test_param_name, def_name[len(prefix) :]
+    return None
+
+
 def _fix_conditional_oneofs(schema: Dict[str, Any]) -> None:
     """Make conditional discriminated unions unambiguous for JSON Schema validators.
 
@@ -38,22 +59,14 @@ def _fix_conditional_oneofs(schema: Dict[str, Any]) -> None:
     if not defs:
         return
 
-    absent_test_params: Dict[str, str] = {}
-    for def_name in defs:
-        m = WHEN_ABSENT_RE.match(def_name)
-        if m:
-            absent_test_params[m.group(1)] = def_name
-
-    if not absent_test_params:
+    atp = _absent_test_params(defs)
+    if not atp:
         return
 
     for def_name, def_schema in defs.items():
-        if def_name.startswith("When_") and "___absent" not in def_name:
-            for test_param_name in absent_test_params:
-                prefix = f"When_{test_param_name}_"
-                if def_name.startswith(prefix):
-                    _make_field_required(def_schema, test_param_name)
-                    break
+        match = _match_when_branch(def_name, atp)
+        if match:
+            _make_field_required(def_schema, match[0])
 
 
 def _make_field_required(def_schema: Dict[str, Any], field_name: str) -> None:
@@ -65,6 +78,78 @@ def _make_field_required(def_schema: Dict[str, Any], field_name: str) -> None:
         required.append(field_name)
         def_schema["required"] = required
     props[field_name].pop("default", None)
+
+
+def _discriminator_key(def_schema: Dict[str, Any], test_param_name: str, value_suffix: str) -> str:
+    """Derive the discriminator mapping key from the branch's const value.
+
+    Uses the actual ``const`` value from the schema property so boolean branches
+    map to ``"true"``/``"false"`` (JSON style) rather than ``"True"``/``"False"``.
+    """
+    props = def_schema.get("properties", {})
+    test_prop = props.get(test_param_name, {})
+    const = test_prop.get("const")
+    if const is not None:
+        return json.dumps(const) if isinstance(const, bool) else str(const)
+    return value_suffix
+
+
+def _add_conditional_discriminators(schema: Dict[str, Any]) -> None:
+    """Add OpenAPI 3.1 discriminator objects and human-readable titles to conditional oneOfs."""
+    defs = schema.get("$defs", {})
+    if not defs:
+        return
+
+    atp = _absent_test_params(defs)
+    if not atp:
+        return
+
+    for def_name, def_schema in defs.items():
+        if def_name in atp.values():
+            for param_name, absent_name in atp.items():
+                if def_name == absent_name:
+                    def_schema["title"] = f"When {param_name} is absent"
+                    break
+        else:
+            match = _match_when_branch(def_name, atp)
+            if match:
+                def_schema["title"] = f"When {match[0]} = {match[1]}"
+
+    for def_schema in defs.values():
+        one_of = def_schema.get("oneOf")
+        if not isinstance(one_of, list):
+            continue
+
+        test_param_name = _conditional_test_param_for_oneof(one_of, atp)
+        if test_param_name is None:
+            continue
+
+        mapping: Dict[str, str] = {}
+        for branch in one_of:
+            ref = branch.get("$ref", "")
+            branch_def_name = ref.rsplit("/", 1)[-1] if "/" in ref else ""
+            match = _match_when_branch(branch_def_name, atp)
+            if match and match[0] == test_param_name:
+                branch_def = defs.get(branch_def_name, {})
+                key = _discriminator_key(branch_def, test_param_name, match[1])
+                mapping[key] = ref
+
+        if mapping:
+            def_schema["discriminator"] = {
+                "propertyName": test_param_name,
+                "mapping": mapping,
+            }
+
+
+def _conditional_test_param_for_oneof(one_of: List[Any], absent_test_params: Dict[str, str]) -> Any:
+    """Return the test parameter name if this oneOf is a conditional discriminated union."""
+    for branch in one_of:
+        ref = branch.get("$ref", "")
+        branch_def_name = ref.rsplit("/", 1)[-1] if "/" in ref else ""
+        for param_name, absent_name in absent_test_params.items():
+            if branch_def_name == absent_name:
+                return param_name
+    return None
 
 
 COLLECTION_RUNTIME_NESTED_DEFS = frozenset(["DataCollectionNestedListRuntime", "DataCollectionNestedRecordRuntime"])
@@ -143,6 +228,7 @@ def _walk_and_normalize(node: Any) -> None:
 def to_json_schema(model, mode: MODE = DEFAULT_JSON_SCHEMA_MODE) -> Dict[str, Any]:
     schema = model.model_json_schema(schema_generator=CustomGenerateJsonSchema, mode=mode)
     _fix_conditional_oneofs(schema)
+    _add_conditional_discriminators(schema)
     _fix_collection_runtime_oneofs(schema)
     _normalize_annotated_types_keywords(schema)
     return schema

--- a/lib/galaxy/tool_util/parameters/json.py
+++ b/lib/galaxy/tool_util/parameters/json.py
@@ -1,7 +1,9 @@
 import json
+import re
 from typing import (
     Any,
     Dict,
+    List,
 )
 
 from pydantic.json_schema import GenerateJsonSchema
@@ -9,6 +11,8 @@ from typing_extensions import Literal
 
 MODE = Literal["validation", "serialization"]
 DEFAULT_JSON_SCHEMA_MODE: MODE = "validation"
+
+WHEN_ABSENT_RE = re.compile(r"^When_(.+)___absent$")
 
 
 class CustomGenerateJsonSchema(GenerateJsonSchema):
@@ -19,8 +23,95 @@ class CustomGenerateJsonSchema(GenerateJsonSchema):
         return json_schema
 
 
+def _fix_conditional_oneofs(schema: Dict[str, Any]) -> None:
+    """Make conditional discriminated unions unambiguous for JSON Schema validators.
+
+    Pydantic uses a custom callable discriminator for conditionals that doesn't
+    translate to JSON Schema. The result is a bare oneOf where explicit When branches
+    (When_<test>_<value>) overlap with the absent branch (When_<test>___absent) because
+    the test parameter field has a default and is therefore not required.
+
+    Fix: for each explicit When branch, add the test parameter to ``required`` and
+    remove its ``default``. This makes ``oneOf`` branches mutually exclusive.
+    """
+    defs = schema.get("$defs", {})
+    if not defs:
+        return
+
+    absent_test_params: Dict[str, str] = {}
+    for def_name in defs:
+        m = WHEN_ABSENT_RE.match(def_name)
+        if m:
+            absent_test_params[m.group(1)] = def_name
+
+    if not absent_test_params:
+        return
+
+    for def_name, def_schema in defs.items():
+        if def_name.startswith("When_") and "___absent" not in def_name:
+            for test_param_name in absent_test_params:
+                prefix = f"When_{test_param_name}_"
+                if def_name.startswith(prefix):
+                    _make_field_required(def_schema, test_param_name)
+                    break
+
+
+def _make_field_required(def_schema: Dict[str, Any], field_name: str) -> None:
+    props = def_schema.get("properties", {})
+    if field_name not in props:
+        return
+    required: List[str] = def_schema.get("required", [])
+    if field_name not in required:
+        required.append(field_name)
+        def_schema["required"] = required
+    props[field_name].pop("default", None)
+
+
+COLLECTION_RUNTIME_NESTED_DEFS = frozenset(["DataCollectionNestedListRuntime", "DataCollectionNestedRecordRuntime"])
+
+
+def _fix_collection_runtime_oneofs(schema: Dict[str, Any]) -> None:
+    """Convert collection runtime oneOf to anyOf to avoid discriminator overlap.
+
+    The Pydantic callable discriminator routes by collection_type pattern but
+    JSON Schema can't represent that. The nested variants have collection_type
+    as plain string which overlaps with the Literal const branches, causing
+    oneOf to reject valid inputs that match multiple branches. anyOf accepts
+    if at least one branch matches, which is the correct semantic here.
+    """
+    _walk_and_fix_collection_oneofs(schema)
+
+
+def _walk_and_fix_collection_oneofs(node: Any) -> None:
+    if not isinstance(node, dict):
+        if isinstance(node, list):
+            for item in node:
+                _walk_and_fix_collection_oneofs(item)
+        return
+
+    if "oneOf" in node:
+        one_of = node["oneOf"]
+        if isinstance(one_of, list) and _is_collection_runtime_oneof(one_of):
+            node["anyOf"] = node.pop("oneOf")
+
+    for value in node.values():
+        _walk_and_fix_collection_oneofs(value)
+
+
+def _is_collection_runtime_oneof(branches: List[Any]) -> bool:
+    for branch in branches:
+        ref = branch.get("$ref", "")
+        def_name = ref.rsplit("/", 1)[-1] if "/" in ref else ""
+        if def_name in COLLECTION_RUNTIME_NESTED_DEFS:
+            return True
+    return False
+
+
 def to_json_schema(model, mode: MODE = DEFAULT_JSON_SCHEMA_MODE) -> Dict[str, Any]:
-    return model.model_json_schema(schema_generator=CustomGenerateJsonSchema, mode=mode)
+    schema = model.model_json_schema(schema_generator=CustomGenerateJsonSchema, mode=mode)
+    _fix_conditional_oneofs(schema)
+    _fix_collection_runtime_oneofs(schema)
+    return schema
 
 
 def to_json_schema_string(model, mode: MODE = DEFAULT_JSON_SCHEMA_MODE) -> str:

--- a/lib/galaxy/tool_util/parameters/json.py
+++ b/lib/galaxy/tool_util/parameters/json.py
@@ -107,10 +107,44 @@ def _is_collection_runtime_oneof(branches: List[Any]) -> bool:
     return False
 
 
+_ANNOTATED_TYPES_TO_JSON_SCHEMA = {
+    "ge": "minimum",
+    "gt": "exclusiveMinimum",
+    "le": "maximum",
+    "lt": "exclusiveMaximum",
+}
+
+
+def _normalize_annotated_types_keywords(schema: Dict[str, Any]) -> None:
+    """Convert annotated_types constraint keys to standard JSON Schema keywords.
+
+    When annotated_types constraints (Ge, Gt, Le, Lt) are applied to Union types,
+    Pydantic emits them as raw keys (ge, gt, le, lt) instead of the standard
+    JSON Schema keywords (minimum, exclusiveMinimum, etc.). Normalize these.
+    """
+    _walk_and_normalize(schema)
+
+
+def _walk_and_normalize(node: Any) -> None:
+    if not isinstance(node, dict):
+        if isinstance(node, list):
+            for item in node:
+                _walk_and_normalize(item)
+        return
+
+    for at_key, js_key in _ANNOTATED_TYPES_TO_JSON_SCHEMA.items():
+        if at_key in node and js_key not in node:
+            node[js_key] = node.pop(at_key)
+
+    for value in node.values():
+        _walk_and_normalize(value)
+
+
 def to_json_schema(model, mode: MODE = DEFAULT_JSON_SCHEMA_MODE) -> Dict[str, Any]:
     schema = model.model_json_schema(schema_generator=CustomGenerateJsonSchema, mode=mode)
     _fix_conditional_oneofs(schema)
     _fix_collection_runtime_oneofs(schema)
+    _normalize_annotated_types_keywords(schema)
     return schema
 
 

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -307,6 +307,8 @@ def _json_schema_extra_for_validators(validators: Sequence[VT]) -> Dict[str, Any
 
     Regex pattern is emitted here rather than as a type annotation because
     StringConstraints is incompatible with non-string types like AnyUrl.
+    Negated length uses ``not: {minLength, maxLength}`` since the non-negated
+    form is handled by annotated_types.
     """
     extra: Dict[str, Any] = {}
     for v in validators:
@@ -316,6 +318,16 @@ def _json_schema_extra_for_validators(validators: Sequence[VT]) -> Dict[str, Any
             if not pattern.startswith("^"):
                 pattern = "^" + pattern
             extra["pattern"] = pattern
+            break
+    for v in validators:
+        if isinstance(v, LengthParameterValidatorModel) and v.negate:
+            not_constraint: Dict[str, Any] = {}
+            if v.min is not None:
+                not_constraint["minLength"] = v.min
+            if v.max is not None:
+                not_constraint["maxLength"] = v.max
+            if not_constraint:
+                extra["not"] = not_constraint
             break
     return extra
 
@@ -1500,6 +1512,11 @@ class ColorParameterModel(BaseGalaxyToolParameterModelDefinition):
     parameter_type: Literal["gx_color"] = "gx_color"
     type: Literal["color"]
     value: Optional[str] = None
+
+    def field_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().field_kwargs()
+        kwargs["json_schema_extra"]["pattern"] = "^#[0-9a-f]{6}$"
+        return kwargs
 
     @property
     def py_type(self) -> Type:

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -19,6 +19,7 @@ from typing import (
     Union,
 )
 
+import annotated_types
 from pydantic import (
     AfterValidator,
     AliasChoices,
@@ -174,7 +175,11 @@ def _label_value_dicts(options: List[Any]) -> List[Dict[str, Any]]:
 
 
 def dynamic_model_information_from_py_type(
-    param_model: ParamModel, py_type: Type, requires_value: Optional[bool] = None, validators=None
+    param_model: ParamModel,
+    py_type: Type,
+    requires_value: Optional[bool] = None,
+    validators=None,
+    extra_json_schema: Optional[Dict[str, Any]] = None,
 ):
     name = safe_field_name(param_model.name)
     if requires_value is None:
@@ -186,6 +191,8 @@ def dynamic_model_information_from_py_type(
         validators["not_null"] = field_validator(name)(Validators.validate_not_none)
 
     field_kwargs = param_model.field_kwargs()
+    if extra_json_schema:
+        field_kwargs.setdefault("json_schema_extra", {}).update(extra_json_schema)
     return DynamicModelInformation(
         name,
         (py_type, Field(initialize, alias=param_model.name if param_model.name != name else None, **field_kwargs)),
@@ -272,14 +279,58 @@ def pydantic_to_galaxy_type(value: Any) -> Any:
 VT = TypeVar("VT", bound=StaticValidatorModel)
 
 
+def _json_schema_annotations_for(static_validator_models: Sequence[VT]) -> List[Any]:
+    """Extract JSON Schema-representable constraint annotations from validators.
+
+    Non-negated in_range and length validators have direct annotated_types
+    equivalents that Pydantic emits as JSON Schema keywords. Regex is handled
+    separately via json_schema_extra since StringConstraints is incompatible
+    with non-string types (e.g. AnyUrl).
+    """
+    annotations: List[Any] = []
+    for v in static_validator_models:
+        if isinstance(v, InRangeParameterValidatorModel) and not v.negate:
+            if v.min is not None:
+                annotations.append(annotated_types.Gt(v.min) if v.exclude_min else annotated_types.Ge(v.min))
+            if v.max is not None:
+                annotations.append(annotated_types.Lt(v.max) if v.exclude_max else annotated_types.Le(v.max))
+        elif isinstance(v, LengthParameterValidatorModel) and not v.negate:
+            if v.min is not None:
+                annotations.append(annotated_types.MinLen(v.min))
+            if v.max is not None:
+                annotations.append(annotated_types.MaxLen(v.max))
+    return annotations
+
+
+def _json_schema_extra_for_validators(validators: Sequence[VT]) -> Dict[str, Any]:
+    """Extract JSON Schema keywords for validators best handled via json_schema_extra.
+
+    Regex pattern is emitted here rather than as a type annotation because
+    StringConstraints is incompatible with non-string types like AnyUrl.
+    """
+    extra: Dict[str, Any] = {}
+    for v in validators:
+        if isinstance(v, RegexParameterValidatorModel) and not v.negate:
+            pattern = v.expression
+            # Python re.match anchors at start; JSON Schema pattern does not
+            if not pattern.startswith("^"):
+                pattern = "^" + pattern
+            extra["pattern"] = pattern
+            break
+    return extra
+
+
 def decorate_type_with_validators_if_needed(
     py_type: Type, static_validator_models: Sequence[VT], optional: bool = False
 ) -> Type:
     pydantic_validator = pydantic_validator_for(static_validator_models, optional=optional)
+    json_schema_annotations = _json_schema_annotations_for(static_validator_models)
+    all_annotations = json_schema_annotations[:]
     if pydantic_validator:
-        return expand_annotation(py_type, [pydantic_validator])
-    else:
-        return py_type
+        all_annotations.append(pydantic_validator)
+    if all_annotations:
+        return expand_annotation(py_type, all_annotations)
+    return py_type
 
 
 # Looks like Annotated only work with one PlainValidator so condensing all static validators
@@ -339,7 +390,12 @@ class TextParameterModel(BaseGalaxyToolParameterModelDefinition):
         requires_value = self.request_requires_value
         if state_representation in ("job_internal", "job_runtime"):
             requires_value = True
-        return dynamic_model_information_from_py_type(self, py_type, requires_value=requires_value)
+        return dynamic_model_information_from_py_type(
+            self,
+            py_type,
+            requires_value=requires_value,
+            extra_json_schema=_json_schema_extra_for_validators(self.validators),
+        )
 
     @property
     def request_requires_value(self) -> bool:
@@ -1535,7 +1591,12 @@ class DirectoryUriParameterModel(BaseGalaxyToolParameterModelDefinition):
         requires_value = self.request_requires_value
         if _is_landing_request(state_representation):
             requires_value = False
-        return dynamic_model_information_from_py_type(self, py_type, requires_value=requires_value)
+        return dynamic_model_information_from_py_type(
+            self,
+            py_type,
+            requires_value=requires_value,
+            extra_json_schema=_json_schema_extra_for_validators(self.validators),
+        )
 
     @property
     def request_requires_value(self) -> bool:

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -481,7 +481,7 @@ class FileHash(StrictModel):
 
 
 class BaseDataRequest(StrictModel):
-    url: StrictStr = Field(..., alias="location")
+    url: StrictStr = Field(..., alias="location", validation_alias=AliasChoices("url", "location"))
     name: Optional[StrictStr] = None
     ext: StrictStr
     dbkey: StrictStr = "?"
@@ -1634,6 +1634,7 @@ class SelectParameterModel(BaseGalaxyToolParameterModelDefinition):
             py_type = self.py_type_if_required(allow_connections=False)
             if self.multiple:
                 validators = {"from_string": field_validator(self.name, mode="before")(SelectParameterModel.split_str)}
+                py_type = union_type([StrictStr, py_type])
             py_type = optional_if_needed(py_type, self.optional)
         elif state_representation == "test_case_json":
             # in JSON test case representation, lists are already validated as lists (no string splitting)
@@ -1876,11 +1877,13 @@ class DataColumnParameterModel(BaseGalaxyToolParameterModelDefinition):
                 validators = {
                     "from_string": field_validator(self.name, mode="before")(DataColumnParameterModel.split_str)
                 }
+                py_type = union_type([StrictStr, self.py_type])
             else:
                 validators = {}
+                py_type = self.py_type
             requires_value = self.request_requires_value
             return dynamic_model_information_from_py_type(
-                self, self.py_type, validators=validators, requires_value=requires_value
+                self, py_type, validators=validators, requires_value=requires_value
             )
         elif state_representation == "test_case_json":
             # JSON test cases accept lists directly (no string splitting)

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     galaxy-tool-util-models
     galaxy-util[image-util]>=22.1
     conda-package-streaming
+    jsonschema
     lxml!=4.2.2
     MarkupSafe
     packaging

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -344,7 +344,7 @@ gx_text_expression_validation:
   - parameter: {__class__: 'ConnectedValue'}
   workflow_step_linked_invalid:
   - parameter: ''
-  json_schema_skip:
+  _json_schema_skip:
     request_invalid: "expression validator uses AfterValidator"
     workflow_step_linked_invalid: "expression validator uses AfterValidator"
 
@@ -368,7 +368,7 @@ gx_text_empty_validation:
   - parameter: {__class__: 'ConnectedValue'}
   workflow_step_linked_invalid:
   - parameter: ''
-  json_schema_skip:
+  _json_schema_skip:
     request_invalid: "empty_field validator uses AfterValidator"
     job_internal_invalid: "empty_field validator uses AfterValidator"
     job_runtime_invalid: "empty_field validator uses AfterValidator"
@@ -936,7 +936,7 @@ gx_directory_uri:
   - parameter: "justsomestring"
   - parameter: true
   - parameter: null
-  json_schema_skip:
+  _json_schema_skip:
     request_invalid: "regex validator uses AfterValidator"
     job_internal_invalid: "regex validator uses AfterValidator"
     job_runtime_invalid: "regex validator uses AfterValidator"
@@ -956,7 +956,7 @@ gx_directory_uri_validation:
   - parameter: "gxfiles://tooshort/index.json"
   - parameter: "gxfiles://mycoolsource/api/wrongex.js"
   - parameter: "gxfiles://mycoolsource/badexp.json"
-  json_schema_skip:
+  _json_schema_skip:
     request_invalid: "regex/length/expression validators use AfterValidator"
     workflow_step_linked_invalid: "regex/length/expression validators use AfterValidator"
 
@@ -1066,7 +1066,7 @@ gx_hidden_validation:
   - parameter: "http://mycoolservice.com/index.json"
   - parameter: "http://mycoolservice.com/api/wrongex.js"
   - parameter: "http://mycoolservice.com/badexp.json"
-  json_schema_skip:
+  _json_schema_skip:
     request_invalid: "regex/length/expression validators use AfterValidator"
     workflow_step_linked_invalid: "regex/length/expression validators use AfterValidator"
 

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -308,6 +308,8 @@ gx_int_validation_range:
   - parameter: 10
   workflow_step_linked_valid:
    - parameter: {__class__: 'ConnectedValue'}
+  json_schema_skip:
+    request_invalid: "in_range validator uses AfterValidator, not representable in JSON Schema"
 
 gx_int_min_max:
   request_valid:
@@ -321,6 +323,9 @@ gx_int_min_max:
   - parameter: {__class__: 'ConnectedValue'}
   workflow_step_linked_invalid:
   - parameter: -1
+  json_schema_skip:
+    request_invalid: "in_range validator uses AfterValidator"
+    workflow_step_linked_invalid: "in_range validator uses AfterValidator"
 
 gx_text_regex_validation:
   request_valid:
@@ -332,6 +337,8 @@ gx_text_regex_validation:
   - parameter: nucleic
   workflow_step_linked_valid:
    - parameter: {__class__: 'ConnectedValue'}
+  json_schema_skip:
+    request_invalid: "regex validator uses AfterValidator"
 
 gx_text_expression_validation:
   request_valid:
@@ -344,6 +351,9 @@ gx_text_expression_validation:
   - parameter: {__class__: 'ConnectedValue'}
   workflow_step_linked_invalid:
   - parameter: ''
+  json_schema_skip:
+    request_invalid: "expression validator uses AfterValidator"
+    workflow_step_linked_invalid: "expression validator uses AfterValidator"
 
 gx_text_empty_validation:
   request_valid:
@@ -365,6 +375,11 @@ gx_text_empty_validation:
   - parameter: {__class__: 'ConnectedValue'}
   workflow_step_linked_invalid:
   - parameter: ''
+  json_schema_skip:
+    request_invalid: "empty_field validator uses AfterValidator"
+    job_internal_invalid: "empty_field validator uses AfterValidator"
+    job_runtime_invalid: "empty_field validator uses AfterValidator"
+    workflow_step_linked_invalid: "empty_field validator uses AfterValidator"
 
 gx_text:
   request_valid: &gx_text_request_valid
@@ -569,6 +584,8 @@ gx_text_length_validation:
   request_invalid:
   - parameter: "s"  # too short
   - parameter: "mytext1231231231sd"  # too long
+  json_schema_skip:
+    request_invalid: "length validator uses AfterValidator"
 
 gx_text_length_validation_negate:
   request_valid:
@@ -576,6 +593,8 @@ gx_text_length_validation_negate:
   - parameter: "mytext123mocowdowees"
   request_invalid:
   - parameter: "goldilocks"
+  json_schema_skip:
+    request_invalid: "length validator with negate uses AfterValidator"
 
 gx_select:
   request_valid:
@@ -928,6 +947,10 @@ gx_directory_uri:
   - parameter: "justsomestring"
   - parameter: true
   - parameter: null
+  json_schema_skip:
+    request_invalid: "regex validator uses AfterValidator"
+    job_internal_invalid: "regex validator uses AfterValidator"
+    job_runtime_invalid: "regex validator uses AfterValidator"
 
 gx_directory_uri_validation:
   request_valid:
@@ -944,6 +967,9 @@ gx_directory_uri_validation:
   - parameter: "gxfiles://tooshort/index.json"
   - parameter: "gxfiles://mycoolsource/api/wrongex.js"
   - parameter: "gxfiles://mycoolsource/badexp.json"
+  json_schema_skip:
+    request_invalid: "regex/length/expression validators use AfterValidator"
+    workflow_step_linked_invalid: "regex/length/expression validators use AfterValidator"
 
 gx_hidden:
   request_valid:
@@ -1051,6 +1077,9 @@ gx_hidden_validation:
   - parameter: "http://mycoolservice.com/index.json"
   - parameter: "http://mycoolservice.com/api/wrongex.js"
   - parameter: "http://mycoolservice.com/badexp.json"
+  json_schema_skip:
+    request_invalid: "regex/length/expression validators use AfterValidator"
+    workflow_step_linked_invalid: "regex/length/expression validators use AfterValidator"
 
 gx_float:
   request_valid:
@@ -1200,6 +1229,8 @@ gx_float_validation_range:
   - parameter: 10
   - parameter: 0
   - parameter: 9.8  # endpoint not included because specified in validator
+  json_schema_skip:
+    request_invalid: "in_range validator uses AfterValidator"
 
 gx_float_min_max:
   request_valid:
@@ -1210,6 +1241,8 @@ gx_float_min_max:
   request_invalid:
   - parameter: 10
   - parameter: 0
+  json_schema_skip:
+    request_invalid: "in_range validator uses AfterValidator"
 
 gx_color:
   request_valid:
@@ -1235,6 +1268,10 @@ gx_color:
     - parameter: 'foobar'
     - parameter: 5
     - parameter: {__class__: 'ConnectedValue2'}
+  json_schema_skip:
+    request_invalid: "color regex validator uses AfterValidator"
+    workflow_step_invalid: "color regex validator uses AfterValidator"
+    workflow_step_linked_invalid: "color regex validator uses AfterValidator"
 
 gx_data:
   request_valid:

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -584,8 +584,6 @@ gx_text_length_validation_negate:
   - parameter: "mytext123mocowdowees"
   request_invalid:
   - parameter: "goldilocks"
-  json_schema_skip:
-    request_invalid: "length validator with negate uses AfterValidator"
 
 gx_select:
   request_valid:
@@ -1255,10 +1253,6 @@ gx_color:
     - parameter: 'foobar'
     - parameter: 5
     - parameter: {__class__: 'ConnectedValue2'}
-  json_schema_skip:
-    request_invalid: "color regex validator uses AfterValidator"
-    workflow_step_invalid: "color regex validator uses AfterValidator"
-    workflow_step_linked_invalid: "color regex validator uses AfterValidator"
 
 gx_data:
   request_valid:

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -308,8 +308,6 @@ gx_int_validation_range:
   - parameter: 10
   workflow_step_linked_valid:
    - parameter: {__class__: 'ConnectedValue'}
-  json_schema_skip:
-    request_invalid: "in_range validator uses AfterValidator, not representable in JSON Schema"
 
 gx_int_min_max:
   request_valid:
@@ -323,9 +321,6 @@ gx_int_min_max:
   - parameter: {__class__: 'ConnectedValue'}
   workflow_step_linked_invalid:
   - parameter: -1
-  json_schema_skip:
-    request_invalid: "in_range validator uses AfterValidator"
-    workflow_step_linked_invalid: "in_range validator uses AfterValidator"
 
 gx_text_regex_validation:
   request_valid:
@@ -337,8 +332,6 @@ gx_text_regex_validation:
   - parameter: nucleic
   workflow_step_linked_valid:
    - parameter: {__class__: 'ConnectedValue'}
-  json_schema_skip:
-    request_invalid: "regex validator uses AfterValidator"
 
 gx_text_expression_validation:
   request_valid:
@@ -584,8 +577,6 @@ gx_text_length_validation:
   request_invalid:
   - parameter: "s"  # too short
   - parameter: "mytext1231231231sd"  # too long
-  json_schema_skip:
-    request_invalid: "length validator uses AfterValidator"
 
 gx_text_length_validation_negate:
   request_valid:
@@ -1229,8 +1220,6 @@ gx_float_validation_range:
   - parameter: 10
   - parameter: 0
   - parameter: 9.8  # endpoint not included because specified in validator
-  json_schema_skip:
-    request_invalid: "in_range validator uses AfterValidator"
 
 gx_float_min_max:
   request_valid:
@@ -1241,8 +1230,6 @@ gx_float_min_max:
   request_invalid:
   - parameter: 10
   - parameter: 0
-  json_schema_skip:
-    request_invalid: "in_range validator uses AfterValidator"
 
 gx_color:
   request_valid:

--- a/test/unit/tool_util/test_parameter_specification.py
+++ b/test/unit/tool_util/test_parameter_specification.py
@@ -121,6 +121,8 @@ def _test_file(file: str, specification=None, parameter_bundle: Optional[ToolPar
     }
 
     for valid_or_invalid, tests in combos.items():
+        if valid_or_invalid not in assertion_functions:
+            continue
         assertion_function = assertion_functions[valid_or_invalid]
         assertion_function(parameter_bundle, tests)
 

--- a/test/unit/tool_util/test_parameter_specification_json_schema.py
+++ b/test/unit/tool_util/test_parameter_specification_json_schema.py
@@ -1,0 +1,130 @@
+"""Validate parameter_specification.yml entries against JSON Schema generated from Pydantic models.
+
+This mirrors test_parameter_specification.py but validates against JSON Schema (Draft 2020-12)
+instead of Pydantic models directly. The goal is to prove the exported JSON Schemas are usable
+from non-Python toolkits.
+
+AfterValidator-based Galaxy validators (regex, expression, in_range, length, empty_field) do not
+emit JSON Schema keywords, so some *_invalid entries are expected to pass JSON Schema validation.
+These are annotated with json_schema_skip in parameter_specification.yml.
+"""
+
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Set,
+)
+
+import jsonschema
+import yaml
+
+from galaxy.tool_util.parameters.json import to_json_schema
+from galaxy.tool_util.unittest_utils.parameters import (
+    parameter_bundle_for_file,
+)
+from galaxy.tool_util_models.parameters import (
+    create_field_model,
+    RawStateDict,
+    StateRepresentationT,
+    ToolParameterBundleModel,
+)
+from galaxy.util.resources import resource_string
+
+REPRESENTATION_KEYS = [
+    "relaxed_request",
+    "request",
+    "request_internal",
+    "request_internal_dereferenced",
+    "landing_request",
+    "landing_request_internal",
+    "job_internal",
+    "job_runtime",
+    "test_case_xml",
+    "test_case_json",
+    "workflow_step",
+    "workflow_step_linked",
+]
+
+STATE_REPRESENTATION_FOR_KEY: Dict[str, StateRepresentationT] = {k: k for k in REPRESENTATION_KEYS}  # type: ignore[misc]
+
+
+def specification_object():
+    try:
+        yaml_str = resource_string(__name__, "parameter_specification.yml")
+    except AttributeError:
+        yaml_str = open("test/unit/tool_util/parameter_specification.yml").read()
+    return yaml.safe_load(yaml_str)
+
+
+def _json_schema_for(bundle: ToolParameterBundleModel, state_representation: StateRepresentationT) -> Dict[str, Any]:
+    model = create_field_model(bundle.parameters, name="TestModel", state_representation=state_representation)
+    return to_json_schema(model)
+
+
+def _json_schema_validates(schema: Dict[str, Any], state_dict: RawStateDict) -> bool:
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = list(validator.iter_errors(state_dict))
+    return len(errors) == 0
+
+
+def _test_file_json_schema(
+    file: str,
+    specification=None,
+    parameter_bundle: Optional[ToolParameterBundleModel] = None,
+):
+    spec = specification or specification_object()
+    combos = spec[file]
+    if parameter_bundle is None:
+        parameter_bundle = parameter_bundle_for_file(file)
+    assert parameter_bundle
+
+    json_schema_skip: Dict[str, str] = combos.get("json_schema_skip", {}) or {}
+    json_schema_valid_skip: Dict[str, str] = combos.get("json_schema_valid_skip", {}) or {}
+    skipped_invalid_keys: Set[str] = set(json_schema_skip.keys())
+    skipped_valid_keys: Set[str] = set(json_schema_valid_skip.keys())
+
+    failures: List[str] = []
+
+    for combo_key, test_cases in combos.items():
+        if combo_key in ("json_schema_skip", "json_schema_valid_skip"):
+            continue
+        if not isinstance(test_cases, list):
+            continue
+
+        if combo_key.endswith("_valid"):
+            is_valid = True
+            rep_key = combo_key[: -len("_valid")]
+        elif combo_key.endswith("_invalid"):
+            is_valid = False
+            rep_key = combo_key[: -len("_invalid")]
+        else:
+            continue
+
+        state_representation = STATE_REPRESENTATION_FOR_KEY.get(rep_key)
+        if state_representation is None:
+            continue
+
+        schema = _json_schema_for(parameter_bundle, state_representation)
+
+        for i, test_case in enumerate(test_cases):
+            passes = _json_schema_validates(schema, test_case)
+
+            if is_valid and not passes and combo_key not in skipped_valid_keys:
+                failures.append(f"{file}/{combo_key}[{i}]: valid entry REJECTED by JSON Schema: {test_case}")
+            elif not is_valid and passes and combo_key not in skipped_invalid_keys:
+                failures.append(
+                    f"{file}/{combo_key}[{i}]: invalid entry ACCEPTED by JSON Schema (not skipped): {test_case}"
+                )
+
+    if failures:
+        raise AssertionError(
+            f"{len(failures)} JSON Schema validation divergence(s) for {file}:\n" + "\n".join(failures)
+        )
+
+
+def test_specification_json_schema():
+    parameter_spec = specification_object()
+    for file in parameter_spec.keys():
+        _test_file_json_schema(file, parameter_spec)

--- a/test/unit/tool_util/test_parameter_specification_json_schema.py
+++ b/test/unit/tool_util/test_parameter_specification_json_schema.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
 )
 
 import jsonschema
@@ -132,7 +133,9 @@ def test_specification_json_schema():
         _test_file_json_schema(file, parameter_spec)
 
 
-def _conditional_type_def(file: str, state_representation: StateRepresentationT = "request") -> Dict[str, Any]:
+def _conditional_type_def(
+    file: str, state_representation: StateRepresentationT = "request"
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     bundle = parameter_bundle_for_file(file)
     schema = _json_schema_for(bundle, state_representation)
     defs = schema.get("$defs", {})

--- a/test/unit/tool_util/test_parameter_specification_json_schema.py
+++ b/test/unit/tool_util/test_parameter_specification_json_schema.py
@@ -11,6 +11,7 @@ in JSON Schema are annotated with _json_schema_skip in parameter_specification.y
 knows to tolerate those *_invalid entries passing validation.
 """
 
+import sys
 from typing import (
     Any,
     Dict,
@@ -21,7 +22,12 @@ from typing import (
 )
 
 import jsonschema
+import pytest
 import yaml
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="jsonschema<4.24 on Python 3.8 mishandles additionalProperties in anyOf"
+)
 
 from galaxy.tool_util.parameters.json import to_json_schema
 from galaxy.tool_util.unittest_utils.parameters import (

--- a/test/unit/tool_util/test_parameter_specification_json_schema.py
+++ b/test/unit/tool_util/test_parameter_specification_json_schema.py
@@ -130,3 +130,47 @@ def test_specification_json_schema():
     parameter_spec = specification_object()
     for file in parameter_spec.keys():
         _test_file_json_schema(file, parameter_spec)
+
+
+def _conditional_type_def(file: str, state_representation: StateRepresentationT = "request") -> Dict[str, Any]:
+    bundle = parameter_bundle_for_file(file)
+    schema = _json_schema_for(bundle, state_representation)
+    defs = schema.get("$defs", {})
+    matches = {k: v for k, v in defs.items() if "oneOf" in v}
+    assert len(matches) == 1, f"Expected exactly one oneOf def, got {list(matches.keys())}"
+    return next(iter(matches.values())), defs
+
+
+def test_boolean_conditional_discriminator():
+    cond_def, defs = _conditional_type_def("gx_conditional_boolean")
+    disc = cond_def.get("discriminator")
+    assert disc is not None
+    assert disc["propertyName"] == "test_parameter"
+    mapping = disc["mapping"]
+    assert "true" in mapping
+    assert "false" in mapping
+    assert len(mapping) == 2
+
+    assert defs["When_test_parameter_True"]["title"] == "When test_parameter = True"
+    assert defs["When_test_parameter_False"]["title"] == "When test_parameter = False"
+    assert defs["When_test_parameter___absent"]["title"] == "When test_parameter is absent"
+
+
+def test_select_conditional_discriminator():
+    cond_def, defs = _conditional_type_def("gx_conditional_select")
+    disc = cond_def.get("discriminator")
+    assert disc is not None
+    assert disc["propertyName"] == "test_parameter"
+    mapping = disc["mapping"]
+    assert set(mapping.keys()) == {"a", "b", "c"}
+
+    assert defs["When_test_parameter_a"]["title"] == "When test_parameter = a"
+    assert defs["When_test_parameter___absent"]["title"] == "When test_parameter is absent"
+
+
+def test_job_internal_no_discriminator():
+    bundle = parameter_bundle_for_file("gx_conditional_boolean")
+    schema = _json_schema_for(bundle, "job_internal")
+    defs = schema.get("$defs", {})
+    for def_schema in defs.values():
+        assert "discriminator" not in def_schema

--- a/test/unit/tool_util/test_parameter_specification_json_schema.py
+++ b/test/unit/tool_util/test_parameter_specification_json_schema.py
@@ -4,9 +4,11 @@ This mirrors test_parameter_specification.py but validates against JSON Schema (
 instead of Pydantic models directly. The goal is to prove the exported JSON Schemas are usable
 from non-Python toolkits.
 
-AfterValidator-based Galaxy validators (regex, expression, in_range, length, empty_field) do not
-emit JSON Schema keywords, so some *_invalid entries are expected to pass JSON Schema validation.
-These are annotated with json_schema_skip in parameter_specification.yml.
+Many Galaxy validators now emit native JSON Schema keywords (pattern, minimum/maximum,
+minLength/maxLength, exclusiveMinimum/exclusiveMaximum, and negated length via not:{}).
+Remaining AfterValidator-only constraints (expression, empty_field) that cannot be represented
+in JSON Schema are annotated with _json_schema_skip in parameter_specification.yml so the test
+knows to tolerate those *_invalid entries passing validation.
 """
 
 from typing import (
@@ -80,15 +82,15 @@ def _test_file_json_schema(
         parameter_bundle = parameter_bundle_for_file(file)
     assert parameter_bundle
 
-    json_schema_skip: Dict[str, str] = combos.get("json_schema_skip", {}) or {}
-    json_schema_valid_skip: Dict[str, str] = combos.get("json_schema_valid_skip", {}) or {}
+    json_schema_skip: Dict[str, str] = combos.get("_json_schema_skip", {}) or {}
+    json_schema_valid_skip: Dict[str, str] = combos.get("_json_schema_valid_skip", {}) or {}
     skipped_invalid_keys: Set[str] = set(json_schema_skip.keys())
     skipped_valid_keys: Set[str] = set(json_schema_valid_skip.keys())
 
     failures: List[str] = []
 
     for combo_key, test_cases in combos.items():
-        if combo_key in ("json_schema_skip", "json_schema_valid_skip"):
+        if combo_key in ("_json_schema_skip", "_json_schema_valid_skip"):
             continue
         if not isinstance(test_cases, list):
             continue

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -2449,7 +2449,7 @@ def test_linting_functional_tool_multi_select(lint_ctx):
     run_lint_module(lint_ctx, tests, tool_source)
     warn_message = lint_ctx.warn_messages[0]
     assert (
-        "Test 2: failed to validate test parameters against inputs - tests won't run on a modern Galaxy tool profile version. Validation errors are [5 validation errors for"
+        "Test 2: failed to validate test parameters against inputs - tests won't run on a modern Galaxy tool profile version. Validation errors are [6 validation errors for"
         in str(warn_message)
     )
 


### PR DESCRIPTION
The idea was to start testing parameters_specification.yml against the JSON schema generated from the Pydantic models. (Some background about tool state model and how they are validated can be found [here](https://jmchilton.github.io/galaxy-brain/research/component-tool-state-specification/).)The tests to test certain restrictions on inputs that cannot be expressed in JSON schema but this code does at least ensure all valid tests validate for all model types and parameter types.

Downstream work allows validating workflows using either the Pydantic models or the JSON Schema - this work enables that second option. The Pydantic models are stronger assertions on the state but inherently less cross-platform and less portable - there is a lot of value in allowing both options and testing both options I think.

The schema change was... surprising but Claude made a convincing case it is right and reflects how APIs are already used in the client and that rebuild schema commit message has details outlined.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
