### PR TITLE
[26.0] Serialize data provider errors as MessageException subclasses

### DIFF
--- a/lib/galaxy/visualization/data_providers/basic.py
+++ b/lib/galaxy/visualization/data_providers/basic.py
@@ -1,6 +1,13 @@
-from json import loads
+from json import (
+    JSONDecodeError,
+    loads,
+)
 
 from galaxy.datatypes.tabular import Tabular
+from galaxy.exceptions import (
+    RequestParameterInvalidException,
+    RequestParameterMissingException,
+)
 from galaxy.model import DatasetInstance
 
 
@@ -37,7 +44,9 @@ class ColumnDataProvider(BaseDataProvider):
     def __init__(self, original_dataset, max_lines_returned=MAX_LINES_RETURNED):
         # Compatibility check.
         if not isinstance(original_dataset.datatype, Tabular):
-            raise Exception("Data provider can only be used with tabular data")
+            raise RequestParameterInvalidException(
+                "The 'column_with_stats' data provider can only be used with tabular datasets"
+            )
 
         # Attribute init.
         self.original_dataset = original_dataset
@@ -50,7 +59,7 @@ class ColumnDataProvider(BaseDataProvider):
         where each list is a line of data.
         """
         if not columns:
-            raise TypeError("parameter required: columns")
+            raise RequestParameterMissingException("parameter required: columns")
 
         # TODO: validate kwargs
         try:
@@ -75,12 +84,22 @@ class ColumnDataProvider(BaseDataProvider):
             start_val = int(self.original_dataset.metadata.comment_lines)
 
         # columns is an array of ints for now (should handle column names later)
-        columns = loads(columns)
-        for column in columns:
-            assert column < self.original_dataset.metadata.columns and column >= 0, (
-                f"column index ({column}) must be positive and less"
-                f" than the number of columns: {self.original_dataset.metadata.columns}"
+        try:
+            columns = loads(columns)
+        except (JSONDecodeError, TypeError):
+            raise RequestParameterInvalidException(
+                "parameter 'columns' must be a JSON-encoded list of integer column indices"
             )
+        if not isinstance(columns, list) or not all(isinstance(column, int) for column in columns):
+            raise RequestParameterInvalidException(
+                "parameter 'columns' must be a JSON-encoded list of integer column indices"
+            )
+        num_columns = self.original_dataset.metadata.columns
+        for column in columns:
+            if column < 0 or column >= num_columns:
+                raise RequestParameterInvalidException(
+                    f"column index ({column}) must be in the range [0, {num_columns})"
+                )
 
         # set up the response, column lists
         response = {}

--- a/lib/galaxy/visualization/data_providers/phyloviz/baseparser.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/baseparser.py
@@ -3,6 +3,8 @@ from typing import (
     Any,
 )
 
+from galaxy.exceptions import MalformedContents
+
 
 class Node:
     """Node class of PhyloTree, which represents a CLAUDE in a phylogenetic tree"""
@@ -96,7 +98,7 @@ class PhyloTree:
                 # transfer temporary stored attr to root
                 jsonTree[key] = value
         else:
-            raise Exception("Root is not assigned!")
+            raise MalformedContents("Phylogeny file has no root node assigned")
         return jsonTree
 
 

--- a/lib/galaxy/visualization/data_providers/phyloviz/newickparser.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/newickparser.py
@@ -1,5 +1,6 @@
 import re
 
+from galaxy.exceptions import MalformedContents
 from .baseparser import (
     Base_Parser,
     PhyloTree,
@@ -46,7 +47,7 @@ class Newick_Parser(Base_Parser):
         """elements separated by comma could be empty"""
 
         if string.find("(") != -1:
-            raise Exception(f"Tree is not well form, location: {string}")
+            raise MalformedContents(f"Newick tree is malformed at: {string}")
 
         childrenString = string.split(",")
         childrenNodes = []

--- a/lib/galaxy/visualization/data_providers/registry.py
+++ b/lib/galaxy/visualization/data_providers/registry.py
@@ -22,6 +22,7 @@ from galaxy.datatypes.tabular import (
     Vcf,
 )
 from galaxy.datatypes.xml import Phyloxml
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.model import NoConverterException
 from galaxy.visualization.data_providers import genome
 from galaxy.visualization.data_providers.basic import (
@@ -109,8 +110,13 @@ class DataProviderRegistry:
                 if name == original_dataset.ext:
                     data_provider = data_provider_class(original_dataset=original_dataset)
                 else:
-                    converted_dataset = original_dataset.get_converted_dataset(trans, name)
-                    deps = original_dataset.get_converted_dataset_deps(trans, name)
+                    try:
+                        converted_dataset = original_dataset.get_converted_dataset(trans, name)
+                        deps = original_dataset.get_converted_dataset_deps(trans, name)
+                    except NoConverterException:
+                        raise RequestParameterInvalidException(
+                            f"Conversion from '{original_dataset.ext}' to '{name}' not possible"
+                        )
                     data_provider = data_provider_class(
                         original_dataset=original_dataset, converted_dataset=converted_dataset, dependencies=deps
                     )

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -9,7 +9,10 @@ from galaxy.model.unittest_utils.store_fixtures import (
     TEST_SOURCE_URI,
 )
 from galaxy.tool_util.verify.test_data import TestDataResolver
-from galaxy_test.base.api_asserts import assert_has_keys
+from galaxy_test.base.api_asserts import (
+    assert_error_message_contains,
+    assert_has_keys,
+)
 from galaxy_test.base.decorators import (
     requires_admin,
     requires_new_history,
@@ -455,6 +458,48 @@ class TestDatasetsApi(ApiTestCase):
         display = display_response.json()
         self._assert_has_key(display, "data")
         assert "\nA" in display["data"][0]
+
+    def test_raw_data_tabular_missing_columns_returns_400(self, history_id):
+        # Regression for https://github.com/galaxyproject/galaxy/issues/22393 — a tabular
+        # dataset queried via data_type=raw_data without a `columns` parameter used to raise
+        # a bare TypeError that bubbled up as a 500; it should be a 400 MessageException.
+        contents = "1\t2\t3\nA\tB\tC\n"
+        hda = self.dataset_populator.new_dataset(history_id, content=contents, wait=True, file_type="tabular")
+        response = self._get(f"datasets/{hda['id']}", {"data_type": "raw_data"})
+        self._assert_status_code_is(response, 400)
+        assert_error_message_contains(response, "columns")
+
+    def test_raw_data_tabular_invalid_column_index_returns_400(self, history_id):
+        contents = "1\t2\t3\nA\tB\tC\n"
+        hda = self.dataset_populator.new_dataset(history_id, content=contents, wait=True, file_type="tabular")
+        response = self._get(
+            f"datasets/{hda['id']}",
+            {"data_type": "raw_data", "columns": "[99]"},
+        )
+        self._assert_status_code_is(response, 400)
+        assert_error_message_contains(response, "column index")
+
+    def test_raw_data_tabular_invalid_columns_json_returns_400(self, history_id):
+        contents = "1\t2\t3\nA\tB\tC\n"
+        hda = self.dataset_populator.new_dataset(history_id, content=contents, wait=True, file_type="tabular")
+        response = self._get(
+            f"datasets/{hda['id']}",
+            {"data_type": "raw_data", "columns": "not-json"},
+        )
+        self._assert_status_code_is(response, 400)
+        assert_error_message_contains(response, "JSON")
+
+    def test_raw_data_no_converter_returns_400(self, history_id):
+        # Requesting a provider whose name requires a converter that is not available should
+        # return a 400 MessageException, not a bare NoConverterException bubbling up as a 500.
+        contents = "1\t2\t3\nA\tB\tC\n"
+        hda = self.dataset_populator.new_dataset(history_id, content=contents, wait=True, file_type="tabular")
+        response = self._get(
+            f"datasets/{hda['id']}",
+            {"data_type": "raw_data", "provider": "column_with_stats"},
+        )
+        self._assert_status_code_is(response, 400)
+        assert_error_message_contains(response, "Conversion")
 
     def test_bam_chunking_through_display_endpoint(self, history_id):
         # This endpoint does not use data providers and instead overrides display_data


### PR DESCRIPTION
Invalid or missing parameters for the dataset visualization data providers used to raise bare TypeError/AssertionError/json.JSONDecodeError exceptions that bubbled up through the API as generic 500s (e.g. issue #22393's "TypeError: parameter required: columns"). Replace the user-reachable bare raises and asserts in basic.py, phyloviz parsers, and the registry with appropriate MessageException subclasses so the API serializes proper 400 responses, and catch NoConverterException at the registry entry point the same way services/datasets.py already does for _get_or_create_converted.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
