### PR TITLE
[26.0] Fix data manager URL for managers with '+' version suffix

### DIFF
--- a/lib/galaxy/model/store/_bco_convert_utils.py
+++ b/lib/galaxy/model/store/_bco_convert_utils.py
@@ -1,5 +1,3 @@
-import urllib.parse
-
 from galaxy.model import (
     Workflow,
     WorkflowStep,
@@ -8,6 +6,7 @@ from galaxy.schema.bco import (
     ExecutionDomainUri,
     SoftwarePrerequisite,
 )
+from galaxy.tool_util.identifiers import uri_safe_tool_id
 
 
 class SoftwarePrerequisiteTracker:
@@ -25,12 +24,12 @@ class SoftwarePrerequisiteTracker:
         tool_version = step.tool_version
         assert tool_id
         self._recorded_tools.add(tool_id)
-        uri_safe_tool_id = urllib.parse.quote(tool_id)
+        safe_tool_id = uri_safe_tool_id(tool_id)
         if "repos/" in tool_id:
             # tool shed tool - give them a link...
-            uri = f"https://{uri_safe_tool_id}"
+            uri = f"https://{safe_tool_id}"
         else:
-            uri = f"gxstocktools://galaxyproject.org/{uri_safe_tool_id}"
+            uri = f"gxstocktools://galaxyproject.org/{safe_tool_id}"
 
         access_time = None  # used to be uuid - but Pydanic validation... rightfully... disallows this
         software_prerequisite = SoftwarePrerequisite(

--- a/lib/galaxy/tool_util/identifiers.py
+++ b/lib/galaxy/tool_util/identifiers.py
@@ -1,0 +1,8 @@
+from urllib.parse import quote
+
+
+def uri_safe_tool_id(tool_id: str) -> str:
+    # Shed tool ids contain ``+`` in their version suffix (e.g.
+    # ``.../1.3.1+galaxy1``). In a query string the ``+`` decodes to a
+    # literal space unless percent-encoded as ``%2B``.
+    return quote(tool_id)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -74,6 +74,7 @@ from galaxy.tool_util.deps import (
 )
 from galaxy.tool_util.deps.requirements import CredentialsRequirement
 from galaxy.tool_util.fetcher import ToolLocationFetcher
+from galaxy.tool_util.identifiers import uri_safe_tool_id
 from galaxy.tool_util.loader import (
     imported_macro_paths,
     raw_tool_xml_tree,
@@ -3488,8 +3489,10 @@ class DataSourceTool(OutputParameterJSONTool):
         return True
 
     def _build_GALAXY_URL_parameter(self):
+        assert self.id, "Tool id must be set to build GALAXY_URL parameter for data_source tool"
         return ToolParameter.build(
-            self, XML(f'<param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id={self.id}" />')
+            self,
+            XML(f'<param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id={uri_safe_tool_id(self.id)}" />'),
         )
 
     def parse_inputs(self, tool_source):
@@ -3561,7 +3564,10 @@ class AsyncDataSourceTool(DataSourceTool):
     tool_type = "data_source_async"
 
     def _build_GALAXY_URL_parameter(self):
-        return ToolParameter.build(self, XML(f'<param name="GALAXY_URL" type="baseurl" value="/async/{self.id}" />'))
+        assert self.id, "Tool id must be set to build GALAXY_URL parameter for data_source_async tool"
+        return ToolParameter.build(
+            self, XML(f'<param name="GALAXY_URL" type="baseurl" value="/async/{uri_safe_tool_id(self.id)}" />')
+        )
 
 
 class DataDestinationTool(Tool):

--- a/lib/galaxy/webapps/galaxy/controllers/data_manager.py
+++ b/lib/galaxy/webapps/galaxy/controllers/data_manager.py
@@ -8,6 +8,7 @@ from galaxy.model import (
     DataManagerJobAssociation,
     Job,
 )
+from galaxy.tool_util.identifiers import uri_safe_tool_id
 from galaxy.util import (
     nice_size,
     unicodify,
@@ -34,7 +35,7 @@ class DataManager(BaseUIController):
         ):
             data_managers.append(
                 {
-                    "toolUrl": web.url_for(f"/?tool_id={data_manager.tool.id}"),
+                    "toolUrl": web.url_for(f"/?tool_id={uri_safe_tool_id(data_manager.tool.id)}"),
                     "id": data_manager_id,
                     "name": data_manager.name,
                     "description": data_manager.description.lower(),
@@ -90,7 +91,7 @@ class DataManager(BaseUIController):
             "dataManager": {
                 "name": data_manager.name,
                 "description": data_manager.description.lower(),
-                "toolUrl": web.url_for(f"/?tool_id={data_manager.tool.id}"),
+                "toolUrl": web.url_for(f"/?tool_id={uri_safe_tool_id(data_manager.tool.id)}"),
             },
             "jobs": jobs,
             "viewOnly": not_is_admin,
@@ -155,7 +156,7 @@ class DataManager(BaseUIController):
                 "id": data_manager_id,
                 "name": data_manager.name,
                 "description": data_manager.description.lower(),
-                "toolUrl": web.url_for(f"/?tool_id={data_manager.tool.id}"),
+                "toolUrl": web.url_for(f"/?tool_id={uri_safe_tool_id(data_manager.tool.id)}"),
             },
             "hdaInfo": hda_info,
             "dataManagerOutput": data_manager_output,

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -9,6 +9,7 @@ from markupsafe import escape
 import galaxy.util
 from galaxy import web
 from galaxy.model import HistoryDatasetAssociation
+from galaxy.tool_util.identifiers import uri_safe_tool_id
 from galaxy.tools import DataSourceTool
 from galaxy.web import (
     error,
@@ -74,7 +75,7 @@ class ToolRunner(BaseUIController):
             return __tool_404__()
         # FIXME: Tool class should define behavior
         if tool.tool_type in ["default", "interactivetool"]:
-            return trans.response.send_redirect(url_for(f"/?tool_id={tool_id}"))
+            return trans.response.send_redirect(url_for(f"/?tool_id={uri_safe_tool_id(tool_id)}"))
 
         # execute tool without displaying form
         # (used for datasource tools, but note that data_source_async tools


### PR DESCRIPTION
controllers/data_manager.py built query strings by f-string interpolation, so shed ids like '…/1.3.1+galaxy1' had their '+' sent verbatim and then decoded as space by vue-router. Wrap the id in urllib.parse.quote so it goes out as '%2Bgalaxy1' and round-trips through the router intact.

Fixes #22497

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
