### PR TITLE
[26.0] Fix Content-Disposition header with trailing whitespace

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -2043,6 +2043,7 @@ def lowercase_alphanum_to_hex(lowercase_alphanum: str) -> str:
 
 
 def to_content_disposition(target: str) -> str:
+    target = target.strip()
     filename, ext = os.path.splitext(target)
     character_limit = 255 - len(ext)
     sanitized_filename = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in filename)[0:character_limit] + ext

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -202,3 +202,21 @@ def test_validate_doi_fail_too_long():
 def test_ready_name_for_url(input_name, expected_output):
     """Test that ready_name_for_url correctly sanitizes names for URL use."""
     assert util.ready_name_for_url(input_name) == expected_output
+
+
+@pytest.mark.parametrize(
+    "target,expected_substring",
+    [
+        ("normal.txt", 'filename="normal.txt"'),
+        ("file.gz ", 'filename="file.gz"'),
+        (" file.gz", 'filename="file.gz"'),
+        (" file.gz ", 'filename="file.gz"'),
+        ("Galaxy102-[name].fastqsanger.gz ", 'filename="Galaxy102-[name].fastqsanger.gz"'),
+    ],
+)
+def test_to_content_disposition(target, expected_substring):
+    result = util.to_content_disposition(target)
+    assert result.startswith("attachment; ")
+    assert expected_substring in result
+    # Ensure no trailing whitespace in the header value
+    assert result == result.strip()


### PR DESCRIPTION
Strip whitespace from target filename before building the Content-Disposition header to prevent h11 LocalProtocolError when dataset names contain trailing spaces.

Fixes GALAXY-MAIN-4KSCZZZ0015E3 / https://github.com/galaxyproject/galaxy/issues/22378

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
