### PR TITLE
Pass chat history to agents as structured messages

### DIFF
--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.messages import ModelMessage
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
@@ -66,6 +67,21 @@ log = logging.getLogger(__name__)
 # Literal inlines enum values in JSON schema, avoiding $defs that vLLM can't handle
 ConfidenceLiteral = Literal["low", "medium", "high"]
 
+MAX_HISTORY_MESSAGES = 40
+"""Cap on prior messages passed as pydantic-ai ``message_history``.
+
+~20 turn-pairs; tool-heavy turns produce 3-5 messages each. Bounds total token
+load while preserving enough recent context to keep multi-turn conversations
+coherent.
+"""
+
+TOOL_HELPER_HISTORY_MESSAGES = 8
+"""Tighter cap when a sub-agent is invoked from inside a `@agent.tool` call.
+
+Tool-context turns burn token budget faster (tool call + tool return +
+follow-up), so we hand the sub-agent a smaller window.
+"""
+
 __all__ = [
     "ActionSuggestion",
     "ActionType",
@@ -78,9 +94,29 @@ __all__ = [
     "extract_structured_output",
     "extract_usage_info",
     "GalaxyAgentDependencies",
+    "MAX_HISTORY_MESSAGES",
     "normalize_llm_text",
     "SimpleGalaxyAgent",
+    "TOOL_HELPER_HISTORY_MESSAGES",
+    "truncate_message_history",
 ]
+
+
+def truncate_message_history(history: list[ModelMessage], limit: int = MAX_HISTORY_MESSAGES) -> list[ModelMessage]:
+    """Cap conversation history at ``limit`` recent messages, preserving the first one.
+
+    Keeps ``history[0]`` -- typically the user's original request, which anchors
+    intent across long conversations -- and the most recent ``limit`` messages.
+    """
+    if len(history) <= limit:
+        return history
+    log.info(
+        "Truncating conversation history from %d to %d messages (first + last %d)",
+        len(history),
+        limit + 1,
+        limit,
+    )
+    return [history[0]] + history[-limit:]
 
 
 def extract_result_content(result: Any) -> str:
@@ -259,15 +295,50 @@ class BaseGalaxyAgent(ABC):
             return self._validation_error_response(validation_error)
 
         try:
-            full_prompt = self._prepare_prompt(query, context or {})
-            result = await self._run_with_retry(full_prompt)
-            return self._format_response(result, query, context or {})
+            ctx = context or {}
+            message_history = self._extract_message_history(ctx)
+            full_prompt = self._prepare_prompt(query, self._strip_history_from_context(ctx))
+            result = await self._run_with_retry(full_prompt, message_history=message_history)
+            return self._format_response(result, query, ctx)
 
         except (UnexpectedModelBehavior, OSError, ValueError) as e:
             log.warning(f"Error in {self.agent_type} agent: {e}")
             return self._get_fallback_response(query, str(e))
 
-    async def _run_with_retry(self, prompt: str, max_retries: int = 3, base_delay: float = 1.0):
+    @staticmethod
+    def _extract_message_history(
+        context: Optional[dict[str, Any]],
+        limit: int = MAX_HISTORY_MESSAGES,
+    ) -> Optional[list[ModelMessage]]:
+        """Pull ``conversation_history`` out of context and truncate it.
+
+        Returns None when history is missing/empty so callers can pass it
+        straight to ``agent.run(..., message_history=...)`` without branching.
+        """
+        if not context:
+            return None
+        history = context.get("conversation_history")
+        if not history:
+            return None
+        return truncate_message_history(history, limit=limit)
+
+    @staticmethod
+    def _strip_history_from_context(context: dict[str, Any]) -> dict[str, Any]:
+        """Drop ``conversation_history`` before rendering context as text.
+
+        ``_prepare_prompt`` stringifies whatever's in the context dict; the raw
+        ``ModelMessage`` repr is noise once we're passing the history through
+        the structured ``message_history`` channel.
+        """
+        return {k: v for k, v in context.items() if k != "conversation_history"}
+
+    async def _run_with_retry(
+        self,
+        prompt: str,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+        message_history: Optional[list[ModelMessage]] = None,
+    ):
         """Run the agent with exponential backoff for retryable errors."""
         last_exception = None
 
@@ -278,7 +349,12 @@ class BaseGalaxyAgent(ABC):
 
         for attempt in range(max_retries + 1):
             try:
-                return await self.agent.run(prompt, deps=self.deps, model_settings=model_settings)
+                return await self.agent.run(
+                    prompt,
+                    deps=self.deps,
+                    model_settings=model_settings,
+                    message_history=message_history,
+                )
 
             except Exception as e:
                 last_exception = e
@@ -551,16 +627,7 @@ class BaseGalaxyAgent(ABC):
 
             target_agent = ctx.deps.get_agent(agent_type, ctx.deps)
 
-            full_query = query
-            if context and "conversation_history" in context:
-                history = context["conversation_history"]
-                if history and len(history) > 0:
-                    history_text = "Previous conversation:\n"
-                    for msg in history[-4:]:
-                        role = msg.get("role", "unknown")
-                        content = msg.get("content", "")[:200]
-                        history_text += f"{role}: {content}\n"
-                    full_query = f"{history_text}\nCurrent request: {query}"
+            message_history = self._extract_message_history(context, limit=TOOL_HELPER_HISTORY_MESSAGES)
 
             target_model_settings = {
                 "temperature": target_agent._get_temperature(),
@@ -568,10 +635,11 @@ class BaseGalaxyAgent(ABC):
             }
 
             result = await target_agent.agent.run(
-                full_query,
+                query,
                 deps=ctx.deps,
                 usage=usage or ctx.usage,
                 model_settings=target_model_settings,
+                message_history=message_history,
             )
 
             response_data = extract_result_content(result)

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -9,7 +9,10 @@ from abc import (
     ABC,
     abstractmethod,
 )
-from collections.abc import Callable
+from collections.abc import (
+    Callable,
+    Sequence,
+)
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -37,7 +40,14 @@ if TYPE_CHECKING:
 
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UnexpectedModelBehavior
-from pydantic_ai.messages import ModelMessage
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    UserPromptPart,
+)
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.settings import ModelSettings
@@ -117,6 +127,41 @@ def truncate_message_history(history: list[ModelMessage], limit: int = MAX_HISTO
         limit,
     )
     return [history[0]] + history[-limit:]
+
+
+def _coerce_message_history(history: Sequence[Any]) -> list[ModelMessage]:
+    """Normalize API-formatted and legacy role/content chat history."""
+    messages: list[ModelMessage] = []
+    skipped = 0
+
+    for item in history:
+        if isinstance(item, (ModelRequest, ModelResponse)):
+            messages.append(item)
+            continue
+
+        if not isinstance(item, dict):
+            skipped += 1
+            continue
+
+        role = str(item.get("role", "")).lower()
+        content = item.get("content")
+        if content is None:
+            skipped += 1
+            continue
+
+        if role == "assistant":
+            messages.append(ModelResponse(parts=[TextPart(content=str(content))]))
+        elif role == "user":
+            messages.append(ModelRequest(parts=[UserPromptPart(content=str(content))]))
+        elif role == "system":
+            messages.append(ModelRequest(parts=[SystemPromptPart(content=str(content))]))
+        else:
+            skipped += 1
+
+    if skipped:
+        log.warning("Ignored %d unsupported conversation_history message(s)", skipped)
+
+    return messages
 
 
 def extract_result_content(result: Any) -> str:
@@ -310,7 +355,7 @@ class BaseGalaxyAgent(ABC):
         context: Optional[dict[str, Any]],
         limit: int = MAX_HISTORY_MESSAGES,
     ) -> Optional[list[ModelMessage]]:
-        """Pull ``conversation_history`` out of context and truncate it.
+        """Pull ``conversation_history`` out of context, normalize it, and truncate it.
 
         Returns None when history is missing/empty so callers can pass it
         straight to ``agent.run(..., message_history=...)`` without branching.
@@ -320,7 +365,13 @@ class BaseGalaxyAgent(ABC):
         history = context.get("conversation_history")
         if not history:
             return None
-        return truncate_message_history(history, limit=limit)
+        if isinstance(history, (str, bytes)) or not isinstance(history, Sequence):
+            log.warning("Ignoring unsupported conversation_history value of type %s", type(history).__name__)
+            return None
+        messages = _coerce_message_history(history)
+        if not messages:
+            return None
+        return truncate_message_history(messages, limit=limit)
 
     @staticmethod
     def _strip_history_from_context(context: dict[str, Any]) -> dict[str, Any]:

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -272,15 +272,13 @@ class QueryRouterAgent(BaseGalaxyAgent):
             return self._validation_error_response(validation_error)
 
         try:
-            if context and context.get("conversation_history"):
-                log.info(f"Router: Conversation has {len(context['conversation_history'])} messages")
+            message_history = self._extract_message_history(context)
+            if message_history:
+                log.info(f"Router: passing {len(message_history)} prior messages as message_history")
             else:
-                log.info("Router: Processing query with no conversation history")
+                log.info("Router: processing query with no conversation history")
 
-            full_query = self._build_query_with_context(query, context)
-            log.info(f"Router: Full query length={len(full_query)} (original={len(query)})")
-
-            result = await self._run_with_retry(full_query)
+            result = await self._run_with_retry(query, message_history=message_history)
             content = extract_result_content(result)
 
             try:
@@ -310,27 +308,6 @@ class QueryRouterAgent(BaseGalaxyAgent):
         except (OSError, ValueError) as e:
             log.warning(f"Router agent error, using fallback: {e}")
             return self._handle_fallback(query, context, str(e))
-
-    def _build_query_with_context(self, query: str, context: Optional[dict[str, Any]]) -> str:
-        if not context or "conversation_history" not in context:
-            return query
-
-        history = context["conversation_history"]
-        if not history:
-            return query
-
-        max_history = 6
-        if len(history) > max_history:
-            log.debug(f"Router: Truncating conversation history from {len(history)} to {max_history} messages")
-
-        history_text = "Previous conversation:\n"
-        for msg in history[-max_history:]:
-            role = msg.get("role", "unknown")
-            content = msg.get("content", "")
-            history_text += f"{role}: {content}\n"
-        history_text += f"\nCurrent query: {query}"
-
-        return history_text
 
     def _handle_fallback(self, query: str, context: Optional[dict[str, Any]], error_msg: str) -> AgentResponse:
         query_lower = query.lower()

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -178,10 +178,12 @@ class ChatAPI:
                 # Build context with conversation history
                 full_context: dict[str, Any] = query_context.copy() if query_context else {}
 
-                # If we have an exchange_id, ALWAYS load conversation history from database (source of truth)
+                # If we have an exchange_id, ALWAYS load conversation history from database (source of truth).
+                # Use structured pydantic-ai message format so the router can pass it through as
+                # ``message_history`` rather than flattening it into a text blob.
                 if exchange_id:
                     db_history = await anyio.to_thread.run_sync(
-                        partial(self.chat_manager.get_chat_history, trans, exchange_id, format_for_pydantic_ai=False)
+                        partial(self.chat_manager.get_chat_history, trans, exchange_id, format_for_pydantic_ai=True)
                     )
                     if db_history:
                         full_context["conversation_history"] = db_history

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -32,6 +32,7 @@ import pytest
 pydantic_ai = pytest.importorskip("pydantic_ai")
 from pydantic_ai import Agent
 from pydantic_ai.messages import (
+    ModelMessage,
     ModelRequest,
     ModelResponse,
     SystemPromptPart,
@@ -344,7 +345,7 @@ class TestAgentUnitMocked:
         assert "rephrase your question" in response.content.lower()
 
     def test_truncate_message_history_under_limit_returns_unchanged(self):
-        history = [
+        history: list[ModelMessage] = [
             ModelRequest(parts=[UserPromptPart(content="hello")]),
             ModelResponse(parts=[TextPart(content="hi")]),
         ]
@@ -352,7 +353,7 @@ class TestAgentUnitMocked:
         assert truncate_message_history(history, limit=40) is history
 
     def test_truncate_message_history_keeps_first_plus_last_n(self):
-        history = []
+        history: list[ModelMessage] = []
         for i in range(50):
             history.append(ModelRequest(parts=[UserPromptPart(content=f"q{i}")]))
             history.append(ModelResponse(parts=[TextPart(content=f"r{i}")]))
@@ -364,7 +365,7 @@ class TestAgentUnitMocked:
         assert truncated[-10:] == history[-10:]  # most recent preserved
 
     def test_truncate_message_history_at_exact_boundary(self):
-        history = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(10)]
+        history: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(10)]
 
         # At-boundary: returned as-is, not truncated to first+last-10 (which would lose nothing here)
         assert truncate_message_history(history, limit=10) is history
@@ -375,7 +376,7 @@ class TestAgentUnitMocked:
         assert QueryRouterAgent._extract_message_history({"conversation_history": []}) is None
 
     def test_extract_message_history_truncates(self):
-        history = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(50)]
+        history: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(50)]
 
         # Default limit is MAX_HISTORY_MESSAGES (40), so 50 -> 41 (first + last 40)
         result = QueryRouterAgent._extract_message_history({"conversation_history": history})
@@ -435,7 +436,7 @@ class TestAgentUnitMocked:
     async def test_router_passes_message_history_to_run(self):
         """Router should hand the structured history to ``agent.run`` via ``message_history``."""
         router = QueryRouterAgent(self.deps)
-        history = [
+        history: list[ModelMessage] = [
             ModelRequest(parts=[UserPromptPart(content="What histories do I have?")]),
             ModelResponse(parts=[TextPart(content="You have 3.")]),
         ]

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -335,6 +335,123 @@ class TestAgentUnitMocked:
         assert response.confidence == ConfidenceLevel.LOW
         assert "rephrase your question" in response.content.lower()
 
+    def test_truncate_message_history_under_limit_returns_unchanged(self):
+        from pydantic_ai.messages import (
+            ModelRequest,
+            ModelResponse,
+            TextPart,
+            UserPromptPart,
+        )
+
+        from galaxy.agents.base import truncate_message_history
+
+        history = [
+            ModelRequest(parts=[UserPromptPart(content="hello")]),
+            ModelResponse(parts=[TextPart(content="hi")]),
+        ]
+
+        assert truncate_message_history(history, limit=40) is history
+
+    def test_truncate_message_history_keeps_first_plus_last_n(self):
+        from pydantic_ai.messages import (
+            ModelRequest,
+            ModelResponse,
+            TextPart,
+            UserPromptPart,
+        )
+
+        from galaxy.agents.base import truncate_message_history
+
+        history = []
+        for i in range(50):
+            history.append(ModelRequest(parts=[UserPromptPart(content=f"q{i}")]))
+            history.append(ModelResponse(parts=[TextPart(content=f"r{i}")]))
+
+        truncated = truncate_message_history(history, limit=10)
+
+        assert len(truncated) == 11  # first + last 10
+        assert truncated[0] is history[0]  # original intent preserved
+        assert truncated[-10:] == history[-10:]  # most recent preserved
+
+    def test_truncate_message_history_at_exact_boundary(self):
+        from pydantic_ai.messages import (
+            ModelRequest,
+            UserPromptPart,
+        )
+
+        from galaxy.agents.base import truncate_message_history
+
+        history = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(10)]
+
+        # At-boundary: returned as-is, not truncated to first+last-10 (which would lose nothing here)
+        assert truncate_message_history(history, limit=10) is history
+
+    def test_extract_message_history_returns_none_for_empty_context(self):
+        assert QueryRouterAgent._extract_message_history(None) is None
+        assert QueryRouterAgent._extract_message_history({}) is None
+        assert QueryRouterAgent._extract_message_history({"conversation_history": []}) is None
+
+    def test_extract_message_history_truncates(self):
+        from pydantic_ai.messages import (
+            ModelRequest,
+            UserPromptPart,
+        )
+
+        history = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(50)]
+
+        # Default limit is MAX_HISTORY_MESSAGES (40), so 50 -> 41 (first + last 40)
+        result = QueryRouterAgent._extract_message_history({"conversation_history": history})
+        assert result is not None
+        assert len(result) == 41
+        assert result[0] is history[0]
+
+    @pytest.mark.asyncio
+    async def test_router_passes_message_history_to_run(self):
+        """Router should hand the structured history to ``agent.run`` via ``message_history``."""
+        from pydantic_ai.messages import (
+            ModelRequest,
+            ModelResponse,
+            TextPart,
+            UserPromptPart,
+        )
+
+        router = QueryRouterAgent(self.deps)
+        history = [
+            ModelRequest(parts=[UserPromptPart(content="What histories do I have?")]),
+            ModelResponse(parts=[TextPart(content="You have 3.")]),
+        ]
+
+        with mock.patch.object(router, "_run_with_retry") as mock_run:
+            mock_result = mock.Mock(spec=["output"])
+            mock_result.output = "Following up: here is more detail."
+            mock_run.return_value = mock_result
+
+            await router.process(
+                "Tell me more about the second one",
+                context={"conversation_history": history},
+            )
+
+            mock_run.assert_called_once()
+            args, kwargs = mock_run.call_args
+            assert kwargs["message_history"] == history
+            # The query itself should not have history pre-pended as a text blob
+            assert args[0] == "Tell me more about the second one"
+
+    @pytest.mark.asyncio
+    async def test_router_runs_without_history_for_fresh_conversation(self):
+        router = QueryRouterAgent(self.deps)
+
+        with mock.patch.object(router, "_run_with_retry") as mock_run:
+            mock_result = mock.Mock(spec=["output"])
+            mock_result.output = "Hi there."
+            mock_run.return_value = mock_result
+
+            await router.process("Hello")
+
+            mock_run.assert_called_once()
+            _, kwargs = mock_run.call_args
+            assert kwargs["message_history"] is None
+
     @pytest.mark.asyncio
     async def test_custom_tool_rejects_prompt_injection_query(self):
         self.mock_config.ai_model = "gpt-4o"

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -405,6 +405,67 @@ class TestAgentUnitMocked:
         assert len(result) == 41
         assert result[0] is history[0]
 
+    def test_extract_message_history_converts_legacy_role_content_dicts(self):
+        from pydantic_ai.messages import (
+            ModelRequest,
+            ModelResponse,
+            SystemPromptPart,
+            TextPart,
+            UserPromptPart,
+        )
+
+        result = QueryRouterAgent._extract_message_history(
+            {
+                "conversation_history": [
+                    {"role": "system", "content": "Follow Galaxy policy."},
+                    {"role": "user", "content": "What histories do I have?"},
+                    {"role": "assistant", "content": "You have 3 histories."},
+                ]
+            }
+        )
+
+        assert result is not None
+        assert isinstance(result[0], ModelRequest)
+        assert isinstance(result[0].parts[0], SystemPromptPart)
+        assert result[0].parts[0].content == "Follow Galaxy policy."
+        assert isinstance(result[1], ModelRequest)
+        assert isinstance(result[1].parts[0], UserPromptPart)
+        assert result[1].parts[0].content == "What histories do I have?"
+        assert isinstance(result[2], ModelResponse)
+        assert isinstance(result[2].parts[0], TextPart)
+        assert result[2].parts[0].content == "You have 3 histories."
+
+    def test_extract_message_history_ignores_unsupported_legacy_messages(self):
+        from pydantic_ai.messages import (
+            ModelRequest,
+            UserPromptPart,
+        )
+
+        result = QueryRouterAgent._extract_message_history(
+            {
+                "conversation_history": [
+                    {"role": "tool", "content": "unsupported role"},
+                    {"role": "user", "content": "Keep this one"},
+                    {"role": "assistant"},
+                    object(),
+                ]
+            }
+        )
+
+        assert result is not None
+        assert len(result) == 1
+        assert isinstance(result[0], ModelRequest)
+        assert isinstance(result[0].parts[0], UserPromptPart)
+        assert result[0].parts[0].content == "Keep this one"
+
+    def test_extract_message_history_returns_none_for_unsupported_history_shape(self):
+        assert (
+            QueryRouterAgent._extract_message_history(
+                {"conversation_history": {"role": "user", "content": "Not a message list"}}
+            )
+            is None
+        )
+
     @pytest.mark.asyncio
     async def test_router_passes_message_history_to_run(self):
         """Router should hand the structured history to ``agent.run`` via ``message_history``."""

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -31,6 +31,13 @@ import pytest
 # Skip entire module if pydantic_ai is not installed
 pydantic_ai = pytest.importorskip("pydantic_ai")
 from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    UserPromptPart,
+)
 from pydantic_ai.models.test import TestModel
 
 from galaxy.agents import (
@@ -39,6 +46,7 @@ from galaxy.agents import (
     GalaxyAgentDependencies,
     QueryRouterAgent,
 )
+from galaxy.agents.base import truncate_message_history
 from galaxy.agents.registry import build_default_registry
 
 agent_registry = build_default_registry()
@@ -336,15 +344,6 @@ class TestAgentUnitMocked:
         assert "rephrase your question" in response.content.lower()
 
     def test_truncate_message_history_under_limit_returns_unchanged(self):
-        from pydantic_ai.messages import (
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            UserPromptPart,
-        )
-
-        from galaxy.agents.base import truncate_message_history
-
         history = [
             ModelRequest(parts=[UserPromptPart(content="hello")]),
             ModelResponse(parts=[TextPart(content="hi")]),
@@ -353,15 +352,6 @@ class TestAgentUnitMocked:
         assert truncate_message_history(history, limit=40) is history
 
     def test_truncate_message_history_keeps_first_plus_last_n(self):
-        from pydantic_ai.messages import (
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            UserPromptPart,
-        )
-
-        from galaxy.agents.base import truncate_message_history
-
         history = []
         for i in range(50):
             history.append(ModelRequest(parts=[UserPromptPart(content=f"q{i}")]))
@@ -374,13 +364,6 @@ class TestAgentUnitMocked:
         assert truncated[-10:] == history[-10:]  # most recent preserved
 
     def test_truncate_message_history_at_exact_boundary(self):
-        from pydantic_ai.messages import (
-            ModelRequest,
-            UserPromptPart,
-        )
-
-        from galaxy.agents.base import truncate_message_history
-
         history = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(10)]
 
         # At-boundary: returned as-is, not truncated to first+last-10 (which would lose nothing here)
@@ -392,11 +375,6 @@ class TestAgentUnitMocked:
         assert QueryRouterAgent._extract_message_history({"conversation_history": []}) is None
 
     def test_extract_message_history_truncates(self):
-        from pydantic_ai.messages import (
-            ModelRequest,
-            UserPromptPart,
-        )
-
         history = [ModelRequest(parts=[UserPromptPart(content=f"m{i}")]) for i in range(50)]
 
         # Default limit is MAX_HISTORY_MESSAGES (40), so 50 -> 41 (first + last 40)
@@ -406,14 +384,6 @@ class TestAgentUnitMocked:
         assert result[0] is history[0]
 
     def test_extract_message_history_converts_legacy_role_content_dicts(self):
-        from pydantic_ai.messages import (
-            ModelRequest,
-            ModelResponse,
-            SystemPromptPart,
-            TextPart,
-            UserPromptPart,
-        )
-
         result = QueryRouterAgent._extract_message_history(
             {
                 "conversation_history": [
@@ -436,11 +406,6 @@ class TestAgentUnitMocked:
         assert result[2].parts[0].content == "You have 3 histories."
 
     def test_extract_message_history_ignores_unsupported_legacy_messages(self):
-        from pydantic_ai.messages import (
-            ModelRequest,
-            UserPromptPart,
-        )
-
         result = QueryRouterAgent._extract_message_history(
             {
                 "conversation_history": [
@@ -469,13 +434,6 @@ class TestAgentUnitMocked:
     @pytest.mark.asyncio
     async def test_router_passes_message_history_to_run(self):
         """Router should hand the structured history to ``agent.run`` via ``message_history``."""
-        from pydantic_ai.messages import (
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            UserPromptPart,
-        )
-
         router = QueryRouterAgent(self.deps)
         history = [
             ModelRequest(parts=[UserPromptPart(content="What histories do I have?")]),


### PR DESCRIPTION
The chat router was flattening prior turns into a "Previous conversation:\nrole: content\n..." text blob and prepending it to the user's query. pydantic-ai already supports a structured `message_history` parameter on `agent.run()`, and `ChatManager.get_chat_history(format_for_pydantic_ai=True)` already returns a `list[ModelMessage]` -- the API just wasn't using it.

This switches the chat API to the structured path and plumbs `message_history` through `BaseGalaxyAgent.process()` and the sub-agent calls inside `_call_agent_from_tool`. The router's `_build_query_with_context` text-concat goes away, along with the magic `max_history = 6` cap; truncation now goes through `truncate_message_history()` (first message + last 40, configurable via `MAX_HISTORY_MESSAGES`). Sub-agents called from inside a tool get a tighter `TOOL_HELPER_HISTORY_MESSAGES = 8` window since tool-context turns burn token budget faster.

`_extract_message_history()` accepts both shapes: pydantic-ai `ModelMessage` objects from the chat API path, and legacy `{role, content}` dicts from any direct caller still on the old shape. Malformed entries are logged and dropped rather than crashing the run.

## Test plan
- [x] `pytest test/unit/app/test_agents.py::TestAgentUnitMocked` -- 30 passed (added 9 new tests covering truncation boundaries, legacy-shape coercion, unsupported-shape rejection, router passthrough, fresh-conversation path)
- [ ] Manual smoke: run a multi-turn ChatGXY conversation and confirm follow-up turns reference earlier context