### PR TITLE
[26.0] Fix UnicodeError on empty-label URLs in fetch validation

### DIFF
--- a/client/src/utils/upload.test.ts
+++ b/client/src/utils/upload.test.ts
@@ -426,6 +426,13 @@ describe("createUrlUploadItem", () => {
         expect(item.deferred).toBe(true);
         expect(item.dbkey).toBe("hg38");
     });
+
+    test("trims surrounding whitespace from URL", () => {
+        const item = createUrlUploadItem("  http://example.com/data.bed\n", "historyId");
+
+        expect(item.url).toBe("http://example.com/data.bed");
+        expect(item.name).toBe("data.bed");
+    });
 });
 
 describe("parseContentToUploadItems", () => {
@@ -459,6 +466,22 @@ describe("parseContentToUploadItems", () => {
         expect(() => parseContentToUploadItems("http://example.com/valid.txt\ninvalid-not-a-url", "historyId")).toThrow(
             "Invalid URL: invalid-not-a-url",
         );
+    });
+
+    test("throws on network URL with empty DNS labels", () => {
+        expect(() => parseContentToUploadItems("https://.../SRR1957099.fastq.gz", "historyId")).toThrow(
+            "Invalid URL: https://.../SRR1957099.fastq.gz",
+        );
+    });
+
+    test("accepts Galaxy file-source URIs", () => {
+        const content = "gxfiles://myftp/file.txt\ndrs://example.org/abc\nzenodo://record/123";
+        const items = parseContentToUploadItems(content, "historyId");
+
+        expect(items).toHaveLength(3);
+        expect((items[0] as { url: string }).url).toBe("gxfiles://myftp/file.txt");
+        expect((items[1] as { url: string }).url).toBe("drs://example.org/abc");
+        expect((items[2] as { url: string }).url).toBe("zenodo://record/123");
     });
 
     test("handles whitespace around URLs", () => {
@@ -535,6 +558,12 @@ describe("buildUploadPayload", () => {
         const items: ApiUploadItem[] = [createUrlUploadItem("not-a-valid-url", "historyId")];
 
         expect(() => buildUploadPayload(items)).toThrow("Invalid URL: not-a-valid-url");
+    });
+
+    test("rejects network URL with empty DNS labels", () => {
+        const items: ApiUploadItem[] = [createUrlUploadItem("https://.../SRR1957099.fastq.gz", "historyId")];
+
+        expect(() => buildUploadPayload(items)).toThrow("Invalid URL: https://.../SRR1957099.fastq.gz");
     });
 });
 

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -48,7 +48,7 @@ import type { UploadRowModel } from "@/components/Upload/model";
 import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
 import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString } from "@/utils/simple-error";
-import { isUrl } from "@/utils/url";
+import { isUrl, isValidUrl } from "@/utils/url";
 
 import { createTusUpload, type FileStream, type NamedBlob, type UploadableFile } from "./tusUpload";
 
@@ -393,12 +393,13 @@ export function createUrlUploadItem(
     historyId: string,
     options: Partial<Omit<UrlUploadItem, "src" | "url" | "historyId">> = {},
 ): UrlUploadItem {
+    const trimmedUrl = url.trim();
     // Extract filename from URL if not provided
-    const defaultName = url.split("/").pop()?.split("?")[0] || DEFAULT_FILE_NAME;
+    const defaultName = trimmedUrl.split("/").pop()?.split("?")[0] || DEFAULT_FILE_NAME;
 
     return {
         src: "url",
-        url,
+        url: trimmedUrl,
         historyId,
         name: options.name ?? defaultName,
         size: options.size ?? 0,
@@ -493,7 +494,7 @@ export function parseContentToUploadItems(
     // If first line is a URL, treat all lines as URLs
     if (isUrl(firstLine)) {
         return lines.filter(Boolean).map((urlLine) => {
-            if (!isUrl(urlLine)) {
+            if (!isValidUrl(urlLine)) {
                 throw new Error(`Invalid URL: ${urlLine}`);
             }
             return createUrlUploadItem(urlLine, historyId, options);
@@ -581,7 +582,7 @@ function validateItemContent(item: ApiUploadItem): void {
             if (!item.url || item.url.trim().length === 0) {
                 throw new Error(`No URL for upload item: ${item.name}`);
             }
-            if (!isUrl(item.url)) {
+            if (!isValidUrl(item.url)) {
                 throw new Error(`Invalid URL: ${item.url}`);
             }
             break;

--- a/client/src/utils/upload/itemMappers.ts
+++ b/client/src/utils/upload/itemMappers.ts
@@ -68,7 +68,7 @@ export function mapToPasteUrlUpload(item: PasteUrlItem, targetHistoryId: string)
         spaceToTab: item.spaceToTab,
         toPosixLines: item.toPosixLines,
         deferred: item.deferred,
-        url: item.url,
+        url: item.url.trim(),
     };
 }
 

--- a/client/src/utils/url.test.js
+++ b/client/src/utils/url.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, test } from "vitest";
 
-import { addSearchParams, isUrl } from "./url";
+import { addSearchParams, isUrl, isValidNetworkUrl, isValidUrl } from "./url";
 
 describe("test url utilities", () => {
     it("adding parameters to url", async () => {
@@ -13,5 +13,60 @@ describe("test url utilities", () => {
         expect(isUrl("xyz://")).toBeFalsy();
         expect(isUrl("ftp://")).toBeTruthy();
         expect(isUrl("http://")).toBeTruthy();
+    });
+
+    test("network url validation accepts well-formed hosts", () => {
+        expect(isValidNetworkUrl("https://example.com/x")).toBe(true);
+        expect(isValidNetworkUrl("http://sub.example.org/path?q=1")).toBe(true);
+        expect(isValidNetworkUrl("ftp://ftp.example.org/a")).toBe(true);
+    });
+
+    test("network url validation rejects empty DNS labels", () => {
+        expect(isValidNetworkUrl("https://.../foo")).toBe(false);
+        expect(isValidNetworkUrl("https://./foo")).toBe(false);
+        expect(isValidNetworkUrl("https://..example.com/x")).toBe(false);
+        expect(isValidNetworkUrl("https:///foo")).toBe(false);
+    });
+
+    test("network url validation rejects non-network schemes", () => {
+        expect(isValidNetworkUrl("gxfiles://foo")).toBe(false);
+        expect(isValidNetworkUrl("drs://example.org/123")).toBe(false);
+        expect(isValidNetworkUrl("not-a-url")).toBe(false);
+    });
+
+    test("isValidUrl accepts custom Galaxy file-source schemes", () => {
+        expect(isValidUrl("gxfiles://myftp/file.txt")).toBe(true);
+        expect(isValidUrl("gxuserfiles://mysource/x")).toBe(true);
+        expect(isValidUrl("drs://example.org/abc")).toBe(true);
+        expect(isValidUrl("zenodo://record/123")).toBe(true);
+        expect(isValidUrl("invenio://record/123")).toBe(true);
+        expect(isValidUrl("dataverse://doi/x")).toBe(true);
+        expect(isValidUrl("base64://aGVsbG8=")).toBe(true);
+    });
+
+    test("isValidUrl accepts well-formed network urls", () => {
+        expect(isValidUrl("https://example.com/")).toBe(true);
+        expect(isValidUrl("https://example.com/file.txt")).toBe(true);
+        expect(isValidUrl("ftp://ftp.example.org/a")).toBe(true);
+    });
+
+    test("isValidUrl rejects network urls with empty DNS labels", () => {
+        expect(isValidUrl("https://.../foo")).toBe(false);
+        expect(isValidUrl("https://./foo")).toBe(false);
+        expect(isValidUrl("https:///foo")).toBe(false);
+    });
+
+    test("isValidUrl rejects unknown schemes and non-urls", () => {
+        expect(isValidUrl("")).toBe(false);
+        expect(isValidUrl("not-a-url")).toBe(false);
+        expect(isValidUrl("xyz://foo")).toBe(false);
+    });
+
+    test("isValidUrl tolerates surrounding whitespace", () => {
+        expect(isValidUrl("  https://example.com/x  ")).toBe(true);
+        expect(isValidUrl("\thttps://example.com/x\n")).toBe(true);
+        expect(isValidUrl("   gxfiles://myftp/file.txt   ")).toBe(true);
+        expect(isValidUrl("   ")).toBe(false);
+        expect(isValidUrl("  https://.../x  ")).toBe(false);
     });
 });

--- a/client/src/utils/url.ts
+++ b/client/src/utils/url.ts
@@ -37,6 +37,44 @@ export function isUrl(content: string): boolean {
     return URI_PREFIXES.some((prefix) => content.startsWith(prefix));
 }
 
+const NETWORK_SCHEMES = ["http://", "https://", "ftp://", "ftps://"];
+
+export function isNetworkUrl(content: string): boolean {
+    return NETWORK_SCHEMES.some((prefix) => content.startsWith(prefix));
+}
+
+/**
+ * Structural validation for http(s)/ftp(s) URLs destined for the server
+ * fetch endpoint. Rejects empty DNS labels (leading/trailing dot, consecutive
+ * dots, or pure punctuation) that would otherwise crash server-side idna
+ * encoding and surface as an opaque 500.
+ */
+export function isValidNetworkUrl(content: string): boolean {
+    const prefix = NETWORK_SCHEMES.find((p) => content.startsWith(p));
+    if (!prefix) {
+        return false;
+    }
+    const afterScheme = content.slice(prefix.length);
+    const authorityEnd = afterScheme.search(/[/?#]/);
+    const authority = authorityEnd === -1 ? afterScheme : afterScheme.slice(0, authorityEnd);
+    const hostAndPort = authority.includes("@") ? authority.slice(authority.lastIndexOf("@") + 1) : authority;
+    let host = hostAndPort;
+    if (!host.startsWith("[")) {
+        const portIdx = host.lastIndexOf(":");
+        if (portIdx !== -1) {
+            host = host.slice(0, portIdx);
+        }
+    }
+    if (!host) {
+        return false;
+    }
+    // IPv6 literals are bracketed; they have no DNS labels to validate.
+    if (host.startsWith("[")) {
+        return true;
+    }
+    return !host.split(".").some((label) => label.length === 0);
+}
+
 export async function urlData<R>({ url, headers, params, errorSimplify = true }: UrlDataOptions): Promise<R> {
     try {
         headers = headers || {};
@@ -75,41 +113,24 @@ export interface UrlValidationResult {
 }
 
 /**
- * Validates a URL string and returns detailed validation results.
- * Checks for required fields, valid hostname, and meaningful content.
- *
- * @param url - The URL string to validate
- * @returns Validation result with isValid flag and error message
- *
- * @example
- * ```typescript
- * const result = validateUrl("https://example.org/data.txt");
- * if (!result.isValid) {
- *   console.error(result.message);
- * }
- * ```
+ * Validates a URL string for use in upload flows. Accepts any URI whose scheme
+ * appears in URI_PREFIXES (including Galaxy file-source schemes like
+ * gxfiles://, drs://, zenodo://, etc.). For http(s)/ftp(s) URLs it also applies
+ * a structural host check to reject empty DNS labels that would crash
+ * server-side idna encoding.
  */
 export function validateUrl(url: string): UrlValidationResult {
-    if (!url.trim()) {
+    const trimmed = url.trim();
+    if (!trimmed) {
         return { isValid: false, message: "URL is required" };
     }
-
-    try {
-        const urlObj = new URL(url);
-
-        if (!urlObj.host) {
-            return { isValid: false, message: "URL must include a valid hostname" };
-        }
-
-        const hasContent = urlObj.pathname !== "/" || urlObj.search || urlObj.hash;
-        if (!hasContent) {
-            return { isValid: false, message: "URL should point to a specific file or resource" };
-        }
-
-        return { isValid: true, message: null };
-    } catch {
+    if (!isUrl(trimmed)) {
         return { isValid: false, message: "URL format is invalid or missing protocol" };
     }
+    if (isNetworkUrl(trimmed) && !isValidNetworkUrl(trimmed)) {
+        return { isValid: false, message: "URL must include a valid hostname" };
+    }
+    return { isValid: true, message: null };
 }
 
 /**

--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -94,13 +94,15 @@ def split_port(parsed_url: str, url: str) -> tuple[str, int]:
 
 def validate_non_local(uri: str, ip_allowlist: list[IpAllowedListEntryT]) -> str:
     # If it doesn't look like a URL, ignore it.
-    if not (uri.lstrip().startswith("http://") or uri.lstrip().startswith("https://")):
+    if not (uri.strip().startswith("http://") or uri.strip().startswith("https://")):
         return uri
 
-    # Strip leading whitespace before passing url to urlparse()
-    url = uri.lstrip()
+    # Strip surrounding whitespace before passing url to urlparse()
+    url = uri.strip()
     # Extract hostname component
     parsed_url = urlparse(url).netloc
+    if not parsed_url:
+        raise RequestParameterInvalidException(f"Could not verify url '{url}'.")
     # If credentials are in this URL, we need to strip those.
     if parsed_url.count("@") > 0:
         # credentials.
@@ -134,8 +136,10 @@ def validate_non_local(uri: str, ip_allowlist: list[IpAllowedListEntryT]) -> str
     # Call getaddrinfo to resolve hostname into tuples containing IPs.
     try:
         addrinfo = socket.getaddrinfo(parsed_url, port)
-    except socket.gaierror as e:
-        log.debug("Could not resolve url '%': %'", url, e)
+    except (socket.gaierror, UnicodeError) as e:
+        # UnicodeError covers idna codec failures (e.g. empty DNS labels in hosts like '...' or '..example.com')
+        # which are not wrapped as socket.gaierror.
+        log.debug("Could not resolve url '%s': '%s'", url, e)
         raise RequestParameterInvalidException(f"Could not verify url '{url}'.")
     # Get the IP addresses that this entry resolves to (uniquely)
     # We drop:

--- a/test/unit/files/test_uris.py
+++ b/test/unit/files/test_uris.py
@@ -1,8 +1,11 @@
 import ipaddress
 
+import pytest
+
 from galaxy.exceptions import (
     AdminRequiredException,
     ConfigDoesNotAllowException,
+    RequestParameterInvalidException,
 )
 from galaxy.files.uris import (
     validate_non_local,
@@ -37,6 +40,28 @@ def test_validate():
     # check that only admins can acess files...
     assert not validates("file://foo/bar", False, [])
     assert validates("file://foo/bar", True, [])
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "https://.../SRR1957099.fastq.gz",
+        "https://./foo",
+        "https://..example.com/x",
+        "https:///foo",
+        "http:// /foo",
+    ],
+)
+def test_validate_non_local_rejects_malformed_host(bad_url):
+    with pytest.raises(RequestParameterInvalidException):
+        validate_non_local(bad_url, [])
+
+
+def test_validate_non_local_strips_surrounding_whitespace():
+    # Leading whitespace was already tolerated; trailing whitespace used to
+    # slip through to getaddrinfo and raise an opaque error.
+    assert validates_as_non_local("  http://google.com/x  ", [])
+    assert validates_as_non_local("\thttp://google.com/x\n", [])
 
 
 def validates_as_non_local(uri: str, allow_list):


### PR DESCRIPTION
socket.getaddrinfo raises UnicodeError (not gaierror) for hosts with empty DNS labels (e.g. 'https://.../path'), producing a 500 instead of a user-friendly 400. Reject empty netloc up-front and broaden the exception catch. Add isValidNetworkUrl on the client so the upload UI doesn't submit obviously broken URLs.

Fixes #22522

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
