### PR TITLE
Validate generated UserToolSource semantically before returning it

### DIFF
--- a/lib/galaxy/agents/custom_tool.py
+++ b/lib/galaxy/agents/custom_tool.py
@@ -28,6 +28,7 @@ from .base import (
     extract_structured_output,
     GalaxyAgentDependencies,
 )
+from .validators import validate_user_tool_source
 
 log = logging.getLogger(__name__)
 
@@ -100,6 +101,33 @@ class CustomToolAgent(BaseGalaxyAgent):
 
             tool_dict = tool.model_dump(by_alias=True, exclude_none=True)
             tool_yaml = yaml.dump(tool_dict, default_flow_style=False, sort_keys=False)
+
+            validation_errors = validate_user_tool_source(tool)
+            if validation_errors:
+                log.warning(
+                    "CustomToolAgent produced a UserToolSource that failed semantic validation: %s",
+                    validation_errors,
+                )
+                bullet_list = "\n".join(f"- {issue}" for issue in validation_errors)
+                content = (
+                    "The model produced a tool definition, but it has semantic problems "
+                    "that need to be fixed before it can be saved:\n\n"
+                    f"{bullet_list}\n\n"
+                    "The generated YAML is included in metadata for diagnosis."
+                )
+                return self._build_response(
+                    content=content,
+                    confidence=ConfidenceLevel.LOW,
+                    method="validation_error",
+                    result=result,
+                    query=query,
+                    error="validation_failed",
+                    agent_data={
+                        "validation_errors": validation_errors,
+                        "tool_yaml": tool_yaml,
+                        "tool_id": tool.id,
+                    },
+                )
 
             response_content = f"""I've created a custom Galaxy tool:
 

--- a/lib/galaxy/agents/validators/__init__.py
+++ b/lib/galaxy/agents/validators/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic validators for agent-generated artifacts."""
+
+from .custom_tool_validator import validate_user_tool_source
+
+__all__ = ["validate_user_tool_source"]

--- a/lib/galaxy/agents/validators/custom_tool_validator.py
+++ b/lib/galaxy/agents/validators/custom_tool_validator.py
@@ -1,0 +1,188 @@
+"""Structural semantic validator for ``UserToolSource`` instances.
+
+Pydantic catches schema-level issues but not semantic ones -- a tool
+definition can be schema-valid yet reference undeclared inputs in its
+``shell_command`` template, have malformed citations, or list a container
+that doesn't match expected registry shapes. This module catches those
+deterministically before any LLM critic touches the tool. Pure code:
+no LLM calls, no network, no registry resolution. Container shape is
+checked as a string only; verifying the image actually exists is left
+as future work (intentionally opt-in/cached so the cheap structural
+check stays cheap).
+"""
+
+import re
+from collections.abc import Iterable
+from typing import (
+    Optional,
+)
+
+from galaxy.tool_util_models import UserToolSource
+from galaxy.tool_util_models.tool_source import Citation
+
+# Tool ID: lowercase letters, digits, underscores; must start with a letter.
+_TOOL_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# DOI: '10.<registrant>/<suffix>' per Crossref's published shape.
+_DOI_RE = re.compile(r"^10\.\d{4,9}/.+$")
+
+# BibTeX entries open with '@<type>{' -- e.g. '@article{', '@inproceedings{'.
+_BIBTEX_RE = re.compile(r"^@[a-zA-Z]+\s*\{", re.MULTILINE)
+
+# References inside shell_command. Templates use ecmascript-style $(...) blocks
+# (see YamlTemplateConfigFile in tool_source.py). We pull every $(<expr>) and
+# extract the leading 'inputs.<name>' identifier from each. Anything fancier
+# (map/join over a multiple input, conditionals) is intentionally not parsed --
+# we only flag obvious typos, not hairy expressions.
+_TEMPLATE_BLOCK_RE = re.compile(r"\$\((.*?)\)", re.DOTALL)
+_INPUTS_REF_RE = re.compile(r"\binputs\.([A-Za-z_][A-Za-z0-9_]*)")
+
+# Docker Hub-style image references. Allow optional registry path segments and
+# an optional tag. Examples that should pass: 'busybox', 'ubuntu:latest',
+# 'biocontainers/blast:2.13.0', 'library/python:3.11-slim'.
+_DOCKER_IMAGE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9._-]+)*(:[\w][\w.-]*)?$")
+
+_CONTAINER_PREFIXES = ("quay.io/biocontainers/", "docker://", "oras://")
+
+
+def _input_names(tool: UserToolSource) -> set[str]:
+    """Collect declared input names. Skips any input the model couldn't expose
+    a name on -- pydantic validation already requires it on real instances."""
+    names: set[str] = set()
+    for param in tool.inputs or []:
+        # YamlGalaxyToolParameter is a RootModel; the concrete param hangs off .root.
+        root = getattr(param, "root", param)
+        name = getattr(root, "name", None)
+        if name:
+            names.add(name)
+    return names
+
+
+def _output_names(tool: UserToolSource) -> Iterable[str]:
+    for output in tool.outputs or []:
+        name = getattr(output, "name", None)
+        if name:
+            yield name
+
+
+def _command_input_refs(shell_command: str) -> set[str]:
+    """Extract every 'inputs.<name>' identifier referenced from shell_command.
+
+    Limitation: only catches identifiers that appear literally as
+    ``inputs.<name>`` inside a ``$(...)`` block. Computed/aliased references
+    (``const x = inputs; x.foo``) slip through. That's fine -- the goal is
+    catching obvious typos cheaply, not modelling ecmascript scope.
+    """
+    refs: set[str] = set()
+    for block in _TEMPLATE_BLOCK_RE.findall(shell_command or ""):
+        for match in _INPUTS_REF_RE.findall(block):
+            refs.add(match)
+    return refs
+
+
+def _validate_container(container: Optional[str]) -> Optional[str]:
+    if not container or not container.strip():
+        return "container is required and must be non-empty"
+    value = container.strip()
+    if value.startswith(_CONTAINER_PREFIXES):
+        return None
+    if _DOCKER_IMAGE_RE.match(value):
+        return None
+    return (
+        f"container '{container}' does not match a recognized shape "
+        "(quay.io/biocontainers/..., docker://..., oras://..., or <image>[:<tag>])"
+    )
+
+
+def _validate_citation(citation: Citation, index: int) -> Optional[str]:
+    content = (citation.content or "").strip()
+    if not content:
+        return f"citation #{index + 1} has empty content"
+    citation_type = (citation.type or "").strip().lower()
+    if citation_type == "doi":
+        if not _DOI_RE.match(content):
+            return (
+                f"citation #{index + 1} declared as DOI but '{content}' does not match DOI shape (^10\\.\\d{{4,9}}/.+$)"
+            )
+        return None
+    if citation_type == "bibtex":
+        if not _BIBTEX_RE.search(content):
+            return f"citation #{index + 1} declared as bibtex but content does not start with '@<type>{{'"
+        return None
+    # Type wasn't explicitly doi/bibtex -- accept if the content shape is one of
+    # the two known forms. Lets a slightly mis-typed entry through instead of
+    # fighting models that emit type='reference' or similar.
+    if _DOI_RE.match(content) or _BIBTEX_RE.search(content):
+        return None
+    return f"citation #{index + 1} (type={citation.type!r}) is neither a recognizable DOI nor a BibTeX entry"
+
+
+def validate_user_tool_source(tool: UserToolSource) -> Optional[list[str]]:
+    """Return a list of human-readable error strings, or ``None`` if valid.
+
+    See module docstring for scope. The list is order-stable so callers can
+    surface it directly without reshuffling.
+    """
+    errors: list[str] = []
+
+    # Required fields populated.
+    if not tool.name or not tool.name.strip():
+        errors.append("name is required and must be non-empty")
+    if not tool.version or not tool.version.strip():
+        errors.append("version is required and must be non-empty")
+    if not tool.description or not tool.description.strip():
+        errors.append("description is required and must be non-empty")
+
+    # Tool ID format.
+    if not tool.id:
+        errors.append("id is required")
+    elif not _TOOL_ID_RE.match(tool.id):
+        errors.append(
+            f"id '{tool.id}' must match ^[a-z][a-z0-9_]*$ "
+            "(lowercase, start with a letter, only letters/digits/underscores)"
+        )
+
+    # Container shape.
+    container_error = _validate_container(tool.container)
+    if container_error:
+        errors.append(container_error)
+
+    # Citations: at least one, each well-shaped.
+    if not tool.citations:
+        errors.append("at least one citation is required")
+    else:
+        for idx, citation in enumerate(tool.citations):
+            citation_error = _validate_citation(citation, idx)
+            if citation_error:
+                errors.append(citation_error)
+
+    # Command-template references must point at declared inputs.
+    declared_inputs = _input_names(tool)
+    referenced = _command_input_refs(tool.shell_command or "")
+    undeclared = sorted(referenced - declared_inputs)
+    for name in undeclared:
+        errors.append(f"shell_command references inputs.{name} but no input named '{name}' is declared")
+
+    # Outputs: a declared output should appear in the command (named on the
+    # command line) OR have from_work_dir set. We accept anything else as a
+    # false-negative tradeoff -- catching genuinely abandoned outputs matters
+    # less than not yelling at clever templates.
+    command = tool.shell_command or ""
+    for name in _output_names(tool):
+        if name in command:
+            continue
+        produced = False
+        for output in tool.outputs or []:
+            if getattr(output, "name", None) != name:
+                continue
+            from_work_dir = getattr(output, "from_work_dir", None)
+            if from_work_dir:
+                produced = True
+                break
+        if not produced:
+            errors.append(
+                f"output '{name}' is declared but not referenced in shell_command "
+                "and has no from_work_dir set -- it will never be produced"
+            )
+
+    return errors or None

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -123,7 +123,7 @@ class TestAgentUnitMocked:
             mock_tool = UserToolSource(
                 **{
                     "class": "GalaxyUserTool",
-                    "id": "test-tool",
+                    "id": "test_tool",
                     "name": "Test Tool",
                     "version": "1.0.0",
                     "description": "A test tool",
@@ -131,6 +131,7 @@ class TestAgentUnitMocked:
                     "shell_command": "echo test",
                     "inputs": [],
                     "outputs": [],
+                    "citations": [{"type": "doi", "content": "10.1000/xyz123"}],
                 }
             )
 
@@ -141,7 +142,7 @@ class TestAgentUnitMocked:
             response = await agent.process("Create a test tool")
 
             assert response.confidence.value in ["high", "medium"]
-            assert response.metadata["tool_id"] == "test-tool"
+            assert response.metadata["tool_id"] == "test_tool"
             assert response.metadata["method"] == "structured"
 
     @pytest.mark.asyncio
@@ -577,6 +578,202 @@ class TestAgentUnitLiveLLM:
         assert response.metadata["method"] == "simple_template"
         assert "tool_id" in response.metadata
         assert "tool_yaml" in response.metadata
+
+
+def _make_user_tool_source(**overrides) -> UserToolSource:
+    """Build a canonical-valid UserToolSource for validator tests, with overrides."""
+    payload: dict = {
+        "class": "GalaxyUserTool",
+        "id": "echo_tool",
+        "name": "Echo",
+        "version": "0.1.0",
+        "description": "Echo input text to a file",
+        "container": "quay.io/biocontainers/python:3.13",
+        "shell_command": "echo '$(inputs.message)' > out.txt",
+        "inputs": [
+            {"name": "message", "type": "text", "value": "hi"},
+        ],
+        "outputs": [
+            {"name": "out", "type": "data", "format": "txt", "from_work_dir": "out.txt"},
+        ],
+        "citations": [
+            {"type": "doi", "content": "10.1093/bioinformatics/btx123"},
+        ],
+    }
+    # Pop top-level overrides like 'citations=None' to remove the key entirely.
+    for key, value in overrides.items():
+        if value is _SENTINEL_REMOVE:
+            payload.pop(key, None)
+        else:
+            payload[key] = value
+    return UserToolSource(**payload)
+
+
+_SENTINEL_REMOVE = object()
+
+
+class TestCustomToolValidator:
+    """Tests for the deterministic UserToolSource semantic validator."""
+
+    def test_validator_accepts_valid_tool(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        tool = _make_user_tool_source()
+        assert validate_user_tool_source(tool) is None
+
+    def test_validator_rejects_missing_container(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        tool = _make_user_tool_source(container="   ")
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        assert any("container" in e for e in errors)
+
+    def test_validator_rejects_bad_tool_id(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        tool = _make_user_tool_source(id="Bad-ID")
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        assert any("id" in e and "Bad-ID" in e for e in errors)
+
+    def test_validator_rejects_undeclared_command_variable(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        tool = _make_user_tool_source(
+            shell_command="echo '$(inputs.undeclared)' > out.txt",
+        )
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        assert any("undeclared" in e for e in errors)
+
+    def test_validator_rejects_no_citations(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        tool = _make_user_tool_source(citations=_SENTINEL_REMOVE)
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        assert any("citation" in e for e in errors)
+
+        # An explicitly-empty list should also fail.
+        tool = _make_user_tool_source(citations=[])
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        assert any("citation" in e for e in errors)
+
+    def test_validator_accepts_doi_and_bibtex(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        bibtex = "@article{smith2020,\n  title = {A Tool},\n  author = {Smith, J.},\n  year = {2020}\n}"
+        tool = _make_user_tool_source(
+            citations=[
+                {"type": "doi", "content": "10.1093/bioinformatics/btab456"},
+                {"type": "bibtex", "content": bibtex},
+            ]
+        )
+        assert validate_user_tool_source(tool) is None
+
+    def test_validator_rejects_malformed_container(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        tool = _make_user_tool_source(container="not a valid !!! image string")
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        assert any("container" in e for e in errors)
+
+    def test_validator_rejects_empty_required_fields(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        # name is the only field that pydantic strictly requires non-empty;
+        # version and description default to None at the model level. The
+        # validator must still flag empty/whitespace strings.
+        tool = _make_user_tool_source(name="   ", version="", description="   ")
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        joined = "\n".join(errors)
+        assert "name" in joined
+        assert "version" in joined
+        assert "description" in joined
+
+    def test_validator_returns_multiple_errors(self):
+        from galaxy.agents.validators import validate_user_tool_source
+
+        tool = _make_user_tool_source(
+            id="Bad-ID",
+            container="",
+            citations=[],
+            shell_command="echo '$(inputs.nope)' > out.txt",
+        )
+        errors = validate_user_tool_source(tool)
+        assert errors is not None
+        assert len(errors) >= 4
+        joined = "\n".join(errors)
+        assert "Bad-ID" in joined
+        assert "container" in joined
+        assert "citation" in joined
+        assert "nope" in joined
+
+
+class TestCustomToolAgentValidation:
+    """Integration: CustomToolAgent surfaces validator failures as low-confidence."""
+
+    def setup_method(self):
+        self.mock_config = mock.Mock()
+        self.mock_config.ai_api_key = "test-key"
+        self.mock_config.ai_model = "gpt-4o"
+        self.mock_config.ai_api_base_url = "http://localhost:4000/v1/"
+
+        self.mock_user = mock.Mock()
+        self.mock_user.id = 1
+        self.mock_user.username = "test_user"
+
+        self.mock_trans = mock.Mock()
+        self.mock_trans.app.config = self.mock_config
+        self.mock_trans.user = self.mock_user
+
+        self.deps = GalaxyAgentDependencies(
+            trans=self.mock_trans,
+            user=self.mock_user,
+            config=self.mock_config,
+            get_agent=agent_registry.get_agent,
+            job_manager=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_agent_surfaces_validation_errors(self):
+        agent = CustomToolAgent(self.deps)
+
+        broken_tool = UserToolSource(
+            **{
+                "class": "GalaxyUserTool",
+                "id": "Broken-Tool",  # bad id format
+                "name": "Broken",
+                "version": "0.1.0",
+                "description": "broken",
+                "container": "ubuntu:latest",
+                "shell_command": "echo '$(inputs.missing)'",
+                "inputs": [],
+                "outputs": [],
+                # no citations on purpose
+            }
+        )
+
+        with mock.patch.object(agent.agent, "run") as mock_run:
+            mock_result = mock.Mock()
+            mock_result.output = broken_tool
+            mock_run.return_value = mock_result
+
+            response = await agent.process("Create a tool")
+
+        assert response.confidence == ConfidenceLevel.LOW
+        assert response.metadata.get("error") == "validation_failed"
+        assert response.metadata.get("method") == "validation_error"
+        validation_errors = response.metadata.get("validation_errors")
+        assert isinstance(validation_errors, list) and validation_errors
+        # The original tool yaml should still be in metadata for diagnosis.
+        assert response.metadata.get("tool_yaml")
+        # User-facing content names at least one of the issues.
+        assert "missing" in response.content or "Broken-Tool" in response.content
 
 
 @pytestmark_live_llm

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -47,6 +47,7 @@ from galaxy.agents.orchestrator import (
     AgentPlan,
     WorkflowOrchestratorAgent,
 )
+from galaxy.agents.validators import validate_user_tool_source
 from galaxy.schema.agents import ConfidenceLevel
 from galaxy.tool_util_models import UserToolSource
 from galaxy.util.unittest_utils import pytestmark_live_llm
@@ -616,13 +617,11 @@ class TestCustomToolValidator:
     """Tests for the deterministic UserToolSource semantic validator."""
 
     def test_validator_accepts_valid_tool(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         tool = _make_user_tool_source()
         assert validate_user_tool_source(tool) is None
 
     def test_validator_rejects_missing_container(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         tool = _make_user_tool_source(container="   ")
         errors = validate_user_tool_source(tool)
@@ -630,7 +629,6 @@ class TestCustomToolValidator:
         assert any("container" in e for e in errors)
 
     def test_validator_rejects_bad_tool_id(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         tool = _make_user_tool_source(id="Bad-ID")
         errors = validate_user_tool_source(tool)
@@ -638,7 +636,6 @@ class TestCustomToolValidator:
         assert any("id" in e and "Bad-ID" in e for e in errors)
 
     def test_validator_rejects_undeclared_command_variable(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         tool = _make_user_tool_source(
             shell_command="echo '$(inputs.undeclared)' > out.txt",
@@ -648,7 +645,6 @@ class TestCustomToolValidator:
         assert any("undeclared" in e for e in errors)
 
     def test_validator_rejects_no_citations(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         tool = _make_user_tool_source(citations=_SENTINEL_REMOVE)
         errors = validate_user_tool_source(tool)
@@ -662,7 +658,6 @@ class TestCustomToolValidator:
         assert any("citation" in e for e in errors)
 
     def test_validator_accepts_doi_and_bibtex(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         bibtex = "@article{smith2020,\n  title = {A Tool},\n  author = {Smith, J.},\n  year = {2020}\n}"
         tool = _make_user_tool_source(
@@ -674,7 +669,6 @@ class TestCustomToolValidator:
         assert validate_user_tool_source(tool) is None
 
     def test_validator_rejects_malformed_container(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         tool = _make_user_tool_source(container="not a valid !!! image string")
         errors = validate_user_tool_source(tool)
@@ -682,7 +676,6 @@ class TestCustomToolValidator:
         assert any("container" in e for e in errors)
 
     def test_validator_rejects_empty_required_fields(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         # name is the only field that pydantic strictly requires non-empty;
         # version and description default to None at the model level. The
@@ -696,7 +689,6 @@ class TestCustomToolValidator:
         assert "description" in joined
 
     def test_validator_returns_multiple_errors(self):
-        from galaxy.agents.validators import validate_user_tool_source
 
         tool = _make_user_tool_source(
             id="Bad-ID",


### PR DESCRIPTION
The `CustomToolAgent` accepted any `UserToolSource` that pydantic could parse, even when the tool definition was structurally valid but semantically broken -- a `shell_command` referencing `inputs.foo` with no input named `foo`, an empty container string, citations that aren't actually DOIs or BibTeX, a tool ID with hyphens that won't import cleanly. Pydantic catches schema-level issues; this adds a deterministic semantic pass that catches the rest before any LLM critic touches the tool.

New module: `lib/galaxy/agents/validators/custom_tool_validator.py`. Pure code, no LLM calls, no network, no registry resolution. Rules checked:

- `id` matches `^[a-z][a-z0-9_]*$` (snake_case, leading letter)
- `container` is non-empty and matches a recognized shape (`quay.io/biocontainers/...`, `docker://...`, `oras://...`, or a Docker Hub-style `<image>[:<tag>]`)
- At least one citation, each well-shaped: DOI matches `^10\.\d{4,9}/.+$`, BibTeX starts with `@<type>{`, and a citation with no explicit type passes if the content matches either form
- Every `inputs.<name>` referenced in `shell_command` corresponds to a declared input name
- Every declared output appears in the command OR has `from_work_dir` set (so it'll actually be produced)
- `name`, `version`, `description` are non-empty strings

Container resolution (does `quay.io/biocontainers/samtools:1.17` actually exist?) is intentionally out of scope here -- it'd add network flakiness to a check that should stay cheap. Per the plan it'd be opt-in / cached if added later.

`CustomToolAgent.process()` runs the validator after pydantic parses the model output. If validation fails, the agent returns a low-confidence response with `error="validation_failed"`, a bullet list of the failures in the user-facing content, and the original tool YAML attached to metadata for diagnosis.

One existing test fixture had to bump from `id="test-tool"` (hyphen) to `id="test_tool"` and add a citation -- the fixture was previously a "wrong shape" that didn't fail because nothing validated; now it has to be a valid shape because the pipeline does.

## Test plan
- [x] `pytest test/unit/app/test_agents.py` -- 30 passed (10 new: validator happy path, missing/malformed container, bad id, undeclared command variable, no/empty citations, DOI+BibTeX acceptance, empty required fields, multi-error case, integration test confirming the agent surfaces failures as low-confidence with metadata)
- [ ] Manual smoke: ask CustomToolAgent to wrap a tool, confirm a deliberately broken description (e.g. citing inputs that don't exist) surfaces as a validation error rather than a success