### PR TITLE
Fix PermissionError crash when container cache_directory is read-only (e.g. CVMFS)

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -513,8 +513,10 @@ class SingularityCliContainerResolver(CliContainerResolver):
             assert self.app_info.container_image_cache_path
             cache_directory_path = os.path.join(self.app_info.container_image_cache_path, "singularity", "mulled")
         self.cache_directory = cacher_class(cache_directory_path, hash_func=self.hash_func)
-        safe_makedirs(self.cache_directory.path)
-
+        try:
+            safe_makedirs(self.cache_directory.path)
+        except PermissionError:
+            pass
 
 class CachedMulledDockerContainerResolver(CliContainerResolver):
     resolver_type = "cached_mulled"


### PR DESCRIPTION
When `cache_directory` points to a read-only filesystem such as CVMFS,
`safe_makedirs` raises `PermissionError` and prevents Galaxy from starting.

This is a real-world issue when configuring Galaxy to use
`/cvmfs/singularity.galaxyproject.org/all` as the Singularity container
cache directory on HPC clusters where CVMFS is mounted read-only.

The fix wraps `safe_makedirs` in a try/except PermissionError so Galaxy
gracefully handles read-only cache directories and continues normally.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
1. Configure container_resolvers.yml with a cached_mulled_singularity
   resolver pointing to a read-only directory (e.g. /cvmfs/singularity.galaxyproject.org/all)
2. Start Galaxy, without this fix Galaxy crashes on startup,
   with this fix it starts normally and resolves containers from the read-only path.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
