### PR TITLE
Use now() wrapper instead of datetime.now()

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -53,7 +53,7 @@ from galaxy.model import (
     Job,
     User,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.objectstore import BaseObjectStore
 from galaxy.objectstore.caching import check_caches

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -53,7 +53,6 @@ from galaxy.model import (
     Job,
     User,
 )
-from galaxy.util import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.objectstore import BaseObjectStore
 from galaxy.objectstore.caching import check_caches
@@ -85,7 +84,10 @@ from galaxy.short_term_storage import ShortTermStorageMonitor
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.tools import create_tool_from_representation
 from galaxy.tools.data_fetch import do_fetch
-from galaxy.util import galaxy_directory
+from galaxy.util import (
+    galaxy_directory,
+    now,
+)
 from galaxy.util.custom_logging import get_logger
 from galaxy.workflow.completion_hooks import WorkflowCompletionHookRegistry
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -53,6 +53,7 @@ from galaxy.jobs.runners.util.pykube_util import (
     Service,
     service_object_dict,
 )
+from galaxy.model.orm.now import now
 from galaxy.util.bytesize import ByteSize
 
 if TYPE_CHECKING:
@@ -748,7 +749,7 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
                         if self.runner_params.get("k8s_unschedulable_walltime_limit"):
                             creation_time_str = k8s_job.obj["metadata"].get("creationTimestamp")
                             creation_time = datetime.strptime(creation_time_str, "%Y-%m-%dT%H:%M:%SZ")
-                            elapsed_seconds = (datetime.utcnow() - creation_time).total_seconds()
+                            elapsed_seconds = (now() - creation_time).total_seconds()
                             if elapsed_seconds > self.runner_params["k8s_unschedulable_walltime_limit"]:
                                 return self._handle_unschedulable_job(k8s_job, job_state)
                             else:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -53,7 +53,7 @@ from galaxy.jobs.runners.util.pykube_util import (
     Service,
     service_object_dict,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.util.bytesize import ByteSize
 
 if TYPE_CHECKING:

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from galaxy import model
 from galaxy.jobs.runners import JobState
+from galaxy.model.orm.now import now
 from ._safe_eval import safe_eval
 
 if TYPE_CHECKING:
@@ -127,7 +128,7 @@ class _ExpressionContext:
         if self._lazy_context is None:
             runner_state = getattr(self._job_state, "runner_state", None) or JobState.runner_states.UNKNOWN_ERROR
             attempt = 1
-            now = datetime.utcnow()
+            current_time = now()
             last_running_state = None
             last_queued_state = None
             for state in self._job_state.job_wrapper.get_job().state_history:
@@ -141,9 +142,9 @@ class _ExpressionContext:
             seconds_running = 0
             seconds_since_queued = 0
             if last_running_state:
-                seconds_running = (now - last_running_state.create_time).total_seconds()
+                seconds_running = (current_time - last_running_state.create_time).total_seconds()
             if last_queued_state:
-                seconds_since_queued = (now - last_queued_state.create_time).total_seconds()
+                seconds_since_queued = (current_time - last_queued_state.create_time).total_seconds()
 
             self._lazy_context = {
                 "walltime_reached": runner_state == JobState.runner_states.WALLTIME_REACHED,

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 from galaxy import model

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from galaxy import model
 from galaxy.jobs.runners import JobState
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from ._safe_eval import safe_eval
 
 if TYPE_CHECKING:

--- a/lib/galaxy/managers/credentials.py
+++ b/lib/galaxy/managers/credentials.py
@@ -15,7 +15,7 @@ from galaxy.model import (
     User,
     UserCredentials,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.credentials import (
     CredentialsContextResponse,

--- a/lib/galaxy/managers/credentials.py
+++ b/lib/galaxy/managers/credentials.py
@@ -15,7 +15,6 @@ from galaxy.model import (
     User,
     UserCredentials,
 )
-from galaxy.util import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.credentials import (
     CredentialsContextResponse,
@@ -29,6 +28,7 @@ from galaxy.security.vault import (
     Vault,
 )
 from galaxy.tool_util.deps.requirements import CredentialsRequirement
+from galaxy.util import now
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/managers/export_tracker.py
+++ b/lib/galaxy/managers/export_tracker.py
@@ -15,10 +15,10 @@ from sqlalchemy.orm.scoping import scoped_session
 
 from galaxy.exceptions import ObjectNotFound
 from galaxy.model import StoreExportAssociation
-from galaxy.util import now
 from galaxy.schema.fields import Security
 from galaxy.schema.schema import ExportObjectType
 from galaxy.structured_app import MinimalManagerApp
+from galaxy.util import now
 
 
 class StoreExportTracker:

--- a/lib/galaxy/managers/export_tracker.py
+++ b/lib/galaxy/managers/export_tracker.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm.scoping import scoped_session
 
 from galaxy.exceptions import ObjectNotFound
 from galaxy.model import StoreExportAssociation
+from galaxy.model.orm.now import now
 from galaxy.schema.fields import Security
 from galaxy.schema.schema import ExportObjectType
 from galaxy.structured_app import MinimalManagerApp
@@ -98,7 +99,7 @@ class StoreExportTracker:
         Returns:
             List of export associations for the user.
         """
-        cutoff_date = datetime.utcnow() - timedelta(days=days)
+        cutoff_date = now() - timedelta(days=days)
         stmt = (
             select(StoreExportAssociation)
             .where(

--- a/lib/galaxy/managers/export_tracker.py
+++ b/lib/galaxy/managers/export_tracker.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm.scoping import scoped_session
 
 from galaxy.exceptions import ObjectNotFound
 from galaxy.model import StoreExportAssociation
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.schema.fields import Security
 from galaxy.schema.schema import ExportObjectType
 from galaxy.structured_app import MinimalManagerApp

--- a/lib/galaxy/managers/export_tracker.py
+++ b/lib/galaxy/managers/export_tracker.py
@@ -1,8 +1,5 @@
 import json
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import timedelta
 from typing import (
     Optional,
     Union,

--- a/lib/galaxy/managers/history_audit_monitor.py
+++ b/lib/galaxy/managers/history_audit_monitor.py
@@ -33,7 +33,7 @@ from galaxy.model import (
     HistoryAudit,
 )
 from galaxy.model.mapping import GalaxyModelMapping
-from galaxy.model.orm.now import now
+from galaxy.util import now
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/managers/history_audit_monitor.py
+++ b/lib/galaxy/managers/history_audit_monitor.py
@@ -16,10 +16,7 @@ from collections import (
     OrderedDict,
 )
 from collections.abc import Iterator
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import timedelta
 from typing import (
     Any,
     Optional,

--- a/lib/galaxy/managers/history_audit_monitor.py
+++ b/lib/galaxy/managers/history_audit_monitor.py
@@ -36,6 +36,7 @@ from galaxy.model import (
     HistoryAudit,
 )
 from galaxy.model.mapping import GalaxyModelMapping
+from galaxy.model.orm.now import now
 
 log = logging.getLogger(__name__)
 
@@ -223,11 +224,11 @@ class HistoryAuditMonitor:
 
     def _poll_audit_table(self) -> None:
         """Poll history_audit for recent changes."""
-        last_check = datetime.utcnow() - timedelta(seconds=self.poll_interval)
+        last_check = now() - timedelta(seconds=self.poll_interval)
 
         while not self._exit.is_set():
             try:
-                check_time = datetime.utcnow()
+                check_time = now()
                 stmt = (
                     sa_select(HistoryAudit.history_id)
                     .where(HistoryAudit.update_time > last_check)

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -47,7 +47,7 @@ from galaxy.managers.jobs import (
 from galaxy.managers.licenses import LicensesManager
 from galaxy.model import Job
 from galaxy.model.item_attrs import get_item_annotation_str
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.schema import PdfDocumentType
 from galaxy.schema.tasks import GeneratePdfDownload
 from galaxy.short_term_storage import (

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -47,13 +47,13 @@ from galaxy.managers.jobs import (
 from galaxy.managers.licenses import LicensesManager
 from galaxy.model import Job
 from galaxy.model.item_attrs import get_item_annotation_str
-from galaxy.util import now
 from galaxy.schema import PdfDocumentType
 from galaxy.schema.tasks import GeneratePdfDownload
 from galaxy.short_term_storage import (
     ShortTermStorageMonitor,
     storage_context,
 )
+from galaxy.util import now
 from galaxy.util.markdown import literal_via_fence
 from galaxy.util.resources import resource_string
 from galaxy.util.sanitize_html import sanitize_html

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -48,7 +48,7 @@ from galaxy.model import (
     UserNotificationAssociation,
     UserRoleAssociation,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.notifications import (
     AnyNotificationContent,

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -48,7 +48,6 @@ from galaxy.model import (
     UserNotificationAssociation,
     UserRoleAssociation,
 )
-from galaxy.util import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.notifications import (
     AnyNotificationContent,
@@ -72,6 +71,7 @@ from galaxy.schema.notifications import (
     UserNotificationUpdateRequest,
 )
 from galaxy.schema.schema import AsyncTaskResultSummary
+from galaxy.util import now
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -48,6 +48,7 @@ from galaxy.model import (
     UserNotificationAssociation,
     UserRoleAssociation,
 )
+from galaxy.model.orm.now import now
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.notifications import (
     AnyNotificationContent,
@@ -143,7 +144,7 @@ class NotificationManager:
 
     @property
     def _now(self):
-        return datetime.utcnow()
+        return now()
 
     @property
     def _notification_is_active(self):

--- a/lib/galaxy/managers/queue_metrics.py
+++ b/lib/galaxy/managers/queue_metrics.py
@@ -34,11 +34,11 @@ from sqlalchemy import (
 from galaxy.managers.sse import SSEConnectionManager
 from galaxy.model import WorkerProcess
 from galaxy.model.mapping import GalaxyModelMapping
-from galaxy.util import now
 from galaxy.queues import (
     all_control_queues_for_declare,
     DEFAULT_ACTIVE_PROCESS_WINDOW_SECONDS,
 )
+from galaxy.util import now
 from galaxy.web_stack import ApplicationStack
 
 if TYPE_CHECKING:

--- a/lib/galaxy/managers/queue_metrics.py
+++ b/lib/galaxy/managers/queue_metrics.py
@@ -34,7 +34,7 @@ from sqlalchemy import (
 from galaxy.managers.sse import SSEConnectionManager
 from galaxy.model import WorkerProcess
 from galaxy.model.mapping import GalaxyModelMapping
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.queues import (
     all_control_queues_for_declare,
     DEFAULT_ACTIVE_PROCESS_WINDOW_SECONDS,

--- a/lib/galaxy/managers/sse.py
+++ b/lib/galaxy/managers/sse.py
@@ -19,7 +19,7 @@ from typing import (
     Optional,
 )
 
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.web.statsd_client import VanillaGalaxyStatsdClient
 
 log = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 def make_event_id() -> str:
     """Return an SSE ``id`` string for Last-Event-ID replay.
 
-    Uses ``galaxy.model.orm.now`` so the timestamp format matches the rest of
+    Uses ``galaxy.util.now`` so the timestamp format matches the rest of
     Galaxy's database-backed timestamps (timezone-naive UTC). Kept in one place
     so producers and the parse path cannot drift.
     """

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -44,7 +44,6 @@ from galaxy.model.db.user import (
     get_user_by_email,
     get_user_by_username,
 )
-from galaxy.util import now
 from galaxy.security.validate_user_input import (
     VALID_EMAIL_RE,
     validate_email,
@@ -56,6 +55,7 @@ from galaxy.structured_app import (
     BasicSharedApp,
     MinimalManagerApp,
 )
+from galaxy.util import now
 from galaxy.util.hash_util import new_secure_hash_v2
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -44,7 +44,7 @@ from galaxy.model.db.user import (
     get_user_by_email,
     get_user_by_username,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.security.validate_user_input import (
     VALID_EMAIL_RE,
     validate_email,

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -7,7 +7,6 @@ import logging
 import random
 import string
 import time
-from datetime import datetime
 from typing import (
     Any,
     Optional,
@@ -45,6 +44,7 @@ from galaxy.model.db.user import (
     get_user_by_email,
     get_user_by_username,
 )
+from galaxy.model.orm.now import now
 from galaxy.security.validate_user_input import (
     VALID_EMAIL_RE,
     validate_email,
@@ -472,13 +472,13 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             return None, "Please provide a token or a user and password."
         if token:
             token_result = trans.sa_session.get(self.app.model.PasswordResetToken, token)
-            if not token_result or not token_result.expiration_time > datetime.utcnow():
+            if not token_result or not token_result.expiration_time > now():
                 return None, "Invalid or expired password reset token, please request a new one."
             user = token_result.user
             message = self.__set_password(trans, user, password, confirm)
             if message:
                 return None, message
-            token_result.expiration_time = datetime.utcnow()
+            token_result.expiration_time = now()
             trans.sa_session.add(token_result)
             return user, "Password has been changed. Token has been invalidated."
         else:
@@ -548,7 +548,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         template_context = {
             "name": escape(username),
             "user_email": escape(email),
-            "date": datetime.utcnow().strftime("%D"),
+            "date": now().strftime("%D"),
             "hostname": trans.request.host,
             "activation_url": activation_link,
             "terms_url": self.app.config.terms_url,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -165,7 +165,7 @@ from galaxy.model.item_attrs import (
     get_item_annotation_str,
     UsesAnnotations,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.objectstore import USER_OBJECTS_SCHEME
 from galaxy.objectstore.templates import (

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -165,7 +165,6 @@ from galaxy.model.item_attrs import (
     get_item_annotation_str,
     UsesAnnotations,
 )
-from galaxy.util import now
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.objectstore import USER_OBJECTS_SCHEME
 from galaxy.objectstore.templates import (
@@ -201,6 +200,7 @@ from galaxy.util import (
     enum_values,
     hex_to_lowercase_alphanum,
     listify,
+    now,
     ready_name_for_url,
     unicodify,
     unique_id,

--- a/lib/galaxy/model/database_heartbeat.py
+++ b/lib/galaxy/model/database_heartbeat.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 
 from galaxy.model import WorkerProcess
 from galaxy.model.base import check_database_connection
-from galaxy.model.orm.now import now
+from galaxy.util import now
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/186d4835587b_drop_job_state_history_update_time_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/186d4835587b_drop_job_state_history_update_time_.py
@@ -15,7 +15,7 @@ from galaxy.model.migrations.util import (
     add_column,
     drop_column,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 
 # revision identifiers, used by Alembic.
 revision = "186d4835587b"

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/570bce1e82f9_drop_cloudauthz_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/570bce1e82f9_drop_cloudauthz_table.py
@@ -14,7 +14,7 @@ from galaxy.model.migrations.util import (
     drop_table,
     transaction,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 
 # revision identifiers, used by Alembic.
 revision = "570bce1e82f9"

--- a/lib/galaxy/model/orm/now.py
+++ b/lib/galaxy/model/orm/now.py
@@ -1,7 +1,4 @@
-from datetime import (
-    datetime,
-    timezone,
-)
+from galaxy.util import now
 
 # NOTE REGARDING TIMESTAMPS:
 #   It is currently difficult to have the timestamps calculated by the
@@ -9,13 +6,6 @@ from datetime import (
 #   also saves us from needing to postfetch on postgres. HOWEVER: it
 #   relies on the client's clock being set correctly, so if clustering
 #   web servers, use a time server to ensure synchronization
-
-
-def now():
-    """
-    Return the current time in UTC without any timezone information.
-    """
-    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 __all__ = ("now",)

--- a/lib/galaxy/model/orm/now.py
+++ b/lib/galaxy/model/orm/now.py
@@ -6,6 +6,8 @@ from galaxy.util import now
 #   also saves us from needing to postfetch on postgres. HOWEVER: it
 #   relies on the client's clock being set correctly, so if clustering
 #   web servers, use a time server to ensure synchronization
+#
+# This function lives since 26.1 in galaxy.utils.
 
 
 __all__ = ("now",)

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -49,7 +49,7 @@ from galaxy.model.db.role import (
     get_npns_roles,
     get_private_user_role,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.security import (
     Action,
     get_permitted_actions,

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1,10 +1,7 @@
 import logging
 import socket
 import sqlite3
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import timedelta
 from typing import (
     Optional,
 )

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -49,13 +49,15 @@ from galaxy.model.db.role import (
     get_npns_roles,
     get_private_user_role,
 )
-from galaxy.util import now
 from galaxy.security import (
     Action,
     get_permitted_actions,
     RBACAgent,
 )
-from galaxy.util import listify
+from galaxy.util import (
+    listify,
+    now,
+)
 from galaxy.util.bunch import Bunch
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -52,6 +52,7 @@ from galaxy.model.db.role import (
     get_npns_roles,
     get_private_user_role,
 )
+from galaxy.model.orm.now import now
 from galaxy.security import (
     Action,
     get_permitted_actions,
@@ -1706,7 +1707,7 @@ class HostAgent(RBACAgent):
                     hdadaa.site,
                 )
                 return False  # remote addr is not in the server list
-            if (datetime.utcnow() - hdadaa.update_time) > timedelta(seconds=60):
+            if (now() - hdadaa.update_time) > timedelta(seconds=60):
                 log.debug(
                     "Denying access to private dataset with hda: %d.  Authorization was granted, but has expired.",
                     hda.id,
@@ -1725,7 +1726,7 @@ class HostAgent(RBACAgent):
         )
         hdadaa = self.sa_session.scalars(stmt).first()
         if hdadaa:
-            hdadaa.update_time = datetime.utcnow()
+            hdadaa.update_time = now()
         else:
             hdadaa = HistoryDatasetAssociationDisplayAtAuthorization(hda=hda, user=user, site=site)
         self.sa_session.add(hdadaa)

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -30,12 +30,14 @@ from galaxy.model.custom_types import (
     MutableJSONType,
     TrimmedString,
 )
-from galaxy.util import now
 from galaxy.tool_util.toolbox.base import (
     AbstractToolBox,
     DynamicToolConfDict,
 )
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    now,
+)
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.tool_shed import common_util

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -30,7 +30,7 @@ from galaxy.model.custom_types import (
     MutableJSONType,
     TrimmedString,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.tool_util.toolbox.base import (
     AbstractToolBox,
     DynamicToolConfDict,

--- a/lib/galaxy/model/unittest_utils/store_fixtures.py
+++ b/lib/galaxy/model/unittest_utils/store_fixtures.py
@@ -6,7 +6,7 @@ from typing import (
 )
 from uuid import uuid4
 
-from galaxy.model.orm.now import now
+from galaxy.util import now
 
 TEST_SOURCE_URI = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/2.bed"
 TEST_SOURCE_URI_SIMPLE_LINE = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/simple_line.txt"

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -16,7 +16,8 @@ try:
 except ImportError:
     BlobServiceClient = None  # type: ignore[assignment,unused-ignore,misc]
 
-from galaxy.model.orm.now import now
+from galaxy.util import now
+
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     enable_cache_monitor,

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -4,10 +4,7 @@ Object Store plugin for the Microsoft Azure Block Blob Storage system
 
 import logging
 import os
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import timedelta
 
 try:
     from azure.common import AzureHttpError

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -17,7 +17,6 @@ except ImportError:
     BlobServiceClient = None  # type: ignore[assignment,unused-ignore,misc]
 
 from galaxy.util import now
-
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     enable_cache_monitor,

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     BlobServiceClient = None  # type: ignore[assignment,unused-ignore,misc]
 
+from galaxy.model.orm.now import now
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     enable_cache_monitor,
@@ -325,7 +326,7 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
                     container_name=self.container_name,
                     blob_name=rel_path,
                     permission=BlobSasPermissions(read=True),
-                    expiry=datetime.utcnow() + timedelta(hours=1),
+                    expiry=now() + timedelta(hours=1),
                 )
                 return f"{url}?{token}"
             except AzureHttpError:

--- a/lib/galaxy/queues/__init__.py
+++ b/lib/galaxy/queues/__init__.py
@@ -20,7 +20,7 @@ from kombu import (
 from sqlalchemy import select
 
 from galaxy.model import WorkerProcess
-from galaxy.model.orm.now import now
+from galaxy.util import now
 
 if TYPE_CHECKING:
     from galaxy.web_stack import ApplicationStack

--- a/lib/galaxy/short_term_storage/__init__.py
+++ b/lib/galaxy/short_term_storage/__init__.py
@@ -33,11 +33,11 @@ from galaxy.exceptions import (
 )
 from galaxy.exceptions.error_codes import error_codes_by_int_code
 from galaxy.exceptions.utils import api_error_to_dict
-from galaxy.util import now
 from galaxy.schema.schema import OptionalNumberT
 from galaxy.util import (
     directory_hash_id,
     is_uuid,
+    now,
     safe_makedirs,
 )
 

--- a/lib/galaxy/short_term_storage/__init__.py
+++ b/lib/galaxy/short_term_storage/__init__.py
@@ -33,7 +33,7 @@ from galaxy.exceptions import (
 )
 from galaxy.exceptions.error_codes import error_codes_by_int_code
 from galaxy.exceptions.utils import api_error_to_dict
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.schema.schema import OptionalNumberT
 from galaxy.util import (
     directory_hash_id,

--- a/lib/galaxy/short_term_storage/__init__.py
+++ b/lib/galaxy/short_term_storage/__init__.py
@@ -33,6 +33,7 @@ from galaxy.exceptions import (
 )
 from galaxy.exceptions.error_codes import error_codes_by_int_code
 from galaxy.exceptions.utils import api_error_to_dict
+from galaxy.model.orm.now import now
 from galaxy.schema.schema import OptionalNumberT
 from galaxy.util import (
     directory_hash_id,
@@ -40,7 +41,6 @@ from galaxy.util import (
     safe_makedirs,
 )
 
-now = datetime.utcnow
 DEFAULT_STORAGE_DURATION = 24 * 60 * 60  # store for a day by default
 
 

--- a/lib/galaxy/tools/error_reports/plugins/influxdb.py
+++ b/lib/galaxy/tools/error_reports/plugins/influxdb.py
@@ -9,6 +9,7 @@ except ImportError:
     # This middleware will never be used without influxdb.
     influxdb = None
 
+from galaxy.model.orm.now import now
 from galaxy.util import unicodify
 from . import ErrorPlugin
 
@@ -41,7 +42,7 @@ class InfluxDBPlugin(ErrorPlugin):
             [
                 {
                     "measurement": "galaxy_tool_error",
-                    "time": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "time": now().strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "fields": {"value": 1},
                     "tags": {
                         "exit_code": job.exit_code,

--- a/lib/galaxy/tools/error_reports/plugins/influxdb.py
+++ b/lib/galaxy/tools/error_reports/plugins/influxdb.py
@@ -8,7 +8,7 @@ except ImportError:
     # This middleware will never be used without influxdb.
     influxdb = None
 
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.util import unicodify
 from . import ErrorPlugin
 

--- a/lib/galaxy/tools/error_reports/plugins/influxdb.py
+++ b/lib/galaxy/tools/error_reports/plugins/influxdb.py
@@ -1,6 +1,5 @@
 """The module describes the ``influxdb`` error plugin plugin."""
 
-import datetime
 import logging
 
 try:

--- a/lib/galaxy/tools/error_reports/plugins/influxdb.py
+++ b/lib/galaxy/tools/error_reports/plugins/influxdb.py
@@ -8,8 +8,10 @@ except ImportError:
     # This middleware will never be used without influxdb.
     influxdb = None
 
-from galaxy.util import now
-from galaxy.util import unicodify
+from galaxy.util import (
+    now,
+    unicodify,
+)
 from . import ErrorPlugin
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -641,22 +641,22 @@ def pretty_print_time_interval(time=False, precise=False, utc=False):
     credit: http://stackoverflow.com/questions/1551382/user-friendly-time-format-in-python
     """
     if utc:
-        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        current_time = now()
     else:
-        now = datetime.now()
+        current_time = datetime.now()
     if isinstance(time, (int, float)):
-        diff = now - datetime.fromtimestamp(time)
+        diff = current_time - datetime.fromtimestamp(time)
     elif isinstance(time, datetime):
-        diff = now - time
+        diff = current_time - time
     elif isinstance(time, str):
         try:
             time = datetime.strptime(time, "%Y-%m-%dT%H:%M:%S.%f")
         except ValueError:
             # MySQL may not support microseconds precision
             time = datetime.strptime(time, "%Y-%m-%dT%H:%M:%S")
-        diff = now - time
+        diff = current_time - time
     else:
-        diff = now - now
+        diff = current_time - current_time
     second_diff = diff.seconds
     day_diff = diff.days
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -67,6 +67,14 @@ from typing_extensions import (
     Self,
 )
 
+
+def now():
+    """
+    Return the current time in UTC without any timezone information.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 try:
     import grp
 except ImportError:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -633,7 +633,7 @@ def pretty_print_time_interval(time=False, precise=False, utc=False):
     credit: http://stackoverflow.com/questions/1551382/user-friendly-time-format-in-python
     """
     if utc:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
     else:
         now = datetime.now()
     if isinstance(time, (int, float)):

--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -13,7 +13,7 @@ from babel import default_locale
 from babel.dates import format_timedelta
 from routes import url_for
 
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.util.json import safe_dumps as dumps  # noqa: F401
 from .tags import (
     javascript_link,

--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -16,6 +16,7 @@ from babel import default_locale
 from babel.dates import format_timedelta
 from routes import url_for
 
+from galaxy.model.orm.now import now
 from galaxy.util.json import safe_dumps as dumps  # noqa: F401
 from .tags import (
     javascript_link,
@@ -29,14 +30,14 @@ def time_ago(x):
     Convert a datetime to a string.
     """
     # If the date is more than one week ago, then display the actual date instead of in words
-    if datetime.utcnow() - x > timedelta(weeks=1):  # Greater than a week difference
+    if now() - x > timedelta(weeks=1):  # Greater than a week difference
         return x.strftime("%b %d, %Y")
     else:
         # Workaround https://github.com/python-babel/babel/issues/137
         kwargs = {}
         if not default_locale("LC_TIME"):
             kwargs["locale"] = "en_US_POSIX"
-        return format_timedelta(x - datetime.utcnow(), threshold=1, add_direction=True, **kwargs)  # type: ignore[arg-type] # https://github.com/python/mypy/issues/9676
+        return format_timedelta(x - now(), threshold=1, add_direction=True, **kwargs)  # type: ignore[arg-type] # https://github.com/python/mypy/issues/9676
 
 
 def iff(a, b, c):

--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -7,10 +7,7 @@ GalaxyWebTransaction in galaxy/webapps/base/webapp.py
 """
 
 import re
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import timedelta
 
 from babel import default_locale
 from babel.dates import format_timedelta

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -19,7 +19,7 @@ from galaxy import (
 from galaxy.exceptions import Conflict
 from galaxy.managers import users
 from galaxy.model.db.user import get_user_by_email
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.security.validate_user_input import (
     is_valid_email_str,
     validate_email,

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -19,13 +19,13 @@ from galaxy import (
 from galaxy.exceptions import Conflict
 from galaxy.managers import users
 from galaxy.model.db.user import get_user_by_email
-from galaxy.util import now
 from galaxy.security.validate_user_input import (
     is_valid_email_str,
     validate_email,
     validate_publicname,
 )
 from galaxy.structured_app import StructuredApp
+from galaxy.util import now
 from galaxy.web import (
     expose_api_anonymous_and_sessionless,
     url_for,

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -19,6 +19,7 @@ from galaxy import (
 from galaxy.exceptions import Conflict
 from galaxy.managers import users
 from galaxy.model.db.user import get_user_by_email
+from galaxy.model.orm.now import now
 from galaxy.security.validate_user_input import (
     is_valid_email_str,
     validate_email,
@@ -246,7 +247,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
         #  Activation is forced and the user is not active yet. Check the grace period.
         activation_grace_period = trans.app.config.activation_grace_period
         delta = timedelta(hours=int(activation_grace_period))
-        time_difference = datetime.utcnow() - create_time
+        time_difference = now() - create_time
         return time_difference > delta or activation_grace_period == 0
 
     @web.expose

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -17,7 +17,7 @@ from galaxy import model
 from galaxy.exceptions import HandlerAssignmentError
 from galaxy.jobs.handler import InvocationGrabber
 from galaxy.model.base import check_database_connection
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.schema.invocation import (
     FailureReason,
     InvocationFailureDatasetFailed,

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -17,7 +17,6 @@ from galaxy import model
 from galaxy.exceptions import HandlerAssignmentError
 from galaxy.jobs.handler import InvocationGrabber
 from galaxy.model.base import check_database_connection
-from galaxy.util import now
 from galaxy.schema.invocation import (
     FailureReason,
     InvocationFailureDatasetFailed,
@@ -29,6 +28,7 @@ from galaxy.schema.tasks import (
     RequestUser,
 )
 from galaxy.util import (
+    now,
     plugin_config,
     unicodify,
 )

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -9,7 +9,7 @@ from unittest import SkipTest
 import requests
 from dateutil.parser import isoparse
 
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.util.unittest_utils import transient_failure
 from galaxy_test.api.test_tools import TestsTools
 from galaxy_test.base.api_asserts import assert_status_code_is_ok

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -9,6 +9,7 @@ from unittest import SkipTest
 import requests
 from dateutil.parser import isoparse
 
+from galaxy.model.orm.now import now
 from galaxy.util.unittest_utils import transient_failure
 from galaxy_test.api.test_tools import TestsTools
 from galaxy_test.base.api_asserts import assert_status_code_is_ok
@@ -105,13 +106,13 @@ class TestJobsApi(ApiTestCase, TestsTools):
 
     @requires_new_history
     def test_index_date_filter(self, history_id):
-        two_weeks_ago = (datetime.datetime.utcnow() - datetime.timedelta(14)).isoformat()
-        last_week = (datetime.datetime.utcnow() - datetime.timedelta(7)).isoformat()
-        before = datetime.datetime.utcnow().isoformat()
+        two_weeks_ago = (now() - datetime.timedelta(14)).isoformat()
+        last_week = (now() - datetime.timedelta(7)).isoformat()
+        before = now().isoformat()
         today = before[:10]
-        tomorrow = (datetime.datetime.utcnow() + datetime.timedelta(1)).isoformat()[:10]
+        tomorrow = (now() + datetime.timedelta(1)).isoformat()[:10]
         self.__history_with_new_dataset(history_id)
-        after = datetime.datetime.utcnow().isoformat()
+        after = now().isoformat()
 
         # Test using dates
         jobs = self.__jobs_index(data={"date_range_min": today, "date_range_max": tomorrow})

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -47,7 +47,7 @@ from galaxy.model.custom_types import (
     MutableJSONType,
     TrimmedString,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.security.validate_user_input import validate_password_str
 from galaxy.util import unique_id

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -47,10 +47,12 @@ from galaxy.model.custom_types import (
     MutableJSONType,
     TrimmedString,
 )
-from galaxy.util import now
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.security.validate_user_input import validate_password_str
-from galaxy.util import unique_id
+from galaxy.util import (
+    now,
+    unique_id,
+)
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.hash_util import new_insecure_hash

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ log_level = DEBUG
 consider_namespace_packages = true
 filterwarnings =
     error::pydantic.warnings.PydanticDeprecatedSince20
+    error:.*utcnow.*:DeprecationWarning
     ignore::DeprecationWarning:pkg_resources
     ignore::DeprecationWarning:refgenconf
     ignore::UserWarning:refgenconf

--- a/test/integration/resubmission_runners.py
+++ b/test/integration/resubmission_runners.py
@@ -4,7 +4,7 @@ import time
 from galaxy import model
 from galaxy.jobs.runners import JobState
 from galaxy.jobs.runners.local import LocalJobRunner
-from galaxy.model.orm.now import now
+from galaxy.util import now
 
 
 class FailsJobRunner(LocalJobRunner):

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -8,6 +8,7 @@ from typing import (
 )
 from uuid import uuid4
 
+from galaxy.model.orm.now import now
 from galaxy_test.base.populators import (
     DatasetPopulator,
     WorkflowPopulator,
@@ -61,7 +62,7 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         user1 = self._create_test_user()
         user2 = self._create_test_user()
 
-        before_creating_notifications = datetime.utcnow()
+        before_creating_notifications = now()
 
         # Only user1 will receive this notification
         subject1 = f"notification_{uuid4()}"
@@ -81,7 +82,7 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         created_response_3 = self._send_broadcast_notification("test_notification_status 3")
         assert created_response_3["total_notifications_sent"] == 1
 
-        after_creating_notifications = datetime.utcnow()
+        after_creating_notifications = now()
 
         # The default user should have received only the broadcasted notifications
         status = self._get_notifications_status_since(before_creating_notifications)
@@ -158,7 +159,7 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         user1 = self._create_test_user()
         user2 = self._create_test_user()
 
-        before_creating_notifications = datetime.utcnow()
+        before_creating_notifications = now()
 
         subject = f"notification_{uuid4()}"
         created_response = self._send_test_notification_to(
@@ -265,8 +266,8 @@ class NotificationsIntegrationBase(IntegrationTestCase):
         assert updated_response["source"] == "updated_source"
 
     def test_admins_get_all_broadcasted_even_inactive(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        tomorrow = now() + timedelta(days=1)
+        yesterday = now() - timedelta(days=1)
         self._send_broadcast_notification(subject="Active")
         self._send_broadcast_notification(subject="Scheduled", publication_time=tomorrow)
         self._send_broadcast_notification(subject="Expired", expiration_time=yesterday)

--- a/test/integration/test_notifications.py
+++ b/test/integration/test_notifications.py
@@ -8,7 +8,7 @@ from typing import (
 )
 from uuid import uuid4
 
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy_test.base.populators import (
     DatasetPopulator,
     WorkflowPopulator,

--- a/test/unit/app/managers/test_NotificationManager.py
+++ b/test/unit/app/managers/test_NotificationManager.py
@@ -24,7 +24,6 @@ from galaxy.model import (
     Role,
     User,
 )
-from galaxy.util import now
 from galaxy.schema.notifications import (
     BroadcastNotificationContent,
     BroadcastNotificationCreateRequest,
@@ -40,6 +39,7 @@ from galaxy.schema.notifications import (
     UserNotificationPreferences,
     UserNotificationUpdateRequest,
 )
+from galaxy.util import now
 from .base import BaseTestCase
 
 

--- a/test/unit/app/managers/test_NotificationManager.py
+++ b/test/unit/app/managers/test_NotificationManager.py
@@ -24,6 +24,7 @@ from galaxy.model import (
     Role,
     User,
 )
+from galaxy.model.orm.now import now
 from galaxy.schema.notifications import (
     BroadcastNotificationContent,
     BroadcastNotificationCreateRequest,
@@ -88,7 +89,7 @@ class NotificationManagerBaseTestCase(NotificationsBaseTestCase):
         return created_notification, notifications_sent
 
     def _has_expired(self, expiration_time: Optional[datetime]) -> bool:
-        return expiration_time < datetime.utcnow() if expiration_time else False
+        return expiration_time < now() if expiration_time else False
 
     def _assert_notification_expected(self, actual_notification: Any, expected_notification: dict[str, Any]):
         assert actual_notification
@@ -146,13 +147,13 @@ class TestBroadcastNotifications(NotificationManagerBaseTestCase):
         assert actual_notification.id == created_notification.id
 
     def test_get_all_broadcasted_notifications(self):
-        now = datetime.utcnow()
-        next_week = now + timedelta(days=7)
-        next_month = now + timedelta(days=30)
+        current_time = now()
+        next_week = current_time + timedelta(days=7)
+        next_month = current_time + timedelta(days=30)
 
         notification_data = self._default_broadcast_notification_data()
         notification_data["content"]["subject"] = "Recent Notification"
-        notification_data["publication_time"] = now
+        notification_data["publication_time"] = current_time
         self._send_broadcast_notification(notification_data)
 
         notification_data = self._default_broadcast_notification_data()
@@ -179,18 +180,18 @@ class TestBroadcastNotifications(NotificationManagerBaseTestCase):
         assert notifications[0].content["subject"] == "Scheduled Next Month Notification"
 
     def test_update_broadcasted_notification(self):
-        next_month = datetime.utcnow() + timedelta(days=30)
+        next_month = now() + timedelta(days=30)
         notification_data = self._default_broadcast_notification_data()
         notification_data["content"]["subject"] = "Old Scheduled Notification"
         notification_data["publication_time"] = next_month
         actual_notification = self._send_broadcast_notification(notification_data)
 
-        now = datetime.utcnow()
+        current_time = now()
         expected_content = BroadcastNotificationContent(subject="Updated Notification", message="Updated Message")
         update_request = NotificationBroadcastUpdateRequest(
             source="updated_source",
             variant=NotificationVariant.warning,
-            publication_time=now,
+            publication_time=current_time,
             content=expected_content,
         )
         updated_count = self.notification_manager.update_broadcasted_notification(
@@ -206,7 +207,7 @@ class TestBroadcastNotifications(NotificationManagerBaseTestCase):
         assert content["message"] == expected_content.message
 
     def test_cleanup_expired_broadcast_notifications(self):
-        one_hour_ago = datetime.utcnow() - timedelta(hours=1)
+        one_hour_ago = now() - timedelta(hours=1)
         notification_data = self._default_broadcast_notification_data()
         notification_data["expiration_time"] = one_hour_ago
         actual_notification = self._send_broadcast_notification(notification_data)
@@ -290,7 +291,7 @@ class TestUserNotifications(NotificationManagerBaseTestCase):
 
     def test_scheduled_notifications(self):
         user = self._create_test_user()
-        tomorrow = datetime.utcnow() + timedelta(hours=24)
+        tomorrow = now() + timedelta(hours=24)
         expected_notification = self._default_test_notification_data()
         expected_notification["source"] = "test_scheduled"
         expected_notification["publication_time"] = tomorrow
@@ -347,8 +348,10 @@ class TestUserNotifications(NotificationManagerBaseTestCase):
 
     def test_cleanup_expired_notifications(self):
         user = self._create_test_user()
-        now = datetime.utcnow()
-        notification, _ = self._send_message_notification_to_users([user], notification={"expiration_time": now})
+        current_time = now()
+        notification, _ = self._send_message_notification_to_users(
+            [user], notification={"expiration_time": current_time}
+        )
         user_notification = self.notification_manager.get_user_notification(user, notification.id, active_only=False)
         assert user_notification
         assert self._has_expired(user_notification.expiration_time) is True

--- a/test/unit/app/managers/test_NotificationManager.py
+++ b/test/unit/app/managers/test_NotificationManager.py
@@ -24,7 +24,7 @@ from galaxy.model import (
     Role,
     User,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.schema.notifications import (
     BroadcastNotificationContent,
     BroadcastNotificationCreateRequest,

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -20,8 +20,8 @@ from galaxy.managers import (
     histories,
     users,
 )
-from galaxy.util import now
 from galaxy.security.passwords import check_password
+from galaxy.util import now
 from .base import BaseTestCase
 
 # =============================================================================

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -4,7 +4,6 @@ User Manager testing.
 Executable directly using: python -m test.unit.managers.test_UserManager
 """
 
-from datetime import datetime
 from unittest.mock import patch
 
 from sqlalchemy import (
@@ -21,6 +20,7 @@ from galaxy.managers import (
     histories,
     users,
 )
+from galaxy.model.orm.now import now
 from galaxy.security.passwords import check_password
 from .base import BaseTestCase
 
@@ -178,7 +178,7 @@ class TestUserManager(BaseTestCase):
         )
         assert check_password(default_password, user2.password)
         assert not check_password(changed_password, user2.password)
-        prt.expiration_time = datetime.utcnow()
+        prt.expiration_time = now()
         user, message = self.user_manager.change_password(
             self.trans, token=prt.token, password=default_password, confirm=default_password
         )

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -20,7 +20,7 @@ from galaxy.managers import (
     histories,
     users,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.security.passwords import check_password
 from .base import BaseTestCase
 

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -9,7 +9,7 @@ from galaxy.managers.markdown_util import (
     ready_galaxy_markdown_for_export,
     to_basic_markdown,
 )
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from .base import BaseTestCase
 
 

--- a/test/unit/data/test_bco_utils.py
+++ b/test/unit/data/test_bco_utils.py
@@ -1,7 +1,7 @@
 import json
 
 from galaxy.model import WorkflowStep
-from galaxy.model.orm.now import now
+from galaxy.util import now
 from galaxy.model.store._bco_convert_utils import SoftwarePrerequisiteTracker
 from galaxy.schema.bco import (
     BioComputeObjectCore,

--- a/test/unit/data/test_bco_utils.py
+++ b/test/unit/data/test_bco_utils.py
@@ -1,7 +1,6 @@
 import json
 
 from galaxy.model import WorkflowStep
-from galaxy.util import now
 from galaxy.model.store._bco_convert_utils import SoftwarePrerequisiteTracker
 from galaxy.schema.bco import (
     BioComputeObjectCore,
@@ -21,6 +20,7 @@ from galaxy.schema.bco.util import (
     galaxy_execution_domain,
     write_to_file,
 )
+from galaxy.util import now
 
 
 def example_bc_core_object() -> BioComputeObjectCore:


### PR DESCRIPTION
We should use the now() wrapper I think to make sure everything is in UTC?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
