### PR TITLE
[26.0] Fix sample sheet upload without sample-sheet-specific columns

### DIFF
--- a/lib/galaxy/model/dataset_collections/types/sample_sheet.py
+++ b/lib/galaxy/model/dataset_collections/types/sample_sheet.py
@@ -1,12 +1,13 @@
-from typing import cast
+from typing import (
+    cast,
+    Optional,
+)
 
 from galaxy.exceptions import RequestParameterMissingException
 from galaxy.model import DatasetCollectionElement
+from galaxy.tool_util_models.sample_sheet import SampleSheetRow
 from . import BaseDatasetCollectionType
-from .sample_sheet_util import (
-    OptionalSampleSheetRows,
-    validate_row,
-)
+from .sample_sheet_util import validate_row
 
 
 class SampleSheetDatasetCollectionType(BaseDatasetCollectionType):
@@ -15,18 +16,21 @@ class SampleSheetDatasetCollectionType(BaseDatasetCollectionType):
     collection_type = "sample_sheet"
 
     def generate_elements(self, dataset_instances, **kwds):
-        rows = cast(OptionalSampleSheetRows, kwds.get("rows", None))
+        rows = cast(Optional[dict[str, Optional[SampleSheetRow]]], kwds.get("rows", None))
         column_definitions = kwds.get("column_definitions", None)
-        if rows is None:
-            raise RequestParameterMissingException(
-                "Missing or null parameter 'rows' required for 'sample_sheet' collection types."
-            )
-        if len(dataset_instances) != len(rows):
-            self._validation_failed("Supplied element do not match 'rows'.")
+        if not column_definitions:
+            rows = rows if rows is not None else dict.fromkeys(dataset_instances)
+        else:
+            if rows is None:
+                raise RequestParameterMissingException(
+                    "Missing or null parameter 'rows' required for 'sample_sheet' collection types."
+                )
+            if len(dataset_instances) != len(rows):
+                self._validation_failed("Supplied element do not match 'rows'.")
 
         all_element_identifiers = list(dataset_instances.keys())
         for identifier, element in dataset_instances.items():
-            columns = rows[identifier]
+            columns = rows.get(identifier)
             validate_row(columns, column_definitions, all_element_identifiers)
             association = DatasetCollectionElement(
                 element=element,

--- a/lib/galaxy/model/dataset_collections/types/sample_sheet_util.py
+++ b/lib/galaxy/model/dataset_collections/types/sample_sheet_util.py
@@ -95,9 +95,11 @@ def _validate_column_definition(column_definition: SampleSheetColumnDefinition):
 
 
 def validate_row(
-    row: SampleSheetRow, column_definitions: Optional[SampleSheetColumnDefinitions], element_identifiers: list[str]
+    row: Optional[SampleSheetRow],
+    column_definitions: Optional[SampleSheetColumnDefinitions],
+    element_identifiers: list[str],
 ):
-    if column_definitions is None:
+    if not column_definitions:
         return
     if row is None:
         raise RequestParameterInvalidException(

--- a/test/unit/data/dataset_collections/test_sample_sheet_type.py
+++ b/test/unit/data/dataset_collections/test_sample_sheet_type.py
@@ -1,0 +1,52 @@
+import pytest
+
+from galaxy.exceptions import (
+    RequestParameterInvalidException,
+    RequestParameterMissingException,
+)
+from galaxy.model import HistoryDatasetAssociation
+from galaxy.model.dataset_collections.types.sample_sheet import SampleSheetDatasetCollectionType
+
+
+def _make_instances(*identifiers):
+    return {identifier: HistoryDatasetAssociation(extension="txt") for identifier in identifiers}
+
+
+def test_generate_elements_no_column_definitions_no_rows():
+    # Uploading a sample_sheet collection without any sample-sheet-specific
+    # columns (no column_definitions, no rows) should succeed and produce one
+    # element per identifier with empty columns.
+    instances = _make_instances("a", "b")
+    elements = list(SampleSheetDatasetCollectionType().generate_elements(instances))
+    assert [e.element_identifier for e in elements] == ["a", "b"]
+    assert all(e.columns is None for e in elements)
+
+
+def test_generate_elements_empty_list_column_definitions_no_rows():
+    instances = _make_instances("a", "b")
+    elements = list(SampleSheetDatasetCollectionType().generate_elements(instances, column_definitions=[], rows=None))
+    assert [e.element_identifier for e in elements] == ["a", "b"]
+    assert all(e.columns is None for e in elements)
+
+
+def test_generate_elements_rows_required_with_column_definitions():
+    instances = _make_instances("a", "b")
+    column_definitions = [{"type": "int", "name": "replicate", "optional": False}]
+    with pytest.raises(RequestParameterMissingException):
+        list(
+            SampleSheetDatasetCollectionType().generate_elements(
+                instances, column_definitions=column_definitions, rows=None
+            )
+        )
+
+
+def test_generate_elements_rows_validated_with_column_definitions():
+    instances = _make_instances("a", "b")
+    column_definitions = [{"type": "int", "name": "replicate", "optional": False}]
+    rows = {"a": [1], "b": None}
+    with pytest.raises(RequestParameterInvalidException):
+        list(
+            SampleSheetDatasetCollectionType().generate_elements(
+                instances, column_definitions=column_definitions, rows=rows
+            )
+        )

--- a/test/unit/data/dataset_collections/test_sample_sheet_util.py
+++ b/test/unit/data/dataset_collections/test_sample_sheet_util.py
@@ -33,6 +33,19 @@ def test_sample_sheet_validation_skipped_on_empty_definitions():
     validate_row([0, 1], None)  # just ensure no exception is thrown
 
 
+def test_sample_sheet_validation_skipped_on_empty_list_definitions():
+    # Empty list of column definitions should also short-circuit validation,
+    # so a missing row is not treated as an error.
+    validate_row(None, [])
+    validate_row([0, 1], [])
+
+
+def test_sample_sheet_validation_missing_row_when_definitions_declared():
+    # When column definitions exist, a missing row is still an error.
+    with pytest.raises(RequestParameterInvalidException):
+        validate_row(None, [{"type": "int", "name": "replicate", "optional": False}])
+
+
 def test_sample_sheet_validation_number_columns():
     with pytest.raises(RequestParameterInvalidException):
         validate_row([0, 1], [{"type": "int", "name": "replicate number", "default_value": 0, "optional": False}])


### PR DESCRIPTION
When a collection typed as `sample_sheet` was populated without any column definitions (or with an empty list), `validate_row` raised `RequestParameterInvalidException: Sample sheet row is missing` because the early-return only triggered on `column_definitions is None` and `generate_elements` unconditionally required a rows dict.

Treat missing/empty column_definitions as list-like: skip row validation and synthesize per-identifier `None` rows.

Refs https://github.com/galaxyproject/galaxy/issues/22487

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
