### PR TITLE
[26.0] Reject malformed dataset ids in data tool parameter

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2039,6 +2039,25 @@ ItemFromSrcCollection = Union[
 ]
 
 
+def _decode_dataset_id(value, security: "IdEncodingHelper", parameter_name: str) -> int:
+    """Coerce a value into an integer dataset PK or raise ParameterValueError.
+
+    Accepts int, digit string, or 16-char encoded id. Anything else
+    (including ``src:...``-prefixed strings, which should arrive as
+    ``{src, id}`` dicts via :func:`src_id_to_item`) is rejected so
+    malformed input surfaces as a 4xx instead of a SQL crash.
+    """
+    if isinstance(value, int):
+        return value
+    s = str(value)
+    if s.isdigit():
+        return int(s)
+    if len(s) == 16:
+        log.warning("Encoded ID where unencoded ID expected.")
+        return int(security.decode_id(s))
+    raise ParameterValueError(f"invalid dataset id {value!r}", parameter_name)
+
+
 def src_id_to_item(
     sa_session: "Session", value: typing.MutableMapping[str, Any], security: "IdEncodingHelper"
 ) -> ItemFromSrcAny:
@@ -2197,12 +2216,8 @@ class DataToolParameter(BaseDataToolParameter):
                 ):
                     rval.append(single_value)
                 else:
-                    if len(str(single_value)) == 16:
-                        # Could never really have an ID this big anyway - postgres doesn't
-                        # support that for integer column types.
-                        log.warning("Encoded ID where unencoded ID expected.")
-                        single_value = trans.security.decode_id(single_value)
-                    rval.append(trans.sa_session.query(HistoryDatasetAssociation).get(single_value))
+                    pk = _decode_dataset_id(single_value, trans.security, self.name)
+                    rval.append(trans.sa_session.get(HistoryDatasetAssociation, pk))
                 if len(found_srcs) > 1 and "hdca" in found_srcs:
                     raise ParameterValueError(
                         "if collections are supplied to multiple data input parameter, only collections may be used",
@@ -2222,7 +2237,8 @@ class DataToolParameter(BaseDataToolParameter):
         elif isinstance(value, HistoryDatasetCollectionAssociation) or isinstance(value, DatasetCollectionElement):
             rval.append(value)
         else:
-            rval.append(session.get(HistoryDatasetAssociation, int(value)))
+            pk = _decode_dataset_id(value, trans.security, self.name)
+            rval.append(session.get(HistoryDatasetAssociation, pk))
         dataset_matcher_factory = get_dataset_matcher_factory(trans)
         dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
         for v in rval:

--- a/test/unit/app/tools/test_data_parameters.py
+++ b/test/unit/app/tools/test_data_parameters.py
@@ -3,8 +3,11 @@ from typing import (
     Optional,
 )
 
+import pytest
+
 from galaxy import model
 from galaxy.app_unittest_utils import galaxy_mock
+from galaxy.tools.parameters.basic import ParameterValueError
 from .util import BaseParameterTestCase
 
 
@@ -32,6 +35,15 @@ class TestDataToolParameter(BaseParameterTestCase):
         # not sure the UI should really allow this but easy enough
         # to just filter it out.
         assert [hda] == self.param.to_python(f"{hda.id},None", self.app)
+
+    def test_from_json_rejects_src_prefixed_string(self):
+        bogus = "hda:f9cad7b01a472135e2c8f5464c5c5ecb"
+        with pytest.raises(ParameterValueError, match="invalid dataset id"):
+            self.param.from_json([bogus], self.trans)
+
+    def test_from_json_rejects_garbage_string(self):
+        with pytest.raises(ParameterValueError, match="invalid dataset id"):
+            self.param.from_json("not-an-id", self.trans)
 
     def test_field_filter_on_types(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)


### PR DESCRIPTION
Strings like "hda:<encoded_id>" reached SQLAlchemy as the HDA primary key and crashed Postgres with InvalidTextRepresentation (xref #22616). The "src:id" shape is not part of the API surface — those inputs should arrive as {src, id} dicts via src_id_to_item — so reject anything that isn't an int, digit string, or 16-char encoded id with ParameterValueError, which the parameter pipeline maps to a 4xx.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
