### PR TITLE
[26.0] Fix silent OIDC failure when pkce is missing

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -7,6 +7,7 @@ from social_core.exceptions import (
     AuthCanceled,
     AuthTokenError,
 )
+from social_core.utils import module_member
 
 from galaxy import (
     exceptions,
@@ -25,6 +26,7 @@ from galaxy.util.resources import (
     resource_path,
 )
 from .psa_authnz import (
+    BACKENDS,
     BACKENDS_NAME,
     PSAAuthnz,
 )
@@ -143,6 +145,21 @@ class AuthnzManager:
 
             if len(self.oidc_backends_config) == 0:
                 raise exceptions.ConfigurationError("No valid provider configuration parsed.")
+            # Force-import each configured backend so missing conditional
+            # dependencies (e.g. pkce) fail Galaxy startup with an actionable
+            # error instead of surfacing as a silent 401 on first OIDC login
+            # (issue #22502).
+            for idp in self.oidc_backends_config:
+                try:
+                    module_member(BACKENDS[idp])
+                except ImportError as e:
+                    raise exceptions.ConfigurationError(
+                        f"Failed to import OIDC backend for provider '{idp}' "
+                        f"({BACKENDS[idp]}): {e}. This typically indicates a "
+                        "missing conditional dependency; re-run Galaxy's "
+                        "common_startup or install requirements from "
+                        "lib/galaxy/dependencies/conditional-requirements.txt."
+                    )
         except ImportError:
             raise
         except (etree.ParseError, exceptions.ConfigurationError) as e:

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -131,16 +131,15 @@ class ConditionalDependencies:
         except OSError:
             pass
 
-        # Parse oidc_backends_config_file specifically for PKCE support.
-        self.pkce_support = False
-        oidc_backend_conf_xml = self.config_object.oidc_backends_config_file
-        try:
-            for pkce_support_element in parse_xml(oidc_backend_conf_xml).iterfind("./provider/pkce_support"):
-                if pkce_support_element.text == "true":
-                    self.pkce_support = True
-                    break
-        except OSError:
-            pass
+        # Install pkce whenever OIDC is in use. PKCE can be toggled per-provider
+        # in oidc_backends_config.xml at runtime, so tying the install decision
+        # to any top-level OIDC signal avoids rebuilding the venv when
+        # pkce_support is flipped (issue #22502).
+        self.oidc_active = (
+            asbool(self.config.get("enable_oidc", False))
+            or bool(self.config.get("oidc_auth_pipeline"))
+            or bool(self.config.get("oidc_auth_pipeline_extra"))
+        )
 
         # Parse error report config
         error_report_yml = self.config_object.error_report_file
@@ -323,7 +322,7 @@ class ConditionalDependencies:
         return "hashicorp" == self.vault_type
 
     def check_pkce(self):
-        return self.pkce_support
+        return self.oidc_active
 
     def check_rucio_clients(self):
         return "rucio" in self.object_stores

--- a/test/unit/app/dependencies/test_deps.py
+++ b/test/unit/app/dependencies/test_deps.py
@@ -109,6 +109,36 @@ def test_vault_hashicorp_configured():
         assert cds.check_hvac()
 
 
+def test_pkce_default_disabled():
+    with _config_context() as cc:
+        cds = cc.get_cond_deps()
+        assert cds.check_pkce() is False
+
+
+def test_pkce_enabled_when_enable_oidc():
+    with _config_context() as cc:
+        cds = cc.get_cond_deps(config={"enable_oidc": True})
+        assert cds.check_pkce() is True
+
+
+def test_pkce_disabled_when_enable_oidc_off():
+    with _config_context() as cc:
+        cds = cc.get_cond_deps(config={"enable_oidc": False})
+        assert cds.check_pkce() is False
+
+
+def test_pkce_enabled_via_auth_pipeline():
+    with _config_context() as cc:
+        cds = cc.get_cond_deps(config={"oidc_auth_pipeline": ["galaxy.authnz.psa_authnz.verify"]})
+        assert cds.check_pkce() is True
+
+
+def test_pkce_enabled_via_auth_pipeline_extra():
+    with _config_context() as cc:
+        cds = cc.get_cond_deps(config={"oidc_auth_pipeline_extra": ["galaxy.authnz.psa_authnz.verify"]})
+        assert cds.check_pkce() is True
+
+
 @pytest.mark.parametrize(
     "config,expected",
     [


### PR DESCRIPTION
pkce is a conditional dependency; oidc.py imports it unconditionally. Previously the install gate only fired when a provider had <pkce_support>true</pkce_support> in oidc_backends_config.xml, so deployers who enabled OIDC without that flag (or flipped it later without rebuilding the venv) hit ModuleNotFoundError on first OIDC login with no clear cause.

Widen the install gate: mark pkce for install whenever OIDC is in use (enable_oidc, oidc_auth_pipeline, or oidc_auth_pipeline_extra). Additionally, force-import each configured backend at AuthnzManager init so any remaining missing conditional dep fails Galaxy startup with an actionable ConfigurationError instead of silently breaking OIDC login later.

Fixes #22502

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
