### PR TITLE
[26.0] Preserve falsy workflow parameter values on workflow rerun

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -161,17 +161,18 @@ const formInputs = computed(() => {
             if (props.requestState) {
                 if (props.isRerun) {
                     const requestStateKeys = Object.keys(props.requestState);
+                    const stateKey = String(rerunStateIndex);
 
                     let value;
-                    if (props.requestState[rerunStateIndex]) {
+                    if (stateKey in props.requestState) {
                         // request state has the step_label as key
-                        value = props.requestState[rerunStateIndex];
-                    } else if (requestStateKeys[i] !== undefined && requestStateKeys[i] === "") {
+                        value = props.requestState[stateKey];
+                    } else if (requestStateKeys[i] === "") {
                         // request state has "" as key on the `i` position
                         value = Object.values(props.requestState)[i];
                     }
 
-                    if (value) {
+                    if (value !== undefined) {
                         if (stepType === "data_input" || stepType === "data_collection_input") {
                             // Note: This is different from workflow landings because `WorkflowInvocationRequestModel`
                             //       does not provide an object with `values` property.
@@ -182,9 +183,8 @@ const formInputs = computed(() => {
                             stepAsInput.value = value;
                         }
                     }
-                } else if (props.requestState[stepLabel]) {
-                    const value = props.requestState[stepLabel];
-                    stepAsInput.value = value;
+                } else if (String(stepLabel) in props.requestState) {
+                    stepAsInput.value = props.requestState[String(stepLabel)];
                 }
             }
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -648,6 +648,7 @@ tool_form:
     parameter_div: 'div.ui-form-element[id="form-element-${parameter}"]'
     parameter_error: 'div.ui-form-element[id="form-element-${parameter}"] .ui-form-error-text'
     parameter_checkbox: 'div.ui-form-element[id="form-element-${parameter}"] .ui-switch'
+    parameter_checkbox_input: 'div.ui-form-element[id="form-element-${parameter}"] input[type="checkbox"]'
     parameter_select: 'div.ui-form-element[id="form-element-${parameter}"] .multiselect'
     parameter_input: 'div.ui-form-element[id="form-element-${parameter}"] .ui-input'
     parameter_textarea: 'div.ui-form-element[id="form-element-${parameter}"] textarea'

--- a/lib/galaxy/selenium/playwright_element.py
+++ b/lib/galaxy/selenium/playwright_element.py
@@ -110,6 +110,16 @@ class PlaywrightElement:
         """
         return self._element.is_enabled()
 
+    def is_selected(self) -> bool:
+        """
+        Check if a checkbox, radio button, or option is selected.
+
+        Playwright's is_checked() only handles checkbox/radio inputs and raises
+        for <option> elements, so fall back to evaluating the element's
+        ``checked``/``selected`` property to mirror Selenium's behavior.
+        """
+        return bool(self._element.evaluate("(el) => !!(el.checked || el.selected)"))
+
     def submit(self) -> None:
         """
         Submit a form element.

--- a/lib/galaxy/selenium/web_element_protocol.py
+++ b/lib/galaxy/selenium/web_element_protocol.py
@@ -62,6 +62,10 @@ class WebElementProtocol(Protocol):
         """Check if the element is enabled (not disabled)."""
         ...
 
+    def is_selected(self) -> bool:
+        """Check if a checkbox, radio, or option element is selected."""
+        ...
+
     def submit(self) -> None:
         """Submit a form element."""
         ...

--- a/lib/galaxy_test/selenium/test_workflow_rerun.py
+++ b/lib/galaxy_test/selenium/test_workflow_rerun.py
@@ -9,6 +9,19 @@ from .framework import (
     UsesHistoryItemAssertions,
 )
 
+WORKFLOW_BOOLEAN_PARAMETER_DEFAULT_TRUE = """
+class: GalaxyWorkflow
+inputs:
+  bool_param:
+    type: boolean
+    default: true
+steps:
+  echo_bool:
+    tool_id: gx_boolean
+    in:
+      parameter: bool_param
+"""
+
 
 class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows):
     ensure_registered = True
@@ -64,6 +77,76 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         # Find that the changed input badge exists
         form_element.changed_value_badge.wait_for_visible()
         self.screenshot("workflow_rerun_changed_input")
+
+    @selenium_test
+    @managed_history
+    def test_workflow_rerun_preserves_false_boolean_parameter(self):
+        """Regression test for boolean workflow parameters reverting to default on rerun.
+
+        Setting a boolean ``parameter_input`` to ``false`` (overriding a
+        ``default: true``), running the workflow, and re-running the invocation
+        previously caused the form to silently fall back to the default value
+        because of a falsy-value check in WorkflowRunFormSimple.vue. The form
+        should instead show the value the user actually used.
+        """
+        invocations = self.components.invocations
+
+        self.workflow_run_open_workflow(WORKFLOW_BOOLEAN_PARAMETER_DEFAULT_TRUE)
+
+        # Override the boolean default of true to false before submitting.
+        # The boolean is the workflow's only input, hence step_index 0.
+        self._toggle_workflow_run_boolean(parameter="0", target=False)
+        self.screenshot("workflow_run_boolean_false_before_submit")
+
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.workflow_run_wait_for_ok(hid=1)
+
+        # Submitting lands us on the new invocation page; the rerun button is
+        # right there on the invocation state details. We're still in the
+        # invocation's history, so no "switch history" confirmation appears.
+        invocations.state_details.wait_for_visible()
+        invocations.workflow_rerun_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        # The boolean should be preserved as false on the rerun form rather than
+        # silently reset to the workflow's default of true.
+        checkbox = self.components.tool_form.parameter_checkbox_input(parameter="0").wait_for_present()
+        assert (
+            not checkbox.is_selected()
+        ), "Boolean parameter input was reset to its default 'true' instead of preserving the previous run's 'false' value"
+
+        # Without changes, the boolean should not be flagged as a changed input.
+        form_element = self.components.workflow_run.form_element._(index=0)
+        form_element.changed_value_badge.assert_absent()
+        self.screenshot("workflow_rerun_boolean_preserved_false")
+
+        # Toggling the value back to true should flag it as changed.
+        self._toggle_workflow_run_boolean(parameter="0", target=True)
+        form_element.changed_value_badge.wait_for_visible()
+        self.screenshot("workflow_rerun_boolean_changed_input")
+
+        # Submit the rerun and verify the new invocation actually recorded the
+        # value shown in the form (true) on its Inputs tab.
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.workflow_run_wait_for_ok(hid=2)
+        invocations.state_details.wait_for_visible()
+        invocations.invocation_tab(label="Inputs").wait_for_and_click()
+        self._assert_input_table_has_parameter("bool_param", "true")
+        self.screenshot("workflow_rerun_boolean_inputs_tab")
+
+    @retry_assertion_during_transitions
+    def _assert_input_table_has_parameter(self, label: str, value: str):
+        table = self.wait_for_selector('[data-description="input table"]')
+        text = table.text
+        assert label in text, f"Expected input label '{label}' in inputs table, got: {text!r}"
+        assert value in text, f"Expected input value '{value}' in inputs table, got: {text!r}"
+
+    def _toggle_workflow_run_boolean(self, parameter: str, target: bool):
+        checkbox = self.components.tool_form.parameter_checkbox_input(parameter=parameter).wait_for_present()
+        if checkbox.is_selected() != target:
+            self.execute_script("arguments[0].click();", checkbox)
 
     @retry_assertion_during_transitions
     def _assert_history_name_is(self, expected_name=None):


### PR DESCRIPTION
Re-running a workflow invocation through the simple run form silently discarded `false`, `0`, and `""` values for `parameter_input` steps and fell back to the workflow's default. The rerun-state hydration in WorkflowRunFormSimple.vue used truthiness checks (`if (requestState[k])` and `if (value)`) where it should have checked for key presence and `!== undefined`. As a result a boolean parameter set to `false` on the original run came back as the default `true` on rerun, with no "Changed Input" badge to flag the discrepancy.

Switch the lookup to `key in requestState` and the assignment guard to `value !== undefined` so falsy-but-defined values are preserved. Add a selenium regression test that runs gx_boolean with the parameter toggled to false, reruns, and asserts both the form state (preserved false, no changed-input badge; toggling to true raises the badge) and the new invocation's Inputs tab.

<img width="1277" height="350" alt="Screenshot 2026-04-29 at 17 59 59" src="https://github.com/user-attachments/assets/849fedee-5d16-47b4-bfb8-898ccec43084" />


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
