### PR TITLE
[26.0] Catch end of file error when reading corrupted tabular dataset

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -165,6 +165,10 @@ class TabularData(Text):
                         cursor = f.read(1)
             except UnicodeDecodeError:
                 raise InvalidFileFormatError("Dataset appears to contain binary data, cannot display.")
+            except EOFError:
+                raise InvalidFileFormatError(
+                    "Dataset appears to be a truncated or corrupt compressed file, cannot display."
+                )
             last_read = f.tell()
         return ck_data, last_read
 


### PR DESCRIPTION
Fix: #22452

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
