### PR TITLE
Update label for invert parameter in grep.xml for clarity

### DIFF
--- a/tools/filters/grep.xml
+++ b/tools/filters/grep.xml
@@ -24,7 +24,7 @@
   </configfiles>
   <inputs>
     <param format="txt" name="input" type="data" label="Select lines from"/>
-    <param name="invert" type="select" label="that">
+    <param name="invert" type="select" label="that are">
       <option value="">Matching</option>
       <option value="-v">NOT Matching</option>
     </param>


### PR DESCRIPTION
The label in grep was missing a verb. 
I added "are" to enhance clarity, so that the full sentence would now read:

Select lines from _File_ that **are** Matching the pattern

I hope this is the correct place - if not, please let me know.

