### PR TITLE
[26.0] Fix error handling for Help Forum integration

### DIFF
--- a/client/src/components/Tool/ToolHelpForum.vue
+++ b/client/src/components/Tool/ToolHelpForum.vue
@@ -6,10 +6,12 @@ import { computed, onMounted, ref } from "vue";
 import { GalaxyApi } from "@/api";
 import { galaxyLogo } from "@/components/icons/galaxyIcons";
 import { useConfigStore } from "@/stores/configurationStore";
+import { errorMessageAsString } from "@/utils/simple-error";
 import { getShortToolId } from "@/utils/tool";
 
 import { createTopicUrl, type HelpForumPost, type HelpForumTopic, useHelpURLs } from "./helpForumUrls";
 
+import Alert from "@/components/Alert.vue";
 import Heading from "@/components/Common/Heading.vue";
 import ExternalLink from "@/components/ExternalLink.vue";
 
@@ -22,6 +24,7 @@ const toolHelpTag = "tool-help";
 
 const topics = ref<HelpForumTopic[]>([]);
 const posts = ref<HelpForumPost[]>([]);
+const errorMessage = ref("");
 const helpAvailable = computed(() => topics.value.length > 0);
 
 const root = ref(null);
@@ -36,7 +39,7 @@ onMounted(async () => {
         },
     });
     if (error) {
-        console.error("Error fetching help forum data", error);
+        errorMessage.value = errorMessageAsString(error, "Failed to search the Help Forum.");
     }
 
     topics.value = data?.topics ?? [];
@@ -66,12 +69,14 @@ const configStore = useConfigStore();
     <div ref="root" class="tool-help-forum mt-2 mb-4">
         <Heading h2 separator bold size="sm">Help Forum</Heading>
 
+        <Alert v-if="errorMessage" variant="warning" :message="errorMessage" />
+
         <p v-if="helpAvailable">
             Following questions on the
             <ExternalLink :href="configStore.config.help_forum_api_url"> Help Forum </ExternalLink> may be related to
             this tool:
         </p>
-        <p v-else>
+        <p v-else-if="!errorMessage">
             There are no questions on the
             <ExternalLink :href="configStore.config.help_forum_api_url"> Help Forum </ExternalLink>
             about this tool.

--- a/lib/galaxy/webapps/galaxy/services/help.py
+++ b/lib/galaxy/webapps/galaxy/services/help.py
@@ -2,9 +2,10 @@ import logging
 
 from galaxy.config import GalaxyAppConfiguration
 from galaxy.exceptions import (
+    GatewayTimeoutException,
     InternalServerError,
-    MessageException,
     ServerNotConfiguredForRequest,
+    UpstreamProxyError,
 )
 from galaxy.schema.help import HelpForumSearchResponse
 from galaxy.security.idencoding import IdEncodingHelper
@@ -45,19 +46,40 @@ class HelpService(ServiceBase):
                     "q": query,
                 },
             )
-        except requests.exceptions.ConnectionError:
-            raise MessageException(
+        except requests.exceptions.ConnectionError as e:
+            log.error("Could not connect to the Galaxy Help Forum at %s: %s", forum_search_url, e)
+            raise UpstreamProxyError(
                 "Could not connect to the Galaxy Help Forum. The service may be temporarily unavailable."
             )
-        except requests.exceptions.Timeout:
-            raise MessageException("The request to the Galaxy Help Forum timed out. Please try again later.")
+        except requests.exceptions.Timeout as e:
+            log.error("Request to the Galaxy Help Forum at %s timed out: %s", forum_search_url, e)
+            raise GatewayTimeoutException("The request to the Galaxy Help Forum timed out. Please try again later.")
         except requests.exceptions.RequestException as e:
+            log.error("Unexpected error requesting the Galaxy Help Forum at %s: %s", forum_search_url, e)
             raise InternalServerError(f"An error occurred while requesting the Galaxy Help Forum: {e}")
 
         if not response.ok:
-            raise MessageException(
-                f"The Galaxy Help Forum returned an error (HTTP {response.status_code}). Please try again later."
-            )
+            if 400 <= response.status_code < 500:
+                log.error(
+                    "The Galaxy Help Forum returned a client error (HTTP %d) from %s. "
+                    "This likely indicates a misconfigured URL or API key.",
+                    response.status_code,
+                    forum_search_url,
+                )
+                raise InternalServerError(
+                    f"The Galaxy Help Forum returned an error (HTTP {response.status_code}). "
+                    "This may indicate a misconfigured URL or API key that requires admin intervention."
+                )
+            else:
+                log.error(
+                    "The Galaxy Help Forum returned a server error (HTTP %d) from %s",
+                    response.status_code,
+                    forum_search_url,
+                )
+                raise UpstreamProxyError(
+                    f"The Galaxy Help Forum returned an error (HTTP {response.status_code}). "
+                    "The service may be temporarily unavailable. Please try again later."
+                )
 
         try:
             return HelpForumSearchResponse(**response.json())

--- a/lib/galaxy/webapps/galaxy/services/help.py
+++ b/lib/galaxy/webapps/galaxy/services/help.py
@@ -1,7 +1,11 @@
 import logging
 
 from galaxy.config import GalaxyAppConfiguration
-from galaxy.exceptions import ServerNotConfiguredForRequest
+from galaxy.exceptions import (
+    InternalServerError,
+    MessageException,
+    ServerNotConfiguredForRequest,
+)
 from galaxy.schema.help import HelpForumSearchResponse
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import requests
@@ -34,10 +38,28 @@ class HelpService(ServiceBase):
         if not self.config.help_forum_api_url:
             raise ServerNotConfiguredForRequest("Help forum API URL is not configured.")
         forum_search_url = f"{self.config.help_forum_api_url}/search.json"
-        response = requests.get(
-            url=forum_search_url,
-            params={
-                "q": query,
-            },
-        )
-        return HelpForumSearchResponse(**response.json())
+        try:
+            response = requests.get(
+                url=forum_search_url,
+                params={
+                    "q": query,
+                },
+            )
+        except requests.exceptions.ConnectionError:
+            raise MessageException(
+                "Could not connect to the Galaxy Help Forum. The service may be temporarily unavailable."
+            )
+        except requests.exceptions.Timeout:
+            raise MessageException("The request to the Galaxy Help Forum timed out. Please try again later.")
+        except requests.exceptions.RequestException as e:
+            raise InternalServerError(f"An error occurred while requesting the Galaxy Help Forum: {e}")
+
+        if not response.ok:
+            raise MessageException(
+                f"The Galaxy Help Forum returned an error (HTTP {response.status_code}). Please try again later."
+            )
+
+        try:
+            return HelpForumSearchResponse(**response.json())
+        except ValueError as e:
+            raise InternalServerError(f"Received an unexpected response format from the Galaxy Help Forum: {e}")

--- a/lib/galaxy/webapps/galaxy/services/help.py
+++ b/lib/galaxy/webapps/galaxy/services/help.py
@@ -46,36 +46,22 @@ class HelpService(ServiceBase):
                     "q": query,
                 },
             )
-        except requests.exceptions.ConnectionError as e:
-            log.error("Could not connect to the Galaxy Help Forum at %s: %s", forum_search_url, e)
+        except requests.exceptions.ConnectionError:
             raise UpstreamProxyError(
                 "Could not connect to the Galaxy Help Forum. The service may be temporarily unavailable."
             )
-        except requests.exceptions.Timeout as e:
-            log.error("Request to the Galaxy Help Forum at %s timed out: %s", forum_search_url, e)
+        except requests.exceptions.Timeout:
             raise GatewayTimeoutException("The request to the Galaxy Help Forum timed out. Please try again later.")
         except requests.exceptions.RequestException as e:
-            log.error("Unexpected error requesting the Galaxy Help Forum at %s: %s", forum_search_url, e)
             raise InternalServerError(f"An error occurred while requesting the Galaxy Help Forum: {e}")
 
         if not response.ok:
             if 400 <= response.status_code < 500:
-                log.error(
-                    "The Galaxy Help Forum returned a client error (HTTP %d) from %s. "
-                    "This likely indicates a misconfigured URL or API key.",
-                    response.status_code,
-                    forum_search_url,
-                )
                 raise InternalServerError(
                     f"The Galaxy Help Forum returned an error (HTTP {response.status_code}). "
                     "This may indicate a misconfigured URL or API key that requires admin intervention."
                 )
             else:
-                log.error(
-                    "The Galaxy Help Forum returned a server error (HTTP %d) from %s",
-                    response.status_code,
-                    forum_search_url,
-                )
                 raise UpstreamProxyError(
                     f"The Galaxy Help Forum returned an error (HTTP {response.status_code}). "
                     "The service may be temporarily unavailable. Please try again later."


### PR DESCRIPTION
Fixes #22599

The Help forum returned `Service Unavailable` (503), but there was no error handling in the `/api/help/forum/search` endpoint. The `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` error in #22599 was somewhat misleading because `response.json()` was trying to parse the 503 HTML error as JSON.

This properly handles most errors and surfaces the connectivity ones to the user to clarify expectations. Potential parsing errors are still considered internal, but should be reported more clearly in Sentry.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
