### PR TITLE
Migrate WebDAV file source to fsspec/webdav4

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5902,8 +5902,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Default value for use_temp_files for webdav plugins that don't
-    explicitly declare this.
+    Deprecated. This option is ignored by the fsspec-based WebDAV file
+    source.
 :Default: ``true``
 :Type: bool
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -3173,8 +3173,8 @@ galaxy:
   # to new_file_path if not set.
   #file_source_temp_dir: null
 
-  # Default value for use_temp_files for webdav plugins that don't
-  # explicitly declare this.
+  # Deprecated. This option is ignored by the fsspec-based WebDAV file
+  # source.
   #file_source_webdav_use_temp_files: true
 
   # Number of seconds before file source content listings are refreshed.
@@ -3231,4 +3231,3 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
-

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -24,13 +24,11 @@ gravity:
   # ``supervisor`` is the default process manager when Gravity is invoked as a non-root user.
   # ``systemd`` is the default when Gravity is invoked as root.
   # ``multiprocessing`` is the default when Gravity is invoked as the foreground shortcut ``galaxy`` instead of ``galaxyctl``
-  # Valid options are: supervisor, systemd, multiprocessing
-  # process_manager:
+  # process_manager: null
 
   # What command to write to the process manager configs
   # `gravity` (`galaxyctl exec <service-name>`) is the default
   # `direct` (each service's actual command) is also supported.
-  # Valid options are: gravity, direct
   # service_command_style: gravity
 
   # Use the process manager's *service instance* functionality for services that can run multiple instances.
@@ -45,46 +43,45 @@ gravity:
   # Memory limit (in GB), processes exceeding the limit will be killed. Default is no limit. If set, this is default value
   # for all services. Setting ``memory_limit`` on an individual service overrides this value. Ignored if ``process_manager``
   # is ``supervisor``.
-  # memory_limit:
+  # memory_limit: null
 
   # Memory usage throttle limit (in GB), processes exceeding the limit are throttled and put under heavy reclaim pressure.
   # If set, this is the default value for all services. Setting ``memory_high`` on an individual service overrides this
   # value. Ignored if ``process_manager`` is ``supervisor``.
-  # memory_high:
+  # memory_high: null
 
   # Specify Galaxy config file (galaxy.yml), if the Gravity config is separate from the Galaxy config. Assumed to be the
   # same file as the Gravity config if a ``galaxy`` key exists at the root level, otherwise, this option is required.
-  # galaxy_config_file:
+  # galaxy_config_file: null
 
   # Specify Galaxy's root directory.
   # Gravity will attempt to find the root directory, but you can set the directory explicitly with this option.
-  # galaxy_root:
+  # galaxy_root: null
 
   # User to run Galaxy as, required when using the systemd process manager as root.
   # Ignored if ``process_manager`` is ``supervisor`` or user-mode (non-root) ``systemd``.
-  # galaxy_user:
+  # galaxy_user: null
 
   # Group to run Galaxy as, optional when using the systemd process manager as root.
   # Ignored if ``process_manager`` is ``supervisor`` or user-mode (non-root) ``systemd``.
-  # galaxy_group:
+  # galaxy_group: null
 
   # Set to a directory that should contain log files for the processes controlled by Gravity.
   # If not specified defaults to ``<galaxy_data_dir>/gravity/log``.
-  # log_dir:
+  # log_dir: null
 
   # Run Galaxy processes in the specified journal namespace (sets the value of ``LogNamespace=`` in the systemd service
   # units). This allows you to keep Galaxy log messages separate in the system journal from other log messages. Ignored if
   # ``process_manager`` is not ``systemd``. See ``systemd.exec(5)`` for details.
-  # log_namespace:
+  # log_namespace: null
 
   # Set to Galaxy's virtualenv directory.
   # If not specified, Gravity assumes all processes are on PATH. This option is required in most circumstances when using
   # the ``systemd`` process manager.
-  # virtualenv:
+  # virtualenv: null
 
   # Select the application server.
   # ``gunicorn`` is the default application server.
-  # Valid options are: gunicorn
   # app_server: gunicorn
 
   # Override the default instance name.
@@ -119,7 +116,7 @@ gravity:
     # preload: true
 
     # umask under which service should be executed
-    # umask:
+    # umask: null
 
     # Value of supervisor startsecs, systemd TimeoutStartSec
     # start_timeout: 15
@@ -133,123 +130,22 @@ gravity:
     # Memory limit (in GB). If the service exceeds the limit, it will be killed. Default is no limit or the value of the
     # ``memory_limit`` setting at the top level of the Gravity configuration, if set. Ignored if ``process_manager`` is
     # ``supervisor``.
-    # memory_limit:
+    # memory_limit: null
 
     # Memory usage throttle limit (in GB). If the service exceeds the limit, processes are throttled and put under heavy
     # reclaim pressure. Default is no limit or the value of the ``memory_high`` setting at the top level of the Gravity
     # configuration, if set. Ignored if ``process_manager`` is ``supervisor``.
-    # memory_high:
+    # memory_high: null
 
     # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
     # names.
     # environment: {}
 
   # Configuration for Celery Processes.
-  celery:
-
-    # Enable Celery distributed task queue.
-    # enable: true
-
-    # Enable Celery Beat periodic task runner.
-    # enable_beat: true
-
-    # Number of Celery Workers to start.
-    # concurrency: 2
-
-    # Log Level to use for Celery Worker.
-    # Valid options are: DEBUG, INFO, WARNING, ERROR
-    # loglevel: DEBUG
-
-    # Queues to join
-    # queues: celery,galaxy.internal,galaxy.external
-
-    # Pool implementation
-    # Valid options are: prefork, eventlet, gevent, solo, processes, threads
-    # pool: threads
-
-    # Extra arguments to pass to Celery command line.
-    # extra_args:
-
-    # umask under which service should be executed
-    # umask:
-
-    # Value of supervisor startsecs, systemd TimeoutStartSec
-    # start_timeout: 10
-
-    # Value of supervisor stopwaitsecs, systemd TimeoutStopSec
-    # stop_timeout: 10
-
-    # Memory limit (in GB). If the service exceeds the limit, it will be killed. Default is no limit or the value of the
-    # ``memory_limit`` setting at the top level of the Gravity configuration, if set. Ignored if ``process_manager`` is
-    # ``supervisor``.
-    # memory_limit:
-
-    # Memory usage throttle limit (in GB). If the service exceeds the limit, processes are throttled and put under heavy
-    # reclaim pressure. Default is no limit or the value of the ``memory_high`` setting at the top level of the Gravity
-    # configuration, if set. Ignored if ``process_manager`` is ``supervisor``.
-    # memory_high:
-
-    # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
-    # names.
-    # environment: {}
+  # celery: {}
 
   # Configuration for gx-it-proxy.
-  gx_it_proxy:
-
-    # Set to true to start gx-it-proxy
-    # enable: false
-
-    # gx-it-proxy version
-    # version: '>=0.0.6'
-
-    # Public-facing IP of the proxy
-    # ip: localhost
-
-    # Public-facing port of the proxy
-    # port: 4002
-
-    # Database to monitor.
-    # Should be set to the same value as ``interactivetools_map`` (or ``interactivetoolsproxy_map``) in the ``galaxy:`` section. This is
-    # ignored if either ``interactivetools_map`` or ``interactivetoolsproxy_map`` are set.
-    # sessions: database/interactivetools_map.sqlite
-
-    # Include verbose messages in gx-it-proxy
-    # verbose: true
-
-    # Forward all requests to IP.
-    # This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
-    # forward_ip:
-
-    # Forward all requests to port.
-    # This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
-    # forward_port:
-
-    # Rewrite location blocks with proxy port.
-    # This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
-    # reverse_proxy: false
-
-    # umask under which service should be executed
-    # umask:
-
-    # Value of supervisor startsecs, systemd TimeoutStartSec
-    # start_timeout: 10
-
-    # Value of supervisor stopwaitsecs, systemd TimeoutStopSec
-    # stop_timeout: 10
-
-    # Memory limit (in GB). If the service exceeds the limit, it will be killed. Default is no limit or the value of the
-    # ``memory_limit`` setting at the top level of the Gravity configuration, if set. Ignored if ``process_manager`` is
-    # ``supervisor``.
-    # memory_limit:
-
-    # Memory usage throttle limit (in GB). If the service exceeds the limit, processes are throttled and put under heavy
-    # reclaim pressure. Default is no limit or the value of the ``memory_high`` setting at the top level of the Gravity
-    # configuration, if set. Ignored if ``process_manager`` is ``supervisor``.
-    # memory_high:
-
-    # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
-    # names.
-    # environment: {}
+  # gx_it_proxy: {}
 
   # Configuration for tusd server (https://github.com/tus/tusd).
   # The ``tusd`` binary must be installed manually and made available on PATH (e.g in galaxy's .venv/bin directory).
@@ -296,7 +192,7 @@ gravity:
     # extra_args:
 
     # umask under which service should be executed
-    # umask:
+    # umask: null
 
     # Value of supervisor startsecs, systemd TimeoutStartSec
     # start_timeout: 10
@@ -307,73 +203,19 @@ gravity:
     # Memory limit (in GB). If the service exceeds the limit, it will be killed. Default is no limit or the value of the
     # ``memory_limit`` setting at the top level of the Gravity configuration, if set. Ignored if ``process_manager`` is
     # ``supervisor``.
-    # memory_limit:
+    # memory_limit: null
 
     # Memory usage throttle limit (in GB). If the service exceeds the limit, processes are throttled and put under heavy
     # reclaim pressure. Default is no limit or the value of the ``memory_high`` setting at the top level of the Gravity
     # configuration, if set. Ignored if ``process_manager`` is ``supervisor``.
-    # memory_high:
+    # memory_high: null
 
     # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
     # names.
     # environment: {}
 
   # Configuration for Galaxy Reports.
-  reports:
-
-    # Enable Galaxy Reports server.
-    # enable: false
-
-    # Path to reports.yml, relative to galaxy.yml if not absolute
-    # config_file: reports.yml
-
-    # The socket to bind. A string of the form: ``HOST``, ``HOST:PORT``, ``unix:PATH``, ``fd://FD``. An IP is a valid HOST.
-    # bind: localhost:9001
-
-    # Controls the number of Galaxy Reports application processes Gunicorn will spawn.
-    # It is not generally necessary to increase this for the low-traffic Reports server.
-    # workers: 1
-
-    # Gunicorn workers silent for more than this many seconds are killed and restarted.
-    # Value is a positive number or 0. Setting it to 0 has the effect of infinite timeouts by disabling timeouts for all workers entirely.
-    # timeout: 300
-
-    # URL prefix to serve from.
-    # The corresponding nginx configuration is (replace <url_prefix> and <bind> with the values from these options):
-    #
-    # location /<url_prefix>/ {
-    #     proxy_pass http://<bind>/;
-    # }
-    #
-    # If <bind> is a unix socket, you will need a ``:`` after the socket path but before the trailing slash like so:
-    #     proxy_pass http://unix:/run/reports.sock:/;
-    # url_prefix:
-
-    # Extra arguments to pass to Gunicorn command line.
-    # extra_args:
-
-    # umask under which service should be executed
-    # umask:
-
-    # Value of supervisor startsecs, systemd TimeoutStartSec
-    # start_timeout: 10
-
-    # Value of supervisor stopwaitsecs, systemd TimeoutStopSec
-    # stop_timeout: 10
-
-    # Memory limit (in GB). If the service exceeds the limit, it will be killed. Default is no limit or the value of the
-    # ``memory_limit`` setting at the top level of the Gravity configuration, if set. Ignored if ``process_manager`` is
-    # ``supervisor``.
-    # memory_limit:
-
-    # Memory usage throttle limit (in GB). If the service exceeds the limit, processes are throttled and put under heavy
-    # reclaim pressure. Default is no limit or the value of the ``memory_high`` setting at the top level of the Gravity
-    # configuration, if set. Ignored if ``process_manager`` is ``supervisor``.
-    # memory_high:
-
-    # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
-    # names.
-    # environment: {}
+  # reports: {}
 
   # Configure dynamic handlers in this section.
   # See https://docs.galaxyproject.org/en/latest/admin/scaling.html#dynamically-defined-handlers for details.
@@ -3231,3 +3073,4 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
+

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4359,7 +4359,7 @@ mapping:
         type: bool
         default: true
         desc: |
-          Default value for use_temp_files for webdav plugins that don't explicitly declare this.
+          Deprecated. This option is ignored by the fsspec-based WebDAV file source.
 
       file_source_listings_expiry_time:
         type: int

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -258,12 +258,14 @@ class ConditionalDependencies:
     def check_fs_dropboxfs(self):
         return "dropbox" in self.file_sources
 
-    def check_fs_webdavfs(self):
+    def check_webdav4(self):
         return "webdav" in self.file_sources
 
+    def check_fs_webdavfs(self):
+        return self.check_webdav4()
+
     def check_webdavclient3(self):
-        # fs.webdavfs dependency for which we need an unreleased version
-        return self.check_fs_webdavfs()
+        return self.check_webdav4()
 
     def check_fs_anvilfs(self):
         # pyfilesystem plugin access to terra on anvil

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -261,12 +261,6 @@ class ConditionalDependencies:
     def check_webdav4(self):
         return "webdav" in self.file_sources
 
-    def check_fs_webdavfs(self):
-        return self.check_webdav4()
-
-    def check_webdavclient3(self):
-        return self.check_webdav4()
-
     def check_fs_anvilfs(self):
         # pyfilesystem plugin access to terra on anvil
         return "anvil" in self.file_sources

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -21,9 +21,7 @@ fastmcp>=2.13.0
 redis>=5.3.0,<6
 
 # For file sources plugins
-fs.webdavfs>=0.4.2  # type: webdav
-# webdavclient3 on the develop branch contains an important fix for username-based authentification containing the '@' symbol
-webdavclient3 @ git+https://github.com/ezhov-evgeny/webdav-client-python-3@98c23d1abd15efc3db9cfc756429f00041578bc2
+webdav4[fsspec]  # type: webdav
 fs.dropboxfs>=1.0.3  # type: dropbox
 fs.sshfs  # type: ssh
 fs.anvilfs # type: anvil

--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -52,7 +52,6 @@ class FileSourcePluginsConfig(BaseModel):
     ftp_upload_dir: Optional[str] = None
     ftp_upload_purge: bool = True
     tmp_dir: Optional[str] = None
-    webdav_use_temp_files: Optional[bool] = None
     listings_expiry_time: Optional[int] = None
 
     @staticmethod
@@ -67,7 +66,6 @@ class FileSourcePluginsConfig(BaseModel):
         kwds["ftp_upload_dir"] = config.ftp_upload_dir
         kwds["ftp_upload_purge"] = config.ftp_upload_purge
         kwds["tmp_dir"] = config.file_source_temp_dir
-        kwds["webdav_use_temp_files"] = config.file_source_webdav_use_temp_files
         kwds["listings_expiry_time"] = config.file_source_listings_expiry_time
 
         return FileSourcePluginsConfig(**kwds)
@@ -81,7 +79,6 @@ class FileSourcePluginsConfig(BaseModel):
             "ftp_upload_dir": self.ftp_upload_dir,
             "ftp_upload_purge": self.ftp_upload_purge,
             "tmp_dir": self.tmp_dir,
-            "webdav_use_temp_files": self.webdav_use_temp_files,
             "listings_expiry_time": self.listings_expiry_time,
         }
 
@@ -96,7 +93,6 @@ class FileSourcePluginsConfig(BaseModel):
             ftp_upload_purge=as_dict["ftp_upload_purge"],
             # Always provided for new jobs, remove in 25.0
             tmp_dir=as_dict.get("tmp_dir"),
-            webdav_use_temp_files=as_dict.get("webdav_use_temp_files"),
             listings_expiry_time=as_dict.get("listings_expiry_time"),
         )
 

--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -45,6 +45,8 @@ def _normalize_base_url(base_url: Optional[str]) -> Optional[str]:
 
 
 def _compose_base_url(url: Optional[str], root: Optional[str]) -> Optional[str]:
+    # WebDAV "root" is the service endpoint path (for example Nextcloud's
+    # /remote.php/dav/files/user), not a directory prefix inside the file source.
     if not url:
         return None
     url = url.rstrip("/")
@@ -69,7 +71,6 @@ class WebDavFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfigur
         if not isinstance(data, dict):
             return data
         normalized = dict(data)
-        normalized["root"] = _normalize_root(normalized.get("root"))
         normalized["base_url"] = _normalize_base_url(
             normalized.get("base_url") or _compose_base_url(normalized.get("url"), normalized.get("root"))
         )
@@ -97,7 +98,6 @@ class WebDavFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
         if not isinstance(data, dict):
             return data
         normalized = dict(data)
-        normalized["root"] = _normalize_root(normalized.get("root"))
         normalized["base_url"] = _normalize_base_url(
             normalized.get("base_url") or _compose_base_url(normalized.get("url"), normalized.get("root"))
         )

--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -140,7 +140,7 @@ class WebDavFilesSource(FsspecFilesSource[WebDavFileSourceTemplateConfiguration,
 
         config = context.config
         auth = (config.login, config.password) if config.login or config.password else None
-        return WebdavFileSystem(config.base_url, auth=auth, **cache_options)
+        return WebdavFileSystem(config.base_url, auth=auth)
 
     def _to_filesystem_path(self, path: str, config: WebDavFileSourceConfiguration) -> str:
         if path in ("", "/"):
@@ -152,9 +152,6 @@ class WebDavFilesSource(FsspecFilesSource[WebDavFileSourceTemplateConfiguration,
             return "/"
         return filesystem_path if filesystem_path.startswith("/") else f"/{filesystem_path}"
 
-    def _get_cache_options(self, config: WebDavFileSourceConfiguration) -> dict[str, Any]:
-        # webdav4 does not accept fsspec listing-cache constructor kwargs and forwards unexpected values to its client implementation.
-        return {}
 
 
 __all__ = ("WebDavFilesSource",)

--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -1,11 +1,6 @@
-try:
-    from webdavfs.webdavfs import WebDAVFS
-except ImportError:
-    WebDAVFS = None
-
-import tempfile
 from typing import (
     Annotated,
+    Any,
     Optional,
     Union,
 )
@@ -13,86 +8,153 @@ from typing import (
 from pydantic import (
     Field,
     field_validator,
+    model_validator,
 )
 
-from galaxy.files.models import (
-    BaseFileSourceConfiguration,
-    BaseFileSourceTemplateConfiguration,
-    FilesSourceRuntimeContext,
-)
+from galaxy.files.models import FilesSourceRuntimeContext
 from galaxy.util.config_templates import TemplateExpansion
-from ._pyfilesystem2 import PyFilesystem2FilesSource
+from ._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+
+try:
+    from webdav4.fsspec import WebdavFileSystem
+except ImportError:
+    WebdavFileSystem = None
 
 
-class WebDavFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
+def _normalize_root(root: Optional[str]) -> Optional[str]:
+    if root is None:
+        return None
+    root = root.strip()
+    if not root or root == "/":
+        return None
+    return f"/{root.strip('/')}"
+
+
+def _normalize_base_url(base_url: Optional[str]) -> Optional[str]:
+    if base_url is None:
+        return None
+    base_url = base_url.strip()
+    if not base_url:
+        return None
+    return base_url.rstrip("/")
+
+
+def _compose_base_url(url: Optional[str], root: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    url = url.rstrip("/")
+    normalized_root = _normalize_root(root)
+    if normalized_root:
+        return f"{url}{normalized_root}"
+    return url
+
+
+class WebDavFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
     url: Union[str, TemplateExpansion, None] = None
     root: Optional[Union[str, TemplateExpansion]] = None
+    base_url: Union[str, TemplateExpansion, None] = None
     login: Optional[Union[str, TemplateExpansion]] = None
     password: Optional[Union[str, TemplateExpansion]] = None
     temp_path: Optional[Union[str, TemplateExpansion]] = None
     use_temp_files: Union[bool, TemplateExpansion] = True
 
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_endpoint(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        normalized["root"] = _normalize_root(normalized.get("root"))
+        normalized["base_url"] = _normalize_base_url(
+            normalized.get("base_url") or _compose_base_url(normalized.get("url"), normalized.get("root"))
+        )
+        return normalized
 
-class WebDavFileSourceConfiguration(BaseFileSourceConfiguration):
-    # Override url field to make it required for WebDAV - we keep a default but validate it's provided
-    url: Annotated[
+
+class WebDavFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
+    url: Optional[str] = None
+    root: Optional[str] = None
+    base_url: Annotated[
         str,
         Field(
-            title="WebDAV URL",
-            description="The URL of the WebDAV server. This is required for WebDAV file sources.",
+            title="WebDAV base URL",
+            description="The fully-qualified WebDAV endpoint URL used to access this file source.",
         ),
-    ] = None  # type: ignore[assignment]
-    root: Optional[str] = None
+    ]
     login: Optional[str] = None
     password: Optional[str] = None
     temp_path: Optional[str] = None
-    use_temp_files: bool = True  # Default to True to avoid memory issues with large files.
+    use_temp_files: bool = True
 
-    @field_validator("url")
+    @model_validator(mode="before")
     @classmethod
-    def validate_url_required(cls, v):
-        if v is None or v == "":
-            raise ValueError("url is required for WebDAV file source")
+    def normalize_endpoint(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        normalized = dict(data)
+        normalized["root"] = _normalize_root(normalized.get("root"))
+        normalized["base_url"] = _normalize_base_url(
+            normalized.get("base_url") or _compose_base_url(normalized.get("url"), normalized.get("root"))
+        )
+        return normalized
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url_required(cls, v: str) -> str:
+        if not v:
+            raise ValueError("base_url is required for WebDAV file source")
         return v
 
 
-class WebDavFilesSource(PyFilesystem2FilesSource[WebDavFileSourceTemplateConfiguration, WebDavFileSourceConfiguration]):
+class WebDavFilesSource(FsspecFilesSource[WebDavFileSourceTemplateConfiguration, WebDavFileSourceConfiguration]):
     plugin_type = "webdav"
-    required_module = WebDAVFS
-    required_package = "fs.webdavfs"
-    allow_key_error_on_empty_directories = True
+    required_module = WebdavFileSystem
+    required_package = "webdav4"
 
     template_config_class = WebDavFileSourceTemplateConfiguration
     resolved_config_class = WebDavFileSourceConfiguration
 
-    def _open_fs(self, context: FilesSourceRuntimeContext[WebDavFileSourceConfiguration]):
-        if WebDAVFS is None:
+    def __init__(self, template_config: WebDavFileSourceTemplateConfiguration):
+        defaults: dict[str, Any] = {}
+        if (
+            "use_temp_files" not in template_config.model_fields_set
+            and template_config.file_sources_config.webdav_use_temp_files is not None
+        ):
+            defaults["use_temp_files"] = template_config.file_sources_config.webdav_use_temp_files
+        if defaults:
+            template_config = self._apply_defaults_to_template(defaults, template_config)
+        super().__init__(template_config)
+
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[WebDavFileSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ):
+        if WebdavFileSystem is None:
             raise self.required_package_exception
 
         config = context.config
-        file_sources_config = self._file_sources_config
-        use_temp_files = config.use_temp_files
-        if file_sources_config and file_sources_config.webdav_use_temp_files is not None:
-            use_temp_files = file_sources_config.webdav_use_temp_files
+        auth = (config.login, config.password) if config.login or config.password else None
+        return WebdavFileSystem(config.base_url, auth=auth, **cache_options)
 
-        if use_temp_files:
-            temp_path = config.temp_path
-            if temp_path is None and file_sources_config and file_sources_config.tmp_dir:
-                temp_path = file_sources_config.tmp_dir
-            if temp_path is None:
-                temp_path = tempfile.mkdtemp(prefix="webdav_")
-            config.temp_path = temp_path
-        config.use_temp_files = use_temp_files
+    def _to_filesystem_path(self, path: str, config: WebDavFileSourceConfiguration) -> str:
+        if path in ("", "/"):
+            return ""
+        return path.lstrip("/")
 
-        handle = WebDAVFS(
-            url=config.url,
-            root=config.root,
-            login=config.login,
-            password=config.password,
-            temp_path=config.temp_path,
-            use_temp_files=config.use_temp_files,
-        )
-        return handle
+    def _adapt_entry_path(self, filesystem_path: str, config: WebDavFileSourceConfiguration) -> str:
+        if not filesystem_path or filesystem_path == "/":
+            return "/"
+        return filesystem_path if filesystem_path.startswith("/") else f"/{filesystem_path}"
+
+    def _get_cache_options(self, config: WebDavFileSourceConfiguration) -> dict[str, Any]:
+        # webdav4 does not accept fsspec listing-cache constructor kwargs and forwards unexpected values to its client implementation.
+        return {}
 
 
 __all__ = ("WebDavFilesSource",)

--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -1,14 +1,11 @@
 from typing import (
     Annotated,
-    Any,
     Optional,
     Union,
 )
 
 from pydantic import (
     Field,
-    field_validator,
-    model_validator,
 )
 
 from galaxy.files.models import FilesSourceRuntimeContext
@@ -26,59 +23,14 @@ except ImportError:
     WebdavFileSystem = None
 
 
-def _normalize_root(root: Optional[str]) -> Optional[str]:
-    if root is None:
-        return None
-    root = root.strip()
-    if not root or root == "/":
-        return None
-    return f"/{root.strip('/')}"
-
-
-def _normalize_base_url(base_url: Optional[str]) -> Optional[str]:
-    if base_url is None:
-        return None
-    base_url = base_url.strip()
-    if not base_url:
-        return None
-    return base_url.rstrip("/")
-
-
-def _compose_base_url(url: Optional[str], root: Optional[str]) -> Optional[str]:
-    # WebDAV "root" is the service endpoint path (for example Nextcloud's
-    # /remote.php/dav/files/user), not a directory prefix inside the file source.
-    if not url:
-        return None
-    url = url.rstrip("/")
-    normalized_root = _normalize_root(root)
-    if normalized_root:
-        return f"{url}{normalized_root}"
-    return url
-
-
 class WebDavFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
-    url: Union[str, TemplateExpansion, None] = None
     root: Optional[Union[str, TemplateExpansion]] = None
-    base_url: Union[str, TemplateExpansion, None] = None
+    base_url: Union[str, TemplateExpansion]
     login: Optional[Union[str, TemplateExpansion]] = None
     password: Optional[Union[str, TemplateExpansion]] = None
-    temp_path: Optional[Union[str, TemplateExpansion]] = None
-    use_temp_files: Union[bool, TemplateExpansion] = True
-
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_endpoint(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
-            return data
-        normalized = dict(data)
-        normalized["base_url"] = _normalize_base_url(
-            normalized.get("base_url") or _compose_base_url(normalized.get("url"), normalized.get("root"))
-        )
-        return normalized
 
 
 class WebDavFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
-    url: Optional[str] = None
     root: Optional[str] = None
     base_url: Annotated[
         str,
@@ -89,26 +41,6 @@ class WebDavFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
     ]
     login: Optional[str] = None
     password: Optional[str] = None
-    temp_path: Optional[str] = None
-    use_temp_files: bool = True
-
-    @model_validator(mode="before")
-    @classmethod
-    def normalize_endpoint(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
-            return data
-        normalized = dict(data)
-        normalized["base_url"] = _normalize_base_url(
-            normalized.get("base_url") or _compose_base_url(normalized.get("url"), normalized.get("root"))
-        )
-        return normalized
-
-    @field_validator("base_url")
-    @classmethod
-    def validate_base_url_required(cls, v: str) -> str:
-        if not v:
-            raise ValueError("base_url is required for WebDAV file source")
-        return v
 
 
 class WebDavFilesSource(FsspecFilesSource[WebDavFileSourceTemplateConfiguration, WebDavFileSourceConfiguration]):
@@ -119,16 +51,17 @@ class WebDavFilesSource(FsspecFilesSource[WebDavFileSourceTemplateConfiguration,
     template_config_class = WebDavFileSourceTemplateConfiguration
     resolved_config_class = WebDavFileSourceConfiguration
 
-    def __init__(self, template_config: WebDavFileSourceTemplateConfiguration):
-        defaults: dict[str, Any] = {}
-        if (
-            "use_temp_files" not in template_config.model_fields_set
-            and template_config.file_sources_config.webdav_use_temp_files is not None
-        ):
-            defaults["use_temp_files"] = template_config.file_sources_config.webdav_use_temp_files
-        if defaults:
-            template_config = self._apply_defaults_to_template(defaults, template_config)
-        super().__init__(template_config)
+    @staticmethod
+    def _webdav_endpoint(base_url: str, root: Optional[str]) -> str:
+        # WebDAV "root" is the service endpoint path (for example Nextcloud's
+        # /remote.php/dav/files/user), not a directory prefix inside the file source.
+        base_url = base_url.strip().rstrip("/")
+        if not base_url:
+            raise ValueError("base_url is required for WebDAV file source")
+        root = root.strip().strip("/") if root else ""
+        if root:
+            return f"{base_url}/{root}"
+        return base_url
 
     def _open_fs(
         self,
@@ -140,7 +73,7 @@ class WebDavFilesSource(FsspecFilesSource[WebDavFileSourceTemplateConfiguration,
 
         config = context.config
         auth = (config.login, config.password) if config.login or config.password else None
-        return WebdavFileSystem(config.base_url, auth=auth)
+        return WebdavFileSystem(self._webdav_endpoint(config.base_url, config.root), auth=auth)
 
     def _to_filesystem_path(self, path: str, config: WebDavFileSourceConfiguration) -> str:
         if path in ("", "/"):
@@ -151,7 +84,6 @@ class WebDavFilesSource(FsspecFilesSource[WebDavFileSourceTemplateConfiguration,
         if not filesystem_path or filesystem_path == "/":
             return "/"
         return filesystem_path if filesystem_path.startswith("/") else f"/{filesystem_path}"
-
 
 
 __all__ = ("WebDavFilesSource",)

--- a/lib/galaxy/files/templates/examples/production_webdav.yml
+++ b/lib/galaxy/files/templates/examples/production_webdav.yml
@@ -4,7 +4,7 @@
   description: |
     The WebDAV protocol is a simple way to access files over the internet. Here, you can connect to any WebDAV server.
   variables:
-    url:
+    base_url:
       label: Server Domain (e.g. https://myowncloud.org)
       type: string
       help: |
@@ -35,8 +35,9 @@
         to log in to the WebDAV server.
   configuration:
     type: webdav
-    url: '{{ variables.url }}'
+    base_url: '{{ variables.base_url }}'
     root: '{{ variables.root }}'
     login: '{{ variables.login }}'
     writable: '{{ variables.writable }}'
     password: '{{ secrets.password }}'
+    

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -8,6 +8,7 @@ from typing import (
 
 from pydantic import (
     Field,
+    model_validator,
     RootModel,
 )
 
@@ -235,7 +236,7 @@ class OnedataFileSourceConfiguration(StrictModel):
 
 class WebdavFileSourceTemplateConfiguration(StrictModel):
     type: Literal["webdav"]
-    url: Union[str, TemplateExpansion]
+    base_url: Union[str, TemplateExpansion]
     root: Union[str, TemplateExpansion]
     login: Union[str, TemplateExpansion]
     password: Union[str, TemplateExpansion]
@@ -243,14 +244,34 @@ class WebdavFileSourceTemplateConfiguration(StrictModel):
     template_start: Optional[str] = None
     template_end: Optional[str] = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def ensure_base_url(cls, data: Any) -> Any:
+        # Keep persisted user file source templates created before the WebDAV
+        # url -> base_url rename loadable in the preferences UI.
+        if isinstance(data, dict) and "base_url" not in data and "url" in data:
+            data = dict(data)
+            data["base_url"] = data.pop("url")
+        return data
+
 
 class WebdavFileSourceConfiguration(StrictModel):
     type: Literal["webdav"]
-    url: str
+    base_url: str
     root: str
     login: str
     password: str
     writable: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def ensure_base_url(cls, data: Any) -> Any:
+        # Keep persisted user file source configurations created before the WebDAV
+        # url -> base_url rename loadable in the preferences UI.
+        if isinstance(data, dict) and "base_url" not in data and "url" in data:
+            data = dict(data)
+            data["base_url"] = data.pop("url")
+        return data
 
 
 class eLabFTWFileSourceTemplateConfiguration(StrictModel):  # noqa

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -234,7 +234,19 @@ class OnedataFileSourceConfiguration(StrictModel):
     writable: bool = False
 
 
-class WebdavFileSourceTemplateConfiguration(StrictModel):
+class WebdavConfigMixin:
+    @model_validator(mode="before")
+    @classmethod
+    def ensure_base_url(cls, data: Any) -> Any:
+        # Keep persisted user file sources created before the WebDAV
+        # url -> base_url rename loadable in the preferences UI.
+        if isinstance(data, dict) and "base_url" not in data and "url" in data:
+            data = dict(data)
+            data["base_url"] = data.pop("url")
+        return data
+
+
+class WebdavFileSourceTemplateConfiguration(WebdavConfigMixin, StrictModel):
     type: Literal["webdav"]
     base_url: Union[str, TemplateExpansion]
     root: Union[str, TemplateExpansion]
@@ -244,34 +256,14 @@ class WebdavFileSourceTemplateConfiguration(StrictModel):
     template_start: Optional[str] = None
     template_end: Optional[str] = None
 
-    @model_validator(mode="before")
-    @classmethod
-    def ensure_base_url(cls, data: Any) -> Any:
-        # Keep persisted user file source templates created before the WebDAV
-        # url -> base_url rename loadable in the preferences UI.
-        if isinstance(data, dict) and "base_url" not in data and "url" in data:
-            data = dict(data)
-            data["base_url"] = data.pop("url")
-        return data
 
-
-class WebdavFileSourceConfiguration(StrictModel):
+class WebdavFileSourceConfiguration(WebdavConfigMixin, StrictModel):
     type: Literal["webdav"]
     base_url: str
     root: str
     login: str
     password: str
     writable: bool = False
-
-    @model_validator(mode="before")
-    @classmethod
-    def ensure_base_url(cls, data: Any) -> Any:
-        # Keep persisted user file source configurations created before the WebDAV
-        # url -> base_url rename loadable in the preferences UI.
-        if isinstance(data, dict) and "base_url" not in data and "url" in data:
-            data = dict(data)
-            data["base_url"] = data.pop("url")
-        return data
 
 
 class eLabFTWFileSourceTemplateConfiguration(StrictModel):  # noqa

--- a/test/integration/file_sources_conf.yml
+++ b/test/integration/file_sources_conf.yml
@@ -1,6 +1,6 @@
 - type: webdav
   id: test1
   doc: Test WebDAV server.
-  url: http://127.0.0.1:7083
+  base_url: http://127.0.0.1:7083
   login: alice  
   password: secret1234

--- a/test/integration/test_webdav.py
+++ b/test/integration/test_webdav.py
@@ -11,6 +11,8 @@ from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
+pytest.importorskip("webdav4.fsspec")
+
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 FILE_SOURCES_JOB_CONF = os.path.join(SCRIPT_DIRECTORY, "file_sources_conf.yml")
 

--- a/test/unit/app/dependencies/test_deps.py
+++ b/test/unit/app/dependencies/test_deps.py
@@ -75,7 +75,7 @@ def test_fs_default():
     with _config_context() as cc:
         cds = cc.get_cond_deps()
         assert not cds.check_fs_dropboxfs()
-        assert not cds.check_fs_webdavfs()
+        assert not cds.check_webdav4()
 
 
 def test_fs_configured():
@@ -86,7 +86,7 @@ def test_fs_configured():
         }
         cds = cc.get_cond_deps(config=config)
         assert cds.check_fs_dropboxfs()
-        assert cds.check_fs_webdavfs()
+        assert cds.check_webdav4()
 
 
 def test_yaml_jobconf_runners():

--- a/test/unit/app/tools/test_data_fetch.py
+++ b/test/unit/app/tools/test_data_fetch.py
@@ -429,7 +429,6 @@ def _execute_context(allow_localhost=False):
                             "ftp_upload_dir": None,
                             "ftp_upload_purge": True,
                             "tmp_dir": None,
-                            "webdav_use_temp_files": None,
                             "listings_expiry_time": None,
                         },
                     },

--- a/test/unit/files/test_webdav.py
+++ b/test/unit/files/test_webdav.py
@@ -18,6 +18,8 @@ from ._util import (
 )
 from .test_posix import _download_and_check_file
 
+pytest.importorskip("webdav4.fsspec")
+
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "webdav_file_sources_conf.yml")
 FILE_SOURCES_CONF_NO_USE_TEMP_FILES = os.path.join(SCRIPT_DIRECTORY, "webdav_file_sources_without_use_temp_conf.yml")
@@ -69,9 +71,15 @@ def test_sniff_to_tmp():
 def test_serialization():
     configs = [FILE_SOURCES_CONF_NO_USE_TEMP_FILES, FILE_SOURCES_CONF]
     for config in configs:
+        file_sources_o = configured_file_sources(config)
+        original = file_source_as_webdav(file_sources_o._file_sources[0])
+        assert original._get_runtime_context().config.base_url == "http://127.0.0.1:7083"
+
         # serialize the configured file sources and rematerialize them,
         # ensure they still function. This is needed for uploading files.
-        file_sources = serialize_and_recover(configured_file_sources(config))
+        file_sources = serialize_and_recover(file_sources_o)
+        recovered = file_source_as_webdav(file_sources._file_sources[0])
+        assert recovered._get_runtime_context().config.base_url == "http://127.0.0.1:7083"
 
         res = list_root(file_sources, "gxfiles://test1", recursive=True)
         assert find_file_a(res)
@@ -114,9 +122,15 @@ def test_serialization_user():
     file_sources_o = configured_file_sources(USER_FILE_SOURCES_CONF)
     user_context = user_context_fixture()
 
+    original = file_source_as_webdav(file_sources_o._file_sources[0])
+    assert original._get_runtime_context(user_context=user_context).config.base_url == "http://127.0.0.1:7083"
+
     res = list_root(file_sources_o, "gxfiles://test1", recursive=True, user_context=user_context)
     assert find_file_a(res)
 
     file_sources = serialize_and_recover(file_sources_o, user_context=user_context)
+    recovered = file_source_as_webdav(file_sources._file_sources[0])
+    assert recovered._get_runtime_context().config.base_url == "http://127.0.0.1:7083"
+
     res = list_root(file_sources, "gxfiles://test1", recursive=True, user_context=None)
     assert find_file_a(res)

--- a/test/unit/files/test_webdav.py
+++ b/test/unit/files/test_webdav.py
@@ -4,7 +4,6 @@ import os
 
 import pytest
 
-from galaxy.files.plugins import FileSourcePluginsConfig
 from galaxy.files.sources import BaseFilesSource
 from galaxy.files.sources.webdav import WebDavFilesSource
 from ._util import (
@@ -22,7 +21,6 @@ pytest.importorskip("webdav4.fsspec")
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "webdav_file_sources_conf.yml")
-FILE_SOURCES_CONF_NO_USE_TEMP_FILES = os.path.join(SCRIPT_DIRECTORY, "webdav_file_sources_without_use_temp_conf.yml")
 USER_FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "webdav_user_file_sources_conf.yml")
 
 skip_if_no_webdav = pytest.mark.skipif(not os.environ.get("GALAXY_TEST_WEBDAV"), reason="GALAXY_TEST_WEBDAV not set")
@@ -69,46 +67,23 @@ def test_sniff_to_tmp():
 
 @skip_if_no_webdav
 def test_serialization():
-    configs = [FILE_SOURCES_CONF_NO_USE_TEMP_FILES, FILE_SOURCES_CONF]
-    for config in configs:
-        file_sources_o = configured_file_sources(config)
-        original = file_source_as_webdav(file_sources_o._file_sources[0])
-        assert original._get_runtime_context().config.base_url == "http://127.0.0.1:7083"
+    file_sources_o = configured_file_sources(FILE_SOURCES_CONF)
+    original = file_source_as_webdav(file_sources_o._file_sources[0])
+    assert original._get_runtime_context().config.base_url == "http://127.0.0.1:7083"
 
-        # serialize the configured file sources and rematerialize them,
-        # ensure they still function. This is needed for uploading files.
-        file_sources = serialize_and_recover(file_sources_o)
-        recovered = file_source_as_webdav(file_sources._file_sources[0])
-        assert recovered._get_runtime_context().config.base_url == "http://127.0.0.1:7083"
+    # serialize the configured file sources and rematerialize them,
+    # ensure they still function. This is needed for uploading files.
+    file_sources = serialize_and_recover(file_sources_o)
+    recovered = file_source_as_webdav(file_sources._file_sources[0])
+    assert recovered._get_runtime_context().config.base_url == "http://127.0.0.1:7083"
 
-        res = list_root(file_sources, "gxfiles://test1", recursive=True)
-        assert find_file_a(res)
+    res = list_root(file_sources, "gxfiles://test1", recursive=True)
+    assert find_file_a(res)
 
-        res = list_root(file_sources, "gxfiles://test1", recursive=False)
-        assert find_file_a(res)
+    res = list_root(file_sources, "gxfiles://test1", recursive=False)
+    assert find_file_a(res)
 
-        _download_and_check_file(file_sources)
-
-
-@skip_if_no_webdav
-def test_config_options():
-    file_sources = configured_file_sources(FILE_SOURCES_CONF)
-    fs = file_source_as_webdav(file_sources._file_sources[0])
-    assert fs.template_config.use_temp_files
-    assert fs._get_runtime_context().config.use_temp_files == fs.template_config.use_temp_files
-
-    file_sources = configured_file_sources(FILE_SOURCES_CONF_NO_USE_TEMP_FILES)
-    fs = file_source_as_webdav(file_sources._file_sources[0])
-    assert not fs.template_config.use_temp_files
-    assert fs._get_runtime_context().config.use_temp_files == fs.template_config.use_temp_files
-
-    disable_default_use_temp = FileSourcePluginsConfig(
-        webdav_use_temp_files=False,
-    )
-    file_sources = configured_file_sources(FILE_SOURCES_CONF, disable_default_use_temp)
-    fs = file_source_as_webdav(file_sources._file_sources[0])
-    assert not fs.template_config.use_temp_files
-    assert fs._get_runtime_context().config.use_temp_files == fs.template_config.use_temp_files
+    _download_and_check_file(file_sources)
 
 
 def file_source_as_webdav(file_source: BaseFilesSource) -> WebDavFilesSource:

--- a/test/unit/files/webdav_file_sources_conf.yml
+++ b/test/unit/files/webdav_file_sources_conf.yml
@@ -1,6 +1,6 @@
 - type: webdav
   id: test1
   doc: Test WebDAV server.
-  url: http://127.0.0.1:7083
+  base_url: http://127.0.0.1:7083
   login: alice
   password: secret1234  

--- a/test/unit/files/webdav_file_sources_without_use_temp_conf.yml
+++ b/test/unit/files/webdav_file_sources_without_use_temp_conf.yml
@@ -1,7 +1,0 @@
-- type: webdav
-  id: test1
-  doc: Test WebDAV server.
-  url: http://127.0.0.1:7083
-  login: alice
-  password: secret1234  
-  use_temp_files: false

--- a/test/unit/files/webdav_user_file_sources_conf.yml
+++ b/test/unit/files/webdav_user_file_sources_conf.yml
@@ -1,6 +1,6 @@
 - type: webdav
   id: test1
   doc: Test WebDAV server.
-  url: http://127.0.0.1:7083
+  base_url: http://127.0.0.1:7083
   login: ${user.username}
   password: ${user.preferences['webdav|password']}


### PR DESCRIPTION
Replace the WebDAV file source backend from fs.webdavfs to webdav4 via Galaxy’s FsspecFilesSource,

This PR includes renaming the WebDAV file source template config field from `url` to `base_url`. The change avoids the reserved `url` field used by other file source machinery, which fixes the current serialization bug where import/export jobs could lose the WebDAV endpoint after file source rehydration.

Migration sub-issue https://github.com/galaxyproject/galaxy/issues/21869

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
