### PR TITLE
[26.0] Respect workflow object store preference for mapped step outputs

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1855,8 +1855,8 @@ class MinimalJobWrapper(HasResourceParameters):
 
         if object_store_id is None:
             object_store_id = job.preferred_object_store_id
-        if object_store_id is None and job.workflow_invocation_step:
-            workflow_invocation_step = job.workflow_invocation_step
+        workflow_invocation_step = job.effective_workflow_invocation_step
+        if object_store_id is None and workflow_invocation_step:
             invocation_object_stores = workflow_invocation_step.preferred_object_stores
             if invocation_object_stores.is_split_configuration:
                 # Redo for subworkflows...

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1657,7 +1657,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     interactivetool_entry_points: Mapped[list["InteractiveToolEntryPoint"]] = relationship(
         back_populates="job", uselist=True
     )
-    implicit_collection_jobs_association: Mapped["ImplicitCollectionJobsJobAssociation"] = relationship(
+    implicit_collection_jobs_association: Mapped[Optional["ImplicitCollectionJobsJobAssociation"]] = relationship(
         back_populates="job", uselist=False
     )
     container: Mapped[Optional["JobContainerAssociation"]] = relationship(back_populates="job", uselist=False)
@@ -1673,6 +1673,27 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     credentials_context_associations: Mapped[list["JobCredentialsContextAssociation"]] = relationship(
         back_populates="job"
     )
+
+    @property
+    def effective_workflow_invocation_step(self) -> Optional["WorkflowInvocationStep"]:
+        """The WorkflowInvocationStep backing this job, including mapped steps.
+
+        For non-mapped steps this is the direct ``workflow_invocation_step`` back-ref.
+        For mapped steps ``WorkflowInvocationStep.job_id`` is NULL — the step points
+        at an ``ImplicitCollectionJobs`` instead, and each job is linked to that ICJ
+        via ``ImplicitCollectionJobsJobAssociation``. Resolve it by querying
+        ``WorkflowInvocationStep`` using the ICJ id.
+        """
+        if self.workflow_invocation_step is not None:
+            return self.workflow_invocation_step
+        icj_assoc = self.implicit_collection_jobs_association
+        if icj_assoc is None:
+            return None
+        icj_id = icj_assoc.implicit_collection_jobs_id
+        session = required_object_session(self)
+        return session.execute(
+            select(WorkflowInvocationStep).where(WorkflowInvocationStep.implicit_collection_jobs_id == icj_id)
+        ).scalar_one_or_none()
 
     dict_collection_visible_keys = [
         "id",

--- a/test/integration/objectstore/test_selection_with_user_preferred_object_store.py
+++ b/test/integration/objectstore/test_selection_with_user_preferred_object_store.py
@@ -141,6 +141,32 @@ text_input1: |
   samp2\t20.0
 """
 
+WORKFLOW_WITH_MAPPED_COLLECTION_OUTPUT = """
+class: GalaxyWorkflow
+inputs:
+  input_collection:
+    type: collection
+    collection_type: list
+outputs:
+  wf_output_1:
+    outputSource: cat_mapped/out_file1
+steps:
+  cat_mapped:
+    tool_id: cat
+    in:
+      input1: input_collection
+"""
+
+WORKFLOW_MAPPED_COLLECTION_TEST_DATA = """
+input_collection:
+  collection_type: list
+  elements:
+    - identifier: el1
+      content: "data 1"
+    - identifier: el2
+      content: "data 2"
+"""
+
 
 def assert_storage_name_is(storage_dict: dict[str, Any], name: str):
     storage_name = storage_dict["name"]
@@ -365,6 +391,67 @@ class TestObjectStoreSelectionWithPreferredObjectStoresIntegration(BaseObjectSto
             )
             assert_storage_name_is(output_info, "Static Storage")
             assert_storage_name_is(intermediate_dict, "Dynamic EBS")
+
+    def test_workflow_mapped_collection_objectstore_selection(self):
+        # Regression for https://github.com/galaxyproject/galaxy/issues/21846
+        with self.dataset_populator.test_history() as history_id:
+            element_storages = self._run_workflow_with_mapped_collection(
+                history_id,
+                WORKFLOW_WITH_MAPPED_COLLECTION_OUTPUT,
+                WORKFLOW_MAPPED_COLLECTION_TEST_DATA,
+            )
+            for storage in element_storages:
+                assert_storage_name_is(storage, "Default Store")
+
+        with self.dataset_populator.test_history() as history_id:
+            element_storages = self._run_workflow_with_mapped_collection(
+                history_id,
+                WORKFLOW_WITH_MAPPED_COLLECTION_OUTPUT,
+                WORKFLOW_MAPPED_COLLECTION_TEST_DATA,
+                extra_invocation_kwds={"preferred_object_store_id": "static"},
+            )
+            for storage in element_storages:
+                assert_storage_name_is(storage, "Static Storage")
+
+    def test_workflow_mapped_collection_objectstore_selection_split(self):
+        # Regression for https://github.com/galaxyproject/galaxy/issues/21846
+        with self.dataset_populator.test_history() as history_id:
+            element_storages = self._run_workflow_with_mapped_collection(
+                history_id,
+                WORKFLOW_WITH_MAPPED_COLLECTION_OUTPUT,
+                WORKFLOW_MAPPED_COLLECTION_TEST_DATA,
+                extra_invocation_kwds={
+                    "preferred_outputs_object_store_id": "static",
+                    "preferred_intermediate_object_store_id": "dynamic_ebs",
+                },
+            )
+            for storage in element_storages:
+                assert_storage_name_is(storage, "Static Storage")
+
+    def _run_workflow_with_mapped_collection(
+        self,
+        history_id: str,
+        workflow: str,
+        test_data: str,
+        extra_invocation_kwds: Optional[dict[str, Any]] = None,
+    ):
+        self.workflow_populator.run_workflow(
+            workflow,
+            test_data=test_data,
+            history_id=history_id,
+            extra_invocation_kwds=extra_invocation_kwds,
+        )
+        # Find the implicit collection in the history and inspect element storage
+        history_contents = self.dataset_populator.get_history_contents(history_id, data={"v": "dev"})
+        hdca = None
+        for entry in history_contents:
+            if entry.get("history_content_type") == "dataset_collection" and entry.get("visible", True):
+                hdca = entry
+        assert hdca is not None, "No collection found in history"
+        hdca_details = self.dataset_populator.get_history_collection_details(history_id, content_id=hdca["id"])
+        elements = hdca_details["elements"]
+        assert len(elements) > 0, "Collection has no elements"
+        return [self._storage_info(element["object"]) for element in elements]
 
     def _run_workflow_with_collections_1(self, history_id: str, extra_invocation_kwds: Optional[dict[str, Any]] = None):
         wf_run = self.workflow_populator.run_workflow(


### PR DESCRIPTION
Fix issue https://github.com/galaxyproject/galaxy/issues/21846: storage class selection was ignored for collection
outputs produced by workflow steps that map over a collection input.

For a non-mapped step, WorkflowInvocationStep.job_id references the
single job and the back-ref job.workflow_invocation_step is used in
Job._set_object_store_ids_full() to apply the invocation's preferred
object store. For a mapped step, WorkflowInvocationStep.job_id is NULL;
the step instead references an ImplicitCollectionJobs, and each of the
individual mapped jobs is linked to that ICJ via
ImplicitCollectionJobsJobAssociation. Those jobs therefore had
job.workflow_invocation_step == None and fell through to the user or
history default store, silently ignoring the invocation preference.

Add Job.effective_workflow_invocation_step which falls back to
resolving the step via ImplicitCollectionJobs, and use it in
_set_object_store_ids_full() so the split- and unified-config branches
both work for mapped outputs.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
