### PR TITLE
[26.0] Handle list-valued tool_id in ToolRunner.__get_tool

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -8,6 +8,7 @@ from markupsafe import escape
 
 import galaxy.util
 from galaxy import web
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.model import HistoryDatasetAssociation
 from galaxy.tool_util.identifiers import uri_safe_tool_id
 from galaxy.tools import DataSourceTool
@@ -39,6 +40,14 @@ class ToolRunner(BaseUIController):
         return self.index(trans, tool_id=tool_id, **kwd)
 
     def __get_tool(self, tool_id, tool_version=None):
+        # webob's params.mixed() returns a list when a form/query key is repeated
+        # (some data sources redirect back with tool_id duplicated); accept that
+        # case only when every value agrees.
+        if isinstance(tool_id, list):
+            unique_ids = set(tool_id)
+            if len(unique_ids) != 1:
+                raise RequestParameterInvalidException(f"Conflicting tool_id values supplied: {tool_id!r}")
+            tool_id = unique_ids.pop()
         # Some data sources send back redirects ending with `/`, this takes care of that case
         tool_id = tool_id.rstrip("/")
         return self.get_toolbox().get_tool(tool_id, tool_version=tool_version)


### PR DESCRIPTION
When a POST to /tool_runner arrives with `tool_id` repeated (some data source tools redirect back with duplicated parameters), webob's `params.mixed()` delivers it as a list. Commit 30cc4e6bf04 ("Remove unused ToolBox.get_tool_components") dropped the `listify()` normalization that previously masked this; `tool_id.rstrip("/")` now raises `AttributeError: 'list' object has no attribute 'rstrip'`.

Collapse duplicate values to a single id, and raise `RequestParameterInvalidException` if the list contains conflicting ids.

Fixes https://github.com/galaxyproject/galaxy/issues/22543

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
