### PR TITLE
Use shared host_port_and_url helper in integration driver

### DIFF
--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -37,6 +37,7 @@ from galaxy_test.base.api import (
     UsesApiTestCaseMixin,
     UsesCeleryTasks,
 )
+from galaxy_test.base.testcase import host_port_and_url
 from .driver_util import GalaxyTestDriver
 
 if TYPE_CHECKING:
@@ -203,11 +204,7 @@ class IntegrationInstance(UsesApiTestCaseMixin, UsesCeleryTasks):
 
     def _configure_interactor(self):
         # Setup attributes needed for API testing...
-        server_wrapper = self._test_driver.server_wrappers[0]
-        host = server_wrapper.host
-        port = server_wrapper.port
-        prefix = server_wrapper.prefix or ""
-        self.url = f"http://{host}:{port}{prefix.rstrip('/')}/"
+        self.host, self.port, self.url = host_port_and_url(self._test_driver)
         self._setup_interactor()
 
     def restart(self, handle_reconfig=None):


### PR DESCRIPTION
## Summary
- Import and use the shared helper in IntegrationInstance._configure_interactor.
- Remove duplicated host/port/url composition logic from the integration driver utility.
- Keep URL construction behavior centralized in a single test utility helper.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).