### PR TITLE
Parameterize GCP Batch job naming for better tracking

### DIFF
--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -202,7 +202,7 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
 
         # Generate unique job name
         prefix = params.get("job_id_prefix", "galaxy-job")
-        job_name = f"{prefix}-{int(time.time())}-{os.urandom(4).hex()}"
+        job_name = f"{prefix}-{int(time.time())}-{os.urandom(4).hex()}-{job_wrapper.get_id_tag()}"
 
         # Create the batch job specification
         batch_job = self._create_batch_job_spec(job_wrapper, ajs, params)

--- a/lib/galaxy/jobs/runners/gcp_batch.py
+++ b/lib/galaxy/jobs/runners/gcp_batch.py
@@ -94,6 +94,8 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
             "custom_vm_image": dict(map=str, default=None),
             # Job cleanup: if true, delete GCP Batch jobs after Galaxy marks them complete
             "delete_completed_jobs": dict(map=bool, default=True),
+            # Prefix for GCP Batch job IDs (helps identify which Galaxy server submitted a job)
+            "job_id_prefix": dict(map=str, default="galaxy-job"),
             # Object store fallback (for future use)
             "use_object_store": dict(map=bool, default=False),
             "object_store_path": dict(map=str, default=None),
@@ -194,12 +196,13 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
         """Submit a job to Google Cloud Batch and return the job name."""
         log.debug("Starting _submit_batch_job for job %s", job_wrapper.get_id_tag())
 
-        # Generate unique job name
-        job_name = f"galaxy-job-{int(time.time())}-{os.urandom(4).hex()}"
-
         # Get job destination parameters
         job_destination = job_wrapper.job_destination
         params = self._get_job_params(job_destination)
+
+        # Generate unique job name
+        prefix = params.get("job_id_prefix", "galaxy-job")
+        job_name = f"{prefix}-{int(time.time())}-{os.urandom(4).hex()}"
 
         # Create the batch job specification
         batch_job = self._create_batch_job_spec(job_wrapper, ajs, params)
@@ -252,6 +255,7 @@ class GoogleCloudBatchJobRunner(AsynchronousJobRunner):
             "use_object_store",
             "object_store_path",
             "service_account_email",
+            "job_id_prefix",
         ]:
             params[key] = job_destination.params.get(key, self.runner_params.get(key))
 


### PR DESCRIPTION
This PR enhances the Google Cloud Batch job runner with improved job identification:

1. Configurable job prefix: Added `job_id_prefix` parameter to customize the prefix of Batch job names (defaults to "galaxy-job")
1. Include Galaxy job ID: Append Galaxy job ID to Batch job names for easier correlation between Galaxy jobs and GCP Batch jobs

Job name format: {prefix}-{timestamp}-{random_hex}-{galaxy_job_id}

Example: galaxy-job-1672531200-a1b2c3d4-123

These changes improve debugging and monitoring by making it easier to track jobs across Galaxy and Google Cloud Console without affecting existing functionality.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
