### PR TITLE
[26.0] Handle `JSONDecodeError` when reading container details file

### DIFF
--- a/lib/galaxy/job_metrics/__init__.py
+++ b/lib/galaxy/job_metrics/__init__.py
@@ -12,6 +12,7 @@ collect the output of these from a job directory.
 """
 
 import collections
+import json
 import logging
 import os
 from abc import (
@@ -231,7 +232,7 @@ class JobInstrumenter(JobInstrumenterI):
                 properties = plugin.job_properties(job_id, job_directory)
                 if properties:
                     per_plugin_properties[plugin.plugin_type] = properties
-            except FileNotFoundError as e:
+            except (FileNotFoundError, json.JSONDecodeError) as e:
                 log.warning("Failed to collect job properties for plugin %s: %s", plugin, e)
             except Exception:
                 log.exception("Failed to collect job properties for plugin %s", plugin)

--- a/lib/galaxy/job_metrics/instrumenters/core.py
+++ b/lib/galaxy/job_metrics/instrumenters/core.py
@@ -117,9 +117,6 @@ class CorePlugin(InstrumentPlugin):
                 return json.load(fh)
         except FileNotFoundError:
             return {}
-        except json.JSONDecodeError:
-            log.warning("Failed to parse container details file in %s, file may be corrupted", job_directory)
-            return {}
 
     def __record_galaxy_slots_command(self, job_directory):
         galaxy_slots_file = self.__galaxy_slots_file(job_directory)

--- a/lib/galaxy/job_metrics/instrumenters/core.py
+++ b/lib/galaxy/job_metrics/instrumenters/core.py
@@ -117,6 +117,9 @@ class CorePlugin(InstrumentPlugin):
                 return json.load(fh)
         except FileNotFoundError:
             return {}
+        except json.JSONDecodeError:
+            log.warning("Failed to parse container details file in %s, file may be corrupted", job_directory)
+            return {}
 
     def __record_galaxy_slots_command(self, job_directory):
         galaxy_slots_file = self.__galaxy_slots_file(job_directory)

--- a/test/unit/job_metrics/test_core.py
+++ b/test/unit/job_metrics/test_core.py
@@ -1,5 +1,6 @@
 import subprocess
 
+from galaxy.job_metrics import JobMetrics
 from galaxy.job_metrics.instrumenters.core import (
     CONTAINER_ID,
     CONTAINER_TYPE,
@@ -21,11 +22,12 @@ def test_core_instrumentation(tmpdir):
 
 def test_corrupted_container_file_is_ignored(tmpdir):
     """Verify graceful handling when Pulsar writes an HTTP error page instead of valid JSON (galaxyproject/galaxy#22192)."""
-    core_plugin = CorePlugin()
     tmpdir.join("__instrument_core_container").write("<html><body><h1>502 Bad Gateway</h1></body></html>")
-    properties = core_plugin.job_properties(1, tmpdir)
-    assert CONTAINER_ID not in properties
-    assert CONTAINER_TYPE not in properties
+    metrics = JobMetrics()
+    per_plugin = metrics.collect_properties("default", 1, tmpdir)
+    core_properties = per_plugin.get("core", {})
+    assert CONTAINER_ID not in core_properties
+    assert CONTAINER_TYPE not in core_properties
 
 
 def _run_plugin(plugin, work_dir, env=None):

--- a/test/unit/job_metrics/test_core.py
+++ b/test/unit/job_metrics/test_core.py
@@ -1,6 +1,8 @@
 import subprocess
 
 from galaxy.job_metrics.instrumenters.core import (
+    CONTAINER_ID,
+    CONTAINER_TYPE,
     CorePlugin,
     GALAXY_MEMORY_MB_KEY,
     GALAXY_SLOTS_KEY,
@@ -15,6 +17,15 @@ def test_core_instrumentation(tmpdir):
     properties = core_plugin.job_properties(1, tmpdir)
     assert properties[GALAXY_SLOTS_KEY] == 4
     assert properties[GALAXY_MEMORY_MB_KEY] == 1024
+
+
+def test_corrupted_container_file_is_ignored(tmpdir):
+    """Verify graceful handling when Pulsar writes an HTTP error page instead of valid JSON (galaxyproject/galaxy#22192)."""
+    core_plugin = CorePlugin()
+    tmpdir.join("__instrument_core_container").write("<html><body><h1>502 Bad Gateway</h1></body></html>")
+    properties = core_plugin.job_properties(1, tmpdir)
+    assert CONTAINER_ID not in properties
+    assert CONTAINER_TYPE not in properties
 
 
 def _run_plugin(plugin, work_dir, env=None):


### PR DESCRIPTION
When Pulsar downloads a file and the remote server (e.g. nginx) returns a 502, the HTML error body gets written verbatim to the container.json file. Galaxy's __read_container_details() only caught FileNotFoundError, so json.JSONDecodeError would bubble up through collect_properties().

The job still completed normally (the outer handler caught it), but container metrics were silently lost. Now we catch JSONDecodeError separately and log a warning to aid debugging, distinguishing corrupted files from simply missing ones.

Fixes: https://github.com/galaxyproject/pulsar/issues/443

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
