### PR TITLE
[26.0] Fix UI no longer auto-decompressing files

### DIFF
--- a/client/src/components/Upload/model.ts
+++ b/client/src/components/Upload/model.ts
@@ -41,6 +41,7 @@ export interface UploadRowModel {
     targetHistoryId?: string;
     toPosixLines: boolean;
     id?: string;
+    autoDecompress: boolean;
 }
 
 export const defaultModel: UploadRowModel = {
@@ -62,4 +63,5 @@ export const defaultModel: UploadRowModel = {
     spaceToTab: false,
     status: "init",
     toPosixLines: true,
+    autoDecompress: true,
 };

--- a/client/src/composables/zipExplorer.ts
+++ b/client/src/composables/zipExplorer.ts
@@ -185,6 +185,7 @@ export function useZipExplorer() {
                 ext: defaultModel.extension,
                 space_to_tab: defaultModel.spaceToTab,
                 to_posix_lines: defaultModel.toPosixLines,
+                auto_decompress: defaultModel.autoDecompress,
                 deferred: defaultModel.deferred ?? false,
             };
             uploadItems.push(uploadItem);

--- a/client/src/utils/upload-queue.test.js
+++ b/client/src/utils/upload-queue.test.js
@@ -221,11 +221,11 @@ describe("UploadQueue", () => {
             history_id: "historyId",
             targets: [
                 {
-                    auto_decompress: false,
+                    auto_decompress: true,
                     destination: { type: "hdas" },
                     elements: [
                         {
-                            auto_decompress: false,
+                            auto_decompress: true,
                             dbkey: "?",
                             deferred: true,
                             ext: "auto",
@@ -236,7 +236,7 @@ describe("UploadQueue", () => {
                             url: "http://test.me.0",
                         },
                         {
-                            auto_decompress: false,
+                            auto_decompress: true,
                             dbkey: "?",
                             deferred: true,
                             ext: "auto",
@@ -247,7 +247,7 @@ describe("UploadQueue", () => {
                             url: "http://test.me.1",
                         },
                         {
-                            auto_decompress: false,
+                            auto_decompress: true,
                             dbkey: "?",
                             deferred: true,
                             ext: "auto",

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -115,6 +115,8 @@ interface UploadItemCommon {
     deferred: boolean;
     /** Optional hash values for verification */
     hashes?: FetchDatasetHash[];
+    /** Whether to auto-decompress the upload */
+    auto_decompress: boolean;
 }
 
 /** Upload item from a local file */
@@ -368,6 +370,7 @@ export function createPastedUploadItem(
         to_posix_lines: options.to_posix_lines ?? uploadItemDefaults.to_posix_lines,
         deferred: options.deferred ?? uploadItemDefaults.deferred,
         hashes: options.hashes,
+        auto_decompress: true,
     };
 }
 
@@ -408,6 +411,7 @@ export function createUrlUploadItem(
         to_posix_lines: options.to_posix_lines ?? uploadItemDefaults.to_posix_lines,
         deferred: options.deferred ?? uploadItemDefaults.deferred,
         hashes: options.hashes,
+        auto_decompress: true,
     };
 }
 
@@ -432,6 +436,7 @@ export function toApiUploadItem(item: NewUploadItem): ApiUploadItem {
         to_posix_lines: item.toPosixLines,
         deferred: item.deferred,
         hashes: item.hashes,
+        auto_decompress: true,
     };
 
     switch (item.uploadMode) {
@@ -519,7 +524,7 @@ function buildDataElement(item: ApiUploadItem): ApiDataElement {
         name: normalizeFileName(item.name),
         space_to_tab: item.space_to_tab,
         to_posix_lines: item.to_posix_lines,
-        auto_decompress: false,
+        auto_decompress: true,
         deferred: item.deferred,
     };
 
@@ -656,7 +661,7 @@ export function buildUploadPayload(items: ApiUploadItem[], options: BuildPayload
         history_id: historyId,
         targets: [
             {
-                auto_decompress: false,
+                auto_decompress: true,
                 destination: { type: "hdas" },
                 elements,
             },

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -334,6 +334,7 @@ export function createFileUploadItem(
         to_posix_lines: options.to_posix_lines ?? uploadItemDefaults.to_posix_lines,
         deferred: options.deferred ?? uploadItemDefaults.deferred,
         hashes: options.hashes,
+        auto_decompress: true,
     };
 }
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/22433 and restores older Galaxy behavior. A couple things post merge -

- [x] I only tested the legacy upload route - we should verify the other new UI.
- [ ] We have some very esoteric advanced upload options in the UI - but we don't have one for disabling this auto-decompression. I think this behavior is very Galaxy in the way that like data tables are very Galaxy - we should have options in the UI that enable a more principled treatment of data ingestion.

Some follow ups from stuff I said during the meeting: 

- I think I was wrong about the source of the error - I think it was refactoring done during beta upload handling but I could be wrong.
- I was right about auto_decompress not really having anything to do with "auto" though I think - because if I upload a txt.gz file and specify a 'txt' extension - you get a 'txt' file now (as you did in 25.0 verified with the testing I did for https://github.com/galaxyproject/galaxy/issues/22433).

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. See manual testing I documented in https://github.com/galaxyproject/galaxy/issues/22433.  

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
