### PR TITLE
[26.0] Fix workflow extract NoneType on LDDA leaf in implicit collection

### DIFF
--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -313,19 +313,20 @@ class WorkflowSummary:
             for assoc in cja:
                 job = assoc.job
                 self.job_id2representative_job[job.id] = representative_job
-        # This whole elif condition may no longer be needed do to additional
-        # tracking with creating_job_associations. Will delete at some point.
+        # Fallback for implicit output collections lacking creating_job_associations
+        # (e.g. reached via Sentry GALAXY-MAIN-121W / issue #22359). Trace via a leaf
+        # HDA's creating job instead.
         elif dataset_collection.implicit_output_name:
             # TODO: Optimize db call
             element = dataset_collection.collection.first_dataset_element
-            if not element:
-                # Got no dataset instance to walk back up to creating job.
+            dataset_instance = element.hda if element else None
+            if not dataset_instance:
+                # Got no dataset instance to walk back up to creating job
+                # (empty collection, or leaf element is not an HDA - e.g. LDDA).
                 # TODO track this via tool request model
                 job = DatasetCollectionCreationJob(dataset_collection)
                 self.jobs[job] = [(None, dataset_collection)]
                 return
-            else:
-                dataset_instance = element.hda
             if not self.__check_state(dataset_instance):
                 # Just checking the state of one instance, don't need more but
                 # makes me wonder if even need this check at all?


### PR DESCRIPTION
first_dataset_element can return a DCE without an HDA, making element.hda None. Guard it like the empty-collection case. Fixes at the last exception in #22359 I think.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
