### PR TITLE
Mount fastmcp at subapp root

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -429,7 +429,7 @@ def get_mcp_app(gx_app):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_user()
 
-    mcp_app = mcp.http_app()
+    mcp_app = mcp.http_app(path="/")
     mcp_app.state.mcp_server = mcp
 
     logger.info("MCP server initialized (Streamable HTTP)")


### PR DESCRIPTION
So the final path is /api/mcp, not /api/mcp/mcp as it is now.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
