### PR TITLE
Add `enable_statsd_middleware` option to send backend execution timing to statsd without enabling web request timing

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3325,6 +3325,20 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_statsd_middleware``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Default is true if statsd_host is set. Enable the statsd
+    middleware. If false and statsd_host is also set, only timing of
+    certain performance-critical backend tasks (e.g. the job handler
+    monitor loop time) data will be sent to statsd, but not web
+    request timing.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~
 ``statsd_host``
 ~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1922,6 +1922,12 @@ galaxy:
   # self-signed certificate.
   #sentry_ca_certs: null
 
+  # Default is true if statsd_host is set. Enable the statsd middleware.
+  # If false and statsd_host is also set, only timing of certain
+  # performance-critical backend tasks (e.g. the job handler monitor
+  # loop time) data will be sent to statsd, but not web request timing.
+  #enable_statsd_middleware: false
+
   # Log to statsd Statsd is an external statistics aggregator
   # (https://github.com/etsy/statsd) Enabling the following options will
   # cause galaxy to log request timing and other statistics to the

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2448,6 +2448,17 @@ mapping:
           Use this option to provide the path to location of the CA (Certificate Authority)
           certificate file if the sentry server uses a self-signed certificate.
 
+      enable_statsd_middleware:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Default is true if statsd_host is set.
+          Enable the statsd middleware. If false and statsd_host is also set,
+          only timing of certain performance-critical backend tasks (e.g. the
+          job handler monitor loop time) data will be sent to statsd, but not
+          web request timing.
+
       statsd_host:
         type: str
         required: false

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1023,7 +1023,8 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
     # other middleware):
     app = wrap_if_allowed(app, stack, httpexceptions.make_middleware, name="paste.httpexceptions", args=(conf,))
     # Statsd request timing and profiling
-    if statsd_host := conf.get("statsd_host", None):
+    statsd_host = conf.get("statsd_host", None)
+    if statsd_host and conf.get("enable_statsd_middleware", statsd_host is not None):
         from galaxy.web.framework.middleware.statsd import StatsdMiddleware
 
         app = wrap_if_allowed(


### PR DESCRIPTION
Web request timing is pretty useless as it creates measurements for every single distinct web request, including all the vulnerability probing. And we have Sentry. But loop execution timing is still useful.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
