### PR TITLE
Add shared OneDrive file source via msgraphfs

### DIFF
--- a/doc/source/admin/data.md
+++ b/doc/source/admin/data.md
@@ -626,6 +626,49 @@ a production Galaxy instance but Dropbox operates on a different scale.
 For more information on what Dropbox considers a "development" app versus a "production"
 app - checkout the [Dropbox documentation](https://www.dropbox.com/developers/reference/developer-guide#production-approval).
 
+#### OneDrive via `msgraphfs` (shared admin-configured drive)
+
+Galaxy can be configured with a shared Microsoft drive file source using the
+`onedrive` plugin backed by [`msgraphfs`](https://github.com/acsone/msgraphfs).
+This is **not** a per-user OAuth 2.0 flow where each Galaxy user connects their own account.
+Instead, the Galaxy administrator configures one Microsoft Entra application and exposes a single
+shared drive or document library to Galaxy users through `file_sources_conf.yml`.
+
+To configure this file source step by step:
+
+1. Create or open a Microsoft Entra application registration for your Galaxy instance.
+2. Copy the `Application (client) ID` and `Directory (tenant) ID` from the application's
+   overview page.
+3. Under `Certificates & secrets`, create a client secret and copy its `Value` (remember, you can 
+   only see it once after creation, so copy it immediately).
+4. Under `API permissions`, add Microsoft Graph **application** permissions:
+   - `Files.Read.All` for read-only browsing/import.
+   - `Files.ReadWrite.All` if you want Galaxy to export files back to the drive.
+5. Grant admin consent for the application permissions.
+6. Add values to Galaxy env variables:
+   - `Directory (tenant) ID` to `GALAXY_ONEDRIVE_TENANT_ID`
+   - `Application (client) ID` to `GALAXY_ONEDRIVE_CLIENT_ID`
+   - Secret's `Value` to `GALAXY_ONEDRIVE_CLIENT_SECRET`
+
+7. To discover the `drive_id`, use Microsoft Graph Explorer or another Graph client while signed
+into an account that can inspect the target Microsoft 365 tenant resources:
+
+7.1. Search for the target SharePoint site's drive:
+
+   ```http
+   GET https://graph.microsoft.com/v1.0/sites/root/drives
+   ```
+
+7.2. Copy the `id` field of the document library or drive you want Galaxy to expose.
+7.3. Set that value as `GALAXY_ONEDRIVE_DRIVE_ID`.
+
+Once these values are available in the environment, Galaxy can load the `onedrive` file source
+from `file_sources_conf.yml` and expose the configured shared drive to users in the remote files UI.
+
+This shared `onedrive` configuration is intended for Microsoft 365 / SharePoint-style tenant
+resources and is generally **not** a good fit for personal Microsoft accounts. Administrators testing
+/ setting this configuration will need access to an organizational tenant.
+
 ## Playing Nicer with Ansible
 
 Many large instances of Galaxy are configured with Ansible and much of the existing administrator

--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -4,6 +4,20 @@
   doc: Your Dropbox files - configure an access token via the user preferences
   access_token: ${user.preferences['dropbox|access_token']}
 
+# Admin-configured Microsoft OneDrive / SharePoint drive via msgraphfs
+# This is a shared file source for all Galaxy users, not a per-user OAuth2 connection.
+# It is best suited to an organizational drive or SharePoint document library that
+# the Microsoft Entra application can access with application permissions.
+- type: onedrive
+  id: onedrive-shared
+  label: Shared OneDrive
+  doc: Shared Microsoft drive exposed through Microsoft Graph app credentials.
+  tenant_id: ${environ['GALAXY_ONEDRIVE_TENANT_ID']}
+  client_id: ${environ['GALAXY_ONEDRIVE_CLIENT_ID']}
+  client_secret: ${environ['GALAXY_ONEDRIVE_CLIENT_SECRET']}
+  drive_id: ${environ['GALAXY_ONEDRIVE_DRIVE_ID']}
+  writable: true
+
 - type: webdav
   id: owncloud1
   label: OwnCloud

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -350,6 +350,9 @@ class ConditionalDependencies:
     def check_adlfs(self):
         return "azureflat" in self.file_sources
 
+    def check_msgraphfs(self):
+        return "onedrive" in self.file_sources
+
     def check_huggingface_hub(self):
         return "huggingface" in self.file_sources
 

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -34,6 +34,7 @@ fs-basespace # type: basespace
 fs-azureblob # type: azure
 rspace-client>=2.6.1,<3  # type: rspace
 adlfs
+msgraphfs # type: onedrive
 huggingface_hub
 omero-py #type: omero
 

--- a/lib/galaxy/files/sources/onedrive.py
+++ b/lib/galaxy/files/sources/onedrive.py
@@ -1,6 +1,5 @@
 import logging
 from typing import (
-    Optional,
     Union,
 )
 
@@ -38,9 +37,7 @@ class OneDriveFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
     drive_id: str
 
 
-class OneDriveFilesSource(
-    FsspecFilesSource[OneDriveFileSourceTemplateConfiguration, OneDriveFileSourceConfiguration]
-):
+class OneDriveFilesSource(FsspecFilesSource[OneDriveFileSourceTemplateConfiguration, OneDriveFileSourceConfiguration]):
     plugin_type = "onedrive"
     required_module = MSGDriveFS
     required_package = REQUIRED_PACKAGE

--- a/lib/galaxy/files/sources/onedrive.py
+++ b/lib/galaxy/files/sources/onedrive.py
@@ -1,0 +1,76 @@
+import logging
+from typing import (
+    Optional,
+    Union,
+)
+
+from galaxy.files.models import FilesSourceRuntimeContext
+from galaxy.files.sources._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+from galaxy.util.config_templates import TemplateExpansion
+
+try:
+    from msgraphfs import MSGDriveFS
+except ImportError:
+    MSGDriveFS = None
+
+
+REQUIRED_PACKAGE = "msgraphfs"
+
+log = logging.getLogger(__name__)
+
+
+class OneDriveFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
+    tenant_id: Union[str, TemplateExpansion]
+    client_id: Union[str, TemplateExpansion]
+    client_secret: Union[str, TemplateExpansion]
+    drive_id: Union[str, TemplateExpansion]
+
+
+class OneDriveFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    drive_id: str
+
+
+class OneDriveFilesSource(
+    FsspecFilesSource[OneDriveFileSourceTemplateConfiguration, OneDriveFileSourceConfiguration]
+):
+    plugin_type = "onedrive"
+    required_module = MSGDriveFS
+    required_package = REQUIRED_PACKAGE
+
+    template_config_class = OneDriveFileSourceTemplateConfiguration
+    resolved_config_class = OneDriveFileSourceConfiguration
+
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[OneDriveFileSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ):
+        if MSGDriveFS is None:
+            raise self.required_package_exception
+
+        config = context.config
+        return MSGDriveFS(
+            tenant_id=config.tenant_id,
+            client_id=config.client_id,
+            client_secret=config.client_secret,
+            drive_id=config.drive_id,
+            **cache_options,
+        )
+
+    def _adapt_entry_path(self, filesystem_path: str, config: OneDriveFileSourceConfiguration) -> str:
+        if filesystem_path == "/":
+            return filesystem_path
+        if filesystem_path.startswith("/"):
+            return filesystem_path
+        return f"/{filesystem_path}"
+
+
+__all__ = ("OneDriveFilesSource",)


### PR DESCRIPTION
This PR adds OneDrive file source implementation backed by [msgraphfs](https://github.com/acsone/msgraphfs/) and Galaxy’s FsspecFilesSource base class.

The implementation is scoped to an admin-configured shared Microsoft drive:
- it is configured through `file_sources_conf.yml`
- it uses Microsoft Graph application credentials

This implementation is NOT a per-user OAuth2 OneDrive integration. It is intended for Microsoft 365 / SharePoint-style tenant resources that can be accessed with Graph application permissions.

I was not able to validate this end to end locally because this msgraphfs-based design targets Microsoft 365 / SharePoint tenant resources accessed with application credentials. My personal Microsoft account does not expose the required SharePoint sites API surface, and I do not currently have access to a Microsoft 365 developer sandbox or organizational tenant for live testing.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
