### PR TITLE
[26.0] Don't skip ``pypi-publish`` job if ``check-permissions`` was skipped

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -67,6 +67,7 @@ jobs:
           path: dist/
 
   pypi-publish:
+    if: always() && needs.build-python-packages.result == 'success'
     needs: [build-python-packages]
     name: Upload packages to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
In GitHub Actions, the default behaviour for any job is to run only if all its direct and indirect dependencies have a status of `success`.
On a `release` event, the `check-permissions` job is skipped because of its `if:` condition.
The `build-python-packages` job (which depends on `check-permissions`) runs anyway because it has an explicit `if:` condition which overrides the default behaviour.
The `pypi-publish` job (which depends on `build-python-packages`) was instead skipped because id had no `if:` condition and one of its ancestors (`check-permissions`) was skipped.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
