### PR TITLE
Replace agent structured-output denylist with capability table

### DIFF
--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -698,8 +698,8 @@ class BaseGalaxyAgent(ABC):
         Resolution order:
           1. Agent-specific ``structured_output_override`` in inference_services
           2. Global ``default.structured_output_override`` in inference_services
-          3. Glob match against the shipped capability table
-          4. The capability table's ``default`` block (true if absent)
+          3. Glob match against the admin capability table, or shipped sample
+          4. The selected table's ``default`` block (true if absent)
         """
         override = self._get_agent_config("structured_output_override")
         if override is not None:

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -108,57 +108,45 @@ _DEFAULT_MODEL_CAPABILITIES: dict[str, Any] = {
     "default": {"structured_output": True},
 }
 
-# Search order for the capability table. First hit wins.
-_MODEL_CAPABILITIES_BASENAME = "agent_model_capabilities.yml"
-_MODEL_CAPABILITIES_SEARCH_PATHS = (
-    # Admin-edited copy in the runtime config directory.
-    os.path.join("config", _MODEL_CAPABILITIES_BASENAME),
-    # The shipped sample (what most installs will end up reading).
-    os.path.join(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-        "config",
-        "sample",
-        _MODEL_CAPABILITIES_BASENAME + ".sample",
-    ),
-    os.path.join("config", _MODEL_CAPABILITIES_BASENAME + ".sample"),
-)
-
-_model_capabilities_cache: Optional[dict[str, Any]] = None
+_model_capabilities_cache: dict[str, dict[str, Any]] = {}
 
 
-def _load_model_capabilities(force_reload: bool = False) -> dict[str, Any]:
-    """Return the parsed model-capabilities table, loading it on first use.
+def _load_model_capabilities(path: Optional[str], force_reload: bool = False) -> dict[str, Any]:
+    """Return the parsed model-capabilities table for ``path``.
 
-    Looks at a small set of standard locations and parses the first one that
-    exists. Falls back to a sane hardcoded default if nothing is found or the
-    file fails to parse -- we'd rather keep agents working than block on a
-    missing config file.
+    ``path`` should come from ``config.agent_model_capabilities_file``, which
+    Galaxy resolves at startup (admin override in ``config_dir`` if present,
+    otherwise the shipped sample under ``sample_config_dir``). Falls back to a
+    sane hardcoded default when the input is missing, not a string, or points
+    at a file we can't parse -- we'd rather keep agents working than block on
+    a misconfigured deployment.
     """
-    global _model_capabilities_cache
-    if _model_capabilities_cache is not None and not force_reload:
-        return _model_capabilities_cache
+    if not isinstance(path, str) or not path:
+        return _DEFAULT_MODEL_CAPABILITIES
 
-    for path in _MODEL_CAPABILITIES_SEARCH_PATHS:
-        if not os.path.exists(path):
-            continue
-        try:
-            with open(path) as fh:
-                parsed = yaml.safe_load(fh) or {}
-        except (OSError, yaml.YAMLError) as exc:
-            log.warning("Could not parse model capabilities at %s: %s", path, exc)
-            continue
-        if not isinstance(parsed, dict):
-            log.warning("Ignoring model capabilities at %s: not a mapping", path)
-            continue
-        _model_capabilities_cache = parsed
-        return _model_capabilities_cache
+    if not force_reload and path in _model_capabilities_cache:
+        return _model_capabilities_cache[path]
 
-    log.warning(
-        "Model capabilities file not found (looked in %s); falling back to built-in defaults.",
-        ", ".join(_MODEL_CAPABILITIES_SEARCH_PATHS),
-    )
-    _model_capabilities_cache = _DEFAULT_MODEL_CAPABILITIES
-    return _model_capabilities_cache
+    if not os.path.exists(path):
+        log.warning("Model capabilities file not found at %s; using built-in defaults.", path)
+        _model_capabilities_cache[path] = _DEFAULT_MODEL_CAPABILITIES
+        return _DEFAULT_MODEL_CAPABILITIES
+
+    try:
+        with open(path) as fh:
+            parsed = yaml.safe_load(fh) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        log.warning("Could not parse model capabilities at %s: %s; using built-in defaults.", path, exc)
+        _model_capabilities_cache[path] = _DEFAULT_MODEL_CAPABILITIES
+        return _DEFAULT_MODEL_CAPABILITIES
+
+    if not isinstance(parsed, dict):
+        log.warning("Ignoring model capabilities at %s: not a mapping; using built-in defaults.", path)
+        _model_capabilities_cache[path] = _DEFAULT_MODEL_CAPABILITIES
+        return _DEFAULT_MODEL_CAPABILITIES
+
+    _model_capabilities_cache[path] = parsed
+    return parsed
 
 
 def _capability_for_model(model_name: str, capability: str, table: dict[str, Any]) -> Optional[bool]:
@@ -698,15 +686,18 @@ class BaseGalaxyAgent(ABC):
         Resolution order:
           1. Agent-specific ``structured_output_override`` in inference_services
           2. Global ``default.structured_output_override`` in inference_services
-          3. Glob match against the admin capability table, or shipped sample
-          4. The selected table's ``default`` block (true if absent)
+          3. Glob match in the capability table at ``config.agent_model_capabilities_file``
+             (Galaxy resolves this to the admin override in ``config_dir`` if present,
+             otherwise the shipped sample under ``sample_config_dir``)
+          4. The capability table's ``default`` block (true if absent)
         """
         override = self._get_agent_config("structured_output_override")
         if override is not None:
             return bool(override)
 
         model_name = self._get_agent_config("model", "")
-        capability = _capability_for_model(model_name, "structured_output", _load_model_capabilities())
+        capabilities_path = getattr(self.deps.config, "agent_model_capabilities_file", None)
+        capability = _capability_for_model(model_name, "structured_output", _load_model_capabilities(capabilities_path))
         if capability is None:
             return True
         return capability

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -3,7 +3,9 @@ Base classes for Galaxy AI agents.
 """
 
 import asyncio
+import fnmatch
 import logging
+import os
 import random
 from abc import (
     ABC,
@@ -24,6 +26,8 @@ from typing import (
     TYPE_CHECKING,
     Union,
 )
+
+import yaml
 
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import User
@@ -94,6 +98,97 @@ TOOL_HELPER_HISTORY_MESSAGES = 8
 Tool-context turns burn token budget faster (tool call + tool return +
 follow-up), so we hand the sub-agent a smaller window.
 """
+
+# Hardcoded fallback if the capability YAML can't be located. Mirrors the
+# previous behaviour (deepseek -> no structured output, everything else yes).
+_DEFAULT_MODEL_CAPABILITIES: dict[str, Any] = {
+    "model_capabilities": [
+        {"pattern": "deepseek*", "structured_output": False},
+    ],
+    "default": {"structured_output": True},
+}
+
+# Search order for the capability table. First hit wins.
+_MODEL_CAPABILITIES_BASENAME = "agent_model_capabilities.yml"
+_MODEL_CAPABILITIES_SEARCH_PATHS = (
+    # Admin-edited copy in the runtime config directory.
+    os.path.join("config", _MODEL_CAPABILITIES_BASENAME),
+    # The shipped sample (what most installs will end up reading).
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "config",
+        "sample",
+        _MODEL_CAPABILITIES_BASENAME + ".sample",
+    ),
+    os.path.join("config", _MODEL_CAPABILITIES_BASENAME + ".sample"),
+)
+
+_model_capabilities_cache: Optional[dict[str, Any]] = None
+
+
+def _load_model_capabilities(force_reload: bool = False) -> dict[str, Any]:
+    """Return the parsed model-capabilities table, loading it on first use.
+
+    Looks at a small set of standard locations and parses the first one that
+    exists. Falls back to a sane hardcoded default if nothing is found or the
+    file fails to parse -- we'd rather keep agents working than block on a
+    missing config file.
+    """
+    global _model_capabilities_cache
+    if _model_capabilities_cache is not None and not force_reload:
+        return _model_capabilities_cache
+
+    for path in _MODEL_CAPABILITIES_SEARCH_PATHS:
+        if not os.path.exists(path):
+            continue
+        try:
+            with open(path) as fh:
+                parsed = yaml.safe_load(fh) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            log.warning("Could not parse model capabilities at %s: %s", path, exc)
+            continue
+        if not isinstance(parsed, dict):
+            log.warning("Ignoring model capabilities at %s: not a mapping", path)
+            continue
+        _model_capabilities_cache = parsed
+        return _model_capabilities_cache
+
+    log.warning(
+        "Model capabilities file not found (looked in %s); falling back to built-in defaults.",
+        ", ".join(_MODEL_CAPABILITIES_SEARCH_PATHS),
+    )
+    _model_capabilities_cache = _DEFAULT_MODEL_CAPABILITIES
+    return _model_capabilities_cache
+
+
+def _capability_for_model(model_name: str, capability: str, table: dict[str, Any]) -> Optional[bool]:
+    """Look up `capability` for `model_name` against the parsed table.
+
+    Strips any `provider:` prefix before matching. Returns None when neither
+    a pattern nor a default entry covers the capability -- callers decide
+    what to do with that.
+    """
+    if not model_name:
+        return None
+
+    bare_name = model_name.split(":", 1)[1] if ":" in model_name else model_name
+    bare_name = bare_name.lower()
+
+    for entry in table.get("model_capabilities", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        pattern = entry.get("pattern")
+        if not pattern:
+            continue
+        if fnmatch.fnmatch(bare_name, pattern.lower()):
+            if capability in entry:
+                return bool(entry[capability])
+
+    default_block = table.get("default") or {}
+    if isinstance(default_block, dict) and capability in default_block:
+        return bool(default_block[capability])
+    return None
+
 
 __all__ = [
     "ActionSuggestion",
@@ -600,13 +695,21 @@ class BaseGalaxyAgent(ABC):
     def _supports_structured_output(self) -> bool:
         """Check if current model supports structured output (tool calling/JSON mode).
 
-        Assumes support by default, excluding known-failing models.
+        Resolution order:
+          1. Agent-specific ``structured_output_override`` in inference_services
+          2. Global ``default.structured_output_override`` in inference_services
+          3. Glob match against the shipped capability table
+          4. The capability table's ``default`` block (true if absent)
         """
-        model_name = self._get_agent_config("model", "").lower()
+        override = self._get_agent_config("structured_output_override")
+        if override is not None:
+            return bool(override)
 
-        # TODO: revisit this list as model support improves
-        unsupported = ["deepseek"]
-        return not any(m in model_name for m in unsupported)
+        model_name = self._get_agent_config("model", "")
+        capability = _capability_for_model(model_name, "structured_output", _load_model_capabilities())
+        if capability is None:
+            return True
+        return capability
 
     def _requires_structured_output(self) -> bool:
         """Override in agents that require structured output to function."""

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -725,6 +725,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     }
 
     add_sample_file_to_defaults = {
+        "agent_model_capabilities_file",
         "build_sites_config_file",
         "datatypes_config_file",
         "tool_data_table_config_path",

--- a/lib/galaxy/config/sample/agent_model_capabilities.yml.sample
+++ b/lib/galaxy/config/sample/agent_model_capabilities.yml.sample
@@ -1,0 +1,55 @@
+# Capability hints for Galaxy agent inference models.
+#
+# Galaxy's agent stack (CustomToolAgent, ErrorAnalysisAgent, ...) needs to know
+# whether the configured model supports "structured output" -- pydantic-ai's
+# tool-calling / JSON-schema mode. Most modern hosted models do; some local
+# inference backends and a handful of specific model families do not.
+#
+# This file maps fnmatch-style globs against the configured model name (the
+# bare name -- any "openai:", "anthropic:", or "google:" prefix is stripped
+# before matching). The first matching pattern wins. If nothing matches, the
+# `default` block applies.
+#
+# Admins can override per-agent or globally in galaxy.yml under
+# inference_services using `structured_output_override: true|false`. That
+# override beats whatever this table says -- useful when you're running a
+# private model that isn't in the list yet.
+
+model_capabilities:
+  # DeepSeek's R1 family routinely fails on complex nested JSON schemas.
+  - pattern: "deepseek*"
+    structured_output: false
+
+  # OpenAI GPT-4 family -- full tool-calling support.
+  - pattern: "gpt-4*"
+    structured_output: true
+  - pattern: "gpt-5*"
+    structured_output: true
+  - pattern: "o1*"
+    structured_output: true
+  - pattern: "o3*"
+    structured_output: true
+
+  # Anthropic Claude.
+  - pattern: "claude-*"
+    structured_output: true
+
+  # Google Gemini.
+  - pattern: "gemini-*"
+    structured_output: true
+
+  # Meta Llama (3.x and 4.x both handle tool calls well in practice).
+  - pattern: "llama*"
+    structured_output: true
+
+  # Mistral / Mixtral.
+  - pattern: "mistral*"
+    structured_output: true
+  - pattern: "mixtral*"
+    structured_output: true
+
+# Fallback for any model not matched above. Most modern models support
+# structured output, so we assume true rather than locking new models out
+# of features like CustomToolAgent.
+default:
+  structured_output: true

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -3045,7 +3045,11 @@ galaxy:
   # jupyterlite: { model: gpt-4o } } Set static_responses to a YAML file
   # path to replace all LLM calls with deterministic responses for
   # testing: inference_services: { static_responses:
-  # test/integration/static_agents.yml }
+  # test/integration/static_agents.yml } Per-agent or default-block
+  # ``structured_output_override: true|false`` beats the shipped
+  # capability table at config/agent_model_capabilities.yml.sample,
+  # which is consulted to decide whether the configured model can
+  # produce tool-calling / JSON-mode output.
   #inference_services: null
 
   # Path to the SQLite FTS5 database used by the GTN training agent.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -3046,10 +3046,12 @@ galaxy:
   # path to replace all LLM calls with deterministic responses for
   # testing: inference_services: { static_responses:
   # test/integration/static_agents.yml } Per-agent or default-block
-  # ``structured_output_override: true|false`` beats the shipped
-  # capability table at config/agent_model_capabilities.yml.sample,
-  # which is consulted to decide whether the configured model can
-  # produce tool-calling / JSON-mode output.
+  # ``structured_output_override: true|false`` beats the model capability
+  # table. Admins can place overrides in config/agent_model_capabilities.yml;
+  # otherwise Galaxy reads the shipped sample from
+  # lib/galaxy/config/sample/agent_model_capabilities.yml.sample. The table is
+  # consulted to decide whether the configured model can produce tool-calling /
+  # JSON-mode output.
   #inference_services: null
 
   # Path to the SQLite FTS5 database used by the GTN training agent.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1,21 +1,21 @@
 # Galaxy is configured by default to be usable in a single-user development
 # environment.  To tune the application for a multi-user production
 # environment, see the documentation at:
-#
+# 
 #  https://docs.galaxyproject.org/en/master/admin/production.html
-#
+# 
 # Throughout this sample configuration file, except where stated otherwise,
 # uncommented values override the default if left unset, whereas commented
 # values are set to the default value.  Relative paths are relative to the root
 # Galaxy directory.
-#
+# 
 # Examples of many of these options are explained in more detail in the Galaxy
 # Community Hub.
-#
+# 
 #   https://galaxyproject.org/admin/config
-#
+# 
 # Config hackers are encouraged to check there before asking for help.
-#
+# 
 # Configuration for Gravity process manager.
 # ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
 gravity:
@@ -3046,19 +3046,29 @@ galaxy:
   # path to replace all LLM calls with deterministic responses for
   # testing: inference_services: { static_responses:
   # test/integration/static_agents.yml } Per-agent or default-block
-  # ``structured_output_override: true|false`` beats the model capability
-  # table. Admins can place overrides in config/agent_model_capabilities.yml;
-  # otherwise Galaxy reads the shipped sample from
-  # lib/galaxy/config/sample/agent_model_capabilities.yml.sample. The table is
-  # consulted to decide whether the configured model can produce tool-calling /
-  # JSON-mode output.
+  # ``structured_output_override: true|false`` beats the model
+  # capability table -- see ``agent_model_capabilities_file`` for the
+  # table's location and contents.
   #inference_services: null
+
+  # YAML file with capability hints for agent inference models. Maps
+  # fnmatch-style globs against model names to features such as
+  # structured-output (tool-calling / JSON-mode) support. Galaxy ships a
+  # sample populated with common model families; admins can drop a file
+  # named ``agent_model_capabilities.yml`` in ``config_dir`` to override
+  # the shipped table for private models. ``inference_services``
+  # ``structured_output_override`` overrides this table for a specific
+  # agent or default block.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #agent_model_capabilities_file: agent_model_capabilities.yml
 
   # Path to the SQLite FTS5 database used by the GTN training agent.
   # Resolves against ``data_dir`` so admins can place it in a
   # mutable-data directory. The file is downloaded automatically on
   # first use from ``gtn_database_url`` if it does not exist.
-  # The default value is: gtn/gtn_search.db
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
   #gtn_database_path: gtn/gtn_search.db
 
   # URL used to download the GTN search database when the local file at
@@ -3299,3 +3309,4 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
+

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4158,11 +4158,23 @@ mapping:
           deterministic responses for testing:
           inference_services: { static_responses: test/integration/static_agents.yml }
           Per-agent or default-block ``structured_output_override: true|false``
-          beats the model capability table. Admins can place overrides in
-          config/agent_model_capabilities.yml; otherwise Galaxy reads the
-          shipped sample from lib/galaxy/config/sample/agent_model_capabilities.yml.sample.
-          The table is consulted to decide whether the configured model can
-          produce tool-calling / JSON-mode output.
+          beats the model capability table -- see ``agent_model_capabilities_file``
+          for the table's location and contents.
+
+      agent_model_capabilities_file:
+        type: str
+        default: agent_model_capabilities.yml
+        path_resolves_to: config_dir
+        required: false
+        desc: |
+          YAML file with capability hints for agent inference models. Maps
+          fnmatch-style globs against model names to features such as
+          structured-output (tool-calling / JSON-mode) support. Galaxy ships a
+          sample populated with common model families; admins can drop a file
+          named ``agent_model_capabilities.yml`` in ``config_dir`` to override
+          the shipped table for private models. ``inference_services``
+          ``structured_output_override`` overrides this table for a specific
+          agent or default block.
 
       gtn_database_path:
         type: str

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4158,9 +4158,11 @@ mapping:
           deterministic responses for testing:
           inference_services: { static_responses: test/integration/static_agents.yml }
           Per-agent or default-block ``structured_output_override: true|false``
-          beats the shipped capability table at config/agent_model_capabilities.yml.sample,
-          which is consulted to decide whether the configured model can produce
-          tool-calling / JSON-mode output.
+          beats the model capability table. Admins can place overrides in
+          config/agent_model_capabilities.yml; otherwise Galaxy reads the
+          shipped sample from lib/galaxy/config/sample/agent_model_capabilities.yml.sample.
+          The table is consulted to decide whether the configured model can
+          produce tool-calling / JSON-mode output.
 
       gtn_database_path:
         type: str

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4157,6 +4157,10 @@ mapping:
           Set static_responses to a YAML file path to replace all LLM calls with
           deterministic responses for testing:
           inference_services: { static_responses: test/integration/static_agents.yml }
+          Per-agent or default-block ``structured_output_override: true|false``
+          beats the shipped capability table at config/agent_model_capabilities.yml.sample,
+          which is consulted to decide whether the configured model can produce
+          tool-calling / JSON-mode output.
 
       gtn_database_path:
         type: str

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -897,6 +897,79 @@ class TestAgentUnitMocked:
         agent = WorkflowOrchestratorAgent(self.deps)
         return agent
 
+    def test_supports_structured_output_capability_table_match(self):
+        """Glob-matched models in the capability table should answer correctly."""
+        self.mock_config.inference_services = None
+
+        self.mock_config.ai_model = "deepseek-r1"
+        deepseek_agent = ErrorAnalysisAgent(self.deps)
+        assert deepseek_agent._supports_structured_output() is False
+
+        self.mock_config.ai_model = "gpt-4o"
+        gpt_agent = ErrorAnalysisAgent(self.deps)
+        assert gpt_agent._supports_structured_output() is True
+
+    def test_supports_structured_output_admin_override_takes_precedence(self):
+        """Admin override beats whatever the capability table says."""
+        # Per-agent override flips deepseek (table says False) to True.
+        self.mock_config.ai_model = "deepseek-r1"
+        self.mock_config.inference_services = {
+            "error_analysis": {"structured_output_override": True},
+        }
+        agent = ErrorAnalysisAgent(self.deps)
+        assert agent._supports_structured_output() is True
+
+        # Default-block override applies when there's no per-agent setting.
+        self.mock_config.inference_services = {
+            "default": {"structured_output_override": False},
+        }
+        self.mock_config.ai_model = "gpt-4o"
+        gpt_agent = ErrorAnalysisAgent(self.deps)
+        assert gpt_agent._supports_structured_output() is False
+
+    def test_supports_structured_output_falls_back_to_default(self):
+        """Unknown model names hit the table's default block."""
+        self.mock_config.inference_services = None
+        self.mock_config.ai_model = "some-totally-new-model-2030"
+        agent = ErrorAnalysisAgent(self.deps)
+        # Shipped sample sets default.structured_output: true.
+        assert agent._supports_structured_output() is True
+
+    def test_capability_table_glob_matching(self):
+        """Globs should match wildcard suffixes (e.g. gpt-4-turbo)."""
+        from galaxy.agents.base import (
+            _capability_for_model,
+            _load_model_capabilities,
+        )
+
+        table = _load_model_capabilities()
+        assert _capability_for_model("gpt-4-turbo", "structured_output", table) is True
+        assert _capability_for_model("gpt-4o-mini", "structured_output", table) is True
+        assert _capability_for_model("claude-3-5-sonnet", "structured_output", table) is True
+        # Provider prefixes get stripped before matching.
+        assert _capability_for_model("openai:gpt-4o", "structured_output", table) is True
+        assert _capability_for_model("anthropic:claude-3-5-sonnet", "structured_output", table) is True
+        # DeepSeek family is explicitly opted out.
+        assert _capability_for_model("deepseek-r1", "structured_output", table) is False
+        assert _capability_for_model("deepseek-v3", "structured_output", table) is False
+
+    def test_capability_table_loads_with_missing_file(self, monkeypatch):
+        """Force every search path to miss; loader should warn and use defaults."""
+        from galaxy.agents import base as agents_base
+
+        monkeypatch.setattr(agents_base, "_MODEL_CAPABILITIES_SEARCH_PATHS", ())
+        monkeypatch.setattr(agents_base, "_model_capabilities_cache", None)
+
+        table = agents_base._load_model_capabilities(force_reload=True)
+
+        # Should be the hardcoded fallback.
+        assert table is agents_base._DEFAULT_MODEL_CAPABILITIES
+        assert agents_base._capability_for_model("deepseek-r1", "structured_output", table) is False
+        assert agents_base._capability_for_model("gpt-4o", "structured_output", table) is True
+
+        # Reset cache so subsequent tests pick up the real file again.
+        monkeypatch.setattr(agents_base, "_model_capabilities_cache", None)
+
 
 @pytestmark_live_llm
 class TestAgentUnitLiveLLM:

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -53,7 +53,10 @@ from galaxy.agents.base import truncate_message_history
 from galaxy.agents.registry import build_default_registry
 
 agent_registry = build_default_registry()
+from galaxy.agents import base as agents_base
 from galaxy.agents.base import (
+    _capability_for_model,
+    _load_model_capabilities,
     AgentResponse,
     AgentRunState,
     AgentType,
@@ -937,11 +940,6 @@ class TestAgentUnitMocked:
 
     def test_capability_table_glob_matching(self):
         """Globs should match wildcard suffixes (e.g. gpt-4-turbo)."""
-        from galaxy.agents.base import (
-            _capability_for_model,
-            _load_model_capabilities,
-        )
-
         table = _load_model_capabilities()
         assert _capability_for_model("gpt-4-turbo", "structured_output", table) is True
         assert _capability_for_model("gpt-4o-mini", "structured_output", table) is True
@@ -955,8 +953,6 @@ class TestAgentUnitMocked:
 
     def test_capability_table_loads_with_missing_file(self, monkeypatch):
         """Force every search path to miss; loader should warn and use defaults."""
-        from galaxy.agents import base as agents_base
-
         monkeypatch.setattr(agents_base, "_MODEL_CAPABILITIES_SEARCH_PATHS", ())
         monkeypatch.setattr(agents_base, "_model_capabilities_cache", None)
 
@@ -964,8 +960,8 @@ class TestAgentUnitMocked:
 
         # Should be the hardcoded fallback.
         assert table is agents_base._DEFAULT_MODEL_CAPABILITIES
-        assert agents_base._capability_for_model("deepseek-r1", "structured_output", table) is False
-        assert agents_base._capability_for_model("gpt-4o", "structured_output", table) is True
+        assert _capability_for_model("deepseek-r1", "structured_output", table) is False
+        assert _capability_for_model("gpt-4o", "structured_output", table) is True
 
         # Reset cache so subsequent tests pick up the real file again.
         monkeypatch.setattr(agents_base, "_model_capabilities_cache", None)

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -78,6 +78,15 @@ class TestAgentUnitMocked:
         self.mock_config.ai_api_key = "test-key"
         self.mock_config.ai_model = "llama-4-scout"
         self.mock_config.ai_api_base_url = "http://localhost:4000/v1/"
+        # Point at the shipped capability sample so _supports_structured_output
+        # exercises the real table rather than the built-in fallback.
+        self.mock_config.agent_model_capabilities_file = os.path.join(
+            os.path.dirname(agents_base.__file__),
+            "..",
+            "config",
+            "sample",
+            "agent_model_capabilities.yml.sample",
+        )
 
         self.mock_user = mock.Mock()
         self.mock_user.id = 1
@@ -940,7 +949,7 @@ class TestAgentUnitMocked:
 
     def test_capability_table_glob_matching(self):
         """Globs should match wildcard suffixes (e.g. gpt-4-turbo)."""
-        table = _load_model_capabilities()
+        table = _load_model_capabilities(self.mock_config.agent_model_capabilities_file)
         assert _capability_for_model("gpt-4-turbo", "structured_output", table) is True
         assert _capability_for_model("gpt-4o-mini", "structured_output", table) is True
         assert _capability_for_model("claude-3-5-sonnet", "structured_output", table) is True
@@ -951,20 +960,17 @@ class TestAgentUnitMocked:
         assert _capability_for_model("deepseek-r1", "structured_output", table) is False
         assert _capability_for_model("deepseek-v3", "structured_output", table) is False
 
-    def test_capability_table_loads_with_missing_file(self, monkeypatch):
-        """Force every search path to miss; loader should warn and use defaults."""
-        monkeypatch.setattr(agents_base, "_MODEL_CAPABILITIES_SEARCH_PATHS", ())
-        monkeypatch.setattr(agents_base, "_model_capabilities_cache", None)
-
-        table = agents_base._load_model_capabilities(force_reload=True)
-
-        # Should be the hardcoded fallback.
+    def test_capability_table_falls_back_when_file_is_missing(self):
+        """Pointing at a non-existent path should fall back to the built-in defaults."""
+        table = _load_model_capabilities("/nonexistent/path/agent_model_capabilities.yml", force_reload=True)
         assert table is agents_base._DEFAULT_MODEL_CAPABILITIES
         assert _capability_for_model("deepseek-r1", "structured_output", table) is False
         assert _capability_for_model("gpt-4o", "structured_output", table) is True
 
-        # Reset cache so subsequent tests pick up the real file again.
-        monkeypatch.setattr(agents_base, "_model_capabilities_cache", None)
+    def test_capability_table_falls_back_when_path_is_unset(self):
+        """A None or non-string path (e.g. unset config option) yields the built-in defaults."""
+        assert _load_model_capabilities(None) is agents_base._DEFAULT_MODEL_CAPABILITIES
+        assert _load_model_capabilities("") is agents_base._DEFAULT_MODEL_CAPABILITIES
 
 
 @pytestmark_live_llm


### PR DESCRIPTION
`BaseGalaxyAgent._supports_structured_output()` was hardcoded to `["deepseek"]` -- a denylist that's wrong as soon as a new structured-output-friendly model ships under the wrong substring or a known-bad model lands in a different package. This swaps the denylist for a small YAML table at `lib/galaxy/config/sample/agent_model_capabilities.yml.sample` and a four-step resolution order in `_supports_structured_output()`:

1. Per-agent `structured_output_override` from `inference_services` config
2. Default-block `structured_output_override` from `inference_services`
3. Glob match in the capability table (admin's `config/agent_model_capabilities.yml` if present, otherwise the shipped sample)
4. The selected table's `default` block (true if absent)

The shipped table covers gpt-4*/gpt-5*/o1*/o3*/claude-*/gemini-*/llama*/mistral*/mixtral* as supporting structured output, and `deepseek*` as not. Provider prefixes (`openai:`, `anthropic:`, `google:`) are stripped before matching. New models default to `true` rather than locking them out of features like `CustomToolAgent`.

If the file is missing or malformed, the loader logs a warning and falls back to a built-in default that mirrors the previous denylist behavior, so agents keep working. Admins overriding via `galaxy.yml` always win, which is what they need when running a private model that isn't in the upstream table.

## Test plan
- [x] `pytest test/unit/app/test_agents.py::TestAgentUnitMocked` -- 25 passed (5 new: capability-table glob match for known model families, admin override beats table, unknown-model fallback, provider-prefix stripping, missing-file fallback to built-in defaults)
- [ ] Manual smoke: switch the configured model to deepseek-r1 and confirm CustomToolAgent's "model_capability" error path still triggers