### PR TITLE
[26.0] Fix filtering of Data Source Tools in Upload Activity

### DIFF
--- a/client/src/components/Panels/Upload/methods/DataSourceToolsUpload.vue
+++ b/client/src/components/Panels/Upload/methods/DataSourceToolsUpload.vue
@@ -10,7 +10,7 @@ import ToolsListTable from "@/components/ToolsList/ToolsListTable.vue";
 const toolStore = useToolStore();
 const { loading } = storeToRefs(toolStore);
 
-const whooshQuery = computed(() => createWhooshQuery({ section: "Get Data" }));
+const whooshQuery = computed(() => createWhooshQuery({ section: '"Get Data"' }));
 
 const toolsInGetDataSection = computed(() => Object.values(toolStore.getToolsById(whooshQuery.value)));
 


### PR DESCRIPTION
Fixes #22457

The previous filter was matching "get" and "data" individually, which included other unwanted sections.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to http://localhost:5173/upload/data-source-tools
  - Check that only tools within the section "Get Data" are displayed now.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
