### PR TITLE
[26.0] Fix notification channels not processed correctly

### DIFF
--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -240,7 +240,7 @@ class NotificationManager:
         return self._is_subscribed_to_category(category_settings)
 
     def _send_via_channels(self, notification: Notification, user: User, channel_settings: NotificationChannelSettings):
-        channels = channel_settings.model_fields_set
+        channels = type(channel_settings).model_fields
         for channel in channels:
             if channel not in self.channel_plugins:
                 continue  # Skip unsupported channels

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -240,15 +240,11 @@ class NotificationManager:
         return self._is_subscribed_to_category(category_settings)
 
     def _send_via_channels(self, notification: Notification, user: User, channel_settings: NotificationChannelSettings):
-        channels = type(channel_settings).model_fields
-        for channel in channels:
-            if channel not in self.channel_plugins:
-                continue  # Skip unsupported channels
+        for channel, plugin in self.channel_plugins.items():
             user_opted_out = getattr(channel_settings, channel, False) is False
             if user_opted_out and not self._is_urgent(notification):
                 continue  # Skip sending to opted-out users unless it's an urgent notification
             try:
-                plugin = self.channel_plugins[channel]
                 plugin.send(notification, user)
             except Exception as e:
                 log.error(

--- a/test/unit/app/managers/test_NotificationManager.py
+++ b/test/unit/app/managers/test_NotificationManager.py
@@ -6,7 +6,10 @@ from typing import (
     Any,
     Optional,
 )
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
 import pytest
 
@@ -394,6 +397,25 @@ class TestUserNotifications(NotificationManagerBaseTestCase):
         self._send_message_notification_to_users([user], notification=notification_data)
         user_notifications = self.notification_manager.get_user_notifications(user)
         assert len(user_notifications) == 1
+
+    def test_send_via_channels_uses_all_channel_fields(self):
+        user = self._create_test_user()
+        notification_data = NotificationCreateData(**self._default_test_notification_data())
+        notification = self.notification_manager._create_notification_model(notification_data)
+
+        push_plugin = MagicMock()
+        email_plugin = MagicMock()
+        self.notification_manager.channel_plugins = {
+            "push": push_plugin,
+            "email": email_plugin,
+        }
+
+        # `email` remains at its default value (True) and should still be considered.
+        channel_settings = NotificationChannelSettings(push=False)
+        self.notification_manager._send_via_channels(notification, user, channel_settings)
+
+        push_plugin.send.assert_not_called()
+        email_plugin.send.assert_called_once_with(notification, user)
 
 
 class TestUserNotificationsWithTasks(NotificationManagerBaseTestCaseWithTasks):


### PR DESCRIPTION
Dispatching notifications via email or push silently stopped working since `channel_settings.model_fields_set` was returning an empty dictionary after one of the pydantic updates.

Includes a regression test that fails without the fix.

Discovered while working on #22404

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
