### PR TITLE
Add ``RetrySession`` to automatically retry idempotent HTTP requests

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
@@ -65,7 +65,7 @@ def _new_versions(quay, conda):
 
 def run_channel(args, build_last_n_versions: int = 1) -> None:
     """Build list of involucro commands (as shell snippet) to run."""
-    session = requests.session()
+    session = requests.Session()
     for pkg_name, pkg_tests in get_affected_packages(args):
         repo_data = _fetch_repo_data(args)
         c = conda_versions(pkg_name, repo_data)

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -123,7 +123,7 @@ def quay_repository(namespace: str, pkg_name: str, session: Optional[Session] = 
     assert pkg_name is not None
     url = f"https://quay.io/api/v1/repository/{namespace}/{pkg_name}"
     if not session:
-        session = requests.session()
+        session = requests.Session()
     response = session.get(url, timeout=MULLED_SOCKET_TIMEOUT)
     data = response.json()
     return data

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -62,8 +62,6 @@ from boltons.iterutils import (
     default_enter,
     remap,
 )
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 from typing_extensions import (
     Literal,
     Self,
@@ -1945,9 +1943,7 @@ def build_url(base_url, port=80, scheme="http", pathspec=None, params=None, dose
 def url_get(base_url, auth=None, pathspec=None, params=None, max_retries=5, backoff_factor=1):
     """Make contact with the uri provided and return any contents."""
     full_url = build_url(base_url, pathspec=pathspec, params=params)
-    retries = Retry(total=max_retries, backoff_factor=backoff_factor, status_forcelist=[429])
-    with requests.Session() as s:
-        s.mount(base_url, HTTPAdapter(max_retries=retries))
+    with requests.RetrySession(total=max_retries, backoff_factor=backoff_factor, status_forcelist=[429]) as s:
         response = s.get(full_url, auth=auth)
     response.raise_for_status()
     return response.text

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -63,7 +63,7 @@ from boltons.iterutils import (
     remap,
 )
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry  # type: ignore[import-untyped, unused-ignore]
+from requests.packages.urllib3.util.retry import Retry
 from typing_extensions import (
     Literal,
     Self,
@@ -1945,10 +1945,10 @@ def build_url(base_url, port=80, scheme="http", pathspec=None, params=None, dose
 def url_get(base_url, auth=None, pathspec=None, params=None, max_retries=5, backoff_factor=1):
     """Make contact with the uri provided and return any contents."""
     full_url = build_url(base_url, pathspec=pathspec, params=params)
-    s = requests.Session()
     retries = Retry(total=max_retries, backoff_factor=backoff_factor, status_forcelist=[429])
-    s.mount(base_url, HTTPAdapter(max_retries=retries))
-    response = s.get(full_url, auth=auth)
+    with requests.Session() as s:
+        s.mount(base_url, HTTPAdapter(max_retries=retries))
+        response = s.get(full_url, auth=auth)
     response.raise_for_status()
     return response.text
 

--- a/lib/galaxy/util/requests.py
+++ b/lib/galaxy/util/requests.py
@@ -1,4 +1,7 @@
-from typing import Callable
+from typing import (
+    Callable,
+    Union,
+)
 
 import requests
 from requests import (  # noqa: F401
@@ -6,15 +9,31 @@ from requests import (  # noqa: F401
     exceptions as exceptions,
     Response as Response,
 )
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from typing_extensions import ParamSpec
 
 from .user_agent import get_default_headers
+
+DEFAULT_RETRIES = 3
+DEFAULT_BACKOFF_FACTOR = 0.1
 
 
 class Session(requests.Session):
     def __init__(self) -> None:
         super().__init__()
         self.headers.update(get_default_headers())
+
+
+class RetrySession(Session):
+    def __init__(
+        self, total: Union[bool, int, None] = DEFAULT_RETRIES, backoff_factor: float = DEFAULT_BACKOFF_FACTOR, **kwargs
+    ) -> None:
+        super().__init__()
+        retry = Retry(total=total, backoff_factor=backoff_factor, **kwargs)
+        adapter = HTTPAdapter(max_retries=retry)
+        self.mount("https://", adapter)
+        self.mount("http://", adapter)
 
 
 Param = ParamSpec("Param")

--- a/lib/galaxy/util/requests.py
+++ b/lib/galaxy/util/requests.py
@@ -1,8 +1,4 @@
-from typing import (
-    Callable,
-    cast,
-    TypeVar,
-)
+from typing import Callable
 
 import requests
 from requests import (  # noqa: F401
@@ -14,32 +10,29 @@ from typing_extensions import ParamSpec
 
 from .user_agent import get_default_headers
 
+
+class Session(requests.Session):
+    def __init__(self) -> None:
+        super().__init__()
+        self.headers.update(get_default_headers())
+
+
 Param = ParamSpec("Param")
-RetType = TypeVar("RetType")
 
 
-def default_user_agent_decorator(f: Callable[Param, RetType]) -> Callable[Param, RetType]:
-
-    def wrapper(*args: Param.args, **kwargs: Param.kwargs) -> RetType:
-        headers = cast(dict, kwargs.pop("headers", None) or {})
-        headers.update(get_default_headers())
-        is_session = f in (requests.session, requests.Session)
-        if not is_session:
-            kwargs["headers"] = headers
-        rval = f(*args, **kwargs)
-        if is_session:
-            rval.headers = headers  # type: ignore[attr-defined]
-        return rval
+def _request_decorator(f: Callable[Param, Response]) -> Callable[Param, Response]:
+    def wrapper(*args: Param.args, **kwargs: Param.kwargs) -> Response:
+        with Session() as s:
+            return getattr(s, f.__name__)(*args, **kwargs)
 
     return wrapper
 
 
-delete = default_user_agent_decorator(requests.delete)
-get = default_user_agent_decorator(requests.get)
-head = default_user_agent_decorator(requests.head)
-patch = default_user_agent_decorator(requests.patch)
-post = default_user_agent_decorator(requests.post)
-options = default_user_agent_decorator(requests.options)
-put = default_user_agent_decorator(requests.put)
-session = default_user_agent_decorator(requests.session)
-Session = default_user_agent_decorator(requests.Session)
+delete = _request_decorator(requests.delete)
+get = _request_decorator(requests.get)
+head = _request_decorator(requests.head)
+patch = _request_decorator(requests.patch)
+post = _request_decorator(requests.post)
+options = _request_decorator(requests.options)
+put = _request_decorator(requests.put)
+session = Session

--- a/lib/galaxy/webapps/galaxy/api/container_resolution.py
+++ b/lib/galaxy/webapps/galaxy/api/container_resolution.py
@@ -64,7 +64,7 @@ class ContainerResolutionAPIController(BaseGalaxyAPIController):
         :returns:   a dictified description of the container dependency, with attribute
                     ``dependency_type: None`` if no match was found.
         """
-        kwds["session"] = requests.session()
+        kwds["session"] = requests.Session()
         return self._view.resolve(index=index, **kwds)
 
     @expose_api
@@ -84,7 +84,7 @@ class ContainerResolutionAPIController(BaseGalaxyAPIController):
         :rtype:     list
         :returns:   list of items returned from resolve()
         """
-        kwds["session"] = requests.session()
+        kwds["session"] = requests.Session()
         return self._view.resolve_toolbox(**kwds)
 
     @expose_api
@@ -103,7 +103,7 @@ class ContainerResolutionAPIController(BaseGalaxyAPIController):
         """
         kwds.update(payload)
         kwds["install"] = True
-        kwds["session"] = requests.session()
+        kwds["session"] = requests.Session()
         return self._view.resolve_toolbox(**kwds)
 
     @expose_api

--- a/test/unit/util/test_requests.py
+++ b/test/unit/util/test_requests.py
@@ -1,7 +1,12 @@
+import socket
+import threading
+
 import pytest
 import responses
+from requests.adapters import HTTPAdapter
 
 from galaxy.util import requests as galaxy_requests
+from galaxy.util.requests import DEFAULT_RETRIES
 from galaxy.util.user_agent import get_default_headers
 
 EXPECTED_USER_AGENT = get_default_headers()["user-agent"]
@@ -25,6 +30,75 @@ def test_user_agent_and_caller_headers_are_set(method: str):
 
 
 @pytest.mark.parametrize("method", (galaxy_requests.Session, galaxy_requests.session))
-def test_session_has_user_agent_header(method):
+def test_Session_has_user_agent_header(method):
     s: galaxy_requests.Session = method()
     assert s.headers["user-agent"] == EXPECTED_USER_AGENT
+
+
+def test_Session_has_no_retry_adapter():
+    s = galaxy_requests.Session()
+    for url in ("https://example.com/", "http://example.com/"):
+        adapter = s.get_adapter(url)
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries.total == 0  # requests default: no retries
+
+
+# --- RetrySession ---
+
+
+def test_RetrySession_has_user_agent_header():
+    s = galaxy_requests.RetrySession()
+    assert s.headers["user-agent"] == EXPECTED_USER_AGENT
+
+
+def test_retry_session_has_retry_adapter():
+    s = galaxy_requests.RetrySession()
+    for url in ("https://example.com/", "http://example.com/"):
+        adapter = s.get_adapter(url)
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter.max_retries.total == DEFAULT_RETRIES
+
+
+# --- Retry behaviour ---
+
+
+@pytest.fixture()
+def connection_reset_server():
+    """A TCP server that accepts connections and immediately closes them."""
+    attempts = 0
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.listen(10)
+    stop = threading.Event()
+    sock.settimeout(0.1)
+
+    def serve():
+        nonlocal attempts
+        while not stop.is_set():
+            try:
+                conn, _ = sock.accept()
+            except socket.timeout:  # noqa: UP041  # Python <=3.9 support, replace with TimeoutError in Python 3.10+
+                continue
+            except OSError:
+                break
+            attempts += 1
+            conn.close()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}", lambda: attempts
+    stop.set()
+    sock.close()
+    thread.join()
+
+
+@pytest.mark.parametrize("method", ("delete", "get", "head", "options", "put"))
+def test_RetrySession_retries_idempotent_methods(method: str, connection_reset_server):
+    """RetrySession retries idempotent methods on connection failure."""
+    url, get_attempts = connection_reset_server
+    with galaxy_requests.RetrySession() as s:
+        with pytest.raises(galaxy_requests.exceptions.ConnectionError):
+            getattr(s, method)(url)
+    assert get_attempts() == 1 + DEFAULT_RETRIES

--- a/test/unit/util/test_requests.py
+++ b/test/unit/util/test_requests.py
@@ -1,0 +1,30 @@
+import pytest
+import responses
+
+from galaxy.util import requests as galaxy_requests
+from galaxy.util.user_agent import get_default_headers
+
+EXPECTED_USER_AGENT = get_default_headers()["user-agent"]
+
+
+# --- User-Agent header injection ---
+
+
+@pytest.mark.parametrize("method", ("delete", "get", "head", "options", "patch", "post", "put"))
+@responses.activate
+def test_user_agent_and_caller_headers_are_set(method: str):
+    """All methods inject the Galaxy user-agent and preserve caller-supplied headers."""
+    responses.add(getattr(responses, method.upper()), "https://example.com/", status=200)
+    getattr(galaxy_requests, method)("https://example.com/", headers={"X-Custom": "value"})
+    req_headers = responses.calls[0].request.headers
+    assert req_headers["user-agent"] == EXPECTED_USER_AGENT
+    assert req_headers["X-Custom"] == "value"
+
+
+# --- Session factory ---
+
+
+@pytest.mark.parametrize("method", (galaxy_requests.Session, galaxy_requests.session))
+def test_session_has_user_agent_header(method):
+    s: galaxy_requests.Session = method()
+    assert s.headers["user-agent"] == EXPECTED_USER_AGENT


### PR DESCRIPTION
Add a `RetrySession` subclass of `Session` that configures a urllib3 `Retry` adapter restricted to idempotent HTTP methods (`Retry.DEFAULT_ALLOWED_METHODS`). `total`, `backoff_factor`, and any additional `Retry` keyword arguments can be passed to `RetrySession.__init__()`, defaulting to 3 retries and a 0.1s backoff factor.

Callers that need retry behaviour on transient failures (e.g. internal Galaxy-to-Galaxy calls, object store access) can opt in explicitly by using `RetrySession` instead of plain `Session`.

Also:
- Update `url_get()` in `galaxy.util` to use `RetrySession` instead of manually constructing a `Retry` adapter and mounting it.
- Make `Session` a proper subclass of `requests.Session` that sets the Galaxy user-agent header in `__init__`, so all session-level operations (including streaming) automatically carry the correct header.
- Replace `default_user_agent_decorator` with a cleaner `_request_decorator` that creates a `Session` instance per call, removing the need for `cast` and `TypeVar`.
- Fix uses of deprecated `session()` function (replaced with `Session()`)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
