### PR TITLE
[26.0] Move job-level filters inside CTE in job cache query

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -666,21 +666,18 @@ class JobSearch:
         history_id: Union[int, None],
     ) -> "Select[tuple[int]]":
         """Build subquery that selects a job with correct job parameters."""
-        job_ids_materialized_cte = stmt.cte("job_ids_cte")
-        outer_select_columns = [job_ids_materialized_cte.c[col.name] for col in stmt.selected_columns]
-        stmt = select(*outer_select_columns).select_from(job_ids_materialized_cte)
-        stmt = (
-            stmt.join(model.Job, model.Job.id == job_ids_materialized_cte.c.job_id)
-            .join(model.History, model.Job.history_id == model.History.id)
-            .where(
-                and_(
-                    model.Job.tool_id == tool_id,
-                    or_(
-                        model.Job.user_id == user_id,
-                        model.History.published == true(),
-                    ),
-                    model.Job.copied_from_job_id.is_(None),  # Always pick original job
-                )
+        # Apply job-level filters BEFORE the CTE so they are included in the
+        # materialized result.  This lets PostgreSQL use selective indexes
+        # (e.g. on tool_id) inside the CTE instead of scanning the entire job
+        # table first and filtering afterwards.
+        stmt = stmt.join(model.History, model.Job.history_id == model.History.id).where(
+            and_(
+                model.Job.tool_id == tool_id,
+                or_(
+                    model.Job.user_id == user_id,
+                    model.History.published == true(),
+                ),
+                model.Job.copied_from_job_id.is_(None),  # Always pick original job
             )
         )
         if tool_version:
@@ -705,6 +702,14 @@ class JobSearch:
         if wildcard_param_dump.get("__when_value__") is False:
             job_states = {Job.states.SKIPPED}
         stmt = stmt.where(Job.state.in_(job_states))
+
+        # Wrap in a CTE to materialize the filtered job IDs.  This prevents
+        # the planner from choosing poor join orders for the subsequent
+        # job_parameter joins (important when tool_id is not highly selective).
+        job_ids_materialized_cte = stmt.cte("job_ids_cte")
+        outer_select_columns = [job_ids_materialized_cte.c[col.name] for col in stmt.selected_columns]
+        stmt = select(*outer_select_columns).select_from(job_ids_materialized_cte)
+        stmt = stmt.join(model.Job, model.Job.id == job_ids_materialized_cte.c.job_id)
 
         for k, v in wildcard_param_dump.items():
             if v == {"__class__": "RuntimeValue"}:


### PR DESCRIPTION
The job cache/deduplication query wraps the initial job-matching statement in a materialized CTE (job_ids_cte), then applies selective filters (tool_id, state, user_id, etc.) outside the CTE. This forces PostgreSQL to materialize the entire inner query — up to a full sequential scan of the job table — before any filtering can occur.

The CTE itself is valuable: it acts as a materialization fence that prevents poor join ordering on the subsequent job_parameter joins, which matters when tool_id is not highly selective. The fix moves the job-level filters before the CTE so they participate in the materialized scan, while keeping the CTE boundary before the job_parameter joins.

Before (filters outside CTE — full table scan):

  WITH job_ids_cte AS (
    SELECT job.id AS job_id
    FROM job GROUP BY job.id
  )
  SELECT job_ids_cte.job_id
  FROM job_ids_cte
  JOIN job ON job.id = job_ids_cte.job_id
  JOIN history ON job.history_id = history.id
  JOIN job_parameter AS p1 ON p1.job_id = job.id
  WHERE job.tool_id = '...'
    AND job.state IN ('ok')
    AND p1.name = '...' AND p1.value = '...'

After (filters inside CTE — index scan):

  WITH job_ids_cte AS (
    SELECT job.id AS job_id
    FROM job
    JOIN history ON job.history_id = history.id
    WHERE job.tool_id = '...'
      AND job.state IN ('ok')
    GROUP BY job.id
  )
  SELECT job_ids_cte.job_id
  FROM job_ids_cte
  JOIN job ON job.id = job_ids_cte.job_id
  JOIN job_parameter AS p1 ON p1.job_id = job.id
  WHERE p1.name = '...' AND p1.value = '...'

The query time before the fix was 230 seconds, after it's 392.283 ms.
The tool itself was `tp_text_file_with_recurring_lines` which has no input datasets that the query planner could use to optimize. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
