### PR TITLE
[26.0] Release notes PRs update

### DIFF
--- a/doc/source/releases/26.0_announce_user.rst
+++ b/doc/source/releases/26.0_announce_user.rst
@@ -123,6 +123,9 @@ Visualizations Updates
 ===========================================================
 
 .. visualizations
+* Update openlayers plugin
+  (thanks to `@guerler <https://github.com/guerler>`__).
+  `Pull Request 22435`_
 * Bump tiffviewer visualization to v0.0.4
   (thanks to `@davelopez <https://github.com/davelopez>`__).
   `Pull Request 22168`_

--- a/doc/source/releases/26.0_prs.rst
+++ b/doc/source/releases/26.0_prs.rst
@@ -1,5 +1,13 @@
 
 .. github_links
+.. _Pull Request 21870: https://github.com/galaxyproject/galaxy/pull/21870
+.. _Pull Request 22411: https://github.com/galaxyproject/galaxy/pull/22411
+.. _Pull Request 22413: https://github.com/galaxyproject/galaxy/pull/22413
+.. _Pull Request 22414: https://github.com/galaxyproject/galaxy/pull/22414
+.. _Pull Request 22421: https://github.com/galaxyproject/galaxy/pull/22421
+.. _Pull Request 22431: https://github.com/galaxyproject/galaxy/pull/22431
+.. _Pull Request 22435: https://github.com/galaxyproject/galaxy/pull/22435
+.. _Pull Request 22441: https://github.com/galaxyproject/galaxy/pull/22441
 .. _Pull Request 22386: https://github.com/galaxyproject/galaxy/pull/22386
 .. _Pull Request 22383: https://github.com/galaxyproject/galaxy/pull/22383
 .. _Pull Request 22405: https://github.com/galaxyproject/galaxy/pull/22405


### PR DESCRIPTION
Ran the `galaxy-release-util` command to gather some final PRs for 26.0 release.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
