### PR TITLE
[26.0] Drop --frozen-lockfile from prebuilt client install

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -215,7 +215,7 @@ if [ $FETCH_WHEELS -eq 1 ]; then
 fi
 
 # Check client build state.
-if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
+if [ "$SKIP_CLIENT_BUILD" -eq 0 ]; then
     if [ -f static/client_build_hash.txt ]; then
         # If git is not used and static/client_build_hash.txt is present, next
         # client rebuilds must be done manually by the admin
@@ -239,7 +239,7 @@ else
 fi
 
 # Build client if necessary.
-if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
+if [ "$SKIP_CLIENT_BUILD" -eq 0 ]; then
     # Ensure pnpm is installed
     INSTALL_PNPM=0
     if ! command -v pnpm >/dev/null; then
@@ -277,9 +277,8 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
         fi
         cd -
     else
-        # Install prebuilt client
-        # shellcheck disable=SC2086
-        if pnpm install $PNPM_INSTALL_OPTS; then
+        # No root pnpm-lock.yaml is shipped, so --frozen-lockfile can't apply here.
+        if pnpm install; then
             if ! (pnpm run stage) then
                 echo "ERROR: Galaxy prebuilt client install failed. See ./client/README.md for more information, including how to get help."
                 exit 1


### PR DESCRIPTION
The prebuilt client install path (`GALAXY_INSTALL_PREBUILT_CLIENT=1`, which planemo uses) fails with:

```
 ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
ERROR: Galaxy prebuilt client dependency installation failed.
```

No root `pnpm-lock.yaml` is shipped, so `--frozen-lockfile` can never succeed here. This drops the flag from the prebuilt branch only; the dev/source branch still uses `$PNPM_INSTALL_OPTS` against `client/pnpm-lock.yaml`.

Also quotes `$SKIP_CLIENT_BUILD` in two places to clear pre-existing shellcheck SC2086 warnings on the same file.

Planning to follow up on `dev` for 26.1 by removing the npm-based prebuilt path entirely in favor of the existing `galaxy-web-client` Python wheel.

## Test plan

- [ ] Fresh venv, `GALAXY_INSTALL_PREBUILT_CLIENT=1 bash scripts/common_startup.sh` completes where it previously failed with `ERR_PNPM_NO_LOCKFILE`.
- [ ] Dev-source path still runs `pnpm install --frozen-lockfile` against `client/pnpm-lock.yaml` (unchanged).
- [ ] Marius re-runs the failing planemo invocation against a checkout including this commit.