### PR TITLE
[26.0] Fix `get_structure` when it is passed a DCE with nested elements

### DIFF
--- a/lib/galaxy/model/dataset_collections/matching.py
+++ b/lib/galaxy/model/dataset_collections/matching.py
@@ -3,6 +3,7 @@ from typing import Optional
 from galaxy import exceptions
 from galaxy.util import bunch
 from .structure import (
+    get_collection,
     get_structure,
     leaf,
 )
@@ -32,11 +33,6 @@ class CollectionsToMatch:
         return self.collections.items()
 
 
-def get_child_collection(item):
-    # item could be HDCA or DCE
-    return getattr(item, "child_collection", item.collection)
-
-
 class MatchingCollections:
     """Structure holding the result of matching a list of collections
     together. This class being different than the class above and being
@@ -59,7 +55,7 @@ class MatchingCollections:
         self, input_name, hdca, child_collection, collection_type_description, subcollection_type
     ):
         structure = get_structure(
-            hdca, collection_type_description, leaf_subcollection_type=subcollection_type, collection=child_collection
+            child_collection, collection_type_description, leaf_subcollection_type=subcollection_type
         )
         if not self.linked_structure:
             self.linked_structure = structure
@@ -73,7 +69,7 @@ class MatchingCollections:
 
     def slice_collections(self):
         self.linked_structure.when_values = self.when_values
-        return self.linked_structure.walk_collections(self.collections)
+        return self.linked_structure.walk_collections({k: get_collection(v) for k, v in self.collections.items()})
 
     def subcollection_mapping_type(self, input_name):
         return self.subcollection_types[input_name]
@@ -94,7 +90,7 @@ class MatchingCollections:
     def map_over_action_tuples(self, input_name):
         if input_name not in self.action_tuples:
             collection_instance = self.collections[input_name]
-            self.action_tuples[input_name] = get_child_collection(collection_instance).dataset_action_tuples
+            self.action_tuples[input_name] = get_collection(collection_instance).dataset_action_tuples
         return self.action_tuples[input_name]
 
     def is_mapped_over(self, input_name):
@@ -113,7 +109,7 @@ class MatchingCollections:
             # (not dce.collection which is the *parent*).
             # Both collection_type_description and get_structure must
             # use the same collection so the type and elements agree.
-            child_collection = get_child_collection(hdca)
+            child_collection = get_collection(hdca)
             collection_type_description = collection_type_descriptions.for_collection_type(
                 child_collection.collection_type
             )
@@ -125,10 +121,9 @@ class MatchingCollections:
                 )
             else:
                 structure = get_structure(
-                    hdca,
+                    child_collection,
                     collection_type_description,
                     leaf_subcollection_type=subcollection_type,
-                    collection=child_collection,
                 )
                 matching_collections.unlinked_structures.append(structure)
 

--- a/lib/galaxy/model/dataset_collections/matching.py
+++ b/lib/galaxy/model/dataset_collections/matching.py
@@ -55,8 +55,12 @@ class MatchingCollections:
         self.action_tuples = {}
         self.when_values = None
 
-    def __attempt_add_to_linked_match(self, input_name, hdca, collection_type_description, subcollection_type):
-        structure = get_structure(hdca, collection_type_description, leaf_subcollection_type=subcollection_type)
+    def __attempt_add_to_linked_match(
+        self, input_name, hdca, child_collection, collection_type_description, subcollection_type
+    ):
+        structure = get_structure(
+            hdca, collection_type_description, leaf_subcollection_type=subcollection_type, collection=child_collection
+        )
         if not self.linked_structure:
             self.linked_structure = structure
             self.collections[input_name] = hdca
@@ -104,17 +108,28 @@ class MatchingCollections:
         matching_collections = MatchingCollections()
         for input_key, to_match in sorted(collections_to_match.items()):
             hdca = to_match.hdca
+            # Resolve the contained collection: for an HDCA this is
+            # hdca.collection; for a DCE it is dce.child_collection
+            # (not dce.collection which is the *parent*).
+            # Both collection_type_description and get_structure must
+            # use the same collection so the type and elements agree.
+            child_collection = get_child_collection(hdca)
             collection_type_description = collection_type_descriptions.for_collection_type(
-                get_child_collection(hdca).collection_type
+                child_collection.collection_type
             )
             subcollection_type = to_match.subcollection_type
 
             if to_match.linked:
                 matching_collections.__attempt_add_to_linked_match(
-                    input_key, hdca, collection_type_description, subcollection_type
+                    input_key, hdca, child_collection, collection_type_description, subcollection_type
                 )
             else:
-                structure = get_structure(hdca, collection_type_description, leaf_subcollection_type=subcollection_type)
+                structure = get_structure(
+                    hdca,
+                    collection_type_description,
+                    leaf_subcollection_type=subcollection_type,
+                    collection=child_collection,
+                )
                 matching_collections.unlinked_structures.append(structure)
 
         return matching_collections

--- a/lib/galaxy/model/dataset_collections/structure.py
+++ b/lib/galaxy/model/dataset_collections/structure.py
@@ -112,10 +112,8 @@ class Tree(BaseTree):
             column_definitions=dataset_collection.column_definitions,
         )
 
-    def walk_collections(self, hdca_dict):
-        # Resolve each HDCA/DCE to its contained DatasetCollection so
-        # element indices align with the structure's children.
-        return self._walk_collections(dict_map(lambda hdca: get_collection(hdca), hdca_dict))
+    def walk_collections(self, collection_dict):
+        return self._walk_collections(collection_dict)
 
     def _walk_collections(self, collection_dict):
         for index, (_identifier, substructure) in enumerate(self.children):
@@ -242,7 +240,9 @@ def get_collection(
       - ``collection``: the collection it wraps
 
     This helper returns the *contained* collection in both cases
-    (child_collection for DCE, collection for HDCA/adapters).
+    (child_collection for DCE, collection for HDCA/adapters) and is
+    intended for callers that still hold a wrapper object and need a
+    DatasetCollection to pass to ``get_structure`` or ``walk_collections``.
     """
     if (
         isinstance(dataset_collection_instance, DatasetCollectionElement)
@@ -253,44 +253,29 @@ def get_collection(
 
 
 def get_structure(
-    dataset_collection_instance: "CollectionLike",
+    collection: "DatasetCollection",
     collection_type_description: "CollectionTypeDescription",
     leaf_subcollection_type: Optional[str] = None,
-    collection: Optional["DatasetCollection"] = None,
 ):
     """Build a Tree (or UninitializedTree) describing a collection's shape.
 
     ``collection_type_description`` controls the depth of the tree:
     elements below ``leaf_subcollection_type`` are treated as leaves.
-
-    ``collection`` is the DatasetCollection to enumerate elements from.
-    When omitted, ``dataset_collection_instance.collection`` is used —
-    which is correct for an HDCA but **not** for a DCE (where
-    ``.collection`` is the *parent*).  Callers that hold a DCE should
-    resolve the contained collection themselves and pass it explicitly
-    (see ``matching.for_collections``).
     """
     if leaf_subcollection_type:
-        # Strip the leaf type from the description so it becomes a leaf
-        # in the resulting tree.  E.g. "list:paired" with
-        # leaf_subcollection_type="paired" → description becomes "list".
-        collection_type_description = collection_type_description.effective_collection_type_description(
-            leaf_subcollection_type
-        )
-        if (
-            isinstance(dataset_collection_instance, DatasetCollectionElement)
-            and dataset_collection_instance.child_collection
-        ):
-            # DCE whose child_collection *is* the leaf subcollection.
-            # We don't need to enumerate its elements — just record the
-            # type so multiply() can combine it with the mapping structure.
-            collection_type_description = (
+        if not collection_type_description.has_subcollections_of_type(leaf_subcollection_type):
+            # The described collection IS the leaf subcollection (no deeper
+            # structure to strip). Don't enumerate its elements; just record
+            # the type so multiply() can combine it with the mapping structure.
+            return UninitializedTree(
                 collection_type_description.collection_type_description_factory.for_collection_type(
                     leaf_subcollection_type
                 )
             )
-            return UninitializedTree(collection_type_description)
-
-    if collection is None:
-        collection = dataset_collection_instance.collection
+        # Strip the leaf type from the description so it becomes a leaf
+        # in the resulting tree. E.g. "list:paired" with
+        # leaf_subcollection_type="paired" → description becomes "list".
+        collection_type_description = collection_type_description.effective_collection_type_description(
+            leaf_subcollection_type
+        )
     return Tree.for_dataset_collection(collection, collection_type_description)

--- a/lib/galaxy/model/dataset_collections/structure.py
+++ b/lib/galaxy/model/dataset_collections/structure.py
@@ -1,9 +1,21 @@
 """Module for reasoning about structure of and matching hierarchical collections of data."""
 
-from typing import TYPE_CHECKING
+from typing import (
+    Optional,
+    TYPE_CHECKING,
+    Union,
+)
+
+from galaxy.model import DatasetCollectionElement
 
 if TYPE_CHECKING:
+    from galaxy.model import (
+        DatasetCollection,
+        HistoryDatasetCollectionAssociation,
+    )
     from .type_description import CollectionTypeDescription
+
+    CollectionLike = Union[DatasetCollectionElement, "HistoryDatasetCollectionAssociation"]
 
 
 class Leaf:
@@ -101,7 +113,9 @@ class Tree(BaseTree):
         )
 
     def walk_collections(self, hdca_dict):
-        return self._walk_collections(dict_map(lambda hdca: hdca.collection, hdca_dict))
+        # Resolve each HDCA/DCE to its contained DatasetCollection so
+        # element indices align with the structure's children.
+        return self._walk_collections(dict_map(lambda hdca: get_collection(hdca), hdca_dict))
 
     def _walk_collections(self, collection_dict):
         for index, (_identifier, substructure) in enumerate(self.children):
@@ -215,14 +229,61 @@ def dict_map(func, input_dict):
     return {k: func(v) for k, v in input_dict.items()}
 
 
+def get_collection(
+    dataset_collection_instance: "CollectionLike",
+) -> "DatasetCollection":
+    """Return the DatasetCollection contained by a collection instance.
+
+    A DatasetCollectionElement has two collection references:
+      - ``collection``: the **parent** collection this element belongs to
+      - ``child_collection``: the nested collection this element *contains*
+
+    An HDCA has one:
+      - ``collection``: the collection it wraps
+
+    This helper returns the *contained* collection in both cases
+    (child_collection for DCE, collection for HDCA/adapters).
+    """
+    if (
+        isinstance(dataset_collection_instance, DatasetCollectionElement)
+        and dataset_collection_instance.child_collection
+    ):
+        return dataset_collection_instance.child_collection
+    return dataset_collection_instance.collection
+
+
 def get_structure(
-    dataset_collection_instance, collection_type_description: "CollectionTypeDescription", leaf_subcollection_type=None
+    dataset_collection_instance: "CollectionLike",
+    collection_type_description: "CollectionTypeDescription",
+    leaf_subcollection_type: Optional[str] = None,
+    collection: Optional["DatasetCollection"] = None,
 ):
+    """Build a Tree (or UninitializedTree) describing a collection's shape.
+
+    ``collection_type_description`` controls the depth of the tree:
+    elements below ``leaf_subcollection_type`` are treated as leaves.
+
+    ``collection`` is the DatasetCollection to enumerate elements from.
+    When omitted, ``dataset_collection_instance.collection`` is used —
+    which is correct for an HDCA but **not** for a DCE (where
+    ``.collection`` is the *parent*).  Callers that hold a DCE should
+    resolve the contained collection themselves and pass it explicitly
+    (see ``matching.for_collections``).
+    """
     if leaf_subcollection_type:
+        # Strip the leaf type from the description so it becomes a leaf
+        # in the resulting tree.  E.g. "list:paired" with
+        # leaf_subcollection_type="paired" → description becomes "list".
         collection_type_description = collection_type_description.effective_collection_type_description(
             leaf_subcollection_type
         )
-        if hasattr(dataset_collection_instance, "child_collection"):
+        if (
+            isinstance(dataset_collection_instance, DatasetCollectionElement)
+            and dataset_collection_instance.child_collection
+        ):
+            # DCE whose child_collection *is* the leaf subcollection.
+            # We don't need to enumerate its elements — just record the
+            # type so multiply() can combine it with the mapping structure.
             collection_type_description = (
                 collection_type_description.collection_type_description_factory.for_collection_type(
                     leaf_subcollection_type
@@ -230,5 +291,6 @@ def get_structure(
             )
             return UninitializedTree(collection_type_description)
 
-    collection = dataset_collection_instance.collection
+    if collection is None:
+        collection = dataset_collection_instance.collection
     return Tree.for_dataset_collection(collection, collection_type_description)

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -25,6 +25,7 @@ from galaxy.exceptions import ToolInputsNotOKException
 from galaxy.model import ToolRequest
 from galaxy.model.dataset_collections.matching import MatchingCollections
 from galaxy.model.dataset_collections.structure import (
+    get_collection,
     get_structure,
     tool_output_to_structure,
 )
@@ -518,7 +519,9 @@ class ExecutionTracker:
             subcollection_mapping_type = collection_info.subcollection_mapping_type(input_name)
 
         return get_structure(
-            input_collection, collection_type_description, leaf_subcollection_type=subcollection_mapping_type
+            get_collection(input_collection),
+            collection_type_description,
+            leaf_subcollection_type=subcollection_mapping_type,
         )
 
     def _structure_for_output(self, trans, tool_output):
@@ -708,7 +711,9 @@ class ExecutionTracker:
     def walk_implicit_collections(self):
         collection_info = self.collection_info
         assert collection_info
-        return collection_info.structure.walk_collections(self.implicit_collections)
+        return collection_info.structure.walk_collections(
+            {k: get_collection(v) for k, v in self.implicit_collections.items()}
+        )
 
     def new_execution_slices(self):
         if self.collection_info is None:

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2747,8 +2747,34 @@ class TestToolsApi(ApiTestCase, TestsTools):
             self._assert_status_code_is(response, 200)
 
             response_object = response.json()
-            assert len(response_object["outputs"]) == 1
-            assert len(response_object["jobs"]) == 1
+            assert len(response_object["jobs"]) == 2
+            assert len(response_object["implicit_collections"]) == 1
+
+    def test_can_map_over_dce_from_larger_list_paired(self):
+        """Regression: mapping a DCE should use the child collection structure,
+        not the parent list structure. Previously raised KeyError when the parent
+        list had more elements than the child pair collection."""
+        with self.dataset_populator.test_history() as history_id:
+            pair_ids = []
+            for _ in range(3):
+                pair_id = self.dataset_collection_populator.create_pair_in_history(
+                    history_id, contents=["0", "0"], wait=True
+                ).json()["outputs"][0]["id"]
+                pair_ids.append(pair_id)
+            ok_hdca = self.dataset_collection_populator.create_list_from_pairs(history_id, pair_ids)
+            dce_id = ok_hdca.json()["elements"][0]["id"]
+
+            inputs = {
+                "input1": {
+                    "batch": True,
+                    "values": [{"src": "dce", "id": dce_id, "map_over_type": None}],
+                },
+            }
+            response = self._run_cat1(history_id, inputs=inputs)
+            self._assert_status_code_is(response, 200)
+
+            response_object = response.json()
+            assert len(response_object["jobs"]) == 2
             assert len(response_object["implicit_collections"]) == 1
 
     @skip_without_tool("identifier_source")

--- a/test/unit/data/dataset_collections/test_structure.py
+++ b/test/unit/data/dataset_collections/test_structure.py
@@ -12,7 +12,7 @@ factory = CollectionTypeDescriptionFactory(None)
 
 def test_get_structure_simple():
     paired_type_description = factory.for_collection_type("paired")
-    tree = get_structure(pair_instance(), paired_type_description)
+    tree = get_structure(pair_instance().collection, paired_type_description)
     assert len(tree.children) == 2
     assert tree.children[0][0] == "left"  # why not forward?
     assert tree.children[0][1].is_leaf
@@ -20,7 +20,7 @@ def test_get_structure_simple():
 
 def test_get_structure_list_paired_over_paired():
     paired_type_description = factory.for_collection_type("list:paired")
-    tree = get_structure(list_paired_instance(), paired_type_description, "paired")
+    tree = get_structure(list_paired_instance().collection, paired_type_description, "paired")
     assert tree.collection_type_description.collection_type == "list"
     assert len(tree.children) == 3
     assert tree.children[0][0] == "data1"
@@ -29,7 +29,7 @@ def test_get_structure_list_paired_over_paired():
 
 def test_get_structure_list_of_lists():
     list_of_lists_type_description = factory.for_collection_type("list:list")
-    tree = get_structure(list_of_lists_instance(), list_of_lists_type_description)
+    tree = get_structure(list_of_lists_instance().collection, list_of_lists_type_description)
     assert tree.collection_type_description.collection_type == "list:list"
     assert len(tree.children) == 2
     assert tree.children[0][0] == "outer1"
@@ -38,7 +38,7 @@ def test_get_structure_list_of_lists():
 
 def test_get_structure_list_of_lists_over_list():
     list_of_lists_type_description = factory.for_collection_type("list:list")
-    tree = get_structure(list_of_lists_instance(), list_of_lists_type_description, "list")
+    tree = get_structure(list_of_lists_instance().collection, list_of_lists_type_description, "list")
     assert tree.collection_type_description.collection_type == "list"
     assert len(tree.children) == 2
     assert tree.children[0][0] == "outer1"
@@ -47,7 +47,7 @@ def test_get_structure_list_of_lists_over_list():
 
 def test_get_structure_list_paired_or_unpaired():
     list_pair_or_unpaired_description = factory.for_collection_type("list:paired_or_unpaired")
-    tree = get_structure(list_of_paired_and_unpaired_instance(), list_pair_or_unpaired_description)
+    tree = get_structure(list_of_paired_and_unpaired_instance().collection, list_pair_or_unpaired_description)
     assert tree.collection_type_description.collection_type == "list:paired_or_unpaired"
     assert len(tree.children) == 2
     assert tree.children[0][0] == "el1"
@@ -57,7 +57,7 @@ def test_get_structure_list_paired_or_unpaired():
 def test_get_structure_list_paired_or_unpaired_over_paired_or_unpaired():
     list_pair_or_unpaired_description = factory.for_collection_type("list:paired_or_unpaired")
     tree = get_structure(
-        list_of_paired_and_unpaired_instance(), list_pair_or_unpaired_description, "paired_or_unpaired"
+        list_of_paired_and_unpaired_instance().collection, list_pair_or_unpaired_description, "paired_or_unpaired"
     )
     assert tree.collection_type_description.collection_type == "list"
     assert len(tree.children) == 2
@@ -67,7 +67,7 @@ def test_get_structure_list_paired_or_unpaired_over_paired_or_unpaired():
 
 def test_get_structure_list_of_lists_over_single_datasests():
     list_of_lists_type_description = factory.for_collection_type("list:list")
-    tree = get_structure(list_of_lists_instance(), list_of_lists_type_description, "single_datasets")
+    tree = get_structure(list_of_lists_instance().collection, list_of_lists_type_description, "single_datasets")
     assert tree.collection_type_description.collection_type == "list:list"
     assert len(tree.children) == 2
     assert tree.children[0][0] == "outer1"


### PR DESCRIPTION
`DatasetCollectionElement` has two collection references:
- `collection`: the parent collection this element belongs to
- `child_collection`: the nested collection this element contains

`get_structure()` and `walk_collections()` unconditionally used `.collection`, which for a DCE returns the parent (e.g. the full list:paired). Meanwhile the job expansion correctly used `child_collection` (e.g. the paired sub-collection). This mismatch caused a `KeyError` when the parent had more elements than the child.

Bug scenario: given a list:paired with 3 pairs, mapping a single DCE (one pair with forward+reverse) over a simple tool input:

```python
get_structure(dce, "paired" desc, leaf_subcollection_type=None)
```

The old code did `dce.collection` → parent list:paired DC (3 elements), building Tree("paired", 3 children). But the expansion used `dce.child_collection` → paired DC (2 elements), creating 2 jobs.
`precreate_dataset_collection` iterated the 3 structure children and accessed `completed_collection[2]`, raising `KeyError` since only indices 0 and 1 existed.

Extract a `_get_collection()` helper that uses `isinstance()` checks to return child_collection for DCE and collection for HDCA/adapters, and use it in both `get_structure()` and `walk_collections()`.

Fixes https://github.com/galaxyproject/galaxy/issues/22450 and probably https://github.com/galaxyproject/galaxy/issues/22423 and https://github.com/galaxyproject/galaxy/issues/19554

Note how `test_can_map_over_dce_on_non_multiple_data_param` actually tested the broken behavior, this has been verifiably broken since https://github.com/galaxyproject/galaxy/pull/19900, though the broken behavior predates the PR. A pair mapped over a single input should create 2 jobs.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
