### PR TITLE
[26.0] Allow batch-wrapped HDCA on single data param in from_json

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2163,7 +2163,9 @@ class DataToolParameter(BaseDataToolParameter):
             if self.default_object:
                 return raw_to_galaxy(trans.app, trans.history, self.default_object)
             return None
+        batch_wrapper = False
         if isinstance(value, MutableMapping) and "values" in value:
+            batch_wrapper = bool(value.get("batch"))
             value = self.to_python(value, trans.app)
         if isinstance(value, str) and value.find(",") > 0:
             value = [int(value_part) for value_part in value.split(",")]
@@ -2277,15 +2279,24 @@ class DataToolParameter(BaseDataToolParameter):
             if len(rval) > 0:
                 single_value = rval[0]
                 if isinstance(single_value, HistoryDatasetCollectionAssociation):
+                    if batch_wrapper:
+                        # A batch wrapper ({"batch": true, "values": [...]})
+                        # only reaches ``from_json`` during tool form building
+                        # (``/api/tools/{id}/build``); at execution time
+                        # ``expand_meta_parameters`` has already replaced the
+                        # wrapper with per-element values. Returning the HDCA
+                        # lets the form re-render and preserves the user's
+                        # map-over selection.
+                        return single_value
                     # A non-multiple data parameter cannot reduce a dataset
                     # collection. Without this check the HDCA is silently
                     # accepted here, then ``collect_input_dataset_collections``
                     # rewrites the state to a list of the collection's HDAs and
                     # ``wrap_values`` later crashes with a raw ``TypeError``
                     # (https://github.com/galaxyproject/galaxy/issues/22401).
-                    # Map-over remains supported via ``{"batch": true, ...}``,
-                    # which is expanded to per-element jobs before reaching
-                    # ``from_json``.
+                    # Map-over is still supported via ``{"batch": true, ...}``;
+                    # at execution time that wrapper is expanded to per-element
+                    # jobs before reaching ``from_json``.
                     raise ParameterValueError(
                         "dataset collection supplied to single input dataset parameter; "
                         "to run the tool over each element of the collection, use the map-over option",

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2511,6 +2511,23 @@ class TestToolsApi(ApiTestCase, TestsTools):
         collection.assert_has_dataset_element("reverse").with_contents_stripped("reverse")
 
     @skip_without_tool("identifier_in_conditional")
+    def test_hdca_accepted_via_batch_for_single_data_param_in_conditional(self, history_id):
+        # Regression test: tool form building (/api/tools/{id}/build) must
+        # accept a batch-wrapped HDCA for a non-multiple ``data`` parameter.
+        # The reject-HDCA check added for
+        # https://github.com/galaxyproject/galaxy/issues/22401 only applies at
+        # execution time; at build time the batch wrapper has not yet been
+        # expanded and reaches ``DataToolParameter.from_json`` intact.
+        hdca_id = self._build_pair(history_id, ["123", "456"])
+        inputs = {
+            "outer_cond|multi_input": False,
+            "outer_cond|input1": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]},
+        }
+        # ``build_tool_state`` calls ``raise_for_status`` internally, so any
+        # non-2xx response (e.g. the 400 this test guards against) fails loudly.
+        self.dataset_populator.build_tool_state("identifier_in_conditional", history_id, inputs)
+
+    @skip_without_tool("identifier_in_conditional")
     def test_hdca_rejected_for_single_data_param_in_conditional(self, history_id):
         # Regression test for https://github.com/galaxyproject/galaxy/issues/22401 .
         # Submitting a paired collection (no batch wrapper) to a non-multiple


### PR DESCRIPTION
The HDCA rejection added in b3f6dd71a7 (#22401) only considered the execution path, where ``expand_meta_parameters`` unwraps ``{"batch": true, "values": [...]}`` before ``check_param`` runs. Tool form building (``/api/tools/{id}/build``) takes a different path: ``populate_state`` → ``check_param`` → ``from_json`` receives the raw batch wrapper, which ``to_python`` then unwraps to an HDCA, tripping the new rejection and returning a 400. That breaks the form re-render every time a user picks a paired collection for a non-multiple ``data`` parameter in the UI.

Remember whether the incoming value was a batch wrapper and, when it was, return the HDCA instead of raising. Execution is unaffected because the wrapper never reaches ``from_json`` there.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
