### PR TITLE
[26.0] Fix job files API purged input check

### DIFF
--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -1310,8 +1310,8 @@ def map_tool_to_destination(
         raise JobMappingException(e)
 
     # Get all inputs from tool and databases
-    inp_data: dict[str, DatasetInstance] = {da.name: da.dataset for da in job.input_datasets}
-    inp_data.update([(da.name, da.dataset) for da in job.input_library_datasets])
+    inp_data: dict[str, DatasetInstance] = {da.name: da.dataset for da in job.input_datasets if da.dataset}
+    inp_data.update([(da.name, da.dataset) for da in job.input_library_datasets if da.dataset])
 
     if config is not None and str(tool.old_id) in config["tools"]:
         if "rules" in config["tools"][str(tool.old_id)]:

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -552,7 +552,7 @@ class JobSearch:
         # and the ids that have been used in the job that has already been run in `used_ids`.
         requested_ids = []
         data_types = []
-        used_ids: list[Label[int]] = []
+        used_ids: list[Label[int] | Label[int | None]] = []
         for k, input_list in input_data.items():
             # k will be matched against the JobParameter.name column. This can be prefixed depending on whether
             # the input is in a repeat, or not (section and conditional)
@@ -787,7 +787,7 @@ class JobSearch:
         self,
         stmt: "Select[tuple[int]]",
         data_conditions: list["ColumnElement[bool]"],
-        used_ids: list["Label[int]"],
+        used_ids: list["Label[int] | Label[int | None]"],
         k,
         v,
         identifier,
@@ -854,7 +854,7 @@ class JobSearch:
         self,
         stmt: "Select[tuple[int]]",
         data_conditions: list["ColumnElement[bool]"],
-        used_ids: list["Label[int]"],
+        used_ids: list["Label[int] | Label[int | None]"],
         k,
         v,
         value_index: int,
@@ -877,7 +877,7 @@ class JobSearch:
         self,
         stmt: "Select[tuple[int]]",
         data_conditions: list["ColumnElement[bool]"],
-        used_ids: list["Label[int]"],
+        used_ids: list["Label[int] | Label[int | None]"],
         k,
         v,
         user_id: int,
@@ -1125,7 +1125,7 @@ class JobSearch:
         self,
         stmt: "Select[tuple[int]]",
         data_conditions: list["ColumnElement[bool]"],
-        used_ids: list["Label[int]"],
+        used_ids: list["Label[int] | Label[int | None]"],
         k,
         v,
         user_id: int,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2658,11 +2658,15 @@ class JobToInputDatasetAssociation(Base, RepresentById):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     job_id: Mapped[int] = mapped_column(ForeignKey("job.id"), index=True, nullable=True)
-    dataset_id: Mapped[int] = mapped_column(ForeignKey("history_dataset_association.id"), index=True, nullable=True)
+    dataset_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("history_dataset_association.id"), index=True, nullable=True
+    )
     dataset_version: Mapped[Optional[int]]
     name: Mapped[str] = mapped_column(String(255), nullable=True)
     adapter: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONType, nullable=True)
-    dataset: Mapped["HistoryDatasetAssociation"] = relationship(lazy="joined", back_populates="dependent_jobs")
+    dataset: Mapped[Optional["HistoryDatasetAssociation"]] = relationship(
+        lazy="joined", back_populates="dependent_jobs"
+    )
     job: Mapped["Job"] = relationship(back_populates="input_datasets")
 
     def __init__(self, name, dataset, adapter_json=None):

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -6,13 +6,19 @@ import logging
 import os
 import re
 import shutil
+from typing import Union
 
 from galaxy import (
     exceptions,
     util,
 )
 from galaxy.managers.context import ProvidesAppContext
-from galaxy.model import Job
+from galaxy.model import (
+    Job,
+    JobToOutputDatasetAssociation,
+    JobToOutputLibraryDatasetAssociation,
+)
+from galaxy.structured_app import MinimalManagerApp
 from galaxy.web import (
     expose_api_anonymous_and_sessionless,
     expose_api_raw_anonymous_and_sessionless,
@@ -35,7 +41,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
     """
 
     @expose_api_raw_anonymous_and_sessionless
-    def index(self, trans: ProvidesAppContext, job_id, **kwargs):
+    def index(self, trans: ProvidesAppContext, job_id: str, **kwargs):
         """
         GET /api/jobs/{job_id}/files
 
@@ -74,7 +80,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
                 raise
 
     @expose_api_anonymous_and_sessionless
-    def create(self, trans, job_id, payload, **kwargs):
+    def create(self, trans: ProvidesAppContext, job_id: str, payload, **kwargs):
         """
         create( self, trans, job_id, payload, **kwargs )
         * POST /api/jobs/{job_id}/files
@@ -180,7 +186,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         return None
 
     @expose_api_anonymous_and_sessionless
-    def tus_hooks(self, trans, **kwds):
+    def tus_hooks(self, trans: ProvidesAppContext, **kwds):
         """No-op but if hook specified the way we do for user upload it would hit this action.
 
         Exposed as PATCH /api/job_files/tus_hooks and documented in the docstring for
@@ -188,7 +194,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         """
         pass
 
-    def __authorize_job_access(self, trans, encoded_job_id, **kwargs):
+    def __authorize_job_access(self, trans: ProvidesAppContext, encoded_job_id: str, **kwargs):
         for key in ["path", "job_key"]:
             if key not in kwargs:
                 error_message = f"Job files action requires a valid '{key}'."
@@ -201,12 +207,13 @@ class JobFilesAPIController(BaseGalaxyAPIController):
 
         # Verify job is active. Don't update the contents of complete jobs.
         job = trans.sa_session.get(Job, job_id)
+        assert job
         if job.state not in Job.non_ready_states:
             error_message = "Attempting to read or modify the files of a job that has already completed."
             raise exceptions.ItemAccessibilityException(error_message)
         return job
 
-    def __check_job_can_write_to_path(self, trans, job, path):
+    def __check_job_can_write_to_path(self, trans: ProvidesAppContext, job: Job, path: str):
         """Verify an idealized job runner should actually be able to write to
         the specified path - it must be a dataset output, a dataset "extra
         file", or a some place in the working directory of this job.
@@ -219,23 +226,25 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         if not in_work_dir and not self.__is_output_dataset_path(job, path):
             raise exceptions.ItemAccessibilityException("Job is not authorized to write to supplied path.")
 
-    def __is_output_dataset_path(self, job, path):
+    def __is_output_dataset_path(self, job: Job, path: str):
         """Check if is an output path for this job or a file in the an
         output's extra files path.
         """
-        da_lists = [job.output_datasets, job.output_library_datasets]
-        for da_list in da_lists:
-            for job_dataset_association in da_list:
-                dataset = job_dataset_association.dataset
-                if not dataset:
-                    continue
-                if os.path.abspath(dataset.get_file_name()) == os.path.abspath(path):
-                    return True
-                elif util.in_directory(path, dataset.extra_files_path):
-                    return True
+        all_output_assocs: list[Union[JobToOutputDatasetAssociation, JobToOutputLibraryDatasetAssociation]] = [
+            *job.output_datasets,
+            *job.output_library_datasets,
+        ]
+        for assoc in all_output_assocs:
+            dataset = assoc.dataset
+            if not dataset:
+                continue
+            if os.path.abspath(dataset.get_file_name()) == os.path.abspath(path):
+                return True
+            elif util.in_directory(path, dataset.extra_files_path):
+                return True
         return False
 
-    def __in_working_directory(self, job, path, app):
+    def __in_working_directory(self, job: Job, path: str, app: MinimalManagerApp):
         working_directory = app.object_store.get_filename(
             job, base_dir="job_work", dir_only=True, extra_dir=str(job.id)
         )

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -339,7 +339,7 @@ class FastAPIJobs:
         for job_input_assoc in job.input_datasets:
             input_dataset_instance = job_input_assoc.dataset
             if input_dataset_instance is None:
-                continue  # type: ignore[unreachable]  # TODO if job_input_assoc.dataset is indeed never None, remove the above check
+                continue
             if input_dataset_instance.get_total_size() == 0:
                 has_empty_inputs = True
             input_instance_id = input_dataset_instance.id


### PR DESCRIPTION
and update type annotation to match reality.

Make JobToInputDatasetAssociation.dataset_id and .dataset Optional to reflect the actual database schema (nullable=True). Update type annotations in JobSearch and JobFilesAPIController to match.

Fixes https://github.com/galaxyproject/galaxy/issues/22369

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
