### PR TITLE
[26.0] Don't retry JobNotReadyException in job destination mapping

### DIFF
--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -227,6 +227,8 @@ class JobRunnerMapper:
     def __handle_rule(self, rule_function: Callable, destination: JobDestination) -> JobDestination:
         try:
             job_destination = self.__invoke_expand_function(rule_function, destination)
+        except JobNotReadyException:
+            raise
         except Exception as e:
             # Rules have varying quality and don't raise a consistent set of standard exceptions.
             # so ... if we get an error here let's try again without resource params encoded


### PR DESCRIPTION
JobNotReadyException means "try again later", not "there's an error with the rule". The generic except Exception retry logic in __handle_rule was catching it and retrying without resource params, which is nonsensical for this exception type. Let it propagate immediately so it's properly caught by __verify_job_ready.
Rule is https://github.com/galaxyproject/usegalaxy-playbook/blob/c6bc580286cd1ae2e3f0505863b64f6cc594d634/env/common/templates/galaxy/config/tpv/tools.yaml.j2#L1586

Fixes https://github.com/galaxyproject/galaxy/issues/22376

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
