### PR TITLE
Add a Search to Invocation View

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -38,7 +38,7 @@ const queryInput = ref<string>();
 const queryTimer = ref<ReturnType<typeof setTimeout> | null>(null);
 const titleClear = ref("Clear Search (esc)");
 const titleAdvanced = ref("Toggle Advanced Search");
-const toolInput = ref<InstanceType<typeof GFormInput> | null>(null);
+const inputField = ref<InstanceType<typeof GFormInput> | null>(null);
 
 function clearTimer() {
     if (queryTimer.value) {
@@ -70,8 +70,12 @@ watch(
 function clearBox(event?: KeyboardEvent) {
     if (!event || event.key === "Escape") {
         queryInput.value = "";
-        toolInput.value?.focus();
+        focusInput();
     }
+}
+
+function focusInput() {
+    inputField.value?.focus();
 }
 
 function onToggle() {
@@ -84,12 +88,16 @@ watchImmediate(
         queryInput.value = newQuery;
     },
 );
+
+defineExpose({
+    focusInput,
+});
 </script>
 
 <template>
     <BInputGroup>
         <GFormInput
-            ref="toolInput"
+            ref="inputField"
             v-model="queryInput"
             class="search-query form-control"
             autocomplete="off"

--- a/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.vue
@@ -123,13 +123,7 @@ watch(
                             :target="`step-icon-${step.order_index}`"
                             :tool-id="step.tool_id"
                             :tool-version="step.tool_version" />
-                        <WorkflowStepTitle
-                            :step-tool-id="step.tool_id"
-                            :step-tool-uuid="step.tool_uuid"
-                            :step-subworkflow-id="step.subworkflow_id"
-                            :step-label="step.label"
-                            :step-type="step.type"
-                            :step-index="step.order_index" />
+                        <WorkflowStepTitle :workflow-step="step" />
                         <WorkflowTree :input="step" :skip-head="true" />
                     </div>
                 </div>

--- a/client/src/components/Panels/SearchPanel.vue
+++ b/client/src/components/Panels/SearchPanel.vue
@@ -1,33 +1,13 @@
 <script setup lang="ts">
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { computed, ref, watch } from "vue";
+import { ref } from "vue";
 
-import { getIconForSearchData } from "@/components/Workflow/Editor/modules/itemIcons";
-import { useWorkflowStores } from "@/composables/workflowStores";
-import type { SearchData, SearchResult } from "@/stores/workflowSearchStore";
+import type { SearchData } from "@/stores/workflowSearchStore";
 
-import GButton from "@/components/BaseComponents/GButton.vue";
+import GraphSearch from "../Workflow/GraphSearch.vue";
 import DelayedInput from "@/components/Common/DelayedInput.vue";
 import ActivityPanel from "@/components/Panels/ActivityPanel.vue";
 
 const currentQuery = ref("");
-
-const searchEmpty = computed(() => currentQuery.value.trim() === "");
-
-const { undoRedoStore, searchStore } = useWorkflowStores();
-
-const results = ref<SearchResult[]>([]);
-
-watch(
-    () => [currentQuery.value, undoRedoStore.changeId],
-    () => {
-        if (!searchEmpty.value) {
-            results.value = searchStore.searchWorkflow(currentQuery.value);
-        } else {
-            results.value = [];
-        }
-    },
-);
 
 const emit = defineEmits<{
     (e: "result-clicked", result: SearchData): void;
@@ -38,75 +18,6 @@ const emit = defineEmits<{
     <ActivityPanel title="Search">
         <DelayedInput placeholder="search workflow" :delay="200" @change="(v) => (currentQuery = v)" />
 
-        <div v-if="searchEmpty" class="search-help">
-            <p>Type to search all steps and comments in the workflow graph.</p>
-            <p>Use any of the following keywords to narrow your search:</p>
-            <ul>
-                <li>step</li>
-                <li>input</li>
-                <li>output</li>
-                <li>comment</li>
-            </ul>
-        </div>
-
-        <div v-else class="result-text">
-            <span>Found {{ results.length }} result{{ results.length === 1 ? "" : "s" }} in workflow.</span>
-            <span v-if="results.length > 0">Click a result to view it in the workflow.</span>
-        </div>
-
-        <div class="result-list">
-            <GButton
-                v-for="result in results"
-                :key="result.searchData.id"
-                outline
-                class="result-button"
-                @click="emit('result-clicked', result.searchData)">
-                <FontAwesomeIcon fixed-width class="result-icon" :icon="getIconForSearchData(result.searchData)" />
-                {{ result.searchData.prettyName }}
-            </GButton>
-        </div>
+        <GraphSearch :current-query="currentQuery" @result-clicked="(result) => emit('result-clicked', result)" />
     </ActivityPanel>
 </template>
-
-<style lang="scss" scoped>
-.result-text {
-    margin-top: var(--spacing-3);
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-1);
-    margin-bottom: var(--spacing-2);
-}
-
-.result-list {
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-2);
-
-    .result-button {
-        text-align: start;
-        align-items: start;
-
-        .result-icon {
-            margin-top: var(--spacing-1);
-        }
-    }
-}
-
-.search-help {
-    margin-top: var(--spacing-3);
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-2);
-
-    p,
-    ul {
-        margin: 0;
-        padding: 0;
-    }
-
-    ul {
-        padding-left: var(--spacing-4);
-    }
-}
-</style>

--- a/client/src/components/Workflow/Editor/AreaHighlight.test.ts
+++ b/client/src/components/Workflow/Editor/AreaHighlight.test.ts
@@ -1,0 +1,72 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AreaHighlight from "./AreaHighlight.vue";
+
+const localVue = getLocalVue();
+
+describe("AreaHighlight", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("starts without the blink class", () => {
+        const wrapper = mount(AreaHighlight as object, { localVue });
+        expect(wrapper.classes()).not.toContain("blink");
+    });
+
+    it("adds blink class 100ms after show() and removes it after 1100ms total", async () => {
+        const wrapper = mount(AreaHighlight as object, { localVue });
+        const bounds = { x: 10, y: 20, width: 100, height: 50 };
+
+        const vm = wrapper.vm as unknown as InstanceType<typeof AreaHighlight>;
+        vm.show(bounds);
+
+        // Not yet blinking — waiting for the 100ms delay
+        expect(wrapper.classes()).not.toContain("blink");
+
+        // After 100ms the blink class appears
+        await vi.advanceTimersByTimeAsync(100);
+        expect(wrapper.classes()).toContain("blink");
+
+        // After the 1000ms animation the blink class is removed
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(wrapper.classes()).not.toContain("blink");
+    });
+
+    it("positions the element based on bounds passed to show()", async () => {
+        const wrapper = mount(AreaHighlight as object, { localVue });
+        const bounds = { x: 15, y: 30, width: 200, height: 80 };
+
+        const vm = wrapper.vm as unknown as InstanceType<typeof AreaHighlight>;
+        vm.show(bounds);
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        const style = wrapper.attributes("style");
+        expect(style).toContain("left: 15px");
+        expect(style).toContain("top: 30px");
+        expect(style).toContain("width: 200px");
+        expect(style).toContain("height: 80px");
+    });
+
+    it("resets blink before restarting when show() is called again", async () => {
+        const wrapper = mount(AreaHighlight as object, { localVue });
+        const vm = wrapper.vm as unknown as InstanceType<typeof AreaHighlight>;
+        const bounds = { x: 0, y: 0, width: 50, height: 50 };
+
+        vm.show(bounds);
+        await vi.advanceTimersByTimeAsync(100);
+        expect(wrapper.classes()).toContain("blink");
+
+        // Calling show again resets blink immediately
+        vm.show(bounds);
+        await wrapper.vm.$nextTick();
+        expect(wrapper.classes()).not.toContain("blink");
+    });
+});

--- a/client/src/components/Workflow/Editor/AreaHighlight.vue
+++ b/client/src/components/Workflow/Editor/AreaHighlight.vue
@@ -21,6 +21,8 @@ async function show(area: Rectangle) {
     blink.value = false;
     await wait(100);
     blink.value = true;
+    await wait(1000);
+    blink.value = false;
 }
 
 defineExpose({

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -70,7 +70,6 @@
                             showAttributes(e);
                         }
                     "
-                    @onHighlightRegion="(bounds) => onHighlightRegion(bounds, false)"
                     @onRefactor="onAttemptRefactor"
                     @onScrollTo="onScrollTo" />
                 <UndoRedoStack v-else-if="isActiveSideBar('workflow-undo-redo')" :store-id="id" />
@@ -646,7 +645,7 @@ export default {
         const scrollToId = ref(null);
 
         function onHighlightRegion(bounds, moveTo = true) {
-            workflowGraph.value.highlightGraphRegion(bounds, moveTo);
+            stateStore.pendingHighlight = { bounds, moveTo };
         }
 
         function onScrollTo(stepId) {

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -7,7 +7,6 @@ import { type ConfirmDialogOptions, useConfirmDialog } from "@/composables/confi
 import { useWorkflowStores } from "@/composables/workflowStores";
 import type { Steps } from "@/stores/workflowStepStore";
 
-import type { Rectangle } from "./modules/geometry";
 import {
     bestPracticeWarningAnnotation,
     bestPracticeWarningAnnotationLength,
@@ -85,7 +84,6 @@ const emit = defineEmits<{
             | ReturnType<typeof fixAllIssues>,
     ): void;
     (e: "onScrollTo", stepId: Number): void;
-    (e: "onHighlightRegion", bounds: Rectangle): void;
 }>();
 
 function onAttributes(highlight: string) {
@@ -176,7 +174,7 @@ function onHighlight(item: LintState) {
         "name" in item ? item.name : undefined,
     );
     if (bounds) {
-        emit("onHighlightRegion", bounds);
+        stateStore.pendingHighlight = { bounds, moveTo: false };
     }
 }
 

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -46,7 +46,7 @@ const props = defineProps({
 });
 
 const { stateStore, stepStore, connectionStore } = useWorkflowStores();
-const { scale, activeNodeId, draggingPosition, draggingTerminal } = storeToRefs(stateStore);
+const { scale, activeNodeId, draggingPosition, draggingTerminal, pendingHighlight } = storeToRefs(stateStore);
 
 const { focusedNodeIds } = useFocusedNodes(activeNodeId, connectionStore);
 const canvas: Ref<HTMLElement | null> = ref(null);
@@ -210,22 +210,19 @@ const { comments } = storeToRefs(commentStore);
 
 const areaHighlight = ref<InstanceType<typeof AreaHighlight>>();
 
-watch(
-    () => stateStore.pendingHighlight,
-    (pending) => {
-        if (pending) {
-            const centerPosition = {
-                x: pending.bounds.x + pending.bounds.width / 2.0,
-                y: pending.bounds.y + pending.bounds.height / 2.0,
-            };
-            areaHighlight.value?.show(pending.bounds);
-            if (pending.moveTo !== false) {
-                moveTo(centerPosition);
-            }
-            stateStore.pendingHighlight = null;
+watch(pendingHighlight, (pending) => {
+    if (pending) {
+        pendingHighlight.value = null;
+        const centerPosition = {
+            x: pending.bounds.x + pending.bounds.width / 2.0,
+            y: pending.bounds.y + pending.bounds.height / 2.0,
+        };
+        areaHighlight.value?.show(pending.bounds);
+        if (pending.moveTo !== false) {
+            moveTo(centerPosition);
         }
-    },
-);
+    }
+});
 
 defineExpose({
     fitWorkflow,

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -13,7 +13,7 @@ import { useD3Zoom } from "./composables/d3Zoom";
 import { useFocusedNodes } from "./composables/useFocusedNodes";
 import { useViewportBoundingBox } from "./composables/viewportBoundingBox";
 import { useWorkflowBoundingBox } from "./composables/workflowBoundingBox";
-import type { Rectangle, Vector } from "./modules/geometry";
+import type { Vector } from "./modules/geometry";
 import type { OutputTerminals } from "./modules/terminals";
 import { maxZoom, minZoom } from "./modules/zoomLevels";
 
@@ -210,19 +210,27 @@ const { comments } = storeToRefs(commentStore);
 
 const areaHighlight = ref<InstanceType<typeof AreaHighlight>>();
 
-function highlightGraphRegion(bounds: Rectangle, moveToPosition: boolean = true) {
-    const centerPosition = { x: bounds.x + bounds.width / 2.0, y: bounds.y + bounds.height / 2.0 };
-    areaHighlight.value?.show(bounds);
-    if (moveToPosition) {
-        moveTo(centerPosition);
-    }
-}
+watch(
+    () => stateStore.pendingHighlight,
+    (pending) => {
+        if (pending) {
+            const centerPosition = {
+                x: pending.bounds.x + pending.bounds.width / 2.0,
+                y: pending.bounds.y + pending.bounds.height / 2.0,
+            };
+            areaHighlight.value?.show(pending.bounds);
+            if (pending.moveTo !== false) {
+                moveTo(centerPosition);
+            }
+            stateStore.pendingHighlight = null;
+        }
+    },
+);
 
 defineExpose({
     fitWorkflow,
     setZoom,
     moveTo,
-    highlightGraphRegion,
     setTransform: d3SetTransform,
 });
 </script>

--- a/client/src/components/Workflow/GraphSearch.vue
+++ b/client/src/components/Workflow/GraphSearch.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed, ref, watch } from "vue";
+
+import { getIconForSearchData } from "@/components/Workflow/Editor/modules/itemIcons";
+import { useWorkflowStores } from "@/composables/workflowStores";
+import type { SearchData, SearchResult } from "@/stores/workflowSearchStore";
+
+import GButton from "@/components/BaseComponents/GButton.vue";
+
+const props = defineProps<{
+    currentQuery: string;
+}>();
+
+const searchEmpty = computed(() => props.currentQuery.trim() === "");
+
+const { undoRedoStore, searchStore } = useWorkflowStores();
+
+const results = ref<SearchResult[]>([]);
+
+watch(
+    () => [props.currentQuery, undoRedoStore.changeId],
+    () => {
+        if (!searchEmpty.value) {
+            results.value = searchStore.searchWorkflow(props.currentQuery);
+        } else {
+            results.value = [];
+        }
+    },
+);
+
+const emit = defineEmits<{
+    (e: "result-clicked", result: SearchData): void;
+}>();
+</script>
+
+<template>
+    <div>
+        <div v-if="searchEmpty" class="search-help">
+            <p>Type to search all steps and comments in the workflow graph.</p>
+            <p>Use any of the following keywords to narrow your search:</p>
+            <ul>
+                <li>step</li>
+                <li>input</li>
+                <li>output</li>
+                <li>comment</li>
+            </ul>
+        </div>
+
+        <div v-else class="result-text">
+            <span>Found {{ results.length }} result{{ results.length === 1 ? "" : "s" }} in workflow.</span>
+            <span v-if="results.length > 0">Click a result to view it in the workflow.</span>
+        </div>
+
+        <div class="result-list">
+            <GButton
+                v-for="result in results"
+                :key="result.searchData.id"
+                outline
+                class="result-button"
+                @click="emit('result-clicked', result.searchData)">
+                <FontAwesomeIcon fixed-width class="result-icon" :icon="getIconForSearchData(result.searchData)" />
+                {{ result.searchData.prettyName }}
+            </GButton>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.result-text {
+    margin-top: var(--spacing-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+    margin-bottom: var(--spacing-2);
+}
+
+.result-list {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+
+    .result-button {
+        text-align: start;
+        align-items: start;
+
+        .result-icon {
+            margin-top: var(--spacing-1);
+        }
+    }
+}
+
+.search-help {
+    margin-top: var(--spacing-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-2);
+
+    p,
+    ul {
+        margin: 0;
+        padding: 0;
+    }
+
+    ul {
+        padding-left: var(--spacing-4);
+    }
+}
+</style>

--- a/client/src/components/Workflow/Invocation/Graph/WorkflowInvocationSteps.vue
+++ b/client/src/components/Workflow/Invocation/Graph/WorkflowInvocationSteps.vue
@@ -6,9 +6,13 @@ import { computed, ref, watch } from "vue";
 
 import type { StepJobSummary, WorkflowInvocationElementView } from "@/api/invocations";
 import { isWorkflowInput } from "@/components/Workflow/constants";
+import { getStepTitle } from "@/components/WorkflowInvocationState/util";
 import { useInvocationGraph } from "@/composables/useInvocationGraph";
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
+import { useToolStore } from "@/stores/toolStore";
+import { useWorkflowStore } from "@/stores/workflowStore";
 
+import DelayedInput from "@/components/Common/DelayedInput.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import WorkflowInvocationStep from "@/components/WorkflowInvocationState/WorkflowInvocationStep.vue";
 
@@ -21,17 +25,55 @@ const props = defineProps<{
     stepsJobsSummary: StepJobSummary[];
 }>();
 
-const stepsDiv = ref<HTMLDivElement>();
-
 const { workflow, loading, error } = useWorkflowInstance(props.invocation.workflow_id);
+
+const toolStore = useToolStore();
+const workflowStore = useWorkflowStore();
+
+const currentQuery = ref("");
 
 const workflowId = computed(() => workflow.value?.id);
 const workflowVersion = computed(() => workflow.value?.version);
-const workflowInputSteps = workflow.value
-    ? Object.values(workflow.value.steps).filter((step) => isWorkflowInput(step.type))
-    : [];
-const oneOrNoInput = computed(() => workflowInputSteps.length <= 1);
-const expandInvocationInputs = ref(oneOrNoInput.value);
+
+const filteredWorkflowSteps = computed(() => {
+    if (!workflow.value) {
+        return [];
+    }
+
+    // If there is no search query, return all steps
+    const steps = Object.values(workflow.value.steps);
+    if (!currentQuery.value) {
+        return steps;
+    }
+
+    // Filter steps based on the search query matching the step title
+    const query = currentQuery.value.toLowerCase().trim();
+    return steps.filter((step) => {
+        const invocationStep = props.invocation.steps[step.id];
+
+        const toolId = step.tool_uuid || step.tool_id;
+        const toolName = toolId ? toolStore.getToolNameById(toolId) : undefined;
+        const subworkflowName =
+            "workflow_id" in step && step.workflow_id
+                ? workflowStore.getStoredWorkflowByInstanceId(step.workflow_id)?.name
+                : undefined;
+        const title = getStepTitle(
+            step.id,
+            step.type,
+            invocationStep?.workflow_step_label || undefined,
+            toolName,
+            subworkflowName,
+        );
+        return title.toLowerCase().includes(query);
+    });
+});
+
+/** Workflow steps of the input type, filtered if there is a current query */
+const workflowInputSteps = computed(() => filteredWorkflowSteps.value.filter((step) => isWorkflowInput(step.type)));
+
+/** When there are 2+ inputs they are grouped in a collapsible portlet; otherwise inputs render inline. */
+const oneOrNoInput = computed(() => workflowInputSteps.value.length <= 1);
+const expandInvocationInputs = ref(false);
 
 const {
     steps: graphSteps,
@@ -42,6 +84,14 @@ const {
     computed(() => props.stepsJobsSummary),
     workflowId,
     workflowVersion,
+);
+
+// Expand the inputs portlet while searching so results aren't hidden inside it
+watch(
+    () => currentQuery.value,
+    (newVal) => {
+        expandInvocationInputs.value = newVal.trim().length > 0;
+    },
 );
 
 watch(
@@ -62,40 +112,65 @@ watch(
     <BAlert v-else-if="error" variant="danger" show>
         {{ error }}
     </BAlert>
-    <div v-else-if="graphSteps && workflow" ref="stepsDiv" class="d-flex flex-column w-100">
-        <!-- Input Steps grouped in a separate portlet -->
-        <div v-if="!oneOrNoInput" class="ui-portlet-section w-100">
-            <div
-                class="portlet-header portlet-operations"
-                role="button"
-                tabindex="0"
-                @keyup.enter="expandInvocationInputs = !expandInvocationInputs"
-                @click="expandInvocationInputs = !expandInvocationInputs">
-                <span :id="`step-icon-invocation-inputs-section`">
-                    <FontAwesomeIcon class="portlet-title-icon" :icon="faSignInAlt" />
-                </span>
-                <span class="portlet-title-text">
-                    <u v-localize class="step-title ml-2">Workflow Inputs</u>
-                </span>
-                <FontAwesomeIcon class="float-right" :icon="expandInvocationInputs ? faChevronUp : faChevronDown" />
+    <div v-else-if="graphSteps && workflow" class="steps-container">
+        <div class="px-1 pt-1 pb-2">
+            <DelayedInput placeholder="search steps" :delay="200" @change="(v) => (currentQuery = v)" />
+        </div>
+
+        <div v-if="filteredWorkflowSteps.length" class="steps-content">
+            <!-- Input Steps grouped in a separate portlet -->
+            <div v-if="!oneOrNoInput" class="ui-portlet-section w-100">
+                <div
+                    class="portlet-header portlet-operations"
+                    role="button"
+                    tabindex="0"
+                    @keyup.enter="expandInvocationInputs = !expandInvocationInputs"
+                    @click="expandInvocationInputs = !expandInvocationInputs">
+                    <span :id="`step-icon-invocation-inputs-section`">
+                        <FontAwesomeIcon class="portlet-title-icon" :icon="faSignInAlt" />
+                    </span>
+                    <span class="portlet-title-text">
+                        <u v-localize class="step-title ml-2">Workflow Inputs</u>
+                    </span>
+                    <FontAwesomeIcon class="float-right" :icon="expandInvocationInputs ? faChevronUp : faChevronDown" />
+                </div>
+            </div>
+            <div v-for="step in filteredWorkflowSteps" :key="step.id">
+                <!-- TODO: This may or may not be needed (factor being how performant the step API calls are; seem pretty quick):
+                    We potentially need to consider the fact that in this Steps view, we are constantly fetching all steps
+                    until they are terminal, as opposed to the graph (Overview) view where we only fetch the singular step
+                    that is visible. The advantage of this is that we can show reactive step status in the steps list without needing to
+                    click into each step. If we only fetch expanded steps, the steps wouldn't update their status until clicked on.
+                -->
+                <WorkflowInvocationStep
+                    v-if="!isWorkflowInput(step.type) || oneOrNoInput || expandInvocationInputs"
+                    :class="{ 'mx-1': !oneOrNoInput && isWorkflowInput(step.type) }"
+                    :data-index="step.id"
+                    :invocation="props.invocation"
+                    :workflow-step="step"
+                    :graph-step="graphSteps[step.id]"
+                    :expanded="undefined" />
             </div>
         </div>
-        <div v-for="step in workflow.steps" :key="step.id">
-            <!-- TODO: This may or may not be needed (factor being how performant the step API calls are; seem pretty quick):
-                We potentially need to consider the fact that in this Steps view, we are constantly fetching all steps
-                until they are terminal, as opposed to the graph (Overview) view where we only fetch the singular step
-                that is visible. The advantage of this is that we can show reactive step status in the steps list without needing to
-                click into each step. If we only fetch expanded steps, the steps wouldn't update their status until clicked on.
-            -->
-            <WorkflowInvocationStep
-                v-if="!isWorkflowInput(step.type) || (isWorkflowInput(step.type) && expandInvocationInputs)"
-                :class="{ 'mx-1': !oneOrNoInput && isWorkflowInput(step.type) }"
-                :data-index="step.id"
-                :invocation="props.invocation"
-                :workflow-step="step"
-                :graph-step="graphSteps[step.id]"
-                :expanded="undefined" />
-        </div>
+
+        <BAlert v-else variant="info" show> No steps match the search query. </BAlert>
     </div>
     <BAlert v-else variant="info" show> There are no steps to display. </BAlert>
 </template>
+
+<style scoped lang="scss">
+.steps-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+}
+
+.steps-content {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    min-height: 0;
+}
+</style>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationError.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationError.vue
@@ -141,16 +141,8 @@ function handleFailingStepClick() {
                 Problem occurred at this step:
                 <strong>
                     <WorkflowStepTitle
-                        :step-index="dependentWorkflowStep.id"
-                        :step-label="
-                            dependentInvocationStep?.workflow_step_label || `Step ${dependentWorkflowStep.id + 1}`
-                        "
-                        :step-type="dependentWorkflowStep.type"
-                        :step-tool-id="dependentWorkflowStep.tool_id"
-                        :step-tool-uuid="dependentWorkflowStep.tool_uuid"
-                        :step-subworkflow-id="
-                            'workflow_id' in dependentWorkflowStep ? dependentWorkflowStep.workflow_id : null
-                        " />
+                        :invocation-step="dependentInvocationStep"
+                        :workflow-step="dependentWorkflowStep" />
                 </strong>
             </GCard>
             <GCard v-if="failingStepInfo" clickable grid-view @click="handleFailingStepClick">

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationInputOutputTabs.vue
@@ -18,7 +18,7 @@ const OUTPUTS_NOT_AVAILABLE_YET_MSG =
 
 const props = defineProps<{
     invocation: WorkflowInvocationElementView;
-    tab?: "steps" | "inputs" | "outputs" | "report" | "export" | "metrics" | "debug";
+    tab?: "inputs" | "outputs";
     terminal?: boolean;
 }>();
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faSearch, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faChevronRight, faSearch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, onMounted, ref, watch } from "vue";
 
@@ -75,13 +75,15 @@ function onHighlightRegion(bounds: Rectangle) {
                 :title="toggled ? 'Close Search' : buttonTitle"
                 :transparent="toggled"
                 @click="toggled = !toggled">
-                <FontAwesomeIcon :icon="toggled ? faTimes : faSearch" fixed-width />
+                <FontAwesomeIcon :icon="toggled ? faChevronRight : faSearch" fixed-width />
             </GButton>
         </div>
 
-        <div v-if="toggled && canvasContainerEl" class="workflow-invocation-search-results">
-            <GraphSearch :current-query="currentQuery" @result-clicked="(data) => onHighlightRegion(data.bounds)" />
-        </div>
+        <Transition name="search-results">
+            <div v-if="toggled && canvasContainerEl" class="workflow-invocation-search-results">
+                <GraphSearch :current-query="currentQuery" @result-clicked="(data) => onHighlightRegion(data.bounds)" />
+            </div>
+        </Transition>
     </div>
 </template>
 
@@ -105,5 +107,28 @@ function onHighlightRegion(bounds: Rectangle) {
 
     max-height: 50vh;
     overflow-y: auto;
+}
+
+.search-results-enter-active {
+    animation: search-drop-in 0.2s ease;
+}
+
+.search-results-leave-active {
+    transition:
+        opacity 0.2s ease,
+        transform 0.2s ease;
+    transform-origin: top right;
+}
+
+.search-results-leave-to {
+    opacity: 0;
+    transform: translateY(-6px) scaleY(0.95);
+}
+
+@keyframes search-drop-in {
+    from {
+        opacity: 0;
+        transform: translateY(-6px) scaleY(0.95);
+    }
 }
 </style>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faChevronRight, faSearch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
 import type { SearchData } from "@/stores/workflowSearchStore";
@@ -21,6 +21,7 @@ const storeId = computed(() => `invocation-${props.invocationId}`);
 
 const { stateStore } = provideScopedWorkflowStores(storeId);
 
+const searchInput = ref<InstanceType<typeof DelayedInput> | null>(null);
 const toggled = ref(false);
 
 const currentQuery = ref("");
@@ -60,6 +61,14 @@ function onHighlightRegion(data: SearchData) {
         stateStore.activeNodeId = Number(data.stepId);
     }
 }
+
+async function toggleSearch() {
+    toggled.value = !toggled.value;
+    if (toggled.value) {
+        await nextTick();
+        searchInput.value?.focusInput();
+    }
+}
 </script>
 
 <template>
@@ -67,6 +76,7 @@ function onHighlightRegion(data: SearchData) {
         <div class="d-flex align-items-center flex-gapx-1">
             <DelayedInput
                 v-if="toggled"
+                ref="searchInput"
                 placeholder="search workflow"
                 :expanded.sync="toggled"
                 :delay="200"
@@ -75,7 +85,7 @@ function onHighlightRegion(data: SearchData) {
                 tooltip
                 :title="toggled ? 'Close Search' : buttonTitle"
                 :transparent="toggled"
-                @click="toggled = !toggled">
+                @click="toggleSearch">
                 <FontAwesomeIcon :icon="toggled ? faChevronRight : faSearch" fixed-width />
             </GButton>
         </div>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { faSearch, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed, onMounted, ref, watch } from "vue";
+
+import { provideScopedWorkflowStores } from "@/composables/workflowStores";
+import { capitalizeFirstLetter } from "@/utils/strings";
+
+import type { Rectangle } from "../Workflow/Editor/modules/geometry";
+
+import GButton from "../BaseComponents/GButton.vue";
+import GraphSearch from "../Workflow/GraphSearch.vue";
+import DelayedInput from "@/components/Common/DelayedInput.vue";
+
+const props = defineProps<{
+    invocationId: string;
+    workflowId: string;
+    tab?: "steps" | "inputs" | "outputs";
+}>();
+
+const storeId = computed(() => `invocation-${props.invocationId}`);
+
+provideScopedWorkflowStores(storeId);
+
+const toggled = ref(false);
+
+const currentQuery = ref("");
+
+const canvasContainerEl = ref<HTMLElement | null>(null);
+
+onMounted(() => {
+    canvasContainerEl.value = document.getElementById("canvas-container");
+});
+
+watch(toggled, (val) => {
+    if (val) {
+        canvasContainerEl.value = document.getElementById("canvas-container");
+    }
+});
+
+const buttonTitle = computed(() => {
+    if (!props.tab) {
+        return "Search Invocation Graph";
+    } else {
+        return `Search Invocation ${capitalizeFirstLetter(props.tab)}`;
+    }
+});
+
+// reset query, and toggled when tab changes
+watch(
+    () => props.tab,
+    () => {
+        currentQuery.value = "";
+        toggled.value = false;
+    },
+);
+
+function onHighlightRegion(bounds: Rectangle) {
+    // TODO: Implement the logic to highlight the region in the workflow graph based on the bounds
+    console.log("Highlighting region:", bounds);
+}
+</script>
+
+<template>
+    <div class="search-container">
+        <div class="d-flex align-items-center flex-gapx-1">
+            <DelayedInput
+                v-if="toggled"
+                placeholder="search workflow"
+                :expanded.sync="toggled"
+                :delay="200"
+                @change="(v) => (currentQuery = v)" />
+            <GButton
+                tooltip
+                :title="toggled ? 'Close Search' : buttonTitle"
+                :transparent="toggled"
+                @click="toggled = !toggled">
+                <FontAwesomeIcon :icon="toggled ? faTimes : faSearch" fixed-width />
+            </GButton>
+        </div>
+
+        <div v-if="toggled && canvasContainerEl" class="workflow-invocation-search-results">
+            <GraphSearch :current-query="currentQuery" @result-clicked="(data) => onHighlightRegion(data.bounds)" />
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.search-container {
+    position: relative;
+}
+
+.workflow-invocation-search-results {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: var(--spacing);
+    background: var(--color-grey-100);
+    border: 1px solid var(--color-grey-200);
+    border-radius: var(--spacing-2);
+    box-shadow: 0 4px 12px var(--color-grey-300);
+    padding: var(--spacing-3);
+    z-index: 9999;
+    min-width: 280px;
+
+    max-height: 50vh;
+    overflow-y: auto;
+}
+</style>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
@@ -4,9 +4,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, onMounted, ref, watch } from "vue";
 
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
+import type { SearchData } from "@/stores/workflowSearchStore";
 import { capitalizeFirstLetter } from "@/utils/strings";
-
-import type { Rectangle } from "../Workflow/Editor/modules/geometry";
 
 import GButton from "../BaseComponents/GButton.vue";
 import GraphSearch from "../Workflow/GraphSearch.vue";
@@ -20,7 +19,7 @@ const props = defineProps<{
 
 const storeId = computed(() => `invocation-${props.invocationId}`);
 
-provideScopedWorkflowStores(storeId);
+const { stateStore } = provideScopedWorkflowStores(storeId);
 
 const toggled = ref(false);
 
@@ -55,9 +54,11 @@ watch(
     },
 );
 
-function onHighlightRegion(bounds: Rectangle) {
-    // TODO: Implement the logic to highlight the region in the workflow graph based on the bounds
-    console.log("Highlighting region:", bounds);
+function onHighlightRegion(data: SearchData) {
+    stateStore.pendingHighlight = { bounds: data.bounds };
+    // TODO: It would make sense to activate the node in the graph in the case of
+    // a step, input or output search result; but for that we need the `SearchData`
+    // to contain a `stepId` field.
 }
 </script>
 
@@ -81,7 +82,7 @@ function onHighlightRegion(bounds: Rectangle) {
 
         <Transition name="search-results">
             <div v-if="toggled && canvasContainerEl" class="workflow-invocation-search-results">
-                <GraphSearch :current-query="currentQuery" @result-clicked="(data) => onHighlightRegion(data.bounds)" />
+                <GraphSearch :current-query="currentQuery" @result-clicked="onHighlightRegion" />
             </div>
         </Transition>
     </div>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
@@ -5,7 +5,6 @@ import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import { provideScopedWorkflowStores } from "@/composables/workflowStores";
 import type { SearchData } from "@/stores/workflowSearchStore";
-import { capitalizeFirstLetter } from "@/utils/strings";
 
 import GButton from "../BaseComponents/GButton.vue";
 import GraphSearch from "../Workflow/GraphSearch.vue";
@@ -14,7 +13,6 @@ import DelayedInput from "@/components/Common/DelayedInput.vue";
 const props = defineProps<{
     invocationId: string;
     workflowId: string;
-    tab?: "steps" | "inputs" | "outputs";
 }>();
 
 const storeId = computed(() => `invocation-${props.invocationId}`);
@@ -37,23 +35,6 @@ watch(toggled, (val) => {
         canvasContainerEl.value = document.getElementById("canvas-container");
     }
 });
-
-const buttonTitle = computed(() => {
-    if (!props.tab) {
-        return "Search Invocation Graph";
-    } else {
-        return `Search Invocation ${capitalizeFirstLetter(props.tab)}`;
-    }
-});
-
-// reset query, and toggled when tab changes
-watch(
-    () => props.tab,
-    () => {
-        currentQuery.value = "";
-        toggled.value = false;
-    },
-);
 
 function onHighlightRegion(data: SearchData) {
     stateStore.pendingHighlight = { bounds: data.bounds };
@@ -78,12 +59,11 @@ async function toggleSearch() {
                 v-if="toggled"
                 ref="searchInput"
                 placeholder="search workflow"
-                :expanded.sync="toggled"
                 :delay="200"
                 @change="(v) => (currentQuery = v)" />
             <GButton
                 tooltip
-                :title="toggled ? 'Close Search' : buttonTitle"
+                :title="toggled ? 'Close Search' : 'Search Invocation Graph'"
                 :transparent="toggled"
                 @click="toggleSearch">
                 <FontAwesomeIcon :icon="toggled ? faChevronRight : faSearch" fixed-width />

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSearch.vue
@@ -56,9 +56,9 @@ watch(
 
 function onHighlightRegion(data: SearchData) {
     stateStore.pendingHighlight = { bounds: data.bounds };
-    // TODO: It would make sense to activate the node in the graph in the case of
-    // a step, input or output search result; but for that we need the `SearchData`
-    // to contain a `stepId` field.
+    if ("stepId" in data) {
+        stateStore.activeNodeId = Number(data.stepId);
+    }
 }
 </script>
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -38,6 +38,7 @@ import WorkflowInvocationFeedback from "./WorkflowInvocationFeedback.vue";
 import WorkflowInvocationInputOutputTabs from "./WorkflowInvocationInputOutputTabs.vue";
 import WorkflowInvocationMetrics from "./WorkflowInvocationMetrics.vue";
 import WorkflowInvocationOverview from "./WorkflowInvocationOverview.vue";
+import WorkflowInvocationSearch from "./WorkflowInvocationSearch.vue";
 import WorkflowInvocationShare from "./WorkflowInvocationShare.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -436,16 +437,16 @@ async function onCancel() {
                 Debug
             </BNavItem>
 
-            <div class="ml-auto d-flex align-items-center">
-                <BBadge
-                    v-if="tabsDisabled"
-                    v-g-tooltip.hover
-                    class="mr-1"
-                    :title="disabledTabTooltip"
-                    variant="primary">
+            <div class="ml-auto d-flex align-items-center flex-gapx-1">
+                <WorkflowInvocationSearch
+                    v-if="!props.tab || ['steps', 'inputs', 'outputs'].includes(props.tab)"
+                    :tab="props.tab"
+                    :invocation-id="props.invocationId"
+                    :workflow-id="invocation.workflow_id" />
+                <BBadge v-if="tabsDisabled" v-g-tooltip.hover :title="disabledTabTooltip" variant="primary">
                     <FontAwesomeIcon :icon="faExclamation" />
                 </BBadge>
-                <BBadge v-if="isPolling" v-g-tooltip.hover class="mr-1" title="Polling for updates" variant="link">
+                <BBadge v-if="isPolling" v-g-tooltip.hover title="Polling for updates" variant="link">
                     <FontAwesomeIcon :icon="faSpinner" spin />
                 </BBadge>
                 <GButton

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -42,9 +42,11 @@ import WorkflowInvocationSearch from "./WorkflowInvocationSearch.vue";
 import WorkflowInvocationShare from "./WorkflowInvocationShare.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
+type InvocationViewTab = "steps" | "inputs" | "outputs" | "report" | "export" | "metrics" | "debug";
+
 interface Props {
     invocationId: string;
-    tab?: "steps" | "inputs" | "outputs" | "report" | "export" | "metrics" | "debug";
+    tab?: InvocationViewTab;
     isSubworkflow?: boolean;
     isFullPage?: boolean;
     success?: boolean;
@@ -268,6 +270,10 @@ onUnmounted(() => {
     clearTimeout(jobStatesInterval.value);
 });
 
+function isValidSearchTab(tab: InvocationViewTab): tab is "steps" | "inputs" | "outputs" {
+    return ["steps", "inputs", "outputs"].includes(tab);
+}
+
 async function pollStepStatesUntilTerminal() {
     if (!invocationSchedulingTerminal.value) {
         await invocationStore.fetchInvocationById({ id: props.invocationId });
@@ -439,7 +445,7 @@ async function onCancel() {
 
             <div class="ml-auto d-flex align-items-center flex-gapx-1">
                 <WorkflowInvocationSearch
-                    v-if="!props.tab || ['steps', 'inputs', 'outputs'].includes(props.tab)"
+                    v-if="!props.tab || isValidSearchTab(props.tab)"
                     :tab="props.tab"
                     :invocation-id="props.invocationId"
                     :workflow-id="invocation.workflow_id" />
@@ -485,6 +491,7 @@ async function onCancel() {
                     :is-full-page="props.isFullPage" />
             </div>
             <WorkflowInvocationInputOutputTabs
+                v-if="props.tab === 'inputs' || props.tab === 'outputs'"
                 :invocation="invocation"
                 :terminal="invocationAndJobTerminal"
                 :tab="props.tab" />

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -270,10 +270,6 @@ onUnmounted(() => {
     clearTimeout(jobStatesInterval.value);
 });
 
-function isValidSearchTab(tab: InvocationViewTab): tab is "steps" | "inputs" | "outputs" {
-    return ["steps", "inputs", "outputs"].includes(tab);
-}
-
 async function pollStepStatesUntilTerminal() {
     if (!invocationSchedulingTerminal.value) {
         await invocationStore.fetchInvocationById({ id: props.invocationId });
@@ -445,8 +441,7 @@ async function onCancel() {
 
             <div class="ml-auto d-flex align-items-center flex-gapx-1">
                 <WorkflowInvocationSearch
-                    v-if="!props.tab || isValidSearchTab(props.tab)"
-                    :tab="props.tab"
+                    v-if="!props.tab"
                     :invocation-id="props.invocationId"
                     :workflow-id="invocation.workflow_id" />
                 <BBadge v-if="tabsDisabled" v-g-tooltip.hover :title="disabledTabTooltip" variant="primary">
@@ -456,7 +451,7 @@ async function onCancel() {
                     <FontAwesomeIcon :icon="faSpinner" spin />
                 </BBadge>
                 <GButton
-                    v-if="!props.isFullPage && !invocationAndJobTerminal"
+                    v-if="!invocationAndJobTerminal"
                     tooltip
                     class="my-1"
                     title="Cancel scheduling of workflow invocation"
@@ -469,7 +464,7 @@ async function onCancel() {
             </div>
         </BNav>
 
-        <div class="mt-1 d-flex flex-column overflow-auto">
+        <div class="mt-1 d-flex flex-column overflow-auto tab-content-container">
             <div v-if="onOverviewTab">
                 <WorkflowInvocationOverview
                     class="invocation-overview"
@@ -480,7 +475,7 @@ async function onCancel() {
                     :is-subworkflow="isSubworkflow"
                     :invocation-messages="uniqueMessages" />
             </div>
-            <div v-if="props.tab === 'steps'">
+            <div v-if="props.tab === 'steps'" class="steps-tab-content">
                 <BAlert v-if="isSubworkflow" variant="info" show>
                     <span v-localize>Subworkflow steps are not available.</span>
                 </BAlert>
@@ -569,6 +564,17 @@ async function onCancel() {
     max-height: 0;
     opacity: 0;
     transform: translateY(-6px);
+}
+
+.tab-content-container {
+    flex: 1;
+    min-height: 0;
+}
+
+.steps-tab-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .progress-bars {

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -260,20 +260,8 @@ onUnmounted(() => {
                                                     v-for="stepInput in Object.values(props.workflowStep.input_steps)"
                                                     :key="stepInput.source_step">
                                                     <WorkflowStepTitle
-                                                        :step-index="stepInput.source_step"
-                                                        :step-label="
-                                                            props.invocation.steps[stepInput.source_step]
-                                                                ?.workflow_step_label ||
-                                                            `Step ${stepInput.source_step + 1}`
-                                                        "
-                                                        :step-type="props.workflowStep.type"
-                                                        :step-tool-id="props.workflowStep.tool_id"
-                                                        :step-tool-uuid="props.workflowStep.tool_uuid"
-                                                        :step-subworkflow-id="
-                                                            'workflow_id' in props.workflowStep
-                                                                ? props.workflowStep.workflow_id
-                                                                : null
-                                                        " />
+                                                        :invocation-step="props.invocation.steps[stepInput.source_step]"
+                                                        :workflow-step="props.workflowStep" />
                                                 </li>
                                             </ul>
                                         </template>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStepHeader.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStepHeader.vue
@@ -26,14 +26,6 @@ const props = defineProps<Props>();
 
 const invocationStore = useInvocationStore();
 
-const stepLabel = computed(() => {
-    const rawStepLabel = props.invocationStep?.workflow_step_label;
-    if (rawStepLabel == null) {
-        return undefined;
-    }
-    return rawStepLabel;
-});
-
 const isPolling = computed(() =>
     props.invocationStep ? invocationStore.isLoadingInvocationStep(props.invocationStep.id) : false,
 );
@@ -52,15 +44,7 @@ const isPolling = computed(() =>
                 :tool-version="props.workflowStep.tool_version" />
             <span class="portlet-title-text">
                 <u class="step-title">
-                    <WorkflowStepTitle
-                        :step-index="props.workflowStep.id"
-                        :step-label="stepLabel"
-                        :step-type="props.workflowStep.type"
-                        :step-tool-id="props.workflowStep.tool_id"
-                        :step-tool-uuid="props.workflowStep.tool_uuid"
-                        :step-subworkflow-id="
-                            'workflow_id' in props.workflowStep ? props.workflowStep.workflow_id : null
-                        " />
+                    <WorkflowStepTitle :invocation-step="props.invocationStep" :workflow-step="props.workflowStep" />
                 </u>
             </span>
         </div>

--- a/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowStepTitle.vue
@@ -3,17 +3,16 @@ import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, ref, watch } from "vue";
 
+import type { InvocationStep } from "@/api/invocations";
+import type { WorkflowStepTyped } from "@/api/workflows";
+import { getStepTitle } from "@/components/WorkflowInvocationState/util";
 import { useToolStore } from "@/stores/toolStore";
 import { useWorkflowStore } from "@/stores/workflowStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 interface WorkflowInvocationStepTitleProps {
-    stepIndex: number;
-    stepLabel?: string;
-    stepType: string;
-    stepToolId?: string | null;
-    stepToolUuid?: string | null;
-    stepSubworkflowId?: string | null;
+    workflowStep: WorkflowStepTyped;
+    invocationStep?: InvocationStep;
 }
 
 const props = defineProps<WorkflowInvocationStepTitleProps>();
@@ -21,55 +20,33 @@ const props = defineProps<WorkflowInvocationStepTitleProps>();
 const workflowStore = useWorkflowStore();
 const toolStore = useToolStore();
 
-const subWorkflow = computed(() => {
-    if (props.stepSubworkflowId) {
-        return workflowStore.getStoredWorkflowByInstanceId(props.stepSubworkflowId);
-    }
-    return null;
-});
-const toolName = computed(() => {
-    const toolId = props.stepToolUuid || props.stepToolId;
-    if (toolId) {
-        return toolStore.getToolNameById(toolId);
-    }
-    return "";
-});
+const stepSubworkflowId = computed(() => ("workflow_id" in props.workflowStep ? props.workflowStep.workflow_id : null));
+const toolId = computed(() => props.workflowStep.tool_uuid || props.workflowStep.tool_id);
 
 const title = computed(() => {
-    const oneBasedStepIndex = props.stepIndex + 1;
-    if (props.stepLabel) {
-        return `Step ${oneBasedStepIndex}: ${props.stepLabel}`;
-    }
-    const workflowStepType = props.stepType;
-    switch (workflowStepType) {
-        case "tool":
-            return `Step ${oneBasedStepIndex}: ${toolName.value}`;
-        case "subworkflow": {
-            const subworkflow = subWorkflow.value;
-            const label = subworkflow ? subworkflow.name : "Subworkflow";
-            return `Step ${oneBasedStepIndex}: ${label}`;
-        }
-        case "parameter_input":
-            return `Step ${oneBasedStepIndex}: Parameter input`;
-        case "data_input":
-            return `Step ${oneBasedStepIndex}: Data input`;
-        case "data_collection_input":
-            return `Step ${oneBasedStepIndex}: Data collection input`;
-        default:
-            return `Step ${oneBasedStepIndex}: Unknown step type '${workflowStepType}'`;
-    }
+    const toolName = toolId.value ? toolStore.getToolNameById(toolId.value) : undefined;
+    const subworkflowName = stepSubworkflowId.value
+        ? workflowStore.getStoredWorkflowByInstanceId(stepSubworkflowId.value)?.name
+        : undefined;
+    return getStepTitle(
+        props.workflowStep.id,
+        props.workflowStep.type,
+        props.invocationStep?.workflow_step_label || undefined,
+        toolName || undefined,
+        subworkflowName,
+    );
 });
+
 const hoverError = ref("");
 
 async function initStores() {
-    const toolId = props.stepToolUuid || props.stepToolId;
-    if (toolId && !toolStore.getToolForId(toolId)) {
-        toolStore.fetchToolForId(toolId);
+    if (toolId.value && !toolStore.getToolForId(toolId.value)) {
+        toolStore.fetchToolForId(toolId.value);
     }
 
-    if (props.stepSubworkflowId) {
+    if (stepSubworkflowId.value) {
         try {
-            await workflowStore.fetchWorkflowForInstanceId(props.stepSubworkflowId);
+            await workflowStore.fetchWorkflowForInstanceId(stepSubworkflowId.value);
         } catch (e) {
             hoverError.value = errorMessageAsString(e, "Error fetching subworkflow");
         }
@@ -77,7 +54,7 @@ async function initStores() {
 }
 
 watch(
-    props,
+    () => [props.workflowStep, props.invocationStep],
     async () => {
         await initStores();
     },

--- a/client/src/components/WorkflowInvocationState/util.test.ts
+++ b/client/src/components/WorkflowInvocationState/util.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { getStepTitle } from "./util";
+
+describe("getStepTitle", () => {
+    it("uses label when provided, regardless of type", () => {
+        expect(getStepTitle(0, "tool", "My Label")).toBe("Step 1: My Label");
+        expect(getStepTitle(2, "data_input", "Custom")).toBe("Step 3: Custom");
+    });
+
+    it("uses 1-based step index", () => {
+        expect(getStepTitle(0, "data_input")).toBe("Step 1: Data input");
+        expect(getStepTitle(4, "data_input")).toBe("Step 5: Data input");
+    });
+
+    it("formats tool step with tool name", () => {
+        expect(getStepTitle(0, "tool", undefined, "FastQC")).toBe("Step 1: FastQC");
+    });
+
+    it("uses 'Unknown tool' default when tool name omitted", () => {
+        expect(getStepTitle(0, "tool")).toBe("Step 1: Unknown tool");
+    });
+
+    it("formats subworkflow step with subworkflow name", () => {
+        expect(getStepTitle(1, "subworkflow", undefined, undefined, "My Subworkflow")).toBe("Step 2: My Subworkflow");
+    });
+
+    it("uses 'Subworkflow' default when subworkflow name omitted", () => {
+        expect(getStepTitle(0, "subworkflow")).toBe("Step 1: Subworkflow");
+    });
+
+    it("formats input types correctly", () => {
+        expect(getStepTitle(0, "parameter_input")).toBe("Step 1: Parameter input");
+        expect(getStepTitle(0, "data_input")).toBe("Step 1: Data input");
+        expect(getStepTitle(0, "data_collection_input")).toBe("Step 1: Data collection input");
+    });
+
+    it("handles unknown step types", () => {
+        expect(getStepTitle(0, "some_future_type")).toBe("Step 1: Unknown step type 'some_future_type'");
+    });
+});

--- a/client/src/components/WorkflowInvocationState/util.ts
+++ b/client/src/components/WorkflowInvocationState/util.ts
@@ -85,3 +85,32 @@ export function isTerminal(jobSummary: InvocationJobsSummary) {
         return !anyNonTerminal;
     }
 }
+
+export function getStepTitle(
+    stepIndex: number,
+    stepType: string,
+    stepLabel?: string,
+    toolName = "Unknown tool",
+    subworkflowName = "Subworkflow",
+): string {
+    const oneBasedStepIndex = stepIndex + 1;
+    if (stepLabel) {
+        return `Step ${oneBasedStepIndex}: ${stepLabel}`;
+    }
+    const workflowStepType = stepType;
+    switch (workflowStepType) {
+        case "tool":
+            return `Step ${oneBasedStepIndex}: ${toolName}`;
+        case "subworkflow": {
+            return `Step ${oneBasedStepIndex}: ${subworkflowName}`;
+        }
+        case "parameter_input":
+            return `Step ${oneBasedStepIndex}: Parameter input`;
+        case "data_input":
+            return `Step ${oneBasedStepIndex}: Data input`;
+        case "data_collection_input":
+            return `Step ${oneBasedStepIndex}: Data collection input`;
+        default:
+            return `Step ${oneBasedStepIndex}: Unknown step type '${workflowStepType}'`;
+    }
+}

--- a/client/src/stores/workflowEditorStateStore.ts
+++ b/client/src/stores/workflowEditorStateStore.ts
@@ -1,6 +1,7 @@
 import type { UseElementBoundingReturn } from "@vueuse/core";
 import { computed, reactive, ref, set, type UnwrapRef } from "vue";
 
+import type { Rectangle } from "@/components/Workflow/Editor/modules/geometry";
 import type { OutputTerminals } from "@/components/Workflow/Editor/modules/terminals";
 import reportDefault from "@/components/Workflow/Editor/reportDefault";
 
@@ -46,6 +47,7 @@ export const useWorkflowStateStore = defineScopedStore("workflowStateStore", () 
     const stepLoadingState = ref<StepLoadingState>({});
     const multiSelectedSteps = ref<Record<number, boolean>>({});
     const hasChanges = ref(false);
+    const pendingHighlight = ref<{ bounds: Rectangle; moveTo?: boolean } | null>(null);
     const report = ref<WorkflowReport>({
         markdown: reportDefault,
     });
@@ -61,6 +63,7 @@ export const useWorkflowStateStore = defineScopedStore("workflowStateStore", () 
         stepPosition.value = {};
         stepLoadingState.value = {};
         multiSelectedSteps.value = {};
+        pendingHighlight.value = null;
         report.value = {
             markdown: reportDefault,
         };
@@ -149,6 +152,7 @@ export const useWorkflowStateStore = defineScopedStore("workflowStateStore", () 
         hasChanges,
         stepPosition,
         stepLoadingState,
+        pendingHighlight,
         $reset,
         getInputTerminalPosition,
         getOutputTerminalPosition,

--- a/client/src/stores/workflowSearchStore.test.ts
+++ b/client/src/stores/workflowSearchStore.test.ts
@@ -1,0 +1,125 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type NewStep, useWorkflowStepStore } from "@/stores/workflowStepStore";
+
+import { useWorkflowSearchStore } from "./workflowSearchStore";
+
+const WORKFLOW_ID = "mock-workflow";
+
+const toolStep: NewStep = {
+    name: "FastQC",
+    label: "quality_check",
+    type: "tool",
+    annotation: "QC tool",
+    input_connections: {},
+    inputs: [
+        {
+            name: "input1",
+            label: "Input Dataset",
+            input_type: "dataset",
+            extensions: [],
+            multiple: false,
+            optional: false,
+        },
+    ],
+    outputs: [{ name: "html_file", type: "data", multiple: false, optional: false, extensions: [] }],
+    tool_state: {},
+    workflow_outputs: [],
+};
+
+function createEl(id: string) {
+    const el = document.createElement("div");
+    el.id = id;
+    document.body.appendChild(el);
+    return el;
+}
+
+function setupDom(stepId: number) {
+    createEl("canvas-container");
+    createEl(`wf-node-step-${stepId}`);
+    createEl(`node-${stepId}-input-input1`);
+    createEl(`node-${stepId}-output-html_file`);
+}
+
+describe("workflowSearchStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        document.body.innerHTML = "";
+    });
+
+    describe("search results", () => {
+        it("finds a step by name", () => {
+            const step = useWorkflowStepStore(WORKFLOW_ID).addStep(toolStep);
+            setupDom(step.id);
+
+            const results = useWorkflowSearchStore(WORKFLOW_ID).searchWorkflow("FastQC");
+
+            expect(results.length).toBeGreaterThan(0);
+            expect(results.some((r) => r.searchData.type === "step")).toBe(true);
+        });
+
+        it("finds a step by label", () => {
+            const step = useWorkflowStepStore(WORKFLOW_ID).addStep(toolStep);
+            setupDom(step.id);
+
+            const results = useWorkflowSearchStore(WORKFLOW_ID).searchWorkflow("quality_check");
+
+            expect(results.some((r) => r.searchData.type === "step")).toBe(true);
+        });
+
+        it("finds a step by annotation", () => {
+            const step = useWorkflowStepStore(WORKFLOW_ID).addStep(toolStep);
+            setupDom(step.id);
+
+            const results = useWorkflowSearchStore(WORKFLOW_ID).searchWorkflow("QC tool");
+
+            expect(results.some((r) => r.searchData.type === "step")).toBe(true);
+        });
+
+        it("returns empty results for a non-matching query", () => {
+            const step = useWorkflowStepStore(WORKFLOW_ID).addStep(toolStep);
+            setupDom(step.id);
+
+            const results = useWorkflowSearchStore(WORKFLOW_ID).searchWorkflow("zzz-no-match");
+
+            expect(results).toHaveLength(0);
+        });
+
+        it("finds input terminal by label", () => {
+            const step = useWorkflowStepStore(WORKFLOW_ID).addStep(toolStep);
+            setupDom(step.id);
+
+            const results = useWorkflowSearchStore(WORKFLOW_ID).searchWorkflow("Input Dataset");
+
+            expect(results.some((r) => r.searchData.type === "input")).toBe(true);
+        });
+    });
+
+    describe("search cache (regression: ref-vs-null bug)", () => {
+        it("does not crash on the first call when the cache is empty", () => {
+            // Before the fix, `searchDataCacheData` (a Ref) was always truthy, so the
+            // cache guard `&& searchDataCacheData` passed on the very first call and
+            // returned null. Then searchWorkflow called null.map(...) → TypeError.
+            const step = useWorkflowStepStore(WORKFLOW_ID).addStep(toolStep);
+            setupDom(step.id);
+
+            const searchStore = useWorkflowSearchStore(WORKFLOW_ID);
+            expect(() => searchStore.searchWorkflow("FastQC")).not.toThrow();
+            expect(searchStore.searchWorkflow("FastQC")).toBeInstanceOf(Array);
+        });
+
+        it("does not re-collect DOM data on a repeated call with the same changeId", () => {
+            const step = useWorkflowStepStore(WORKFLOW_ID).addStep(toolStep);
+            setupDom(step.id);
+
+            const searchStore = useWorkflowSearchStore(WORKFLOW_ID);
+            searchStore.searchWorkflow("FastQC"); // primes the cache
+
+            const spy = vi.spyOn(document, "getElementById");
+            searchStore.searchWorkflow("FastQC"); // should hit cache, skip DOM traversal
+            expect(spy).not.toHaveBeenCalled();
+            spy.mockRestore();
+        });
+    });
+});

--- a/client/src/stores/workflowSearchStore.ts
+++ b/client/src/stores/workflowSearchStore.ts
@@ -187,7 +187,7 @@ export const useWorkflowSearchStore = defineScopedStore("WorkflowSearchStore", (
 
     /** caches the results of `collectSearchData` depending on the changeId of the `undoRedoStore` */
     function collectSearchDataCached() {
-        if (undoRedoStore.changeId === searchDataCacheId.value && searchDataCacheData) {
+        if (undoRedoStore.changeId === searchDataCacheId.value && searchDataCacheData.value !== null) {
             return searchDataCacheData.value as SearchData[];
         }
 

--- a/client/src/stores/workflowSearchStore.ts
+++ b/client/src/stores/workflowSearchStore.ts
@@ -22,6 +22,7 @@ export type SearchData =
     | {
           type: "step";
           id: string;
+          stepId: string;
           prettyName: string;
           stepType: NewStep["type"];
           bounds: Rectangle;
@@ -33,6 +34,7 @@ export type SearchData =
     | {
           type: "input";
           id: string;
+          stepId: string;
           prettyName: string;
           bounds: Rectangle;
           label: string;
@@ -41,6 +43,7 @@ export type SearchData =
     | {
           type: "output";
           id: string;
+          stepId: string;
           prettyName: string;
           bounds: Rectangle;
           name: string;
@@ -121,6 +124,7 @@ export const useWorkflowSearchStore = defineScopedStore("WorkflowSearchStore", (
                 return {
                     type: "input",
                     id: domId,
+                    stepId: String(step.id),
                     prettyName: `Input "${input.label ?? input.name}" for step ${step.id + 1}`,
                     bounds,
                     label: input.label,
@@ -137,6 +141,7 @@ export const useWorkflowSearchStore = defineScopedStore("WorkflowSearchStore", (
                 return {
                     type: "output",
                     id: domId,
+                    stepId: String(step.id),
                     prettyName: `Output "${workflowOutput?.label ?? output.name}" for step ${step.id + 1}`,
                     bounds,
                     name: output.name,
@@ -150,6 +155,7 @@ export const useWorkflowSearchStore = defineScopedStore("WorkflowSearchStore", (
                 {
                     type: "step",
                     id: domId,
+                    stepId: String(step.id),
                     prettyName: `${step.id + 1}: ${step.label ?? step.name}`,
                     stepType: step.type,
                     bounds,


### PR DESCRIPTION
## Invocation Graph Search:

- Moves the results listing of the existing workflow editor search to its own component (`GraphSearch`)
- Reuses that component to display results in a popover in the top right of the invocation view's tabs

https://github.com/user-attachments/assets/002c5c86-1a02-4a17-8fbc-983ace218657

## Steps Tab Search

This also adds a search to the invocation steps tab:

https://github.com/user-attachments/assets/db79e50a-3c49-45e5-bf48-b47a4bf53367

Fixes https://github.com/galaxyproject/galaxy/issues/20437

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
