### PR TITLE
Show revision creation date in Tool Shed revision dropdown

### DIFF
--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/repository_metadata_bismark.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/repository_metadata_bismark.json
@@ -94,7 +94,13 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}]
+        "invalid_tools": [
+            {
+                "tool_config": "bismark_bowtie_wrapper.xml",
+                "error_message": "Tool XML parsing error"
+            }
+        ],
+        "create_time": "2024-01-15T10:30:00.000000"
     },
     "1:babbdbda7d7a": {
         "model_class": "RepositoryMetadata",
@@ -161,6 +167,16 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": [{"tool_config": "bismark_bowtie_wrapper.xml", "error_message": "Tool XML parsing error"}, {"tool_config": "bismark_bowtie2_wrapper.xml", "error_message": "Tool XML parsing error"}]
+        "invalid_tools": [
+            {
+                "tool_config": "bismark_bowtie_wrapper.xml",
+                "error_message": "Tool XML parsing error"
+            },
+            {
+                "tool_config": "bismark_bowtie2_wrapper.xml",
+                "error_message": "Tool XML parsing error"
+            }
+        ],
+        "create_time": "2024-01-15T10:30:00.000000"
     }
 }

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/repository_metadata_column_maker.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/repository_metadata_column_maker.json
@@ -44,33 +44,84 @@
                 "tests": [
                     {
                         "inputs": [
-                            ["cond", "c3-c2"],
-                            ["input", "1.bed"],
-                            ["round", "no"]
+                            [
+                                "cond",
+                                "c3-c2"
+                            ],
+                            [
+                                "input",
+                                "1.bed"
+                            ],
+                            [
+                                "round",
+                                "no"
+                            ]
                         ],
                         "name": "Test-1",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.bed", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.bed",
+                            "value"
+                        ]
                     },
                     {
                         "inputs": [
-                            ["cond", "c4*1"],
-                            ["input", "1.interval"],
-                            ["round", "no"]
+                            [
+                                "cond",
+                                "c4*1"
+                            ],
+                            [
+                                "input",
+                                "1.interval"
+                            ],
+                            [
+                                "round",
+                                "no"
+                            ]
                         ],
                         "name": "Test-2",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.interval", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.interval",
+                            "value"
+                        ]
                     },
                     {
                         "inputs": [
-                            ["cond", "c4*1"],
-                            ["input", "1.interval"],
-                            ["round", "yes"]
+                            [
+                                "cond",
+                                "c4*1"
+                            ],
+                            [
+                                "input",
+                                "1.interval"
+                            ],
+                            [
+                                "round",
+                                "yes"
+                            ]
                         ],
                         "name": "Test-3",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.interval", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.interval",
+                            "value"
+                        ]
                     }
                 ],
                 "tool_config": "/private/var/folders/1d/bs7mkcjx4t79x1rgbr2ns5br5ng4yk/T/tmps6x53uus/tmpbbvbl8yc/database/files/000/repo_1/column_maker/column_maker.xml",
@@ -79,7 +130,8 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     },
     "1:191823ad7f25": {
         "model_class": "RepositoryMetadata",
@@ -126,33 +178,84 @@
                 "tests": [
                     {
                         "inputs": [
-                            ["cond", "c3-c2"],
-                            ["input", "1.bed"],
-                            ["round", "no"]
+                            [
+                                "cond",
+                                "c3-c2"
+                            ],
+                            [
+                                "input",
+                                "1.bed"
+                            ],
+                            [
+                                "round",
+                                "no"
+                            ]
                         ],
                         "name": "Test-1",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.bed", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.bed",
+                            "value"
+                        ]
                     },
                     {
                         "inputs": [
-                            ["cond", "c4*1"],
-                            ["input", "1.interval"],
-                            ["round", "no"]
+                            [
+                                "cond",
+                                "c4*1"
+                            ],
+                            [
+                                "input",
+                                "1.interval"
+                            ],
+                            [
+                                "round",
+                                "no"
+                            ]
                         ],
                         "name": "Test-2",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.interval", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.interval",
+                            "value"
+                        ]
                     },
                     {
                         "inputs": [
-                            ["cond", "c4*1"],
-                            ["input", "1.interval"],
-                            ["round", "yes"]
+                            [
+                                "cond",
+                                "c4*1"
+                            ],
+                            [
+                                "input",
+                                "1.interval"
+                            ],
+                            [
+                                "round",
+                                "yes"
+                            ]
                         ],
                         "name": "Test-3",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.interval", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.interval",
+                            "value"
+                        ]
                     }
                 ],
                 "tool_config": "/private/var/folders/1d/bs7mkcjx4t79x1rgbr2ns5br5ng4yk/T/tmps6x53uus/tmpbbvbl8yc/database/files/000/repo_1/column_maker/column_maker.xml",
@@ -161,7 +264,8 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     },
     "2:062143ff0665": {
         "model_class": "RepositoryMetadata",
@@ -208,33 +312,84 @@
                 "tests": [
                     {
                         "inputs": [
-                            ["cond", "c3-c2"],
-                            ["input", "1.bed"],
-                            ["round", "no"]
+                            [
+                                "cond",
+                                "c3-c2"
+                            ],
+                            [
+                                "input",
+                                "1.bed"
+                            ],
+                            [
+                                "round",
+                                "no"
+                            ]
                         ],
                         "name": "Test-1",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.bed", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.bed",
+                            "value"
+                        ]
                     },
                     {
                         "inputs": [
-                            ["cond", "c4*1"],
-                            ["input", "1.interval"],
-                            ["round", "no"]
+                            [
+                                "cond",
+                                "c4*1"
+                            ],
+                            [
+                                "input",
+                                "1.interval"
+                            ],
+                            [
+                                "round",
+                                "no"
+                            ]
                         ],
                         "name": "Test-2",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.interval", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.interval",
+                            "value"
+                        ]
                     },
                     {
                         "inputs": [
-                            ["cond", "c4*1"],
-                            ["input", "1.interval"],
-                            ["round", "yes"]
+                            [
+                                "cond",
+                                "c4*1"
+                            ],
+                            [
+                                "input",
+                                "1.interval"
+                            ],
+                            [
+                                "round",
+                                "yes"
+                            ]
                         ],
                         "name": "Test-3",
-                        "outputs": [["name", "value"]],
-                        "required_files": ["1.interval", "value"]
+                        "outputs": [
+                            [
+                                "name",
+                                "value"
+                            ]
+                        ],
+                        "required_files": [
+                            "1.interval",
+                            "value"
+                        ]
                     }
                 ],
                 "tool_config": "/private/var/folders/1d/bs7mkcjx4t79x1rgbr2ns5br5ng4yk/T/tmps6x53uus/tmpbbvbl8yc/database/files/000/repo_1/column_maker/column_maker.xml",
@@ -243,6 +398,7 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     }
 }

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_metadata_multi_tools.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_metadata_multi_tools.json
@@ -76,7 +76,8 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     },
     "1:m1m1m1m1m1m1": {
         "model_class": "RepositoryMetadata",
@@ -155,7 +156,8 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     },
     "2:m2m2m2m2m2m2": {
         "model_class": "RepositoryMetadata",
@@ -254,6 +256,7 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     }
 }

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_metadata_no_tools.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_metadata_no_tools.json
@@ -33,6 +33,7 @@
         },
         "repository_dependencies": [],
         "tools": [],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     }
 }

--- a/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_metadata_with_deps.json
+++ b/lib/tool_shed/webapp/frontend/src/components/MetadataInspector/__fixtures__/simulated_metadata_with_deps.json
@@ -66,7 +66,8 @@
                 },
                 "repository_dependencies": [],
                 "tools": [],
-                "invalid_tools": []
+                "invalid_tools": [],
+                "create_time": "2024-06-01T00:00:00.000000"
             },
             {
                 "model_class": "RepositoryMetadata",
@@ -117,7 +118,8 @@
                         "version_string_cmd": null
                     }
                 ],
-                "invalid_tools": []
+                "invalid_tools": [],
+                "create_time": "2024-07-01T00:00:00.000000"
             }
         ],
         "tools": [
@@ -142,6 +144,7 @@
                 "version_string_cmd": null
             }
         ],
-        "invalid_tools": []
+        "invalid_tools": [],
+        "create_time": "2024-01-15T10:30:00.000000"
     }
 }

--- a/lib/tool_shed/webapp/frontend/src/components/RevisionSelect.vue
+++ b/lib/tool_shed/webapp/frontend/src/components/RevisionSelect.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue"
+import { parseISO, format } from "date-fns"
 import { useModelWrapper } from "@/modelWrapper"
 
 import { components } from "@/schema"
@@ -19,9 +20,15 @@ const options = computed(() => {
     const opts = []
     const revisions = props.revisions || {}
     for (const key of Object.keys(revisions)) {
+        const revision = revisions[key]
+        let label = key
+        if (revision?.create_time) {
+            const date = parseISO(`${revision.create_time}Z`)
+            label = `${key} (${format(date, "yyyy-MM-dd")})`
+        }
         opts.push({
-            label: key,
-            value: revisions[key]?.changeset_revision,
+            label,
+            value: revision?.changeset_revision,
         })
     }
     return opts
@@ -51,7 +58,7 @@ const selection = useModelWrapper(props, emit, "modelValue")
             map-options
             emit-value
             class="q-mr-sm"
-            style="width: 250px"
+            style="width: 350px"
         >
             <template #no-option>
                 <q-item>

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -2707,6 +2707,8 @@ export interface components {
         RepositoryDependency: {
             /** Changeset Revision */
             changeset_revision: string
+            /** Create Time */
+            create_time: string
             /** Downloadable */
             downloadable: boolean
             /** Has Repository Dependencies */
@@ -2805,6 +2807,8 @@ export interface components {
         RepositoryRevisionMetadata: {
             /** Changeset Revision */
             changeset_revision: string
+            /** Create Time */
+            create_time: string
             /** Downloadable */
             downloadable: boolean
             /** Has Repository Dependencies */
@@ -2848,6 +2852,8 @@ export interface components {
         RepositoryRevisionMetadataPreview: {
             /** Changeset Revision */
             changeset_revision: string
+            /** Create Time */
+            create_time?: string | null
             /** Downloadable */
             downloadable: boolean
             /** Has Repository Dependencies */

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -731,6 +731,7 @@ class RepositoryMetadata(Dictifiable):
         "includes_tool_dependencies",
         "includes_tools_for_display_in_tool_panel",
         "includes_workflows",
+        "create_time",
     ]
     dict_element_visible_keys = [
         "id",
@@ -746,6 +747,7 @@ class RepositoryMetadata(Dictifiable):
         "includes_tool_dependencies",
         "includes_tools_for_display_in_tool_panel",
         "includes_workflows",
+        "create_time",
         "repository_dependencies",
     ]
 

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -188,6 +188,7 @@ class RepositoryRevisionMetadata(BaseModel):
     has_repository_dependencies: bool
     includes_tools: bool
     includes_tools_for_display_in_tool_panel: bool
+    create_time: str
     # Deprecate these...
     includes_tool_dependencies: Optional[bool] = None
     includes_datatypes: Optional[bool] = None
@@ -241,6 +242,7 @@ class RepositoryRevisionMetadataPreview(BaseModel):
     has_repository_dependencies: bool
     includes_tools: bool
     includes_tools_for_display_in_tool_panel: bool
+    create_time: Optional[str] = None
     includes_tool_dependencies: Optional[bool] = None
     includes_datatypes: Optional[bool] = None
     includes_workflows: Optional[bool] = None


### PR DESCRIPTION
Expose the existing create_time column from the RepositoryMetadata model in the API response and display it alongside the changeset hash in the revision selector (e.g. "26:4a196b9c72c2 (2024-01-15)").

Closes #22475 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
