### PR TITLE
[26.0] Silence social_core's noisy handle_http_errors logging

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -125,6 +125,17 @@ LOGGING_CONFIG_DEFAULT: dict[str, Any] = {
             "level": "INFO",
             "qualname": "sentry_sdk.errors",
         },
+        "social": {
+            # social_core's handle_http_errors decorator calls
+            # social_logger.exception(...) on every OAuth provider HTTP
+            # error (e.g. 400 invalid_grant when an auth code is
+            # reused/expired), then re-raises AuthCanceled/AuthForbidden/
+            # etc. which AuthnzManager.callback() already catches and
+            # logs appropriately (see #22300). The library-side exception
+            # log is pure Sentry noise — see #22400.
+            "level": "CRITICAL",
+            "qualname": "social",
+        },
     },
     "filters": {
         "stack": {


### PR DESCRIPTION
social_core's `@handle_http_errors` decorator calls `social_logger.exception("Request failed with %d: %s", ...)` on every OAuth provider HTTP error, then re-raises AuthCanceled/AuthForbidden/ AuthUnreachableProvider so the caller can handle it. The library-side exception log fires *before* the re-raise, so it hits Sentry's LoggingIntegration as an ERROR even though Galaxy's `AuthnzManager.callback()` catches the wrapped exception cleanly at WARNING (see #22300).

This is the source of the ~weekly `HTTPError: 400 Client Error` Sentry noise reported in #22400 — the typical `invalid_grant` case (reused or expired authorization code) is a client-side OAuth failure, not a server bug, and is already surfaced to the user via the existing `except AuthCanceled` handler added in #22300.

Set the `"social"` logger level to CRITICAL in LOGGING_CONFIG_DEFAULT. This is the only logger named `"social"` in the social_core package (all backend modules use per-module `getLogger(__name__)` loggers), so the change is surgical: it drops the duplicate library-side log record without affecting any of Galaxy's own auth logging.

Fixes #22400

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
