### PR TITLE
Better Auth0 OIDC support

### DIFF
--- a/lib/galaxy/authnz/auth0.py
+++ b/lib/galaxy/authnz/auth0.py
@@ -1,0 +1,8 @@
+from galaxy.authnz.oidc import GalaxyOpenIdConnect
+from social_core.backends.auth0_openidconnect import Auth0OpenIdConnectAuth
+
+
+class GalaxyAuth0OpenIdConnect(GalaxyOpenIdConnect, Auth0OpenIdConnectAuth):
+    name = "auth0"
+    EXTRA_DATA = ["id_token", "refresh_token", ("sub", "id"), "picture", "expires_in"]
+

--- a/lib/galaxy/authnz/auth0.py
+++ b/lib/galaxy/authnz/auth0.py
@@ -1,8 +1,8 @@
-from galaxy.authnz.oidc import GalaxyOpenIdConnect
 from social_core.backends.auth0_openidconnect import Auth0OpenIdConnectAuth
+
+from galaxy.authnz.oidc import GalaxyOpenIdConnect
 
 
 class GalaxyAuth0OpenIdConnect(GalaxyOpenIdConnect, Auth0OpenIdConnectAuth):
     name = "auth0"
     EXTRA_DATA = ["id_token", "refresh_token", ("sub", "id"), "picture", "expires_in"]
-

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -189,6 +189,8 @@ class AuthnzManager:
             rtv["end_user_registration_endpoint"] = config_xml.find("end_user_registration_endpoint").text
         if config_xml.find("profile_url") is not None:
             rtv["profile_url"] = config_xml.find("profile_url").text
+        if config_xml.find("domain") is not None:
+            rtv["domain"] = config_xml.find("domain").text
 
         # this is a EGI Check-in specific config
         if config_xml.find("checkin_env") is not None:

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -223,6 +223,8 @@ class PSAAuthnz(IdentityProvider):
             self.config[setting_name("URL")] = oidc_backend_config.get("url")
         if oidc_backend_config.get("username_key") is not None:
             self.config[setting_name("USERNAME_KEY")] = oidc_backend_config.get("username_key")
+        if oidc_backend_config.get("domain") is not None:
+            self.config[setting_name("DOMAIN")] = oidc_backend_config.get("domain")
 
         # OIDC-specific settings (only set for OIDC backends)
         if self._is_oidc_backend():

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -72,6 +72,7 @@ BACKENDS = {
     "tapis": "galaxy.authnz.tapis.TapisOAuth2",
     "keycloak": "galaxy.authnz.keycloak.KeycloakOpenIdConnect",
     "cilogon": "galaxy.authnz.cilogon.CILogonOpenIdConnect",
+    "auth0": "galaxy.authnz.auth0.GalaxyAuth0OpenIdConnect",
 }
 
 BACKENDS_NAME = {
@@ -88,6 +89,7 @@ BACKENDS_NAME = {
     "tapis": "tapis",
     "keycloak": "keycloak",
     "cilogon": "cilogon",
+    "auth0": "auth0",
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
+++ b/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
@@ -177,6 +177,13 @@
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
+                            <xs:element name="domain" minOccurs="0" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Provider domain (e.g. for Auth0)
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
                         </xs:all>
                         <xs:attribute name="name" type="xs:string" use="required">
                             <xs:annotation>

--- a/test/unit/authnz/test_psa_authnz.py
+++ b/test/unit/authnz/test_psa_authnz.py
@@ -68,6 +68,7 @@ def mock_oidc_backend_config_file(tmp_path):
             <redirect_uri>$galaxy_url/authnz/$provider_name/callback</redirect_uri>
             <enable_idp_logout>true</enable_idp_logout>
             <accepted_audiences>gxyclient</accepted_audiences>
+            <domain>example.com</domain>
         </provider>
     </OIDC>
     """
@@ -321,6 +322,29 @@ def test_oidc_config_custom_auth_pipeline(mock_oidc_config_file, mock_oidc_backe
         app_config=mock_app.config,
     )
     assert psa_authnz.config["SOCIAL_AUTH_PIPELINE"] == custom_auth_pipeline
+
+
+def test_oidc_backend_config_file_parsing(mock_oidc_config_file, mock_oidc_backend_config_file):
+    """Basic test of backend config XML parsing"""
+    mock_app = MagicMock()
+    mock_app.config = SimpleNamespace(
+        oidc_auth_pipeline=None,
+        oidc_auth_pipeline_extra=None,
+        oidc=defaultdict(dict),
+        fixed_delegated_auth=False,
+    )
+    manager = AuthnzManager(
+        app=mock_app, oidc_config_file=mock_oidc_config_file, oidc_backends_config_file=mock_oidc_backend_config_file
+    )
+
+    parsed = manager.oidc_backends_config["oidc"]
+    assert parsed["url"] == "login.example.com"
+    assert parsed["client_id"] == "gxyclient"
+    assert parsed["client_secret"] == "dummyclientsecret"
+    assert parsed["redirect_uri"] == "$galaxy_url/authnz/$provider_name/callback"
+    assert parsed["enable_idp_logout"] is True
+    assert parsed["accepted_audiences"] == "gxyclient"
+    assert parsed["domain"] == "example.com"
 
 
 def test_oidc_config_auth_pipeline_extra(mock_oidc_config_file, mock_oidc_backend_config_file):


### PR DESCRIPTION
Adding a specific provider/subclass for Auth0 OIDC (I also added an Auth0 OIDC class to python-social-auth). In our Auth0 implementation we have so far relied on the generic OIDC provider, but it's helpful to have a specific provider class for it, particularly to get refresh tokens working correctly.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
