### PR TITLE
[26.0] Fix unqualified structured_like resolution, add linters

### DIFF
--- a/lib/galaxy/tool_util/linters/output.py
+++ b/lib/galaxy/tool_util/linters/output.py
@@ -259,6 +259,122 @@ def _check_pattern(node):
         return True
 
 
+class OutputsStructuredLikeReference(Linter):
+    @classmethod
+    def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
+        tool_xml = getattr(tool_source, "xml_tree", None)
+        if not tool_xml:
+            return
+        param_qualified_paths = _collect_param_qualified_paths(tool_xml)
+        for output in tool_xml.findall("./outputs/collection[@structured_like]"):
+            structured_like = output.attrib["structured_like"]
+            _check_unqualified_reference(
+                lint_ctx, cls.name(), output, structured_like, "structured_like", param_qualified_paths
+            )
+
+
+class OutputsFormatSourceReference(Linter):
+    @classmethod
+    def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
+        tool_xml = getattr(tool_source, "xml_tree", None)
+        if not tool_xml:
+            return
+        param_qualified_paths = _collect_param_qualified_paths(tool_xml)
+        output_names = {
+            o.attrib["name"]
+            for o in tool_xml.findall("./outputs/data[@name]") + tool_xml.findall("./outputs/collection[@name]")
+        }
+        for output in tool_xml.findall("./outputs/data[@format_source]") + tool_xml.findall(
+            "./outputs/collection[@format_source]"
+        ):
+            format_source = output.attrib["format_source"]
+            # format_source can reference other outputs, skip if it matches an output name
+            if format_source in output_names:
+                continue
+            _check_unqualified_reference(
+                lint_ctx, cls.name(), output, format_source, "format_source", param_qualified_paths
+            )
+
+
+def _check_unqualified_reference(
+    lint_ctx: "LintContext",
+    linter_name: str,
+    node: "Element",
+    ref_value: str,
+    attr_name: str,
+    param_qualified_paths: dict,
+):
+    if "|" in ref_value:
+        return
+    # Check if it matches a top-level param directly
+    top_level_match = any(qp == ref_value for paths in param_qualified_paths.values() for qp in paths)
+    if top_level_match:
+        return
+    matches = param_qualified_paths.get(ref_value, [])
+    output_name = node.attrib.get("name", "unknown")
+    if len(matches) == 1:
+        lint_ctx.warn(
+            f"Output '{output_name}' uses unqualified {attr_name}='{ref_value}'. "
+            f"Use the qualified name '{matches[0]}'.",
+            linter=linter_name,
+            node=node,
+        )
+    elif len(matches) > 1:
+        lint_ctx.warn(
+            f"Output '{output_name}' uses ambiguous unqualified {attr_name}='{ref_value}' "
+            f"matching multiple inputs: {', '.join(matches)}. Use a qualified name.",
+            linter=linter_name,
+            node=node,
+        )
+    else:
+        lint_ctx.error(
+            f"Output '{output_name}' references {attr_name}='{ref_value}' "
+            f"which does not match any input parameter.",
+            linter=linter_name,
+            node=node,
+        )
+
+
+def _collect_param_qualified_paths(tool_xml: "ElementTree") -> dict:
+    """Build a map of unqualified param name -> list of qualified paths."""
+    param_paths: dict = {}
+    parent_map = {child: parent for parent in tool_xml.iter() for child in parent}
+    for param in tool_xml.findall("./inputs//param"):
+        name = param.attrib.get("name")
+        if not name:
+            argument = param.attrib.get("argument")
+            if argument:
+                name = argument.lstrip("-").replace("-", "_")
+        if not name:
+            continue
+        qualified = _get_qualified_name(param, parent_map)
+        param_paths.setdefault(name, []).append(qualified)
+    return param_paths
+
+
+def _get_qualified_name(param_elem: "Element", parent_map: dict) -> str:
+    """Walk up the XML tree to build the qualified path for a param element."""
+    name = param_elem.attrib.get("name")
+    if not name:
+        argument = param_elem.attrib.get("argument")
+        if argument:
+            name = argument.lstrip("-").replace("-", "_")
+    parts = [name] if name else []
+    current = param_elem
+    while True:
+        parent = parent_map.get(current)
+        if parent is None:
+            break
+        if parent.tag in ("conditional", "section"):
+            parent_name = parent.attrib.get("name")
+            if parent_name:
+                parts.insert(0, parent_name)
+        elif parent.tag in ("inputs", "tool"):
+            break
+        current = parent
+    return "|".join(parts)
+
+
 def _has_tool_provided_metadata(tool_xml: "ElementTree") -> bool:
     outputs = tool_xml.find("./outputs")
     if outputs is not None:

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -481,25 +481,26 @@ class ExecutionTracker:
         return output_collection_name
 
     def sliced_input_collection_structure(self, input_name):
-        unqualified_recurse = Version(str(self.tool.profile)) < Version("18.09") and "|" not in input_name
+        unqualified_recurse = Version(str(self.tool.profile)) < Version("26.0") and "|" not in input_name
 
-        def find_collection(input_dict, input_name):
+        def find_collection(input_dict, input_name, path_prefix=""):
             for key, value in input_dict.items():
                 if key == input_name:
-                    return value
+                    return value, f"{path_prefix}{key}"
                 if isinstance(value, dict):
                     if "|" in input_name:
                         prefix, rest_input_name = input_name.split("|", 1)
                         if key == prefix:
-                            return find_collection(value, rest_input_name)
+                            return find_collection(value, rest_input_name, f"{path_prefix}{key}|")
                     elif unqualified_recurse:
                         # Looking for "input1" instead of "cond|input1" for instance.
                         # See discussion on https://github.com/galaxyproject/galaxy/issues/6157.
-                        unqualified_match = find_collection(value, input_name)
+                        unqualified_match, qualified_path = find_collection(value, input_name, f"{path_prefix}{key}|")
                         if unqualified_match:
-                            return unqualified_match
+                            return unqualified_match, qualified_path
+            return None, None
 
-        input_collection = find_collection(self.example_params, input_name)
+        input_collection, qualified_name = find_collection(self.example_params, input_name)
         if input_collection is None:
             raise Exception("Failed to find referenced collection in inputs.")
 
@@ -512,10 +513,10 @@ class ExecutionTracker:
             )
         )
         subcollection_mapping_type = None
-        if self.is_implicit_input(input_name):
+        if self.is_implicit_input(qualified_name):
             collection_info = self.collection_info
             assert collection_info
-            subcollection_mapping_type = collection_info.subcollection_mapping_type(input_name)
+            subcollection_mapping_type = collection_info.subcollection_mapping_type(qualified_name)
 
         return get_structure(
             input_collection, collection_type_description, leaf_subcollection_type=subcollection_mapping_type

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -711,6 +711,89 @@ OUTPUTS_FILTER_EXPRESSION = """
 </tool>
 """
 
+OUTPUTS_STRUCTURED_LIKE_UNQUALIFIED = """
+<tool id="id" name="name">
+    <inputs>
+        <conditional name="cond">
+            <param name="cond_param" type="select">
+                <option value="paired">Paired</option>
+            </param>
+            <when value="paired">
+                <param name="input1" type="data_collection" collection_type="paired" format="data" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <collection name="list_output" structured_like="input1" type="paired" inherit_format="true" />
+    </outputs>
+</tool>
+"""
+
+OUTPUTS_STRUCTURED_LIKE_QUALIFIED = """
+<tool id="id" name="name">
+    <inputs>
+        <conditional name="cond">
+            <param name="cond_param" type="select">
+                <option value="paired">Paired</option>
+            </param>
+            <when value="paired">
+                <param name="input1" type="data_collection" collection_type="paired" format="data" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <collection name="list_output" structured_like="cond|input1" type="paired" inherit_format="true" />
+    </outputs>
+</tool>
+"""
+
+OUTPUTS_STRUCTURED_LIKE_MISSING = """
+<tool id="id" name="name">
+    <inputs>
+        <param name="input2" type="data" format="data" />
+    </inputs>
+    <outputs>
+        <collection name="list_output" structured_like="nonexistent" type="paired" inherit_format="true" />
+    </outputs>
+</tool>
+"""
+
+OUTPUTS_FORMAT_SOURCE_UNQUALIFIED = """
+<tool id="id" name="name">
+    <inputs>
+        <conditional name="cond">
+            <param name="cond_param" type="select">
+                <option value="yes">Yes</option>
+            </param>
+            <when value="yes">
+                <param name="input1" type="data" format="data" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="output1" format_source="input1" />
+    </outputs>
+</tool>
+"""
+
+OUTPUTS_FORMAT_SOURCE_QUALIFIED = """
+<tool id="id" name="name">
+    <inputs>
+        <conditional name="cond">
+            <param name="cond_param" type="select">
+                <option value="yes">Yes</option>
+            </param>
+            <when value="yes">
+                <param name="input1" type="data" format="data" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="output1" format_source="cond|input1" />
+    </outputs>
+</tool>
+"""
+
 # tool xml for repeats linter
 REPEATS = """
 <tool id="id" name="name">
@@ -1881,6 +1964,41 @@ def test_outputs_filter_expression(lint_ctx):
     assert not lint_ctx.error_messages
 
 
+def test_outputs_structured_like_unqualified(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_STRUCTURED_LIKE_UNQUALIFIED)
+    run_lint_module(lint_ctx, output, tool_source)
+    assert "unqualified structured_like='input1'" in lint_ctx.warn_messages
+    assert "cond|input1" in lint_ctx.warn_messages
+    assert "structured_like" not in lint_ctx.error_messages
+
+
+def test_outputs_structured_like_qualified(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_STRUCTURED_LIKE_QUALIFIED)
+    run_lint_module(lint_ctx, output, tool_source)
+    assert "structured_like" not in lint_ctx.warn_messages
+    assert "structured_like" not in lint_ctx.error_messages
+
+
+def test_outputs_structured_like_missing(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_STRUCTURED_LIKE_MISSING)
+    run_lint_module(lint_ctx, output, tool_source)
+    assert "does not match any input" in lint_ctx.error_messages
+
+
+def test_outputs_format_source_unqualified(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_UNQUALIFIED)
+    run_lint_module(lint_ctx, output, tool_source)
+    assert "unqualified format_source='input1'" in lint_ctx.warn_messages
+    assert "cond|input1" in lint_ctx.warn_messages
+
+
+def test_outputs_format_source_qualified(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_SOURCE_QUALIFIED)
+    run_lint_module(lint_ctx, output, tool_source)
+    assert "format_source" not in lint_ctx.warn_messages
+    assert "format_source" not in lint_ctx.error_messages
+
+
 def test_stdio_default_for_default_profile(lint_ctx):
     tool_source = get_xml_tool_source(STDIO_DEFAULT_FOR_DEFAULT_PROFILE)
     run_lint_module(lint_ctx, stdio, tool_source)
@@ -2425,7 +2543,7 @@ def test_skip_by_module(lint_ctx):
 def test_list_linters():
     linter_names = Linter.list_listers()
     # make sure to add/remove a test for new/removed linters if this number changes
-    assert len(linter_names) == 143
+    assert len(linter_names) == 145
     assert "Linter" not in linter_names
     # make sure that linters from all modules are available
     for prefix in [


### PR DESCRIPTION
Move the profile version gate for unqualified structured_like resolution from 18.09 to 26.0 so tools with profiles < 26.0 can still resolve unqualified references when the input is inside a conditional or section, since there are tools out there that do this. We didn't have a linter so there wasn't really a chance tool authors would catch this.

Also track the resolved qualified name for downstream is_implicit_input/subcollection_mapping_type lookups.

Add linters OutputsStructuredLikeReference and
OutputsFormatSourceReference that warn when structured_like or format_source use unqualified references to nested inputs.

Fixes https://github.com/galaxyproject/galaxy/issues/22429


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
