### PR TITLE
[26.0] Offload AsyncClient construction to worker thread

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/proxy.py
+++ b/lib/galaxy/webapps/galaxy/api/proxy.py
@@ -88,8 +88,8 @@ class FastAPIProxy:
         # This is to prevent the server from hanging indefinitely
         timeout = httpx.Timeout(10.0, connect=60.0)
 
+        client = await anyio.to_thread.run_sync(partial(httpx.AsyncClient, timeout=timeout))
         response = None
-        client = httpx.AsyncClient(timeout=timeout)
         streaming = False
         try:
             response = await self._handle_redirects_validation(request, url, trans, headers, client)


### PR DESCRIPTION
https://github.com/encode/httpx/discussions/3707
Pulled out of https://github.com/galaxyproject/galaxy/pull/22207

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
