### PR TITLE
Add IIIF File Source Support

### DIFF
--- a/client/src/api/fileSources.ts
+++ b/client/src/api/fileSources.ts
@@ -74,6 +74,11 @@ export const templateTypes: FileSourceTypesDetail = {
         icon: faHubspot,
         message: "This is a file repository plugin that connects with the Hugging Face Hub.",
     },
+    iiif: {
+        icon: faNetworkWired,
+        message:
+            "This is a read-only file repository plugin that connects to IIIF (International Image Interoperability Framework) sources. IIIF is a framework widely used by museums, libraries, and archives for delivering high-resolution image-based cultural heritage materials.",
+    },
     omero: {
         icon: faNetworkWired,
         message: "This is a file repository plugin that connects with an OMERO server.",

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -12845,6 +12845,7 @@ export interface components {
                 | "rspace"
                 | "dataverse"
                 | "huggingface"
+                | "iiif"
                 | "omero";
             /** Variables */
             variables?:
@@ -24483,6 +24484,7 @@ export interface components {
                 | "rspace"
                 | "dataverse"
                 | "huggingface"
+                | "iiif"
                 | "omero";
             /** Uri Root */
             uri_root: string;

--- a/client/src/utils/url.ts
+++ b/client/src/utils/url.ts
@@ -31,6 +31,7 @@ export const URI_PREFIXES = [
     "elabftw://",
     "zip://",
     "ascp://",
+    "iiif://",
 ];
 
 export function isUrl(content: string): boolean {

--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -313,3 +313,12 @@
   api_key: ${user.user_vault.read_secret('preferences/elabftw/api_key')}
   writable: true
   endpoint: ${user.preferences['elabftw|endpoint']}
+
+# IIIF (International Image Interoperability Framework) file source
+# For examples and to find public IIIF resources, visit: [https://iiif.io/guides/finding_resources/](https://iiif.io/guides/finding_resources/)
+- type: iiif
+  id: iiif-cambridge-scientific-instrument
+  label: Cambridge Scientific Instrument Company
+  doc: Browse and import canvases from the Cambridge Digital Library
+  manifest_url: "https://cudl.lib.cam.ac.uk/iiif/collection/csic"
+  writable: false

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -356,6 +356,9 @@ class ConditionalDependencies:
     def check_omero_py(self):
         return "omero" in self.file_sources
 
+    def check_iiif_fsspec(self):
+        return "iiif" in self.file_sources
+
 
 def strip_comment(line):
     # lifted from https://github.com/tox-dev/tox/commit/3c6b4f204e89852c4b7536b246a66d20be6d39ec

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -36,6 +36,7 @@ rspace-client>=2.6.1,<3  # type: rspace
 adlfs
 huggingface_hub
 omero-py #type: omero
+iiif-fsspec # type: iiif
 
 # Vault backend
 hvac

--- a/lib/galaxy/files/sources/iiif.py
+++ b/lib/galaxy/files/sources/iiif.py
@@ -5,6 +5,7 @@ from fsspec import AbstractFileSystem
 
 from galaxy.exceptions import MessageException
 from galaxy.files.models import (
+    AnyRemoteEntry,
     FilesSourceRuntimeContext,
     RemoteDirectory,
     RemoteFile,
@@ -50,12 +51,12 @@ class IIIFFilesSource(FsspecFilesSource[IIIFFileSourceTemplateConfiguration, III
 
         return IIIFFileSystem(**cache_options)
 
-    def _to_filesystem_path(self, path: str) -> str:
+    def _to_filesystem_path(self, path: str, config: IIIFFileSourceConfiguration) -> str:
         if path in ("", "/"):
-            return self.manifest_url
+            return self._normalize_manifest_url(config.manifest_url)
         return path.lstrip("/")
 
-    def _info_to_entry(self, info: dict):
+    def _info_to_entry(self, info: dict, config: IIIFFileSourceConfiguration) -> AnyRemoteEntry:
         filesystem_path = info["name"]
         entry_path = filesystem_path
         entry_name = self._entry_name_from_info(info, filesystem_path)
@@ -74,10 +75,6 @@ class IIIFFilesSource(FsspecFilesSource[IIIFFileSourceTemplateConfiguration, III
         if isinstance(iiif_label, str) and iiif_label:
             return iiif_label
         return os.path.basename(filesystem_path.rstrip("/"))
-
-    @property
-    def manifest_url(self) -> str:
-        return self._normalize_manifest_url(self.template_config.manifest_url)
 
     @staticmethod
     def _normalize_manifest_url(manifest_url: str) -> str:

--- a/lib/galaxy/files/sources/iiif.py
+++ b/lib/galaxy/files/sources/iiif.py
@@ -22,7 +22,7 @@ from galaxy.util.config_templates import TemplateExpansion
 try:
     from iiif_fsspec import IIIFFileSystem
 except ImportError:
-    IIIFFileSystem = None  # type: ignore[assignment,misc]
+    IIIFFileSystem = None
 
 
 class IIIFFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):

--- a/lib/galaxy/files/sources/iiif.py
+++ b/lib/galaxy/files/sources/iiif.py
@@ -1,0 +1,98 @@
+import os
+from typing import Union
+
+from fsspec import AbstractFileSystem
+
+from galaxy.exceptions import MessageException
+from galaxy.files.models import (
+    FilesSourceRuntimeContext,
+    RemoteDirectory,
+    RemoteFile,
+)
+from galaxy.files.sources._defaults import DEFAULT_SCHEME
+from galaxy.files.sources._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+from galaxy.util.config_templates import TemplateExpansion
+
+try:
+    from iiif_fsspec import IIIFFileSystem
+except ImportError:
+    IIIFFileSystem = None  # type: ignore[assignment,misc]
+
+
+class IIIFFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
+    manifest_url: Union[str, TemplateExpansion]
+
+
+class IIIFFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
+    manifest_url: str
+
+
+class IIIFFilesSource(FsspecFilesSource[IIIFFileSourceTemplateConfiguration, IIIFFileSourceConfiguration]):
+    plugin_type = "iiif"
+    required_module = IIIFFileSystem
+    required_package = "iiif-fsspec"
+
+    template_config_class = IIIFFileSourceTemplateConfiguration
+    resolved_config_class = IIIFFileSourceConfiguration
+
+    def _open_fs(
+        self,
+        _context: FilesSourceRuntimeContext[IIIFFileSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ) -> AbstractFileSystem:
+        if IIIFFileSystem is None:
+            raise self.required_package_exception
+
+        return IIIFFileSystem(**cache_options)
+
+    def _to_filesystem_path(self, path: str) -> str:
+        if path in ("", "/"):
+            return self.manifest_url
+        return path.lstrip("/")
+
+    def _info_to_entry(self, info: dict):
+        filesystem_path = info["name"]
+        entry_path = filesystem_path
+        entry_name = self._entry_name_from_info(info, filesystem_path)
+        uri = self.uri_from_path(entry_path)
+
+        if info.get("type") == "directory":
+            return RemoteDirectory(name=entry_name, uri=uri, path=entry_path)
+
+        size = int(info.get("size", 0))
+        ctime = self._get_formatted_timestamp(info)
+        hashes = self._get_file_hashes(info)
+        return RemoteFile(name=entry_name, size=size, ctime=ctime, uri=uri, path=entry_path, hashes=hashes)
+
+    def _entry_name_from_info(self, info: dict, filesystem_path: str) -> str:
+        iiif_label = info.get("iiif_label")
+        if isinstance(iiif_label, str) and iiif_label:
+            return iiif_label
+        return os.path.basename(filesystem_path.rstrip("/"))
+
+    @property
+    def manifest_url(self) -> str:
+        return self._normalize_manifest_url(self.template_config.manifest_url)
+
+    @staticmethod
+    def _normalize_manifest_url(manifest_url: str) -> str:
+        return manifest_url.rstrip("/")
+
+    def _write_from(
+        self,
+        _target_path: str,
+        _native_path: str,
+        _context: FilesSourceRuntimeContext[IIIFFileSourceConfiguration],
+    ):
+        raise MessageException("IIIF file sources are read-only and do not support exporting files.")
+
+    def get_scheme(self) -> str:
+        return self.scheme if self.scheme and self.scheme != DEFAULT_SCHEME else "iiif"
+
+
+__all__ = ("IIIFFilesSource",)

--- a/lib/galaxy/files/templates/examples/production_iiif.yml
+++ b/lib/galaxy/files/templates/examples/production_iiif.yml
@@ -1,0 +1,20 @@
+- id: iiif
+  version: 0
+  name: IIIF Manifest
+  description: |
+      Browse and import image canvases from an [IIIF (International Image Interoperability Framework)](https://iiif.io/) Presentation API manifest. IIIF is a framework used by museums, libraries, and archives to deliver high-quality digital images of cultural heritage materials through a standardized API. You can find public IIIF resources at [https://iiif.io/guides/finding_resources/](https://iiif.io/guides/finding_resources/).
+
+      The images imported from the IIIF manifest will be added to your Galaxy history as new datasets, allowing you to analyze and work with them using Galaxy's tools and workflows.
+  variables:
+      manifest_url:
+          label: IIIF Manifest URL
+          type: string
+          help: |
+              Full URL to a IIIF Presentation manifest JSON document. IIIF manifests are structured descriptions of digitized collections that can include metadata, image sequences, and navigation information.
+
+              For examples and to find public IIIF resources, visit: [https://iiif.io/guides/finding_resources/](https://iiif.io/guides/finding_resources/)
+
+              Example: https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json
+  configuration:
+      type: iiif
+      manifest_url: "{{ variables.manifest_url }}"

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -47,6 +47,7 @@ FileSourceTemplateType = Literal[
     "rspace",
     "dataverse",
     "huggingface",
+    "iiif",
     "omero",
 ]
 
@@ -333,6 +334,18 @@ class HuggingFaceFileSourceConfiguration(StrictModel):
     endpoint: Optional[str] = None
 
 
+class IIIFFileSourceTemplateConfiguration(StrictModel):
+    type: Literal["iiif"]
+    manifest_url: Union[str, TemplateExpansion]
+    template_start: Optional[str] = None
+    template_end: Optional[str] = None
+
+
+class IIIFFileSourceConfiguration(StrictModel):
+    type: Literal["iiif"]
+    manifest_url: str
+
+
 class OmeroFileSourceTemplateConfiguration(StrictModel):
     type: Literal["omero"]
     username: Union[str, TemplateExpansion]
@@ -370,6 +383,7 @@ FileSourceTemplateConfiguration = Annotated[
         RSpaceFileSourceTemplateConfiguration,
         DataverseFileSourceTemplateConfiguration,
         HuggingFaceFileSourceTemplateConfiguration,
+        IIIFFileSourceTemplateConfiguration,
         OmeroFileSourceTemplateConfiguration,
     ],
     Field(discriminator="type"),
@@ -392,6 +406,7 @@ FileSourceConfiguration = Annotated[
         RSpaceFileSourceConfiguration,
         DataverseFileSourceConfiguration,
         HuggingFaceFileSourceConfiguration,
+        IIIFFileSourceConfiguration,
         OmeroFileSourceConfiguration,
     ],
     Field(discriminator="type"),
@@ -472,6 +487,7 @@ TypesToConfigurationClasses: dict[FileSourceTemplateType, type[FileSourceConfigu
     "rspace": RSpaceFileSourceConfiguration,
     "dataverse": DataverseFileSourceConfiguration,
     "huggingface": HuggingFaceFileSourceConfiguration,
+    "iiif": IIIFFileSourceConfiguration,
     "omero": OmeroFileSourceConfiguration,
 }
 


### PR DESCRIPTION
## Summary

This PR adds support for IIIF (International Image Interoperability Framework) as a new file source type in Galaxy. This read-only integration enables users to browse and import high-resolution image-based cultural heritage materials from museums, libraries, and archives directly into Galaxy histories.

## Motivation

IIIF is a widely adopted framework used by cultural heritage institutions worldwide to deliver high-quality digital images of rare books, manuscripts, photographs, artwork, and other digitized collections. By integrating IIIF as a file source, Galaxy users can:

- Access curated digital collections from major institutions without leaving Galaxy
- Import high-resolution primary source materials for analysis and processing
- Work with digitized historical documents, scientific illustrations, and artwork using Galaxy's tools and workflows
- Bridge the gap between digital humanities/scientific research and computational analysis

## Requirements

Admins must install the [`iiif-fsspec` package](https://github.com/davelopez/iiif-fsspec) conditional dependency to use IIIF file sources:
```bash
pip install iiif-fsspec
```

## Configuration Example
As an admin, you can add entries like this in your `config/file_sources_conf.yml` or use the user-template approach explained below, step by step.
```yaml
- type: iiif
  id: iiif-cambridge-scientific-instrument
  label: Cambridge Scientific Instrument Company
  doc: Browse and import canvases from the Cambridge Digital Library
  manifest_url: "https://cudl.lib.cam.ac.uk/iiif/collection/csic"
  writable: false
```


Suggested test manifests:
- Cambridge Digital Library collection: `https://cudl.lib.cam.ac.uk/iiif/collection/csic`
- Oxford Digital Bodleian collection: `https://iiif.bodleian.ox.ac.uk/iiif/collection/top`
- Example from IIIF Cookbook: `https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json`



## See it in action
Note: the size in MB displayed is just an estimation based on the width and height of the images, since the images are compressed in JPG, there is no accurate way to know their size in a fast and reliable way.

https://github.com/user-attachments/assets/ac1bdf18-96e3-4b3e-b1de-bae49cbb9325


## Resources

- **IIIF Official Website**: https://iiif.io/
- **Finding Public IIIF Resources**: https://iiif.io/guides/finding_resources/
- **iiif-fsspec Package**: https://github.com/davelopez/iiif-fsspec

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Make sure the `iiif-fsspec` conditional dependency is installed
  - Add the `- include: ./lib/galaxy/files/templates/examples/production_iiif.yml` template to your `config/file_source_templates.yml`
  - Launch Galaxy
  - Go to http://localhost:5173/file_source_instances/create and create your IIIF connection
  
    <img width="1205" height="688" alt="image" src="https://github.com/user-attachments/assets/244f8f6d-04d1-401e-a54c-0f274e729ce2" />

  - Fill in the form and use (for example) `https://iiif.bodleian.ox.ac.uk/iiif/collection/top` in the manifest field.
  
    <img width="1207" height="512" alt="image" src="https://github.com/user-attachments/assets/eada43fa-0d5e-471a-9ed1-af46225b11ca" />

  - Browse and download images from your newly created IIIF source.
  
    <img width="1415" height="941" alt="image" src="https://github.com/user-attachments/assets/46299dd8-1230-47ac-929e-54b4cead984e" />
    <img width="1415" height="941" alt="image" src="https://github.com/user-attachments/assets/9d594d84-433a-4fb5-adc0-c36ee124c3b4" />
    <img width="1415" height="941" alt="image" src="https://github.com/user-attachments/assets/7cf105c2-88a0-4269-864e-964a956cb81d" />
    
    <img width="1415" height="941" alt="image" src="https://github.com/user-attachments/assets/b8a3660b-8b40-43db-aade-2d0cddb07e20" />



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
