### PR TITLE
Patch bar_chart tool for the Python 3 Gnuplot module

### DIFF
--- a/tools/plotting/bar_chart.py
+++ b/tools/plotting/bar_chart.py
@@ -138,5 +138,8 @@ if __name__ == "__main__":
     # The tempfile initialization is here because while inside the main() it seems to create a condition
     # when the file is removed before gnuplot has a chance of accessing it
     gp_data_file = tempfile.NamedTemporaryFile("w")
-    Gnuplot.gp.GnuplotOpts.default_term = "png"
+    try:
+        Gnuplot.gp.GnuplotOpts.default_term = "png"
+    except Exception:
+        Gnuplot.GnuplotOpts.default_term = "png"
     main(gp_data_file.name)

--- a/tools/plotting/bar_chart.py
+++ b/tools/plotting/bar_chart.py
@@ -138,8 +138,5 @@ if __name__ == "__main__":
     # The tempfile initialization is here because while inside the main() it seems to create a condition
     # when the file is removed before gnuplot has a chance of accessing it
     gp_data_file = tempfile.NamedTemporaryFile("w")
-    try:
-        Gnuplot.gp.GnuplotOpts.default_term = "png"
-    except Exception:
-        Gnuplot.GnuplotOpts.default_term = "png"
+    Gnuplot.GnuplotOpts.default_term = "png"
     main(gp_data_file.name)

--- a/tools/plotting/bar_chart.xml
+++ b/tools/plotting/bar_chart.xml
@@ -40,7 +40,7 @@ $colList '$title' '$ylabel' $ymin $ymax '$out_file1' '$pdf_size'
     <data name="out_file1" format="png" />
   </outputs>
   <requirements>
-    <requirement type="package">gnuplot-py</requirement>
+    <requirement type="package" version="1.8">gnuplot-py</requirement>
   </requirements>
   <help>
 **What it does**


### PR DESCRIPTION
The latest bioconda PR https://github.com/bioconda/bioconda-recipes/pull/59637 moved the same 1.8 version of the package forward from python2 to python3. 

With this move, `GnuplotOpts` is now directly accessible from the module `Gnuplot`. We fixed this by moving the tool in tpv to the legacy conda container. 

Would this be the correct approach, or should we bump the tool wrapper version with a new XML file and keep the legacy version optional?

ref: https://github.com/usegalaxy-eu/issues/issues/979

## How to Test the Changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
