### PR TITLE
[26.0] Fix TypeError when generating tour for tool with boolean conditional case

### DIFF
--- a/lib/galaxy/managers/tours.py
+++ b/lib/galaxy/managers/tours.py
@@ -247,7 +247,10 @@ class TourGenerator:
                                 dataset = self._test.inputs[tour_id][0]
                                 step_msg = f"Select dataset: <b>{hid}: {dataset}</b>"
                             else:
-                                case_params = ", ".join(str(v) for v in self._test.inputs[tour_id])
+                                case_params = ", ".join(
+                                    ("Yes" if v is True else "No" if v is False else str(v))
+                                    for v in self._test.inputs[tour_id]
+                                )
                                 step_msg = f"Select parameter(s): <b>{case_params}</b>"
                             cond_case_steps.append(
                                 TourStep(

--- a/lib/galaxy/managers/tours.py
+++ b/lib/galaxy/managers/tours.py
@@ -247,7 +247,7 @@ class TourGenerator:
                                 dataset = self._test.inputs[tour_id][0]
                                 step_msg = f"Select dataset: <b>{hid}: {dataset}</b>"
                             else:
-                                case_params = ", ".join(self._test.inputs[tour_id])
+                                case_params = ", ".join(str(v) for v in self._test.inputs[tour_id])
                                 step_msg = f"Select parameter(s): <b>{case_params}</b>"
                             cond_case_steps.append(
                                 TourStep(

--- a/lib/galaxy_test/selenium/test_tool_describing_tours.py
+++ b/lib/galaxy_test/selenium/test_tool_describing_tours.py
@@ -64,12 +64,21 @@ class TestToolDescribingTours(SeleniumTestCase):
 
     @selenium_test
     def test_generate_tour_boolean_conditional(self):
-        """Regression test for https://github.com/galaxyproject/galaxy/issues/22460.
-
-        Generating a tour for a tool whose conditional has a boolean inner parameter
-        (explicitly set in the first test case) previously raised a TypeError.
-        """
         self.tool_open("gx_conditional_boolean")
         self.tool_form_generate_tour()
         popover_component = self.components.tour.popover._
         popover_component.wait_for_visible()
+
+        # Intro step: advance to the outer conditional step.
+        popover_component.next.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        # Advance to the inner boolean_parameter case step.
+        popover_component.next.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # tests[0] specifies boolean_parameter="true" → tour should render "Yes".
+        text = popover_component.content.wait_for_visible().text
+        assert "Yes" in text, text
+
+        popover_component.end.wait_for_and_click()
+        popover_component.wait_for_absent_or_hidden()

--- a/lib/galaxy_test/selenium/test_tool_describing_tours.py
+++ b/lib/galaxy_test/selenium/test_tool_describing_tours.py
@@ -61,3 +61,15 @@ class TestToolDescribingTours(SeleniumTestCase):
         self.tool_form_execute()
         self.history_panel_wait_for_hid_ok(2)
         self.screenshot("tool_describing_tour_3_after_execute")
+
+    @selenium_test
+    def test_generate_tour_boolean_conditional(self):
+        """Regression test for https://github.com/galaxyproject/galaxy/issues/22460.
+
+        Generating a tour for a tool whose conditional has a boolean inner parameter
+        (explicitly set in the first test case) previously raised a TypeError.
+        """
+        self.tool_open("gx_conditional_boolean")
+        self.tool_form_generate_tour()
+        popover_component = self.components.tour.popover._
+        popover_component.wait_for_visible()

--- a/test/functional/tools/parameters/gx_conditional_boolean.xml
+++ b/test/functional/tools/parameters/gx_conditional_boolean.xml
@@ -17,6 +17,19 @@
     </inputs>
     <tests>
         <test>
+            <conditional name="conditional_parameter">
+                <param name="test_parameter" value="false" />
+                <param name="boolean_parameter" value="true" />
+            </conditional>
+            <expand macro="assert_output">
+                <has_line line="test: false" />
+            </expand>
+            <expand macro="assert_inputs_json">
+                <has_json_property_with_value property="test_parameter" value="false" />
+                <has_json_property_with_value property="boolean_parameter" value="true" />
+            </expand>
+        </test>
+        <test>
             <expand macro="assert_output">
                 <has_line line="test: false" />
             </expand>


### PR DESCRIPTION
Generating a tour for a tool whose conditional has a boolean parameter explicitly set in the first test case crashed with `TypeError: sequence item 0: expected str instance, bool found`. This happened because the test input is stored as `[True]`/`[False]` (a list containing a Python bool), and the tour generator tried to `str.join` the list without coercing to strings first.

Changes:
- Coerce values to `str` before joining in `TourGenerator` (`managers/tours.py`)
- Added selenium test targeting a dedicated tool that could reproduce the failure

Fixes https://github.com/galaxyproject/galaxy/issues/22460

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
