### PR TITLE
[26.0] Truncate dataset name in export arcname to avoid OSError

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -3082,7 +3082,7 @@ def get_export_dataset_filename(name: str, ext: str, encoded_id: str, conversion
     """
     Builds a filename for a dataset using its name an extension.
     """
-    base = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in name)
+    base = "".join(c in FILENAME_VALID_CHARS and c or "_" for c in name)[:150]
     if not conversion_key:
         return f"{base}_{encoded_id}.{ext}"
     else:

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -51,6 +51,19 @@ TEST_PATH_2_CONVERTED = TESTCASE_DIRECTORY / "2.txt"
 DEFAULT_OBJECT_STORE_BY = "id"
 
 
+def test_get_export_dataset_filename_truncates_long_name():
+    long_name = "https___example.com_" + "a" * 2000 + ".fastq.gz"
+    filename = store.get_export_dataset_filename(long_name, "fastqsanger.gz", "abcdef1234567890", conversion_key=None)
+    assert len(filename.encode("utf-8")) <= 255
+    assert filename.endswith("_abcdef1234567890.fastqsanger.gz")
+
+    filename_conv = store.get_export_dataset_filename(
+        long_name, "bam", "abcdef1234567890", conversion_key="0123456789abcdef"
+    )
+    assert len(filename_conv.encode("utf-8")) <= 255
+    assert filename_conv.endswith("_abcdef1234567890_conversion_0123456789abcdef.bam")
+
+
 def test_import_export_history():
     """Test a simple job import/export after decompressing an archive (like history import/export tool)."""
     app = _mock_app()


### PR DESCRIPTION
Long dataset names (e.g. S3 upload URLs used as HDA names) produced export arcnames exceeding the 255-byte POSIX NAME_MAX, causing history exports to fail with `OSError: [Errno 36] File name too long` inside `serialize_files`. Cap the sanitized base name at 150 chars to match the convention used by other filename-sanitization sites.

Fixes GALAXY-MAIN-4KSCZZZ0015TD

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
