### PR TITLE
Replace v-b-tooltip in RemoteFilesUpload with v-g-tooltip

### DIFF
--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -682,13 +682,13 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <template v-slot:cell(user)="{ item }">
                         <span
                             v-if="urlTracker.isAtRoot.value && !item.isLeaf && item.url.startsWith(USER_FILE_PREFIX)"
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             title="You created this file source">
                             <FontAwesomeIcon :icon="faUser" class="text-primary" fixed-width />
                         </span>
                         <span
                             v-else-if="urlTracker.isAtRoot.value && !item.isLeaf"
-                            v-b-tooltip.hover.noninteractive
+                            v-g-tooltip.hover.noninteractive
                             title="This file source was created by an administrator and is globally available">
                             <FontAwesomeIcon :icon="faGlobe" class="text-primary" fixed-width />
                         </span>


### PR DESCRIPTION
Replaced BootstrapVue tooltip directive usage with the custom v-g-tooltip directive and kept the tooltip behavior consistent with the new tooltip system in this component.

Follow-up related to #21956 and aligned with #21962.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
