### PR TITLE
Add MaveDB filesource based on mavedb-fsspec

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -13092,6 +13092,7 @@ export interface components {
                 | "dataverse"
                 | "huggingface"
                 | "iiif"
+                | "mavedb"
                 | "omero"
                 | "ssh";
             /** Variables */
@@ -25381,6 +25382,7 @@ export interface components {
                 | "dataverse"
                 | "huggingface"
                 | "iiif"
+                | "mavedb"
                 | "omero"
                 | "ssh";
             /** Uri Root */

--- a/client/src/api/fileSources.ts
+++ b/client/src/api/fileSources.ts
@@ -32,6 +32,10 @@ export const templateTypes: FileSourceTypesDetail = {
         icon: faGoogleDrive,
         message: "This is a  repository plugin that connects with the commercial Google Drive service.",
     },
+    mavedb: {
+        icon: faNetworkWired,
+        message: "This is a repository plugin that connects with MaveDB score set files.",
+    },
     onedrive: {
         icon: faCloud,
         message: "This is a repository plugin that connects with Microsoft OneDrive.",

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -363,6 +363,9 @@ class ConditionalDependencies:
     def check_iiif_fsspec(self):
         return "iiif" in self.file_sources
 
+    def check_mavedb_fsspec(self):
+        return "mavedb" in self.file_sources
+
 
 def strip_comment(line):
     # lifted from https://github.com/tox-dev/tox/commit/3c6b4f204e89852c4b7536b246a66d20be6d39ec

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -36,6 +36,7 @@ huggingface_hub
 omero-py #type: omero
 iiif-fsspec # type: iiif
 fs-irods # type: irods, depends on python-irodsclient
+mavedb-fsspec>=0.1.0 # type: mavedb
 
 # Vault backend
 hvac

--- a/lib/galaxy/files/sources/mavedb.py
+++ b/lib/galaxy/files/sources/mavedb.py
@@ -5,8 +5,14 @@ from typing import (
 
 from fsspec import AbstractFileSystem
 
-from galaxy.exceptions import AuthenticationRequired, MessageException
-from galaxy.files.models import AnyRemoteEntry, FilesSourceRuntimeContext
+from galaxy.exceptions import (
+    AuthenticationRequired,
+    MessageException,
+)
+from galaxy.files.models import (
+    AnyRemoteEntry,
+    FilesSourceRuntimeContext,
+)
 from galaxy.files.sources._defaults import DEFAULT_SCHEME
 from galaxy.files.sources._fsspec import (
     CacheOptionsDictType,
@@ -20,7 +26,7 @@ try:
     from mavedb_fsspec import MaveDBFileSystem
     from mavedb_fsspec.client import DEFAULT_BASE_URL
 except ImportError:
-    MaveDBFileSystem = None  # type: ignore[misc, assignment]
+    MaveDBFileSystem = None
     DEFAULT_BASE_URL = "https://api.mavedb.org/api/v1"
 
 
@@ -78,7 +84,7 @@ class MaveDBFilesSource(FsspecFilesSource[MaveDBFileSourceTemplateConfiguration,
         try:
             cache_options = self._get_cache_options(context.config)
             fs = self._open_fs(context, cache_options)
-            entries, total_count = fs.list_score_sets(  # type: ignore[attr-defined]
+            entries, total_count = fs.list_score_sets(
                 collection=collection,
                 limit=limit,
                 offset=offset,

--- a/lib/galaxy/files/sources/mavedb.py
+++ b/lib/galaxy/files/sources/mavedb.py
@@ -1,0 +1,114 @@
+from typing import (
+    Optional,
+    Union,
+)
+
+from fsspec import AbstractFileSystem
+
+from galaxy.exceptions import AuthenticationRequired, MessageException
+from galaxy.files.models import AnyRemoteEntry, FilesSourceRuntimeContext
+from galaxy.files.sources._defaults import DEFAULT_SCHEME
+from galaxy.files.sources._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+from galaxy.util.config_templates import TemplateExpansion
+
+try:
+    from mavedb_fsspec import MaveDBFileSystem
+    from mavedb_fsspec.client import DEFAULT_BASE_URL
+except ImportError:
+    MaveDBFileSystem = None  # type: ignore[misc, assignment]
+    DEFAULT_BASE_URL = "https://api.mavedb.org/api/v1"
+
+
+class MaveDBFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
+    base_url: Union[str, TemplateExpansion] = DEFAULT_BASE_URL
+    api_key: Union[str, TemplateExpansion, None] = None
+    timeout: Union[float, TemplateExpansion] = 30.0
+
+
+class MaveDBFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
+    base_url: str = DEFAULT_BASE_URL
+    api_key: Optional[str] = None
+    timeout: float = 30.0
+
+
+class MaveDBFilesSource(FsspecFilesSource[MaveDBFileSourceTemplateConfiguration, MaveDBFileSourceConfiguration]):
+    plugin_type = "mavedb"
+    required_module = MaveDBFileSystem
+    required_package = "mavedb-fsspec"
+
+    template_config_class = MaveDBFileSourceTemplateConfiguration
+    resolved_config_class = MaveDBFileSourceConfiguration
+
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[MaveDBFileSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ) -> AbstractFileSystem:
+        if MaveDBFileSystem is None:
+            raise self.required_package_exception
+
+        config = context.config
+        return MaveDBFileSystem(
+            base_url=config.base_url,
+            api_key=config.api_key,
+            timeout=config.timeout,
+            **cache_options,
+        )
+
+    def _list(
+        self,
+        context: FilesSourceRuntimeContext[MaveDBFileSourceConfiguration],
+        path="/",
+        recursive=False,
+        write_intent: bool = False,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query: Optional[str] = None,
+        sort_by: Optional[str] = None,
+    ) -> tuple[list[AnyRemoteEntry], int]:
+        collection = path.strip("/")
+        if recursive or collection not in {"score-sets", "my-score-sets"}:
+            return super()._list(context, path, recursive, write_intent, limit, offset, query, sort_by)
+
+        try:
+            cache_options = self._get_cache_options(context.config)
+            fs = self._open_fs(context, cache_options)
+            entries, total_count = fs.list_score_sets(  # type: ignore[attr-defined]
+                collection=collection,
+                limit=limit,
+                offset=offset,
+                query=query,
+            )
+            return [self._info_to_entry(entry, context.config) for entry in entries], total_count
+        except PermissionError as e:
+            raise AuthenticationRequired(
+                f"Permission Denied. Reason: {e}. Please check your credentials in your preferences for {self.label}."
+            )
+        except Exception as e:
+            raise MessageException(f"Problem listing file source path {path}. Reason: {e}") from e
+
+    def _info_to_entry(self, info: dict, config: MaveDBFileSourceConfiguration) -> AnyRemoteEntry:
+        entry = super()._info_to_entry(info, config)
+        display_name = info.get("display_name")
+        if display_name:
+            entry.name = display_name
+        return entry
+
+    def _write_from(
+        self,
+        _target_path: str,
+        _native_path: str,
+        _context: FilesSourceRuntimeContext[MaveDBFileSourceConfiguration],
+    ):
+        raise MessageException("MaveDB file sources are read-only and do not support exporting files.")
+
+    def get_scheme(self) -> str:
+        return self.scheme if self.scheme and self.scheme != DEFAULT_SCHEME else "mavedb"
+
+
+__all__ = ("MaveDBFilesSource",)

--- a/lib/galaxy/files/sources/mavedb.py
+++ b/lib/galaxy/files/sources/mavedb.py
@@ -3,8 +3,6 @@ from typing import (
     Union,
 )
 
-from fsspec import AbstractFileSystem
-
 from galaxy.exceptions import (
     AuthenticationRequired,
     MessageException,
@@ -54,7 +52,7 @@ class MaveDBFilesSource(FsspecFilesSource[MaveDBFileSourceTemplateConfiguration,
         self,
         context: FilesSourceRuntimeContext[MaveDBFileSourceConfiguration],
         cache_options: CacheOptionsDictType,
-    ) -> AbstractFileSystem:
+    ) -> "MaveDBFileSystem":
         if MaveDBFileSystem is None:
             raise self.required_package_exception
 
@@ -86,6 +84,7 @@ class MaveDBFilesSource(FsspecFilesSource[MaveDBFileSourceTemplateConfiguration,
             cache_options = self._get_cache_options(context.config)
             fs = self._open_fs(context, cache_options)
             try:
+                # Use the MaveDB-specific API for server-side pagination and the total result count.
                 entries, total_count = fs.list_score_sets(
                     collection=collection,
                     limit=limit,

--- a/lib/galaxy/files/sources/mavedb.py
+++ b/lib/galaxy/files/sources/mavedb.py
@@ -63,6 +63,7 @@ class MaveDBFilesSource(FsspecFilesSource[MaveDBFileSourceTemplateConfiguration,
             base_url=config.base_url,
             api_key=config.api_key,
             timeout=config.timeout,
+            skip_instance_cache=True,
             **cache_options,
         )
 
@@ -84,12 +85,17 @@ class MaveDBFilesSource(FsspecFilesSource[MaveDBFileSourceTemplateConfiguration,
         try:
             cache_options = self._get_cache_options(context.config)
             fs = self._open_fs(context, cache_options)
-            entries, total_count = fs.list_score_sets(
-                collection=collection,
-                limit=limit,
-                offset=offset,
-                query=query,
-            )
+            try:
+                entries, total_count = fs.list_score_sets(
+                    collection=collection,
+                    limit=limit,
+                    offset=offset,
+                    query=query,
+                )
+            finally:
+                close = getattr(fs, "close", None)
+                if close is not None:
+                    close()
             return [self._info_to_entry(entry, context.config) for entry in entries], total_count
         except PermissionError as e:
             raise AuthenticationRequired(

--- a/lib/galaxy/files/templates/examples/production_mavedb.yml
+++ b/lib/galaxy/files/templates/examples/production_mavedb.yml
@@ -3,7 +3,7 @@
   name: MaveDB
   description: |
       [MaveDB](https://www.mavedb.org) provides Multiplexed Assays of Variant Effect datasets.
-      This file source exposes read-only score set files through the public MaveDB API.
+      This file source exposes score set files through the public MaveDB API.
   secrets:
       api_key:
           label: MaveDB API key

--- a/lib/galaxy/files/templates/examples/production_mavedb.yml
+++ b/lib/galaxy/files/templates/examples/production_mavedb.yml
@@ -1,0 +1,19 @@
+- id: mavedb
+  version: 0
+  name: MaveDB
+  description: |
+      [MaveDB](https://www.mavedb.org) provides Multiplexed Assays of Variant Effect datasets.
+      This file source exposes read-only score set files through the public MaveDB API.
+  secrets:
+      api_key:
+          label: MaveDB API key
+          optional: true
+          help: |
+              Optional MaveDB API key. Public score set files do not require an API key.
+              A user API key can be generated in the MaveDB settings page for your account
+              and is needed to access private datasets.
+  configuration:
+      type: mavedb
+      base_url: https://api.mavedb.org/api/v1
+      api_key: "{{ secrets.api_key }}"
+      timeout: 30

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -51,6 +51,7 @@ FileSourceTemplateType = Literal[
     "dataverse",
     "huggingface",
     "iiif",
+    "mavedb",
     "omero",
     "ssh",
 ]
@@ -440,6 +441,22 @@ class IIIFFileSourceConfiguration(StrictModel):
     manifest_url: str
 
 
+class MaveDBFileSourceTemplateConfiguration(StrictModel):
+    type: Literal["mavedb"]
+    base_url: Union[str, TemplateExpansion] = "https://api.mavedb.org/api/v1"
+    api_key: Union[str, TemplateExpansion, None] = None
+    timeout: Union[float, TemplateExpansion] = 30.0
+    template_start: Optional[str] = None
+    template_end: Optional[str] = None
+
+
+class MaveDBFileSourceConfiguration(StrictModel):
+    type: Literal["mavedb"]
+    base_url: str = "https://api.mavedb.org/api/v1"
+    api_key: Optional[str] = None
+    timeout: float = 30.0
+
+
 class OmeroFileSourceTemplateConfiguration(StrictModel):
     type: Literal["omero"]
     username: Union[str, TemplateExpansion]
@@ -480,6 +497,7 @@ FileSourceTemplateConfiguration = Annotated[
         DataverseFileSourceTemplateConfiguration,
         HuggingFaceFileSourceTemplateConfiguration,
         IIIFFileSourceTemplateConfiguration,
+        MaveDBFileSourceTemplateConfiguration,
         OmeroFileSourceTemplateConfiguration,
         SshFileSourceTemplateConfiguration,
     ],
@@ -506,6 +524,7 @@ FileSourceConfiguration = Annotated[
         DataverseFileSourceConfiguration,
         HuggingFaceFileSourceConfiguration,
         IIIFFileSourceConfiguration,
+        MaveDBFileSourceConfiguration,
         OmeroFileSourceConfiguration,
         SshFileSourceConfiguration,
     ],
@@ -590,6 +609,7 @@ TypesToConfigurationClasses: dict[FileSourceTemplateType, type[FileSourceConfigu
     "dataverse": DataverseFileSourceConfiguration,
     "huggingface": HuggingFaceFileSourceConfiguration,
     "iiif": IIIFFileSourceConfiguration,
+    "mavedb": MaveDBFileSourceConfiguration,
     "omero": OmeroFileSourceConfiguration,
     "ssh": SshFileSourceConfiguration,
 }


### PR DESCRIPTION
This PR adds a read-only MaveDB file source for Galaxy, backed by https://github.com/PlushZ/mavedb-fsspec.

The file source exposes public score sets under `score-sets/ `and, when a user provides a MaveDB API key, authenticated user score sets under `my-score-sets/`.

Available files per score set include:
```
scores.csv
counts.csv
variants.csv
metadata.json
mapped-variants.json
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
