### PR TITLE
Fix display of BAMs with large headers

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -775,7 +775,7 @@ class BamNative(CompressedArchive, _BamOrSam):
                         # interpret an offset before the first alignment start as the index of
                         # the header line at which the chunk should start
                         header_lines = bamfile.text.strip().replace("\t", " ").splitlines()  # type: ignore[attr-defined]
-                        ck_lines = header_lines[offset:offset + ck_size]
+                        ck_lines = header_lines[offset : offset + ck_size]
                         offset += len(ck_lines)
                         if offset >= len(header_lines):
                             # consumed the entire header, now jump forward to the first alignment

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -771,33 +771,38 @@ class BamNative(CompressedArchive, _BamOrSam):
                 with pysam.AlignmentFile(dataset.get_file_name(), "rb", check_sq=False) as bamfile:
                     if ck_size is None:
                         ck_size = 300  # 300 lines
-                    if offset == 0:
-                        offset = bamfile.tell()
-                        ck_lines = bamfile.text.strip().replace("\t", " ").splitlines()  # type: ignore[attr-defined]
+                    if offset < bamfile.tell():
+                        # interpret an offset before the first alignment start as the index of
+                        # the header line at which the chunk should start
+                        header_lines = bamfile.text.strip().replace("\t", " ").splitlines()  # type: ignore[attr-defined]
+                        ck_lines = header_lines[offset:offset+ck_size]
+                        offset += len(ck_lines)
+                        if offset >= len(header_lines):
+                            # consumed the entire header, now jump forward to the first alignment
+                            offset = bamfile.tell()
                     else:
-                        bamfile.seek(offset)
                         ck_lines = []
-                    for line_number, alignment in enumerate(bamfile, len(ck_lines)):
-                        # return only Header lines if 'header_line_count' exceeds 'ck_size'
-                        # FIXME: Can be problematic if bam has million lines of header
-                        if line_number >= ck_size:
-                            break
+                    if len(ck_lines) < ck_size:
+                        bamfile.seek(offset)
+                        for line_number, alignment in enumerate(bamfile, len(ck_lines)):
+                            if line_number >= ck_size:
+                                break
 
-                        offset = bamfile.tell()
-                        bamline = alignment.to_string()
-                        # With multiple tags, Galaxy would display each as a separate column
-                        # because the 'to_string()' function uses tabs also between tags.
-                        # Below code will turn these extra tabs into spaces.
-                        n_tabs = bamline.count("\t")
-                        if n_tabs > 11:
-                            bamline, *extra_tags = bamline.rsplit("\t", maxsplit=n_tabs - 11)
-                            bamline = f"{bamline} {' '.join(extra_tags)}"
-                        ck_lines.append(bamline)
-                    else:
-                        # Nothing to enumerate; we've either offset to the end
-                        # of the bamfile, or there is no data. (possible with
-                        # header-only bams)
-                        offset = -1
+                            offset = bamfile.tell()
+                            bamline = alignment.to_string()
+                            # With multiple tags, Galaxy would display each as a separate column
+                            # because the 'to_string()' function uses tabs also between tags.
+                            # Below code will turn these extra tabs into spaces.
+                            n_tabs = bamline.count("\t")
+                            if n_tabs > 11:
+                                bamline, *extra_tags = bamline.rsplit("\t", maxsplit=n_tabs - 11)
+                                bamline = f"{bamline} {' '.join(extra_tags)}"
+                            ck_lines.append(bamline)
+                        else:
+                            # Nothing to enumerate; we've either offset to the end
+                            # of the bamfile, or there is no data. (possible with
+                            # header-only bams)
+                            offset = -1
                     ck_data = "\n".join(ck_lines)
             except Exception as e:
                 offset = -1

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -775,7 +775,7 @@ class BamNative(CompressedArchive, _BamOrSam):
                         # interpret an offset before the first alignment start as the index of
                         # the header line at which the chunk should start
                         header_lines = bamfile.text.strip().replace("\t", " ").splitlines()  # type: ignore[attr-defined]
-                        ck_lines = header_lines[offset:offset+ck_size]
+                        ck_lines = header_lines[offset:offset + ck_size]
                         offset += len(ck_lines)
                         if offset >= len(header_lines):
                             # consumed the entire header, now jump forward to the first alignment


### PR DESCRIPTION
For BAM headers with more lines than the chunk size, the previous implementation would:

- return the entire header in a single chunk, which could be problematic for very large headers
- only ever return that one header chunk, i.e. the user had no way to explore the body of the file

With the default chunk size of 300 this would affect BAMs generated against hg38 and after yet another user getting confused by a seemingly truncated file I decided to fix things.
Now also the header part of a BAM can get returned in chunks and will transition seamlessly into the body.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
