### PR TITLE
Honor group-derived roles in unprivileged tool access check

### DIFF
--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -9,8 +9,6 @@ from typing import (
 from uuid import UUID
 
 from sqlalchemy import (
-    exists,
-    false,
     select,
     sql,
     true,
@@ -82,15 +80,7 @@ class DynamicToolManager(ModelManager[DynamicTool]):
     model_class = DynamicTool
 
     def ensure_can_use_unprivileged_tool(self, user: model.User):
-        stmt = select(
-            exists().where(
-                model.UserRoleAssociation.user_id == user.id,
-                model.UserRoleAssociation.role_id == model.Role.id,
-                model.Role.type == model.Role.types.USER_TOOL_EXECUTE,
-                model.Role.deleted == false(),
-            )
-        )
-        if not self.session().execute(stmt).scalar():
+        if not any(role.type == model.Role.types.USER_TOOL_EXECUTE and not role.deleted for role in user.all_roles()):
             raise exceptions.InsufficientPermissionsException("User is not allowed to run unprivileged tools")
 
     def get_tool_by_id_or_uuid(self, id_or_uuid: Union[int, str]) -> Union[DynamicTool, None]:

--- a/lib/galaxy_test/api/test_unprivileged_tools.py
+++ b/lib/galaxy_test/api/test_unprivileged_tools.py
@@ -29,6 +29,14 @@ class TestUnprivilegedToolsApi(ApiTestCase, TestsTools):
             assert dynamic_tool["uuid"], "Dynamic tool UUID not found in response"
             assert dynamic_tool["representation"]["name"] == TOOL_WITH_SHELL_COMMAND["name"]
 
+    def test_create_unprivileged_with_group_inherited_role(self):
+        # Regression: USER_TOOL_EXECUTE granted via group membership must also allow access,
+        # not only direct UserRoleAssociation.
+        with self.dataset_populator.user_tool_execute_permissions_via_group():
+            dynamic_tool = self.dataset_populator.create_unprivileged_tool(UserToolSource(**TOOL_WITH_SHELL_COMMAND))
+            assert dynamic_tool["uuid"], "Dynamic tool UUID not found in response"
+            assert dynamic_tool["representation"]["name"] == TOOL_WITH_SHELL_COMMAND["name"]
+
     def test_list_unprivileged(self):
         with self.dataset_populator.user_tool_execute_permissions():
             dynamic_tool = self.dataset_populator.create_unprivileged_tool(UserToolSource(**TOOL_WITH_SHELL_COMMAND))

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1600,6 +1600,26 @@ class BaseDatasetPopulator(BasePopulator):
             self._delete(f"roles/{role['id']}", admin=True).raise_for_status()
             self._post(f"roles/{role['id']}/purge", admin=True).raise_for_status()
 
+    @contextlib.contextmanager
+    def user_tool_execute_permissions_via_group(self):
+        # Grant USER_TOOL_EXECUTE indirectly: role has no direct user, group binds user to role.
+        role = self.create_role([], role_type="user_tool_execute")
+        group_payload = {
+            "name": self.get_random_name(prefix="testpop-utx-group"),
+            "user_ids": [self.user_id()],
+            "role_ids": [role["id"]],
+        }
+        group_response = self._post("groups", data=group_payload, admin=True, json=True)
+        assert group_response.status_code == 200
+        group = group_response.json()[0]
+        try:
+            yield
+        finally:
+            self._delete(f"groups/{group['id']}", admin=True).raise_for_status()
+            self._post(f"groups/{group['id']}/purge", admin=True).raise_for_status()
+            self._delete(f"roles/{role['id']}", admin=True).raise_for_status()
+            self._post(f"roles/{role['id']}/purge", admin=True).raise_for_status()
+
     def create_quota(self, quota_payload: dict) -> dict:
         using_requirement("admin")
         quota_response = self._post("quotas", data=quota_payload, admin=True, json=True)


### PR DESCRIPTION
DynamicToolManager.ensure_can_use_unprivileged_tool only joined UserRoleAssociation directly, so users granted USER_TOOL_EXECUTE via group membership were denied access. Delegate to User.all_roles(), the project-wide single source of truth for "every role this user has, direct or via groups", instead of maintaining a parallel SQL query that already drifted.

Also adds an api regression test exercising the group-inherited path.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
