### PR TITLE
Replace Ingress with Gateway API HTTPRoute for ITs on Kubernetes

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -216,7 +216,7 @@ class ConditionalDependencies:
     def check_pbs_python(self):
         return "galaxy.jobs.runners.pbs:PBSJobRunner" in self.job_runners
 
-    def check_pykube_ng(self):
+    def check_new_pykube(self):
         return "galaxy.jobs.runners.kubernetes:KubernetesJobRunner" in self.job_runners or which("kubectl")
 
     def check_chronos_python(self):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -44,7 +44,7 @@ hvac
 chronos-python==1.2.1
 
 # Kubernetes job runner
-pykube-ng==23.6.0
+new-pykube>=26.3.0
 
 # Synnefo / Pithos+ object store client
 kamaki

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -24,22 +24,22 @@ from galaxy.jobs.runners import (
     JobState,
 )
 from galaxy.jobs.runners.util.pykube_util import (
+    create_httproute_class,
     deduplicate_entries,
-    DEFAULT_INGRESS_API_VERSION,
+    DEFAULT_HTTPROUTE_API_VERSION,
     DEFAULT_JOB_API_VERSION,
-    delete_ingress,
+    delete_httproute,
     delete_job,
     delete_service,
     ensure_pykube,
-    find_ingress_object_by_name,
+    find_httproute_object_by_name,
     find_job_object_by_name,
     find_pod_object_by_name,
     find_service_object_by_name,
     galaxy_instance_id,
     get_volume_mounts_for_job,
     HTTPError,
-    Ingress,
-    ingress_object_dict,
+    httproute_object_dict,
     is_pod_running,
     is_pod_unschedulable,
     Job,
@@ -129,10 +129,11 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             k8s_walltime_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=172800),
             k8s_unschedulable_walltime_limit=dict(map=int, valid=lambda x: not x or int(x) >= 0, default=None),
             k8s_interactivetools_use_ssl=dict(map=bool, default=False),
-            k8s_interactivetools_ingress_annotations=dict(map=str),
-            k8s_interactivetools_ingress_class=dict(map=str, default=None),
             k8s_interactivetools_tls_secret=dict(map=str, default=None),
-            k8s_ingress_api_version=dict(map=str, default=DEFAULT_INGRESS_API_VERSION),
+            # Gateway API parameters
+            k8s_gateway_name=dict(map=str, default="galaxy-gateway"),
+            k8s_gateway_namespace=dict(map=str, default="gateway-system"),
+            k8s_httproute_api_version=dict(map=str, default=DEFAULT_HTTPROUTE_API_VERSION),
         )
 
         if "runner_param_specs" not in kwargs:
@@ -258,15 +259,17 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         log.debug(f"Configuring entry points and deploying service/ingress for job with ID {ajs.job_id}")
         k8s_service_obj = service_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_service_spec(ajs))
 
-        k8s_ingress_obj = ingress_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_ingress_spec(ajs))
-        log.debug(f"Kubernetes service object: {json.dumps(k8s_service_obj, indent=4)}")
-        log.debug(f"Kubernetes ingress object: {json.dumps(k8s_ingress_obj, indent=4)}")
-        # We avoid creating service and ingress if they already exist (e.g. when Galaxy is restarted or resubmitting a job)
+        # Create service first
         service = Service(self._pykube_api, k8s_service_obj)
         service.create()
-        ingress = Ingress(self._pykube_api, k8s_ingress_obj)
-        ingress.version = self.runner_params["k8s_ingress_api_version"]
-        ingress.create()
+        log.debug(f"Kubernetes service object: {json.dumps(k8s_service_obj, indent=4)}")
+
+        # Create HTTPRoute for Gateway API
+        k8s_httproute_obj = httproute_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_httproute_spec(ajs))
+        log.debug(f"Kubernetes HTTPRoute object: {json.dumps(k8s_httproute_obj, indent=4)}")
+        HTTPRoute = create_httproute_class(self._pykube_api)
+        httproute = HTTPRoute(self._pykube_api, k8s_httproute_obj)
+        httproute.create()
 
     def __get_overridable_params(self, job_wrapper, param_key):
         try:
@@ -409,57 +412,9 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
         }
         return k8s_spec_template
 
-    def __get_k8s_ingress_rules_spec(self, ajs, entry_points):
-        """This represents the template for the "rules" portion of the Ingress spec."""
-        if "v1beta1" in self.runner_params["k8s_ingress_api_version"]:
-            rules_spec = [
-                {
-                    "host": ep["domain"],
-                    "http": {
-                        "paths": [
-                            {
-                                "backend": {
-                                    "serviceName": self.__get_k8s_job_name(
-                                        self.__produce_k8s_job_prefix(), ajs.job_wrapper
-                                    ),
-                                    "servicePort": int(ep["tool_port"]),
-                                },
-                                "path": ep.get("entry_path", "/"),
-                                "pathType": "Prefix",
-                            }
-                        ]
-                    },
-                }
-                for ep in entry_points
-            ]
-        else:
-            rules_spec = [
-                {
-                    "host": ep["domain"],
-                    "http": {
-                        "paths": [
-                            {
-                                "backend": {
-                                    "service": {
-                                        "name": self.__get_k8s_job_name(
-                                            self.__produce_k8s_job_prefix(), ajs.job_wrapper
-                                        ),
-                                        "port": {"number": int(ep["tool_port"])},
-                                    }
-                                },
-                                "path": ep.get("entry_path", "/"),
-                                "pathType": "ImplementationSpecific",
-                            }
-                        ]
-                    },
-                }
-                for ep in entry_points
-            ]
-        return rules_spec
 
-    def __get_k8s_ingress_spec(self, ajs):
-        """The k8s spec template is nothing but a Ingress spec, except that it is nested and does not have an apiversion
-        nor kind."""
+    def __get_k8s_httproute_spec(self, ajs):
+        """The HTTPRoute spec for Gateway API routing."""
         guest_ports = ajs.job_wrapper.guest_ports
         if len(guest_ports) > 0:
             entry_points = []
@@ -468,7 +423,7 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 # sending in self.app as `trans` since it's only used for `.security` so seems to work
                 entry_point_path = self.app.interactivetool_manager.get_entry_point_path(self.app, entry_point)
                 if "?" in entry_point_path:
-                    # Removing all the parameters from the ingress path, but they will still be in the database
+                    # Removing all the parameters from the HTTPRoute path, but they will still be in the database
                     # so the link that the user clicks on will still have them
                     log.warning(
                         "IT urls including parameters (eg: /myit?mykey=myvalue) are only experimentally supported on K8S"
@@ -484,6 +439,8 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 entry_points.append(
                     {"tool_port": entry_point.tool_port, "domain": entry_point_domain, "entry_path": entry_point_path}
                 )
+
+        # Build HTTPRoute spec
         k8s_spec_template = {
             "metadata": {
                 "labels": {
@@ -494,26 +451,52 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 },
                 "annotations": {"app.galaxyproject.org/tool_id": ajs.job_wrapper.tool.id},
             },
-            "spec": {"rules": self.__get_k8s_ingress_rules_spec(ajs, entry_points)},
+            "spec": {
+                "parentRefs": [
+                    {
+                        "name": self.runner_params.get("k8s_gateway_name", "galaxy-gateway"),
+                        "namespace": self.runner_params.get("k8s_gateway_namespace", "gateway-system"),
+                    }
+                ],
+                "hostnames": list({ep["domain"] for ep in entry_points}),
+                "rules": self.__get_k8s_httproute_rules_spec(ajs, entry_points),
+            },
         }
-        default_ingress_class = self.runner_params.get("k8s_interactivetools_ingress_class")
-        if default_ingress_class:
-            k8s_spec_template["spec"]["ingressClassName"] = default_ingress_class
-        if self.runner_params.get("k8s_interactivetools_use_ssl"):
-            domains = list({e["domain"] for e in entry_points})
-            override_secret = self.runner_params.get("k8s_interactivetools_tls_secret")
-            if override_secret:
-                k8s_spec_template["spec"]["tls"] = [
-                    {"hosts": [domain], "secretName": override_secret} for domain in domains
-                ]
-            else:
-                k8s_spec_template["spec"]["tls"] = [
-                    {"hosts": [domain], "secretName": re.sub("[^a-z0-9-]", "-", domain)} for domain in domains
-                ]
-        if self.runner_params.get("k8s_interactivetools_ingress_annotations"):
-            new_ann = yaml.safe_load(self.runner_params.get("k8s_interactivetools_ingress_annotations"))
-            k8s_spec_template["metadata"]["annotations"].update(new_ann)
         return k8s_spec_template
+
+    def __get_k8s_httproute_rules_spec(self, ajs, entry_points):
+        """This represents the template for the HTTPRoute rules spec."""
+        service_name = self.__get_k8s_job_name(self.__produce_k8s_job_prefix(), ajs.job_wrapper)
+
+        rules_spec = []
+        for ep in entry_points:
+            rule = {
+                "matches": [
+                    {
+                        "path": {
+                            "type": "PathPrefix",
+                            "value": ep.get("entry_path", "/"),
+                        }
+                    }
+                ],
+                "backendRefs": [
+                    {
+                        "name": service_name,
+                        "port": int(ep["tool_port"]),
+                    }
+                ],
+            }
+            # Add hostname filter if using domain-based routing
+            if ep["domain"] != f"{self.app.config.interactivetools_proxy_host}":
+                rule["matches"][0]["headers"] = [
+                    {
+                        "name": "Host",
+                        "value": ep["domain"],
+                    }
+                ]
+            rules_spec.append(rule)
+
+        return rules_spec
 
     def __get_k8s_security_context(self, job_wrapper):
         security_context = {}
@@ -900,9 +883,9 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                 )
                 self.work_queue.put((self.__cleanup_k8s_job, new_retryable_job_state))
 
-    def __cleanup_k8s_ingress(self, ingress, job_failed=False):
+    def __cleanup_k8s_httproute(self, httproute, job_failed=False):
         k8s_cleanup_job = self.runner_params["k8s_cleanup_job"]
-        delete_ingress(ingress, k8s_cleanup_job, job_failed)
+        delete_httproute(httproute, k8s_cleanup_job, job_failed)
 
     def __cleanup_k8s_service(self, service, job_failed=False):
         k8s_cleanup_job = self.runner_params["k8s_cleanup_job"]
@@ -987,15 +970,18 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
     def __cleanup_k8s_guest_ports(self, job_wrapper, k8s_job):
         k8s_job_prefix = self.__produce_k8s_job_prefix()
         k8s_job_name = f"{k8s_job_prefix}-{self.__force_label_conformity(job_wrapper.get_id_tag())}"
-        log.debug(f"Deleting service/ingress for job with ID {job_wrapper.get_id_tag()}")
-        ingress_to_delete = find_ingress_object_by_name(
+
+        # Delete HTTPRoute (Gateway API)
+        log.debug(f"Deleting service/HTTPRoute for job with ID {job_wrapper.get_id_tag()}")
+        httproute_to_delete = find_httproute_object_by_name(
             self._pykube_api, k8s_job_name, self.runner_params["k8s_namespace"]
         )
-        if ingress_to_delete and len(ingress_to_delete.response["items"]) > 0:
-            k8s_ingress = Ingress(self._pykube_api, ingress_to_delete.response["items"][0])
-            self.__cleanup_k8s_ingress(k8s_ingress)
+        if httproute_to_delete and len(httproute_to_delete.response["items"]) > 0:
+            HTTPRoute = create_httproute_class(self._pykube_api)
+            k8s_httproute = HTTPRoute(self._pykube_api, httproute_to_delete.response["items"][0])
+            self.__cleanup_k8s_httproute(k8s_httproute)
         else:
-            log.debug(f"No ingress found for job with k8s_job_name {k8s_job_name}")
+            log.debug(f"No HTTPRoute found for job with k8s_job_name {k8s_job_name}")
         service_to_delete = find_service_object_by_name(
             self._pykube_api, k8s_job_name, self.runner_params["k8s_namespace"]
         )

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -13,18 +13,18 @@ try:
     )
     from pykube.http import HTTPClient
     from pykube.objects import (
-        Ingress,
         Job,
         Pod,
         Service,
+        object_factory,
     )
 except ImportError as exc:
     KubeConfig = None
-    Ingress = None
     Job = None
     Pod = None
     Service = None
     HTTPError = None
+    object_factory = None
     K8S_IMPORT_MESSAGE = (
         "The Python pykube package is required to use "
         "this feature, please install it or correct the "
@@ -35,7 +35,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_JOB_API_VERSION = "batch/v1"
 DEFAULT_SERVICE_API_VERSION = "v1"
-DEFAULT_INGRESS_API_VERSION = "networking.k8s.io/v1"
+DEFAULT_HTTPROUTE_API_VERSION = "gateway.networking.k8s.io/v1"
 DEFAULT_NAMESPACE = "default"
 INSTANCE_ID_INVALID_MESSAGE = (
     "Galaxy instance [%s] is either too long "
@@ -81,10 +81,6 @@ def find_service_object_by_name(pykube_api, service_name, namespace=None):
     return Service.objects(pykube_api).filter(field_selector={"metadata.name": service_name}, namespace=namespace)
 
 
-def find_ingress_object_by_name(pykube_api, ingress_name, namespace=None):
-    if not ingress_name:
-        raise ValueError("ingress name must not be empty")
-    return Ingress.objects(pykube_api).filter(field_selector={"metadata.name": ingress_name}, namespace=namespace)
 
 
 def find_job_object_by_name(pykube_api, job_name, namespace=None):
@@ -130,14 +126,14 @@ def delete_job(job, cleanup="always"):
         job.api.raise_for_status(r)
 
 
-def delete_ingress(ingress, cleanup="always", job_failed=False):
+def delete_httproute(httproute, cleanup="always", job_failed=False):
     api_delete = cleanup == "always"
     if not api_delete and cleanup == "onsuccess" and not job_failed:
         api_delete = True
     if api_delete:
         delete_options = {"apiVersion": "v1", "kind": "DeleteOptions", "propagationPolicy": "Background"}
-        r = ingress.api.delete(json=delete_options, **ingress.api_kwargs())
-        ingress.api.raise_for_status(r)
+        r = httproute.api.delete(json=delete_options, **httproute.api_kwargs())
+        httproute.api.raise_for_status(r)
 
 
 def delete_service(service, cleanup="always", job_failed=False):
@@ -177,19 +173,32 @@ def service_object_dict(params, service_name, spec):
     return k8s_service_obj
 
 
-def ingress_object_dict(params, ingress_name, spec):
-    k8s_ingress_obj = {
-        "apiVersion": params.get("k8s_ingress_api_version", DEFAULT_INGRESS_API_VERSION),
-        "kind": "Ingress",
+def httproute_object_dict(params, route_name, spec):
+    k8s_httproute_obj = {
+        "apiVersion": params.get("k8s_httproute_api_version", DEFAULT_HTTPROUTE_API_VERSION),
+        "kind": "HTTPRoute",
         "metadata": {
-            "name": ingress_name,
+            "name": route_name,
             "namespace": params.get("k8s_namespace", DEFAULT_NAMESPACE),
-            # TODO: Add default annotations
         },
     }
-    k8s_ingress_obj["metadata"].update(spec.pop("metadata", {}))
-    k8s_ingress_obj.update(spec)
-    return k8s_ingress_obj
+    k8s_httproute_obj["metadata"].update(spec.pop("metadata", {}))
+    k8s_httproute_obj.update(spec)
+    return k8s_httproute_obj
+
+
+def create_httproute_class(pykube_api):
+    """Create HTTPRoute class dynamically using new-pykube object_factory."""
+    if object_factory is None:
+        raise Exception("new-pykube package required for Gateway API support")
+    return object_factory(pykube_api, DEFAULT_HTTPROUTE_API_VERSION, "HTTPRoute")
+
+
+def find_httproute_object_by_name(pykube_api, route_name, namespace=None):
+    if not route_name:
+        raise ValueError("HTTPRoute name must not be empty")
+    HTTPRoute = create_httproute_class(pykube_api)
+    return HTTPRoute.objects(pykube_api).filter(field_selector={"metadata.name": route_name}, namespace=namespace)
 
 
 def parse_pvc_param_line(pvc_param):
@@ -318,10 +327,10 @@ def galaxy_instance_id(params):
 __all__ = (
     "DEFAULT_JOB_API_VERSION",
     "DEFAULT_SERVICE_API_VERSION",
-    "DEFAULT_INGRESS_API_VERSION",
+    "DEFAULT_HTTPROUTE_API_VERSION",
     "ensure_pykube",
     "find_service_object_by_name",
-    "find_ingress_object_by_name",
+    "find_httproute_object_by_name",
     "find_job_object_by_name",
     "find_pod_object_by_name",
     "galaxy_instance_id",
@@ -330,17 +339,17 @@ __all__ = (
     "is_pod_unschedulable",
     "Job",
     "Service",
-    "Ingress",
     "job_object_dict",
     "service_object_dict",
-    "ingress_object_dict",
+    "httproute_object_dict",
+    "create_httproute_class",
     "Pod",
     "produce_k8s_job_prefix",
     "pull_policy",
     "pykube_client_from_dict",
     "delete_job",
     "delete_service",
-    "delete_ingress",
+    "delete_httproute",
     "get_volume_mounts_for_job",
     "parse_pvc_param_line",
 )


### PR DESCRIPTION
Kubernetes Ingress [has been retired as of March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/). This PR migrates the Kubernetes job runner from traditional Ingress resources to Gateway API HTTPRoute for Interactive Tools routing, enabling compatibility with the new Galaxy Helm chart Gateway API implementation [#531](https://github.com/galaxyproject/galaxy-helm/pull/531).

## Changes

**Dependency Migration**
- Migrated from `pykube-ng==23.6.0` to `new-pykube>=26.3.0` for Gateway API support
- Uses dynamic `object_factory` to create HTTPRoute classes

The `new-pykube` package is a fork of `pykube-ng`, which is no longer being maintained.

**Gateway API Implementation**
- Completely replaced Ingress with HTTPRoute (`gateway.networking.k8s.io/v1`)
- Added new configuration parameters:
  - `k8s_gateway_name` (default: "galaxy-gateway") 
  - `k8s_gateway_namespace` (default: "gateway-system")
  - `k8s_httproute_api_version`
- Implemented HTTPRoute creation with parentRefs, hostnames, and path-based routing rules

**Removed Legacy Code**
- All Ingress-related parameters and functionality
- Ingress spec generation and cleanup methods

## Breaking Changes

- Requires Gateway API CRDs and Gateway resource to be configured in cluster
- Legacy `k8s_interactivetools_ingress_*` parameters no longer supported

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
