### PR TITLE
Tighten the workflow test schema

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -7692,49 +7692,49 @@ export interface components {
         /** BaseUrlParameterModel */
         BaseUrlParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_baseurl
              * @constant
              */
             parameter_type: "gx_baseurl";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "baseurl";
@@ -7935,58 +7935,58 @@ export interface components {
         /** BooleanParameterModel */
         BooleanParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
-            /** falsevalue */
+            /** Falsevalue */
             falsevalue?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_boolean
              * @constant
              */
             parameter_type: "gx_boolean";
-            /** truevalue */
+            /** Truevalue */
             truevalue?: string | null;
             /**
-             * type
+             * Type
              * @constant
              */
             type: "boolean";
             /**
-             * value
+             * Value
              * @default false
              */
             value: boolean | null;
@@ -8351,9 +8351,9 @@ export interface components {
         };
         /** Citation */
         Citation: {
-            /** content */
+            /** Content */
             content: string;
-            /** type */
+            /** Type */
             type: string;
         };
         /** CitationErrorResponse */
@@ -8393,7 +8393,7 @@ export interface components {
         };
         /** CollectionAttributes */
         CollectionAttributes: {
-            /** collection_type */
+            /** Collection Type */
             collection_type?: string | null;
         };
         /** CollectionElementCollectionRequestUri */
@@ -8506,53 +8506,53 @@ export interface components {
         /** ColorParameterModel */
         ColorParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_color
              * @constant
              */
             parameter_type: "gx_color";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "color";
-            /** value */
+            /** Value */
             value?: string | null;
         };
         /** CompositeDataElement */
@@ -8761,57 +8761,57 @@ export interface components {
         /** ConditionalParameterModel */
         ConditionalParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_conditional
              * @constant
              */
             parameter_type: "gx_conditional";
-            /** test_parameter */
+            /** Test Parameter */
             test_parameter:
                 | components["schemas"]["BooleanParameterModel"]
                 | components["schemas"]["SelectParameterModel"];
             /**
-             * type
+             * Type
              * @constant
              */
             type: "conditional";
-            /** whens */
+            /** Whens */
             whens: components["schemas"]["ConditionalWhen"][];
         };
         /** ConditionalWhen */
@@ -8873,20 +8873,19 @@ export interface components {
         };
         /** Container */
         Container: {
-            /** container_id */
+            /** Container Id */
             container_id: string;
             /**
-             * type
+             * Type
              * @enum {string}
              */
             type: "docker" | "singularity";
         };
         /** ContainerRequirement */
         ContainerRequirement: {
-            /** container */
             container: components["schemas"]["Container"];
             /**
-             * type
+             * Type
              * @constant
              */
             type: "container";
@@ -10166,12 +10165,12 @@ export interface components {
         /** CwlBooleanParameterModel */
         CwlBooleanParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_boolean
              * @constant
              */
@@ -10180,43 +10179,43 @@ export interface components {
         /** CwlDirectoryParameterModel */
         CwlDirectoryParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_directory
              * @constant
              */
@@ -10225,43 +10224,43 @@ export interface components {
         /** CwlFileParameterModel */
         CwlFileParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_file
              * @constant
              */
@@ -10270,12 +10269,12 @@ export interface components {
         /** CwlFloatParameterModel */
         CwlFloatParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_float
              * @constant
              */
@@ -10284,12 +10283,12 @@ export interface components {
         /** CwlIntegerParameterModel */
         CwlIntegerParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_integer
              * @constant
              */
@@ -10298,12 +10297,12 @@ export interface components {
         /** CwlNullParameterModel */
         CwlNullParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_null
              * @constant
              */
@@ -10312,12 +10311,12 @@ export interface components {
         /** CwlStringParameterModel */
         CwlStringParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_string
              * @constant
              */
@@ -10326,17 +10325,17 @@ export interface components {
         /** CwlUnionParameterModel */
         CwlUnionParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_union
              * @constant
              */
             parameter_type: "cwl_union";
-            /** parameters */
+            /** Parameters */
             parameters: (
                 | components["schemas"]["CwlIntegerParameterModel"]
                 | components["schemas"]["CwlFloatParameterModel"]
@@ -10460,62 +10459,62 @@ export interface components {
         /** DataCollectionParameterModel */
         DataCollectionParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
-            /** collection_type */
+            /** Collection Type */
             collection_type?: string | null;
             /**
-             * extensions
+             * Extensions
              * @default [
              *       "data"
              *     ]
              */
             extensions: string[];
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_data_collection
              * @constant
              */
             parameter_type: "gx_data_collection";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "data_collection";
-            /** value */
+            /** Value */
             value: {
                 [key: string]: unknown;
             } | null;
@@ -10523,55 +10522,55 @@ export interface components {
         /** DataColumnParameterModel */
         DataColumnParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** multiple */
+            /** Multiple */
             multiple: boolean;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_data_column
              * @constant
              */
             parameter_type: "gx_data_column";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "data_column";
-            /** value */
+            /** Value */
             value?: number | number[] | null;
         };
         /** DataElementsFromTarget */
@@ -10648,12 +10647,12 @@ export interface components {
         /** DataParameterModel */
         DataParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * extensions
+             * Extensions
              * @description Limit inputs to datasets with these extensions. Use 'data' to allow all input datasets.
              * @default [
              *       "data"
@@ -10664,54 +10663,54 @@ export interface components {
              */
             extensions: string[];
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** max */
+            /** Max */
             max?: number | null;
-            /** min */
+            /** Min */
             min?: number | null;
             /**
-             * multiple
+             * Multiple
              * @description Allow multiple values to be selected.
              * @default false
              */
             multiple: boolean;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_data
              * @constant
              */
             parameter_type: "gx_data";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "data";
@@ -11448,54 +11447,54 @@ export interface components {
         /** DirectoryUriParameterModel */
         DirectoryUriParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_directory_uri
              * @constant
              */
             parameter_type: "gx_directory_uri";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "directory";
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: (
@@ -11556,70 +11555,70 @@ export interface components {
         };
         /** DrillDownOptionsDict */
         DrillDownOptionsDict: {
-            /** name */
+            /** Name */
             name: string | null;
-            /** options */
+            /** Options */
             options: components["schemas"]["DrillDownOptionsDict"][];
-            /** selected */
+            /** Selected */
             selected: boolean;
-            /** value */
+            /** Value */
             value: string;
         };
         /** DrillDownParameterModel */
         DrillDownParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * hierarchy
+             * Hierarchy
              * @enum {string}
              */
             hierarchy: "recurse" | "exact";
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** multiple */
+            /** Multiple */
             multiple: boolean;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
-            /** options */
+            /** Options */
             options?: components["schemas"]["DrillDownOptionsDict"][] | null;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_drill_down
              * @constant
              */
             parameter_type: "gx_drill_down";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "drill_down";
@@ -12481,39 +12480,39 @@ export interface components {
         };
         /** FilePatternDatasetCollectionDescription */
         FilePatternDatasetCollectionDescription: {
-            /** assign_primary_output */
+            /** Assign Primary Output */
             assign_primary_output: boolean;
-            /** directory */
+            /** Directory */
             directory: string | null;
             /**
-             * discover_via
+             * Discover Via
              * @constant
              */
             discover_via: "pattern";
-            /** format */
+            /** Format */
             format: string | null;
-            /** match_relative_path */
+            /** Match Relative Path */
             match_relative_path: boolean;
-            /** pattern */
+            /** Pattern */
             pattern: string;
-            /** recurse */
+            /** Recurse */
             recurse: boolean;
             /**
-             * sort_comp
+             * Sort Comp
              * @enum {string}
              */
             sort_comp: "lexical" | "numeric";
             /**
-             * sort_key
+             * Sort Key
              * @enum {string}
              */
             sort_key: "filename" | "name" | "designation" | "dbkey";
             /**
-             * sort_reverse
+             * Sort Reverse
              * @default false
              */
             sort_reverse: boolean;
-            /** visible */
+            /** Visible */
             visible: boolean;
         };
         /** FileRequestUri */
@@ -12738,62 +12737,62 @@ export interface components {
         /** FloatParameterModel */
         FloatParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** max */
+            /** Max */
             max?: number | null;
-            /** min */
+            /** Min */
             min?: number | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_float
              * @constant
              */
             parameter_type: "gx_float";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "float";
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: components["schemas"]["InRangeParameterValidatorModel"][];
-            /** value */
+            /** Value */
             value?: number | null;
         };
         /** FolderLibraryFolderItem */
@@ -13001,51 +13000,51 @@ export interface components {
         /** GenomeBuildParameterModel */
         GenomeBuildParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** multiple */
+            /** Multiple */
             multiple: boolean;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_genomebuild
              * @constant
              */
             parameter_type: "gx_genomebuild";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "genomebuild";
@@ -13166,51 +13165,51 @@ export interface components {
         /** GroupTagParameterModel */
         GroupTagParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** multiple */
+            /** Multiple */
             multiple: boolean;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_group_tag
              * @constant
              */
             parameter_type: "gx_group_tag";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "group_tag";
@@ -14724,10 +14723,10 @@ export interface components {
         };
         /** HelpContent */
         HelpContent: {
-            /** content */
+            /** Content */
             content: string;
             /**
-             * format
+             * Format
              * @enum {string}
              */
             format: "restructuredtext" | "plain_text" | "markdown";
@@ -14989,54 +14988,54 @@ export interface components {
         /** HiddenParameterModel */
         HiddenParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_hidden
              * @constant
              */
             parameter_type: "gx_hidden";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "hidden";
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: (
@@ -15045,7 +15044,7 @@ export interface components {
                 | components["schemas"]["ExpressionParameterValidatorModel"]
                 | components["schemas"]["EmptyFieldParameterValidatorModel"]
             )[];
-            /** value */
+            /** Value */
             value: string | null;
         };
         /**
@@ -15520,21 +15519,20 @@ export interface components {
         /** IncomingToolOutputCollection */
         IncomingToolOutputCollection: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden?: boolean | null;
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name?: string | null;
-            /** structure */
             structure: components["schemas"]["ToolOutputCollectionStructure"];
             /**
              * @description discriminator enum property added by openapi-typescript
@@ -15544,7 +15542,7 @@ export interface components {
         };
         /** IncomingToolOutputDataset */
         IncomingToolOutputDataset: {
-            /** discover_datasets */
+            /** Discover Datasets */
             discover_datasets?:
                 | (
                       | components["schemas"]["FilePatternDatasetCollectionDescription"]
@@ -15552,12 +15550,12 @@ export interface components {
                   )[]
                 | null;
             /**
-             * format
+             * Format
              * @description The short name for the output datatype.
              */
             format?: string | null;
             /**
-             * format_source
+             * Format Source
              * @description This sets the data type of the output dataset(s) to be the same format as that of the specified tool input.
              */
             format_source?: string | null;
@@ -15567,27 +15565,27 @@ export interface components {
              */
             from_work_dir?: string | null;
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden?: boolean | null;
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null;
             /**
-             * metadata_source
+             * Metadata Source
              * @description This copies the metadata information from the tool’s input dataset to serve as default for information that cannot be detected from the output. One prominent use case is interval data with a non-standard column order that cannot be deduced from a header line, but which is known to be identical in the input and output datasets.
              */
             metadata_source?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name?: string | null;
             /**
-             * precreate_directory
+             * Precreate Directory
              * @default false
              */
             precreate_directory: boolean | null;
@@ -15872,61 +15870,61 @@ export interface components {
         /** IntegerParameterModel */
         IntegerParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** max */
+            /** Max */
             max?: number | null;
-            /** min */
+            /** Min */
             min?: number | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_integer
              * @constant
              */
             parameter_type: "gx_integer";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "integer";
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: components["schemas"]["InRangeParameterValidatorModel"][];
-            /** value */
+            /** Value */
             value?: number | null;
         };
         /** InvocationCancellationHistoryDeletedResponse */
@@ -16916,10 +16914,10 @@ export interface components {
         ItemsFromSrc: "url" | "files" | "path" | "ftp_import" | "server_dir";
         /** JavascriptRequirement */
         JavascriptRequirement: {
-            /** expression_lib */
+            /** Expression Lib */
             expression_lib: string[] | null;
             /**
-             * type
+             * Type
              * @constant
              */
             type: "javascript";
@@ -20561,52 +20559,52 @@ export interface components {
         /** RepeatParameterModel */
         RepeatParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
-            /** max */
+            /** Max */
             max?: number | null;
-            /** min */
+            /** Min */
             min?: number | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_repeat
              * @constant
              */
             parameter_type: "gx_repeat";
-            /** parameters */
+            /** Parameters */
             parameters: (
                 | components["schemas"]["CwlIntegerParameterModel"]
                 | components["schemas"]["CwlFloatParameterModel"]
@@ -20637,7 +20635,7 @@ export interface components {
                 | components["schemas"]["SectionParameterModel"]
             )[];
             /**
-             * type
+             * Type
              * @constant
              */
             type: "repeat";
@@ -20708,56 +20706,56 @@ export interface components {
         /** ResourceRequirement */
         ResourceRequirement: {
             /**
-             * cores_max
+             * Cores Max
              * @description Maximum reserved number of CPU cores.
              *     May be a fractional value to indicate to a scheduling algorithm that one core can be allocated to multiple jobs. For example, a value of 0.25 indicates that up to 4 jobs may run in parallel on 1 core. A value of 1.25 means that up to 3 jobs can run on a 4 core system (4/1.25 ≈ 3).
              *     The reported number of CPU cores reserved for the process is a non-zero integer calculated by rounding up the cores request to the next whole number.
              */
             cores_max?: number | null;
             /**
-             * cores_min
+             * Cores Min
              * @description Minimum reserved number of CPU cores.
              *     May be a fractional value to indicate to a scheduling algorithm that one core can be allocated to multiple jobs. For example, a value of 0.25 indicates that up to 4 jobs may run in parallel on 1 core. A value of 1.25 means that up to 3 jobs can run on a 4 core system (4/1.25 ≈ 3).
              *     The reported number of CPU cores reserved for the process is a non-zero integer calculated by rounding up the cores request to the next whole number.
              * @default 1
              */
             cores_min: number | null;
-            /** cuda_compute_capability */
+            /** Cuda Compute Capability */
             cuda_compute_capability?: number | null;
-            /** cuda_device_count_max */
+            /** Cuda Device Count Max */
             cuda_device_count_max?: number | null;
-            /** cuda_device_count_min */
+            /** Cuda Device Count Min */
             cuda_device_count_min?: number | null;
-            /** cuda_version_min */
+            /** Cuda Version Min */
             cuda_version_min?: number | null;
-            /** gpu_memory_min */
+            /** Gpu Memory Min */
             gpu_memory_min?: number | null;
             /**
-             * ram_max
+             * Ram Max
              * @description Maximum reserved RAM in mebibytes (2**20).
              *     May be a fractional value. If so, the actual RAM request is rounded up to the next whole number. The reported amount of RAM reserved for the process is a non-zero integer.
              */
             ram_max?: number | null;
             /**
-             * ram_min
+             * Ram Min
              * @description Minimum reserved RAM in mebibytes (2**20).
              *     May be a fractional value. If so, the actual RAM request is rounded up to the next whole number. The reported amount of RAM reserved for the process is a non-zero integer.
              * @default 256
              */
             ram_min: number | null;
-            /** shm_size */
+            /** Shm Size */
             shm_size?: number | null;
             /**
-             * timelimit
+             * Timelimit
              * @description Maximum time in seconds the tool is allowed to run. Job will be terminated if exceeded.
              */
             timelimit?: number | null;
-            /** tmpdir_max */
+            /** Tmpdir Max */
             tmpdir_max?: number | null;
-            /** tmpdir_min */
+            /** Tmpdir Min */
             tmpdir_min?: number | null;
             /**
-             * type
+             * Type
              * @constant
              */
             type: "resource";
@@ -20826,140 +20824,6 @@ export interface components {
              */
             url: string;
         };
-        /** RootModel[List[Union[Annotated[Union[has_line_model, has_line_matching_model, has_n_lines_model, has_text_model, has_text_matching_model, not_has_text_model, has_n_columns_model, attribute_is_model, attribute_matches_model, element_text_model, element_text_is_model, element_text_matches_model, has_element_with_path_model, has_n_elements_with_path_model, is_valid_xml_model, xml_element_model, has_json_property_with_text_model, has_json_property_with_value_model, has_h5_attribute_model, has_h5_keys_model, has_archive_member_model, has_size_model, has_image_center_of_mass_model, has_image_channels_model, has_image_depth_model, has_image_frames_model, has_image_height_model, has_image_mean_intensity_model, has_image_mean_object_size_model, has_image_n_labels_model, has_image_width_model], FieldInfo(annotation=NoneType, required=True, discriminator='that')], has_line_model_nested, has_line_matching_model_nested, has_n_lines_model_nested, has_text_model_nested, has_text_matching_model_nested, not_has_text_model_nested, has_n_columns_model_nested, attribute_is_model_nested, attribute_matches_model_nested, element_text_model_nested, element_text_is_model_nested, element_text_matches_model_nested, has_element_with_path_model_nested, has_n_elements_with_path_model_nested, is_valid_xml_model_nested, xml_element_model_nested, has_json_property_with_text_model_nested, has_json_property_with_value_model_nested, has_h5_attribute_model_nested, has_h5_keys_model_nested, has_archive_member_model_nested, has_size_model_nested, has_image_center_of_mass_model_nested, has_image_channels_model_nested, has_image_depth_model_nested, has_image_frames_model_nested, has_image_height_model_nested, has_image_mean_intensity_model_nested, has_image_mean_object_size_model_nested, has_image_n_labels_model_nested, has_image_width_model_nested]]] */
-        "RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input": (
-            | (
-                  | components["schemas"]["has_line_model"]
-                  | components["schemas"]["has_line_matching_model"]
-                  | components["schemas"]["has_n_lines_model"]
-                  | components["schemas"]["has_text_model"]
-                  | components["schemas"]["has_text_matching_model"]
-                  | components["schemas"]["not_has_text_model"]
-                  | components["schemas"]["has_n_columns_model"]
-                  | components["schemas"]["attribute_is_model"]
-                  | components["schemas"]["attribute_matches_model"]
-                  | components["schemas"]["element_text_model-Input"]
-                  | components["schemas"]["element_text_is_model"]
-                  | components["schemas"]["element_text_matches_model"]
-                  | components["schemas"]["has_element_with_path_model"]
-                  | components["schemas"]["has_n_elements_with_path_model"]
-                  | components["schemas"]["is_valid_xml_model"]
-                  | components["schemas"]["xml_element_model-Input"]
-                  | components["schemas"]["has_json_property_with_text_model"]
-                  | components["schemas"]["has_json_property_with_value_model"]
-                  | components["schemas"]["has_h5_attribute_model"]
-                  | components["schemas"]["has_h5_keys_model"]
-                  | components["schemas"]["has_archive_member_model-Input"]
-                  | components["schemas"]["has_size_model"]
-                  | components["schemas"]["has_image_center_of_mass_model"]
-                  | components["schemas"]["has_image_channels_model"]
-                  | components["schemas"]["has_image_depth_model"]
-                  | components["schemas"]["has_image_frames_model"]
-                  | components["schemas"]["has_image_height_model"]
-                  | components["schemas"]["has_image_mean_intensity_model"]
-                  | components["schemas"]["has_image_mean_object_size_model"]
-                  | components["schemas"]["has_image_n_labels_model"]
-                  | components["schemas"]["has_image_width_model"]
-              )
-            | components["schemas"]["has_line_model_nested"]
-            | components["schemas"]["has_line_matching_model_nested"]
-            | components["schemas"]["has_n_lines_model_nested"]
-            | components["schemas"]["has_text_model_nested"]
-            | components["schemas"]["has_text_matching_model_nested"]
-            | components["schemas"]["not_has_text_model_nested"]
-            | components["schemas"]["has_n_columns_model_nested"]
-            | components["schemas"]["attribute_is_model_nested"]
-            | components["schemas"]["attribute_matches_model_nested"]
-            | components["schemas"]["element_text_model_nested-Input"]
-            | components["schemas"]["element_text_is_model_nested"]
-            | components["schemas"]["element_text_matches_model_nested"]
-            | components["schemas"]["has_element_with_path_model_nested"]
-            | components["schemas"]["has_n_elements_with_path_model_nested"]
-            | components["schemas"]["is_valid_xml_model_nested"]
-            | components["schemas"]["xml_element_model_nested-Input"]
-            | components["schemas"]["has_json_property_with_text_model_nested"]
-            | components["schemas"]["has_json_property_with_value_model_nested"]
-            | components["schemas"]["has_h5_attribute_model_nested"]
-            | components["schemas"]["has_h5_keys_model_nested"]
-            | components["schemas"]["has_archive_member_model_nested-Input"]
-            | components["schemas"]["has_size_model_nested"]
-            | components["schemas"]["has_image_center_of_mass_model_nested"]
-            | components["schemas"]["has_image_channels_model_nested"]
-            | components["schemas"]["has_image_depth_model_nested"]
-            | components["schemas"]["has_image_frames_model_nested"]
-            | components["schemas"]["has_image_height_model_nested"]
-            | components["schemas"]["has_image_mean_intensity_model_nested"]
-            | components["schemas"]["has_image_mean_object_size_model_nested"]
-            | components["schemas"]["has_image_n_labels_model_nested"]
-            | components["schemas"]["has_image_width_model_nested"]
-        )[];
-        /** RootModel[List[Union[Annotated[Union[has_line_model, has_line_matching_model, has_n_lines_model, has_text_model, has_text_matching_model, not_has_text_model, has_n_columns_model, attribute_is_model, attribute_matches_model, element_text_model, element_text_is_model, element_text_matches_model, has_element_with_path_model, has_n_elements_with_path_model, is_valid_xml_model, xml_element_model, has_json_property_with_text_model, has_json_property_with_value_model, has_h5_attribute_model, has_h5_keys_model, has_archive_member_model, has_size_model, has_image_center_of_mass_model, has_image_channels_model, has_image_depth_model, has_image_frames_model, has_image_height_model, has_image_mean_intensity_model, has_image_mean_object_size_model, has_image_n_labels_model, has_image_width_model], FieldInfo(annotation=NoneType, required=True, discriminator='that')], has_line_model_nested, has_line_matching_model_nested, has_n_lines_model_nested, has_text_model_nested, has_text_matching_model_nested, not_has_text_model_nested, has_n_columns_model_nested, attribute_is_model_nested, attribute_matches_model_nested, element_text_model_nested, element_text_is_model_nested, element_text_matches_model_nested, has_element_with_path_model_nested, has_n_elements_with_path_model_nested, is_valid_xml_model_nested, xml_element_model_nested, has_json_property_with_text_model_nested, has_json_property_with_value_model_nested, has_h5_attribute_model_nested, has_h5_keys_model_nested, has_archive_member_model_nested, has_size_model_nested, has_image_center_of_mass_model_nested, has_image_channels_model_nested, has_image_depth_model_nested, has_image_frames_model_nested, has_image_height_model_nested, has_image_mean_intensity_model_nested, has_image_mean_object_size_model_nested, has_image_n_labels_model_nested, has_image_width_model_nested]]] */
-        "RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output": (
-            | (
-                  | components["schemas"]["has_line_model"]
-                  | components["schemas"]["has_line_matching_model"]
-                  | components["schemas"]["has_n_lines_model"]
-                  | components["schemas"]["has_text_model"]
-                  | components["schemas"]["has_text_matching_model"]
-                  | components["schemas"]["not_has_text_model"]
-                  | components["schemas"]["has_n_columns_model"]
-                  | components["schemas"]["attribute_is_model"]
-                  | components["schemas"]["attribute_matches_model"]
-                  | components["schemas"]["element_text_model-Output"]
-                  | components["schemas"]["element_text_is_model"]
-                  | components["schemas"]["element_text_matches_model"]
-                  | components["schemas"]["has_element_with_path_model"]
-                  | components["schemas"]["has_n_elements_with_path_model"]
-                  | components["schemas"]["is_valid_xml_model"]
-                  | components["schemas"]["xml_element_model-Output"]
-                  | components["schemas"]["has_json_property_with_text_model"]
-                  | components["schemas"]["has_json_property_with_value_model"]
-                  | components["schemas"]["has_h5_attribute_model"]
-                  | components["schemas"]["has_h5_keys_model"]
-                  | components["schemas"]["has_archive_member_model-Output"]
-                  | components["schemas"]["has_size_model"]
-                  | components["schemas"]["has_image_center_of_mass_model"]
-                  | components["schemas"]["has_image_channels_model"]
-                  | components["schemas"]["has_image_depth_model"]
-                  | components["schemas"]["has_image_frames_model"]
-                  | components["schemas"]["has_image_height_model"]
-                  | components["schemas"]["has_image_mean_intensity_model"]
-                  | components["schemas"]["has_image_mean_object_size_model"]
-                  | components["schemas"]["has_image_n_labels_model"]
-                  | components["schemas"]["has_image_width_model"]
-              )
-            | components["schemas"]["has_line_model_nested"]
-            | components["schemas"]["has_line_matching_model_nested"]
-            | components["schemas"]["has_n_lines_model_nested"]
-            | components["schemas"]["has_text_model_nested"]
-            | components["schemas"]["has_text_matching_model_nested"]
-            | components["schemas"]["not_has_text_model_nested"]
-            | components["schemas"]["has_n_columns_model_nested"]
-            | components["schemas"]["attribute_is_model_nested"]
-            | components["schemas"]["attribute_matches_model_nested"]
-            | components["schemas"]["element_text_model_nested-Output"]
-            | components["schemas"]["element_text_is_model_nested"]
-            | components["schemas"]["element_text_matches_model_nested"]
-            | components["schemas"]["has_element_with_path_model_nested"]
-            | components["schemas"]["has_n_elements_with_path_model_nested"]
-            | components["schemas"]["is_valid_xml_model_nested"]
-            | components["schemas"]["xml_element_model_nested-Output"]
-            | components["schemas"]["has_json_property_with_text_model_nested"]
-            | components["schemas"]["has_json_property_with_value_model_nested"]
-            | components["schemas"]["has_h5_attribute_model_nested"]
-            | components["schemas"]["has_h5_keys_model_nested"]
-            | components["schemas"]["has_archive_member_model_nested-Output"]
-            | components["schemas"]["has_size_model_nested"]
-            | components["schemas"]["has_image_center_of_mass_model_nested"]
-            | components["schemas"]["has_image_channels_model_nested"]
-            | components["schemas"]["has_image_depth_model_nested"]
-            | components["schemas"]["has_image_frames_model_nested"]
-            | components["schemas"]["has_image_height_model_nested"]
-            | components["schemas"]["has_image_mean_intensity_model_nested"]
-            | components["schemas"]["has_image_mean_object_size_model_nested"]
-            | components["schemas"]["has_image_n_labels_model_nested"]
-            | components["schemas"]["has_image_width_model_nested"]
-        )[];
         /** RootModel[dict[str, int]] */
         RootModel_dict_str__int__: {
             [key: string]: number;
@@ -20967,49 +20831,49 @@ export interface components {
         /** RulesParameterModel */
         RulesParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_rules
              * @constant
              */
             parameter_type: "gx_rules";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "rules";
@@ -21236,48 +21100,48 @@ export interface components {
         /** SectionParameterModel */
         SectionParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_section
              * @constant
              */
             parameter_type: "gx_section";
-            /** parameters */
+            /** Parameters */
             parameters: (
                 | components["schemas"]["CwlIntegerParameterModel"]
                 | components["schemas"]["CwlFloatParameterModel"]
@@ -21308,7 +21172,7 @@ export interface components {
                 | components["schemas"]["SectionParameterModel"]
             )[];
             /**
-             * type
+             * Type
              * @constant
              */
             type: "section";
@@ -21330,61 +21194,61 @@ export interface components {
         /** SelectParameterModel */
         SelectParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * multiple
+             * Multiple
              * @default false
              */
             multiple: boolean;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
-            /** options */
+            /** Options */
             options?: components["schemas"]["LabelValue"][] | null;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_select
              * @constant
              */
             parameter_type: "gx_select";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "select";
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: components["schemas"]["NoOptionsParameterValidatorModel"][];
@@ -22804,13 +22668,18 @@ export interface components {
         };
         /** TestCollectionCollectionElementAssertions */
         "TestCollectionCollectionElementAssertions-Input": {
-            /** element_tests */
+            /**
+             * Class
+             * @default Collection
+             */
+            class: "Collection" | null;
+            /** Element Tests */
             element_tests?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Input"]
                     | components["schemas"]["TestCollectionCollectionElementAssertions-Input"];
             } | null;
-            /** elements */
+            /** Elements */
             elements?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Input"]
@@ -22819,13 +22688,18 @@ export interface components {
         };
         /** TestCollectionCollectionElementAssertions */
         "TestCollectionCollectionElementAssertions-Output": {
-            /** element_tests */
+            /**
+             * Class
+             * @default Collection
+             */
+            class: "Collection" | null;
+            /** Element Tests */
             element_tests?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Output"]
                     | components["schemas"]["TestCollectionCollectionElementAssertions-Output"];
             } | null;
-            /** elements */
+            /** Elements */
             elements?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Output"]
@@ -22834,92 +22708,180 @@ export interface components {
         };
         /** TestCollectionDatasetElementAssertions */
         "TestCollectionDatasetElementAssertions-Input": {
-            /** asserts */
+            /**
+             * Asserts
+             * @description Assertions about the content of the output.
+             */
             asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
+                | components["schemas"]["assertion_list-Input"]
                 | components["schemas"]["assertion_dict-Input"]
                 | null;
-            /** checksum */
+            /**
+             * Checksum
+             * @description The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.
+             */
             checksum?: string | null;
-            /** compare */
+            /**
+             * Class
+             * @default File
+             */
+            class: "File" | null;
+            /**
+             * Compare
+             * @description Comparison mode used when matching the output against the reference file.
+             */
             compare?: components["schemas"]["OutputCompareType"] | null;
-            /** decompress */
+            /**
+             * Decompress
+             * @description If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.
+             */
             decompress?: boolean | null;
-            /** delta */
+            /**
+             * Delta
+             * @description If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.
+             */
             delta?: number | null;
-            /** delta_frac */
+            /**
+             * Delta Frac
+             * @description If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.
+             */
             delta_frac?: number | null;
-            /** file */
+            /**
+             * File
+             * @description Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.
+             */
             file?: string | null;
-            /** ftype */
+            /**
+             * File Type
+             * @description If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.
+             */
             ftype?: string | null;
-            /** lines_diff */
+            /**
+             * Lines Diff
+             * @description Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).
+             */
             lines_diff?: number | null;
-            /** location */
+            /**
+             * Location
+             * @description URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.
+             */
             location?: string | null;
-            /** metadata */
+            /**
+             * Metadata
+             * @description Mapping of metadata keys to expected values for this output.
+             */
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /** path */
+            /**
+             * Path
+             * @description Filesystem path to a local output file used for comparison.
+             */
             path?: string | null;
-            /** sort */
+            /**
+             * Sort
+             * @description Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.
+             */
             sort?: boolean | null;
         };
         /** TestCollectionDatasetElementAssertions */
         "TestCollectionDatasetElementAssertions-Output": {
-            /** asserts */
+            /**
+             * Asserts
+             * @description Assertions about the content of the output.
+             */
             asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
+                | components["schemas"]["assertion_list-Output"]
                 | components["schemas"]["assertion_dict-Output"]
                 | null;
-            /** checksum */
+            /**
+             * Checksum
+             * @description The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.
+             */
             checksum?: string | null;
-            /** compare */
+            /**
+             * Class
+             * @default File
+             */
+            class: "File" | null;
+            /**
+             * Compare
+             * @description Comparison mode used when matching the output against the reference file.
+             */
             compare?: components["schemas"]["OutputCompareType"] | null;
-            /** decompress */
+            /**
+             * Decompress
+             * @description If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.
+             */
             decompress?: boolean | null;
-            /** delta */
+            /**
+             * Delta
+             * @description If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.
+             */
             delta?: number | null;
-            /** delta_frac */
+            /**
+             * Delta Frac
+             * @description If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.
+             */
             delta_frac?: number | null;
-            /** file */
+            /**
+             * File
+             * @description Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.
+             */
             file?: string | null;
-            /** ftype */
+            /**
+             * File Type
+             * @description If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.
+             */
             ftype?: string | null;
-            /** lines_diff */
+            /**
+             * Lines Diff
+             * @description Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).
+             */
             lines_diff?: number | null;
-            /** location */
+            /**
+             * Location
+             * @description URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.
+             */
             location?: string | null;
-            /** metadata */
+            /**
+             * Metadata
+             * @description Mapping of metadata keys to expected values for this output.
+             */
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /** path */
+            /**
+             * Path
+             * @description Filesystem path to a local output file used for comparison.
+             */
             path?: string | null;
-            /** sort */
+            /**
+             * Sort
+             * @description Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.
+             */
             sort?: boolean | null;
         };
         /** TestCollectionOutputAssertions */
         "TestCollectionOutputAssertions-Input": {
-            /** attributes */
+            /** Attributes */
             attributes?: components["schemas"]["CollectionAttributes"] | null;
             /**
-             * class_
+             * Class
              * @default Collection
              */
             class: "Collection" | null;
-            /** collection_type */
+            /** Collection Type */
             collection_type?: string | null;
-            /** element_count */
+            /** Element Count */
             element_count?: number | null;
-            /** element_tests */
+            /** Element Tests */
             element_tests?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Input"]
                     | components["schemas"]["TestCollectionCollectionElementAssertions-Input"];
             } | null;
-            /** elements */
+            /** Elements */
             elements?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Input"]
@@ -22928,24 +22890,24 @@ export interface components {
         };
         /** TestCollectionOutputAssertions */
         "TestCollectionOutputAssertions-Output": {
-            /** attributes */
+            /** Attributes */
             attributes?: components["schemas"]["CollectionAttributes"] | null;
             /**
-             * class_
+             * Class
              * @default Collection
              */
             class: "Collection" | null;
-            /** collection_type */
+            /** Collection Type */
             collection_type?: string | null;
-            /** element_count */
+            /** Element Count */
             element_count?: number | null;
-            /** element_tests */
+            /** Element Tests */
             element_tests?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Output"]
                     | components["schemas"]["TestCollectionCollectionElementAssertions-Output"];
             } | null;
-            /** elements */
+            /** Elements */
             elements?: {
                 [key: string]:
                     | components["schemas"]["TestCollectionDatasetElementAssertions-Output"]
@@ -22954,80 +22916,158 @@ export interface components {
         };
         /** TestDataOutputAssertions */
         "TestDataOutputAssertions-Input": {
-            /** asserts */
+            /**
+             * Asserts
+             * @description Assertions about the content of the output.
+             */
             asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
+                | components["schemas"]["assertion_list-Input"]
                 | components["schemas"]["assertion_dict-Input"]
                 | null;
-            /** checksum */
+            /**
+             * Checksum
+             * @description The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.
+             */
             checksum?: string | null;
             /**
-             * class_
+             * Class
              * @default File
              */
             class: "File" | null;
-            /** compare */
+            /**
+             * Compare
+             * @description Comparison mode used when matching the output against the reference file.
+             */
             compare?: components["schemas"]["OutputCompareType"] | null;
-            /** decompress */
+            /**
+             * Decompress
+             * @description If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.
+             */
             decompress?: boolean | null;
-            /** delta */
+            /**
+             * Delta
+             * @description If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.
+             */
             delta?: number | null;
-            /** delta_frac */
+            /**
+             * Delta Frac
+             * @description If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.
+             */
             delta_frac?: number | null;
-            /** file */
+            /**
+             * File
+             * @description Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.
+             */
             file?: string | null;
-            /** ftype */
+            /**
+             * File Type
+             * @description If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.
+             */
             ftype?: string | null;
-            /** lines_diff */
+            /**
+             * Lines Diff
+             * @description Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).
+             */
             lines_diff?: number | null;
-            /** location */
+            /**
+             * Location
+             * @description URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.
+             */
             location?: string | null;
-            /** metadata */
+            /**
+             * Metadata
+             * @description Mapping of metadata keys to expected values for this output.
+             */
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /** path */
+            /**
+             * Path
+             * @description Filesystem path to a local output file used for comparison.
+             */
             path?: string | null;
-            /** sort */
+            /**
+             * Sort
+             * @description Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.
+             */
             sort?: boolean | null;
         };
         /** TestDataOutputAssertions */
         "TestDataOutputAssertions-Output": {
-            /** asserts */
+            /**
+             * Asserts
+             * @description Assertions about the content of the output.
+             */
             asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
+                | components["schemas"]["assertion_list-Output"]
                 | components["schemas"]["assertion_dict-Output"]
                 | null;
-            /** checksum */
+            /**
+             * Checksum
+             * @description The target output's checksum should match the value specified here, in the form `hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful for large static files where uploading the whole file is inconvenient.
+             */
             checksum?: string | null;
             /**
-             * class_
+             * Class
              * @default File
              */
             class: "File" | null;
-            /** compare */
+            /**
+             * Compare
+             * @description Comparison mode used when matching the output against the reference file.
+             */
             compare?: components["schemas"]["OutputCompareType"] | null;
-            /** decompress */
+            /**
+             * Decompress
+             * @description If true, decompress files before comparison. Applies to assertions expressed with `assert_contents` or `compare` set to anything but `sim_size`. Useful for testing compressed outputs that are non-deterministic despite having deterministic decompressed contents. By default, only files compressed with bz2, gzip and zip are automatically decompressed.
+             */
             decompress?: boolean | null;
-            /** delta */
+            /**
+             * Delta
+             * @description If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in bytes) between the generated data set and the reference file in `test-data/`. Default is 10000 bytes. Can be combined with `delta_frac`.
+             */
             delta?: number | null;
-            /** delta_frac */
+            /**
+             * Delta Frac
+             * @description If `compare` is set to `sim_size`, the maximum allowed relative size difference between the generated data set and the reference file in `test-data/`. 0.1 means the generated file can differ by at most 10%. Default is not to check for relative size difference. Can be combined with `delta`.
+             */
             delta_frac?: number | null;
-            /** file */
+            /**
+             * File
+             * @description Name of the output file stored in the target `test-data` directory that will be used to compare against the results of executing the tool via the functional test framework.
+             */
             file?: string | null;
-            /** ftype */
+            /**
+             * File Type
+             * @description If specified, this value is checked against the corresponding output's data type. If these do not match, the test will fail.
+             */
             ftype?: string | null;
-            /** lines_diff */
+            /**
+             * Lines Diff
+             * @description Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the number of lines of difference to allow (a modified line counts as two: one added, one removed).
+             */
             lines_diff?: number | null;
-            /** location */
+            /**
+             * Location
+             * @description URL that points to a remote output file that will be downloaded and used for output comparison. Use only when the file cannot be included in the `test-data` folder. May be combined with `file` (downloads when missing on disk) or used alone (filename inferred from the URL). A `checksum` is also used to verify the download when provided.
+             */
             location?: string | null;
-            /** metadata */
+            /**
+             * Metadata
+             * @description Mapping of metadata keys to expected values for this output.
+             */
             metadata?: {
                 [key: string]: unknown;
             } | null;
-            /** path */
+            /**
+             * Path
+             * @description Filesystem path to a local output file used for comparison.
+             */
             path?: string | null;
-            /** sort */
+            /**
+             * Sort
+             * @description Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines of the history data set before comparison; for `diff` and `re_match` the local file is also sorted. Useful for non-deterministic output.
+             */
             sort?: boolean | null;
         };
         /** TestUpdateInstancePayload */
@@ -23053,64 +23093,64 @@ export interface components {
         /** TextParameterModel */
         TextParameterModel: {
             /**
-             * area
+             * Area
              * @default false
              */
             area: boolean;
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null;
             /**
-             * default_options
+             * Default Options
              * @default []
              */
             default_options: components["schemas"]["LabelValue"][];
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null;
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean;
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean;
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string;
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean;
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_text
              * @constant
              */
             parameter_type: "gx_text";
             /**
-             * type
+             * Type
              * @constant
              */
             type: "text";
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: (
@@ -23119,7 +23159,7 @@ export interface components {
                 | components["schemas"]["ExpressionParameterValidatorModel"]
                 | components["schemas"]["EmptyFieldParameterValidatorModel"]
             )[];
-            /** default_value */
+            /** Value */
             value?: string | null;
         };
         /** ToolDataDetails */
@@ -23239,17 +23279,17 @@ export interface components {
         /** ToolOutputBoolean */
         ToolOutputBoolean: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown;
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown;
@@ -23261,36 +23301,36 @@ export interface components {
         };
         /** ToolOutputCollectionStructure */
         ToolOutputCollectionStructure: {
-            /** collection_type */
+            /** Collection Type */
             collection_type?: string | null;
-            /** collection_type_from_rules */
+            /** Collection Type From Rules */
             collection_type_from_rules?: string | null;
-            /** collection_type_source */
+            /** Collection Type Source */
             collection_type_source?: string | null;
-            /** discover_datasets */
+            /** Discover Datasets */
             discover_datasets?:
                 | (
                       | components["schemas"]["FilePatternDatasetCollectionDescription"]
                       | components["schemas"]["ToolProvidedMetadataDatasetCollection"]
                   )[]
                 | null;
-            /** structured_like */
+            /** Structured Like */
             structured_like?: string | null;
         };
         /** ToolOutputFloat */
         ToolOutputFloat: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown;
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown;
@@ -23303,17 +23343,17 @@ export interface components {
         /** ToolOutputInteger */
         ToolOutputInteger: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown;
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown;
@@ -23326,17 +23366,17 @@ export interface components {
         /** ToolOutputText */
         ToolOutputText: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown;
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null;
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown;
@@ -23348,22 +23388,22 @@ export interface components {
         };
         /** ToolProvidedMetadataDatasetCollection */
         ToolProvidedMetadataDatasetCollection: {
-            /** assign_primary_output */
+            /** Assign Primary Output */
             assign_primary_output: boolean;
-            /** directory */
+            /** Directory */
             directory: string | null;
             /**
-             * discover_via
+             * Discover Via
              * @constant
              */
             discover_via: "tool_provided_metadata";
-            /** format */
+            /** Format */
             format: string | null;
-            /** match_relative_path */
+            /** Match Relative Path */
             match_relative_path: boolean;
-            /** recurse */
+            /** Recurse */
             recurse: boolean;
-            /** visible */
+            /** Visible */
             visible: boolean;
         };
         /** ToolReportForDataset */
@@ -26418,40 +26458,40 @@ export interface components {
         };
         /** YamlTemplateConfigFile */
         YamlTemplateConfigFile: {
-            /** content */
+            /** Content */
             content: string;
             /**
-             * eval_engine
+             * Eval Engine
              * @default ecmascript
              * @constant
              */
             eval_engine: "ecmascript";
-            /** filename */
+            /** Filename */
             filename?: string | null;
-            /** name */
+            /** Name */
             name?: string | null;
         };
         /** YamlTestCredential */
         YamlTestCredential: {
             /**
-             * name
+             * Name
              * @description Name of the credentials group.
              */
             name: string;
             /**
-             * secrets
+             * Secrets
              * @description Secrets exposed to the tool environment.
              * @default []
              */
             secrets: components["schemas"]["YamlTestCredentialValue"][];
             /**
-             * variables
+             * Variables
              * @description Variables exposed to the tool environment.
              * @default []
              */
             variables: components["schemas"]["YamlTestCredentialValue"][];
             /**
-             * version
+             * Version
              * @description Version of the credential definition.
              */
             version?: string | null;
@@ -26459,12 +26499,12 @@ export interface components {
         /** YamlTestCredentialValue */
         YamlTestCredentialValue: {
             /**
-             * name
+             * Name
              * @description Name of the credential variable or secret.
              */
             name: string;
             /**
-             * value
+             * Value
              * @description Value of the credential variable or secret.
              */
             value: string;
@@ -26613,7 +26653,7 @@ export interface components {
              * @description Assertions to apply against the tool's standard error.
              */
             assert_stderr?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
+                | components["schemas"]["assertion_list-Input"]
                 | components["schemas"]["assertion_dict-Input"]
                 | null;
             /**
@@ -26621,7 +26661,7 @@ export interface components {
              * @description Assertions to apply against the tool's standard output.
              */
             assert_stdout?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
+                | components["schemas"]["assertion_list-Input"]
                 | components["schemas"]["assertion_dict-Input"]
                 | null;
             /**
@@ -26629,7 +26669,7 @@ export interface components {
              * @description Assertions to apply against the executed command line.
              */
             command?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
+                | components["schemas"]["assertion_list-Input"]
                 | components["schemas"]["assertion_dict-Input"]
                 | null;
             /**
@@ -26680,9 +26720,7 @@ export interface components {
                 [key: string]:
                     | components["schemas"]["TestCollectionOutputAssertions-Input"]
                     | components["schemas"]["TestDataOutputAssertions-Input"]
-                    | boolean
-                    | number
-                    | string;
+                    | (boolean | number | string);
             };
         };
         /**
@@ -26695,7 +26733,7 @@ export interface components {
              * @description Assertions to apply against the tool's standard error.
              */
             assert_stderr?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
+                | components["schemas"]["assertion_list-Output"]
                 | components["schemas"]["assertion_dict-Output"]
                 | null;
             /**
@@ -26703,7 +26741,7 @@ export interface components {
              * @description Assertions to apply against the tool's standard output.
              */
             assert_stdout?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
+                | components["schemas"]["assertion_list-Output"]
                 | components["schemas"]["assertion_dict-Output"]
                 | null;
             /**
@@ -26711,7 +26749,7 @@ export interface components {
              * @description Assertions to apply against the executed command line.
              */
             command?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
+                | components["schemas"]["assertion_list-Output"]
                 | components["schemas"]["assertion_dict-Output"]
                 | null;
             /**
@@ -26762,81 +26800,275 @@ export interface components {
                 [key: string]:
                     | components["schemas"]["TestCollectionOutputAssertions-Output"]
                     | components["schemas"]["TestDataOutputAssertions-Output"]
-                    | boolean
-                    | number
-                    | string;
+                    | (boolean | number | string);
             };
         };
         /** assertion_dict */
         "assertion_dict-Input": {
+            /** Assert Attribute Is */
             attribute_is?: components["schemas"]["base_attribute_is_model"] | null;
+            /** Assert Attribute Matches */
             attribute_matches?: components["schemas"]["base_attribute_matches_model"] | null;
+            /** Assert Element Text */
             element_text?: components["schemas"]["base_element_text_model-Input"] | null;
+            /** Assert Element Text Is */
             element_text_is?: components["schemas"]["base_element_text_is_model"] | null;
+            /** Assert Element Text Matches */
             element_text_matches?: components["schemas"]["base_element_text_matches_model"] | null;
+            /** Assert Has Archive Member */
             has_archive_member?: components["schemas"]["base_has_archive_member_model-Input"] | null;
+            /** Assert Has Element With Path */
             has_element_with_path?: components["schemas"]["base_has_element_with_path_model"] | null;
+            /** Assert Has H5 Attribute */
             has_h5_attribute?: components["schemas"]["base_has_h5_attribute_model"] | null;
+            /** Assert Has H5 Keys */
             has_h5_keys?: components["schemas"]["base_has_h5_keys_model"] | null;
+            /** Assert Has Image Center Of Mass */
             has_image_center_of_mass?: components["schemas"]["base_has_image_center_of_mass_model"] | null;
+            /** Assert Has Image Channels */
             has_image_channels?: components["schemas"]["base_has_image_channels_model"] | null;
+            /** Assert Has Image Depth */
             has_image_depth?: components["schemas"]["base_has_image_depth_model"] | null;
+            /** Assert Has Image Frames */
             has_image_frames?: components["schemas"]["base_has_image_frames_model"] | null;
+            /** Assert Has Image Height */
             has_image_height?: components["schemas"]["base_has_image_height_model"] | null;
+            /** Assert Has Image Mean Intensity */
             has_image_mean_intensity?: components["schemas"]["base_has_image_mean_intensity_model"] | null;
+            /** Assert Has Image Mean Object Size */
             has_image_mean_object_size?: components["schemas"]["base_has_image_mean_object_size_model"] | null;
+            /** Assert Has Image N Labels */
             has_image_n_labels?: components["schemas"]["base_has_image_n_labels_model"] | null;
+            /** Assert Has Image Width */
             has_image_width?: components["schemas"]["base_has_image_width_model"] | null;
+            /** Assert Has Json Property With Text */
             has_json_property_with_text?: components["schemas"]["base_has_json_property_with_text_model"] | null;
+            /** Assert Has Json Property With Value */
             has_json_property_with_value?: components["schemas"]["base_has_json_property_with_value_model"] | null;
+            /** Assert Has Line */
             has_line?: components["schemas"]["base_has_line_model"] | null;
+            /** Assert Has Line Matching */
             has_line_matching?: components["schemas"]["base_has_line_matching_model"] | null;
+            /** Assert Has N Columns */
             has_n_columns?: components["schemas"]["base_has_n_columns_model"] | null;
+            /** Assert Has N Elements With Path */
             has_n_elements_with_path?: components["schemas"]["base_has_n_elements_with_path_model"] | null;
+            /** Assert Has N Lines */
             has_n_lines?: components["schemas"]["base_has_n_lines_model"] | null;
+            /** Assert Has Size */
             has_size?: components["schemas"]["base_has_size_model"] | null;
+            /** Assert Has Text */
             has_text?: components["schemas"]["base_has_text_model"] | null;
+            /** Assert Has Text Matching */
             has_text_matching?: components["schemas"]["base_has_text_matching_model"] | null;
+            /** Assert Is Valid Xml */
             is_valid_xml?: components["schemas"]["base_is_valid_xml_model"] | null;
+            /** Assert Not Has Text */
             not_has_text?: components["schemas"]["base_not_has_text_model"] | null;
+            /** Assert Xml Element */
             xml_element?: components["schemas"]["base_xml_element_model-Input"] | null;
         };
         /** assertion_dict */
         "assertion_dict-Output": {
+            /** Assert Attribute Is */
             attribute_is?: components["schemas"]["base_attribute_is_model"] | null;
+            /** Assert Attribute Matches */
             attribute_matches?: components["schemas"]["base_attribute_matches_model"] | null;
+            /** Assert Element Text */
             element_text?: components["schemas"]["base_element_text_model-Output"] | null;
+            /** Assert Element Text Is */
             element_text_is?: components["schemas"]["base_element_text_is_model"] | null;
+            /** Assert Element Text Matches */
             element_text_matches?: components["schemas"]["base_element_text_matches_model"] | null;
+            /** Assert Has Archive Member */
             has_archive_member?: components["schemas"]["base_has_archive_member_model-Output"] | null;
+            /** Assert Has Element With Path */
             has_element_with_path?: components["schemas"]["base_has_element_with_path_model"] | null;
+            /** Assert Has H5 Attribute */
             has_h5_attribute?: components["schemas"]["base_has_h5_attribute_model"] | null;
+            /** Assert Has H5 Keys */
             has_h5_keys?: components["schemas"]["base_has_h5_keys_model"] | null;
+            /** Assert Has Image Center Of Mass */
             has_image_center_of_mass?: components["schemas"]["base_has_image_center_of_mass_model"] | null;
+            /** Assert Has Image Channels */
             has_image_channels?: components["schemas"]["base_has_image_channels_model"] | null;
+            /** Assert Has Image Depth */
             has_image_depth?: components["schemas"]["base_has_image_depth_model"] | null;
+            /** Assert Has Image Frames */
             has_image_frames?: components["schemas"]["base_has_image_frames_model"] | null;
+            /** Assert Has Image Height */
             has_image_height?: components["schemas"]["base_has_image_height_model"] | null;
+            /** Assert Has Image Mean Intensity */
             has_image_mean_intensity?: components["schemas"]["base_has_image_mean_intensity_model"] | null;
+            /** Assert Has Image Mean Object Size */
             has_image_mean_object_size?: components["schemas"]["base_has_image_mean_object_size_model"] | null;
+            /** Assert Has Image N Labels */
             has_image_n_labels?: components["schemas"]["base_has_image_n_labels_model"] | null;
+            /** Assert Has Image Width */
             has_image_width?: components["schemas"]["base_has_image_width_model"] | null;
+            /** Assert Has Json Property With Text */
             has_json_property_with_text?: components["schemas"]["base_has_json_property_with_text_model"] | null;
+            /** Assert Has Json Property With Value */
             has_json_property_with_value?: components["schemas"]["base_has_json_property_with_value_model"] | null;
+            /** Assert Has Line */
             has_line?: components["schemas"]["base_has_line_model"] | null;
+            /** Assert Has Line Matching */
             has_line_matching?: components["schemas"]["base_has_line_matching_model"] | null;
+            /** Assert Has N Columns */
             has_n_columns?: components["schemas"]["base_has_n_columns_model"] | null;
+            /** Assert Has N Elements With Path */
             has_n_elements_with_path?: components["schemas"]["base_has_n_elements_with_path_model"] | null;
+            /** Assert Has N Lines */
             has_n_lines?: components["schemas"]["base_has_n_lines_model"] | null;
+            /** Assert Has Size */
             has_size?: components["schemas"]["base_has_size_model"] | null;
+            /** Assert Has Text */
             has_text?: components["schemas"]["base_has_text_model"] | null;
+            /** Assert Has Text Matching */
             has_text_matching?: components["schemas"]["base_has_text_matching_model"] | null;
+            /** Assert Is Valid Xml */
             is_valid_xml?: components["schemas"]["base_is_valid_xml_model"] | null;
+            /** Assert Not Has Text */
             not_has_text?: components["schemas"]["base_not_has_text_model"] | null;
+            /** Assert Xml Element */
             xml_element?: components["schemas"]["base_xml_element_model-Output"] | null;
         };
+        /** assertion_list */
+        "assertion_list-Input": (
+            | (
+                  | components["schemas"]["has_line_model"]
+                  | components["schemas"]["has_line_matching_model"]
+                  | components["schemas"]["has_n_lines_model"]
+                  | components["schemas"]["has_text_model"]
+                  | components["schemas"]["has_text_matching_model"]
+                  | components["schemas"]["not_has_text_model"]
+                  | components["schemas"]["has_n_columns_model"]
+                  | components["schemas"]["attribute_is_model"]
+                  | components["schemas"]["attribute_matches_model"]
+                  | components["schemas"]["element_text_model-Input"]
+                  | components["schemas"]["element_text_is_model"]
+                  | components["schemas"]["element_text_matches_model"]
+                  | components["schemas"]["has_element_with_path_model"]
+                  | components["schemas"]["has_n_elements_with_path_model"]
+                  | components["schemas"]["is_valid_xml_model"]
+                  | components["schemas"]["xml_element_model-Input"]
+                  | components["schemas"]["has_json_property_with_text_model"]
+                  | components["schemas"]["has_json_property_with_value_model"]
+                  | components["schemas"]["has_h5_attribute_model"]
+                  | components["schemas"]["has_h5_keys_model"]
+                  | components["schemas"]["has_archive_member_model-Input"]
+                  | components["schemas"]["has_size_model"]
+                  | components["schemas"]["has_image_center_of_mass_model"]
+                  | components["schemas"]["has_image_channels_model"]
+                  | components["schemas"]["has_image_depth_model"]
+                  | components["schemas"]["has_image_frames_model"]
+                  | components["schemas"]["has_image_height_model"]
+                  | components["schemas"]["has_image_mean_intensity_model"]
+                  | components["schemas"]["has_image_mean_object_size_model"]
+                  | components["schemas"]["has_image_n_labels_model"]
+                  | components["schemas"]["has_image_width_model"]
+              )
+            | components["schemas"]["has_line_model_nested"]
+            | components["schemas"]["has_line_matching_model_nested"]
+            | components["schemas"]["has_n_lines_model_nested"]
+            | components["schemas"]["has_text_model_nested"]
+            | components["schemas"]["has_text_matching_model_nested"]
+            | components["schemas"]["not_has_text_model_nested"]
+            | components["schemas"]["has_n_columns_model_nested"]
+            | components["schemas"]["attribute_is_model_nested"]
+            | components["schemas"]["attribute_matches_model_nested"]
+            | components["schemas"]["element_text_model_nested-Input"]
+            | components["schemas"]["element_text_is_model_nested"]
+            | components["schemas"]["element_text_matches_model_nested"]
+            | components["schemas"]["has_element_with_path_model_nested"]
+            | components["schemas"]["has_n_elements_with_path_model_nested"]
+            | components["schemas"]["is_valid_xml_model_nested"]
+            | components["schemas"]["xml_element_model_nested-Input"]
+            | components["schemas"]["has_json_property_with_text_model_nested"]
+            | components["schemas"]["has_json_property_with_value_model_nested"]
+            | components["schemas"]["has_h5_attribute_model_nested"]
+            | components["schemas"]["has_h5_keys_model_nested"]
+            | components["schemas"]["has_archive_member_model_nested-Input"]
+            | components["schemas"]["has_size_model_nested"]
+            | components["schemas"]["has_image_center_of_mass_model_nested"]
+            | components["schemas"]["has_image_channels_model_nested"]
+            | components["schemas"]["has_image_depth_model_nested"]
+            | components["schemas"]["has_image_frames_model_nested"]
+            | components["schemas"]["has_image_height_model_nested"]
+            | components["schemas"]["has_image_mean_intensity_model_nested"]
+            | components["schemas"]["has_image_mean_object_size_model_nested"]
+            | components["schemas"]["has_image_n_labels_model_nested"]
+            | components["schemas"]["has_image_width_model_nested"]
+        )[];
+        /** assertion_list */
+        "assertion_list-Output": (
+            | (
+                  | components["schemas"]["has_line_model"]
+                  | components["schemas"]["has_line_matching_model"]
+                  | components["schemas"]["has_n_lines_model"]
+                  | components["schemas"]["has_text_model"]
+                  | components["schemas"]["has_text_matching_model"]
+                  | components["schemas"]["not_has_text_model"]
+                  | components["schemas"]["has_n_columns_model"]
+                  | components["schemas"]["attribute_is_model"]
+                  | components["schemas"]["attribute_matches_model"]
+                  | components["schemas"]["element_text_model-Output"]
+                  | components["schemas"]["element_text_is_model"]
+                  | components["schemas"]["element_text_matches_model"]
+                  | components["schemas"]["has_element_with_path_model"]
+                  | components["schemas"]["has_n_elements_with_path_model"]
+                  | components["schemas"]["is_valid_xml_model"]
+                  | components["schemas"]["xml_element_model-Output"]
+                  | components["schemas"]["has_json_property_with_text_model"]
+                  | components["schemas"]["has_json_property_with_value_model"]
+                  | components["schemas"]["has_h5_attribute_model"]
+                  | components["schemas"]["has_h5_keys_model"]
+                  | components["schemas"]["has_archive_member_model-Output"]
+                  | components["schemas"]["has_size_model"]
+                  | components["schemas"]["has_image_center_of_mass_model"]
+                  | components["schemas"]["has_image_channels_model"]
+                  | components["schemas"]["has_image_depth_model"]
+                  | components["schemas"]["has_image_frames_model"]
+                  | components["schemas"]["has_image_height_model"]
+                  | components["schemas"]["has_image_mean_intensity_model"]
+                  | components["schemas"]["has_image_mean_object_size_model"]
+                  | components["schemas"]["has_image_n_labels_model"]
+                  | components["schemas"]["has_image_width_model"]
+              )
+            | components["schemas"]["has_line_model_nested"]
+            | components["schemas"]["has_line_matching_model_nested"]
+            | components["schemas"]["has_n_lines_model_nested"]
+            | components["schemas"]["has_text_model_nested"]
+            | components["schemas"]["has_text_matching_model_nested"]
+            | components["schemas"]["not_has_text_model_nested"]
+            | components["schemas"]["has_n_columns_model_nested"]
+            | components["schemas"]["attribute_is_model_nested"]
+            | components["schemas"]["attribute_matches_model_nested"]
+            | components["schemas"]["element_text_model_nested-Output"]
+            | components["schemas"]["element_text_is_model_nested"]
+            | components["schemas"]["element_text_matches_model_nested"]
+            | components["schemas"]["has_element_with_path_model_nested"]
+            | components["schemas"]["has_n_elements_with_path_model_nested"]
+            | components["schemas"]["is_valid_xml_model_nested"]
+            | components["schemas"]["xml_element_model_nested-Output"]
+            | components["schemas"]["has_json_property_with_text_model_nested"]
+            | components["schemas"]["has_json_property_with_value_model_nested"]
+            | components["schemas"]["has_h5_attribute_model_nested"]
+            | components["schemas"]["has_h5_keys_model_nested"]
+            | components["schemas"]["has_archive_member_model_nested-Output"]
+            | components["schemas"]["has_size_model_nested"]
+            | components["schemas"]["has_image_center_of_mass_model_nested"]
+            | components["schemas"]["has_image_channels_model_nested"]
+            | components["schemas"]["has_image_depth_model_nested"]
+            | components["schemas"]["has_image_frames_model_nested"]
+            | components["schemas"]["has_image_height_model_nested"]
+            | components["schemas"]["has_image_mean_intensity_model_nested"]
+            | components["schemas"]["has_image_mean_object_size_model_nested"]
+            | components["schemas"]["has_image_n_labels_model_nested"]
+            | components["schemas"]["has_image_width_model_nested"]
+        )[];
         /**
-         * attribute_is_model
+         * Assert Attribute Is
          * @description Asserts the XML ``attribute`` for the element (or tag) with the specified
          *     XPath-like ``path`` is the specified ``text``.
          *
@@ -26879,14 +27111,15 @@ export interface components {
             that: "attribute_is";
         };
         /**
-         * attribute_is_model_nested
+         * Assert Attribute Is (Nested)
          * @description Nested version of this assertion model.
          */
         attribute_is_model_nested: {
+            /** Assert Attribute Is */
             attribute_is: components["schemas"]["base_attribute_is_model"];
         };
         /**
-         * attribute_matches_model
+         * Assert Attribute Matches
          * @description Asserts the XML ``attribute`` for the element (or tag) with the specified
          *     XPath-like ``path`` matches the regular expression specified by ``expression``.
          *
@@ -26929,10 +27162,11 @@ export interface components {
             that: "attribute_matches";
         };
         /**
-         * attribute_matches_model_nested
+         * Assert Attribute Matches (Nested)
          * @description Nested version of this assertion model.
          */
         attribute_matches_model_nested: {
+            /** Assert Attribute Matches */
             attribute_matches: components["schemas"]["base_attribute_matches_model"];
         };
         /**
@@ -27038,12 +27272,10 @@ export interface components {
          * @description base model for element_text describing attributes.
          */
         "base_element_text_model-Input": {
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Input"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Negate
              * @description A boolean that can be set to true to negate the outcome of the assertion.
@@ -27061,12 +27293,10 @@ export interface components {
          * @description base model for element_text describing attributes.
          */
         "base_element_text_model-Output": {
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Output"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Negate
              * @description A boolean that can be set to true to negate the outcome of the assertion.
@@ -27090,12 +27320,10 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Input"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -27140,12 +27368,10 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Output"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -27937,17 +28163,15 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Attribute
              * @description The XML attribute name to test against from the target XML element.
              */
             attribute?: string | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -27992,17 +28216,15 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Attribute
              * @description The XML attribute name to test against from the target XML element.
              */
             attribute?: string | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -28037,7 +28259,7 @@ export interface components {
             path: string;
         };
         /**
-         * element_text_is_model
+         * Assert Element Text Is
          * @description Asserts the text of the XML element with the specified XPath-like ``path`` is
          *     the specified ``text``.
          *
@@ -28075,14 +28297,15 @@ export interface components {
             that: "element_text_is";
         };
         /**
-         * element_text_is_model_nested
+         * Assert Element Text Is (Nested)
          * @description Nested version of this assertion model.
          */
         element_text_is_model_nested: {
+            /** Assert Element Text Is */
             element_text_is: components["schemas"]["base_element_text_is_model"];
         };
         /**
-         * element_text_matches_model
+         * Assert Element Text Matches
          * @description Asserts the text of the XML element with the specified XPath-like ``path``
          *     matches the regular expression defined by ``expression``.
          *
@@ -28120,14 +28343,15 @@ export interface components {
             that: "element_text_matches";
         };
         /**
-         * element_text_matches_model_nested
+         * Assert Element Text Matches (Nested)
          * @description Nested version of this assertion model.
          */
         element_text_matches_model_nested: {
+            /** Assert Element Text Matches */
             element_text_matches: components["schemas"]["base_element_text_matches_model"];
         };
         /**
-         * element_text_model
+         * Assert Element Text
          * @description This tag allows the developer to recurisively specify additional assertions as
          *     child elements about just the text contained in the element specified by the
          *     XPath-like ``path``, e.g.
@@ -28144,12 +28368,10 @@ export interface components {
          *     by ``negate``.
          */
         "element_text_model-Input": {
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Input"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Negate
              * @description A boolean that can be set to true to negate the outcome of the assertion.
@@ -28168,7 +28390,7 @@ export interface components {
             that: "element_text";
         };
         /**
-         * element_text_model
+         * Assert Element Text
          * @description This tag allows the developer to recurisively specify additional assertions as
          *     child elements about just the text contained in the element specified by the
          *     XPath-like ``path``, e.g.
@@ -28185,12 +28407,10 @@ export interface components {
          *     by ``negate``.
          */
         "element_text_model-Output": {
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Output"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Negate
              * @description A boolean that can be set to true to negate the outcome of the assertion.
@@ -28209,21 +28429,23 @@ export interface components {
             that: "element_text";
         };
         /**
-         * element_text_model_nested
+         * Assert Element Text (Nested)
          * @description Nested version of this assertion model.
          */
         "element_text_model_nested-Input": {
+            /** Assert Element Text */
             element_text: components["schemas"]["base_element_text_model-Input"];
         };
         /**
-         * element_text_model_nested
+         * Assert Element Text (Nested)
          * @description Nested version of this assertion model.
          */
         "element_text_model_nested-Output": {
+            /** Assert Element Text */
             element_text: components["schemas"]["base_element_text_model-Output"];
         };
         /**
-         * has_archive_member_model
+         * Assert Has Archive Member
          * @description This tag allows to check if ``path`` is contained in a compressed file.
          *
          *     The path is a regular expression that is matched against the full paths of the objects in
@@ -28276,12 +28498,10 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Input"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -28321,7 +28541,7 @@ export interface components {
             that: "has_archive_member";
         };
         /**
-         * has_archive_member_model
+         * Assert Has Archive Member
          * @description This tag allows to check if ``path`` is contained in a compressed file.
          *
          *     The path is a regular expression that is matched against the full paths of the objects in
@@ -28374,12 +28594,10 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Output"] | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -28419,21 +28637,23 @@ export interface components {
             that: "has_archive_member";
         };
         /**
-         * has_archive_member_model_nested
+         * Assert Has Archive Member (Nested)
          * @description Nested version of this assertion model.
          */
         "has_archive_member_model_nested-Input": {
+            /** Assert Has Archive Member */
             has_archive_member: components["schemas"]["base_has_archive_member_model-Input"];
         };
         /**
-         * has_archive_member_model_nested
+         * Assert Has Archive Member (Nested)
          * @description Nested version of this assertion model.
          */
         "has_archive_member_model_nested-Output": {
+            /** Assert Has Archive Member */
             has_archive_member: components["schemas"]["base_has_archive_member_model-Output"];
         };
         /**
-         * has_element_with_path_model
+         * Assert Has Element With Path
          * @description Asserts the XML output contains at least one element (or tag) with the specified
          *     XPath-like ``path``, e.g.
          *
@@ -28462,14 +28682,15 @@ export interface components {
             that: "has_element_with_path";
         };
         /**
-         * has_element_with_path_model_nested
+         * Assert Has Element With Path (Nested)
          * @description Nested version of this assertion model.
          */
         has_element_with_path_model_nested: {
+            /** Assert Has Element With Path */
             has_element_with_path: components["schemas"]["base_has_element_with_path_model"];
         };
         /**
-         * has_h5_attribute_model
+         * Assert Has H5 Attribute
          * @description Asserts HDF5 output contains the specified ``value`` for an attribute (``key``), e.g.
          *
          *     ```xml
@@ -28494,14 +28715,15 @@ export interface components {
             value: string;
         };
         /**
-         * has_h5_attribute_model_nested
+         * Assert Has H5 Attribute (Nested)
          * @description Nested version of this assertion model.
          */
         has_h5_attribute_model_nested: {
+            /** Assert Has H5 Attribute */
             has_h5_attribute: components["schemas"]["base_has_h5_attribute_model"];
         };
         /**
-         * has_h5_keys_model
+         * Assert Has H5 Keys
          * @description Asserts the specified HDF5 output has the given keys.
          */
         has_h5_keys_model: {
@@ -28517,14 +28739,15 @@ export interface components {
             that: "has_h5_keys";
         };
         /**
-         * has_h5_keys_model_nested
+         * Assert Has H5 Keys (Nested)
          * @description Nested version of this assertion model.
          */
         has_h5_keys_model_nested: {
+            /** Assert Has H5 Keys */
             has_h5_keys: components["schemas"]["base_has_h5_keys_model"];
         };
         /**
-         * has_image_center_of_mass_model
+         * Assert Has Image Center Of Mass
          * @description Asserts the specified output is an image and has the specified center of mass.
          *
          *     Asserts the output is an image and has a specific center of mass,
@@ -28565,14 +28788,15 @@ export interface components {
             that: "has_image_center_of_mass";
         };
         /**
-         * has_image_center_of_mass_model_nested
+         * Assert Has Image Center Of Mass (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_center_of_mass_model_nested: {
+            /** Assert Has Image Center Of Mass */
             has_image_center_of_mass: components["schemas"]["base_has_image_center_of_mass_model"];
         };
         /**
-         * has_image_channels_model
+         * Assert Has Image Channels
          * @description Asserts the output is an image and has a specific number of channels.
          *
          *     The number of channels is plus/minus ``delta`` (e.g., ``<has_image_channels channels="3" />``).
@@ -28614,14 +28838,15 @@ export interface components {
             that: "has_image_channels";
         };
         /**
-         * has_image_channels_model_nested
+         * Assert Has Image Channels (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_channels_model_nested: {
+            /** Assert Has Image Channels */
             has_image_channels: components["schemas"]["base_has_image_channels_model"];
         };
         /**
-         * has_image_depth_model
+         * Assert Has Image Depth
          * @description Asserts the output is an image and has a specific depth (number of slices).
          *
          *     The depth is plus/minus ``delta`` (e.g., ``<has_image_depth depth="512" delta="2" />``).
@@ -28662,14 +28887,15 @@ export interface components {
             that: "has_image_depth";
         };
         /**
-         * has_image_depth_model_nested
+         * Assert Has Image Depth (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_depth_model_nested: {
+            /** Assert Has Image Depth */
             has_image_depth: components["schemas"]["base_has_image_depth_model"];
         };
         /**
-         * has_image_frames_model
+         * Assert Has Image Frames
          * @description Asserts the output is an image and has a specific number of frames (number of time steps).
          *
          *     The number of frames is plus/minus ``delta`` (e.g., ``<has_image_frames depth="512" delta="2" />``).
@@ -28710,14 +28936,15 @@ export interface components {
             that: "has_image_frames";
         };
         /**
-         * has_image_frames_model_nested
+         * Assert Has Image Frames (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_frames_model_nested: {
+            /** Assert Has Image Frames */
             has_image_frames: components["schemas"]["base_has_image_frames_model"];
         };
         /**
-         * has_image_height_model
+         * Assert Has Image Height
          * @description Asserts the output is an image and has a specific height (in pixels).
          *
          *     The height is plus/minus ``delta`` (e.g., ``<has_image_height height="512" delta="2" />``).
@@ -28758,14 +28985,15 @@ export interface components {
             that: "has_image_height";
         };
         /**
-         * has_image_height_model_nested
+         * Assert Has Image Height (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_height_model_nested: {
+            /** Assert Has Image Height */
             has_image_height: components["schemas"]["base_has_image_height_model"];
         };
         /**
-         * has_image_mean_intensity_model
+         * Assert Has Image Mean Intensity
          * @description Asserts the output is an image and has a specific mean intensity value.
          *
          *     The mean intensity value is plus/minus ``eps`` (e.g., ``<has_image_mean_intensity mean_intensity="0.83" />``).
@@ -28815,14 +29043,15 @@ export interface components {
             that: "has_image_mean_intensity";
         };
         /**
-         * has_image_mean_intensity_model_nested
+         * Assert Has Image Mean Intensity (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_mean_intensity_model_nested: {
+            /** Assert Has Image Mean Intensity */
             has_image_mean_intensity: components["schemas"]["base_has_image_mean_intensity_model"];
         };
         /**
-         * has_image_mean_object_size_model
+         * Assert Has Image Mean Object Size
          * @description Asserts the output is an image with labeled objects which have the specified mean size (number of pixels),
          *
          *     The mean size is plus/minus ``eps`` (e.g., ``<has_image_mean_object_size mean_object_size="111.87" exclude_labels="0" />``).
@@ -28883,14 +29112,15 @@ export interface components {
             that: "has_image_mean_object_size";
         };
         /**
-         * has_image_mean_object_size_model_nested
+         * Assert Has Image Mean Object Size (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_mean_object_size_model_nested: {
+            /** Assert Has Image Mean Object Size */
             has_image_mean_object_size: components["schemas"]["base_has_image_mean_object_size_model"];
         };
         /**
-         * has_image_n_labels_model
+         * Assert Has Image N Labels
          * @description Asserts the output is an image and has the specified labels.
          *
          *     Labels can be a number of labels or unique values (e.g.,
@@ -28958,14 +29188,15 @@ export interface components {
             that: "has_image_n_labels";
         };
         /**
-         * has_image_n_labels_model_nested
+         * Assert Has Image N Labels (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_n_labels_model_nested: {
+            /** Assert Has Image N Labels */
             has_image_n_labels: components["schemas"]["base_has_image_n_labels_model"];
         };
         /**
-         * has_image_width_model
+         * Assert Has Image Width
          * @description Asserts the output is an image and has a specific width (in pixels).
          *
          *     The width is plus/minus ``delta`` (e.g., ``<has_image_width width="512" delta="2" />``).
@@ -29006,14 +29237,15 @@ export interface components {
             width?: number | null;
         };
         /**
-         * has_image_width_model_nested
+         * Assert Has Image Width (Nested)
          * @description Nested version of this assertion model.
          */
         has_image_width_model_nested: {
+            /** Assert Has Image Width */
             has_image_width: components["schemas"]["base_has_image_width_model"];
         };
         /**
-         * has_json_property_with_text_model
+         * Assert Has Json Property With Text
          * @description Asserts the JSON document contains a property or key with the specified text (i.e. string) value.
          *
          *     ```xml
@@ -29038,14 +29270,15 @@ export interface components {
             that: "has_json_property_with_text";
         };
         /**
-         * has_json_property_with_text_model_nested
+         * Assert Has Json Property With Text (Nested)
          * @description Nested version of this assertion model.
          */
         has_json_property_with_text_model_nested: {
+            /** Assert Has Json Property With Text */
             has_json_property_with_text: components["schemas"]["base_has_json_property_with_text_model"];
         };
         /**
-         * has_json_property_with_value_model
+         * Assert Has Json Property With Value
          * @description Asserts the JSON document contains a property or key with the specified JSON value.
          *
          *     ```xml
@@ -29070,14 +29303,15 @@ export interface components {
             value: string;
         };
         /**
-         * has_json_property_with_value_model_nested
+         * Assert Has Json Property With Value (Nested)
          * @description Nested version of this assertion model.
          */
         has_json_property_with_value_model_nested: {
+            /** Assert Has Json Property With Value */
             has_json_property_with_value: components["schemas"]["base_has_json_property_with_value_model"];
         };
         /**
-         * has_line_matching_model
+         * Assert Has Line Matching
          * @description Asserts the specified output contains a line matching the
          *     regular expression specified by the argument expression. If n is given
          *     the assertion checks for exactly n occurrences.
@@ -29122,14 +29356,15 @@ export interface components {
             that: "has_line_matching";
         };
         /**
-         * has_line_matching_model_nested
+         * Assert Has Line Matching (Nested)
          * @description Nested version of this assertion model.
          */
         has_line_matching_model_nested: {
+            /** Assert Has Line Matching */
             has_line_matching: components["schemas"]["base_has_line_matching_model"];
         };
         /**
-         * has_line_model
+         * Assert Has Line
          * @description Asserts the specified output contains the line specified by the
          *     argument line. The exact number of occurrences can be optionally
          *     specified by the argument n
@@ -29174,14 +29409,15 @@ export interface components {
             that: "has_line";
         };
         /**
-         * has_line_model_nested
+         * Assert Has Line (Nested)
          * @description Nested version of this assertion model.
          */
         has_line_model_nested: {
+            /** Assert Has Line */
             has_line: components["schemas"]["base_has_line_model"];
         };
         /**
-         * has_n_columns_model
+         * Assert Has N Columns
          * @description Asserts tabular output  contains the specified
          *     number (``n``) of columns.
          *
@@ -29240,14 +29476,15 @@ export interface components {
             that: "has_n_columns";
         };
         /**
-         * has_n_columns_model_nested
+         * Assert Has N Columns (Nested)
          * @description Nested version of this assertion model.
          */
         has_n_columns_model_nested: {
+            /** Assert Has N Columns */
             has_n_columns: components["schemas"]["base_has_n_columns_model"];
         };
         /**
-         * has_n_elements_with_path_model
+         * Assert Has N Elements With Path
          * @description Asserts the XML output contains the specified number (``n``, optionally with ``delta``) of elements (or
          *     tags) with the specified XPath-like ``path``.
          *
@@ -29301,14 +29538,15 @@ export interface components {
             that: "has_n_elements_with_path";
         };
         /**
-         * has_n_elements_with_path_model_nested
+         * Assert Has N Elements With Path (Nested)
          * @description Nested version of this assertion model.
          */
         has_n_elements_with_path_model_nested: {
+            /** Assert Has N Elements With Path */
             has_n_elements_with_path: components["schemas"]["base_has_n_elements_with_path_model"];
         };
         /**
-         * has_n_lines_model
+         * Assert Has N Lines
          * @description Asserts the specified output contains ``n`` lines allowing
          *     for a difference in the number of lines (delta)
          *     or relative differebce in the number of lines
@@ -29348,14 +29586,15 @@ export interface components {
             that: "has_n_lines";
         };
         /**
-         * has_n_lines_model_nested
+         * Assert Has N Lines (Nested)
          * @description Nested version of this assertion model.
          */
         has_n_lines_model_nested: {
+            /** Assert Has N Lines */
             has_n_lines: components["schemas"]["base_has_n_lines_model"];
         };
         /**
-         * has_size_model
+         * Assert Has Size
          * @description Asserts the specified output has a size of the specified value
          *
          *     Attributes size and value or synonyms though value is considered deprecated.
@@ -29401,14 +29640,15 @@ export interface components {
             value?: string | number | null;
         };
         /**
-         * has_size_model_nested
+         * Assert Has Size (Nested)
          * @description Nested version of this assertion model.
          */
         has_size_model_nested: {
+            /** Assert Has Size */
             has_size: components["schemas"]["base_has_size_model"];
         };
         /**
-         * has_text_matching_model
+         * Assert Has Text Matching
          * @description Asserts the specified output contains text matching the
          *     regular expression specified by the argument expression.
          *     If n is given the assertion checks for exactly n (nonoverlapping)
@@ -29454,14 +29694,15 @@ export interface components {
             that: "has_text_matching";
         };
         /**
-         * has_text_matching_model_nested
+         * Assert Has Text Matching (Nested)
          * @description Nested version of this assertion model.
          */
         has_text_matching_model_nested: {
+            /** Assert Has Text Matching */
             has_text_matching: components["schemas"]["base_has_text_matching_model"];
         };
         /**
-         * has_text_model
+         * Assert Has Text
          * @description Asserts specified output contains the substring specified by
          *     the argument text. The exact number of occurrences can be
          *     optionally specified by the argument n
@@ -29506,14 +29747,15 @@ export interface components {
             that: "has_text";
         };
         /**
-         * has_text_model_nested
+         * Assert Has Text (Nested)
          * @description Nested version of this assertion model.
          */
         has_text_model_nested: {
+            /** Assert Has Text */
             has_text: components["schemas"]["base_has_text_model"];
         };
         /**
-         * is_valid_xml_model
+         * Assert Is Valid Xml
          * @description Asserts the output is a valid XML file (e.g. ``<is_valid_xml />``).
          */
         is_valid_xml_model: {
@@ -29524,14 +29766,15 @@ export interface components {
             that: "is_valid_xml";
         };
         /**
-         * is_valid_xml_model_nested
+         * Assert Is Valid Xml (Nested)
          * @description Nested version of this assertion model.
          */
         is_valid_xml_model_nested: {
+            /** Assert Is Valid Xml */
             is_valid_xml: components["schemas"]["base_is_valid_xml_model"];
         };
         /**
-         * not_has_text_model
+         * Assert Not Has Text
          * @description Asserts specified output does not contain the substring
          *     specified by the argument text
          */
@@ -29548,14 +29791,15 @@ export interface components {
             that: "not_has_text";
         };
         /**
-         * not_has_text_model_nested
+         * Assert Not Has Text (Nested)
          * @description Nested version of this assertion model.
          */
         not_has_text_model_nested: {
+            /** Assert Not Has Text */
             not_has_text: components["schemas"]["base_not_has_text_model"];
         };
         /**
-         * xml_element_model
+         * Assert Xml Element
          * @description Assert if the XML file contains element(s) or tag(s) with the specified
          *     [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
          *     or ``min`` and ``max`` are given also the number of occurrences is checked.
@@ -29595,17 +29839,15 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Attribute
              * @description The XML attribute name to test against from the target XML element.
              */
             attribute?: string | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Input"]
-                | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Input"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -29645,7 +29887,7 @@ export interface components {
             that: "xml_element";
         };
         /**
-         * xml_element_model
+         * Assert Xml Element
          * @description Assert if the XML file contains element(s) or tag(s) with the specified
          *     [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
          *     or ``min`` and ``max`` are given also the number of occurrences is checked.
@@ -29685,17 +29927,15 @@ export interface components {
              * @default false
              */
             all: boolean | string;
-            asserts?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Asserts */
+            asserts?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Attribute
              * @description The XML attribute name to test against from the target XML element.
              */
             attribute?: string | null;
-            children?:
-                | components["schemas"]["RootModel_List_Union_Annotated_Union_has_line_model__has_line_matching_model__has_n_lines_model__has_text_model__has_text_matching_model__not_has_text_model__has_n_columns_model__attribute_is_model__attribute_matches_model__element_text_model__element_text_is_model__element_text_matches_model__has_element_with_path_model__has_n_elements_with_path_model__is_valid_xml_model__xml_element_model__has_json_property_with_text_model__has_json_property_with_value_model__has_h5_attribute_model__has_h5_keys_model__has_archive_member_model__has_size_model__has_image_center_of_mass_model__has_image_channels_model__has_image_depth_model__has_image_frames_model__has_image_height_model__has_image_mean_intensity_model__has_image_mean_object_size_model__has_image_n_labels_model__has_image_width_model___FieldInfo_annotation_NoneType__required_True__discriminator__that_____has_line_model_nested__has_line_matching_model_nested__has_n_lines_model_nested__has_text_model_nested__has_text_matching_model_nested__not_has_text_model_nested__has_n_columns_model_nested__attribute_is_model_nested__attribute_matches_model_nested__element_text_model_nested__element_text_is_model_nested__element_text_matches_model_nested__has_element_with_path_model_nested__has_n_elements_with_path_model_nested__is_valid_xml_model_nested__xml_element_model_nested__has_json_property_with_text_model_nested__has_json_property_with_value_model_nested__has_h5_attribute_model_nested__has_h5_keys_model_nested__has_archive_member_model_nested__has_size_model_nested__has_image_center_of_mass_model_nested__has_image_channels_model_nested__has_image_depth_model_nested__has_image_frames_model_nested__has_image_height_model_nested__has_image_mean_intensity_model_nested__has_image_mean_object_size_model_nested__has_image_n_labels_model_nested__has_image_width_model_nested___-Output"]
-                | null;
+            /** Children */
+            children?: components["schemas"]["assertion_list-Output"] | null;
             /**
              * Delta
              * @description Allowed difference with respect to n (default: 0), can be suffixed by ``(k|M|G|T|P|E)i?``
@@ -29735,17 +29975,19 @@ export interface components {
             that: "xml_element";
         };
         /**
-         * xml_element_model_nested
+         * Assert Xml Element (Nested)
          * @description Nested version of this assertion model.
          */
         "xml_element_model_nested-Input": {
+            /** Assert Xml Element */
             xml_element: components["schemas"]["base_xml_element_model-Input"];
         };
         /**
-         * xml_element_model_nested
+         * Assert Xml Element (Nested)
          * @description Nested version of this assertion model.
          */
         "xml_element_model_nested-Output": {
+            /** Assert Xml Element */
             xml_element: components["schemas"]["base_xml_element_model-Output"];
         };
     };

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -305,8 +305,7 @@ def galactic_job_json(
         file_path = value.get("location", None) or value.get("path", None)
         if file_path is None:
             return value
-        if not os.path.isabs(file_path):
-            file_path = os.path.join(test_data_directory, file_path)
+        file_path = abs_path_or_uri(file_path, test_data_directory, resolve_data=resolve_data)
 
         file_type = value.get("filetype", None) or value.get("format", None) or "directory"
 

--- a/lib/galaxy/tool_util/verify/asserts/tabular.py
+++ b/lib/galaxy/tool_util/verify/asserts/tabular.py
@@ -51,7 +51,7 @@ def assert_has_n_columns(
 
     For instance, ``<has_n_columns n="3"/>``. The assertion tests only the first line.
     Number of columns can optionally also be specified with ``delta``. Alternatively the
-    range of expected occurences can be specified by ``min`` and/or ``max``.
+    range of expected occurrences can be specified by ``min`` and/or ``max``.
 
     Optionally a column separator (``sep``, default is ``\t``) `and comment character(s)
     can be specified (``comment``, default is empty string). The first non-comment

--- a/lib/galaxy/tool_util/verify/asserts/text.py
+++ b/lib/galaxy/tool_util/verify/asserts/text.py
@@ -46,8 +46,8 @@ def assert_has_text(
         lambda o, t: o.find(t) >= 0,
         lambda o, t: len(re.findall(re.escape(t), o)),
         "{expected} text '{text}' in output ('{output}')",
-        "{expected} {n}+-{delta} occurences of '{text}' in output ('{output}')",
-        "{expected} that the number of occurences of '{text}' in output is in [{min}:{max}] ('{output}')",
+        "{expected} {n}+-{delta} occurrences of '{text}' in output ('{output}')",
+        "{expected} that the number of occurrences of '{text}' in output is in [{min}:{max}] ('{output}')",
     )
 
 
@@ -123,8 +123,8 @@ def assert_has_text_matching(
 ) -> None:
     """Asserts the specified output contains text matching the
     regular expression specified by the argument expression.
-    If n is given the assertion checks for exacly n (nonoverlapping)
-    occurences.
+    If n is given the assertion checks for exactly n (nonoverlapping)
+    occurrences.
     """
     _assert_presence_number(
         output,
@@ -153,7 +153,7 @@ def assert_has_line_matching(
 ) -> None:
     """Asserts the specified output contains a line matching the
     regular expression specified by the argument expression. If n is given
-    the assertion checks for exactly n occurences."""
+    the assertion checks for exactly n occurrences."""
     _assert_presence_number(
         output,
         expression,

--- a/lib/galaxy/tool_util/verify/asserts/xml.py
+++ b/lib/galaxy/tool_util/verify/asserts/xml.py
@@ -96,7 +96,7 @@ def assert_has_n_elements_with_path(
     ```
 
     Alternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes
-    can be used to specify the range of the expected number of occurences.
+    can be used to specify the range of the expected number of occurrences.
     With ``negate`` the result of the assertion can be inverted.
     """
     assert_xml_element(output, path, n=n, delta=delta, min=min, max=max, negate=negate)
@@ -222,7 +222,7 @@ def assert_xml_element(
 ) -> None:
     """Assert if the XML file contains element(s) or tag(s) with the specified
     [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
-    or ``min`` and ``max`` are given also the number of occurences is checked.
+    or ``min`` and ``max`` are given also the number of occurrences is checked.
 
     ```xml
     <assert_contents>
@@ -232,7 +232,7 @@ def assert_xml_element(
     </assert_contents>
     ```
 
-    With ``negate="true"`` the outcome of the assertions wrt the precence and number
+    With ``negate="true"`` the outcome of the assertions wrt the presence and number
     of ``path`` can be negated. If there are any sub assertions then check them against
 
     - the content of the attribute ``attribute``
@@ -247,7 +247,7 @@ def assert_xml_element(
     ```
 
     Sub-assertions are not subject to the ``negate`` attribute of ``xml_element``.
-    If ``all`` is ``true`` then the sub assertions are checked for all occurences.
+    If ``all`` is ``true`` then the sub assertions are checked for all occurrences.
 
     Note that all other XML assertions can be expressed by this assertion (Galaxy
     also implements the other assertions by calling this one).
@@ -269,7 +269,7 @@ def assert_xml_element(
         lambda x, p: len(x.findall(p)),
         "{expected} path '{text}' in xml",
         "{expected} {n}+-{delta} occurrences of path '{text}' in xml",
-        "{expected} that the number of occurences of path '{text}' in xml is in [{min}:{max}]",
+        "{expected} that the number of occurrences of path '{text}' in xml is in [{min}:{max}]",
     )
 
     # check sub-assertions

--- a/lib/galaxy/tool_util/verify/codegen.py
+++ b/lib/galaxy/tool_util/verify/codegen.py
@@ -27,7 +27,7 @@ from galaxy.tool_util.verify.asserts import assertion_module_and_functions
 from galaxy.tool_util.verify.asserts._types import AssertionParameter as AssertionParameterAnnotation
 from galaxy.util.commands import shell
 
-models_path = os.path.join(os.path.dirname(__file__), "assertion_models.py")
+models_path = os.path.join(os.path.dirname(__file__), "..", "..", "tool_util_models", "assertions.py")
 galaxy_xsd_path = os.path.join(os.path.dirname(__file__), "..", "xsd", "galaxy.xsd")
 
 Children = Literal["allowed", "required", "forbidden"]
@@ -114,17 +114,19 @@ def check_non_negative_if_int(v: typing.Any):
 
 class base_{{assertion.name}}_model(AssertionModel):
     '''base model for {{assertion.name}} describing attributes.'''
+    model_config = ConfigDict(extra="forbid", title="base_{{assertion.name}}_model")
 {% for parameter in assertion.parameters %}
 {% if not parameter.is_deprecated %}
     {{ parameter.name }}: {{ parameter.type_str }} = Field(
         {{ parameter.field_default_str }},
+        title="{{ parameter.title }}",
         description={{ assertion.name }}_{{ parameter.name }}_description,
     )
 {% endif %}
 {% endfor %}
 {% if assertion.children in ["required", "allowed"] %}
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
 {% if assertion.children == "required" %}
     @model_validator(mode='before')
@@ -139,17 +141,19 @@ class base_{{assertion.name}}_model(AssertionModel):
 
 class base_{{assertion.name}}_model_relaxed(AssertionModel):
     '''base model for {{assertion.name}} describing attributes.'''
+    model_config = ConfigDict(extra="forbid", title="base_{{assertion.name}}_model_relaxed")
 {% for parameter in assertion.parameters %}
 {% if not parameter.is_deprecated %}
     {{ parameter.name }}: {{ parameter.lax_type_str }} = Field(
         {{ parameter.field_default_str }},
+        title="{{ parameter.title }}",
         description={{ assertion.name }}_{{ parameter.name }}_description,
     )
 {% endif %}
 {% endfor %}
 {% if assertion.children in ["required", "allowed"] %}
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
 {% if assertion.children == "required" %}
     @model_validator(mode='before')
@@ -164,15 +168,18 @@ class base_{{assertion.name}}_model_relaxed(AssertionModel):
 
 class {{assertion.name}}_model(base_{{assertion.name}}_model):
     r\"\"\"{{ assertion.docstring }}\"\"\"
-    that: Literal["{{assertion.name}}"] = "{{assertion.name}}"
+    model_config = ConfigDict(extra="forbid", title="{{ assertion.title }}")
+    that: Literal["{{assertion.name}}"] = Field("{{assertion.name}}", title="That")
 
 class {{assertion.name}}_model_nested(AssertionModel):
     r\"\"\"Nested version of this assertion model.\"\"\"
-    {{assertion.name}}: base_{{assertion.name}}_model
+    model_config = ConfigDict(extra="forbid", title="{{ assertion.title }} (Nested)")
+    {{assertion.name}}: base_{{assertion.name}}_model = Field(..., title="{{ assertion.title }}")
 
 class {{assertion.name}}_model_relaxed(base_{{assertion.name}}_model_relaxed):
     r\"\"\"{{ assertion.docstring }}\"\"\"
-    that: Literal["{{assertion.name}}"] = "{{assertion.name}}"
+    model_config = ConfigDict(extra="forbid", title="{{ assertion.title }} (Relaxed)")
+    that: Literal["{{assertion.name}}"] = Field("{{assertion.name}}", title="That")
 {% endfor %}
 
 any_assertion_model_flat = Annotated[typing.Union[
@@ -193,15 +200,19 @@ any_assertion_model_flat_relaxed = Annotated[typing.Union[
 {% endfor %}
 ], Field(discriminator="that")]
 
-assertion_list = RootModel[typing.List[typing.Union[any_assertion_model_flat, any_assertion_model_nested]]]
+class assertion_list(RootModel[typing.List[typing.Union[any_assertion_model_flat, any_assertion_model_nested]]]):
+    model_config = ConfigDict(title="assertion_list")
+
 
 # used to model what the XML conversion should look like - not meant to be consumed outside of
 # of Galaxy internals / linting.
-relaxed_assertion_list = RootModel[typing.List[any_assertion_model_flat_relaxed]]
+class relaxed_assertion_list(RootModel[typing.List[any_assertion_model_flat_relaxed]]):
+    model_config = ConfigDict(title="relaxed_assertion_list")
 
 class assertion_dict(AssertionModel):
+    model_config = ConfigDict(extra="forbid", title="assertion_dict")
 {% for assertion in assertions %}
-    {{assertion.name}}: typing.Optional[base_{{assertion.name}}_model] = None
+    {{assertion.name}}: typing.Optional[base_{{assertion.name}}_model] = Field(None, title="{{ assertion.title }}")
 {% endfor %}
 
 
@@ -337,6 +348,10 @@ class AssertionParameter:
         self.name = name
         self.type = type
         self.default_value = default_value
+
+    @property
+    def title(self) -> str:
+        return " ".join(w.capitalize() for w in self.name.split("_"))
 
     @property
     def description(self) -> str:
@@ -489,6 +504,10 @@ class Assertion:
         self.docstring = docstring
         self.children = children
         self.module_and_function = module_and_function
+
+    @property
+    def title(self) -> str:
+        return "Assert " + " ".join(w.capitalize() for w in self.name.split("_"))
 
 
 def arg_parser() -> argparse.ArgumentParser:

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2532,7 +2532,7 @@ $attribute_list::5]]></xs:documentation>
         <xs:annotation>
           <xs:documentation xml:lang="en"><![CDATA[Asserts the specified output contains a line matching the
 regular expression specified by the argument expression. If n is given
-the assertion checks for exactly n occurences.
+the assertion checks for exactly n occurrences.
 
 $attribute_list::5]]></xs:documentation>
         </xs:annotation>
@@ -2653,8 +2653,8 @@ $attribute_list::5]]></xs:documentation>
         <xs:annotation>
           <xs:documentation xml:lang="en"><![CDATA[Asserts the specified output contains text matching the
 regular expression specified by the argument expression.
-If n is given the assertion checks for exacly n (nonoverlapping)
-occurences.
+If n is given the assertion checks for exactly n (nonoverlapping)
+occurrences.
 
 $attribute_list::5]]></xs:documentation>
         </xs:annotation>
@@ -2715,7 +2715,7 @@ number (``n``) of columns.
 
 For instance, ``<has_n_columns n="3"/>``. The assertion tests only the first line.
 Number of columns can optionally also be specified with ``delta``. Alternatively the
-range of expected occurences can be specified by ``min`` and/or ``max``.
+range of expected occurrences can be specified by ``min`` and/or ``max``.
 
 Optionally a column separator (``sep``, default is ``       ``) `and comment character(s)
 can be specified (``comment``, default is empty string). The first non-comment
@@ -2991,7 +2991,7 @@ For example:
 ```
 
 Alternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes
-can be used to specify the range of the expected number of occurences.
+can be used to specify the range of the expected number of occurrences.
 With ``negate`` the result of the assertion can be inverted.
 
 $attribute_list::5]]></xs:documentation>
@@ -3043,7 +3043,7 @@ $attribute_list::5]]></xs:documentation>
         <xs:annotation>
           <xs:documentation xml:lang="en"><![CDATA[Assert if the XML file contains element(s) or tag(s) with the specified
 [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
-or ``min`` and ``max`` are given also the number of occurences is checked.
+or ``min`` and ``max`` are given also the number of occurrences is checked.
 
 ```xml
 <assert_contents>
@@ -3053,7 +3053,7 @@ or ``min`` and ``max`` are given also the number of occurences is checked.
 </assert_contents>
 ```
 
-With ``negate="true"`` the outcome of the assertions wrt the precence and number
+With ``negate="true"`` the outcome of the assertions wrt the presence and number
 of ``path`` can be negated. If there are any sub assertions then check them against
 
 - the content of the attribute ``attribute``
@@ -3068,7 +3068,7 @@ of ``path`` can be negated. If there are any sub assertions then check them agai
 ```
 
 Sub-assertions are not subject to the ``negate`` attribute of ``xml_element``.
-If ``all`` is ``true`` then the sub assertions are checked for all occurences.
+If ``all`` is ``true`` then the sub assertions are checked for all occurrences.
 
 Note that all other XML assertions can be expressed by this assertion (Galaxy
 also implements the other assertions by calling this one).

--- a/lib/galaxy/tool_util_models/__init__.py
+++ b/lib/galaxy/tool_util_models/__init__.py
@@ -172,33 +172,153 @@ class ParsedTool(ToolSourceBaseModel):
 
 
 class BaseTestOutputModel(StrictModel):
-    file: Optional[str] = None
-    path: Optional[str] = None
-    location: Optional[AnyUrl] = None
-    ftype: Optional[str] = None
-    sort: Optional[bool] = None
-    compare: Optional[OutputCompareType] = None
-    checksum: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
-    asserts: Optional[assertions] = None
-    delta: Optional[int] = None
-    delta_frac: Optional[float] = None
-    lines_diff: Optional[int] = None
-    decompress: Optional[bool] = None
+    model_config = ConfigDict(extra="forbid", title="BaseTestOutputModel")
+    file: Annotated[
+        Optional[str],
+        Field(
+            title="File",
+            description=(
+                "Name of the output file stored in the target `test-data` directory that will be used to "
+                "compare against the results of executing the tool via the functional test framework."
+            ),
+        ),
+    ] = None
+    path: Annotated[
+        Optional[str],
+        Field(title="Path", description="Filesystem path to a local output file used for comparison."),
+    ] = None
+    location: Annotated[
+        Optional[AnyUrl],
+        Field(
+            title="Location",
+            description=(
+                "URL that points to a remote output file that will be downloaded and used for output "
+                "comparison. Use only when the file cannot be included in the `test-data` folder. May be "
+                "combined with `file` (downloads when missing on disk) or used alone (filename inferred "
+                "from the URL). A `checksum` is also used to verify the download when provided."
+            ),
+        ),
+    ] = None
+    ftype: Annotated[
+        Optional[str],
+        Field(
+            title="File Type",
+            description=(
+                "If specified, this value is checked against the corresponding output's data type. "
+                "If these do not match, the test will fail."
+            ),
+        ),
+    ] = None
+    sort: Annotated[
+        Optional[bool],
+        Field(
+            title="Sort",
+            description=(
+                "Applies only if `compare` is `diff`, `re_match` or `re_match_multiline`. Sorts the lines "
+                "of the history data set before comparison; for `diff` and `re_match` the local file is "
+                "also sorted. Useful for non-deterministic output."
+            ),
+        ),
+    ] = None
+    compare: Annotated[
+        Optional[OutputCompareType],
+        Field(
+            title="Compare",
+            description="Comparison mode used when matching the output against the reference file.",
+        ),
+    ] = None
+    checksum: Annotated[
+        Optional[str],
+        Field(
+            title="Checksum",
+            description=(
+                "The target output's checksum should match the value specified here, in the form "
+                "`hash_type$hash_value` (e.g. `sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041`). Useful "
+                "for large static files where uploading the whole file is inconvenient."
+            ),
+        ),
+    ] = None
+    metadata: Annotated[
+        Optional[Dict[str, Any]],
+        Field(
+            title="Metadata",
+            description="Mapping of metadata keys to expected values for this output.",
+        ),
+    ] = None
+    asserts: Annotated[
+        Optional[assertions],
+        Field(title="Asserts", description="Assertions about the content of the output."),
+    ] = None
+    delta: Annotated[
+        Optional[int],
+        Field(
+            title="Delta",
+            description=(
+                "If `compare` is set to `sim_size`, the maximum allowed absolute size difference (in "
+                "bytes) between the generated data set and the reference file in `test-data/`. Default "
+                "is 10000 bytes. Can be combined with `delta_frac`."
+            ),
+        ),
+    ] = None
+    delta_frac: Annotated[
+        Optional[float],
+        Field(
+            title="Delta Frac",
+            description=(
+                "If `compare` is set to `sim_size`, the maximum allowed relative size difference between "
+                "the generated data set and the reference file in `test-data/`. 0.1 means the generated "
+                "file can differ by at most 10%. Default is not to check for relative size difference. "
+                "Can be combined with `delta`."
+            ),
+        ),
+    ] = None
+    lines_diff: Annotated[
+        Optional[int],
+        Field(
+            title="Lines Diff",
+            description=(
+                "Applies when `compare` is set to `diff`, `re_match`, or `contains`. For `diff`, the "
+                "number of lines of difference to allow (a modified line counts as two: one added, one "
+                "removed)."
+            ),
+        ),
+    ] = None
+    decompress: Annotated[
+        Optional[bool],
+        Field(
+            title="Decompress",
+            description=(
+                "If true, decompress files before comparison. Applies to assertions expressed with "
+                "`assert_contents` or `compare` set to anything but `sim_size`. Useful for testing "
+                "compressed outputs that are non-deterministic despite having deterministic decompressed "
+                "contents. By default, only files compressed with bz2, gzip and zip are automatically "
+                "decompressed."
+            ),
+        ),
+    ] = None
 
 
 class TestDataOutputAssertions(BaseTestOutputModel):
-    class_: Optional[Literal["File"]] = Field("File", alias="class")
+    model_config = ConfigDict(extra="forbid", title="TestDataOutputAssertions")
+    class_: Optional[Literal["File"]] = Field("File", alias="class", title="Class")
 
 
 class TestCollectionCollectionElementAssertions(StrictModel):
-    class_: Optional[Literal["Collection"]] = Field("Collection", alias="class")
-    elements: Optional[Dict[str, "TestCollectionElementAssertion"]] = None
-    element_tests: Optional[Dict[str, "TestCollectionElementAssertion"]] = None
+    model_config = ConfigDict(extra="forbid", title="TestCollectionCollectionElementAssertions")
+    class_: Optional[Literal["Collection"]] = Field("Collection", alias="class", title="Class")
+    elements: Annotated[
+        Optional[Dict[str, "TestCollectionElementAssertion"]],
+        Field(title="Elements"),
+    ] = None
+    element_tests: Annotated[
+        Optional[Dict[str, "TestCollectionElementAssertion"]],
+        Field(title="Element Tests"),
+    ] = None
 
 
 class TestCollectionDatasetElementAssertions(BaseTestOutputModel):
-    class_: Optional[Literal["File"]] = Field("File", alias="class")
+    model_config = ConfigDict(extra="forbid", title="TestCollectionDatasetElementAssertions")
+    class_: Optional[Literal["File"]] = Field("File", alias="class", title="Class")
 
 
 def _discriminate_collection_element(v):
@@ -224,16 +344,24 @@ TestCollectionCollectionElementAssertions.model_rebuild()
 
 
 class CollectionAttributes(StrictModel):
-    collection_type: CollectionType = None
+    model_config = ConfigDict(extra="forbid", title="CollectionAttributes")
+    collection_type: Annotated[CollectionType, Field(title="Collection Type")] = None
 
 
 class TestCollectionOutputAssertions(StrictModel):
-    class_: Optional[Literal["Collection"]] = Field("Collection", alias="class")
-    elements: Optional[Dict[str, TestCollectionElementAssertion]] = None
-    element_tests: Optional[Dict[str, "TestCollectionElementAssertion"]] = None
-    element_count: Optional[int] = None
-    attributes: Optional[CollectionAttributes] = None
-    collection_type: CollectionType = None
+    model_config = ConfigDict(extra="forbid", title="TestCollectionOutputAssertions")
+    class_: Optional[Literal["Collection"]] = Field("Collection", alias="class", title="Class")
+    elements: Annotated[
+        Optional[Dict[str, TestCollectionElementAssertion]],
+        Field(title="Elements"),
+    ] = None
+    element_tests: Annotated[
+        Optional[Dict[str, "TestCollectionElementAssertion"]],
+        Field(title="Element Tests"),
+    ] = None
+    element_count: Annotated[Optional[int], Field(title="Element Count")] = None
+    attributes: Annotated[Optional[CollectionAttributes], Field(title="Attributes")] = None
+    collection_type: Annotated[CollectionType, Field(title="Collection Type")] = None
 
 
 TestOutputLiteral = Union[bool, int, float, str]
@@ -267,23 +395,25 @@ TestInputValue = Union[bool, int, float, str, List[Any], Dict[str, Any]]
 
 
 class YamlTestCredentialValue(StrictModel):
-    name: Annotated[str, Field(description="Name of the credential variable or secret.")]
-    value: Annotated[str, Field(description="Value of the credential variable or secret.")]
+    model_config = ConfigDict(extra="forbid", title="YamlTestCredentialValue")
+    name: Annotated[str, Field(title="Name", description="Name of the credential variable or secret.")]
+    value: Annotated[str, Field(title="Value", description="Value of the credential variable or secret.")]
 
 
 class YamlTestCredential(StrictModel):
-    name: Annotated[str, Field(description="Name of the credentials group.")]
+    model_config = ConfigDict(extra="forbid", title="YamlTestCredential")
+    name: Annotated[str, Field(title="Name", description="Name of the credentials group.")]
     variables: Annotated[
         List[YamlTestCredentialValue],
-        Field(description="Variables exposed to the tool environment."),
+        Field(title="Variables", description="Variables exposed to the tool environment."),
     ] = []
     secrets: Annotated[
         List[YamlTestCredentialValue],
-        Field(description="Secrets exposed to the tool environment."),
+        Field(title="Secrets", description="Secrets exposed to the tool environment."),
     ] = []
     version: Annotated[
         Optional[str],
-        Field(description="Version of the credential definition."),
+        Field(title="Version", description="Version of the credential definition."),
     ] = None
 
 
@@ -341,13 +471,52 @@ JobDict = Dict[str, Any]
 
 
 class TestJob(StrictModel):
-    doc: Optional[str]
-    job: Job
-    outputs: Dict[str, TestOutputAssertions]
-    expect_failure: Optional[bool] = False
+    model_config = ConfigDict(extra="forbid", title="TestJob")
+    doc: Annotated[
+        Optional[str],
+        Field(title="Doc", description="Describes the purpose of the test."),
+    ] = None
+    job: Annotated[
+        Job,
+        Field(
+            title="Job",
+            description=(
+                "Defines the job to execute. Can be a path to a file or an inline dictionary describing "
+                "the job inputs."
+            ),
+        ),
+    ]
+    outputs: Annotated[
+        Dict[str, TestOutputAssertions],
+        Field(
+            title="Outputs",
+            description=(
+                "Defines assertions about outputs (datasets, collections or parameters). Each key "
+                "corresponds to a labeled output; values are dictionaries describing the expected output."
+            ),
+        ),
+    ]
+    expect_failure: Annotated[
+        Optional[bool],
+        Field(
+            title="Expect Failure",
+            description="If true, the workflow is expected to produce an error.",
+        ),
+    ] = False
 
 
-Tests = RootModel[List[TestJob]]
+class Tests(RootModel[List[TestJob]]):
+    model_config = ConfigDict(
+        title="GalaxyWorkflowTests",
+        json_schema_extra={
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "description": (
+                "Galaxy workflow tests file — a YAML list of test entries asserting the expected "
+                "inputs and outputs of a workflow run."
+            ),
+        },
+    )
+
 
 # TODO: typed dict versions of all thee above for verify code - make this Dict[str, Any] here more
 # specific.

--- a/lib/galaxy/tool_util_models/__init__.py
+++ b/lib/galaxy/tool_util_models/__init__.py
@@ -13,7 +13,6 @@ from typing import (
 )
 
 from pydantic import (
-    AfterValidator,
     AnyUrl,
     BaseModel,
     ConfigDict,
@@ -28,9 +27,14 @@ from typing_extensions import (
     TypedDict,
 )
 
-from ._base import ToolSourceBaseModel
+from ._base import (
+    CollectionType,
+    StrictModel,
+    ToolSourceBaseModel,
+)
 from .assertions import assertions
 from .parameters import ToolParameterT
+from .test_job import Job
 from .tool_outputs import (
     IncomingToolOutput,
     ToolOutput,
@@ -165,11 +169,6 @@ class ParsedTool(ToolSourceBaseModel):
     help: Optional[HelpContent]
 
 
-class StrictModel(BaseModel):
-
-    model_config = ConfigDict(extra="forbid", field_title_generator=lambda field_name, field_info: field_name.lower())
-
-
 class BaseTestOutputModel(StrictModel):
     file: Optional[str] = None
     path: Optional[str] = None
@@ -203,19 +202,6 @@ TestCollectionElementAssertion = Union[
     TestCollectionDatasetElementAssertions, TestCollectionCollectionElementAssertions
 ]
 TestCollectionCollectionElementAssertions.model_rebuild()
-
-
-def _check_collection_type(v: str) -> str:
-    if len(v) == 0:
-        raise ValueError("Invalid empty collection_type specified.")
-    collection_levels = v.split(":")
-    for collection_level in collection_levels:
-        if collection_level not in ["list", "paired", "paired_or_unpaired", "record", "sample_sheet"]:
-            raise ValueError(f"Invalid collection_type specified [{v}]")
-    return v
-
-
-CollectionType = Annotated[Optional[str], AfterValidator(_check_collection_type)]
 
 
 class CollectionAttributes(StrictModel):
@@ -307,12 +293,15 @@ class YamlToolTest(BaseModel):
 UserToolSource.model_rebuild()
 YamlToolSource.model_rebuild()
 
+# Loose alias retained for TestJobDict / TypedDict consumers where helpers
+# still tolerate Dict[str, Any]. The strict, validated shape is `Job` (see
+# galaxy.tool_util_models.test_job).
 JobDict = Dict[str, Any]
 
 
 class TestJob(StrictModel):
     doc: Optional[str]
-    job: JobDict
+    job: Job
     outputs: Dict[str, TestOutputAssertions]
     expect_failure: Optional[bool] = False
 

--- a/lib/galaxy/tool_util_models/__init__.py
+++ b/lib/galaxy/tool_util_models/__init__.py
@@ -16,9 +16,11 @@ from pydantic import (
     AnyUrl,
     BaseModel,
     ConfigDict,
+    Discriminator,
     Field,
     model_validator,
     RootModel,
+    Tag,
 )
 from typing_extensions import (
     Annotated,
@@ -190,16 +192,33 @@ class TestDataOutputAssertions(BaseTestOutputModel):
 
 
 class TestCollectionCollectionElementAssertions(StrictModel):
+    class_: Optional[Literal["Collection"]] = Field("Collection", alias="class")
     elements: Optional[Dict[str, "TestCollectionElementAssertion"]] = None
     element_tests: Optional[Dict[str, "TestCollectionElementAssertion"]] = None
 
 
 class TestCollectionDatasetElementAssertions(BaseTestOutputModel):
-    pass
+    class_: Optional[Literal["File"]] = Field("File", alias="class")
 
 
-TestCollectionElementAssertion = Union[
-    TestCollectionDatasetElementAssertions, TestCollectionCollectionElementAssertions
+def _discriminate_collection_element(v):
+    if isinstance(v, dict):
+        if v.get("class") == "Collection":
+            return "Collection"
+        return "File"
+    if isinstance(v, TestCollectionCollectionElementAssertions):
+        return "Collection"
+    if isinstance(v, TestCollectionDatasetElementAssertions):
+        return "File"
+    return None
+
+
+TestCollectionElementAssertion = Annotated[
+    Union[
+        Annotated[TestCollectionDatasetElementAssertions, Tag("File")],
+        Annotated[TestCollectionCollectionElementAssertions, Tag("Collection")],
+    ],
+    Discriminator(_discriminate_collection_element),
 ]
 TestCollectionCollectionElementAssertions.model_rebuild()
 
@@ -219,7 +238,29 @@ class TestCollectionOutputAssertions(StrictModel):
 
 TestOutputLiteral = Union[bool, int, float, str]
 
-TestOutputAssertions = Union[TestCollectionOutputAssertions, TestDataOutputAssertions, TestOutputLiteral]
+
+def _discriminate_output(v):
+    if isinstance(v, dict):
+        if v.get("class") == "Collection":
+            return "Collection"
+        return "File"
+    if isinstance(v, TestCollectionOutputAssertions):
+        return "Collection"
+    if isinstance(v, TestDataOutputAssertions):
+        return "File"
+    if isinstance(v, (bool, int, float, str)):
+        return "scalar"
+    return None
+
+
+TestOutputAssertions = Annotated[
+    Union[
+        Annotated[TestCollectionOutputAssertions, Tag("Collection")],
+        Annotated[TestDataOutputAssertions, Tag("File")],
+        Annotated[TestOutputLiteral, Tag("scalar")],
+    ],
+    Discriminator(_discriminate_output),
+]
 
 
 TestInputValue = Union[bool, int, float, str, List[Any], Dict[str, Any]]

--- a/lib/galaxy/tool_util_models/_base.py
+++ b/lib/galaxy/tool_util_models/_base.py
@@ -1,10 +1,30 @@
 """Base model classes for tool utilities."""
 
+from typing import Optional
+
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
 )
+from typing_extensions import Annotated
 
 
 class ToolSourceBaseModel(BaseModel):
     model_config = ConfigDict(field_title_generator=lambda field_name, field_info: field_name.lower())
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", field_title_generator=lambda field_name, field_info: field_name.lower())
+
+
+def _check_collection_type(v: str) -> str:
+    if len(v) == 0:
+        raise ValueError("Invalid empty collection_type specified.")
+    for level in v.split(":"):
+        if level not in ("list", "paired", "paired_or_unpaired", "record", "sample_sheet"):
+            raise ValueError(f"Invalid collection_type specified [{v}]")
+    return v
+
+
+CollectionType = Annotated[Optional[str], AfterValidator(_check_collection_type)]

--- a/lib/galaxy/tool_util_models/_base.py
+++ b/lib/galaxy/tool_util_models/_base.py
@@ -11,11 +11,11 @@ from typing_extensions import Annotated
 
 
 class ToolSourceBaseModel(BaseModel):
-    model_config = ConfigDict(field_title_generator=lambda field_name, field_info: field_name.lower())
+    pass
 
 
 class StrictModel(BaseModel):
-    model_config = ConfigDict(extra="forbid", field_title_generator=lambda field_name, field_info: field_name.lower())
+    model_config = ConfigDict(extra="forbid")
 
 
 def _check_collection_type(v: str) -> str:

--- a/lib/galaxy/tool_util_models/assertions.py
+++ b/lib/galaxy/tool_util_models/assertions.py
@@ -84,8 +84,11 @@ has_line_negate_description = """A boolean that can be set to true to negate the
 class base_has_line_model(AssertionModel):
     """base model for has_line describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_line_model")
+
     line: str = Field(
         ...,
+        title="Line",
         description=has_line_line_description,
     )
 
@@ -95,6 +98,7 @@ class base_has_line_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_line_n_description,
     )
 
@@ -102,6 +106,7 @@ class base_has_line_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_line_delta_description,
     )
 
@@ -111,6 +116,7 @@ class base_has_line_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_line_min_description,
     )
 
@@ -120,11 +126,13 @@ class base_has_line_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_line_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_line_negate_description,
     )
 
@@ -132,8 +140,11 @@ class base_has_line_model(AssertionModel):
 class base_has_line_model_relaxed(AssertionModel):
     """base model for has_line describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_line_model_relaxed")
+
     line: str = Field(
         ...,
+        title="Line",
         description=has_line_line_description,
     )
 
@@ -143,6 +154,7 @@ class base_has_line_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_line_n_description,
     )
 
@@ -150,6 +162,7 @@ class base_has_line_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_line_delta_description,
     )
 
@@ -159,6 +172,7 @@ class base_has_line_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_line_min_description,
     )
 
@@ -168,11 +182,13 @@ class base_has_line_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_line_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_line_negate_description,
     )
 
@@ -182,13 +198,15 @@ class has_line_model(base_has_line_model):
     argument line. The exact number of occurrences can be optionally
     specified by the argument n"""
 
-    that: Literal["has_line"] = "has_line"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Line")
+    that: Literal["has_line"] = Field("has_line", title="That")
 
 
 class has_line_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_line: base_has_line_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Line (Nested)")
+    has_line: base_has_line_model = Field(..., title="Assert Has Line")
 
 
 class has_line_model_relaxed(base_has_line_model_relaxed):
@@ -196,7 +214,8 @@ class has_line_model_relaxed(base_has_line_model_relaxed):
     argument line. The exact number of occurrences can be optionally
     specified by the argument n"""
 
-    that: Literal["has_line"] = "has_line"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Line (Relaxed)")
+    that: Literal["has_line"] = Field("has_line", title="That")
 
 
 has_line_matching_expression_description = """The regular expressions to attempt match in the output."""
@@ -217,8 +236,11 @@ has_line_matching_negate_description = """A boolean that can be set to true to n
 class base_has_line_matching_model(AssertionModel):
     """base model for has_line_matching describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_line_matching_model")
+
     expression: str = Field(
         ...,
+        title="Expression",
         description=has_line_matching_expression_description,
     )
 
@@ -228,6 +250,7 @@ class base_has_line_matching_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_line_matching_n_description,
     )
 
@@ -235,6 +258,7 @@ class base_has_line_matching_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_line_matching_delta_description,
     )
 
@@ -244,6 +268,7 @@ class base_has_line_matching_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_line_matching_min_description,
     )
 
@@ -253,11 +278,13 @@ class base_has_line_matching_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_line_matching_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_line_matching_negate_description,
     )
 
@@ -265,8 +292,11 @@ class base_has_line_matching_model(AssertionModel):
 class base_has_line_matching_model_relaxed(AssertionModel):
     """base model for has_line_matching describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_line_matching_model_relaxed")
+
     expression: str = Field(
         ...,
+        title="Expression",
         description=has_line_matching_expression_description,
     )
 
@@ -276,6 +306,7 @@ class base_has_line_matching_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_line_matching_n_description,
     )
 
@@ -283,6 +314,7 @@ class base_has_line_matching_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_line_matching_delta_description,
     )
 
@@ -292,6 +324,7 @@ class base_has_line_matching_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_line_matching_min_description,
     )
 
@@ -301,11 +334,13 @@ class base_has_line_matching_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_line_matching_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_line_matching_negate_description,
     )
 
@@ -313,23 +348,26 @@ class base_has_line_matching_model_relaxed(AssertionModel):
 class has_line_matching_model(base_has_line_matching_model):
     r"""Asserts the specified output contains a line matching the
     regular expression specified by the argument expression. If n is given
-    the assertion checks for exactly n occurrences."""
+    the assertion checks for exactly n occurences."""
 
-    that: Literal["has_line_matching"] = "has_line_matching"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Line Matching")
+    that: Literal["has_line_matching"] = Field("has_line_matching", title="That")
 
 
 class has_line_matching_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_line_matching: base_has_line_matching_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Line Matching (Nested)")
+    has_line_matching: base_has_line_matching_model = Field(..., title="Assert Has Line Matching")
 
 
 class has_line_matching_model_relaxed(base_has_line_matching_model_relaxed):
     r"""Asserts the specified output contains a line matching the
     regular expression specified by the argument expression. If n is given
-    the assertion checks for exactly n occurrences."""
+    the assertion checks for exactly n occurences."""
 
-    that: Literal["has_line_matching"] = "has_line_matching"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Line Matching (Relaxed)")
+    that: Literal["has_line_matching"] = Field("has_line_matching", title="That")
 
 
 has_n_lines_n_description = """Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``"""
@@ -348,12 +386,15 @@ has_n_lines_negate_description = """A boolean that can be set to true to negate 
 class base_has_n_lines_model(AssertionModel):
     """base model for has_n_lines describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_n_lines_model")
+
     n: Annotated[
         typing.Optional[typing.Union[str, int]],
         BeforeValidator(check_bytes),
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_n_lines_n_description,
     )
 
@@ -361,6 +402,7 @@ class base_has_n_lines_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_n_lines_delta_description,
     )
 
@@ -370,6 +412,7 @@ class base_has_n_lines_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_n_lines_min_description,
     )
 
@@ -379,11 +422,13 @@ class base_has_n_lines_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_n_lines_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_n_lines_negate_description,
     )
 
@@ -391,12 +436,15 @@ class base_has_n_lines_model(AssertionModel):
 class base_has_n_lines_model_relaxed(AssertionModel):
     """base model for has_n_lines describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_n_lines_model_relaxed")
+
     n: Annotated[
         typing.Optional[typing.Union[str, int]],
         BeforeValidator(check_bytes),
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_n_lines_n_description,
     )
 
@@ -404,6 +452,7 @@ class base_has_n_lines_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_n_lines_delta_description,
     )
 
@@ -413,6 +462,7 @@ class base_has_n_lines_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_n_lines_min_description,
     )
 
@@ -422,11 +472,13 @@ class base_has_n_lines_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_n_lines_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_n_lines_negate_description,
     )
 
@@ -436,13 +488,15 @@ class has_n_lines_model(base_has_n_lines_model):
     for a difference in the number of lines (delta)
     or relative differebce in the number of lines"""
 
-    that: Literal["has_n_lines"] = "has_n_lines"
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Lines")
+    that: Literal["has_n_lines"] = Field("has_n_lines", title="That")
 
 
 class has_n_lines_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_n_lines: base_has_n_lines_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Lines (Nested)")
+    has_n_lines: base_has_n_lines_model = Field(..., title="Assert Has N Lines")
 
 
 class has_n_lines_model_relaxed(base_has_n_lines_model_relaxed):
@@ -450,7 +504,8 @@ class has_n_lines_model_relaxed(base_has_n_lines_model_relaxed):
     for a difference in the number of lines (delta)
     or relative differebce in the number of lines"""
 
-    that: Literal["has_n_lines"] = "has_n_lines"
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Lines (Relaxed)")
+    that: Literal["has_n_lines"] = Field("has_n_lines", title="That")
 
 
 has_text_text_description = """The text to search for in the output."""
@@ -471,8 +526,11 @@ has_text_negate_description = """A boolean that can be set to true to negate the
 class base_has_text_model(AssertionModel):
     """base model for has_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_text_model")
+
     text: str = Field(
         ...,
+        title="Text",
         description=has_text_text_description,
     )
 
@@ -482,6 +540,7 @@ class base_has_text_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_text_n_description,
     )
 
@@ -489,6 +548,7 @@ class base_has_text_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_text_delta_description,
     )
 
@@ -498,6 +558,7 @@ class base_has_text_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_text_min_description,
     )
 
@@ -507,11 +568,13 @@ class base_has_text_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_text_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_text_negate_description,
     )
 
@@ -519,8 +582,11 @@ class base_has_text_model(AssertionModel):
 class base_has_text_model_relaxed(AssertionModel):
     """base model for has_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_text_model_relaxed")
+
     text: str = Field(
         ...,
+        title="Text",
         description=has_text_text_description,
     )
 
@@ -530,6 +596,7 @@ class base_has_text_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_text_n_description,
     )
 
@@ -537,6 +604,7 @@ class base_has_text_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_text_delta_description,
     )
 
@@ -546,6 +614,7 @@ class base_has_text_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_text_min_description,
     )
 
@@ -555,11 +624,13 @@ class base_has_text_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_text_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_text_negate_description,
     )
 
@@ -569,13 +640,15 @@ class has_text_model(base_has_text_model):
     the argument text. The exact number of occurrences can be
     optionally specified by the argument n"""
 
-    that: Literal["has_text"] = "has_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Text")
+    that: Literal["has_text"] = Field("has_text", title="That")
 
 
 class has_text_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_text: base_has_text_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Text (Nested)")
+    has_text: base_has_text_model = Field(..., title="Assert Has Text")
 
 
 class has_text_model_relaxed(base_has_text_model_relaxed):
@@ -583,7 +656,8 @@ class has_text_model_relaxed(base_has_text_model_relaxed):
     the argument text. The exact number of occurrences can be
     optionally specified by the argument n"""
 
-    that: Literal["has_text"] = "has_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Text (Relaxed)")
+    that: Literal["has_text"] = Field("has_text", title="That")
 
 
 has_text_matching_expression_description = """The regular expressions to attempt match in the output."""
@@ -604,8 +678,11 @@ has_text_matching_negate_description = """A boolean that can be set to true to n
 class base_has_text_matching_model(AssertionModel):
     """base model for has_text_matching describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_text_matching_model")
+
     expression: str = Field(
         ...,
+        title="Expression",
         description=has_text_matching_expression_description,
     )
 
@@ -615,6 +692,7 @@ class base_has_text_matching_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_text_matching_n_description,
     )
 
@@ -622,6 +700,7 @@ class base_has_text_matching_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_text_matching_delta_description,
     )
 
@@ -631,6 +710,7 @@ class base_has_text_matching_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_text_matching_min_description,
     )
 
@@ -640,11 +720,13 @@ class base_has_text_matching_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_text_matching_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_text_matching_negate_description,
     )
 
@@ -652,8 +734,11 @@ class base_has_text_matching_model(AssertionModel):
 class base_has_text_matching_model_relaxed(AssertionModel):
     """base model for has_text_matching describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_text_matching_model_relaxed")
+
     expression: str = Field(
         ...,
+        title="Expression",
         description=has_text_matching_expression_description,
     )
 
@@ -663,6 +748,7 @@ class base_has_text_matching_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_text_matching_n_description,
     )
 
@@ -670,6 +756,7 @@ class base_has_text_matching_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_text_matching_delta_description,
     )
 
@@ -679,6 +766,7 @@ class base_has_text_matching_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_text_matching_min_description,
     )
 
@@ -688,11 +776,13 @@ class base_has_text_matching_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_text_matching_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_text_matching_negate_description,
     )
 
@@ -700,25 +790,28 @@ class base_has_text_matching_model_relaxed(AssertionModel):
 class has_text_matching_model(base_has_text_matching_model):
     r"""Asserts the specified output contains text matching the
     regular expression specified by the argument expression.
-    If n is given the assertion checks for exactly n (nonoverlapping)
-    occurrences."""
+    If n is given the assertion checks for exacly n (nonoverlapping)
+    occurences."""
 
-    that: Literal["has_text_matching"] = "has_text_matching"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Text Matching")
+    that: Literal["has_text_matching"] = Field("has_text_matching", title="That")
 
 
 class has_text_matching_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_text_matching: base_has_text_matching_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Text Matching (Nested)")
+    has_text_matching: base_has_text_matching_model = Field(..., title="Assert Has Text Matching")
 
 
 class has_text_matching_model_relaxed(base_has_text_matching_model_relaxed):
     r"""Asserts the specified output contains text matching the
     regular expression specified by the argument expression.
-    If n is given the assertion checks for exactly n (nonoverlapping)
-    occurrences."""
+    If n is given the assertion checks for exacly n (nonoverlapping)
+    occurences."""
 
-    that: Literal["has_text_matching"] = "has_text_matching"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Text Matching (Relaxed)")
+    that: Literal["has_text_matching"] = Field("has_text_matching", title="That")
 
 
 not_has_text_text_description = """The text to search for in the output."""
@@ -727,8 +820,11 @@ not_has_text_text_description = """The text to search for in the output."""
 class base_not_has_text_model(AssertionModel):
     """base model for not_has_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_not_has_text_model")
+
     text: str = Field(
         ...,
+        title="Text",
         description=not_has_text_text_description,
     )
 
@@ -736,8 +832,11 @@ class base_not_has_text_model(AssertionModel):
 class base_not_has_text_model_relaxed(AssertionModel):
     """base model for not_has_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_not_has_text_model_relaxed")
+
     text: str = Field(
         ...,
+        title="Text",
         description=not_has_text_text_description,
     )
 
@@ -746,20 +845,23 @@ class not_has_text_model(base_not_has_text_model):
     r"""Asserts specified output does not contain the substring
     specified by the argument text"""
 
-    that: Literal["not_has_text"] = "not_has_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Not Has Text")
+    that: Literal["not_has_text"] = Field("not_has_text", title="That")
 
 
 class not_has_text_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    not_has_text: base_not_has_text_model
+    model_config = ConfigDict(extra="forbid", title="Assert Not Has Text (Nested)")
+    not_has_text: base_not_has_text_model = Field(..., title="Assert Not Has Text")
 
 
 class not_has_text_model_relaxed(base_not_has_text_model_relaxed):
     r"""Asserts specified output does not contain the substring
     specified by the argument text"""
 
-    that: Literal["not_has_text"] = "not_has_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Not Has Text (Relaxed)")
+    that: Literal["not_has_text"] = Field("not_has_text", title="That")
 
 
 has_n_columns_n_description = """Desired number, can be suffixed by ``(k|M|G|T|P|E)i?``"""
@@ -784,12 +886,15 @@ has_n_columns_negate_description = """A boolean that can be set to true to negat
 class base_has_n_columns_model(AssertionModel):
     """base model for has_n_columns describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_n_columns_model")
+
     n: Annotated[
         typing.Optional[typing.Union[str, int]],
         BeforeValidator(check_bytes),
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_n_columns_n_description,
     )
 
@@ -797,6 +902,7 @@ class base_has_n_columns_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_n_columns_delta_description,
     )
 
@@ -806,6 +912,7 @@ class base_has_n_columns_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_n_columns_min_description,
     )
 
@@ -815,21 +922,25 @@ class base_has_n_columns_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_n_columns_max_description,
     )
 
     sep: str = Field(
         "	",
+        title="Sep",
         description=has_n_columns_sep_description,
     )
 
     comment: str = Field(
         "",
+        title="Comment",
         description=has_n_columns_comment_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_n_columns_negate_description,
     )
 
@@ -837,12 +948,15 @@ class base_has_n_columns_model(AssertionModel):
 class base_has_n_columns_model_relaxed(AssertionModel):
     """base model for has_n_columns describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_n_columns_model_relaxed")
+
     n: Annotated[
         typing.Optional[typing.Union[str, int]],
         BeforeValidator(check_bytes),
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_n_columns_n_description,
     )
 
@@ -850,6 +964,7 @@ class base_has_n_columns_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_n_columns_delta_description,
     )
 
@@ -859,6 +974,7 @@ class base_has_n_columns_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_n_columns_min_description,
     )
 
@@ -868,21 +984,25 @@ class base_has_n_columns_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_n_columns_max_description,
     )
 
     sep: str = Field(
         "	",
+        title="Sep",
         description=has_n_columns_sep_description,
     )
 
     comment: str = Field(
         "",
+        title="Comment",
         description=has_n_columns_comment_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_n_columns_negate_description,
     )
 
@@ -893,19 +1013,21 @@ class has_n_columns_model(base_has_n_columns_model):
 
     For instance, ``<has_n_columns n="3"/>``. The assertion tests only the first line.
     Number of columns can optionally also be specified with ``delta``. Alternatively the
-    range of expected occurrences can be specified by ``min`` and/or ``max``.
+    range of expected occurences can be specified by ``min`` and/or ``max``.
 
     Optionally a column separator (``sep``, default is ``       ``) `and comment character(s)
     can be specified (``comment``, default is empty string). The first non-comment
     line is used for determining the number of columns."""
 
-    that: Literal["has_n_columns"] = "has_n_columns"
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Columns")
+    that: Literal["has_n_columns"] = Field("has_n_columns", title="That")
 
 
 class has_n_columns_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_n_columns: base_has_n_columns_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Columns (Nested)")
+    has_n_columns: base_has_n_columns_model = Field(..., title="Assert Has N Columns")
 
 
 class has_n_columns_model_relaxed(base_has_n_columns_model_relaxed):
@@ -914,13 +1036,14 @@ class has_n_columns_model_relaxed(base_has_n_columns_model_relaxed):
 
     For instance, ``<has_n_columns n="3"/>``. The assertion tests only the first line.
     Number of columns can optionally also be specified with ``delta``. Alternatively the
-    range of expected occurrences can be specified by ``min`` and/or ``max``.
+    range of expected occurences can be specified by ``min`` and/or ``max``.
 
     Optionally a column separator (``sep``, default is ``       ``) `and comment character(s)
     can be specified (``comment``, default is empty string). The first non-comment
     line is used for determining the number of columns."""
 
-    that: Literal["has_n_columns"] = "has_n_columns"
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Columns (Relaxed)")
+    that: Literal["has_n_columns"] = Field("has_n_columns", title="That")
 
 
 attribute_is_path_description = """The Python xpath-like expression to find the target element."""
@@ -935,23 +1058,29 @@ attribute_is_negate_description = """A boolean that can be set to true to negate
 class base_attribute_is_model(AssertionModel):
     """base model for attribute_is describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_attribute_is_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=attribute_is_path_description,
     )
 
     attribute: str = Field(
         ...,
+        title="Attribute",
         description=attribute_is_attribute_description,
     )
 
     text: str = Field(
         ...,
+        title="Text",
         description=attribute_is_text_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=attribute_is_negate_description,
     )
 
@@ -959,23 +1088,29 @@ class base_attribute_is_model(AssertionModel):
 class base_attribute_is_model_relaxed(AssertionModel):
     """base model for attribute_is describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_attribute_is_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=attribute_is_path_description,
     )
 
     attribute: str = Field(
         ...,
+        title="Attribute",
         description=attribute_is_attribute_description,
     )
 
     text: str = Field(
         ...,
+        title="Text",
         description=attribute_is_text_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=attribute_is_negate_description,
     )
 
@@ -994,13 +1129,15 @@ class attribute_is_model(base_attribute_is_model):
     With ``negate`` the result of the assertion (on the equality) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["attribute_is"] = "attribute_is"
+    model_config = ConfigDict(extra="forbid", title="Assert Attribute Is")
+    that: Literal["attribute_is"] = Field("attribute_is", title="That")
 
 
 class attribute_is_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    attribute_is: base_attribute_is_model
+    model_config = ConfigDict(extra="forbid", title="Assert Attribute Is (Nested)")
+    attribute_is: base_attribute_is_model = Field(..., title="Assert Attribute Is")
 
 
 class attribute_is_model_relaxed(base_attribute_is_model_relaxed):
@@ -1017,7 +1154,8 @@ class attribute_is_model_relaxed(base_attribute_is_model_relaxed):
     With ``negate`` the result of the assertion (on the equality) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["attribute_is"] = "attribute_is"
+    model_config = ConfigDict(extra="forbid", title="Assert Attribute Is (Relaxed)")
+    that: Literal["attribute_is"] = Field("attribute_is", title="That")
 
 
 attribute_matches_path_description = """The Python xpath-like expression to find the target element."""
@@ -1034,23 +1172,29 @@ attribute_matches_negate_description = """A boolean that can be set to true to n
 class base_attribute_matches_model(AssertionModel):
     """base model for attribute_matches describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_attribute_matches_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=attribute_matches_path_description,
     )
 
     attribute: str = Field(
         ...,
+        title="Attribute",
         description=attribute_matches_attribute_description,
     )
 
     expression: Annotated[str, BeforeValidator(check_regex)] = Field(
         ...,
+        title="Expression",
         description=attribute_matches_expression_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=attribute_matches_negate_description,
     )
 
@@ -1058,23 +1202,29 @@ class base_attribute_matches_model(AssertionModel):
 class base_attribute_matches_model_relaxed(AssertionModel):
     """base model for attribute_matches describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_attribute_matches_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=attribute_matches_path_description,
     )
 
     attribute: str = Field(
         ...,
+        title="Attribute",
         description=attribute_matches_attribute_description,
     )
 
     expression: Annotated[str, BeforeValidator(check_regex)] = Field(
         ...,
+        title="Expression",
         description=attribute_matches_expression_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=attribute_matches_negate_description,
     )
 
@@ -1093,13 +1243,15 @@ class attribute_matches_model(base_attribute_matches_model):
     With ``negate`` the result of the assertion (on the matching) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["attribute_matches"] = "attribute_matches"
+    model_config = ConfigDict(extra="forbid", title="Assert Attribute Matches")
+    that: Literal["attribute_matches"] = Field("attribute_matches", title="That")
 
 
 class attribute_matches_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    attribute_matches: base_attribute_matches_model
+    model_config = ConfigDict(extra="forbid", title="Assert Attribute Matches (Nested)")
+    attribute_matches: base_attribute_matches_model = Field(..., title="Assert Attribute Matches")
 
 
 class attribute_matches_model_relaxed(base_attribute_matches_model_relaxed):
@@ -1116,7 +1268,8 @@ class attribute_matches_model_relaxed(base_attribute_matches_model_relaxed):
     With ``negate`` the result of the assertion (on the matching) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["attribute_matches"] = "attribute_matches"
+    model_config = ConfigDict(extra="forbid", title="Assert Attribute Matches (Relaxed)")
+    that: Literal["attribute_matches"] = Field("attribute_matches", title="That")
 
 
 element_text_path_description = """The Python xpath-like expression to find the target element."""
@@ -1127,18 +1280,22 @@ element_text_negate_description = """A boolean that can be set to true to negate
 class base_element_text_model(AssertionModel):
     """base model for element_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_element_text_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=element_text_path_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=element_text_negate_description,
     )
 
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
     @model_validator(mode="before")
     @classmethod
@@ -1151,18 +1308,22 @@ class base_element_text_model(AssertionModel):
 class base_element_text_model_relaxed(AssertionModel):
     """base model for element_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_element_text_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=element_text_path_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=element_text_negate_description,
     )
 
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
     @model_validator(mode="before")
     @classmethod
@@ -1188,13 +1349,15 @@ class element_text_model(base_element_text_model):
     The sub-assertions, which have their own ``negate`` attribute, are not affected
     by ``negate``."""
 
-    that: Literal["element_text"] = "element_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text")
+    that: Literal["element_text"] = Field("element_text", title="That")
 
 
 class element_text_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    element_text: base_element_text_model
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text (Nested)")
+    element_text: base_element_text_model = Field(..., title="Assert Element Text")
 
 
 class element_text_model_relaxed(base_element_text_model_relaxed):
@@ -1213,7 +1376,8 @@ class element_text_model_relaxed(base_element_text_model_relaxed):
     The sub-assertions, which have their own ``negate`` attribute, are not affected
     by ``negate``."""
 
-    that: Literal["element_text"] = "element_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text (Relaxed)")
+    that: Literal["element_text"] = Field("element_text", title="That")
 
 
 element_text_is_path_description = """The Python xpath-like expression to find the target element."""
@@ -1228,18 +1392,23 @@ element_text_is_negate_description = """A boolean that can be set to true to neg
 class base_element_text_is_model(AssertionModel):
     """base model for element_text_is describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_element_text_is_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=element_text_is_path_description,
     )
 
     text: str = Field(
         ...,
+        title="Text",
         description=element_text_is_text_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=element_text_is_negate_description,
     )
 
@@ -1247,18 +1416,23 @@ class base_element_text_is_model(AssertionModel):
 class base_element_text_is_model_relaxed(AssertionModel):
     """base model for element_text_is describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_element_text_is_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=element_text_is_path_description,
     )
 
     text: str = Field(
         ...,
+        title="Text",
         description=element_text_is_text_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=element_text_is_negate_description,
     )
 
@@ -1277,13 +1451,15 @@ class element_text_is_model(base_element_text_is_model):
     With ``negate`` the result of the assertion (on the equality) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["element_text_is"] = "element_text_is"
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text Is")
+    that: Literal["element_text_is"] = Field("element_text_is", title="That")
 
 
 class element_text_is_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    element_text_is: base_element_text_is_model
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text Is (Nested)")
+    element_text_is: base_element_text_is_model = Field(..., title="Assert Element Text Is")
 
 
 class element_text_is_model_relaxed(base_element_text_is_model_relaxed):
@@ -1300,7 +1476,8 @@ class element_text_is_model_relaxed(base_element_text_is_model_relaxed):
     With ``negate`` the result of the assertion (on the equality) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["element_text_is"] = "element_text_is"
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text Is (Relaxed)")
+    that: Literal["element_text_is"] = Field("element_text_is", title="That")
 
 
 element_text_matches_path_description = """The Python xpath-like expression to find the target element."""
@@ -1315,18 +1492,23 @@ element_text_matches_negate_description = (
 class base_element_text_matches_model(AssertionModel):
     """base model for element_text_matches describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_element_text_matches_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=element_text_matches_path_description,
     )
 
     expression: Annotated[str, BeforeValidator(check_regex)] = Field(
         ...,
+        title="Expression",
         description=element_text_matches_expression_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=element_text_matches_negate_description,
     )
 
@@ -1334,18 +1516,23 @@ class base_element_text_matches_model(AssertionModel):
 class base_element_text_matches_model_relaxed(AssertionModel):
     """base model for element_text_matches describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_element_text_matches_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=element_text_matches_path_description,
     )
 
     expression: Annotated[str, BeforeValidator(check_regex)] = Field(
         ...,
+        title="Expression",
         description=element_text_matches_expression_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=element_text_matches_negate_description,
     )
 
@@ -1364,13 +1551,15 @@ class element_text_matches_model(base_element_text_matches_model):
     With ``negate`` the result of the assertion (on the matching) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["element_text_matches"] = "element_text_matches"
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text Matches")
+    that: Literal["element_text_matches"] = Field("element_text_matches", title="That")
 
 
 class element_text_matches_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    element_text_matches: base_element_text_matches_model
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text Matches (Nested)")
+    element_text_matches: base_element_text_matches_model = Field(..., title="Assert Element Text Matches")
 
 
 class element_text_matches_model_relaxed(base_element_text_matches_model_relaxed):
@@ -1387,7 +1576,8 @@ class element_text_matches_model_relaxed(base_element_text_matches_model_relaxed
     With ``negate`` the result of the assertion (on the matching) can be inverted (the
     implicit assertion on the existence of the path is not affected)."""
 
-    that: Literal["element_text_matches"] = "element_text_matches"
+    model_config = ConfigDict(extra="forbid", title="Assert Element Text Matches (Relaxed)")
+    that: Literal["element_text_matches"] = Field("element_text_matches", title="That")
 
 
 has_element_with_path_path_description = """The Python xpath-like expression to find the target element."""
@@ -1400,13 +1590,17 @@ has_element_with_path_negate_description = (
 class base_has_element_with_path_model(AssertionModel):
     """base model for has_element_with_path describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_element_with_path_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=has_element_with_path_path_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_element_with_path_negate_description,
     )
 
@@ -1414,13 +1608,17 @@ class base_has_element_with_path_model(AssertionModel):
 class base_has_element_with_path_model_relaxed(AssertionModel):
     """base model for has_element_with_path describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_element_with_path_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=has_element_with_path_path_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_element_with_path_negate_description,
     )
 
@@ -1435,13 +1633,15 @@ class has_element_with_path_model(base_has_element_with_path_model):
 
     With ``negate`` the result of the assertion can be inverted."""
 
-    that: Literal["has_element_with_path"] = "has_element_with_path"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Element With Path")
+    that: Literal["has_element_with_path"] = Field("has_element_with_path", title="That")
 
 
 class has_element_with_path_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_element_with_path: base_has_element_with_path_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Element With Path (Nested)")
+    has_element_with_path: base_has_element_with_path_model = Field(..., title="Assert Has Element With Path")
 
 
 class has_element_with_path_model_relaxed(base_has_element_with_path_model_relaxed):
@@ -1454,7 +1654,8 @@ class has_element_with_path_model_relaxed(base_has_element_with_path_model_relax
 
     With ``negate`` the result of the assertion can be inverted."""
 
-    that: Literal["has_element_with_path"] = "has_element_with_path"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Element With Path (Relaxed)")
+    that: Literal["has_element_with_path"] = Field("has_element_with_path", title="That")
 
 
 has_n_elements_with_path_path_description = """The Python xpath-like expression to find the target element."""
@@ -1481,8 +1682,11 @@ has_n_elements_with_path_negate_description = (
 class base_has_n_elements_with_path_model(AssertionModel):
     """base model for has_n_elements_with_path describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_n_elements_with_path_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=has_n_elements_with_path_path_description,
     )
 
@@ -1492,6 +1696,7 @@ class base_has_n_elements_with_path_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_n_elements_with_path_n_description,
     )
 
@@ -1499,6 +1704,7 @@ class base_has_n_elements_with_path_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_n_elements_with_path_delta_description,
     )
 
@@ -1508,6 +1714,7 @@ class base_has_n_elements_with_path_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_n_elements_with_path_min_description,
     )
 
@@ -1517,11 +1724,13 @@ class base_has_n_elements_with_path_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_n_elements_with_path_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_n_elements_with_path_negate_description,
     )
 
@@ -1529,8 +1738,11 @@ class base_has_n_elements_with_path_model(AssertionModel):
 class base_has_n_elements_with_path_model_relaxed(AssertionModel):
     """base model for has_n_elements_with_path describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_n_elements_with_path_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=has_n_elements_with_path_path_description,
     )
 
@@ -1540,6 +1752,7 @@ class base_has_n_elements_with_path_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_n_elements_with_path_n_description,
     )
 
@@ -1547,6 +1760,7 @@ class base_has_n_elements_with_path_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_n_elements_with_path_delta_description,
     )
 
@@ -1556,6 +1770,7 @@ class base_has_n_elements_with_path_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_n_elements_with_path_min_description,
     )
 
@@ -1565,11 +1780,13 @@ class base_has_n_elements_with_path_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_n_elements_with_path_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_n_elements_with_path_negate_description,
     )
 
@@ -1585,16 +1802,18 @@ class has_n_elements_with_path_model(base_has_n_elements_with_path_model):
     ```
 
     Alternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes
-    can be used to specify the range of the expected number of occurrences.
+    can be used to specify the range of the expected number of occurences.
     With ``negate`` the result of the assertion can be inverted."""
 
-    that: Literal["has_n_elements_with_path"] = "has_n_elements_with_path"
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Elements With Path")
+    that: Literal["has_n_elements_with_path"] = Field("has_n_elements_with_path", title="That")
 
 
 class has_n_elements_with_path_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_n_elements_with_path: base_has_n_elements_with_path_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Elements With Path (Nested)")
+    has_n_elements_with_path: base_has_n_elements_with_path_model = Field(..., title="Assert Has N Elements With Path")
 
 
 class has_n_elements_with_path_model_relaxed(base_has_n_elements_with_path_model_relaxed):
@@ -1608,36 +1827,44 @@ class has_n_elements_with_path_model_relaxed(base_has_n_elements_with_path_model
     ```
 
     Alternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes
-    can be used to specify the range of the expected number of occurrences.
+    can be used to specify the range of the expected number of occurences.
     With ``negate`` the result of the assertion can be inverted."""
 
-    that: Literal["has_n_elements_with_path"] = "has_n_elements_with_path"
+    model_config = ConfigDict(extra="forbid", title="Assert Has N Elements With Path (Relaxed)")
+    that: Literal["has_n_elements_with_path"] = Field("has_n_elements_with_path", title="That")
 
 
 class base_is_valid_xml_model(AssertionModel):
     """base model for is_valid_xml describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_is_valid_xml_model")
+
 
 class base_is_valid_xml_model_relaxed(AssertionModel):
     """base model for is_valid_xml describing attributes."""
+
+    model_config = ConfigDict(extra="forbid", title="base_is_valid_xml_model_relaxed")
 
 
 class is_valid_xml_model(base_is_valid_xml_model):
     r"""Asserts the output is a valid XML file (e.g. ``<is_valid_xml />``)."""
 
-    that: Literal["is_valid_xml"] = "is_valid_xml"
+    model_config = ConfigDict(extra="forbid", title="Assert Is Valid Xml")
+    that: Literal["is_valid_xml"] = Field("is_valid_xml", title="That")
 
 
 class is_valid_xml_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    is_valid_xml: base_is_valid_xml_model
+    model_config = ConfigDict(extra="forbid", title="Assert Is Valid Xml (Nested)")
+    is_valid_xml: base_is_valid_xml_model = Field(..., title="Assert Is Valid Xml")
 
 
 class is_valid_xml_model_relaxed(base_is_valid_xml_model_relaxed):
     r"""Asserts the output is a valid XML file (e.g. ``<is_valid_xml />``)."""
 
-    that: Literal["is_valid_xml"] = "is_valid_xml"
+    model_config = ConfigDict(extra="forbid", title="Assert Is Valid Xml (Relaxed)")
+    that: Literal["is_valid_xml"] = Field("is_valid_xml", title="That")
 
 
 xml_element_path_description = """The Python xpath-like expression to find the target element."""
@@ -1664,18 +1891,23 @@ xml_element_negate_description = """A boolean that can be set to true to negate 
 class base_xml_element_model(AssertionModel):
     """base model for xml_element describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_xml_element_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=xml_element_path_description,
     )
 
     attribute: typing.Optional[typing.Union[str]] = Field(
         None,
+        title="Attribute",
         description=xml_element_attribute_description,
     )
 
     all: typing.Union[bool, str] = Field(
         False,
+        title="All",
         description=xml_element_all_description,
     )
 
@@ -1685,6 +1917,7 @@ class base_xml_element_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=xml_element_n_description,
     )
 
@@ -1692,6 +1925,7 @@ class base_xml_element_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=xml_element_delta_description,
     )
 
@@ -1701,6 +1935,7 @@ class base_xml_element_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=xml_element_min_description,
     )
 
@@ -1710,33 +1945,40 @@ class base_xml_element_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=xml_element_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=xml_element_negate_description,
     )
 
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
 
 class base_xml_element_model_relaxed(AssertionModel):
     """base model for xml_element describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_xml_element_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=xml_element_path_description,
     )
 
     attribute: typing.Optional[typing.Union[str]] = Field(
         None,
+        title="Attribute",
         description=xml_element_attribute_description,
     )
 
     all: typing.Union[bool, str] = Field(
         False,
+        title="All",
         description=xml_element_all_description,
     )
 
@@ -1746,6 +1988,7 @@ class base_xml_element_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=xml_element_n_description,
     )
 
@@ -1753,6 +1996,7 @@ class base_xml_element_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=xml_element_delta_description,
     )
 
@@ -1762,6 +2006,7 @@ class base_xml_element_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=xml_element_min_description,
     )
 
@@ -1771,22 +2016,24 @@ class base_xml_element_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=xml_element_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=xml_element_negate_description,
     )
 
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
 
 class xml_element_model(base_xml_element_model):
     r"""Assert if the XML file contains element(s) or tag(s) with the specified
     [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
-    or ``min`` and ``max`` are given also the number of occurrences is checked.
+    or ``min`` and ``max`` are given also the number of occurences is checked.
 
     ```xml
     <assert_contents>
@@ -1796,7 +2043,7 @@ class xml_element_model(base_xml_element_model):
     </assert_contents>
     ```
 
-    With ``negate="true"`` the outcome of the assertions wrt the presence and number
+    With ``negate="true"`` the outcome of the assertions wrt the precence and number
     of ``path`` can be negated. If there are any sub assertions then check them against
 
     - the content of the attribute ``attribute``
@@ -1811,24 +2058,26 @@ class xml_element_model(base_xml_element_model):
     ```
 
     Sub-assertions are not subject to the ``negate`` attribute of ``xml_element``.
-    If ``all`` is ``true`` then the sub assertions are checked for all occurrences.
+    If ``all`` is ``true`` then the sub assertions are checked for all occurences.
 
     Note that all other XML assertions can be expressed by this assertion (Galaxy
     also implements the other assertions by calling this one)."""
 
-    that: Literal["xml_element"] = "xml_element"
+    model_config = ConfigDict(extra="forbid", title="Assert Xml Element")
+    that: Literal["xml_element"] = Field("xml_element", title="That")
 
 
 class xml_element_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    xml_element: base_xml_element_model
+    model_config = ConfigDict(extra="forbid", title="Assert Xml Element (Nested)")
+    xml_element: base_xml_element_model = Field(..., title="Assert Xml Element")
 
 
 class xml_element_model_relaxed(base_xml_element_model_relaxed):
     r"""Assert if the XML file contains element(s) or tag(s) with the specified
     [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
-    or ``min`` and ``max`` are given also the number of occurrences is checked.
+    or ``min`` and ``max`` are given also the number of occurences is checked.
 
     ```xml
     <assert_contents>
@@ -1838,7 +2087,7 @@ class xml_element_model_relaxed(base_xml_element_model_relaxed):
     </assert_contents>
     ```
 
-    With ``negate="true"`` the outcome of the assertions wrt the presence and number
+    With ``negate="true"`` the outcome of the assertions wrt the precence and number
     of ``path`` can be negated. If there are any sub assertions then check them against
 
     - the content of the attribute ``attribute``
@@ -1853,12 +2102,13 @@ class xml_element_model_relaxed(base_xml_element_model_relaxed):
     ```
 
     Sub-assertions are not subject to the ``negate`` attribute of ``xml_element``.
-    If ``all`` is ``true`` then the sub assertions are checked for all occurrences.
+    If ``all`` is ``true`` then the sub assertions are checked for all occurences.
 
     Note that all other XML assertions can be expressed by this assertion (Galaxy
     also implements the other assertions by calling this one)."""
 
-    that: Literal["xml_element"] = "xml_element"
+    model_config = ConfigDict(extra="forbid", title="Assert Xml Element (Relaxed)")
+    that: Literal["xml_element"] = Field("xml_element", title="That")
 
 
 has_json_property_with_text_property_description = """The property name to search the JSON document for."""
@@ -1869,13 +2119,17 @@ has_json_property_with_text_text_description = """The expected text value of the
 class base_has_json_property_with_text_model(AssertionModel):
     """base model for has_json_property_with_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_json_property_with_text_model")
+
     property: str = Field(
         ...,
+        title="Property",
         description=has_json_property_with_text_property_description,
     )
 
     text: str = Field(
         ...,
+        title="Text",
         description=has_json_property_with_text_text_description,
     )
 
@@ -1883,13 +2137,17 @@ class base_has_json_property_with_text_model(AssertionModel):
 class base_has_json_property_with_text_model_relaxed(AssertionModel):
     """base model for has_json_property_with_text describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_json_property_with_text_model_relaxed")
+
     property: str = Field(
         ...,
+        title="Property",
         description=has_json_property_with_text_property_description,
     )
 
     text: str = Field(
         ...,
+        title="Text",
         description=has_json_property_with_text_text_description,
     )
 
@@ -1901,13 +2159,17 @@ class has_json_property_with_text_model(base_has_json_property_with_text_model):
     <has_json_property_with_text property="color" text="red" />
     ```"""
 
-    that: Literal["has_json_property_with_text"] = "has_json_property_with_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Json Property With Text")
+    that: Literal["has_json_property_with_text"] = Field("has_json_property_with_text", title="That")
 
 
 class has_json_property_with_text_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_json_property_with_text: base_has_json_property_with_text_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Json Property With Text (Nested)")
+    has_json_property_with_text: base_has_json_property_with_text_model = Field(
+        ..., title="Assert Has Json Property With Text"
+    )
 
 
 class has_json_property_with_text_model_relaxed(base_has_json_property_with_text_model_relaxed):
@@ -1917,7 +2179,8 @@ class has_json_property_with_text_model_relaxed(base_has_json_property_with_text
     <has_json_property_with_text property="color" text="red" />
     ```"""
 
-    that: Literal["has_json_property_with_text"] = "has_json_property_with_text"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Json Property With Text (Relaxed)")
+    that: Literal["has_json_property_with_text"] = Field("has_json_property_with_text", title="That")
 
 
 has_json_property_with_value_property_description = """The property name to search the JSON document for."""
@@ -1930,13 +2193,17 @@ has_json_property_with_value_value_description = (
 class base_has_json_property_with_value_model(AssertionModel):
     """base model for has_json_property_with_value describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_json_property_with_value_model")
+
     property: str = Field(
         ...,
+        title="Property",
         description=has_json_property_with_value_property_description,
     )
 
     value: str = Field(
         ...,
+        title="Value",
         description=has_json_property_with_value_value_description,
     )
 
@@ -1944,13 +2211,17 @@ class base_has_json_property_with_value_model(AssertionModel):
 class base_has_json_property_with_value_model_relaxed(AssertionModel):
     """base model for has_json_property_with_value describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_json_property_with_value_model_relaxed")
+
     property: str = Field(
         ...,
+        title="Property",
         description=has_json_property_with_value_property_description,
     )
 
     value: str = Field(
         ...,
+        title="Value",
         description=has_json_property_with_value_value_description,
     )
 
@@ -1962,13 +2233,17 @@ class has_json_property_with_value_model(base_has_json_property_with_value_model
     <has_json_property_with_value property="skipped_columns" value="[1, 3, 5]" />
     ```"""
 
-    that: Literal["has_json_property_with_value"] = "has_json_property_with_value"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Json Property With Value")
+    that: Literal["has_json_property_with_value"] = Field("has_json_property_with_value", title="That")
 
 
 class has_json_property_with_value_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_json_property_with_value: base_has_json_property_with_value_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Json Property With Value (Nested)")
+    has_json_property_with_value: base_has_json_property_with_value_model = Field(
+        ..., title="Assert Has Json Property With Value"
+    )
 
 
 class has_json_property_with_value_model_relaxed(base_has_json_property_with_value_model_relaxed):
@@ -1978,7 +2253,8 @@ class has_json_property_with_value_model_relaxed(base_has_json_property_with_val
     <has_json_property_with_value property="skipped_columns" value="[1, 3, 5]" />
     ```"""
 
-    that: Literal["has_json_property_with_value"] = "has_json_property_with_value"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Json Property With Value (Relaxed)")
+    that: Literal["has_json_property_with_value"] = Field("has_json_property_with_value", title="That")
 
 
 has_h5_attribute_key_description = """HDF5 attribute to check value of."""
@@ -1989,13 +2265,17 @@ has_h5_attribute_value_description = """Expected value of HDF5 attribute to chec
 class base_has_h5_attribute_model(AssertionModel):
     """base model for has_h5_attribute describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_h5_attribute_model")
+
     key: str = Field(
         ...,
+        title="Key",
         description=has_h5_attribute_key_description,
     )
 
     value: str = Field(
         ...,
+        title="Value",
         description=has_h5_attribute_value_description,
     )
 
@@ -2003,13 +2283,17 @@ class base_has_h5_attribute_model(AssertionModel):
 class base_has_h5_attribute_model_relaxed(AssertionModel):
     """base model for has_h5_attribute describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_h5_attribute_model_relaxed")
+
     key: str = Field(
         ...,
+        title="Key",
         description=has_h5_attribute_key_description,
     )
 
     value: str = Field(
         ...,
+        title="Value",
         description=has_h5_attribute_value_description,
     )
 
@@ -2021,13 +2305,15 @@ class has_h5_attribute_model(base_has_h5_attribute_model):
     <has_h5_attribute key="nchroms" value="15" />
     ```"""
 
-    that: Literal["has_h5_attribute"] = "has_h5_attribute"
+    model_config = ConfigDict(extra="forbid", title="Assert Has H5 Attribute")
+    that: Literal["has_h5_attribute"] = Field("has_h5_attribute", title="That")
 
 
 class has_h5_attribute_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_h5_attribute: base_has_h5_attribute_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has H5 Attribute (Nested)")
+    has_h5_attribute: base_has_h5_attribute_model = Field(..., title="Assert Has H5 Attribute")
 
 
 class has_h5_attribute_model_relaxed(base_has_h5_attribute_model_relaxed):
@@ -2037,7 +2323,8 @@ class has_h5_attribute_model_relaxed(base_has_h5_attribute_model_relaxed):
     <has_h5_attribute key="nchroms" value="15" />
     ```"""
 
-    that: Literal["has_h5_attribute"] = "has_h5_attribute"
+    model_config = ConfigDict(extra="forbid", title="Assert Has H5 Attribute (Relaxed)")
+    that: Literal["has_h5_attribute"] = Field("has_h5_attribute", title="That")
 
 
 has_h5_keys_keys_description = """HDF5 attributes to check value of as a comma-separated string."""
@@ -2046,8 +2333,11 @@ has_h5_keys_keys_description = """HDF5 attributes to check value of as a comma-s
 class base_has_h5_keys_model(AssertionModel):
     """base model for has_h5_keys describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_h5_keys_model")
+
     keys: str = Field(
         ...,
+        title="Keys",
         description=has_h5_keys_keys_description,
     )
 
@@ -2055,8 +2345,11 @@ class base_has_h5_keys_model(AssertionModel):
 class base_has_h5_keys_model_relaxed(AssertionModel):
     """base model for has_h5_keys describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_h5_keys_model_relaxed")
+
     keys: str = Field(
         ...,
+        title="Keys",
         description=has_h5_keys_keys_description,
     )
 
@@ -2064,19 +2357,22 @@ class base_has_h5_keys_model_relaxed(AssertionModel):
 class has_h5_keys_model(base_has_h5_keys_model):
     r"""Asserts the specified HDF5 output has the given keys."""
 
-    that: Literal["has_h5_keys"] = "has_h5_keys"
+    model_config = ConfigDict(extra="forbid", title="Assert Has H5 Keys")
+    that: Literal["has_h5_keys"] = Field("has_h5_keys", title="That")
 
 
 class has_h5_keys_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_h5_keys: base_has_h5_keys_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has H5 Keys (Nested)")
+    has_h5_keys: base_has_h5_keys_model = Field(..., title="Assert Has H5 Keys")
 
 
 class has_h5_keys_model_relaxed(base_has_h5_keys_model_relaxed):
     r"""Asserts the specified HDF5 output has the given keys."""
 
-    that: Literal["has_h5_keys"] = "has_h5_keys"
+    model_config = ConfigDict(extra="forbid", title="Assert Has H5 Keys (Relaxed)")
+    that: Literal["has_h5_keys"] = Field("has_h5_keys", title="That")
 
 
 has_archive_member_path_description = """The regular expression specifying the archive member."""
@@ -2101,13 +2397,17 @@ has_archive_member_negate_description = """A boolean that can be set to true to 
 class base_has_archive_member_model(AssertionModel):
     """base model for has_archive_member describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_archive_member_model")
+
     path: str = Field(
         ...,
+        title="Path",
         description=has_archive_member_path_description,
     )
 
     all: typing.Union[bool, str] = Field(
         False,
+        title="All",
         description=has_archive_member_all_description,
     )
 
@@ -2117,6 +2417,7 @@ class base_has_archive_member_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_archive_member_n_description,
     )
 
@@ -2124,6 +2425,7 @@ class base_has_archive_member_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_archive_member_delta_description,
     )
 
@@ -2133,6 +2435,7 @@ class base_has_archive_member_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_archive_member_min_description,
     )
 
@@ -2142,28 +2445,34 @@ class base_has_archive_member_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_archive_member_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_archive_member_negate_description,
     )
 
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
 
 class base_has_archive_member_model_relaxed(AssertionModel):
     """base model for has_archive_member describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_archive_member_model_relaxed")
+
     path: str = Field(
         ...,
+        title="Path",
         description=has_archive_member_path_description,
     )
 
     all: typing.Union[bool, str] = Field(
         False,
+        title="All",
         description=has_archive_member_all_description,
     )
 
@@ -2173,6 +2482,7 @@ class base_has_archive_member_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="N",
         description=has_archive_member_n_description,
     )
 
@@ -2180,6 +2490,7 @@ class base_has_archive_member_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_archive_member_delta_description,
     )
 
@@ -2189,6 +2500,7 @@ class base_has_archive_member_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_archive_member_min_description,
     )
 
@@ -2198,16 +2510,18 @@ class base_has_archive_member_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_archive_member_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_archive_member_negate_description,
     )
 
-    children: typing.Optional["assertion_list"] = None
-    asserts: typing.Optional["assertion_list"] = None
+    children: typing.Optional["assertion_list"] = Field(None, title="Children")
+    asserts: typing.Optional["assertion_list"] = Field(None, title="Asserts")
 
 
 class has_archive_member_model(base_has_archive_member_model):
@@ -2256,13 +2570,15 @@ class has_archive_member_model(base_has_archive_member_model):
     check if the file is an archive at all, which is also done by the function, is
     not affected."""
 
-    that: Literal["has_archive_member"] = "has_archive_member"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Archive Member")
+    that: Literal["has_archive_member"] = Field("has_archive_member", title="That")
 
 
 class has_archive_member_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_archive_member: base_has_archive_member_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Archive Member (Nested)")
+    has_archive_member: base_has_archive_member_model = Field(..., title="Assert Has Archive Member")
 
 
 class has_archive_member_model_relaxed(base_has_archive_member_model_relaxed):
@@ -2311,7 +2627,8 @@ class has_archive_member_model_relaxed(base_has_archive_member_model_relaxed):
     check if the file is an archive at all, which is also done by the function, is
     not affected."""
 
-    that: Literal["has_archive_member"] = "has_archive_member"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Archive Member (Relaxed)")
+    that: Literal["has_archive_member"] = Field("has_archive_member", title="That")
 
 
 has_size_value_description = """Deprecated alias for `size`"""
@@ -2332,12 +2649,15 @@ has_size_negate_description = """A boolean that can be set to true to negate the
 class base_has_size_model(AssertionModel):
     """base model for has_size describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_size_model")
+
     value: Annotated[
         typing.Optional[typing.Union[str, int]],
         BeforeValidator(check_bytes),
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Value",
         description=has_size_value_description,
     )
 
@@ -2347,6 +2667,7 @@ class base_has_size_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Size",
         description=has_size_size_description,
     )
 
@@ -2354,6 +2675,7 @@ class base_has_size_model(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_size_delta_description,
     )
 
@@ -2363,6 +2685,7 @@ class base_has_size_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_size_min_description,
     )
 
@@ -2372,11 +2695,13 @@ class base_has_size_model(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_size_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_size_negate_description,
     )
 
@@ -2384,12 +2709,15 @@ class base_has_size_model(AssertionModel):
 class base_has_size_model_relaxed(AssertionModel):
     """base model for has_size describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_size_model_relaxed")
+
     value: Annotated[
         typing.Optional[typing.Union[str, int]],
         BeforeValidator(check_bytes),
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Value",
         description=has_size_value_description,
     )
 
@@ -2399,6 +2727,7 @@ class base_has_size_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Size",
         description=has_size_size_description,
     )
 
@@ -2406,6 +2735,7 @@ class base_has_size_model_relaxed(AssertionModel):
         typing.Union[int, str], BeforeValidator(check_bytes), BeforeValidator(check_non_negative_if_int)
     ] = Field(
         0,
+        title="Delta",
         description=has_size_delta_description,
     )
 
@@ -2415,6 +2745,7 @@ class base_has_size_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Min",
         description=has_size_min_description,
     )
 
@@ -2424,11 +2755,13 @@ class base_has_size_model_relaxed(AssertionModel):
         BeforeValidator(check_non_negative_if_int),
     ] = Field(
         None,
+        title="Max",
         description=has_size_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_size_negate_description,
     )
 
@@ -2439,13 +2772,15 @@ class has_size_model(base_has_size_model):
     Attributes size and value or synonyms though value is considered deprecated.
     The size optionally allows for absolute (``delta``) difference."""
 
-    that: Literal["has_size"] = "has_size"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Size")
+    that: Literal["has_size"] = Field("has_size", title="That")
 
 
 class has_size_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_size: base_has_size_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Size (Nested)")
+    has_size: base_has_size_model = Field(..., title="Assert Has Size")
 
 
 class has_size_model_relaxed(base_has_size_model_relaxed):
@@ -2454,7 +2789,8 @@ class has_size_model_relaxed(base_has_size_model_relaxed):
     Attributes size and value or synonyms though value is considered deprecated.
     The size optionally allows for absolute (``delta``) difference."""
 
-    that: Literal["has_size"] = "has_size"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Size (Relaxed)")
+    that: Literal["has_size"] = Field("has_size", title="That")
 
 
 has_image_center_of_mass_center_of_mass_description = """The required center of mass of the image intensities (horizontal and vertical coordinate, separated by a comma)."""
@@ -2475,28 +2811,35 @@ has_image_center_of_mass_eps_description = (
 class base_has_image_center_of_mass_model(AssertionModel):
     """base model for has_image_center_of_mass describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_center_of_mass_model")
+
     center_of_mass: Annotated[str, BeforeValidator(check_center_of_mass)] = Field(
         ...,
+        title="Center Of Mass",
         description=has_image_center_of_mass_center_of_mass_description,
     )
 
     channel: typing.Optional[StrictInt] = Field(
         None,
+        title="Channel",
         description=has_image_center_of_mass_channel_description,
     )
 
     slice: typing.Optional[StrictInt] = Field(
         None,
+        title="Slice",
         description=has_image_center_of_mass_slice_description,
     )
 
     frame: typing.Optional[StrictInt] = Field(
         None,
+        title="Frame",
         description=has_image_center_of_mass_frame_description,
     )
 
     eps: Annotated[typing.Union[StrictInt, StrictFloat], BeforeValidator(check_non_negative_if_set)] = Field(
         0.01,
+        title="Eps",
         description=has_image_center_of_mass_eps_description,
     )
 
@@ -2504,28 +2847,35 @@ class base_has_image_center_of_mass_model(AssertionModel):
 class base_has_image_center_of_mass_model_relaxed(AssertionModel):
     """base model for has_image_center_of_mass describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_center_of_mass_model_relaxed")
+
     center_of_mass: Annotated[str, BeforeValidator(check_center_of_mass)] = Field(
         ...,
+        title="Center Of Mass",
         description=has_image_center_of_mass_center_of_mass_description,
     )
 
     channel: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Channel",
         description=has_image_center_of_mass_channel_description,
     )
 
     slice: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Slice",
         description=has_image_center_of_mass_slice_description,
     )
 
     frame: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Frame",
         description=has_image_center_of_mass_frame_description,
     )
 
     eps: Annotated[typing.Union[float, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0.01,
+        title="Eps",
         description=has_image_center_of_mass_eps_description,
     )
 
@@ -2537,13 +2887,15 @@ class has_image_center_of_mass_model(base_has_image_center_of_mass_model):
     or has an Euclidean distance of ``eps`` or less to that point (e.g.,
     ``<has_image_center_of_mass center_of_mass="511.07, 223.34" />``)."""
 
-    that: Literal["has_image_center_of_mass"] = "has_image_center_of_mass"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Center Of Mass")
+    that: Literal["has_image_center_of_mass"] = Field("has_image_center_of_mass", title="That")
 
 
 class has_image_center_of_mass_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_center_of_mass: base_has_image_center_of_mass_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Center Of Mass (Nested)")
+    has_image_center_of_mass: base_has_image_center_of_mass_model = Field(..., title="Assert Has Image Center Of Mass")
 
 
 class has_image_center_of_mass_model_relaxed(base_has_image_center_of_mass_model_relaxed):
@@ -2553,7 +2905,8 @@ class has_image_center_of_mass_model_relaxed(base_has_image_center_of_mass_model
     or has an Euclidean distance of ``eps`` or less to that point (e.g.,
     ``<has_image_center_of_mass center_of_mass="511.07, 223.34" />``)."""
 
-    that: Literal["has_image_center_of_mass"] = "has_image_center_of_mass"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Center Of Mass (Relaxed)")
+    that: Literal["has_image_center_of_mass"] = Field("has_image_center_of_mass", title="That")
 
 
 has_image_channels_channels_description = """Expected number of channels of the image."""
@@ -2570,28 +2923,35 @@ has_image_channels_negate_description = """A boolean that can be set to true to 
 class base_has_image_channels_model(AssertionModel):
     """base model for has_image_channels describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_channels_model")
+
     channels: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Channels",
         description=has_image_channels_channels_description,
     )
 
     delta: Annotated[StrictInt, BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_channels_delta_description,
     )
 
     min: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_channels_min_description,
     )
 
     max: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_channels_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_channels_negate_description,
     )
 
@@ -2599,28 +2959,35 @@ class base_has_image_channels_model(AssertionModel):
 class base_has_image_channels_model_relaxed(AssertionModel):
     """base model for has_image_channels describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_channels_model_relaxed")
+
     channels: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Channels",
         description=has_image_channels_channels_description,
     )
 
     delta: Annotated[typing.Union[int, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_channels_delta_description,
     )
 
     min: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_channels_min_description,
     )
 
     max: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_channels_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_channels_negate_description,
     )
 
@@ -2632,13 +2999,15 @@ class has_image_channels_model(base_has_image_channels_model):
 
     Alternatively the range of the expected number of channels can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_channels"] = "has_image_channels"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Channels")
+    that: Literal["has_image_channels"] = Field("has_image_channels", title="That")
 
 
 class has_image_channels_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_channels: base_has_image_channels_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Channels (Nested)")
+    has_image_channels: base_has_image_channels_model = Field(..., title="Assert Has Image Channels")
 
 
 class has_image_channels_model_relaxed(base_has_image_channels_model_relaxed):
@@ -2648,7 +3017,8 @@ class has_image_channels_model_relaxed(base_has_image_channels_model_relaxed):
 
     Alternatively the range of the expected number of channels can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_channels"] = "has_image_channels"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Channels (Relaxed)")
+    that: Literal["has_image_channels"] = Field("has_image_channels", title="That")
 
 
 has_image_depth_depth_description = """Expected depth of the image (number of slices)."""
@@ -2665,28 +3035,35 @@ has_image_depth_negate_description = """A boolean that can be set to true to neg
 class base_has_image_depth_model(AssertionModel):
     """base model for has_image_depth describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_depth_model")
+
     depth: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Depth",
         description=has_image_depth_depth_description,
     )
 
     delta: Annotated[StrictInt, BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_depth_delta_description,
     )
 
     min: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_depth_min_description,
     )
 
     max: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_depth_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_depth_negate_description,
     )
 
@@ -2694,28 +3071,35 @@ class base_has_image_depth_model(AssertionModel):
 class base_has_image_depth_model_relaxed(AssertionModel):
     """base model for has_image_depth describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_depth_model_relaxed")
+
     depth: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Depth",
         description=has_image_depth_depth_description,
     )
 
     delta: Annotated[typing.Union[int, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_depth_delta_description,
     )
 
     min: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_depth_min_description,
     )
 
     max: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_depth_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_depth_negate_description,
     )
 
@@ -2726,13 +3110,15 @@ class has_image_depth_model(base_has_image_depth_model):
     The depth is plus/minus ``delta`` (e.g., ``<has_image_depth depth="512" delta="2" />``).
     Alternatively the range of the expected depth can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_depth"] = "has_image_depth"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Depth")
+    that: Literal["has_image_depth"] = Field("has_image_depth", title="That")
 
 
 class has_image_depth_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_depth: base_has_image_depth_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Depth (Nested)")
+    has_image_depth: base_has_image_depth_model = Field(..., title="Assert Has Image Depth")
 
 
 class has_image_depth_model_relaxed(base_has_image_depth_model_relaxed):
@@ -2741,7 +3127,8 @@ class has_image_depth_model_relaxed(base_has_image_depth_model_relaxed):
     The depth is plus/minus ``delta`` (e.g., ``<has_image_depth depth="512" delta="2" />``).
     Alternatively the range of the expected depth can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_depth"] = "has_image_depth"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Depth (Relaxed)")
+    that: Literal["has_image_depth"] = Field("has_image_depth", title="That")
 
 
 has_image_frames_frames_description = """Expected number of frames in the image sequence (number of time steps)."""
@@ -2758,28 +3145,35 @@ has_image_frames_negate_description = """A boolean that can be set to true to ne
 class base_has_image_frames_model(AssertionModel):
     """base model for has_image_frames describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_frames_model")
+
     frames: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Frames",
         description=has_image_frames_frames_description,
     )
 
     delta: Annotated[StrictInt, BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_frames_delta_description,
     )
 
     min: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_frames_min_description,
     )
 
     max: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_frames_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_frames_negate_description,
     )
 
@@ -2787,28 +3181,35 @@ class base_has_image_frames_model(AssertionModel):
 class base_has_image_frames_model_relaxed(AssertionModel):
     """base model for has_image_frames describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_frames_model_relaxed")
+
     frames: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Frames",
         description=has_image_frames_frames_description,
     )
 
     delta: Annotated[typing.Union[int, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_frames_delta_description,
     )
 
     min: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_frames_min_description,
     )
 
     max: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_frames_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_frames_negate_description,
     )
 
@@ -2819,13 +3220,15 @@ class has_image_frames_model(base_has_image_frames_model):
     The number of frames is plus/minus ``delta`` (e.g., ``<has_image_frames depth="512" delta="2" />``).
     Alternatively the range of the expected number of frames can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_frames"] = "has_image_frames"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Frames")
+    that: Literal["has_image_frames"] = Field("has_image_frames", title="That")
 
 
 class has_image_frames_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_frames: base_has_image_frames_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Frames (Nested)")
+    has_image_frames: base_has_image_frames_model = Field(..., title="Assert Has Image Frames")
 
 
 class has_image_frames_model_relaxed(base_has_image_frames_model_relaxed):
@@ -2834,7 +3237,8 @@ class has_image_frames_model_relaxed(base_has_image_frames_model_relaxed):
     The number of frames is plus/minus ``delta`` (e.g., ``<has_image_frames depth="512" delta="2" />``).
     Alternatively the range of the expected number of frames can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_frames"] = "has_image_frames"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Frames (Relaxed)")
+    that: Literal["has_image_frames"] = Field("has_image_frames", title="That")
 
 
 has_image_height_height_description = """Expected height of the image (in pixels)."""
@@ -2851,28 +3255,35 @@ has_image_height_negate_description = """A boolean that can be set to true to ne
 class base_has_image_height_model(AssertionModel):
     """base model for has_image_height describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_height_model")
+
     height: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Height",
         description=has_image_height_height_description,
     )
 
     delta: Annotated[StrictInt, BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_height_delta_description,
     )
 
     min: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_height_min_description,
     )
 
     max: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_height_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_height_negate_description,
     )
 
@@ -2880,28 +3291,35 @@ class base_has_image_height_model(AssertionModel):
 class base_has_image_height_model_relaxed(AssertionModel):
     """base model for has_image_height describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_height_model_relaxed")
+
     height: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Height",
         description=has_image_height_height_description,
     )
 
     delta: Annotated[typing.Union[int, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_height_delta_description,
     )
 
     min: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_height_min_description,
     )
 
     max: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_height_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_height_negate_description,
     )
 
@@ -2912,13 +3330,15 @@ class has_image_height_model(base_has_image_height_model):
     The height is plus/minus ``delta`` (e.g., ``<has_image_height height="512" delta="2" />``).
     Alternatively the range of the expected height can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_height"] = "has_image_height"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Height")
+    that: Literal["has_image_height"] = Field("has_image_height", title="That")
 
 
 class has_image_height_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_height: base_has_image_height_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Height (Nested)")
+    has_image_height: base_has_image_height_model = Field(..., title="Assert Has Image Height")
 
 
 class has_image_height_model_relaxed(base_has_image_height_model_relaxed):
@@ -2927,7 +3347,8 @@ class has_image_height_model_relaxed(base_has_image_height_model_relaxed):
     The height is plus/minus ``delta`` (e.g., ``<has_image_height height="512" delta="2" />``).
     Alternatively the range of the expected height can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_height"] = "has_image_height"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Height (Relaxed)")
+    that: Literal["has_image_height"] = Field("has_image_height", title="That")
 
 
 has_image_mean_intensity_channel_description = """Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel)."""
@@ -2950,38 +3371,47 @@ has_image_mean_intensity_max_description = """An upper bound of the required mea
 class base_has_image_mean_intensity_model(AssertionModel):
     """base model for has_image_mean_intensity describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_mean_intensity_model")
+
     channel: typing.Optional[StrictInt] = Field(
         None,
+        title="Channel",
         description=has_image_mean_intensity_channel_description,
     )
 
     slice: typing.Optional[StrictInt] = Field(
         None,
+        title="Slice",
         description=has_image_mean_intensity_slice_description,
     )
 
     frame: typing.Optional[StrictInt] = Field(
         None,
+        title="Frame",
         description=has_image_mean_intensity_frame_description,
     )
 
     mean_intensity: typing.Optional[typing.Union[StrictInt, StrictFloat]] = Field(
         None,
+        title="Mean Intensity",
         description=has_image_mean_intensity_mean_intensity_description,
     )
 
     eps: Annotated[typing.Union[StrictInt, StrictFloat], BeforeValidator(check_non_negative_if_set)] = Field(
         0.01,
+        title="Eps",
         description=has_image_mean_intensity_eps_description,
     )
 
     min: typing.Optional[typing.Union[StrictInt, StrictFloat]] = Field(
         None,
+        title="Min",
         description=has_image_mean_intensity_min_description,
     )
 
     max: typing.Optional[typing.Union[StrictInt, StrictFloat]] = Field(
         None,
+        title="Max",
         description=has_image_mean_intensity_max_description,
     )
 
@@ -2989,38 +3419,47 @@ class base_has_image_mean_intensity_model(AssertionModel):
 class base_has_image_mean_intensity_model_relaxed(AssertionModel):
     """base model for has_image_mean_intensity describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_mean_intensity_model_relaxed")
+
     channel: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Channel",
         description=has_image_mean_intensity_channel_description,
     )
 
     slice: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Slice",
         description=has_image_mean_intensity_slice_description,
     )
 
     frame: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Frame",
         description=has_image_mean_intensity_frame_description,
     )
 
     mean_intensity: typing.Optional[typing.Union[float, str]] = Field(
         None,
+        title="Mean Intensity",
         description=has_image_mean_intensity_mean_intensity_description,
     )
 
     eps: Annotated[typing.Union[float, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0.01,
+        title="Eps",
         description=has_image_mean_intensity_eps_description,
     )
 
     min: typing.Optional[typing.Union[float, str]] = Field(
         None,
+        title="Min",
         description=has_image_mean_intensity_min_description,
     )
 
     max: typing.Optional[typing.Union[float, str]] = Field(
         None,
+        title="Max",
         description=has_image_mean_intensity_max_description,
     )
 
@@ -3031,13 +3470,15 @@ class has_image_mean_intensity_model(base_has_image_mean_intensity_model):
     The mean intensity value is plus/minus ``eps`` (e.g., ``<has_image_mean_intensity mean_intensity="0.83" />``).
     Alternatively the range of the expected mean intensity value can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_mean_intensity"] = "has_image_mean_intensity"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Mean Intensity")
+    that: Literal["has_image_mean_intensity"] = Field("has_image_mean_intensity", title="That")
 
 
 class has_image_mean_intensity_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_mean_intensity: base_has_image_mean_intensity_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Mean Intensity (Nested)")
+    has_image_mean_intensity: base_has_image_mean_intensity_model = Field(..., title="Assert Has Image Mean Intensity")
 
 
 class has_image_mean_intensity_model_relaxed(base_has_image_mean_intensity_model_relaxed):
@@ -3046,7 +3487,8 @@ class has_image_mean_intensity_model_relaxed(base_has_image_mean_intensity_model
     The mean intensity value is plus/minus ``eps`` (e.g., ``<has_image_mean_intensity mean_intensity="0.83" />``).
     Alternatively the range of the expected mean intensity value can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_mean_intensity"] = "has_image_mean_intensity"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Mean Intensity (Relaxed)")
+    that: Literal["has_image_mean_intensity"] = Field("has_image_mean_intensity", title="That")
 
 
 has_image_mean_object_size_channel_description = """Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel)."""
@@ -3077,28 +3519,35 @@ has_image_mean_object_size_max_description = (
 class base_has_image_mean_object_size_model(AssertionModel):
     """base model for has_image_mean_object_size describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_mean_object_size_model")
+
     channel: typing.Optional[StrictInt] = Field(
         None,
+        title="Channel",
         description=has_image_mean_object_size_channel_description,
     )
 
     slice: typing.Optional[StrictInt] = Field(
         None,
+        title="Slice",
         description=has_image_mean_object_size_slice_description,
     )
 
     frame: typing.Optional[StrictInt] = Field(
         None,
+        title="Frame",
         description=has_image_mean_object_size_frame_description,
     )
 
-    labels: typing.Optional[typing.List[int]] = Field(
+    labels: typing.Optional[typing.List[typing.Union[StrictInt, StrictFloat]]] = Field(
         None,
+        title="Labels",
         description=has_image_mean_object_size_labels_description,
     )
 
-    exclude_labels: typing.Optional[typing.List[int]] = Field(
+    exclude_labels: typing.Optional[typing.List[typing.Union[StrictInt, StrictFloat]]] = Field(
         None,
+        title="Exclude Labels",
         description=has_image_mean_object_size_exclude_labels_description,
     )
 
@@ -3106,11 +3555,13 @@ class base_has_image_mean_object_size_model(AssertionModel):
         typing.Optional[typing.Union[StrictInt, StrictFloat]], BeforeValidator(check_non_negative_if_set)
     ] = Field(
         None,
+        title="Mean Object Size",
         description=has_image_mean_object_size_mean_object_size_description,
     )
 
     eps: Annotated[typing.Union[StrictInt, StrictFloat], BeforeValidator(check_non_negative_if_set)] = Field(
         0.01,
+        title="Eps",
         description=has_image_mean_object_size_eps_description,
     )
 
@@ -3118,6 +3569,7 @@ class base_has_image_mean_object_size_model(AssertionModel):
         typing.Optional[typing.Union[StrictInt, StrictFloat]], BeforeValidator(check_non_negative_if_set)
     ] = Field(
         None,
+        title="Min",
         description=has_image_mean_object_size_min_description,
     )
 
@@ -3125,6 +3577,7 @@ class base_has_image_mean_object_size_model(AssertionModel):
         typing.Optional[typing.Union[StrictInt, StrictFloat]], BeforeValidator(check_non_negative_if_set)
     ] = Field(
         None,
+        title="Max",
         description=has_image_mean_object_size_max_description,
     )
 
@@ -3132,28 +3585,35 @@ class base_has_image_mean_object_size_model(AssertionModel):
 class base_has_image_mean_object_size_model_relaxed(AssertionModel):
     """base model for has_image_mean_object_size describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_mean_object_size_model_relaxed")
+
     channel: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Channel",
         description=has_image_mean_object_size_channel_description,
     )
 
     slice: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Slice",
         description=has_image_mean_object_size_slice_description,
     )
 
     frame: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Frame",
         description=has_image_mean_object_size_frame_description,
     )
 
-    labels: typing.Optional[typing.Union[str, typing.List[int]]] = Field(
+    labels: typing.Optional[typing.Union[str, typing.List[typing.Union[float, int]]]] = Field(
         None,
+        title="Labels",
         description=has_image_mean_object_size_labels_description,
     )
 
-    exclude_labels: typing.Optional[typing.Union[str, typing.List[int]]] = Field(
+    exclude_labels: typing.Optional[typing.Union[str, typing.List[typing.Union[float, int]]]] = Field(
         None,
+        title="Exclude Labels",
         description=has_image_mean_object_size_exclude_labels_description,
     )
 
@@ -3161,21 +3621,25 @@ class base_has_image_mean_object_size_model_relaxed(AssertionModel):
         typing.Optional[typing.Union[float, str]], BeforeValidator(check_non_negative_if_set)
     ] = Field(
         None,
+        title="Mean Object Size",
         description=has_image_mean_object_size_mean_object_size_description,
     )
 
     eps: Annotated[typing.Union[float, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0.01,
+        title="Eps",
         description=has_image_mean_object_size_eps_description,
     )
 
     min: Annotated[typing.Optional[typing.Union[float, str]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_mean_object_size_min_description,
     )
 
     max: Annotated[typing.Optional[typing.Union[float, str]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_mean_object_size_max_description,
     )
 
@@ -3187,13 +3651,17 @@ class has_image_mean_object_size_model(base_has_image_mean_object_size_model):
 
     The labels must be unique."""
 
-    that: Literal["has_image_mean_object_size"] = "has_image_mean_object_size"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Mean Object Size")
+    that: Literal["has_image_mean_object_size"] = Field("has_image_mean_object_size", title="That")
 
 
 class has_image_mean_object_size_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_mean_object_size: base_has_image_mean_object_size_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Mean Object Size (Nested)")
+    has_image_mean_object_size: base_has_image_mean_object_size_model = Field(
+        ..., title="Assert Has Image Mean Object Size"
+    )
 
 
 class has_image_mean_object_size_model_relaxed(base_has_image_mean_object_size_model_relaxed):
@@ -3203,7 +3671,8 @@ class has_image_mean_object_size_model_relaxed(base_has_image_mean_object_size_m
 
     The labels must be unique."""
 
-    that: Literal["has_image_mean_object_size"] = "has_image_mean_object_size"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Mean Object Size (Relaxed)")
+    that: Literal["has_image_mean_object_size"] = Field("has_image_mean_object_size", title="That")
 
 
 has_image_n_labels_channel_description = """Restricts the assertion to a specific channel of the image (where ``0`` corresponds to the first image channel)."""
@@ -3232,53 +3701,65 @@ has_image_n_labels_negate_description = """A boolean that can be set to true to 
 class base_has_image_n_labels_model(AssertionModel):
     """base model for has_image_n_labels describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_n_labels_model")
+
     channel: typing.Optional[StrictInt] = Field(
         None,
+        title="Channel",
         description=has_image_n_labels_channel_description,
     )
 
     slice: typing.Optional[StrictInt] = Field(
         None,
+        title="Slice",
         description=has_image_n_labels_slice_description,
     )
 
     frame: typing.Optional[StrictInt] = Field(
         None,
+        title="Frame",
         description=has_image_n_labels_frame_description,
     )
 
-    labels: typing.Optional[typing.List[int]] = Field(
+    labels: typing.Optional[typing.List[typing.Union[StrictInt, StrictFloat]]] = Field(
         None,
+        title="Labels",
         description=has_image_n_labels_labels_description,
     )
 
-    exclude_labels: typing.Optional[typing.List[int]] = Field(
+    exclude_labels: typing.Optional[typing.List[typing.Union[StrictInt, StrictFloat]]] = Field(
         None,
+        title="Exclude Labels",
         description=has_image_n_labels_exclude_labels_description,
     )
 
     n: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="N",
         description=has_image_n_labels_n_description,
     )
 
     delta: Annotated[StrictInt, BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_n_labels_delta_description,
     )
 
     min: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_n_labels_min_description,
     )
 
     max: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_n_labels_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_n_labels_negate_description,
     )
 
@@ -3286,53 +3767,65 @@ class base_has_image_n_labels_model(AssertionModel):
 class base_has_image_n_labels_model_relaxed(AssertionModel):
     """base model for has_image_n_labels describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_n_labels_model_relaxed")
+
     channel: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Channel",
         description=has_image_n_labels_channel_description,
     )
 
     slice: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Slice",
         description=has_image_n_labels_slice_description,
     )
 
     frame: typing.Optional[typing.Union[str, int]] = Field(
         None,
+        title="Frame",
         description=has_image_n_labels_frame_description,
     )
 
-    labels: typing.Optional[typing.Union[str, typing.List[int]]] = Field(
+    labels: typing.Optional[typing.Union[str, typing.List[typing.Union[float, int]]]] = Field(
         None,
+        title="Labels",
         description=has_image_n_labels_labels_description,
     )
 
-    exclude_labels: typing.Optional[typing.Union[str, typing.List[int]]] = Field(
+    exclude_labels: typing.Optional[typing.Union[str, typing.List[typing.Union[float, int]]]] = Field(
         None,
+        title="Exclude Labels",
         description=has_image_n_labels_exclude_labels_description,
     )
 
     n: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="N",
         description=has_image_n_labels_n_description,
     )
 
     delta: Annotated[typing.Union[int, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_n_labels_delta_description,
     )
 
     min: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_n_labels_min_description,
     )
 
     max: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_n_labels_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_n_labels_negate_description,
     )
 
@@ -3345,13 +3838,15 @@ class has_image_n_labels_model(base_has_image_n_labels_model):
 
     The primary usage of this assertion is to verify the number of objects in images with uniquely labeled objects."""
 
-    that: Literal["has_image_n_labels"] = "has_image_n_labels"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image N Labels")
+    that: Literal["has_image_n_labels"] = Field("has_image_n_labels", title="That")
 
 
 class has_image_n_labels_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_n_labels: base_has_image_n_labels_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image N Labels (Nested)")
+    has_image_n_labels: base_has_image_n_labels_model = Field(..., title="Assert Has Image N Labels")
 
 
 class has_image_n_labels_model_relaxed(base_has_image_n_labels_model_relaxed):
@@ -3362,7 +3857,8 @@ class has_image_n_labels_model_relaxed(base_has_image_n_labels_model_relaxed):
 
     The primary usage of this assertion is to verify the number of objects in images with uniquely labeled objects."""
 
-    that: Literal["has_image_n_labels"] = "has_image_n_labels"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image N Labels (Relaxed)")
+    that: Literal["has_image_n_labels"] = Field("has_image_n_labels", title="That")
 
 
 has_image_width_width_description = """Expected width of the image (in pixels)."""
@@ -3379,28 +3875,35 @@ has_image_width_negate_description = """A boolean that can be set to true to neg
 class base_has_image_width_model(AssertionModel):
     """base model for has_image_width describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_width_model")
+
     width: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Width",
         description=has_image_width_width_description,
     )
 
     delta: Annotated[StrictInt, BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_width_delta_description,
     )
 
     min: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_width_min_description,
     )
 
     max: Annotated[typing.Optional[StrictInt], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_width_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_width_negate_description,
     )
 
@@ -3408,28 +3911,35 @@ class base_has_image_width_model(AssertionModel):
 class base_has_image_width_model_relaxed(AssertionModel):
     """base model for has_image_width describing attributes."""
 
+    model_config = ConfigDict(extra="forbid", title="base_has_image_width_model_relaxed")
+
     width: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Width",
         description=has_image_width_width_description,
     )
 
     delta: Annotated[typing.Union[int, str], BeforeValidator(check_non_negative_if_set)] = Field(
         0,
+        title="Delta",
         description=has_image_width_delta_description,
     )
 
     min: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Min",
         description=has_image_width_min_description,
     )
 
     max: Annotated[typing.Optional[typing.Union[str, int]], BeforeValidator(check_non_negative_if_set)] = Field(
         None,
+        title="Max",
         description=has_image_width_max_description,
     )
 
     negate: typing.Union[bool, str] = Field(
         False,
+        title="Negate",
         description=has_image_width_negate_description,
     )
 
@@ -3440,13 +3950,15 @@ class has_image_width_model(base_has_image_width_model):
     The width is plus/minus ``delta`` (e.g., ``<has_image_width width="512" delta="2" />``).
     Alternatively the range of the expected width can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_width"] = "has_image_width"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Width")
+    that: Literal["has_image_width"] = Field("has_image_width", title="That")
 
 
 class has_image_width_model_nested(AssertionModel):
     r"""Nested version of this assertion model."""
 
-    has_image_width: base_has_image_width_model
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Width (Nested)")
+    has_image_width: base_has_image_width_model = Field(..., title="Assert Has Image Width")
 
 
 class has_image_width_model_relaxed(base_has_image_width_model_relaxed):
@@ -3455,7 +3967,8 @@ class has_image_width_model_relaxed(base_has_image_width_model_relaxed):
     The width is plus/minus ``delta`` (e.g., ``<has_image_width width="512" delta="2" />``).
     Alternatively the range of the expected width can be specified by ``min`` and/or ``max``."""
 
-    that: Literal["has_image_width"] = "has_image_width"
+    model_config = ConfigDict(extra="forbid", title="Assert Has Image Width (Relaxed)")
+    that: Literal["has_image_width"] = Field("has_image_width", title="That")
 
 
 any_assertion_model_flat = Annotated[
@@ -3566,76 +4079,97 @@ any_assertion_model_flat_relaxed = Annotated[
     Field(discriminator="that"),
 ]
 
-assertion_list = RootModel[typing.List[typing.Union[any_assertion_model_flat, any_assertion_model_nested]]]
+
+class assertion_list(RootModel[typing.List[typing.Union[any_assertion_model_flat, any_assertion_model_nested]]]):
+    model_config = ConfigDict(title="assertion_list")
+
 
 # used to model what the XML conversion should look like - not meant to be consumed outside of
 # of Galaxy internals / linting.
-relaxed_assertion_list = RootModel[typing.List[any_assertion_model_flat_relaxed]]
+class relaxed_assertion_list(RootModel[typing.List[any_assertion_model_flat_relaxed]]):
+    model_config = ConfigDict(title="relaxed_assertion_list")
 
 
 class assertion_dict(AssertionModel):
+    model_config = ConfigDict(extra="forbid", title="assertion_dict")
 
-    has_line: typing.Optional[base_has_line_model] = None
+    has_line: typing.Optional[base_has_line_model] = Field(None, title="Assert Has Line")
 
-    has_line_matching: typing.Optional[base_has_line_matching_model] = None
+    has_line_matching: typing.Optional[base_has_line_matching_model] = Field(None, title="Assert Has Line Matching")
 
-    has_n_lines: typing.Optional[base_has_n_lines_model] = None
+    has_n_lines: typing.Optional[base_has_n_lines_model] = Field(None, title="Assert Has N Lines")
 
-    has_text: typing.Optional[base_has_text_model] = None
+    has_text: typing.Optional[base_has_text_model] = Field(None, title="Assert Has Text")
 
-    has_text_matching: typing.Optional[base_has_text_matching_model] = None
+    has_text_matching: typing.Optional[base_has_text_matching_model] = Field(None, title="Assert Has Text Matching")
 
-    not_has_text: typing.Optional[base_not_has_text_model] = None
+    not_has_text: typing.Optional[base_not_has_text_model] = Field(None, title="Assert Not Has Text")
 
-    has_n_columns: typing.Optional[base_has_n_columns_model] = None
+    has_n_columns: typing.Optional[base_has_n_columns_model] = Field(None, title="Assert Has N Columns")
 
-    attribute_is: typing.Optional[base_attribute_is_model] = None
+    attribute_is: typing.Optional[base_attribute_is_model] = Field(None, title="Assert Attribute Is")
 
-    attribute_matches: typing.Optional[base_attribute_matches_model] = None
+    attribute_matches: typing.Optional[base_attribute_matches_model] = Field(None, title="Assert Attribute Matches")
 
-    element_text: typing.Optional[base_element_text_model] = None
+    element_text: typing.Optional[base_element_text_model] = Field(None, title="Assert Element Text")
 
-    element_text_is: typing.Optional[base_element_text_is_model] = None
+    element_text_is: typing.Optional[base_element_text_is_model] = Field(None, title="Assert Element Text Is")
 
-    element_text_matches: typing.Optional[base_element_text_matches_model] = None
+    element_text_matches: typing.Optional[base_element_text_matches_model] = Field(
+        None, title="Assert Element Text Matches"
+    )
 
-    has_element_with_path: typing.Optional[base_has_element_with_path_model] = None
+    has_element_with_path: typing.Optional[base_has_element_with_path_model] = Field(
+        None, title="Assert Has Element With Path"
+    )
 
-    has_n_elements_with_path: typing.Optional[base_has_n_elements_with_path_model] = None
+    has_n_elements_with_path: typing.Optional[base_has_n_elements_with_path_model] = Field(
+        None, title="Assert Has N Elements With Path"
+    )
 
-    is_valid_xml: typing.Optional[base_is_valid_xml_model] = None
+    is_valid_xml: typing.Optional[base_is_valid_xml_model] = Field(None, title="Assert Is Valid Xml")
 
-    xml_element: typing.Optional[base_xml_element_model] = None
+    xml_element: typing.Optional[base_xml_element_model] = Field(None, title="Assert Xml Element")
 
-    has_json_property_with_text: typing.Optional[base_has_json_property_with_text_model] = None
+    has_json_property_with_text: typing.Optional[base_has_json_property_with_text_model] = Field(
+        None, title="Assert Has Json Property With Text"
+    )
 
-    has_json_property_with_value: typing.Optional[base_has_json_property_with_value_model] = None
+    has_json_property_with_value: typing.Optional[base_has_json_property_with_value_model] = Field(
+        None, title="Assert Has Json Property With Value"
+    )
 
-    has_h5_attribute: typing.Optional[base_has_h5_attribute_model] = None
+    has_h5_attribute: typing.Optional[base_has_h5_attribute_model] = Field(None, title="Assert Has H5 Attribute")
 
-    has_h5_keys: typing.Optional[base_has_h5_keys_model] = None
+    has_h5_keys: typing.Optional[base_has_h5_keys_model] = Field(None, title="Assert Has H5 Keys")
 
-    has_archive_member: typing.Optional[base_has_archive_member_model] = None
+    has_archive_member: typing.Optional[base_has_archive_member_model] = Field(None, title="Assert Has Archive Member")
 
-    has_size: typing.Optional[base_has_size_model] = None
+    has_size: typing.Optional[base_has_size_model] = Field(None, title="Assert Has Size")
 
-    has_image_center_of_mass: typing.Optional[base_has_image_center_of_mass_model] = None
+    has_image_center_of_mass: typing.Optional[base_has_image_center_of_mass_model] = Field(
+        None, title="Assert Has Image Center Of Mass"
+    )
 
-    has_image_channels: typing.Optional[base_has_image_channels_model] = None
+    has_image_channels: typing.Optional[base_has_image_channels_model] = Field(None, title="Assert Has Image Channels")
 
-    has_image_depth: typing.Optional[base_has_image_depth_model] = None
+    has_image_depth: typing.Optional[base_has_image_depth_model] = Field(None, title="Assert Has Image Depth")
 
-    has_image_frames: typing.Optional[base_has_image_frames_model] = None
+    has_image_frames: typing.Optional[base_has_image_frames_model] = Field(None, title="Assert Has Image Frames")
 
-    has_image_height: typing.Optional[base_has_image_height_model] = None
+    has_image_height: typing.Optional[base_has_image_height_model] = Field(None, title="Assert Has Image Height")
 
-    has_image_mean_intensity: typing.Optional[base_has_image_mean_intensity_model] = None
+    has_image_mean_intensity: typing.Optional[base_has_image_mean_intensity_model] = Field(
+        None, title="Assert Has Image Mean Intensity"
+    )
 
-    has_image_mean_object_size: typing.Optional[base_has_image_mean_object_size_model] = None
+    has_image_mean_object_size: typing.Optional[base_has_image_mean_object_size_model] = Field(
+        None, title="Assert Has Image Mean Object Size"
+    )
 
-    has_image_n_labels: typing.Optional[base_has_image_n_labels_model] = None
+    has_image_n_labels: typing.Optional[base_has_image_n_labels_model] = Field(None, title="Assert Has Image N Labels")
 
-    has_image_width: typing.Optional[base_has_image_width_model] = None
+    has_image_width: typing.Optional[base_has_image_width_model] = Field(None, title="Assert Has Image Width")
 
 
 assertions = typing.Union[assertion_list, assertion_dict]

--- a/lib/galaxy/tool_util_models/assertions.py
+++ b/lib/galaxy/tool_util_models/assertions.py
@@ -348,7 +348,7 @@ class base_has_line_matching_model_relaxed(AssertionModel):
 class has_line_matching_model(base_has_line_matching_model):
     r"""Asserts the specified output contains a line matching the
     regular expression specified by the argument expression. If n is given
-    the assertion checks for exactly n occurences."""
+    the assertion checks for exactly n occurrences."""
 
     model_config = ConfigDict(extra="forbid", title="Assert Has Line Matching")
     that: Literal["has_line_matching"] = Field("has_line_matching", title="That")
@@ -364,7 +364,7 @@ class has_line_matching_model_nested(AssertionModel):
 class has_line_matching_model_relaxed(base_has_line_matching_model_relaxed):
     r"""Asserts the specified output contains a line matching the
     regular expression specified by the argument expression. If n is given
-    the assertion checks for exactly n occurences."""
+    the assertion checks for exactly n occurrences."""
 
     model_config = ConfigDict(extra="forbid", title="Assert Has Line Matching (Relaxed)")
     that: Literal["has_line_matching"] = Field("has_line_matching", title="That")
@@ -790,8 +790,8 @@ class base_has_text_matching_model_relaxed(AssertionModel):
 class has_text_matching_model(base_has_text_matching_model):
     r"""Asserts the specified output contains text matching the
     regular expression specified by the argument expression.
-    If n is given the assertion checks for exacly n (nonoverlapping)
-    occurences."""
+    If n is given the assertion checks for exactly n (nonoverlapping)
+    occurrences."""
 
     model_config = ConfigDict(extra="forbid", title="Assert Has Text Matching")
     that: Literal["has_text_matching"] = Field("has_text_matching", title="That")
@@ -807,8 +807,8 @@ class has_text_matching_model_nested(AssertionModel):
 class has_text_matching_model_relaxed(base_has_text_matching_model_relaxed):
     r"""Asserts the specified output contains text matching the
     regular expression specified by the argument expression.
-    If n is given the assertion checks for exacly n (nonoverlapping)
-    occurences."""
+    If n is given the assertion checks for exactly n (nonoverlapping)
+    occurrences."""
 
     model_config = ConfigDict(extra="forbid", title="Assert Has Text Matching (Relaxed)")
     that: Literal["has_text_matching"] = Field("has_text_matching", title="That")
@@ -1013,7 +1013,7 @@ class has_n_columns_model(base_has_n_columns_model):
 
     For instance, ``<has_n_columns n="3"/>``. The assertion tests only the first line.
     Number of columns can optionally also be specified with ``delta``. Alternatively the
-    range of expected occurences can be specified by ``min`` and/or ``max``.
+    range of expected occurrences can be specified by ``min`` and/or ``max``.
 
     Optionally a column separator (``sep``, default is ``       ``) `and comment character(s)
     can be specified (``comment``, default is empty string). The first non-comment
@@ -1036,7 +1036,7 @@ class has_n_columns_model_relaxed(base_has_n_columns_model_relaxed):
 
     For instance, ``<has_n_columns n="3"/>``. The assertion tests only the first line.
     Number of columns can optionally also be specified with ``delta``. Alternatively the
-    range of expected occurences can be specified by ``min`` and/or ``max``.
+    range of expected occurrences can be specified by ``min`` and/or ``max``.
 
     Optionally a column separator (``sep``, default is ``       ``) `and comment character(s)
     can be specified (``comment``, default is empty string). The first non-comment
@@ -1802,7 +1802,7 @@ class has_n_elements_with_path_model(base_has_n_elements_with_path_model):
     ```
 
     Alternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes
-    can be used to specify the range of the expected number of occurences.
+    can be used to specify the range of the expected number of occurrences.
     With ``negate`` the result of the assertion can be inverted."""
 
     model_config = ConfigDict(extra="forbid", title="Assert Has N Elements With Path")
@@ -1827,7 +1827,7 @@ class has_n_elements_with_path_model_relaxed(base_has_n_elements_with_path_model
     ```
 
     Alternatively to ``n`` and ``delta`` also the ``min`` and ``max`` attributes
-    can be used to specify the range of the expected number of occurences.
+    can be used to specify the range of the expected number of occurrences.
     With ``negate`` the result of the assertion can be inverted."""
 
     model_config = ConfigDict(extra="forbid", title="Assert Has N Elements With Path (Relaxed)")
@@ -2033,7 +2033,7 @@ class base_xml_element_model_relaxed(AssertionModel):
 class xml_element_model(base_xml_element_model):
     r"""Assert if the XML file contains element(s) or tag(s) with the specified
     [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
-    or ``min`` and ``max`` are given also the number of occurences is checked.
+    or ``min`` and ``max`` are given also the number of occurrences is checked.
 
     ```xml
     <assert_contents>
@@ -2043,7 +2043,7 @@ class xml_element_model(base_xml_element_model):
     </assert_contents>
     ```
 
-    With ``negate="true"`` the outcome of the assertions wrt the precence and number
+    With ``negate="true"`` the outcome of the assertions wrt the presence and number
     of ``path`` can be negated. If there are any sub assertions then check them against
 
     - the content of the attribute ``attribute``
@@ -2058,7 +2058,7 @@ class xml_element_model(base_xml_element_model):
     ```
 
     Sub-assertions are not subject to the ``negate`` attribute of ``xml_element``.
-    If ``all`` is ``true`` then the sub assertions are checked for all occurences.
+    If ``all`` is ``true`` then the sub assertions are checked for all occurrences.
 
     Note that all other XML assertions can be expressed by this assertion (Galaxy
     also implements the other assertions by calling this one)."""
@@ -2077,7 +2077,7 @@ class xml_element_model_nested(AssertionModel):
 class xml_element_model_relaxed(base_xml_element_model_relaxed):
     r"""Assert if the XML file contains element(s) or tag(s) with the specified
     [XPath-like ``path``](https://lxml.de/xpathxslt.html).  If ``n`` and ``delta``
-    or ``min`` and ``max`` are given also the number of occurences is checked.
+    or ``min`` and ``max`` are given also the number of occurrences is checked.
 
     ```xml
     <assert_contents>
@@ -2087,7 +2087,7 @@ class xml_element_model_relaxed(base_xml_element_model_relaxed):
     </assert_contents>
     ```
 
-    With ``negate="true"`` the outcome of the assertions wrt the precence and number
+    With ``negate="true"`` the outcome of the assertions wrt the presence and number
     of ``path`` can be negated. If there are any sub assertions then check them against
 
     - the content of the attribute ``attribute``
@@ -2102,7 +2102,7 @@ class xml_element_model_relaxed(base_xml_element_model_relaxed):
     ```
 
     Sub-assertions are not subject to the ``negate`` attribute of ``xml_element``.
-    If ``all`` is ``true`` then the sub assertions are checked for all occurences.
+    If ``all`` is ``true`` then the sub assertions are checked for all occurrences.
 
     Note that all other XML assertions can be expressed by this assertion (Galaxy
     also implements the other assertions by calling this one)."""

--- a/lib/galaxy/tool_util_models/test_job.py
+++ b/lib/galaxy/tool_util_models/test_job.py
@@ -1,0 +1,182 @@
+"""Pydantic model for the ``job:`` block of Planemo / ``*.gxwf-tests.yml`` tests.
+
+Defines the canonical CWL-style workflow-test input syntax — the shape the
+schema blesses, not every shape the helpers in ``galaxy_test.base.populators``
+happen to tolerate. Legacy ``type: File | Directory | raw`` / ``value`` forms
+are intentionally not modeled; those are left to helper-layer tolerances and
+should not leak into test fixtures.
+
+Follow-up to galaxyproject/galaxy#18884, which modeled ``TestJob.outputs`` but
+left ``TestJob.job`` as ``Dict[str, Any]``.
+"""
+
+from typing import (
+    Optional,
+    Union,
+)
+
+from pydantic import (
+    ConfigDict,
+    Discriminator,
+    Field,
+    RootModel,
+    Tag,
+)
+from typing_extensions import (
+    Annotated,
+    Literal,
+)
+
+from ._base import (
+    CollectionType,
+    StrictModel,
+)
+
+# Mirrored from galaxy.util.hash_util.HashFunctionNames — duplicated rather than
+# imported so this package stays free of a galaxy-util runtime dep. Kept in sync
+# by test/unit/tool_util_models/test_hash_function_names_sync.py, which runs in
+# the monorepo where galaxy.util is available.
+HashFunctionNames = Literal["MD5", "SHA-1", "SHA-256", "SHA-512"]
+
+
+class _StrictJobModel(StrictModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        field_title_generator=lambda field_name, field_info: field_name.lower(),
+    )
+
+
+class HashEntry(_StrictJobModel):
+    hash_function: HashFunctionNames
+    hash_value: str
+
+
+class BaseFile(_StrictJobModel):
+    """Fields common to every ``class: File`` variant."""
+
+    class_: Literal["File"] = Field(alias="class")
+    filetype: Optional[str] = None
+    dbkey: Optional[str] = None
+    decompress: Optional[bool] = None
+    to_posix_lines: Optional[bool] = None
+    space_to_tab: Optional[bool] = None
+    deferred: Optional[bool] = None
+    name: Optional[str] = None
+    info: Optional[str] = None
+    tags: Optional[list[str]] = None
+    hashes: Optional[list[HashEntry]] = None
+    identifier: Optional[str] = None
+
+
+class LocationFile(BaseFile):
+    location: str
+    path: Optional[str] = None
+    contents: Optional[str] = None
+    composite_data: Optional[list[str]] = None
+
+
+class PathFile(BaseFile):
+    path: str
+    location: Optional[str] = None
+    contents: Optional[str] = None
+    composite_data: Optional[list[str]] = None
+
+
+class ContentsFile(BaseFile):
+    """CWL File literal — content inlined as a string."""
+
+    contents: str
+    path: Optional[str] = None
+    location: Optional[str] = None
+    composite_data: Optional[list[str]] = None
+
+
+class CompositeDataFile(BaseFile):
+    composite_data: list[str]
+    path: Optional[str] = None
+    location: Optional[str] = None
+    contents: Optional[str] = None
+
+
+def _discriminate_file(v):
+    if isinstance(v, dict):
+        if "location" in v:
+            return "location"
+        if "path" in v:
+            return "path"
+        if "contents" in v:
+            return "contents"
+        if "composite_data" in v:
+            return "composite_data"
+        return None
+    if isinstance(v, LocationFile):
+        return "location"
+    if isinstance(v, PathFile):
+        return "path"
+    if isinstance(v, ContentsFile):
+        return "contents"
+    if isinstance(v, CompositeDataFile):
+        return "composite_data"
+    return None
+
+
+File = Annotated[
+    Union[
+        Annotated[LocationFile, Tag("location")],
+        Annotated[PathFile, Tag("path")],
+        Annotated[ContentsFile, Tag("contents")],
+        Annotated[CompositeDataFile, Tag("composite_data")],
+    ],
+    Discriminator(_discriminate_file),
+]
+
+
+class Collection(_StrictJobModel):
+    class_: Literal["Collection"] = Field(alias="class")
+    collection_type: CollectionType = None
+    name: Optional[str] = None
+    identifier: Optional[str] = None
+    elements: Optional[list["CollectionElement"]] = None
+    rows: Optional[dict[str, list]] = None
+
+
+CollectionElement = Annotated[
+    Union[File, Collection],
+    Field(discriminator="class_"),
+]
+
+Collection.model_rebuild()
+
+
+class Directory(_StrictJobModel):
+    """CWL-style directory input. Supported by stage_inputs for directory-typed
+    datasets (e.g. bwa_mem2_index test fixtures). Rare in workflow tests; IWC
+    does not use it.
+    """
+
+    class_: Literal["Directory"] = Field(alias="class")
+    path: Optional[str] = None
+    location: Optional[str] = None
+    filetype: Optional[str] = None
+    name: Optional[str] = None
+
+
+# JobParamValue is non-recursive at the list axis: a job-param list may contain
+# files or scalars but not further nested lists. Collection nesting (lists of
+# collections) is recursive via ``CollectionElement``. No observed workflow
+# test value needs a list-of-lists at the job-input level; widen explicitly if
+# that changes rather than defaulting to Any.
+JobParamValue = Union[
+    File,
+    Collection,
+    Directory,
+    str,
+    int,
+    float,
+    bool,
+    None,
+    list[Union[File, str, int, float, bool, None]],
+]
+
+Job = RootModel[dict[str, JobParamValue]]

--- a/lib/galaxy/tool_util_models/test_job.py
+++ b/lib/galaxy/tool_util_models/test_job.py
@@ -11,6 +11,8 @@ left ``TestJob.job`` as ``Dict[str, Any]``.
 """
 
 from typing import (
+    Dict,
+    List,
     Optional,
     Union,
 )
@@ -65,8 +67,8 @@ class BaseFile(_StrictJobModel):
     deferred: Annotated[Optional[bool], Field(title="Deferred")] = None
     name: Annotated[Optional[str], Field(title="Name")] = None
     info: Annotated[Optional[str], Field(title="Info")] = None
-    tags: Annotated[Optional[list[str]], Field(title="Tags")] = None
-    hashes: Annotated[Optional[list[HashEntry]], Field(title="Hashes")] = None
+    tags: Annotated[Optional[List[str]], Field(title="Tags")] = None
+    hashes: Annotated[Optional[List[HashEntry]], Field(title="Hashes")] = None
     identifier: Annotated[Optional[str], Field(title="Identifier")] = None
 
 
@@ -75,7 +77,7 @@ class LocationFile(BaseFile):
     location: Annotated[str, Field(title="Location")]
     path: Annotated[Optional[str], Field(title="Path")] = None
     contents: Annotated[Optional[str], Field(title="Contents")] = None
-    composite_data: Annotated[Optional[list[str]], Field(title="Composite Data")] = None
+    composite_data: Annotated[Optional[List[str]], Field(title="Composite Data")] = None
 
 
 class PathFile(BaseFile):
@@ -83,7 +85,7 @@ class PathFile(BaseFile):
     path: Annotated[str, Field(title="Path")]
     location: Annotated[Optional[str], Field(title="Location")] = None
     contents: Annotated[Optional[str], Field(title="Contents")] = None
-    composite_data: Annotated[Optional[list[str]], Field(title="Composite Data")] = None
+    composite_data: Annotated[Optional[List[str]], Field(title="Composite Data")] = None
 
 
 class ContentsFile(BaseFile):
@@ -93,12 +95,12 @@ class ContentsFile(BaseFile):
     contents: Annotated[str, Field(title="Contents")]
     path: Annotated[Optional[str], Field(title="Path")] = None
     location: Annotated[Optional[str], Field(title="Location")] = None
-    composite_data: Annotated[Optional[list[str]], Field(title="Composite Data")] = None
+    composite_data: Annotated[Optional[List[str]], Field(title="Composite Data")] = None
 
 
 class CompositeDataFile(BaseFile):
     model_config = ConfigDict(extra="forbid", populate_by_name=True, title="CompositeDataFile")
-    composite_data: Annotated[list[str], Field(title="Composite Data")]
+    composite_data: Annotated[List[str], Field(title="Composite Data")]
     path: Annotated[Optional[str], Field(title="Path")] = None
     location: Annotated[Optional[str], Field(title="Location")] = None
     contents: Annotated[Optional[str], Field(title="Contents")] = None
@@ -143,8 +145,8 @@ class Collection(_StrictJobModel):
     collection_type: Annotated[CollectionType, Field(title="Collection Type")] = None
     name: Annotated[Optional[str], Field(title="Name")] = None
     identifier: Annotated[Optional[str], Field(title="Identifier")] = None
-    elements: Annotated[Optional[list["CollectionElement"]], Field(title="Elements")] = None
-    rows: Annotated[Optional[dict[str, list]], Field(title="Rows")] = None
+    elements: Annotated[Optional[List["CollectionElement"]], Field(title="Elements")] = None
+    rows: Annotated[Optional[Dict[str, list]], Field(title="Rows")] = None
 
 
 CollectionElement = Annotated[
@@ -183,9 +185,9 @@ JobParamValue = Union[
     float,
     bool,
     None,
-    list[Union[File, str, int, float, bool, None]],
+    List[Union[File, str, int, float, bool, None]],
 ]
 
 
-class Job(RootModel[dict[str, JobParamValue]]):
+class Job(RootModel[Dict[str, JobParamValue]]):
     model_config = ConfigDict(title="Job")

--- a/lib/galaxy/tool_util_models/test_job.py
+++ b/lib/galaxy/tool_util_models/test_job.py
@@ -43,60 +43,65 @@ class _StrictJobModel(StrictModel):
     model_config = ConfigDict(
         extra="forbid",
         populate_by_name=True,
-        field_title_generator=lambda field_name, field_info: field_name.lower(),
     )
 
 
 class HashEntry(_StrictJobModel):
-    hash_function: HashFunctionNames
-    hash_value: str
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="HashEntry")
+    hash_function: Annotated[HashFunctionNames, Field(title="Hash Function")]
+    hash_value: Annotated[str, Field(title="Hash Value")]
 
 
 class BaseFile(_StrictJobModel):
     """Fields common to every ``class: File`` variant."""
 
-    class_: Literal["File"] = Field(alias="class")
-    filetype: Optional[str] = None
-    dbkey: Optional[str] = None
-    decompress: Optional[bool] = None
-    to_posix_lines: Optional[bool] = None
-    space_to_tab: Optional[bool] = None
-    deferred: Optional[bool] = None
-    name: Optional[str] = None
-    info: Optional[str] = None
-    tags: Optional[list[str]] = None
-    hashes: Optional[list[HashEntry]] = None
-    identifier: Optional[str] = None
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="BaseFile")
+    class_: Literal["File"] = Field(alias="class", title="Class")
+    filetype: Annotated[Optional[str], Field(title="File Type")] = None
+    dbkey: Annotated[Optional[str], Field(title="Dbkey")] = None
+    decompress: Annotated[Optional[bool], Field(title="Decompress")] = None
+    to_posix_lines: Annotated[Optional[bool], Field(title="To POSIX Lines")] = None
+    space_to_tab: Annotated[Optional[bool], Field(title="Space To Tab")] = None
+    deferred: Annotated[Optional[bool], Field(title="Deferred")] = None
+    name: Annotated[Optional[str], Field(title="Name")] = None
+    info: Annotated[Optional[str], Field(title="Info")] = None
+    tags: Annotated[Optional[list[str]], Field(title="Tags")] = None
+    hashes: Annotated[Optional[list[HashEntry]], Field(title="Hashes")] = None
+    identifier: Annotated[Optional[str], Field(title="Identifier")] = None
 
 
 class LocationFile(BaseFile):
-    location: str
-    path: Optional[str] = None
-    contents: Optional[str] = None
-    composite_data: Optional[list[str]] = None
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="LocationFile")
+    location: Annotated[str, Field(title="Location")]
+    path: Annotated[Optional[str], Field(title="Path")] = None
+    contents: Annotated[Optional[str], Field(title="Contents")] = None
+    composite_data: Annotated[Optional[list[str]], Field(title="Composite Data")] = None
 
 
 class PathFile(BaseFile):
-    path: str
-    location: Optional[str] = None
-    contents: Optional[str] = None
-    composite_data: Optional[list[str]] = None
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="PathFile")
+    path: Annotated[str, Field(title="Path")]
+    location: Annotated[Optional[str], Field(title="Location")] = None
+    contents: Annotated[Optional[str], Field(title="Contents")] = None
+    composite_data: Annotated[Optional[list[str]], Field(title="Composite Data")] = None
 
 
 class ContentsFile(BaseFile):
     """CWL File literal — content inlined as a string."""
 
-    contents: str
-    path: Optional[str] = None
-    location: Optional[str] = None
-    composite_data: Optional[list[str]] = None
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="ContentsFile")
+    contents: Annotated[str, Field(title="Contents")]
+    path: Annotated[Optional[str], Field(title="Path")] = None
+    location: Annotated[Optional[str], Field(title="Location")] = None
+    composite_data: Annotated[Optional[list[str]], Field(title="Composite Data")] = None
 
 
 class CompositeDataFile(BaseFile):
-    composite_data: list[str]
-    path: Optional[str] = None
-    location: Optional[str] = None
-    contents: Optional[str] = None
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="CompositeDataFile")
+    composite_data: Annotated[list[str], Field(title="Composite Data")]
+    path: Annotated[Optional[str], Field(title="Path")] = None
+    location: Annotated[Optional[str], Field(title="Location")] = None
+    contents: Annotated[Optional[str], Field(title="Contents")] = None
 
 
 def _discriminate_file(v):
@@ -133,12 +138,13 @@ File = Annotated[
 
 
 class Collection(_StrictJobModel):
-    class_: Literal["Collection"] = Field(alias="class")
-    collection_type: CollectionType = None
-    name: Optional[str] = None
-    identifier: Optional[str] = None
-    elements: Optional[list["CollectionElement"]] = None
-    rows: Optional[dict[str, list]] = None
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="Collection")
+    class_: Literal["Collection"] = Field(alias="class", title="Class")
+    collection_type: Annotated[CollectionType, Field(title="Collection Type")] = None
+    name: Annotated[Optional[str], Field(title="Name")] = None
+    identifier: Annotated[Optional[str], Field(title="Identifier")] = None
+    elements: Annotated[Optional[list["CollectionElement"]], Field(title="Elements")] = None
+    rows: Annotated[Optional[dict[str, list]], Field(title="Rows")] = None
 
 
 CollectionElement = Annotated[
@@ -155,11 +161,12 @@ class Directory(_StrictJobModel):
     does not use it.
     """
 
-    class_: Literal["Directory"] = Field(alias="class")
-    path: Optional[str] = None
-    location: Optional[str] = None
-    filetype: Optional[str] = None
-    name: Optional[str] = None
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, title="Directory")
+    class_: Literal["Directory"] = Field(alias="class", title="Class")
+    path: Annotated[Optional[str], Field(title="Path")] = None
+    location: Annotated[Optional[str], Field(title="Location")] = None
+    filetype: Annotated[Optional[str], Field(title="File Type")] = None
+    name: Annotated[Optional[str], Field(title="Name")] = None
 
 
 # JobParamValue is non-recursive at the list axis: a job-param list may contain
@@ -179,4 +186,6 @@ JobParamValue = Union[
     list[Union[File, str, int, float, bool, None]],
 ]
 
-Job = RootModel[dict[str, JobParamValue]]
+
+class Job(RootModel[dict[str, JobParamValue]]):
+    model_config = ConfigDict(title="Job")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -2718,8 +2718,18 @@ class BaseWorkflowPopulator(BasePopulator):
         use_cached_job: bool = False,
         copy_inputs_to_history: bool = False,
         job_dir: Optional[str] = None,
+        test_data_format: Optional[Literal["cwl_style"]] = None,
     ):
-        """High-level wrapper around workflow API, etc. to invoke format 2 workflows."""
+        """High-level wrapper around workflow API, etc. to invoke format 2 workflows.
+
+        ``test_data_format="cwl_style"`` opts in to strict CWL-style semantics:
+        bare scalars in the ``job:`` dict are routed as literal params (int/text/
+        bool/select values for workflow inputs), and staging goes through
+        :func:`stage_inputs` unconditionally. Legacy ``type: File``/``raw``/
+        ``Directory`` dict forms are rejected at this layer so callers migrate
+        fixtures to ``class: File`` + ``path``/``location``/``contents``.
+        Default ``None`` preserves today's behavior for all existing callers.
+        """
         workflow_populator = self
         if client_convert is None:
             client_convert = not round_trip_format_conversion
@@ -2750,15 +2760,34 @@ class BaseWorkflowPopulator(BasePopulator):
         replacement_parameters = test_data_dict.pop("replacement_parameters", {})
         if history_id is None:
             history_id = self.dataset_populator.new_history()
-        if _uses_class_syntax(test_data_dict):
+        use_stage_inputs = test_data_format == "cwl_style" or _uses_class_syntax(test_data_dict)
+        if use_stage_inputs:
             # Copy because galactic_job_json() mutates the dict in-place
             job_copy = dict(test_data_dict)
-            # Extract raw parameters before staging — galactic_job_json
-            # doesn't understand type: raw and would misinterpret them
             raw_params = {}
             for k, v in list(job_copy.items()):
                 if isinstance(v, dict) and v.get("type") == "raw":
+                    if test_data_format == "cwl_style":
+                        raise ValueError(
+                            f"Legacy 'type: raw' form in job input '{k}' is not allowed with "
+                            "test_data_format='cwl_style'. Use a bare scalar value."
+                        )
                     raw_params[k] = v["value"]
+                    del job_copy[k]
+                elif test_data_format == "cwl_style" and isinstance(v, dict) and v.get("type") in ("File", "Directory"):
+                    raise ValueError(
+                        f"Legacy 'type: {v['type']}' form in job input '{k}' is not allowed with "
+                        "test_data_format='cwl_style'. Use 'class: File' + path/location/contents."
+                    )
+                elif test_data_format == "cwl_style" and not isinstance(v, (dict, list)):
+                    raw_params[k] = v
+                    del job_copy[k]
+                elif (
+                    test_data_format == "cwl_style"
+                    and isinstance(v, list)
+                    and not any(isinstance(x, (dict, list)) for x in v)
+                ):
+                    raw_params[k] = v
                     del job_copy[k]
             staged_job, datasets = stage_inputs(
                 self.dataset_populator.galaxy_interactor,

--- a/lib/galaxy_test/workflow/collection_semantics_cat.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/collection_semantics_cat.gxwf-tests.yml
@@ -85,7 +85,6 @@
       elements:
         - identifier: el1
           class: Collection
-          type: paired_or_unpaired
           elements:
             - identifier: forward
               class: File

--- a/lib/galaxy_test/workflow/collection_semantics_cat.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/collection_semantics_cat.gxwf-tests.yml
@@ -98,6 +98,7 @@
       collection_type: list:paired_or_unpaired
       elements:
         el1:
+          class: Collection
           elements:
             forward:
               asserts:

--- a/lib/galaxy_test/workflow/collection_semantics_list_paired.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/collection_semantics_list_paired.gxwf-tests.yml
@@ -10,7 +10,6 @@
       elements:
         - identifier: el1
           class: Collection
-          type: paired
           elements:
             - identifier: forward
               class: File

--- a/lib/galaxy_test/workflow/collection_semantics_list_paired_or_unpaired.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/collection_semantics_list_paired_or_unpaired.gxwf-tests.yml
@@ -8,7 +8,6 @@
       elements:
         - identifier: el1
           class: Collection
-          type: paired_or_unpaired
           elements:
             - identifier: forward
               class: File
@@ -36,7 +35,6 @@
       elements:
         - identifier: el1
           class: Collection
-          type: paired_or_unpaired
           elements:
             - identifier: forward
               class: File
@@ -63,7 +61,6 @@
       elements:
         - identifier: outer1
           class: Collection
-          type: list
           elements:
             - identifier: el1
               class: File
@@ -73,7 +70,6 @@
               contents: "data from outer1 el2"
         - identifier: outer2
           class: Collection
-          type: list
           elements:
             - identifier: el1
               class: File

--- a/lib/galaxy_test/workflow/collection_semantics_paired_or_unpaired.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/collection_semantics_paired_or_unpaired.gxwf-tests.yml
@@ -52,7 +52,6 @@
       elements:
         - identifier: test_level_1
           class: Collection
-          type: paired
           elements:
             - identifier: forward
               class: File
@@ -75,11 +74,9 @@
       elements:
         - identifier: test_level_2
           class: Collection
-          type: list:paired
           elements:
             - identifier: test_level_1
               class: Collection
-              type: paired
               elements:
                 - identifier: forward
                   class: File
@@ -102,7 +99,6 @@
       elements:
         - identifier: test_level_1
           class: Collection
-          type: paired_or_unpaired
           elements:
             - identifier: forward
               class: File
@@ -127,7 +123,6 @@
       elements:
         - identifier: el1
           class: Collection
-          type: paired
           elements:
             - identifier: forward
               class: File
@@ -152,7 +147,6 @@
       elements:
         - identifier: el1
           class: Collection
-          type: paired
           elements:
             - identifier: forward
               class: File

--- a/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/default_values.gxwf-tests.yml
@@ -11,9 +11,7 @@
     Test that explicit null is not replaced and fails
   expect_failure: true
   job:
-    required_int_with_default:
-      type: raw
-      value: null
+    required_int_with_default: null
   outputs:
     out:
       class: File
@@ -24,9 +22,7 @@
     Test that empty string is not replaced and fails
   expect_failure: true
   job:
-    required_int_with_default:
-      type: raw
-      value: ""
+    required_int_with_default: ""
   outputs:
     out:
       class: File

--- a/lib/galaxy_test/workflow/default_values_optional.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/default_values_optional.gxwf-tests.yml
@@ -11,9 +11,7 @@
     Test that explicit null is not replaced and fails
   expect_failure: true
   job:
-    optional_int_with_default:
-      type: raw
-      value: null
+    optional_int_with_default: null
   outputs:
     out:
       class: File
@@ -24,9 +22,7 @@
     Test that empty string is not replaced and fails
   expect_failure: true
   job:
-    optional_int_with_default:
-      type: raw
-      value: ""
+    optional_int_with_default: ""
   outputs:
     out:
       class: File

--- a/lib/galaxy_test/workflow/directory_index.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/directory_index.gxwf-tests.yml
@@ -13,9 +13,9 @@
     Test that uploading index works
   job:
     reference:
-      type: Directory
-      file_type: bwa_mem2_index
-      value: bwa_mem2_index
+      class: Directory
+      path: bwa_mem2_index
+      filetype: bwa_mem2_index
   outputs:
     output:
       class: File

--- a/lib/galaxy_test/workflow/filter_null.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/filter_null.gxwf-tests.yml
@@ -8,9 +8,7 @@
         - identifier: first
           class: File
           contents: "abc"
-    when:
-      value: true
-      type: raw
+    when: true
   outputs:
     out:
       class: Collection
@@ -26,9 +24,7 @@
         - identifier: first
           class: File
           contents: "abc"
-    when:
-      value: false
-      type: raw
+    when: false
   outputs:
     out:
       class: Collection

--- a/lib/galaxy_test/workflow/integer_into_data_column.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/integer_into_data_column.gxwf-tests.yml
@@ -5,9 +5,7 @@
       class: File
       path: 2.tabular
       filetype: tabular
-    column:
-      value: "2"
-      type: raw
+    column: "2"
   outputs:
     output:
       class: File

--- a/lib/galaxy_test/workflow/multiple_integer_into_data_column.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/multiple_integer_into_data_column.gxwf-tests.yml
@@ -5,9 +5,7 @@
       class: File
       path: 2.tabular
       filetype: tabular
-    column:
-      value: [1, 2]
-      type: raw
+    column: [1, 2]
   outputs:
     output:
       class: File

--- a/lib/galaxy_test/workflow/multiple_text.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/multiple_text.gxwf-tests.yml
@@ -2,11 +2,9 @@
     Test that workflows can run with multiple text parameter fed into a multi select parameter.
   job:
     input:
-      value:
-        - --ex1
-        - ex2
-        - --ex3
-      type: raw
+      - --ex1
+      - ex2
+      - --ex3
   outputs:
     output:
       class: File

--- a/lib/galaxy_test/workflow/multiple_versions.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/multiple_versions.gxwf-tests.yml
@@ -1,9 +1,7 @@
-- doc: | 
+- doc: |
     Test that workflows can run with multiple versions of tools and the version specified matches the one run.
   job:
-    input:
-      value: 1
-      type: raw
+    input: 1
   outputs:
     output_1:
       class: File

--- a/lib/galaxy_test/workflow/optional_param_default_value.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_param_default_value.gxwf-tests.yml
@@ -6,8 +6,8 @@
     NO_REPLACEMENT sentinel.
   job:
     required_input:
-      type: File
-      value: 1.fasta
+      class: File
+      path: 1.fasta
   outputs:
     out:
       class: File

--- a/lib/galaxy_test/workflow/optional_text_param_rescheduling.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_text_param_rescheduling.gxwf-tests.yml
@@ -1,9 +1,7 @@
 - doc: |
     Test that scheduling succeeds even if step needs rescheduling
   job:
-    optional_text:
-      type: raw
-      value: null
+    optional_text: null
   outputs:
     out:
       class: File

--- a/lib/galaxy_test/workflow/optional_text_to_bool.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_text_to_bool.gxwf-tests.yml
@@ -4,8 +4,8 @@
     the conditional downstream step.
   job:
     required_input:
-      type: File
-      value: 1.fasta
+      class: File
+      path: 1.fasta
   outputs:
     out:
       asserts:
@@ -17,8 +17,8 @@
     downstream step runs.
   job:
     required_input:
-      type: File
-      value: 1.fasta
+      class: File
+      path: 1.fasta
     optional_text: some_value
   outputs:
     out:

--- a/lib/galaxy_test/workflow/pick_value_add_tag.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_add_tag.gxwf-tests.yml
@@ -2,12 +2,10 @@
     Test that TagDatasetAction on pick_value adds a tag to the output.
   job:
     input_data:
-      type: File
-      value: 1.bed
-      file_type: bed
-    when:
-      type: raw
-      value: true
+      class: File
+      path: 1.bed
+      filetype: bed
+    when: true
   outputs:
     picked:
       class: File

--- a/lib/galaxy_test/workflow/pick_value_all_non_null_mapped.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_all_non_null_mapped.gxwf-tests.yml
@@ -15,12 +15,8 @@
           class: File
           contents: "line2"
           filetype: bed
-    when_a:
-      type: raw
-      value: true
-    when_b:
-      type: raw
-      value: true
+    when_a: true
+    when_b: true
   outputs:
     picked:
       class: Collection
@@ -42,12 +38,8 @@
           class: File
           contents: "line2"
           filetype: bed
-    when_a:
-      type: raw
-      value: true
-    when_b:
-      type: raw
-      value: false
+    when_a: true
+    when_b: false
   outputs:
     picked:
       class: Collection

--- a/lib/galaxy_test/workflow/pick_value_all_non_null_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_all_non_null_pja.gxwf-tests.yml
@@ -3,15 +3,11 @@
     pick collects both into a list, rename PJA sets collection name.
   job:
     input_data:
-      type: File
-      value: 1.bed
-      file_type: bed
-    when_a:
-      type: raw
-      value: true
-    when_b:
-      type: raw
-      value: true
+      class: File
+      path: 1.bed
+      filetype: bed
+    when_a: true
+    when_b: true
   outputs:
     picked:
       class: Collection
@@ -22,15 +18,11 @@
     non-null output and applies the rename PJA.
   job:
     input_data:
-      type: File
-      value: 1.bed
-      file_type: bed
-    when_a:
-      type: raw
-      value: true
-    when_b:
-      type: raw
-      value: false
+      class: File
+      path: 1.bed
+      filetype: bed
+    when_a: true
+    when_b: false
   outputs:
     picked:
       class: Collection

--- a/lib/galaxy_test/workflow/pick_value_change_datatype.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_change_datatype.gxwf-tests.yml
@@ -2,12 +2,10 @@
     Test that ChangeDatatypeAction on pick_value changes output datatype.
   job:
     input_data:
-      type: File
-      value: 1.bed
-      file_type: bed
-    when:
-      type: raw
-      value: true
+      class: File
+      path: 1.bed
+      filetype: bed
+    when: true
   outputs:
     picked:
       class: File

--- a/lib/galaxy_test/workflow/pick_value_first_non_null_mapped.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_first_non_null_mapped.gxwf-tests.yml
@@ -15,12 +15,8 @@
           class: File
           contents: "line2"
           filetype: bed
-    when_a:
-      type: raw
-      value: true
-    when_b:
-      type: raw
-      value: true
+    when_a: true
+    when_b: true
   outputs:
     picked:
       class: Collection
@@ -51,12 +47,8 @@
           class: File
           contents: "line2"
           filetype: bed
-    when_a:
-      type: raw
-      value: false
-    when_b:
-      type: raw
-      value: true
+    when_a: false
+    when_b: true
   outputs:
     picked:
       class: Collection

--- a/lib/galaxy_test/workflow/pick_value_multi_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_multi_pja.gxwf-tests.yml
@@ -2,12 +2,10 @@
     Test multiple PJAs on pick_value: change datatype, rename, and add tag.
   job:
     input_data:
-      type: File
-      value: 1.bed
-      file_type: bed
-    when:
-      type: raw
-      value: true
+      class: File
+      path: 1.bed
+      filetype: bed
+    when: true
   outputs:
     picked:
       class: File

--- a/lib/galaxy_test/workflow/pick_value_rename.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_rename.gxwf-tests.yml
@@ -2,12 +2,10 @@
     Test that RenameDatasetAction on pick_value renames the output.
   job:
     input_data:
-      type: File
-      value: 1.bed
-      file_type: bed
-    when:
-      type: raw
-      value: true
+      class: File
+      path: 1.bed
+      filetype: bed
+    when: true
   outputs:
     picked:
       class: File

--- a/lib/galaxy_test/workflow/pick_value_skip_pja.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/pick_value_skip_pja.gxwf-tests.yml
@@ -4,12 +4,10 @@
     ChangeDatatypeAction should not corrupt it.
   job:
     input_data:
-      type: File
-      value: 1.bed
-      file_type: bed
-    when:
-      type: raw
-      value: false
+      class: File
+      path: 1.bed
+      filetype: bed
+    when: false
   outputs:
     picked:
       class: File

--- a/lib/galaxy_test/workflow/replacement_parameters_nested.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_nested.gxwf-tests.yml
@@ -1,9 +1,7 @@
 - doc: |
     Test to verify text parameters can be implicitly used as replacement parameters in subworkflows if they are connected up.
   job:
-    replacemeouter: 
-      value: moocow
-      type: raw
+    replacemeouter: moocow
   outputs:
     out1:
       class: File

--- a/lib/galaxy_test/workflow/replacement_parameters_text.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_text.gxwf-tests.yml
@@ -1,9 +1,7 @@
 - doc: |
     Test to verify text parameters can be implicitly used as replacement parameters in workflow step PJAs.
   job:
-    replaceme: 
-      value: moocow
-      type: raw
+    replaceme: moocow
   outputs:
     out1:
       class: File

--- a/lib/galaxy_test/workflow/split_paired_and_unpaired.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/split_paired_and_unpaired.gxwf-tests.yml
@@ -8,7 +8,7 @@
       elements:
         - identifier: el1
           class: Collection
-          type: paired_or_unpaired
+          collection_type: paired_or_unpaired
           elements:
             - identifier: forward
               class: File
@@ -18,7 +18,7 @@
               contents: "reverse content"
         - identifier: el2
           class: Collection
-          type: paired_or_unpaired
+          collection_type: paired_or_unpaired
           elements:
             - identifier: unpaired
               class: File
@@ -37,6 +37,7 @@
       collection_type: list:paired
       elements:
         el1:
+          class: Collection
           elements:
             forward:
               asserts:

--- a/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf-tests.yml
@@ -9,7 +9,6 @@
       elements:
         - identifier: test_level_1
           class: Collection
-          type: list
           elements:
             - identifier: data1
               class: File
@@ -34,11 +33,9 @@
       elements:
         - identifier: test_level_2
           class: Collection
-          type: list:list
           elements:
             - identifier: test_level_1
               class: Collection
-              type: list
               elements:
                 - identifier: data1
                   class: File
@@ -71,15 +68,12 @@
       elements:
         - identifier: test_level_3
           class: Collection
-          type: list:list:list
           elements:
             - identifier: test_level_2
               class: Collection
-              type: list:list
               elements:
                 - identifier: test_level_1
                   class: Collection
-                  type: list
                   elements:
                     - identifier: data1
                       class: File

--- a/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subcollection_rank_sorting.gxwf-tests.yml
@@ -90,6 +90,7 @@
       collection_type: list:list
       elements:
         test_level_3:
+          class: Collection
           elements:
             test_level_2:
               asserts:

--- a/lib/galaxy_test/workflow/subcollection_rank_sorting_paired.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subcollection_rank_sorting_paired.gxwf-tests.yml
@@ -9,7 +9,6 @@
       elements:
         - identifier: test_level_1
           class: Collection
-          type: paired
           elements:
             - identifier: forward
               class: File
@@ -32,11 +31,9 @@
       elements:
         - identifier: test_level_2
           class: Collection
-          type: list:paired
           elements:
             - identifier: test_level_1
               class: Collection
-              type: paired
               elements:
                 - identifier: forward
                   class: File
@@ -65,15 +62,12 @@
       elements:
         - identifier: test_level_3
           class: Collection
-          type: list:list:paired
           elements:
             - identifier: test_level_2
               class: Collection
-              type: list:paired
               elements:
                 - identifier: test_level_1
                   class: Collection
-                  type: paired
                   elements:
                     - identifier: forward
                       class: File

--- a/lib/galaxy_test/workflow/subcollection_rank_sorting_paired.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/subcollection_rank_sorting_paired.gxwf-tests.yml
@@ -81,6 +81,7 @@
       collection_type: list:list
       elements:
         test_level_3:
+          class: Collection
           elements:
             test_level_2:
               asserts:

--- a/lib/galaxy_test/workflow/test_framework_workflows.py
+++ b/lib/galaxy_test/workflow/test_framework_workflows.py
@@ -70,6 +70,7 @@ class TestWorkflow(ApiTestCase):
                     test_data=test_job["job"],
                     history_id=history_id,
                     job_dir=str(workflow_path.parent),
+                    test_data_format="cwl_style",
                 )
                 if TEST_WORKFLOW_AFTER_RERUN:
                     run_summary = self.workflow_populator.rerun(run_summary)

--- a/lib/galaxy_test/workflow/triply_nested_list_mapping.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/triply_nested_list_mapping.gxwf-tests.yml
@@ -8,11 +8,9 @@
       elements:
         - identifier: test_level_2
           class: Collection
-          type: list:list
           elements:
             - identifier: test_level_1
               class: Collection
-              type: list
               elements:
                 - identifier: data1
                   class: File
@@ -40,15 +38,12 @@
       elements:
         - identifier: test_level_3
           class: Collection
-          type: list:list:list
           elements:
             - identifier: test_level_2
               class: Collection
-              type: list:list
               elements:
                 - identifier: test_level_1
                   class: Collection
-                  type: list
                   elements:
                     - identifier: data1
                       class: File

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -1058,49 +1058,49 @@ export interface components {
         /** BaseUrlParameterModel */
         BaseUrlParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_baseurl
              * @constant
              */
             parameter_type: "gx_baseurl"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "baseurl"
@@ -1120,58 +1120,58 @@ export interface components {
         /** BooleanParameterModel */
         BooleanParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
-            /** falsevalue */
+            /** Falsevalue */
             falsevalue?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_boolean
              * @constant
              */
             parameter_type: "gx_boolean"
-            /** truevalue */
+            /** Truevalue */
             truevalue?: string | null
             /**
-             * type
+             * Type
              * @constant
              */
             type: "boolean"
             /**
-             * value
+             * Value
              * @default false
              */
             value: boolean | null
@@ -1245,117 +1245,117 @@ export interface components {
         }
         /** Citation */
         Citation: {
-            /** content */
+            /** Content */
             content: string
-            /** type */
+            /** Type */
             type: string
         }
         /** ColorParameterModel */
         ColorParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_color
              * @constant
              */
             parameter_type: "gx_color"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "color"
-            /** value */
+            /** Value */
             value?: string | null
         }
         /** ConditionalParameterModel */
         ConditionalParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_conditional
              * @constant
              */
             parameter_type: "gx_conditional"
-            /** test_parameter */
+            /** Test Parameter */
             test_parameter:
                 | components["schemas"]["BooleanParameterModel"]
                 | components["schemas"]["SelectParameterModel"]
             /**
-             * type
+             * Type
              * @constant
              */
             type: "conditional"
-            /** whens */
+            /** Whens */
             whens: components["schemas"]["ConditionalWhen"][]
         }
         /** ConditionalWhen */
@@ -1435,12 +1435,12 @@ export interface components {
         /** CwlBooleanParameterModel */
         CwlBooleanParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_boolean
              * @constant
              */
@@ -1449,43 +1449,43 @@ export interface components {
         /** CwlDirectoryParameterModel */
         CwlDirectoryParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_directory
              * @constant
              */
@@ -1494,43 +1494,43 @@ export interface components {
         /** CwlFileParameterModel */
         CwlFileParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_file
              * @constant
              */
@@ -1539,12 +1539,12 @@ export interface components {
         /** CwlFloatParameterModel */
         CwlFloatParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_float
              * @constant
              */
@@ -1553,12 +1553,12 @@ export interface components {
         /** CwlIntegerParameterModel */
         CwlIntegerParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_integer
              * @constant
              */
@@ -1567,12 +1567,12 @@ export interface components {
         /** CwlNullParameterModel */
         CwlNullParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_null
              * @constant
              */
@@ -1581,12 +1581,12 @@ export interface components {
         /** CwlStringParameterModel */
         CwlStringParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_string
              * @constant
              */
@@ -1595,17 +1595,17 @@ export interface components {
         /** CwlUnionParameterModel */
         CwlUnionParameterModel: {
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * parameter_type
+             * Parameter Type
              * @default cwl_union
              * @constant
              */
             parameter_type: "cwl_union"
-            /** parameters */
+            /** Parameters */
             parameters: (
                 | components["schemas"]["CwlIntegerParameterModel"]
                 | components["schemas"]["CwlFloatParameterModel"]
@@ -1620,62 +1620,62 @@ export interface components {
         /** DataCollectionParameterModel */
         DataCollectionParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
-            /** collection_type */
+            /** Collection Type */
             collection_type?: string | null
             /**
-             * extensions
+             * Extensions
              * @default [
              *       "data"
              *     ]
              */
             extensions: string[]
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_data_collection
              * @constant
              */
             parameter_type: "gx_data_collection"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "data_collection"
-            /** value */
+            /** Value */
             value: {
                 [key: string]: unknown
             } | null
@@ -1683,66 +1683,66 @@ export interface components {
         /** DataColumnParameterModel */
         DataColumnParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** multiple */
+            /** Multiple */
             multiple: boolean
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_data_column
              * @constant
              */
             parameter_type: "gx_data_column"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "data_column"
-            /** value */
+            /** Value */
             value?: number | number[] | null
         }
         /** DataParameterModel */
         DataParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * extensions
+             * Extensions
              * @description Limit inputs to datasets with these extensions. Use 'data' to allow all input datasets.
              * @default [
              *       "data"
@@ -1753,54 +1753,54 @@ export interface components {
              */
             extensions: string[]
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** max */
+            /** Max */
             max?: number | null
-            /** min */
+            /** Min */
             min?: number | null
             /**
-             * multiple
+             * Multiple
              * @description Allow multiple values to be selected.
              * @default false
              */
             multiple: boolean
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_data
              * @constant
              */
             parameter_type: "gx_data"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "data"
@@ -1851,54 +1851,54 @@ export interface components {
         /** DirectoryUriParameterModel */
         DirectoryUriParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_directory_uri
              * @constant
              */
             parameter_type: "gx_directory_uri"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "directory"
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: (
@@ -1910,70 +1910,70 @@ export interface components {
         }
         /** DrillDownOptionsDict */
         DrillDownOptionsDict: {
-            /** name */
+            /** Name */
             name: string | null
-            /** options */
+            /** Options */
             options: components["schemas"]["DrillDownOptionsDict"][]
-            /** selected */
+            /** Selected */
             selected: boolean
-            /** value */
+            /** Value */
             value: string
         }
         /** DrillDownParameterModel */
         DrillDownParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * hierarchy
+             * Hierarchy
              * @enum {string}
              */
             hierarchy: "recurse" | "exact"
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** multiple */
+            /** Multiple */
             multiple: boolean
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
-            /** options */
+            /** Options */
             options?: components["schemas"]["DrillDownOptionsDict"][] | null
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_drill_down
              * @constant
              */
             parameter_type: "gx_drill_down"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "drill_down"
@@ -2034,150 +2034,150 @@ export interface components {
         }
         /** FilePatternDatasetCollectionDescription */
         FilePatternDatasetCollectionDescription: {
-            /** assign_primary_output */
+            /** Assign Primary Output */
             assign_primary_output: boolean
-            /** directory */
+            /** Directory */
             directory: string | null
             /**
-             * discover_via
+             * Discover Via
              * @constant
              */
             discover_via: "pattern"
-            /** format */
+            /** Format */
             format: string | null
-            /** match_relative_path */
+            /** Match Relative Path */
             match_relative_path: boolean
-            /** pattern */
+            /** Pattern */
             pattern: string
-            /** recurse */
+            /** Recurse */
             recurse: boolean
             /**
-             * sort_comp
+             * Sort Comp
              * @enum {string}
              */
             sort_comp: "lexical" | "numeric"
             /**
-             * sort_key
+             * Sort Key
              * @enum {string}
              */
             sort_key: "filename" | "name" | "designation" | "dbkey"
             /**
-             * sort_reverse
+             * Sort Reverse
              * @default false
              */
             sort_reverse: boolean
-            /** visible */
+            /** Visible */
             visible: boolean
         }
         /** FloatParameterModel */
         FloatParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** max */
+            /** Max */
             max?: number | null
-            /** min */
+            /** Min */
             min?: number | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_float
              * @constant
              */
             parameter_type: "gx_float"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "float"
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: components["schemas"]["InRangeParameterValidatorModel"][]
-            /** value */
+            /** Value */
             value?: number | null
         }
         /** GenomeBuildParameterModel */
         GenomeBuildParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** multiple */
+            /** Multiple */
             multiple: boolean
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_genomebuild
              * @constant
              */
             parameter_type: "gx_genomebuild"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "genomebuild"
@@ -2185,61 +2185,61 @@ export interface components {
         /** GroupTagParameterModel */
         GroupTagParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** multiple */
+            /** Multiple */
             multiple: boolean
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_group_tag
              * @constant
              */
             parameter_type: "gx_group_tag"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "group_tag"
         }
         /** HelpContent */
         HelpContent: {
-            /** content */
+            /** Content */
             content: string
             /**
-             * format
+             * Format
              * @enum {string}
              */
             format: "restructuredtext" | "plain_text" | "markdown"
@@ -2247,54 +2247,54 @@ export interface components {
         /** HiddenParameterModel */
         HiddenParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_hidden
              * @constant
              */
             parameter_type: "gx_hidden"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "hidden"
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: (
@@ -2303,7 +2303,7 @@ export interface components {
                 | components["schemas"]["ExpressionParameterValidatorModel"]
                 | components["schemas"]["EmptyFieldParameterValidatorModel"]
             )[]
-            /** value */
+            /** Value */
             value: string | null
         }
         /** ImageData */
@@ -2390,61 +2390,61 @@ export interface components {
         /** IntegerParameterModel */
         IntegerParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** max */
+            /** Max */
             max?: number | null
-            /** min */
+            /** Min */
             min?: number | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_integer
              * @constant
              */
             parameter_type: "gx_integer"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "integer"
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: components["schemas"]["InRangeParameterValidatorModel"][]
-            /** value */
+            /** Value */
             value?: number | null
         }
         /** InvalidTool */
@@ -2578,52 +2578,52 @@ export interface components {
         /** RepeatParameterModel */
         RepeatParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
-            /** max */
+            /** Max */
             max?: number | null
-            /** min */
+            /** Min */
             min?: number | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_repeat
              * @constant
              */
             parameter_type: "gx_repeat"
-            /** parameters */
+            /** Parameters */
             parameters: (
                 | components["schemas"]["CwlIntegerParameterModel"]
                 | components["schemas"]["CwlFloatParameterModel"]
@@ -2654,7 +2654,7 @@ export interface components {
                 | components["schemas"]["SectionParameterModel"]
             )[]
             /**
-             * type
+             * Type
              * @constant
              */
             type: "repeat"
@@ -2996,49 +2996,49 @@ export interface components {
         /** RulesParameterModel */
         RulesParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_rules
              * @constant
              */
             parameter_type: "gx_rules"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "rules"
@@ -3046,48 +3046,48 @@ export interface components {
         /** SectionParameterModel */
         SectionParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_section
              * @constant
              */
             parameter_type: "gx_section"
-            /** parameters */
+            /** Parameters */
             parameters: (
                 | components["schemas"]["CwlIntegerParameterModel"]
                 | components["schemas"]["CwlFloatParameterModel"]
@@ -3118,7 +3118,7 @@ export interface components {
                 | components["schemas"]["SectionParameterModel"]
             )[]
             /**
-             * type
+             * Type
              * @constant
              */
             type: "section"
@@ -3126,61 +3126,61 @@ export interface components {
         /** SelectParameterModel */
         SelectParameterModel: {
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * multiple
+             * Multiple
              * @default false
              */
             multiple: boolean
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
-            /** options */
+            /** Options */
             options?: components["schemas"]["LabelValue"][] | null
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_select
              * @constant
              */
             parameter_type: "gx_select"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "select"
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: components["schemas"]["NoOptionsParameterValidatorModel"][]
@@ -3268,19 +3268,18 @@ export interface components {
         }
         /** ShedParsedTool */
         ShedParsedTool: {
-            /** citations */
+            /** Citations */
             citations: components["schemas"]["Citation"][]
-            /** description */
+            /** Description */
             description: string | null
-            /** edam_operations */
+            /** Edam Operations */
             edam_operations: string[]
-            /** edam_topics */
+            /** Edam Topics */
             edam_topics: string[]
-            /** help */
             help: components["schemas"]["HelpContent"] | null
-            /** id */
+            /** Id */
             id: string
-            /** inputs */
+            /** Inputs */
             inputs: (
                 | components["schemas"]["CwlIntegerParameterModel"]
                 | components["schemas"]["CwlFloatParameterModel"]
@@ -3310,11 +3309,11 @@ export interface components {
                 | components["schemas"]["RepeatParameterModel"]
                 | components["schemas"]["SectionParameterModel"]
             )[]
-            /** license */
+            /** License */
             license: string | null
-            /** name */
+            /** Name */
             name: string
-            /** outputs */
+            /** Outputs */
             outputs: (
                 | components["schemas"]["ToolOutputDataset"]
                 | components["schemas"]["ToolOutputCollection"]
@@ -3323,76 +3322,75 @@ export interface components {
                 | components["schemas"]["ToolOutputFloat"]
                 | components["schemas"]["ToolOutputBoolean"]
             )[]
-            /** profile */
+            /** Profile */
             profile: string | null
-            /** repository_revision */
             repository_revision?: components["schemas"]["RepositoryRevisionMetadata"] | null
-            /** version */
+            /** Version */
             version: string | null
-            /** xrefs */
+            /** Xrefs */
             xrefs: components["schemas"]["XrefDict"][]
         }
         /** TextParameterModel */
         TextParameterModel: {
             /**
-             * area
+             * Area
              * @default false
              */
             area: boolean
             /**
-             * argument
+             * Argument
              * @description If the parameter reflects just one command line argument of a certain tool, this tag should be set to that particular argument. It is rendered in parenthesis after the help section, and it will create the name attribute (if not given explicitly) from the argument attribute by stripping leading dashes and replacing all remaining dashes by underscores (e.g. if argument="--long-parameter" then name="long_parameter" is implicit).
              */
             argument?: string | null
             /**
-             * default_options
+             * Default Options
              * @default []
              */
             default_options: components["schemas"]["LabelValue"][]
             /**
-             * help
+             * Help
              * @description Short bit of text, rendered on the tool form just below the associated field to provide information about the field.
              */
             help?: string | null
             /**
-             * hidden
+             * Hidden
              * @default false
              */
             hidden: boolean
             /**
-             * is_dynamic
+             * Is Dynamic
              * @default false
              */
             is_dynamic: boolean
             /**
-             * label
+             * Label
              * @description Will be displayed on the tool page as the label of the parameter.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows or inside command templating.
              */
             name: string
             /**
-             * optional
+             * Optional
              * @description If `false`, parameter must have a value.
              * @default false
              */
             optional: boolean
             /**
-             * parameter_type
+             * Parameter Type
              * @default gx_text
              * @constant
              */
             parameter_type: "gx_text"
             /**
-             * type
+             * Type
              * @constant
              */
             type: "text"
             /**
-             * validators
+             * Validators
              * @default []
              */
             validators: (
@@ -3401,7 +3399,7 @@ export interface components {
                 | components["schemas"]["ExpressionParameterValidatorModel"]
                 | components["schemas"]["EmptyFieldParameterValidatorModel"]
             )[]
-            /** default_value */
+            /** Value */
             value?: string | null
         }
         /** Tool */
@@ -3484,17 +3482,17 @@ export interface components {
         /** ToolOutputBoolean */
         ToolOutputBoolean: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown
@@ -3507,21 +3505,20 @@ export interface components {
         /** ToolOutputCollection */
         ToolOutputCollection: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: boolean
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: string
-            /** structure */
             structure: components["schemas"]["ToolOutputCollectionStructure"]
             /**
              * @description discriminator enum property added by openapi-typescript
@@ -3531,25 +3528,25 @@ export interface components {
         }
         /** ToolOutputCollectionStructure */
         ToolOutputCollectionStructure: {
-            /** collection_type */
+            /** Collection Type */
             collection_type?: string | null
-            /** collection_type_from_rules */
+            /** Collection Type From Rules */
             collection_type_from_rules?: string | null
-            /** collection_type_source */
+            /** Collection Type Source */
             collection_type_source?: string | null
-            /** discover_datasets */
+            /** Discover Datasets */
             discover_datasets?:
                 | (
                       | components["schemas"]["FilePatternDatasetCollectionDescription"]
                       | components["schemas"]["ToolProvidedMetadataDatasetCollection"]
                   )[]
                 | null
-            /** structured_like */
+            /** Structured Like */
             structured_like?: string | null
         }
         /** ToolOutputDataset */
         ToolOutputDataset: {
-            /** discover_datasets */
+            /** Discover Datasets */
             discover_datasets?:
                 | (
                       | components["schemas"]["FilePatternDatasetCollectionDescription"]
@@ -3557,12 +3554,12 @@ export interface components {
                   )[]
                 | null
             /**
-             * format
+             * Format
              * @description The short name for the output datatype.
              */
             format: string
             /**
-             * format_source
+             * Format Source
              * @description This sets the data type of the output dataset(s) to be the same format as that of the specified tool input.
              */
             format_source?: string | null
@@ -3572,27 +3569,27 @@ export interface components {
              */
             from_work_dir?: string | null
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: boolean
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null
             /**
-             * metadata_source
+             * Metadata Source
              * @description This copies the metadata information from the tool’s input dataset to serve as default for information that cannot be detected from the output. One prominent use case is interval data with a non-standard column order that cannot be deduced from a header line, but which is known to be identical in the input and output datasets.
              */
             metadata_source?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: string
             /**
-             * precreate_directory
+             * Precreate Directory
              * @default false
              */
             precreate_directory: boolean | null
@@ -3605,17 +3602,17 @@ export interface components {
         /** ToolOutputFloat */
         ToolOutputFloat: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown
@@ -3628,17 +3625,17 @@ export interface components {
         /** ToolOutputInteger */
         ToolOutputInteger: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown
@@ -3651,17 +3648,17 @@ export interface components {
         /** ToolOutputText */
         ToolOutputText: {
             /**
-             * hidden
+             * Hidden
              * @description If true, the output will not be shown in the history.
              */
             hidden: unknown
             /**
-             * label
+             * Label
              * @description Output label. Will be used as dataset name in history.
              */
             label?: string | null
             /**
-             * name
+             * Name
              * @description Parameter name. Used when referencing parameter in workflows.
              */
             name: unknown
@@ -3673,22 +3670,22 @@ export interface components {
         }
         /** ToolProvidedMetadataDatasetCollection */
         ToolProvidedMetadataDatasetCollection: {
-            /** assign_primary_output */
+            /** Assign Primary Output */
             assign_primary_output: boolean
-            /** directory */
+            /** Directory */
             directory: string | null
             /**
-             * discover_via
+             * Discover Via
              * @constant
              */
             discover_via: "tool_provided_metadata"
-            /** format */
+            /** Format */
             format: string | null
-            /** match_relative_path */
+            /** Match Relative Path */
             match_relative_path: boolean
-            /** recurse */
+            /** Recurse */
             recurse: boolean
-            /** visible */
+            /** Visible */
             visible: boolean
         }
         /** ToolVersion */
@@ -3903,9 +3900,9 @@ export interface components {
         }
         /** XrefDict */
         XrefDict: {
-            /** type */
+            /** Type */
             type: string
-            /** value */
+            /** Value */
             value: string
         }
     }

--- a/test/unit/tool_util/test_data/test_job_fixtures/collection_list.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/collection_list.yml
@@ -1,0 +1,10 @@
+input:
+  class: Collection
+  collection_type: list
+  elements:
+    - identifier: el1
+      class: File
+      path: a.txt
+    - identifier: el2
+      class: File
+      path: b.txt

--- a/test/unit/tool_util/test_data/test_job_fixtures/collection_nested.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/collection_nested.yml
@@ -1,0 +1,13 @@
+input:
+  class: Collection
+  collection_type: list:paired
+  elements:
+    - identifier: p1
+      class: Collection
+      elements:
+        - identifier: forward
+          class: File
+          contents: "F"
+        - identifier: reverse
+          class: File
+          contents: "R"

--- a/test/unit/tool_util/test_data/test_job_fixtures/collection_paired.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/collection_paired.yml
@@ -1,0 +1,10 @@
+input:
+  class: Collection
+  collection_type: paired
+  elements:
+    - identifier: forward
+      class: File
+      contents: "forward content"
+    - identifier: reverse
+      class: File
+      contents: "reverse content"

--- a/test/unit/tool_util/test_data/test_job_fixtures/directory.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/directory.yml
@@ -1,0 +1,4 @@
+reference:
+  class: Directory
+  path: bwa_mem2_index
+  filetype: bwa_mem2_index

--- a/test/unit/tool_util/test_data/test_job_fixtures/file_composite.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/file_composite.yml
@@ -1,0 +1,6 @@
+input:
+  class: File
+  filetype: imzml
+  composite_data:
+    - Example_Continuous.imzML
+    - Example_Continuous.ibd

--- a/test/unit/tool_util/test_data/test_job_fixtures/file_contents.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/file_contents.yml
@@ -1,0 +1,4 @@
+input:
+  class: File
+  contents: "inline file content\n"
+  filetype: txt

--- a/test/unit/tool_util/test_data/test_job_fixtures/file_location.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/file_location.yml
@@ -1,0 +1,7 @@
+input:
+  class: File
+  location: https://example.org/test.fasta
+  filetype: fasta
+  hashes:
+    - hash_function: SHA-256
+      hash_value: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

--- a/test/unit/tool_util/test_data/test_job_fixtures/file_path.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/file_path.yml
@@ -1,0 +1,4 @@
+input:
+  class: File
+  path: 1.fasta
+  filetype: fasta

--- a/test/unit/tool_util/test_data/test_job_fixtures/file_with_tags_and_dbkey.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/file_with_tags_and_dbkey.yml
@@ -1,0 +1,14 @@
+input:
+  class: File
+  path: 1.fasta
+  filetype: fasta
+  dbkey: hg19
+  decompress: true
+  to_posix_lines: true
+  space_to_tab: false
+  deferred: false
+  name: reference-genome
+  info: sample info
+  tags:
+    - group:project
+    - name:reference

--- a/test/unit/tool_util/test_data/test_job_fixtures/list_of_files.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/list_of_files.yml
@@ -1,0 +1,5 @@
+multi_data:
+  - class: File
+    path: a.txt
+  - class: File
+    path: b.txt

--- a/test/unit/tool_util/test_data/test_job_fixtures/list_of_scalars.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/list_of_scalars.yml
@@ -1,0 +1,4 @@
+multi_text:
+  - --ex1
+  - --ex2
+  - --ex3

--- a/test/unit/tool_util/test_data/test_job_fixtures/neg_bad_collection_type.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/neg_bad_collection_type.yml
@@ -1,0 +1,4 @@
+input:
+  class: Collection
+  collection_type: banana
+  elements: []

--- a/test/unit/tool_util/test_data/test_job_fixtures/neg_elements_without_class.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/neg_elements_without_class.yml
@@ -1,0 +1,6 @@
+input:
+  collection_type: list
+  elements:
+    - identifier: el1
+      class: File
+      path: a.txt

--- a/test/unit/tool_util/test_data/test_job_fixtures/neg_file_no_path_or_location.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/neg_file_no_path_or_location.yml
@@ -1,0 +1,3 @@
+input:
+  class: File
+  filetype: fasta

--- a/test/unit/tool_util/test_data/test_job_fixtures/neg_legacy_type_file.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/neg_legacy_type_file.yml
@@ -1,0 +1,4 @@
+input:
+  type: File
+  value: 1.fasta
+  file_type: fasta

--- a/test/unit/tool_util/test_data/test_job_fixtures/neg_legacy_type_raw.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/neg_legacy_type_raw.yml
@@ -1,0 +1,3 @@
+input:
+  type: raw
+  value: 5

--- a/test/unit/tool_util/test_data/test_job_fixtures/neg_top_level_not_dict.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/neg_top_level_not_dict.yml
@@ -1,0 +1,1 @@
+"bare string at top level of job block"

--- a/test/unit/tool_util/test_data/test_job_fixtures/neg_unknown_field.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/neg_unknown_field.yml
@@ -1,0 +1,4 @@
+input:
+  class: File
+  path: 1.fasta
+  flargh: 1

--- a/test/unit/tool_util/test_data/test_job_fixtures/scalars.yml
+++ b/test/unit/tool_util/test_data/test_job_fixtures/scalars.yml
@@ -1,0 +1,5 @@
+text_input: hello
+int_input: 42
+float_input: 3.14
+bool_input: true
+null_input: null

--- a/test/unit/tool_util/test_hash_function_names_sync.py
+++ b/test/unit/tool_util/test_hash_function_names_sync.py
@@ -1,0 +1,14 @@
+"""Guard that the mirrored HashFunctionNames in tool_util_models stays in sync
+with galaxy.util.hash_util. The mirror exists so the package has no runtime
+dep on galaxy.util; this test lives here (not in test/unit/tool_util_models/)
+so it runs in the monorepo env where galaxy.util is importable.
+"""
+
+from typing import get_args
+
+from galaxy.tool_util_models.test_job import HashFunctionNames as MirroredHashFunctionNames
+from galaxy.util.hash_util import HashFunctionNames
+
+
+def test_hash_function_names_in_sync():
+    assert get_args(MirroredHashFunctionNames) == get_args(HashFunctionNames)

--- a/test/unit/tool_util/test_test_format_model.py
+++ b/test/unit/tool_util/test_test_format_model.py
@@ -2,20 +2,78 @@ import os
 from pathlib import Path
 from typing import List
 
+import pytest
 import yaml
+from pydantic import ValidationError
 
 from galaxy.tool_util_models import Tests
+from galaxy.tool_util_models.test_job import Job
 from galaxy.util import galaxy_directory
 from galaxy.util.unittest_utils import skip_unless_environ
 
 TEST_WORKFLOW_DIRECTORY = os.path.join(galaxy_directory(), "lib", "galaxy_test", "workflow")
 IWC_WORKFLOWS_USING_UNVERIFIED_SYNTAX: List[str] = []
 
+# replacement_parameters_legacy.gxwf-tests.yml is a deliberate regression test
+# for Planemo-era implicit replacement_parameters: {...} dicts embedded in
+# job:. That key is popped out by WorkflowPopulator.run_workflow before
+# staging, so the runtime accepts it but it is not canonical workflow-test
+# input syntax and the strict Job schema does not model it.
+WORKFLOW_TESTS_SKIP_STRICT_VALIDATION: List[str] = [
+    "replacement_parameters_legacy.gxwf-tests.yml",
+]
+
+TEST_JOB_FIXTURES_DIR = Path(__file__).parent / "test_data" / "test_job_fixtures"
+
+
+def _load_fixture(name: str):
+    with open(TEST_JOB_FIXTURES_DIR / name) as f:
+        return yaml.safe_load(f)
+
+
+JOB_POSITIVE_FIXTURES = [
+    "file_path.yml",
+    "file_location.yml",
+    "file_composite.yml",
+    "file_contents.yml",
+    "file_with_tags_and_dbkey.yml",
+    "collection_list.yml",
+    "collection_paired.yml",
+    "collection_nested.yml",
+    "directory.yml",
+    "scalars.yml",
+    "list_of_files.yml",
+    "list_of_scalars.yml",
+]
+
+JOB_NEGATIVE_FIXTURES = [
+    "neg_legacy_type_file.yml",
+    "neg_legacy_type_raw.yml",
+    "neg_elements_without_class.yml",
+    "neg_file_no_path_or_location.yml",
+    "neg_unknown_field.yml",
+    "neg_bad_collection_type.yml",
+    "neg_top_level_not_dict.yml",
+]
+
+
+@pytest.mark.parametrize("fixture", JOB_POSITIVE_FIXTURES)
+def test_job_positive_fixtures(fixture: str) -> None:
+    Job.model_validate(_load_fixture(fixture))
+
+
+@pytest.mark.parametrize("fixture", JOB_NEGATIVE_FIXTURES)
+def test_job_negative_fixtures(fixture: str) -> None:
+    with pytest.raises(ValidationError):
+        Job.model_validate(_load_fixture(fixture))
+
 
 def test_validate_workflow_tests():
     path = Path(TEST_WORKFLOW_DIRECTORY)
     test_files = path.glob("*.gxwf-tests.yml")
     for test_file in test_files:
+        if test_file.name in WORKFLOW_TESTS_SKIP_STRICT_VALIDATION:
+            continue
         with open(test_file) as f:
             json = yaml.safe_load(f)
         Tests.model_validate(json)

--- a/test/unit/tool_util/verify/test_asserts.py
+++ b/test/unit/tool_util/verify/test_asserts.py
@@ -173,7 +173,7 @@ def test_has_text_n_success():
 def test_has_text_n_failure():
     """test has_text with n .. negative test"""
     a = run_assertions(TEXT_HAS_TEXT_ASSERTION_N, TEXT_DATA_HAS_TEXT)
-    assert "Expected 2+-0 occurences of 'test text' in output ('test text\n') found 1" in a
+    assert "Expected 2+-0 occurrences of 'test text' in output ('test text\n') found 1" in a
     assert len(a) == 1
 
 
@@ -186,7 +186,7 @@ def test_has_text_n_delta_success():
 def test_has_text_n_delta_failure():
     """test has_text with n and delta .. negative test"""
     a = run_assertions(TEXT_HAS_TEXT_ASSERTION_N_DELTA, TEXT_DATA_HAS_TEXT)
-    assert "Expected 3+-1 occurences of 'test text' in output ('test text\n') found 1" in a
+    assert "Expected 3+-1 occurrences of 'test text' in output ('test text\n') found 1" in a
     assert len(a) == 1
 
 
@@ -199,7 +199,7 @@ def test_has_text_minmax_delta_success():
 def test_has_text_minmax_delta_failure():
     """test has_text with min max .. negative test"""
     a = run_assertions(TEXT_HAS_TEXT_ASSERTION_MIN_MAX, TEXT_DATA_HAS_TEXT)
-    assert "Expected that the number of occurences of 'test text' in output is in [2:4] ('test text\n') found 1" in a
+    assert "Expected that the number of occurrences of 'test text' in output is in [2:4] ('test text\n') found 1" in a
     assert len(a) == 1
 
 
@@ -238,7 +238,7 @@ def test_has_text_negate_n_success():
 def test_has_text_negate_n_failure():
     """test has_text negate with n .. negative test"""
     a = run_assertions(TEXT_HAS_TEXT_ASSERTION_N_NEGATE, TEXT_DATA_HAS_TEXT * 2)
-    assert "Did not expect 2+-0 occurences of 'test text' in output ('test text\ntest text\n') found 2" in a
+    assert "Did not expect 2+-0 occurrences of 'test text' in output ('test text\ntest text\n') found 2" in a
     assert len(a) == 1
 
 
@@ -251,7 +251,7 @@ def test_has_text_negate_n_delta_success():
 def test_has_text_negate_n_delta_failure():
     """test has_text negate with n and delta .. negative test"""
     a = run_assertions(TEXT_HAS_TEXT_ASSERTION_N_DELTA_NEGATE, TEXT_DATA_HAS_TEXT * 2)
-    assert "Did not expect 3+-1 occurences of 'test text' in output ('test text\ntest text\n') found 2" in a
+    assert "Did not expect 3+-1 occurrences of 'test text' in output ('test text\ntest text\n') found 2" in a
     assert len(a) == 1
 
 
@@ -265,7 +265,7 @@ def test_has_text_negate_minmax_delta_failure():
     """test has_text negate with min max .. negative test"""
     a = run_assertions(TEXT_HAS_TEXT_ASSERTION_MIN_MAX_NEGATE, TEXT_DATA_HAS_TEXT * 2)
     assert (
-        "Did not expect that the number of occurences of 'test text' in output is in [2:4] ('test text\ntest text\n') found 2"
+        "Did not expect that the number of occurrences of 'test text' in output is in [2:4] ('test text\ntest text\n') found 2"
         in a
     )
     assert len(a) == 1
@@ -851,7 +851,7 @@ def test_xml_element_failure_due_to_minmax_in_combination_with_negate():
         ),
         VALID_XML,
     )
-    assert "Did not expect that the number of occurences of path './/more' in xml is in [1:3] found 3" in a
+    assert "Did not expect that the number of occurrences of path './/more' in xml is in [1:3] found 3" in a
     assert len(a) == 1
 
 

--- a/test/unit/tool_util_models/test_output_assertions.py
+++ b/test/unit/tool_util_models/test_output_assertions.py
@@ -93,3 +93,81 @@ def test_json_schema_emits_discriminator_for_outputs():
     schema = Tests.model_json_schema()
     dumped = json.dumps(schema)
     assert "discriminator" in dumped or '"oneOf"' in dumped
+
+
+def test_doc_is_optional_on_test_job():
+    tests = Tests.model_validate([{"job": {}, "outputs": {}}])
+    assert tests.root[0].doc is None
+    schema = Tests.model_json_schema()
+    test_job = schema["$defs"]["TestJob"]
+    assert "doc" not in test_job.get("required", [])
+
+
+def test_test_job_top_level_properties_have_descriptions():
+    schema = Tests.model_json_schema()
+    props = schema["$defs"]["TestJob"]["properties"]
+    for name in ("doc", "job", "outputs", "expect_failure"):
+        assert props[name].get("description"), f"missing description on TestJob.{name}"
+
+
+def test_test_job_titles_are_human_readable_not_lowercase():
+    schema = Tests.model_json_schema()
+    props = schema["$defs"]["TestJob"]["properties"]
+    assert props["doc"]["title"] == "Doc"
+    assert props["outputs"]["title"] == "Outputs"
+    assert props["expect_failure"]["title"] == "Expect Failure"
+
+
+def test_assertion_model_titles_are_human_readable():
+    schema = Tests.model_json_schema()
+    defs = schema["$defs"]
+    assert defs["has_text_model"]["title"] == "Assert Has Text"
+    assert defs["has_text_model_nested"]["title"] == "Assert Has Text (Nested)"
+    # Every field in has_text_model has an explicit title.
+    for name, prop in defs["has_text_model"]["properties"].items():
+        assert prop.get("title"), f"has_text_model.{name} missing title"
+
+
+def test_test_data_output_assertions_field_titles():
+    schema = Tests.model_json_schema()
+    props = schema["$defs"]["TestDataOutputAssertions"]["properties"]
+    assert props["lines_diff"]["title"] == "Lines Diff"
+    assert props["class"]["title"] == "Class"
+    assert props["ftype"]["title"] == "File Type"
+
+
+def test_top_level_schema_has_title_description_and_schema():
+    schema = Tests.model_json_schema()
+    assert schema.get("title") == "GalaxyWorkflowTests"
+    assert schema.get("description")
+    assert schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema"
+
+
+def test_root_model_wrappers_have_clean_defs_keys():
+    schema = Tests.model_json_schema()
+    defs = schema["$defs"]
+    assert "Job" in defs
+    assert "assertion_list" in defs
+    # None of the RootModel-auto-generated mangled names should appear.
+    mangled = [k for k in defs if k.startswith("RootModel_")]
+    assert not mangled, f"unexpected mangled RootModel defs: {mangled}"
+
+
+def test_test_data_output_assertions_properties_have_descriptions():
+    schema = Tests.model_json_schema()
+    props = schema["$defs"]["TestDataOutputAssertions"]["properties"]
+    for name in (
+        "asserts",
+        "metadata",
+        "file",
+        "ftype",
+        "sort",
+        "checksum",
+        "compare",
+        "lines_diff",
+        "decompress",
+        "delta",
+        "delta_frac",
+        "location",
+    ):
+        assert props[name].get("description"), f"missing description on TestDataOutputAssertions.{name}"

--- a/test/unit/tool_util_models/test_output_assertions.py
+++ b/test/unit/tool_util_models/test_output_assertions.py
@@ -6,10 +6,10 @@ import pytest
 from pydantic import ValidationError
 
 from galaxy.tool_util_models import (
-    Tests,
     TestCollectionCollectionElementAssertions,
     TestCollectionOutputAssertions,
     TestDataOutputAssertions,
+    Tests,
 )
 
 

--- a/test/unit/tool_util_models/test_output_assertions.py
+++ b/test/unit/tool_util_models/test_output_assertions.py
@@ -1,0 +1,95 @@
+"""Tests for the discriminated `TestOutputAssertions` Union."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from galaxy.tool_util_models import (
+    Tests,
+    TestCollectionCollectionElementAssertions,
+    TestCollectionOutputAssertions,
+    TestDataOutputAssertions,
+)
+
+
+def _one_test(outputs):
+    return [{"doc": "t", "job": {}, "outputs": outputs}]
+
+
+def test_implicit_file_output_validates_as_data():
+    tests = Tests.model_validate(_one_test({"out": {"asserts": [{"that": "has_text", "text": "x"}]}}))
+    out = tests.root[0].outputs["out"]
+    assert isinstance(out, TestDataOutputAssertions)
+
+
+def test_explicit_collection_output_validates_as_collection():
+    tests = Tests.model_validate(_one_test({"out": {"class": "Collection", "elements": {"a": {"asserts": []}}}}))
+    out = tests.root[0].outputs["out"]
+    assert isinstance(out, TestCollectionOutputAssertions)
+
+
+@pytest.mark.parametrize("value", [True, 42, 3.14, "hello"])
+def test_scalar_literal_output_validates(value):
+    tests = Tests.model_validate(_one_test({"out": value}))
+    assert tests.root[0].outputs["out"] == value
+
+
+def test_nested_collection_element_with_class_collection_validates():
+    tests = Tests.model_validate(
+        _one_test(
+            {
+                "out": {
+                    "class": "Collection",
+                    "elements": {
+                        "inner": {
+                            "class": "Collection",
+                            "elements": {"leaf": {"asserts": []}},
+                        }
+                    },
+                }
+            }
+        )
+    )
+    out = tests.root[0].outputs["out"]
+    assert isinstance(out, TestCollectionOutputAssertions)
+    assert out.elements is not None
+    inner = out.elements["inner"]
+    assert isinstance(inner, TestCollectionCollectionElementAssertions)
+
+
+def test_unknown_field_on_file_output_yields_single_error():
+    with pytest.raises(ValidationError) as exc:
+        Tests.model_validate(_one_test({"out": {"asserts": [], "garbage_key": 1}}))
+    errs = exc.value.errors()
+    assert len(errs) == 1
+    err = errs[0]
+    assert err["loc"][:4] == (0, "outputs", "out", "File")
+    assert err["loc"][-1] == "garbage_key"
+    assert err["type"] == "extra_forbidden"
+
+
+def test_unknown_class_value_yields_single_class_literal_error():
+    with pytest.raises(ValidationError) as exc:
+        Tests.model_validate(_one_test({"out": {"class": "Banana"}}))
+    errs = exc.value.errors()
+    assert len(errs) == 1
+    err = errs[0]
+    assert err["loc"][:4] == (0, "outputs", "out", "File")
+    assert err["type"] == "literal_error"
+
+
+def test_bad_asserts_error_scoped_to_file_branch():
+    with pytest.raises(ValidationError) as exc:
+        Tests.model_validate(_one_test({"out": {"asserts": [{"that": "not_a_real_assert"}]}}))
+    errs = exc.value.errors()
+    for err in errs:
+        assert "Collection" not in err["loc"]
+        assert "scalar" not in err["loc"]
+        assert err["loc"][:4] == (0, "outputs", "out", "File")
+
+
+def test_json_schema_emits_discriminator_for_outputs():
+    schema = Tests.model_json_schema()
+    dumped = json.dumps(schema)
+    assert "discriminator" in dumped or '"oneOf"' in dumped


### PR DESCRIPTION
Pulls in some updated version of stuff from https://github.com/galaxyproject/galaxy/pull/17128 that didn't make it into my approach with https://github.com/galaxyproject/galaxy/pull/18884. Also goes some way toward unifying the Planemo workflow test format and the workflow test format we use for the framework tests in Galaxy.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
