### PR TITLE
[26.0] Skip orphan rows during history export

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2952,7 +2952,7 @@ class ImplicitCollectionJobs(Base, Serializable):
         rval = dict_for(
             self,
             populated_state=self.populated_state,
-            jobs=[serialization_options.get_identifier(id_encoder, j_a.job) for j_a in self.jobs],
+            jobs=[serialization_options.get_identifier(id_encoder, j_a.job) for j_a in self.jobs if j_a.job is not None],
         )
         serialization_options.attach_identifier(id_encoder, self, rval)
         return rval

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2952,7 +2952,9 @@ class ImplicitCollectionJobs(Base, Serializable):
         rval = dict_for(
             self,
             populated_state=self.populated_state,
-            jobs=[serialization_options.get_identifier(id_encoder, j_a.job) for j_a in self.jobs if j_a.job is not None],
+            jobs=[
+                serialization_options.get_identifier(id_encoder, j_a.job) for j_a in self.jobs if j_a.job is not None
+            ],
         )
         serialization_options.attach_identifier(id_encoder, self, rval)
         return rval

--- a/test/unit/data/model/test_model.py
+++ b/test/unit/data/model/test_model.py
@@ -56,3 +56,22 @@ def test_io_dicts_excludes_implicit_output_collections():
     # With exclude_implicit_outputs=False (default), they should be included
     io = job.io_dicts(exclude_implicit_outputs=False)
     assert "paired_output" in io.out_collections
+
+
+def test_implicit_collection_jobs_serialize_skips_orphan_associations():
+    """ImplicitCollectionJobsJobAssociation.job_id is nullable; orphan rows
+    (e.g. produced by partial imports) must be skipped on export instead of
+    crashing in SerializationOptions.get_identifier on a None job."""
+    icj = model.ImplicitCollectionJobs()
+    job = model.Job()
+    job.id = 42
+
+    linked = model.ImplicitCollectionJobsJobAssociation()
+    linked.order_index = 0
+    linked.job = job
+    orphan = model.ImplicitCollectionJobsJobAssociation()
+    orphan.order_index = 1  # job left as None
+    icj.jobs = [linked, orphan]
+
+    rval = icj._serialize(id_encoder=None, serialization_options=model.SerializationOptions(for_edit=True))
+    assert rval["jobs"] == [42]


### PR DESCRIPTION
Fixes #22560.

Crash in write_history_to is caused by ImplicitCollectionJobs._serialize accessing j_a.job when job_id is NULL. This state is allowed and created during import when a job reference is missing. Fix filters out these orphan rows, matching the INNER JOIN behavior of related queries, so export completes instead of raising AttributeError. 

Is silently skipping here ok, or should we raise an explicit error message instead?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
