### PR TITLE
Mark History.jobs relationship as viewonly

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1638,7 +1638,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     tool_request: Mapped[Optional["ToolRequest"]] = relationship(back_populates="jobs")
     user: Mapped[Optional["User"]] = relationship()
     galaxy_session: Mapped[Optional["GalaxySession"]] = relationship()
-    history: Mapped[Optional["History"]] = relationship(back_populates="jobs")
+    history: Mapped[Optional["History"]] = relationship()
     library_folder: Mapped[Optional["LibraryFolder"]] = relationship()
     parameters = relationship("JobParameter")
     input_datasets: Mapped[list["JobToInputDatasetAssociation"]] = relationship(
@@ -3591,7 +3591,10 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     galaxy_sessions = relationship("GalaxySessionToHistoryAssociation", back_populates="history")
     workflow_invocations: Mapped[list["WorkflowInvocation"]] = relationship(back_populates="history")
     user: Mapped[Optional["User"]] = relationship(back_populates="histories")
-    jobs: Mapped[list["Job"]] = relationship(back_populates="history")
+    jobs: Mapped[list["Job"]] = relationship(
+        primaryjoin=(lambda: Job.history_id == History.id),
+        viewonly=True,
+    )
     tool_requests: Mapped[list["ToolRequest"]] = relationship(back_populates="history")
 
     update_time = column_property(


### PR DESCRIPTION
Fix SAWarning "Object of type <Job> not in session, add operation along 'History.jobs' will not proceed" during workflow scheduling.

The History.jobs collection is never written to directly — jobs are always associated via job.history/job.history_id on the Job side. Making this viewonly follows the same pattern used for History.datasets.

Fixes current CI failures on dev

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
