### PR TITLE
Add twine check to package test script to lint RST long descriptions

### DIFF
--- a/packages/test.sh
+++ b/packages/test.sh
@@ -43,9 +43,11 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 if command -v uv >/dev/null; then
     uv venv --python "$TEST_PYTHON" "$TEST_ENV_DIR"
     PIP_CMD="$(command -v uv) pip"
+    BUILD_WHEEL_CMD="uv build --wheel --out-dir"
 else
     "$TEST_PYTHON" -m venv "$TEST_ENV_DIR"
     PIP_CMD='python -m pip'
+    BUILD_WHEEL_CMD="pip wheel --no-deps -w"
 fi
 
 # shellcheck disable=SC1091
@@ -53,6 +55,7 @@ fi
 if [ "${PIP_CMD}" = 'python -m pip' ]; then
     ${PIP_CMD} install --upgrade pip setuptools wheel
 fi
+${PIP_CMD} install twine
 if [ $FOR_PULSAR -eq 0 ]; then
     # shellcheck disable=SC2086 - word splitting is intentional for PIP_EXTRA_ARGS
     ${PIP_CMD} install ${PIP_EXTRA_ARGS} -r ../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
@@ -101,5 +104,10 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
         # directly to use the venv we have already activated
         mypy .
     fi
+    DIST_DIR=$(mktemp -d)
+    # shellcheck disable=SC2086 - word splitting is intentional for BUILD_WHEEL_CMD
+    $BUILD_WHEEL_CMD "$DIST_DIR" . >/dev/null
+    twine check "$DIST_DIR"/*
+    rm -rf "$DIST_DIR"
     cd ..
 done < $PACKAGE_LIST_FILE

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -43,19 +43,19 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 if command -v uv >/dev/null; then
     uv venv --python "$TEST_PYTHON" "$TEST_ENV_DIR"
     PIP_CMD="$(command -v uv) pip"
-    BUILD_WHEEL_CMD="uv build --wheel --out-dir"
+    BUILD_WHEEL_CMD="uv build"
 else
     "$TEST_PYTHON" -m venv "$TEST_ENV_DIR"
     PIP_CMD='python -m pip'
-    BUILD_WHEEL_CMD="pip wheel --no-deps -w"
+    BUILD_WHEEL_CMD="python -m build"
 fi
 
 # shellcheck disable=SC1091
 . "${TEST_ENV_DIR}/bin/activate"
 if [ "${PIP_CMD}" = 'python -m pip' ]; then
-    ${PIP_CMD} install --upgrade pip setuptools wheel
+    ${PIP_CMD} install --upgrade build pip setuptools wheel
 fi
-${PIP_CMD} install twine
+${PIP_CMD} install --upgrade twine
 if [ $FOR_PULSAR -eq 0 ]; then
     # shellcheck disable=SC2086 - word splitting is intentional for PIP_EXTRA_ARGS
     ${PIP_CMD} install ${PIP_EXTRA_ARGS} -r ../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
@@ -104,10 +104,8 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
         # directly to use the venv we have already activated
         mypy .
     fi
-    DIST_DIR=$(mktemp -d)
     # shellcheck disable=SC2086 - word splitting is intentional for BUILD_WHEEL_CMD
-    $BUILD_WHEEL_CMD "$DIST_DIR" . >/dev/null
-    twine check "$DIST_DIR"/*
-    rm -rf "$DIST_DIR"
+    $BUILD_WHEEL_CMD -o dist
+    twine check dist/*
     cd ..
 done < $PACKAGE_LIST_FILE

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -43,19 +43,20 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 if command -v uv >/dev/null; then
     uv venv --python "$TEST_PYTHON" "$TEST_ENV_DIR"
     PIP_CMD="$(command -v uv) pip"
-    BUILD_WHEEL_CMD="uv build"
+    BUILD_WHEEL_CMD="$(command -v uv) build"
+    TWINE_CMD="$(command -v uvx) twine"
 else
     "$TEST_PYTHON" -m venv "$TEST_ENV_DIR"
     PIP_CMD='python -m pip'
-    BUILD_WHEEL_CMD="python -m build"
+    BUILD_WHEEL_CMD='python -m build'
+    TWINE_CMD=twine
 fi
 
 # shellcheck disable=SC1091
 . "${TEST_ENV_DIR}/bin/activate"
 if [ "${PIP_CMD}" = 'python -m pip' ]; then
-    ${PIP_CMD} install --upgrade build pip setuptools wheel
+    ${PIP_CMD} install --upgrade build pip setuptools twine wheel
 fi
-${PIP_CMD} install --upgrade twine
 if [ $FOR_PULSAR -eq 0 ]; then
     # shellcheck disable=SC2086 - word splitting is intentional for PIP_EXTRA_ARGS
     ${PIP_CMD} install ${PIP_EXTRA_ARGS} -r ../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
@@ -103,9 +104,11 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
         # make mypy uses uv now and so this legacy code should just run mypy
         # directly to use the venv we have already activated
         mypy .
+
+        # shellcheck disable=SC2086 - word splitting is intentional for BUILD_WHEEL_CMD
+        ${BUILD_WHEEL_CMD} -o dist
+        # shellcheck disable=SC2086 - word splitting is intentional for TWINE_CMD
+        ${TWINE_CMD} check dist/*
     fi
-    # shellcheck disable=SC2086 - word splitting is intentional for BUILD_WHEEL_CMD
-    $BUILD_WHEEL_CMD -o dist
-    twine check dist/*
     cd ..
 done < $PACKAGE_LIST_FILE


### PR DESCRIPTION
When running the create release command via `galaxy-release-util` we discovered an RST lint error.

I feel like those `twine` checks should run alongside the packages CI tests?

`twine check` validates that the `long_description` (README.rst + HISTORY.rst) renders correctly on PyPI. Previously this check only existed in the per-package Makefile `lint-dist` target and in the publish workflow, meaning RST markup errors could slip in through PRs undetected and only surface at release time.

For each package, the script now builds a wheel into a temp directory and runs `twine check` against it. Supports both uv (`uv build --wheel`) and plain pip (`pip wheel --no-deps`) backends.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
