### PR TITLE
[26.0] Show error message when display action not ready

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -597,7 +597,9 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                             )
                         )
                     else:
-                        raise Exception(f"Attempted a view action ({app_action}) on a non-ready display application")
+                        return trans.show_error_message(
+                            f"Attempted a view action ({app_action}) on a non-ready display application"
+                        )
             return dict(msg=msg)
         return trans.show_error_message(
             "You do not have permission to view this dataset at an external display application."


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/22382

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
