### PR TITLE
[26.0] Strip whitespace from URIs in get_file_source_path

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -199,6 +199,7 @@ class ConfiguredFileSources:
 
     def get_file_source_path(self, uri):
         """Parse uri into a FileSource object and a path relative to its base."""
+        uri = uri.strip()
         if "://" not in uri:
             raise exceptions.RequestParameterInvalidException(f"Invalid uri [{uri}]")
         file_source = self.find_best_match(uri)

--- a/test/unit/files/test_posix.py
+++ b/test/unit/files/test_posix.py
@@ -549,3 +549,10 @@ def test_score_url_match_requires_prefix():
     # Embedded scheme must not match
     assert file_source.score_url_match("gxfiles://test1http://evil.com/foo") == 0
     assert file_source.score_url_match("http://evil.com/gxfiles://test1/a") == 0
+
+
+def test_get_file_source_path_strips_whitespace():
+    file_sources = _configured_file_sources()
+    resolved = file_sources.get_file_source_path("\ngxfiles://test1/a\n")
+    assert resolved.file_source is not None
+    assert resolved.path == "/a"


### PR DESCRIPTION
Deferred dataset source_uris can contain stray leading/trailing whitespace (e.g. a newline picked up when the URI was pasted into a workflow input). Commit 4f60a2a2e3d switched score_url_match from substring to strict prefix matching, so such URIs now score 0 on every file source and materialization fails with "Could not find handler for URI [...]" in the workflow scheduler.

Strip the URI once at the top of get_file_source_path so both find_best_match and to_relative_path see the normalized value. This heals already-persisted rows without a data migration.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
