### PR TITLE
Share route_name_index with mounted MCP sub-app

### DIFF
--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -286,6 +286,9 @@ def include_mcp(app: FastAPI, gx_app, mcp_app):
 
     try:
         mcp_path = gx_app.config.mcp_server_path
+        # Requests served by the mounted sub-app see request.app == mcp_app, so
+        # share the parent's route name index for UrlBuilder._url_path_for.
+        mcp_app.state.route_name_index = app.state.route_name_index
         app.mount(mcp_path, mcp_app)
         log.info(f"MCP server (Streamable HTTP) mounted at {mcp_path}")
     except Exception as e:


### PR DESCRIPTION
Requests routed through the mounted MCP sub-app have request.app set to mcp_app, not the parent Galaxy FastAPI app, so UrlBuilder._url_path_for raised AttributeError: 'State' object has no attribute 'route_name_index' when MCP tools (e.g. get_history_contents) built response URLs.

Copy the parent app's route_name_index onto mcp_app.state before mounting so the lookup succeeds regardless of which app handled the request.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
