### PR TITLE
[26.0] Accept bare ftype as valid test output check

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -960,7 +960,16 @@ def __parse_test_attributes(
     has_checksum = md5sum or checksum
     has_nested_tests = extra_files or element_tests or primary_datasets
     has_object = value_object is not VALUE_OBJECT_UNSET
-    if not (assert_list or file or metadata or has_checksum or has_nested_tests or has_object or has_count_assertions):
+    if not (
+        assert_list
+        or file
+        or metadata
+        or ftype
+        or has_checksum
+        or has_nested_tests
+        or has_object
+        or has_count_assertions
+    ):
         raise Exception(
             "Test output defines nothing to check (e.g. must have a 'file' check against, assertions to check, metadata or checksum tests, etc...)"
         )

--- a/test/unit/tool_util/test_test_definition_parsing.py
+++ b/test/unit/tool_util/test_test_definition_parsing.py
@@ -144,6 +144,15 @@ class TestTestParsing(TestCase):
         test_dicts = self._parse_tests()
         self._verify_each(test_dicts[1].to_dict(), BIGWIG_TO_WIG_EXPECTATIONS)
 
+    def test_harmonize_bare_ftype_output_check(self):
+        if in_packages():
+            skip("tool not available when running from packages")
+        tool_path = os.path.join(galaxy_directory(), "lib", "galaxy", "tools", "harmonize_two_collections_list.xml")
+        self._init_tool_for_path(tool_path)
+        test_dicts = [td.to_dict() for td in self._parse_tests()]
+        for td in test_dicts:
+            assert not td.get("exception"), f"Test failed to parse: {td.get('exception')}"
+
     def _verify_each(self, target_dict: dict, expectations: List[Any]):
         exception = target_dict.get("exception")
         assert not exception, f"Test failed to generate with exception {exception}"


### PR DESCRIPTION
Parser rejected output elements with only ftype, though ftype is verified at runtime (interactor.py maps it to file_ext metadata).

Fixes https://github.com/galaxyproject/galaxy/issues/22440 with test. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
