### PR TITLE
Add 'rds.sce' datatype to datatypes_conf.xml.sample

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -857,6 +857,7 @@
     <datatype extension="gal" type="galaxy.datatypes.microarrays:Gal" display_in_upload="true"/>
     <datatype extension="rds" type="galaxy.datatypes.binary:RDS" display_in_upload="true" description="Serialized R object generated with saveRDS"/>
     <datatype extension="phyloseq" type="galaxy.datatypes.binary:RDS" subclass="true" display_in_upload="true" description="Serialized phyloseq object"/>
+    <datatype extension="rds.sce" type="galaxy.datatypes.binary:RDS" subclass="true" display_in_upload="true" description="Stored RDS from a Bioconductor SingleCellExperiment object."/>
     <datatype extension="rdata" type="galaxy.datatypes.binary:RData" mimetype="application/x-gzip" display_in_upload="true" description="Stored data from an R session genearted with save or save.img"/>
     <datatype extension="rdata.sce" type="galaxy.datatypes.binary:RData" mimetype="application/x-gzip" subclass="true" display_in_upload="true" description="Stored RData from a SingleCellObject"/>
     <datatype extension="rdata.xcms.raw" type="galaxy.datatypes.binary:RData" mimetype="application/x-gzip" subclass="true" display_in_upload="true"/>


### PR DESCRIPTION
Added support for 'rds.sce' datatype with description for Bioconductor SingleCellExperiment objects.

This is semantically more correct than the existing `rdata.sce` datatype:

- RData files can contain multiple objects while RDS can only contain one
- In RData files, objects are saved with the name they were assigned to in the R session, while RDS saves a single object without its name.
- Objects in RData files are restored under their unpredictable original name using the `load()` function, while the object imported from an RDS file can be reassigned to a new name in the new session.

The RDS format is much safer for the reasons above and better suited for tracking individual objects produced by tools.

## How to test the changes?
(Select all options that apply) - Not immediately applicable
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. I am currently writing new tools that process single-cell data using Bioconductor packages. Those tools and subcommands will ingest and produce SingleCellExperiment objects that will be written to RDS files.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).


