### PR TITLE
[26.0] Avoid premature commit when copying MetadataFile

### DIFF
--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -633,10 +633,16 @@ class FileParameter(MetadataParameter):
             if wrapped_value:
                 return wrapped_value
             else:
-                # If we've simultaneously copied the  dataset and we've changed the datatype on the
-                # copy we may not have committed the MetadataFile yet, so we need to commit the session.
-                # TODO: It would be great if we can avoid the commit in the future.
-                session.commit()
+                # If we've simultaneously copied the dataset and we've changed the datatype on the
+                # copy we may not have flushed the pending MetadataFile to the DB yet, so the
+                # select above may have missed it. Flush (NOT commit) so the pending INSERT is
+                # visible to the retry SELECT within this session without leaking every other
+                # pending change in the session to concurrent readers. Committing here caused
+                # https://github.com/galaxyproject/galaxy/issues/22194: a mid-loop wrap() inside
+                # JobWrapper.finish() flushed an intermedia expression.json's dataset's
+                # Dataset.state = OK to the DB before exec_after_process had replaced the file,
+                # exposing a globall inconsistent state to the workflow scheduler.
+                session.flush()
             return session.execute(select(galaxy.model.MetadataFile).filter_by(uuid=value)).scalar_one_or_none()
 
     def make_copy(self, value, target_context: MetadataCollection, source_context):


### PR DESCRIPTION
FileParameter.wrap called session.commit() as a last resort when the MetadataFile uuid it was asked to wrap was not yet visible to the session (because it had been add()-ed in a sibling code path but not yet flushed). Committing leaks every pending change in the session to concurrent readers.

Inside JobWrapper.finish(), a mid-loop load_metadata() reaches wrap() via MetadataCollection.from_JSON_dict. If that wrap() commits, it flushes a scratch dataset's Dataset.state = OK assignment (set in a prior iteration at jobs/__init__.py:2199) to the DB. A concurrent workflow scheduler then sees Dataset.state == OK while exec_after_process is still mid-run -- and between the deletion of the scratch expression.json in full_delete() and the deliberate commit at jobs/__init__.py:2297, the HDA's purge flag, dataset_id swap, and extension change are all still uncommitted. to_cwl() falls through all its existing guards, opens get_file_name() (which returns "" because object_store.exists is False), and crashes with FileNotFoundError.

Replacing commit with flush sends the pending INSERT into the current transaction so the retry SELECT finds the MetadataFile (wrap's contract is preserved) without publishing any unrelated pending state to other sessions. The existing TODO on the line already flagged that the commit should go away.

Fixes https://github.com/galaxyproject/galaxy/issues/22194

Working on a test, but claude says i'm a menace and i should be banned for testing this code 🤣 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
