### PR TITLE
Fix mypy and packaging issues; pin rocrate<0.15.0

### DIFF
--- a/lib/galaxy/tool_util/cwl/cwltool_deps.py
+++ b/lib/galaxy/tool_util/cwl/cwltool_deps.py
@@ -16,7 +16,7 @@ try:
     from cwl_utils.types import CWLObjectType
 except ImportError:
     try:
-        from cwltool.utils import CWLObjectType  # type: ignore[attr-defined, unused-ignore]
+        from cwltool.utils import CWLObjectType  # type: ignore[assignment, attr-defined, unused-ignore]
     except ImportError:
         CWLObjectType = object  # type: ignore[assignment, misc]
 
@@ -77,12 +77,14 @@ try:
     from cwltool.utils import (
         JobsType,
         normalizeFilesDirs,
+        OutputCallbackType,
         visit_class,
     )
 except ImportError:
     JobsType = object  # type: ignore[misc, unused-ignore]
     visit_class = None  # type: ignore[assignment]
     normalizeFilesDirs = None  # type: ignore[assignment]
+    OutputCallbackType = None  # type: ignore[misc]
 
 try:
     import schema_salad
@@ -138,6 +140,7 @@ __all__ = (
     "main",
     "needs_shell_quoting",
     "normalizeFilesDirs",
+    "OutputCallbackType",
     "pathmapper",
     "process",
     "Process",

--- a/lib/galaxy/tool_util/cwl/parser.py
+++ b/lib/galaxy/tool_util/cwl/parser.py
@@ -14,6 +14,7 @@ from abc import (
 )
 from typing import (
     Any,
+    cast,
     Dict,
     List,
     Optional,
@@ -70,6 +71,7 @@ if TYPE_CHECKING:
     from .cwltool_deps import (
         CWLObjectType,
         JobsType,
+        OutputCallbackType,
         Process,
         workflow,
     )
@@ -357,7 +359,11 @@ class JobProxy:
             )
 
             runtimeContext = RuntimeContext(job_args)
-            self._cwl_job = next(self._tool_proxy._tool.job(self._input_dict, self._output_callback, runtimeContext))
+            self._cwl_job = next(
+                self._tool_proxy._tool.job(
+                    self._input_dict, cast("OutputCallbackType", self._output_callback), runtimeContext
+                )
+            )
             self._is_command_line_job = hasattr(self._cwl_job, "command_line")
 
     def _normalize_job(self):
@@ -465,7 +471,7 @@ class JobProxy:
         else:
             return {}
 
-    def _output_callback(self, out: Optional["CWLObjectType"], process_status: str):
+    def _output_callback(self, out: Optional["CWLObjectType"], process_status: str) -> None:
         self._process_status = process_status
         if process_status == "success":
             self._final_output = out

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2551,13 +2551,6 @@ class BaseWorkflowPopulator(BasePopulator):
         )
         return ROCrate(crate_response)
 
-    def validate_invocation_crate_directory(self, crate_directory):
-        # TODO: where can a ro_crate be extracted
-        metadata_json_path = crate_directory / "ro-crate-metadata.json"
-        with metadata_json_path.open() as f:
-            metadata_json = json.load(f)
-            assert metadata_json["@context"] == "https://w3id.org/ro/crate/1.1/context"
-
     def invoke_workflow_raw(self, workflow_id: str, request: dict, assert_ok: bool = False) -> Response:
         url = f"workflows/{workflow_id}/invocations"
         invocation_response = self._post(url, data=request, json=True)

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     pypng
     python-magic
     pysam>=0.21
-    rocrate
+    rocrate<0.15.0
     social-auth-core>=4.5.0
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
     tifffile

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -39,8 +39,6 @@ install_requires =
     galaxy-web-framework
     galaxy-web-stack
     galaxy-web-apps
-    galaxy-test-base
-    galaxy-test-driver
     a2wsgi
     alembic
     fastapi>=0.124.0
@@ -48,9 +46,7 @@ install_requires =
     MarkupSafe
     mercurial>=7.2
     Paste
-    playwright
     pydantic>=2.7.4
-    pytest-playwright
     Routes
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
     slowapi
@@ -65,7 +61,10 @@ python_requires = >=3.10
 [options.extras_require]
 test =
     galaxy-test-base
+    galaxy-test-driver
+    playwright
     pytest
+    pytest-playwright
 
 [options.packages.find]
 exclude =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dependencies = [
     "refgenconf>=0.13.0",  # https://github.com/refgenie/refgenconf/pull/149
     "regex",
     "requests",
-    "rocrate",
+    "rocrate<0.15.0",  # https://github.com/crs4/rocrate-validator/issues/107
     "Routes",
     "s3fs>=2023.1.0",
     "schema-salad>=8.7.20240905150001",  # Python 3.13 support


### PR DESCRIPTION
Includes slightly-modified mypy and packaging fixes from https://github.com/galaxyproject/galaxy/pull/22464 , plus:
- Pin rocrate<0.15.0 until roc-validator supports RO-Crate Metadata Specification 1.2

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
