### PR TITLE
[25.1] Fix timestamp parsing in job import/export

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1691,14 +1691,8 @@ class BaseDirectoryImportModelStore(ModelImportStore):
 def restore_times(
     model_object: Union[model.Job, model.WorkflowInvocation, model.WorkflowInvocationStep], attrs: dict[str, Any]
 ) -> None:
-    try:
-        model_object.create_time = datetime.datetime.strptime(attrs["create_time"], "%Y-%m-%dT%H:%M:%S.%f")
-    except Exception:
-        pass
-    try:
-        model_object.update_time = datetime.datetime.strptime(attrs["update_time"], "%Y-%m-%dT%H:%M:%S.%f")
-    except Exception:
-        pass
+    model_object.create_time = datetime.datetime.fromisoformat(attrs["create_time"])
+    model_object.update_time = datetime.datetime.fromisoformat(attrs["update_time"])
 
 
 class DirectoryImportModelStore1901(BaseDirectoryImportModelStore):


### PR DESCRIPTION
Use datetime.fromisoformat() instead of strptime with a rigid format that requires microseconds. When datetime.isoformat() produces timestamps without microseconds (e.g. "2026-04-02T14:28:40"), the strptime format "%Y-%m-%dT%H:%M:%S.%f" fails silently, leaving update_time/create_time as None on the restored model object.

The try/except: pass was silently swallowing parse errors for 5 years, making it hard to debug when timestamps failed to restore. Just check for key presence instead — if the value exists but is malformed, let it fail loudly.
These fields are required by downstream code, so silently skipping them just delays the failure. Let KeyError or ValueError surface at the actual point of failure.

Fixes https://github.com/galaxyproject/galaxy/issues/22371

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
