### PR TITLE
[26.0] Fixes looks_like_flattened_repeat_key helper

### DIFF
--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -201,6 +201,8 @@ def process_key(incoming_key: str, incoming_value: Any, d: dict[str, Any]):
     else:
         # Section / Conditional
         input_name = key_parts[0]
+        if not input_name or input_name.isdigit():
+            raise RequestParameterInvalidException(f"Parameter '{incoming_key}' has an invalid key structure.")
         subdict = d.get(input_name, {})
         if not isinstance(subdict, dict):
             raise RequestParameterInvalidException(f"Parameter '{incoming_key}' received conflicting value.")

--- a/lib/galaxy/util/permutations.py
+++ b/lib/galaxy/util/permutations.py
@@ -159,7 +159,8 @@ def is_in_state(state_dict, key, nested):
 
 
 def looks_like_flattened_repeat_key(key: str) -> bool:
-    return key.rsplit("_", 1)[-1].isdigit()
+    parts = key.rsplit("_", 1)
+    return len(parts) == 2 and parts[1].isdigit()
 
 
 def split_flattened_repeat_key(key: str) -> Tuple[str, int]:

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -2,6 +2,9 @@ from typing import (
     Any,
 )
 
+import pytest
+
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.tools.parameters.wrapped import (
     nested_key_to_path,
     process_key,
@@ -58,10 +61,10 @@ class TestProcessKey:
         }
         assert nested_dict == expected_dict
 
-    def test_process_key_all_digit_top_level(self):
+    def test_process_key_rejects_all_digit_segment(self):
         nested_dict: dict[str, Any] = {}
-        process_key("42", "value", nested_dict)
-        assert nested_dict == {"42": "value"}
+        with pytest.raises(RequestParameterInvalidException):
+            process_key("files|0|filetype", "fastq", nested_dict)
 
 
 class TestParameterParsing(BaseParameterTestCase):

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -58,6 +58,11 @@ class TestProcessKey:
         }
         assert nested_dict == expected_dict
 
+    def test_process_key_all_digit_top_level(self):
+        nested_dict: dict[str, Any] = {}
+        process_key("42", "value", nested_dict)
+        assert nested_dict == {"42": "value"}
+
 
 class TestParameterParsing(BaseParameterTestCase):
     """Test the parsing of XML for most parameter types - in many


### PR DESCRIPTION
Fixes #22577.

Improve `looks_like_flattened_repeat_key` helper to ensure that simple digits do not return true.

And raise an error if a segment contains only a digit, since repeat indices should be underscored, not pipe separated.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
