### PR TITLE
[26.0] Ensure ``x-content-truncated`` header is string

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -510,7 +510,7 @@ class Data(metaclass=DataMeta):
     def _serve_binary_file_contents_as_text(self, trans, data, headers, file_size, max_peek_size):
         headers["content-type"] = "text/html"
         if file_size > max_peek_size:
-            headers["x-content-truncated"] = max_peek_size
+            headers["x-content-truncated"] = str(max_peek_size)
         with open(data.get_file_name(), "rb") as fh:
             return unicodify(fh.read(max_peek_size)), headers
 
@@ -524,7 +524,7 @@ class Data(metaclass=DataMeta):
         with compression_utils.get_fileobj(data.get_file_name(), "rb") as fh:
             # preview large text file
             headers["content-type"] = "text/html"
-            headers["x-content-truncated"] = max_peek_size
+            headers["x-content-truncated"] = str(max_peek_size)
             return unicodify(fh.read(max_peek_size)), headers
 
     def display_data(


### PR DESCRIPTION
Starlette requires all HTTP header values to be strings, but `x-content-truncated` was set to an int (`max_peek_size`), causing `AttributeError: 'int' object has no attribute 'encode'` when previewing datasets larger than the max peek size.

Closes https://github.com/galaxyproject/galaxy/issues/22385 Fixes GALAXY-MAIN-4KSCZZZ0015FH

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
