### PR TITLE
[26.0] Backport rocrate<0.15.0 pin

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -16,12 +16,12 @@ from typing import (
 import yaml
 from gxformat2 import (
     from_galaxy_native,
-    ImporterGalaxyInterface,
     ImportOptions,
     python_to_workflow,
 )
 from gxformat2.abstract import from_dict
 from gxformat2.cytoscape import to_cytoscape
+from gxformat2.interface import ImporterGalaxyInterface
 from gxformat2.yaml import ordered_dump
 from pydantic import (
     BaseModel,

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2508,13 +2508,6 @@ class BaseWorkflowPopulator(BasePopulator):
         )
         return ROCrate(crate_response)
 
-    def validate_invocation_crate_directory(self, crate_directory):
-        # TODO: where can a ro_crate be extracted
-        metadata_json_path = crate_directory / "ro-crate-metadata.json"
-        with metadata_json_path.open() as f:
-            metadata_json = json.load(f)
-            assert metadata_json["@context"] == "https://w3id.org/ro/crate/1.1/context"
-
     def invoke_workflow_raw(self, workflow_id: str, request: dict, assert_ok: bool = False) -> Response:
         url = f"workflows/{workflow_id}/invocations"
         invocation_response = self._post(url, data=request, json=True)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -75,8 +75,8 @@ import yaml
 from bioblend.galaxyclient import GalaxyClient
 from gxformat2 import (
     convert_and_import_workflow,
-    ImporterGalaxyInterface,
 )
+from gxformat2.interface import ImporterGalaxyInterface
 from gxformat2.yaml import ordered_load
 from pydantic import (
     BaseModel,

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -21,8 +21,8 @@ import requests
 import yaml
 from gxformat2 import (
     convert_and_import_workflow,
-    ImporterGalaxyInterface,
 )
+from gxformat2.interface import ImporterGalaxyInterface
 from requests.models import Response
 
 from galaxy.selenium import driver_factory

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     pypng
     python-magic
     pysam>=0.21
-    rocrate
+    rocrate<0.15.0
     social-auth-core>=4.5.0
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
     tifffile

--- a/packages/web_framework/setup.cfg
+++ b/packages/web_framework/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     requests
     Routes
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
+    starlette
     WebOb
 
 packages = find:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
     "refgenconf>=0.12.0",
     "regex",
     "requests",
-    "rocrate",
+    "rocrate<0.15.0",  # https://github.com/crs4/rocrate-validator/issues/107
     "Routes",
     "s3fs>=2023.1.0",
     "schema-salad>=8.7.20240905150001",  # Python 3.13 support


### PR DESCRIPTION
 until roc-validator supports RO-Crate Metadata Specification 1.2 .

rocrate 0.15.0 produces crates conforming to 1.2 spec by default, which causes roc-validator validation errors like:

```
The RO-Crate metadata file descriptor MUST have a `conformsTo` property with the RO-Crate specification version
```

xref https://github.com/crs4/rocrate-validator/issues/107

Also:
- Remove unused `BaseWorkflowPopulator.validate_invocation_crate_directory()` method.
- Import `ImporterGalaxyInterface` from its module since it is not re-exported in gxformat2 0.26.0
- Add missing dependency on starlette to galaxy-web-framework package

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
