### PR TITLE
Select parameters: do not select the first value as default value

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -76,6 +76,10 @@ List of behavior changes associated with profile versions:
 
 - Do not use user preferences to store credentials for tools anymore. Use the new `<credentials>` tag in the `<requirements>` section of the tool XML instead.
 
+### 26.1
+
+- Mandatory select parameters do not automatically use the first option as default
+
 ### Examples
 
 A normal tool:
@@ -5013,8 +5017,7 @@ value is ``select`` (i.e. ``<param type="select" ...>``).
 ```
 
 An option can also be annotated with ``selected="true"`` to specify a
-default option (note that the first option is selected automatically
-if ``optional="false"``).
+default option.
 
 ```xml
 <param name="col" type="select" label="From">

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -973,6 +973,7 @@ class SelectToolParameter(ToolParameter):
     def __init__(self, tool: Optional["Tool"], input_source, context=None):
         input_source = ensure_input_source(input_source)
         super().__init__(tool, input_source)
+        self.profile = tool.profile if tool else None
         self.multiple = input_source.get_bool("multiple", False)
         # Multiple selects are optional by default, single selection is the inverse.
         self.optional = input_source.parse_optional(self.multiple)
@@ -1160,7 +1161,7 @@ class SelectToolParameter(ToolParameter):
             return None
         value = [option.value for option in options if option.selected]
         if len(value) == 0:
-            if not self.optional and not self.multiple and options:
+            if Version(str(self.tool.profile)) < Version("26.1") and not self.optional and not self.multiple and options:
                 # Nothing selected, but not optional and not a multiple select, with some values,
                 # so we have to default to something (the HTML form will anyway)
                 value2: Optional[Union[str, list[str]]] = options[0].value

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1161,7 +1161,7 @@ class SelectToolParameter(ToolParameter):
             return None
         value = [option.value for option in options if option.selected]
         if len(value) == 0:
-            if Version(str(self.tool.profile)) < Version("26.1") and not self.optional and not self.multiple and options:
+            if (self.profile is None or Version(str(self.profile)) < Version("26.1")) and not self.optional and not self.multiple and options:
                 # Nothing selected, but not optional and not a multiple select, with some values,
                 # so we have to default to something (the HTML form will anyway)
                 value2: Optional[Union[str, list[str]]] = options[0].value

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -973,7 +973,6 @@ class SelectToolParameter(ToolParameter):
     def __init__(self, tool: Optional["Tool"], input_source, context=None):
         input_source = ensure_input_source(input_source)
         super().__init__(tool, input_source)
-        self.profile = tool.profile if tool else None
         self.multiple = input_source.get_bool("multiple", False)
         # Multiple selects are optional by default, single selection is the inverse.
         self.optional = input_source.parse_optional(self.multiple)
@@ -1161,17 +1160,11 @@ class SelectToolParameter(ToolParameter):
             return None
         value = [option.value for option in options if option.selected]
         if len(value) == 0:
-            if (self.profile is None or Version(str(self.profile)) < Version("26.1")) and not self.optional and not self.multiple and options:
-                # Nothing selected, but not optional and not a multiple select, with some values,
-                # so we have to default to something (the HTML form will anyway)
-                value2: Optional[Union[str, list[str]]] = options[0].value
-            else:
-                value2 = None
+            return None
         elif len(value) == 1 or not self.multiple:
-            value2 = value[0]
+            return value[0]
         else:
-            value2 = value
-        return value2
+            return value
 
     def to_text(self, value):
         if not isinstance(value, list):


### PR DESCRIPTION
Fixes: https://github.com/galaxyproject/galaxy/issues/9203

Currently non-optional select parameters (with `multiple="false"`) implicitly select the first value as default.
This is bad in case: 

- no useful default exist (but the user needs to be "forced" to select one) or
- dynamically created select lists (in many cases). Consider for instance the `blast_p` entries as shown on eu in the [blastp](https://usegalaxy.eu/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fncbi_blast_plus%2Fncbi_blastp_wrapper%2F2.16.0%2Bgalaxy0&version=latest) and [diamond](https://usegalaxy.eu/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fbgruening%2Fdiamond%2Fbg_diamond%2F2.1.22%2Bgalaxy0&version=latest). There is just no useful sorting order (we could add a column...) which would make the first entry a useful default, but the user should select one. 

We could think about adding an attribute to the `options` tag that allow to specify to select the first entry. 

TODO: 

- [ ] test of the profile version


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
