### PR TITLE
[26.0] Unwrap HDCAs/DCEs nested in multi data input lists

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -27,6 +27,7 @@ from galaxy.model import (
     MetadataFile,
     User,
 )
+from galaxy.model.dataset_collections.adapters import CollectionAdapter
 from galaxy.tools.expressions import do_eval
 from galaxy.tools.parameters.options import ParameterOption
 from galaxy.tools.parameters.workflow_utils import (
@@ -1054,35 +1055,60 @@ def template_or_none(template: Optional[str], context: dict[str, Any]) -> Option
 
 def _get_ref_data(other_values, ref_name):
     """
-    get the list of data sets from ref_name
-    - a KeyError is raised if no such element exists
-    - a ValueError is raised if the element is not of the type DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, HistoryDatasetCollectionAssociation, list
+    Return a flat iterable of dataset instances for ``ref_name``.
+
+    - Raises ``KeyError`` if no such element exists.
+    - Raises ``ValueError`` if the element (or any member of a list
+      element) is not one of the supported types.
+
+    Lists originating from ``multiple="true"`` data inputs may contain
+    HDCAs / ``DatasetCollectionElement``s / ``CollectionAdapter``s (see
+    ``DataToolParameter.from_json``); those are flattened to their
+    dataset instances here so downstream filters can uniformly access
+    ``.metadata`` on an HDA.
+
+    TODO: ``DataToolParameter.from_json`` should not wrap
+    items that already represent multiple datasets (HDCAs, DCEs of a
+    collection) in a list.
     """
     from galaxy.tools.wrappers import (
         DatasetFilenameWrapper,
         DatasetListWrapper,
     )
 
-    ref = other_values[ref_name]
-    if not isinstance(
-        ref,
-        (
-            DatasetFilenameWrapper,
-            HistoryDatasetAssociation,
-            LibraryDatasetDatasetAssociation,
-            DatasetCollectionElement,
-            DatasetListWrapper,
-            HistoryDatasetCollectionAssociation,
-            list,
-        ),
-    ):
-        if is_runtime_value(ref):
-            return []
+    single_types = (
+        DatasetFilenameWrapper,
+        HistoryDatasetAssociation,
+        LibraryDatasetDatasetAssociation,
+    )
+
+    def _unwrap(item):
+        if isinstance(item, single_types):
+            return [item]
+        if isinstance(item, DatasetCollectionElement):
+            return item.dataset_instances
+        if isinstance(item, HistoryDatasetCollectionAssociation):
+            return item.to_hda_representative(multiple=True)
+        if isinstance(item, CollectionAdapter):
+            return item.dataset_instances
         raise ValueError
+
+    ref = other_values[ref_name]
+    if isinstance(ref, single_types):
+        return [ref]
     if isinstance(ref, DatasetCollectionElement):
         return ref.dataset_instances
-    if isinstance(ref, (DatasetFilenameWrapper, HistoryDatasetAssociation, LibraryDatasetDatasetAssociation)):
-        return [ref]
-    elif isinstance(ref, HistoryDatasetCollectionAssociation):
+    if isinstance(ref, HistoryDatasetCollectionAssociation):
         return ref.to_hda_representative(multiple=True)
-    return ref
+    if isinstance(ref, CollectionAdapter):
+        return ref.dataset_instances
+    if isinstance(ref, (list, DatasetListWrapper)):
+        flattened: list = []
+        for item in ref:
+            if item is None:
+                continue
+            flattened.extend(_unwrap(item))
+        return flattened
+    if is_runtime_value(ref):
+        return []
+    raise ValueError

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -286,6 +286,33 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert "hg18_value" in option_values
             assert "mm10_value" in option_values
 
+    @skip_without_tool("dbkey_filter_multi_input")
+    def test_build_request_dbkey_filter_hdca_multi_input(self):
+        # Regression test for https://github.com/galaxyproject/galaxy/issues/22399:
+        # an HDCA passed to a multiple="true" data input must not break a downstream
+        # data_meta filter. Previously this raised
+        # AttributeError: 'MetaData' object has no attribute 'element_is_set'
+        # because _get_ref_data returned the raw list containing the HDCA instead
+        # of unwrapping it to its HDAs.
+        with self.dataset_populator.test_history() as history_id:
+            hda1 = self.dataset_populator.new_dataset(history_id, content="a\nb\nc", dbkey="hg19", wait=True)
+            hda2 = self.dataset_populator.new_dataset(history_id, content="d\ne\nf", dbkey="hg19", wait=True)
+            element_identifiers = [
+                {"name": "sample1", "src": "hda", "id": hda1["id"]},
+                {"name": "sample2", "src": "hda", "id": hda2["id"]},
+            ]
+            hdca = self.dataset_collection_populator.create_list_in_history(
+                history_id,
+                element_identifiers=element_identifiers,
+                direct_upload=False,
+                wait=True,
+            ).json()
+            inputs = {"inputs": [{"src": "hdca", "id": hdca["id"]}]}
+            build = self.dataset_populator.build_tool_state("dbkey_filter_multi_input", history_id, inputs=inputs)
+            option_values = self._get_build_option_values(build, "index")
+            assert "hg19_value" in option_values
+            assert "hg18_value" not in option_values
+
     @skip_without_tool("dbkey_filter_collection_input")
     def test_run_dbkey_filter_nested_collection_dce(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
`_get_ref_data` only unwrapped HDCAs/DCEs when they were the top-level `other_values[ref_name]`. When a `multiple="true"` data input is populated with an HDCA, `DataToolParameter.from_json` returns a `list` containing the HDCA, which `_get_ref_data` returned as-is. The downstream `data_meta` filter then iterated the list and accessed `.metadata.element_is_set(...)` on the HDCA -- resolving to the SQLAlchemy `MetaData` class attribute -- and crashed with `AttributeError: 'MetaData' object has no attribute 'element_is_set'`.

Flatten list members through the same unwrap path: HDCAs via `to_hda_representative`, DCEs and CollectionAdapters via `dataset_instances`. Leaves a TODO that `from_json` ideally shouldn't wrap already-multi values in a list in the first place.

Fixes #22399.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
