### PR TITLE
Fix long title squashing in g-card

### DIFF
--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -323,8 +323,8 @@ function onKeyDown(event: KeyboardEvent) {
                 <div class="d-flex flex-column flex-gapy-1">
                     <div
                         :id="`g-card-${props.id}-header`"
-                        class="d-flex flex-gapy-1 flex-gapx-1 justify-content-between">
-                        <div class="d-flex flex-column">
+                        class="d-flex flex-wrap flex-gapy-1 flex-gapx-1 justify-content-between">
+                        <div class="d-flex flex-column flex-grow-1 g-card-title-section">
                             <div class="d-flex">
                                 <div v-if="selectable">
                                     <slot name="select">
@@ -416,7 +416,7 @@ function onKeyDown(event: KeyboardEvent) {
                             </div>
                         </div>
 
-                        <div class="align-items-start d-flex flex-row-reverse flex-wrap gap-1">
+                        <div class="align-items-start d-flex flex-row-reverse flex-wrap gap-1 flex-shrink-0">
                             <div>
                                 <slot v-if="props.showBookmark" name="bookmark">
                                     <BButton
@@ -731,6 +731,10 @@ function onKeyDown(event: KeyboardEvent) {
                 background-color: lighten($brand-light, 0.5);
             }
         }
+    }
+
+    .g-card-title-section {
+        min-width: 50%;
     }
 
     .g-card-rename {

--- a/client/src/components/Downloads/RecentDownloads.vue
+++ b/client/src/components/Downloads/RecentDownloads.vue
@@ -91,3 +91,9 @@ const breadcrumbItems = [{ title: "Recent Exports & Downloads", to: "/downloads"
         </div>
     </div>
 </template>
+
+<style lang="scss" scoped>
+.recent-downloads {
+    container: cards-list / inline-size;
+}
+</style>


### PR DESCRIPTION
Before:
<img width="891" height="717" alt="Screenshot 2026-05-02 at 11 32 27" src="https://github.com/user-attachments/assets/1d0d2b86-03ad-43fd-95a9-c4a943df0cae" />
After:
<img width="901" height="491" alt="Screenshot 2026-05-02 at 11 32 12" src="https://github.com/user-attachments/assets/3bd2e07e-5165-4363-9241-568d93932934" />

first commit cherry-picked from dannon/invocation-tag-wrap which hasn't been merged yet.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
