### PR TITLE
Restore WebDAV template v0; add v1 for url -> base_url rename

### DIFF
--- a/lib/galaxy/files/templates/examples/production_webdav.yml
+++ b/lib/galaxy/files/templates/examples/production_webdav.yml
@@ -4,6 +4,49 @@
   description: |
     The WebDAV protocol is a simple way to access files over the internet. Here, you can connect to any WebDAV server.
   variables:
+    url:
+      label: Server Domain (e.g. https://myowncloud.org)
+      type: string
+      help: |
+        The domain of the WebDAV server you are connecting to. This should be the full URL
+        including the protocol (http or https) and the domain name.
+    root:
+      label: WebDAV server Path (e.g., /a/sub/path/remote.php/webdav, /remote.php/dav/files/username)
+      type: string
+      help: |
+        The full server path to the WebDAV service.
+    login:
+      label: Username
+      type: string
+      help: |
+        The username to use to connect to the WebDAV server. This should be the username you use
+        to log in to the WebDAV server.
+    writable:
+      label: Writable?
+      type: boolean
+      optional: true
+      default: false
+      help: Allow Galaxy to write data to this WebDAV server.
+  secrets:
+    password:
+      label: Password
+      help: |
+        The password to use to connect to the WebDAV server. This should be the password you use
+        to log in to the WebDAV server.
+  configuration:
+    type: webdav
+    url: '{{ variables.url }}'
+    root: '{{ variables.root }}'
+    login: '{{ variables.login }}'
+    writable: '{{ variables.writable }}'
+    password: '{{ secrets.password }}'
+
+- id: webdav
+  version: 1
+  name: WebDAV (e.g. Nextcloud, Owncloud, Opencloud)
+  description: |
+    The WebDAV protocol is a simple way to access files over the internet. Here, you can connect to any WebDAV server.
+  variables:
     base_url:
       label: Server Domain (e.g. https://myowncloud.org)
       type: string
@@ -40,4 +83,3 @@
     login: '{{ variables.login }}'
     writable: '{{ variables.writable }}'
     password: '{{ secrets.password }}'
-    

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -238,8 +238,9 @@ class WebdavConfigMixin:
     @model_validator(mode="before")
     @classmethod
     def ensure_base_url(cls, data: Any) -> Any:
-        # Keep persisted user file sources created before the WebDAV
-        # url -> base_url rename loadable in the preferences UI.
+        # Accept the version-0 WebDAV template's `url` field as an alias of
+        # `base_url` so that v0 templates and any persisted v0 rendered configs
+        # continue to validate after the rename.
         if isinstance(data, dict) and "base_url" not in data and "url" in data:
             data = dict(data)
             data["base_url"] = data.pop("url")


### PR DESCRIPTION
Existing user file source instances created against v0 of the WebDAV template have `url` in their persisted template_variables dict. Mutating v0 in place to use `base_url` would break those instances on render because `{{ variables.base_url }}` has no value. Instead, restore v0 unchanged and add v1 with the renamed variable so users get an upgrade-available prompt and migrate at their own pace.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
