### PR TITLE
[26.0] Fix crash merging structurally invalid nested collections

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -638,10 +638,7 @@ class DatasetCollectionManager:
 
         new_elements = {}
         for key, element in elements.items():
-            if isinstance(element, DatasetCollection):
-                continue
-
-            if element.get("src") != "new_collection":
+            if not isinstance(element, dict) or element.get("src") != "new_collection":
                 continue
 
             # element is a dict with src new_collection and

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -23,6 +23,7 @@ from galaxy.util import galaxy_root_path
 from galaxy_test.base import rules_test_data
 from galaxy_test.base.api_asserts import (
     assert_error_code_is,
+    assert_error_message_contains,
     assert_file_looks_like_xlsx,
     assert_has_keys,
     assert_status_code_is,
@@ -809,6 +810,24 @@ class TestToolsApi(ApiTestCase, TestsTools):
                 history_id, hid=implicit_collections[0]["hid"]
             )
             assert zipped_hdca["collection_type"] == "list:paired"
+
+    @skip_without_tool("__MERGE_COLLECTION__")
+    def test_merge_collection_rejects_structurally_invalid_inputs(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            list_paired_id = self.dataset_collection_populator.create_list_of_pairs_in_history(
+                history_id, wait=True
+            ).json()["outputs"][0]["id"]
+            plain_list_id = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["a", "b"], wait=True
+            ).json()["outputs"][0]["id"]
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            inputs = {
+                "inputs_0|input": {"src": "hdca", "id": list_paired_id},
+                "inputs_1|input": {"src": "hdca", "id": plain_list_id},
+            }
+            response = self._run("__MERGE_COLLECTION__", history_id, inputs, assert_ok=False)
+            assert_status_code_is(response, 400)
+            assert_error_message_contains(response, "must be a sub-collection")
 
     @skip_without_tool("__EXTRACT_DATASET__")
     @skip_without_tool("cat_data_and_sleep")


### PR DESCRIPTION
`__recursively_create_collections_for_elements` called `.get("src")` on every non-`DatasetCollection` element, assuming a `{"src": "new_collection"}` descriptor dict. When `MERGE_COLLECTION` is given inputs that yield a `list:paired` with a bare HDA in place of a sub-pair, the HDA reaches this loop and raises `AttributeError`, short-circuiting the downstream `_validate_nested_collection_elements` that would have returned a clean `RequestParameterInvalidException`.

Guard the materialization loop with `isinstance(element, dict)` so non-dict elements pass through untouched and validation issues the proper user error.

Fixes https://github.com/galaxyproject/galaxy/issues/22544 and GALAXY-MAIN-4KSCZZZ0015Z5

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
