### PR TITLE
[26.0] Fix dataset preview rendering to preserve newlines

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -508,7 +508,9 @@ class Data(metaclass=DataMeta):
             return open(data.get_file_name(), "rb"), headers
 
     def _serve_binary_file_contents_as_text(self, trans, data, headers, file_size, max_peek_size):
-        headers["content-type"] = "text/html"
+        # Use text/plain so the browser preserves whitespace and line endings
+        # and does not attempt to interpret stray markup as HTML.
+        headers["content-type"] = "text/plain; charset=utf-8"
         if file_size > max_peek_size:
             headers["x-content-truncated"] = str(max_peek_size)
         with open(data.get_file_name(), "rb") as fh:
@@ -522,8 +524,9 @@ class Data(metaclass=DataMeta):
             return self._yield_user_file_content(trans, data, data.get_file_name(), headers), headers
 
         with compression_utils.get_fileobj(data.get_file_name(), "rb") as fh:
-            # preview large text file
-            headers["content-type"] = "text/html"
+            # preview large text file - serve as text/plain so the browser
+            # preserves whitespace/newlines and does not interpret content as HTML.
+            headers["content-type"] = "text/plain; charset=utf-8"
             headers["x-content-truncated"] = str(max_peek_size)
             return unicodify(fh.read(max_peek_size)), headers
 

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -339,6 +339,19 @@ class TestDatasetsApi(ApiTestCase):
         self._assert_status_code_is(display_response, 200)
         assert display_response.text == contents
 
+    def test_display_preview_binary_as_text_uses_text_plain(self, history_id):
+        # Regression test for https://github.com/galaxyproject/galaxy/issues/22395
+        # When previewing an unknown / binary dataset as text the response must use
+        # a text/plain content-type so the iframe preserves whitespace/newlines and
+        # does not interpret stray characters as HTML.
+        contents = "header line\nrow with < and > and &\nfinal line\n"
+        hda1 = self.dataset_populator.new_dataset(history_id, content=contents, file_type="data", wait=True)
+        display_response = self._get(f"histories/{history_id}/contents/{hda1['id']}/display", {"preview": "True"})
+        self._assert_status_code_is(display_response, 200)
+        content_type = display_response.headers.get("content-type", "")
+        assert content_type.startswith("text/plain"), content_type
+        assert display_response.text == contents
+
     def test_display_extra_paths(self, history_id: str):
         test_data_resolver = TestDataResolver()
         with open(test_data_resolver.get_filename("1.fasta")) as fh:


### PR DESCRIPTION
In 25.1 the truncated/binary preview branches rendered through Mako templates that wrapped the content in `<pre>${... | h}</pre>`, which preserved whitespace and HTML-escaped the contents. In 26.0 those templates were removed and the raw bytes are now returned with `Content-Type: text/html`, so browsers collapse newlines and try to interpret stray markup as HTML.

Serve these branches as `text/plain; charset=utf-8` so the iframe preserves newlines and shows the file contents literally.

Closes https://github.com/galaxyproject/galaxy/issues/22395

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
