### PR TITLE
Enhance the workflow editor activity bar

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -40,6 +40,7 @@ const props = withDefaults(
         activityBarId?: string;
         specialActivities?: Activity[];
         exitActivity?: Activity;
+        runActivity?: Activity;
         showAdmin?: boolean;
         optionsTitle?: string;
         optionsTooltip?: string;
@@ -56,6 +57,7 @@ const props = withDefaults(
         activityBarId: "default",
         specialActivities: () => [],
         exitActivity: undefined,
+        runActivity: undefined,
         showAdmin: true,
         optionsTitle: "More",
         optionsHeading: "Additional Activities",
@@ -387,6 +389,17 @@ defineExpose({
                     tooltip="Administer this Galaxy"
                     variant="danger"
                     @click="toggleSidebar('admin')" />
+                <ActivityItem
+                    v-if="props.runActivity"
+                    :id="`${props.runActivity.id}`"
+                    :activity-bar-id="props.activityBarId"
+                    :icon="props.runActivity.icon"
+                    :indicator="props.runActivity.indicator"
+                    :indicator-variant="props.runActivity.indicatorVariant"
+                    :title="props.runActivity.title"
+                    :tooltip="props.runActivity.tooltip"
+                    :variant="props.runActivity.variant"
+                    @click="onActivityClicked(props.runActivity)" />
                 <ActivityItem
                     v-if="props.exitActivity"
                     :id="`${props.exitActivity.id}`"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -18,6 +18,7 @@ import localize from "@/utils/localization";
 
 import ChatHistoryPanel from "../ChatGXY/ChatHistoryPanel.vue";
 import InvocationsPanel from "../Panels/InvocationsPanel.vue";
+import ActivityBarHeader from "./ActivityBarHeader.vue";
 import ActivityItem from "./ActivityItem.vue";
 import InteractiveItem from "./Items/InteractiveItem.vue";
 import NotificationItem from "./Items/NotificationItem.vue";
@@ -47,6 +48,8 @@ const props = withDefaults(
         optionsSearchPlaceholder?: string;
         initialActivity?: string;
         hidePanel?: boolean;
+        headerIcon?: IconDefinition;
+        headerTitle?: string;
     }>(),
     {
         defaultActivities: undefined,
@@ -61,6 +64,8 @@ const props = withDefaults(
         optionsTooltip: "View additional activities",
         initialActivity: undefined,
         hidePanel: false,
+        headerIcon: undefined,
+        headerTitle: undefined,
     },
 );
 
@@ -252,6 +257,11 @@ defineExpose({
             @dragover.prevent="onDragOver"
             @dragenter.prevent="onDragEnter"
             @dragleave.prevent="onDragLeave">
+            <ActivityBarHeader
+                :icon="props.headerIcon"
+                :title="props.headerTitle"
+                :is-side-bar-open="isSideBarOpen"
+                @close-sidebar="activityStore.closeSideBar" />
             <b-nav vertical class="flex-nowrap p-1 h-100 vertical-overflow">
                 <draggable
                     v-model="activities"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -19,6 +19,7 @@ import localize from "@/utils/localization";
 import ChatHistoryPanel from "../ChatGXY/ChatHistoryPanel.vue";
 import InvocationsPanel from "../Panels/InvocationsPanel.vue";
 import ActivityBarHeader from "./ActivityBarHeader.vue";
+import ActivityBarSeparator from "./ActivityBarSeparator.vue";
 import ActivityItem from "./ActivityItem.vue";
 import InteractiveItem from "./Items/InteractiveItem.vue";
 import NotificationItem from "./Items/NotificationItem.vue";
@@ -332,7 +333,8 @@ defineExpose({
                     </div>
                 </draggable>
             </b-nav>
-            <b-nav v-if="!isAnonymous" vertical class="activity-footer flex-nowrap p-1">
+            <ActivityBarSeparator />
+            <b-nav v-if="!isAnonymous" vertical class="flex-nowrap p-1">
                 <template v-for="activity in props.specialActivities">
                     <ActivityItem
                         v-if="activity.panel"
@@ -464,11 +466,6 @@ defineExpose({
 
 .activity-drag-class {
     display: none;
-}
-
-.activity-footer {
-    border-top: $border-default;
-    border-top-style: dotted;
 }
 
 .activity-popper-disabled {

--- a/client/src/components/ActivityBar/ActivityBarHeader.vue
+++ b/client/src/components/ActivityBar/ActivityBarHeader.vue
@@ -3,6 +3,8 @@ import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { faChevronLeft, faHome } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
+import ActivityBarSeparator from "./ActivityBarSeparator.vue";
+
 interface Props {
     /** Whether an activity's side panel is currently open. */
     isSideBarOpen: boolean;
@@ -41,7 +43,7 @@ function closeSidebar(event: KeyboardEvent | MouseEvent) {
             <FontAwesomeIcon :icon="props.isSideBarOpen ? faChevronLeft : props.icon" size="sm" fixed-width />
             <span class="activity-bar-header-text">{{ props.title }}</span>
         </div>
-        <div class="activity-bar-header-divider" />
+        <ActivityBarSeparator />
     </div>
 </template>
 
@@ -65,10 +67,5 @@ function closeSidebar(event: KeyboardEvent | MouseEvent) {
     .activity-bar-header-text {
         font-size: var(--font-size-small);
     }
-}
-
-.activity-bar-header-divider {
-    border-top: var(--border-default);
-    border-top-style: dotted;
 }
 </style>

--- a/client/src/components/ActivityBar/ActivityBarHeader.vue
+++ b/client/src/components/ActivityBar/ActivityBarHeader.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import type { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { faChevronLeft, faHome } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+interface Props {
+    /** Whether an activity's side panel is currently open. */
+    isSideBarOpen: boolean;
+    /** The icon to display in the header. */
+    icon?: IconDefinition;
+    /** The title to display in the header. */
+    title?: string;
+}
+const props = withDefaults(defineProps<Props>(), {
+    icon: () => faHome,
+    title: "Activities",
+});
+
+const emit = defineEmits<{
+    (e: "close-sidebar"): void;
+}>();
+
+function closeSidebar(event: KeyboardEvent | MouseEvent) {
+    if (props.isSideBarOpen && (event instanceof MouseEvent || event.key === "Enter" || event.key === " ")) {
+        emit("close-sidebar");
+    }
+}
+</script>
+
+<template>
+    <div>
+        <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
+        <div
+            class="rounded activity-bar-header-badge"
+            :class="{ 'sidebar-opened': props.isSideBarOpen }"
+            :role="props.isSideBarOpen ? 'button' : undefined"
+            :tabindex="props.isSideBarOpen ? 0 : undefined"
+            :title="props.isSideBarOpen ? 'Close panel' : 'Activity Bar'"
+            @click="closeSidebar"
+            @keydown="closeSidebar">
+            <FontAwesomeIcon :icon="props.isSideBarOpen ? faChevronLeft : props.icon" size="sm" fixed-width />
+            <span class="activity-bar-header-text">{{ props.title }}</span>
+        </div>
+        <div class="activity-bar-header-divider" />
+    </div>
+</template>
+
+<style scoped lang="scss">
+.activity-bar-header-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing);
+    margin: var(--spacing-1);
+    padding: var(--spacing-1) 0;
+    color: var(--color-blue-600);
+
+    &.sidebar-opened {
+        background: var(--color-grey-200);
+        &:hover {
+            color: var(--color-blue-700);
+        }
+    }
+
+    .activity-bar-header-text {
+        font-size: var(--font-size-small);
+    }
+}
+
+.activity-bar-header-divider {
+    border-top: var(--border-default);
+    border-top-style: dotted;
+}
+</style>

--- a/client/src/components/ActivityBar/ActivityBarSeparator.vue
+++ b/client/src/components/ActivityBar/ActivityBarSeparator.vue
@@ -1,0 +1,10 @@
+<template>
+    <div class="activity-bar-separator" />
+</template>
+
+<style scoped lang="scss">
+.activity-bar-separator {
+    border-top: 1px solid var(--color-grey-600);
+    border-top-style: dotted;
+}
+</style>

--- a/client/src/components/Markdown/MarkdownHelp.vue
+++ b/client/src/components/Markdown/MarkdownHelp.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import ExternalLink from "../ExternalLink.vue";
 import DirectiveHelpSection from "./DirectiveHelpSection.vue";
 
 interface MarkdownHelpProps {
@@ -24,7 +25,7 @@ const page = computed(() => props.mode == "page");
 
         <p>
             For an overview of standard Markdown visit the
-            <a href="https://commonmark.org/help/tutorial/">commonmark.org tutorial</a>.
+            <ExternalLink href="https://commonmark.org/help/tutorial/">commonmark.org tutorial</ExternalLink>.
         </p>
 
         <p>

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -15,7 +15,11 @@
             @onRefactor="onRefactor"
             @onShow="hideModal" />
         <MessagesModal :title="messageTitle" :message="messageBody" :error="messageIsError" @onHidden="resetMessage" />
-        <SaveChangesModal :nav-url.sync="navUrl" :show-modal.sync="showSaveChangesModal" @on-proceed="onNavigate" />
+        <SaveChangesModal
+            :append-version="saveChangesAppendVersion"
+            :nav-url="navUrl"
+            :show-modal.sync="showSaveChangesModal"
+            @on-proceed="onNavigate" />
         <GModal
             :show.sync="showSaveAsModal"
             confirm
@@ -624,7 +628,6 @@ export default {
 
         const { specialWorkflowActivities, exitWorkflowActivity, runWorkflowActivity } = useSpecialWorkflowActivities(
             computed(() => ({
-                hasInvalidConnections: hasInvalidConnections.value,
                 lintData: lintData,
             })),
         );
@@ -768,6 +771,7 @@ export default {
             graphOffset: { left: 0, top: 0, width: 0, height: 0 },
             debounceTimer: null,
             showSaveChangesModal: false,
+            saveChangesAppendVersion: false,
             navUrl: "",
             faArrowLeft,
             faArrowRight,
@@ -1008,13 +1012,8 @@ export default {
             }
         },
         async onActivityClicked(activityId) {
-            if (activityId === "save-and-exit") {
-                await this.saveOrCreate();
-                this.$router.push("/workflows/list");
-            }
-
             if (activityId === "exit") {
-                this.$router.push("/workflows/list");
+                this.onNavigate("/workflows/list");
             }
 
             if (activityId === "workflow-download") {
@@ -1123,6 +1122,7 @@ export default {
             } else if (this.hasChanges && !forceSave && !ignoreChanges) {
                 // if there are changes, prompt user to save or discard or cancel
                 this.navUrl = url;
+                this.saveChangesAppendVersion = appendVersion;
                 this.showSaveChangesModal = true;
             } else if (forceSave) {
                 // when forceSave is true, save the workflow before navigating

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -48,6 +48,8 @@
             initial-activity="workflow-editor-attributes"
             :options-icon="faCog"
             :hide-panel="reportActive"
+            :header-icon="faSitemap"
+            header-title="Editor"
             @activityClicked="onActivityClicked">
             <template v-slot:side-panel="{ isActiveSideBar }">
                 <ToolPanel v-if="isActiveSideBar('workflow-editor-tools')" workflow @onInsertTool="onInsertTool" />
@@ -247,7 +249,16 @@
 </template>
 
 <script>
-import { faArrowLeft, faArrowRight, faCog, faKey, faSave, faTimes, faWrench } from "@fortawesome/free-solid-svg-icons";
+import {
+    faArrowLeft,
+    faArrowRight,
+    faCog,
+    faKey,
+    faSave,
+    faSitemap,
+    faTimes,
+    faWrench,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { until, whenever } from "@vueuse/core";
 import { logicAnd, logicNot, logicOr } from "@vueuse/math";
@@ -723,6 +734,7 @@ export default {
             workflowActivities,
             faKey,
             faWrench,
+            faSitemap,
             showDropdown: false,
             lintData,
             onHighlightRegion,

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -39,6 +39,7 @@
             :default-activities="workflowActivities"
             :special-activities="specialWorkflowActivities"
             :exit-activity="exitWorkflowActivity"
+            :run-activity="runWorkflowActivity"
             activity-bar-id="workflow-editor"
             :show-admin="false"
             options-title="Options"
@@ -621,7 +622,7 @@ export default {
         const isNewTempWorkflow = computed(() => !props.workflowId);
         const lintData = useLintData(id, steps, datatypesMapper, annotation, readme, license, creator);
 
-        const { specialWorkflowActivities, exitWorkflowActivity } = useSpecialWorkflowActivities(
+        const { specialWorkflowActivities, exitWorkflowActivity, runWorkflowActivity } = useSpecialWorkflowActivities(
             computed(() => ({
                 hasInvalidConnections: hasInvalidConnections.value,
                 lintData: lintData,
@@ -727,6 +728,7 @@ export default {
             insertMarkdown,
             specialWorkflowActivities,
             exitWorkflowActivity,
+            runWorkflowActivity,
             isNewTempWorkflow,
             saveWorkflowTitle,
             confirm,

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -118,7 +118,7 @@
                 ref="markdownEditor"
                 :markdown-text="report.markdown"
                 mode="report"
-                :title="'Workflow Report: ' + name"
+                :title="'Workflow Report Template: ' + name"
                 :labels="getLabels"
                 :steps="steps"
                 @insert="insertMarkdown"

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -188,14 +188,14 @@
                             variant="secondary"
                             :disabled="!undoRedoStore.hasUndo"
                             @click="undoRedoStore.undo()">
-                            <FontAwesomeIcon :icon="faArrowLeft" />
+                            <FontAwesomeIcon :icon="faUndo" />
                         </b-button>
                         <b-button
                             :title="undoRedoStore.redoText + ' (Ctrl + Shift + Z)'"
                             variant="secondary"
                             :disabled="!undoRedoStore.hasRedo"
                             @click="undoRedoStore.redo()">
-                            <FontAwesomeIcon :icon="faArrowRight" />
+                            <FontAwesomeIcon :icon="faRedo" />
                         </b-button>
                         <b-button
                             id="workflow-save-button"
@@ -254,16 +254,7 @@
 </template>
 
 <script>
-import {
-    faArrowLeft,
-    faArrowRight,
-    faCog,
-    faKey,
-    faSave,
-    faSitemap,
-    faTimes,
-    faWrench,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCog, faKey, faRedo, faSave, faSitemap, faTimes, faUndo, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { until, whenever } from "@vueuse/core";
 import { logicAnd, logicNot, logicOr } from "@vueuse/math";
@@ -773,11 +764,11 @@ export default {
             showSaveChangesModal: false,
             saveChangesAppendVersion: false,
             navUrl: "",
-            faArrowLeft,
-            faArrowRight,
             faTimes,
             faCog,
             faSave,
+            faRedo,
+            faUndo,
         };
     },
     computed: {

--- a/client/src/components/Workflow/Editor/SaveChangesModal.vue
+++ b/client/src/components/Workflow/Editor/SaveChangesModal.vue
@@ -13,10 +13,13 @@ interface Props {
     showModal: boolean;
     /** The URL to navigate to before saving/ignoring changes */
     navUrl: string;
+    /** Whether to append the version to the URL */
+    appendVersion: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     showModal: false,
+    appendVersion: false,
 });
 
 const busy = ref(false);
@@ -24,8 +27,6 @@ const busy = ref(false);
 const emit = defineEmits<{
     /** Proceed with or without saving the changes */
     (e: "on-proceed", url: string, forceSave: boolean, ignoreChanges: boolean, appendVersion: boolean): void;
-    /** Update the nav URL prop */
-    (e: "update:nav-url", url: string): void;
     /** Update the show modal boolean prop */
     (e: "update:show-modal", showModal: boolean): void;
 }>();
@@ -43,18 +44,17 @@ const buttonTitles = {
 
 function closeModal() {
     emit("update:show-modal", false);
-    emit("update:nav-url", "");
 }
 
 function dontSave() {
     busy.value = true;
-    emit("on-proceed", props.navUrl, false, true, true);
+    emit("on-proceed", props.navUrl, false, true, props.appendVersion);
 }
 
 function saveChanges() {
     busy.value = true;
     closeModal();
-    emit("on-proceed", props.navUrl, true, false, true);
+    emit("on-proceed", props.navUrl, true, false, props.appendVersion);
 }
 </script>
 

--- a/client/src/components/Workflow/Editor/modules/activities.test.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.test.ts
@@ -111,18 +111,4 @@ describe("useSpecialWorkflowActivities", () => {
             );
         });
     });
-
-    describe("exitWorkflowActivity tooltip", () => {
-        it("shows save and exit message when connections are valid", () => {
-            const { exitWorkflowActivity } = setUpBestPractices(false);
-            expect(exitWorkflowActivity.value.tooltip).toBe("Save this workflow, then exit the workflow editor");
-        });
-
-        it("shows invalid connections warning when hasInvalidConnections is true", () => {
-            const { exitWorkflowActivity } = setUpBestPractices(true);
-            expect(exitWorkflowActivity.value.tooltip).toBe(
-                "Workflow has invalid connections, review and remove invalid connections",
-            );
-        });
-    });
 });

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -103,8 +103,8 @@ export function useWorkflowActivities(
         {
             title: "Report",
             id: "workflow-editor-report",
-            description: "Edit the report for this workflow.",
-            tooltip: "Edit workflow report",
+            description: "Edit the report template for this workflow.",
+            tooltip: "Edit workflow report template",
             icon: faEdit,
             panel: true,
             visible: true,

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -188,33 +188,14 @@ export function useWorkflowActivities(
             click: true,
             optional: true,
         },
-        {
-            description: "Exit the workflow editor and return to the start screen.",
-            icon: faSignOutAlt,
-            id: "exit",
-            title: "Exit",
-            tooltip: "Exit workflow editor",
-            visible: false,
-            click: true,
-            optional: true,
-        },
     ]);
 }
 
 interface SpecialActivityOptions {
-    hasInvalidConnections: boolean;
     lintData: LintData;
 }
 
 export function useSpecialWorkflowActivities(options: Ref<SpecialActivityOptions>) {
-    const saveHover = computed(() => {
-        if (options.value.hasInvalidConnections) {
-            return "Workflow has invalid connections, review and remove invalid connections";
-        } else {
-            return "Save this workflow, then exit the workflow editor";
-        }
-    });
-
     /** Indicator for best practices activity
      * @returns
      * - `number`: count of critical issues remaining
@@ -282,16 +263,17 @@ export function useSpecialWorkflowActivities(options: Ref<SpecialActivityOptions
         optional: true,
     };
 
-    const exitWorkflowActivity = computed<Activity>(() => ({
-        description: "",
-        icon: faSave,
-        id: "save-and-exit",
-        title: "Save + Exit",
-        tooltip: saveHover.value,
+    const exitWorkflowActivity: Activity = {
+        description:
+            "Exit the workflow editor and return to your Galaxy. If you have unsaved changes you will be prompted to save or discard them.",
+        icon: faSignOutAlt,
+        id: "exit",
+        title: "Exit",
+        tooltip: "Exit workflow editor",
         visible: false,
         click: true,
-        mutable: false,
-    }));
+        optional: true,
+    };
 
     return {
         specialWorkflowActivities,

--- a/client/src/components/Workflow/Editor/modules/activities.ts
+++ b/client/src/components/Workflow/Editor/modules/activities.ts
@@ -124,16 +124,6 @@ export function useWorkflowActivities(
             indicatorVariant: "primary",
         },
         {
-            title: "Run",
-            id: "workflow-run",
-            description: "Run this workflow with specific parameters.",
-            tooltip: "Run workflow",
-            icon: faPlay,
-            visible: true,
-            click: true,
-            optional: true,
-        },
-        {
             description: "Save this workflow.",
             icon: faSave,
             id: "save-workflow",
@@ -281,6 +271,17 @@ export function useSpecialWorkflowActivities(options: Ref<SpecialActivityOptions
         },
     ]);
 
+    const runWorkflowActivity: Activity = {
+        title: "Run",
+        id: "workflow-run",
+        description: "Run this workflow with specific parameters.",
+        tooltip: "Run workflow",
+        icon: faPlay,
+        visible: true,
+        click: true,
+        optional: true,
+    };
+
     const exitWorkflowActivity = computed<Activity>(() => ({
         description: "",
         icon: faSave,
@@ -295,5 +296,6 @@ export function useSpecialWorkflowActivities(options: Ref<SpecialActivityOptions
     return {
         specialWorkflowActivities,
         exitWorkflowActivity,
+        runWorkflowActivity,
     };
 }

--- a/client/src/style/scss/custom_theme_variables.scss
+++ b/client/src/style/scss/custom_theme_variables.scss
@@ -85,6 +85,9 @@ html,
     --masthead-height: #{$masthead-height};
     --masthead-logo-height: calc(var(--masthead-height) - 0.5rem);
 
+    --border-color: #{$border-color};
+    --border-default: #{$border-default};
+
     --masthead-color: #{$masthead-color};
     --masthead-text-color: #{$masthead-text-color};
     --masthead-text-hover: #{$masthead-text-hover};

--- a/client/src/style/scss/custom_theme_variables.scss
+++ b/client/src/style/scss/custom_theme_variables.scss
@@ -85,9 +85,6 @@ html,
     --masthead-height: #{$masthead-height};
     --masthead-logo-height: calc(var(--masthead-height) - 0.5rem);
 
-    --border-color: #{$border-color};
-    --border-default: #{$border-default};
-
     --masthead-color: #{$masthead-color};
     --masthead-text-color: #{$masthead-text-color};
     --masthead-text-hover: #{$masthead-text-hover};


### PR DESCRIPTION
Here are the few enhancements/changes made to the workflow editor (and non editor-main) activity bar (Fixes #22492):

## Activity Bar Title Badge
A badge at the top indicates the context of what type of activity bar is currently active. We've found it to be potentially confusing for users to understand that the main activity bar (outside the editor) works differently from the one within the workflow editor. **Note:** The same badge also allows (and highlights) the capability to toggle-close a currently open panel; something we feel like isn't very evident for novice users (that they can close the panel by clicking on the active activity):

| Home Bar (non-editor) | Workflow Editor Bar |
| ---- | ---- |
| <img width="360" alt="firefox_lrv73jrOii" src="https://github.com/user-attachments/assets/404211db-5462-4128-b61f-09f2f261fd2b" /> | <img width="360" alt="firefox_sBPuTD8Apz" src="https://github.com/user-attachments/assets/065dca54-1b2e-464f-b1ab-0dc74cea90d3" /> |

## Workflow Report renamed to "Workflow Report Template"
The report created in the workflow editor is different from the report that is eventually created _from_ it for the invocation; which makes that in-editor report a **template** rather that the final report. We've renamed this in certain parts of the interface accordingly:

<img width="313" height="93" alt="firefox_Y5jXBmCgKC" src="https://github.com/user-attachments/assets/ddd0a30c-da4d-4dc5-8aa4-c612bad4bee5" />

## An Updated Workflow Editor Activity Bar Footer

<table>
  <tr>
    <td>
      <img width="200" alt="firefox_3I8rILVu2Z" src="https://github.com/user-attachments/assets/22880288-5b4d-431a-af91-e600833db489" />
    </td>
    <td>
      <p>Two changes have been made to the footer-fixed activities in the editor activity bar:</p>
      <ol>
        <li>
        The <b>Run</b> activity has been moved there to a fixed position, which makes sense because it is one of the main actions a user takes in the editor once done editing; previously this was hidden in the main activities.
        </li>
        <li>
        The <b>Save + Exit</b> activity has been replaced with the <b>Exit</b> activity; a singular way to exit the editor out into the main Galaxy, non-editor views - with the user being provided the option of saving and exiting, not saving and just exiting, or cancelling the exit operation. 
        </li>
    </td>
  </tr>
</table>

---

## Change Undo/Redo Button Icons
The traditional icons make more sense?

| Before | After |
| ---- | ---- |
| <img width="197" height="82" alt="firefox_weXroCUAPw" src="https://github.com/user-attachments/assets/bc1c7e99-0cf7-4035-83fd-bc36ed2ea690" /> | <img width="197" height="82" alt="oGkjz4g6E7" src="https://github.com/user-attachments/assets/c6ea4476-ed20-45ae-8c96-d6ef92c66028" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Once any activity bar's any activity's panel is open, try closing it with the panel's header badge
  2. Then, try exiting the editor after making a change and not saving: Note that you'll see a modal asking if you would like to Cancel (not exit), Discard Changes (exit without saving) or Save and Exit.
  3. Observe that each of those functions as you would expect

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
