### PR TITLE
[26.0] Fix testing, publishing and dependencies of packages

### DIFF
--- a/lib/galaxy/tool_util/cwl/cwltool_deps.py
+++ b/lib/galaxy/tool_util/cwl/cwltool_deps.py
@@ -13,6 +13,14 @@ warnings.filterwarnings("ignore", message=r"[\n.]DEPRECATION: Python 2", module=
 from galaxy.util import requests
 
 try:
+    from cwl_utils.types import CWLObjectType
+except ImportError:
+    try:
+        from cwltool.utils import CWLObjectType  # type: ignore[attr-defined, unused-ignore]
+    except ImportError:
+        CWLObjectType = object  # type: ignore[assignment, misc]
+
+try:
     from cwltool import (
         main,
         pathmapper,
@@ -67,13 +75,11 @@ except ImportError:
 
 try:
     from cwltool.utils import (
-        CWLObjectType,
         JobsType,
         normalizeFilesDirs,
         visit_class,
     )
 except ImportError:
-    CWLObjectType = object  # type: ignore[assignment, misc]
     JobsType = object  # type: ignore[misc, unused-ignore]
     visit_class = None  # type: ignore[assignment]
     normalizeFilesDirs = None  # type: ignore[assignment]

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -69,7 +69,7 @@ from galaxy_test.base.testcase import FunctionalTestCase
 try:
     from galaxy_test.driver.driver_util import GalaxyTestDriver
 except ImportError:
-    GalaxyTestDriver = None  # type: ignore[misc,assignment]
+    GalaxyTestDriver = None  # type: ignore[assignment, misc, unused-ignore]
 
 
 def _load_config_file() -> None:

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     galaxy-tool-util[cwl,edam]
     galaxy-tool-shed-schema
     galaxy-tours
-    galaxy-util[image-util]
+    galaxy-util[image-util,jstree]
     galaxy-web-framework
     galaxy-web-stack
     Beaker
@@ -91,6 +91,8 @@ test =
     pykwalify
     pytest
     pytest-asyncio
+    pytest-mock
+    responses
     testfixtures
 
 [options.entry_points]

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -69,6 +69,7 @@ python_requires = >=3.10
 
 [options.extras_require]
 test = 
+    galaxy-config
     pytest
     roc-validator
 

--- a/packages/files/setup.cfg
+++ b/packages/files/setup.cfg
@@ -45,6 +45,7 @@ test =
     galaxy-test-base
     pytest
     gcsfs
+    responses
     s3fs>=2023.1.0
 
 [options.entry_points]

--- a/packages/packages_by_dep_dag.txt
+++ b/packages/packages_by_dep_dag.txt
@@ -20,6 +20,7 @@ tours
 auth
 job_execution
 test_api
+test_selenium
 web_framework
 web_stack
 

--- a/packages/schema/setup.cfg
+++ b/packages/schema/setup.cfg
@@ -31,6 +31,7 @@ version = 26.0.1.dev1
 [options]
 include_package_data = True
 install_requires =
+    galaxy-tool-util-models
     galaxy-util
     pydantic[email]>=2.7.4
 packages = find:

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -36,26 +36,14 @@ fi
 # Change to packages directory.
 cd "$(dirname "$0")"
 
-# Use a throw-away virtualenv
 TEST_PYTHON=${TEST_PYTHON:-"python3"}
-TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 
 if command -v uv >/dev/null; then
-    uv venv --python "$TEST_PYTHON" "$TEST_ENV_DIR"
+    VENV_CMD="uv venv --python $TEST_PYTHON"
     PIP_CMD="$(command -v uv) pip"
 else
-    "$TEST_PYTHON" -m venv "$TEST_ENV_DIR"
+    VENV_CMD="$TEST_PYTHON -m venv"
     PIP_CMD='python -m pip'
-fi
-
-# shellcheck disable=SC1091
-. "${TEST_ENV_DIR}/bin/activate"
-if [ "${PIP_CMD}" = 'python -m pip' ]; then
-    ${PIP_CMD} install --upgrade pip setuptools wheel
-fi
-if [ $FOR_PULSAR -eq 0 ]; then
-    # shellcheck disable=SC2086 - word splitting is intentional for PIP_EXTRA_ARGS
-    ${PIP_CMD} install ${PIP_EXTRA_ARGS} -r ../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
 fi
 
 # Ensure ordered by dependency DAG
@@ -77,8 +65,17 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
 
     cd "$package_dir"
 
+    # Use a throw-away virtualenv
+    TEST_ENV_DIR=$(mktemp -d -t gxpkgtestenvXXXXXX)
+    ${VENV_CMD} "$TEST_ENV_DIR"
+    # shellcheck disable=SC1091
+    . "${TEST_ENV_DIR}/bin/activate"
+    if [ "${PIP_CMD}" = 'python -m pip' ]; then
+        ${PIP_CMD} install --upgrade pip setuptools wheel
+    fi
+
     # Install extras (if needed)
-    # shellcheck disable=SC2086 - word splitting is intentional for PIP_EXTRA_ARGS
+    # shellcheck disable=SC2086 # word splitting is intentional for PIP_EXTRA_ARGS
     if [ "$package_dir" = "util" ]; then
         ${PIP_CMD} install ${PIP_EXTRA_ARGS} '.[image-util,template,jstree,config-template,test]'
     elif [ "$package_dir" = "tool_util" ]; then
@@ -97,6 +94,8 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
     # Ignore exit code 5 (no tests ran)
     pytest "${marker_args[@]}" . || test $? -eq 5
     if [ $FOR_PULSAR -eq 0 ]; then
+        # shellcheck disable=SC2086 # word splitting is intentional for PIP_EXTRA_ARGS
+        ${PIP_CMD} install ${PIP_EXTRA_ARGS} -r ../../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
         # make mypy uses uv now and so this legacy code should just run mypy
         # directly to use the venv we have already activated
         mypy .

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -59,7 +59,8 @@ packages = find:
 python_requires = >=3.10
 
 [options.extras_require]
-test = 
+test =
+    galaxy-test-base
     pytest
 
 [options.packages.find]

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -34,7 +34,7 @@ version = 26.0.1.dev1
 include_package_data = True
 install_requires =
     galaxy-tool-util-models
-    galaxy-util[image-util]>=22.1
+    galaxy-util[template,image-util]>=22.1
     conda-package-streaming
     lxml!=4.2.2
     MarkupSafe
@@ -64,6 +64,7 @@ console_scripts =
 
 [options.extras_require]
 cwl =
+    cwl-utils
     cwltool>=3.1.20230624081518
 mulled =
     jinja2

--- a/packages/tours/setup.cfg
+++ b/packages/tours/setup.cfg
@@ -32,6 +32,8 @@ version = 26.0.1.dev1
 include_package_data = True
 install_requires =
     galaxy-navigation
+    galaxy-schema
+    galaxy-util
     pydantic>=2.7.4
     PyYAML
 packages = find:
@@ -40,6 +42,10 @@ python_requires = >=3.10
 [options.entry_points]
 console_scripts =
         gx-validate-tours = galaxy.tours.validate:main
+
+[options.extras_require]
+test =
+    pytest
 
 [options.packages.find]
 exclude =

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -56,6 +56,7 @@ template =
     fissix;python_version>='3.13'
     future>=1.0.0
 config-template =
+    galaxy-tool-util-models
     Jinja2
     pydantic>=2.7.4
 test =

--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -80,7 +80,7 @@ class TestIsEmailBanned:
         assert is_email_banned("ab+bar@gmail.com", "_", rules)
         assert not is_email_banned("ab-bar@gmail.com", "_", rules)  # different sub-addressing delimiter
 
-    def test_no_canonical_rules(self, monkeypatch, appconfig):
+    def test_no_canonical_rules(self, monkeypatch):
         """No rules loaded."""
         monkeypatch.setattr(validate_user_input, "_read_email_ban_list", lambda a: self.mock_ban_list)
 
@@ -97,7 +97,7 @@ class TestIsEmailBanned:
         assert not is_email_banned("a.b@gmail.com", "_", rules)
         assert not is_email_banned("ab+bar@gmail.com", "_", rules)
 
-    def test_custom_canonical_rules(self, monkeypatch, appconfig):
+    def test_custom_canonical_rules(self, monkeypatch):
         """No rules loaded."""
         monkeypatch.setattr(validate_user_input, "_read_email_ban_list", lambda a: self.mock_ban_list)
 

--- a/test/unit/selenium/test_has_driver.py
+++ b/test/unit/selenium/test_has_driver.py
@@ -888,7 +888,7 @@ class TestUtilityMethods:
     def test_prepend_timeout_message(self, has_driver_instance, request):
         """Test prepending message to timeout exception."""
         backend = request.node.callspec.params.get("has_driver_instance")
-        if backend == "selenium":
+        if backend in ("selenium", "proxy-selenium"):
             original_selenium_exc = SeleniumTimeoutException(msg="original message")
             new_selenium_exception = has_driver_instance.prepend_timeout_message(original_selenium_exc, "New prefix:")
             assert "New prefix:" in new_selenium_exception.msg


### PR DESCRIPTION
- Test and publish the [galaxy-test-selenium package](https://pypi.org/project/galaxy-test-selenium/), whose last release was 22.1.1 .
- Use a separate virtualenv to test each package in order to ensure their dependencies are comprehensively specified.
- Fix missing package dependencies revealed by the previous commit. Fix https://github.com/galaxyproject/galaxy/pull/21155/changes#r3065097385 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
