### PR TITLE
model: get_identifier returns None for None obj

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -489,6 +489,8 @@ class SerializationOptions:
             ret_val["encoded_id"] = obj.temp_id
 
     def get_identifier(self, id_encoder, obj):
+        if obj is None:
+            return None
         if self.for_edit and obj.id:
             return obj.id
         elif obj.id:


### PR DESCRIPTION
Closes #22560. `j_a.job` can be None for orphaned job-association rows; `obj.id` then raises AttributeError during history export.