### PR TITLE
[26.0] Fix job access check for collection-only outputs

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -184,9 +184,10 @@ def safe_aliased(model_class: type[T], name: str) -> type[T]:
 
 
 class JobManager:
-    def __init__(self, app: StructuredApp):
+    def __init__(self, app: StructuredApp, history_manager: HistoryManager):
         self.app = app
         self.dataset_manager = DatasetManager(app)
+        self.history_manager = history_manager
 
     def index_query(self, trans: ProvidesUserContext, payload: JobIndexQueryPayload) -> sqlalchemy.engine.ScalarResult:
         """The caller is responsible for security checks on the resulting job if
@@ -358,14 +359,25 @@ class JobManager:
         elif trans.galaxy_session:
             belongs_to_user = job.session_id == trans.galaxy_session.id
         if not trans.user_is_admin and not belongs_to_user:
-            # Check access granted via output datasets.
-            if not job.output_datasets:
-                raise ItemAccessibilityException("Job has no output datasets.")
-            for data_assoc in job.output_datasets:
-                if not self.dataset_manager.is_accessible(data_assoc.dataset.dataset, trans.user):
-                    raise ItemAccessibilityException("You are not allowed to rerun this job.")
+            if not self._user_can_access_job(job, trans.user):
+                raise ItemAccessibilityException("You are not allowed to access this job.")
         trans.sa_session.refresh(job)
         return job
+
+    def _user_can_access_job(self, job: Job, user: Optional[User]) -> bool:
+        has_outputs = bool(job.output_datasets) or bool(job.output_dataset_collection_instances)
+        if has_outputs:
+            datasets_ok = all(
+                self.dataset_manager.is_accessible(da.dataset.dataset, user) for da in job.output_datasets
+            )
+            collections_ok = all(
+                self.dataset_manager.is_accessible(hda.dataset, user)
+                for hdca_assoc in job.output_dataset_collection_instances
+                for hda in hdca_assoc.dataset_collection_instance.dataset_instances
+            )
+            if datasets_ok and collections_ok:
+                return True
+        return job.history is not None and self.history_manager.is_accessible(job.history, user)
 
     def get_job_console_output(
         self, trans, job, stdout_position=-1, stdout_length=0, stderr_position=-1, stderr_length=0

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -141,7 +141,7 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
         hda_manager = trans.app.hda_manager
         history_manager = trans.app.history_manager
         workflow_manager = trans.app.workflow_manager
-        job_manager = JobManager(trans.app)
+        job_manager = JobManager(trans.app, history_manager)
         collection_manager = trans.app.dataset_collection_manager
 
         def _remap(container, line):

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -387,6 +387,54 @@ steps:
         assert show_jobs_response.json()["external_id"] is not None
         assert show_jobs_response.json()["command_line"] is not None
 
+    @skip_without_tool("collection_creates_pair")
+    @pytest.mark.require_new_history
+    def test_show_collection_only_job_public(self, history_id):
+        # Regression test for https://github.com/galaxyproject/galaxy/issues/22602.
+        job_id, hdca_id = self._run_collection_only_job(history_id)
+        hdca = self.dataset_populator.get_history_collection_details(history_id, content_id=hdca_id)
+        for element in hdca["elements"]:
+            response = self.dataset_populator.make_dataset_public_raw(history_id, element["object"]["id"])
+            assert_status_code_is_ok(response)
+        with self._different_user(anon=True):
+            show_jobs_response = self._get(f"jobs/{job_id}")
+            self._assert_status_code_is(show_jobs_response, 200)
+            assert show_jobs_response.json()["id"] == job_id
+
+    @skip_without_tool("collection_creates_pair")
+    @pytest.mark.require_new_history
+    def test_show_collection_only_job_private_denied(self, history_id):
+        job_id, hdca_id = self._run_collection_only_job(history_id)
+        hdca = self.dataset_populator.get_history_collection_details(history_id, content_id=hdca_id)
+        for element in hdca["elements"]:
+            self.dataset_populator.make_private(history_id, element["object"]["id"])
+        with self._different_user():
+            show_jobs_response = self._get(f"jobs/{job_id}")
+            self._assert_status_code_is(show_jobs_response, 403)
+
+    @pytest.mark.require_new_history
+    def test_show_job_accessible_via_public_history(self, history_id):
+        self.__history_with_new_dataset(history_id)
+        jobs_response = self._get("jobs", data={"history_id": history_id})
+        job_id = jobs_response.json()[0]["id"]
+        self.dataset_populator.make_public(history_id)
+        with self._different_user():
+            show_jobs_response = self._get(f"jobs/{job_id}")
+            self._assert_status_code_is(show_jobs_response, 200)
+            assert show_jobs_response.json()["id"] == job_id
+
+    def _run_collection_only_job(self, history_id):
+        input_id = self.dataset_populator.new_dataset(history_id, content="a\nb\nc\nd\n", wait=True)["id"]
+        run_response = self.dataset_populator.run_tool(
+            tool_id="collection_creates_pair",
+            inputs={"input1": {"src": "hda", "id": input_id}},
+            history_id=history_id,
+        )
+        job_id = run_response["jobs"][0]["id"]
+        self.dataset_populator.wait_for_job(job_id, assert_ok=True)
+        hdca_id = run_response["output_collections"][0]["id"]
+        return job_id, hdca_id
+
     def _run_detect_errors(self, history_id, inputs):
         payload = self.dataset_populator.run_tool_payload(
             tool_id="detect_errors_aggressive",


### PR DESCRIPTION
`JobManager.get_accessible_job` raised "Job has no output datasets" for non-owners (incl. anonymous users) on jobs that produced only dataset collections, even when the underlying datasets were public. Extend the access check to also consider `output_dataset_collection_instances` and fall back to `HistoryManager.is_accessible` on the job's history.

Fixes https://github.com/galaxyproject/galaxy/issues/22602

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
