### PR TITLE
[26.0] Change Tool Shed `/api/users/current` from 404 to 403 when not authenticated

### DIFF
--- a/lib/tool_shed/webapp/api2/users.py
+++ b/lib/tool_shed/webapp/api2/users.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
 
 import tool_shed.util.shed_util_common as suc
 from galaxy.exceptions import (
+    AuthenticationRequired,
     InsufficientPermissionsException,
     ObjectNotFound,
     RequestParameterInvalidException,
@@ -134,7 +135,7 @@ class FastAPIUsers:
     def current(self, trans: SessionRequestContext = DependsOnTrans) -> User:
         user = trans.user
         if not user:
-            raise ObjectNotFound()
+            raise AuthenticationRequired()
 
         return get_api_user(trans.app, user)
 


### PR DESCRIPTION
This allow the use of nginx `auth_check` via this route.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
