### PR TITLE
Add user-defined-tool operations to the agent-operations layer

### DIFF
--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -920,6 +920,31 @@ class AgentOperationsManager:
         return {"uuid": uuid, "deactivated": True}
 
     def run_user_tool(self, history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        from sqlalchemy import select
+
+        from galaxy.model import UserDynamicToolAssociation
+
+        user = self.trans.user
+        if not user:
+            raise ValueError("User must be authenticated")
+
+        dynamic_tool = self.dynamic_tools_manager.get_unprivileged_tool_by_uuid(user, tool_uuid)
+        if dynamic_tool is None:
+            raise ValueError(f"User-defined tool {tool_uuid!r} not found")
+        # UDT deactivation is per-user by design: deactivate_unprivileged_tool only
+        # flips the user-association, leaving DynamicTool.active intact so other
+        # users sharing the underlying tool aren't affected. The runtime check has
+        # to look at the association, not just dynamic_tool.active.
+        session = self.dynamic_tools_manager.session()
+        assoc_active = session.scalar(
+            select(UserDynamicToolAssociation.active).where(
+                UserDynamicToolAssociation.user_id == user.id,
+                UserDynamicToolAssociation.dynamic_tool_id == dynamic_tool.id,
+            )
+        )
+        if not dynamic_tool.active or not assoc_active:
+            raise ValueError(f"User-defined tool {tool_uuid!r} is deactivated")
+
         payload = {
             "history_id": history_id,
             "tool_uuid": tool_uuid,

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -895,3 +895,14 @@ class AgentOperationsManager:
             "tools": [t.to_dict() for t in tools],
             "count": len(tools),
         }
+
+    def create_user_tool(self, representation: dict[str, Any]) -> dict[str, Any]:
+        from galaxy.tool_util_models.dynamic_tool_models import DynamicUnprivilegedToolCreatePayload
+
+        user = self.trans.user
+        if not user:
+            raise ValueError("User must be authenticated")
+
+        payload = DynamicUnprivilegedToolCreatePayload(src="representation", representation=representation)
+        dynamic_tool = self.dynamic_tools_manager.create_unprivileged_tool(user, payload)
+        return dynamic_tool.to_dict()

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -918,3 +918,12 @@ class AgentOperationsManager:
 
         self.dynamic_tools_manager.deactivate_unprivileged_tool(user, dynamic_tool)
         return {"uuid": uuid, "deactivated": True}
+
+    def run_user_tool(self, history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        payload = {
+            "history_id": history_id,
+            "tool_uuid": tool_uuid,
+            "inputs": inputs,
+        }
+        result = self.tools_service._create(self.trans, payload)
+        return self._encode_ids_in_response(result)

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -10,8 +10,12 @@ from typing import (
     Optional,
 )
 
+from sqlalchemy import select
+
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.hdas import HDAManager
+from galaxy.managers.tools import DynamicToolManager
+from galaxy.model import UserDynamicToolAssociation
 from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
@@ -29,6 +33,9 @@ from galaxy.schema.schema import (
 )
 from galaxy.schema.workflows import InvokeWorkflowPayload
 from galaxy.structured_app import MinimalManagerApp
+from galaxy.tool_util_models.dynamic_tool_models import DynamicUnprivilegedToolCreatePayload
+from galaxy.webapps.galaxy.services.invocations import InvocationIndexPayload
+from galaxy.webapps.galaxy.services.workflows import WorkflowIndexPayload
 
 log = logging.getLogger(__name__)
 
@@ -152,8 +159,6 @@ class AgentOperationsManager:
     @property
     def dynamic_tools_manager(self):
         if self._dynamic_tools_manager is None:
-            from galaxy.managers.tools import DynamicToolManager
-
             self._dynamic_tools_manager = self.app[DynamicToolManager]
         return self._dynamic_tools_manager
 
@@ -438,8 +443,6 @@ class AgentOperationsManager:
         show_shared: bool = True,
         search: str | None = None,
     ) -> dict[str, Any]:
-        from galaxy.webapps.galaxy.services.workflows import WorkflowIndexPayload
-
         payload = WorkflowIndexPayload(
             limit=limit,
             offset=offset,
@@ -524,8 +527,6 @@ class AgentOperationsManager:
         decoded_history_id = None
         if history_id:
             decoded_history_id = self.trans.security.decode_id(history_id)
-
-        from galaxy.webapps.galaxy.services.invocations import InvocationIndexPayload
 
         payload = InvocationIndexPayload(
             workflow_id=decoded_workflow_id,
@@ -897,8 +898,6 @@ class AgentOperationsManager:
         }
 
     def create_user_tool(self, representation: dict[str, Any]) -> dict[str, Any]:
-        from galaxy.tool_util_models.dynamic_tool_models import DynamicUnprivilegedToolCreatePayload
-
         user = self.trans.user
         if not user:
             raise ValueError("User must be authenticated")
@@ -920,10 +919,6 @@ class AgentOperationsManager:
         return {"uuid": uuid, "deactivated": True}
 
     def run_user_tool(self, history_id: str, tool_uuid: str, inputs: dict[str, Any]) -> dict[str, Any]:
-        from sqlalchemy import select
-
-        from galaxy.model import UserDynamicToolAssociation
-
         user = self.trans.user
         if not user:
             raise ValueError("User must be authenticated")

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -30,12 +30,12 @@ from galaxy.schema.invocation import InvocationSerializationParams
 from galaxy.schema.schema import (
     CreateHistoryPayload,
     DatasetSourceType,
+    InvocationIndexPayload,
+    WorkflowIndexPayload,
 )
 from galaxy.schema.workflows import InvokeWorkflowPayload
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.tool_util_models.dynamic_tool_models import DynamicUnprivilegedToolCreatePayload
-from galaxy.webapps.galaxy.services.invocations import InvocationIndexPayload
-from galaxy.webapps.galaxy.services.workflows import WorkflowIndexPayload
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -61,6 +61,7 @@ class AgentOperationsManager:
         self._invocations_service: Optional[Any] = None
         self._hda_manager: Optional[HDAManager] = None
         self._dataset_collections_service: Optional[Any] = None
+        self._dynamic_tools_manager: Optional[Any] = None
 
     def _encode_id(self, value: int) -> str:
         return self.trans.security.encode_id(value)
@@ -147,6 +148,14 @@ class AgentOperationsManager:
 
             self._dataset_collections_service = self.app[DatasetCollectionsService]
         return self._dataset_collections_service
+
+    @property
+    def dynamic_tools_manager(self):
+        if self._dynamic_tools_manager is None:
+            from galaxy.managers.tools import DynamicToolManager
+
+            self._dynamic_tools_manager = self.app[DynamicToolManager]
+        return self._dynamic_tools_manager
 
     def connect(self) -> dict[str, Any]:
         config = self.app.config
@@ -872,4 +881,17 @@ class AgentOperationsManager:
             "active": user.active,
             "deleted": user.deleted,
             "create_time": user.create_time.isoformat() if user.create_time else None,
+        }
+
+    # ==================== User-Defined Tools (UDT) ====================
+
+    def list_user_tools(self, active: bool = True) -> dict[str, Any]:
+        user = self.trans.user
+        if not user:
+            raise ValueError("User must be authenticated")
+
+        tools = list(self.dynamic_tools_manager.list_unprivileged_tools(user, active=active))
+        return {
+            "tools": [t.to_dict() for t in tools],
+            "count": len(tools),
         }

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -906,3 +906,15 @@ class AgentOperationsManager:
         payload = DynamicUnprivilegedToolCreatePayload(src="representation", representation=representation)
         dynamic_tool = self.dynamic_tools_manager.create_unprivileged_tool(user, payload)
         return dynamic_tool.to_dict()
+
+    def delete_user_tool(self, uuid: str) -> dict[str, Any]:
+        user = self.trans.user
+        if not user:
+            raise ValueError("User must be authenticated")
+
+        dynamic_tool = self.dynamic_tools_manager.get_unprivileged_tool_by_uuid(user, uuid)
+        if dynamic_tool is None:
+            raise ValueError(f"User-defined tool {uuid!r} not found")
+
+        self.dynamic_tools_manager.deactivate_unprivileged_tool(user, dynamic_tool)
+        return {"uuid": uuid, "deactivated": True}

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1637,6 +1637,10 @@ class WorkflowIndexQueryPayload(Model):
     skip_step_counts: bool = False
 
 
+class WorkflowIndexPayload(WorkflowIndexQueryPayload):
+    missing_tools: bool = False
+
+
 class JobIndexSortByEnum(str, Enum):
     create_time = "create_time"
     update_time = "update_time"
@@ -1687,6 +1691,10 @@ class InvocationIndexQueryPayload(Model):
     )
     offset: Optional[int] = Field(default=0, description="Number of invocations to skip")
     include_nested_invocations: bool = True
+
+
+class InvocationIndexPayload(InvocationIndexQueryPayload):
+    instance: bool = Field(default=False, description="Is provided workflow id for Workflow instead of StoredWorkflow?")
 
 
 PageSortByEnum = Literal["create_time", "title", "update_time", "username"]

--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -447,6 +447,64 @@ def get_mcp_app(gx_app):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.list_user_tools(active)
 
+    @mcp.tool()
+    def create_user_tool(representation: dict[str, Any], api_key: str, ctx: MCPContext) -> dict[str, Any]:
+        """Create a user-defined tool in Galaxy from a YAML tool definition.
+
+        User-defined tools are lightweight, containerized tools that can be
+        created without admin privileges. They are stored in the database,
+        scoped to the creating user, and can be embedded in workflows
+        (importing the workflow automatically creates the tool for the
+        importing user).
+
+        Requires the USER_TOOL_EXECUTE role on the calling user and
+        enable_beta_tool_formats=true in the Galaxy config; both are enforced
+        by the underlying manager and surface as permission/config errors here.
+
+        Args:
+            representation: The tool definition as a dictionary matching the
+                GalaxyUserTool schema. Required fields:
+                - class: "GalaxyUserTool" (exactly this string)
+                - id: tool identifier (lowercase, no spaces, 3-255 chars)
+                - version: version string (e.g. "0.1.0")
+                - name: display name shown in Galaxy tool menu
+                - container: container image as a STRING (e.g. "python:3.12-slim"),
+                  NOT a dict -- this is a common mistake
+                - shell_command: the command to execute, with $(inputs.name.path)
+                  for data inputs and $(inputs.name) for parameter inputs
+                - inputs: list of input dicts, each with "name" and "type"
+                  (type can be: "data", "integer", "float", "text", "boolean")
+                - outputs: list of output dicts, each with "name", "type": "data",
+                  "format" (e.g. "tabular", "vcf", "bed"), and "from_work_dir"
+
+        Returns:
+            Dict with the created tool's id, uuid, tool_id, active status, and
+            the validated representation.
+
+        Example:
+            create_user_tool({
+                "class": "GalaxyUserTool",
+                "id": "my_filter",
+                "version": "0.1.0",
+                "name": "My Filter",
+                "container": "python:3.12-slim",
+                "shell_command": "python3 -c 'import sys; ...'",
+                "inputs": [{"name": "input1", "type": "data", "format": "tabular"}],
+                "outputs": [
+                    {"name": "output1", "type": "data",
+                     "format": "tabular", "from_work_dir": "out.tsv"}
+                ]
+            })
+
+        NEXT STEPS:
+        - Run the tool: run_user_tool(history_id, tool_uuid, inputs)
+        - List your tools: list_user_tools()
+        - Delete a tool: delete_user_tool(uuid)
+        """
+        with _mcp_error_handler("create_user_tool"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.create_user_tool(representation)
+
     mcp_app = mcp.http_app(path="/")
     mcp_app.state.mcp_server = mcp
 

--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -429,6 +429,24 @@ def get_mcp_app(gx_app):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_user()
 
+    # ==================== User-Defined Tools (UDT) ====================
+
+    @mcp.tool()
+    def list_user_tools(api_key: str, ctx: MCPContext, active: bool = True) -> dict[str, Any]:
+        """List user-defined tools belonging to the current user.
+
+        Args:
+            active: If True (default), only show active tools. Set False to
+                include deactivated tools.
+
+        Returns:
+            Dict with 'tools' (list of user tools, each with id, uuid, tool_id,
+            name, and active status) and 'count'.
+        """
+        with _mcp_error_handler("list_user_tools"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.list_user_tools(active)
+
     mcp_app = mcp.http_app(path="/")
     mcp_app.state.mcp_server = mcp
 

--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -505,6 +505,23 @@ def get_mcp_app(gx_app):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.create_user_tool(representation)
 
+    @mcp.tool()
+    def delete_user_tool(uuid: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
+        """Deactivate a user-defined tool. Deactivated tools are not loaded into the toolbox.
+
+        Existing job history that referenced the tool is preserved; only
+        future runs are blocked.
+
+        Args:
+            uuid: The UUID of the tool to deactivate. Get this from list_user_tools().
+
+        Returns:
+            Dict confirming deactivation: {"uuid": ..., "deactivated": True}.
+        """
+        with _mcp_error_handler("delete_user_tool"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.delete_user_tool(uuid)
+
     mcp_app = mcp.http_app(path="/")
     mcp_app.state.mcp_server = mcp
 

--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -522,6 +522,47 @@ def get_mcp_app(gx_app):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.delete_user_tool(uuid)
 
+    @mcp.tool()
+    def run_user_tool(
+        history_id: str,
+        tool_uuid: str,
+        inputs: dict[str, Any],
+        api_key: str,
+        ctx: MCPContext,
+    ) -> dict[str, Any]:
+        """Run a user-defined tool by UUID, producing outputs in the given history.
+
+        Resolution happens through the tool service's standard run path,
+        which accepts tool_uuid in the payload and dispatches via the
+        toolbox's unprivileged-tool resolver -- so this is functionally a
+        UUID-keyed counterpart to run_tool().
+
+        Args:
+            history_id: Galaxy history ID where outputs will be placed.
+            tool_uuid: The UUID of the user-defined tool (from create_user_tool
+                or list_user_tools).
+            inputs: Tool input parameters keyed by input name.
+                - Dataset inputs: {"input_name": {"src": "hda", "id": "<dataset_id>"}}
+                - Collection inputs: {"input_name": {"src": "hdca", "id": "<collection_id>"}}
+                - Scalar parameters: {"param_name": value}
+
+        Returns:
+            Dict with job info (job_id, history_id, state) and output dataset IDs.
+
+        Example:
+            run_user_tool(
+                history_id="abc123",
+                tool_uuid="61d15277-a911-45ef-aa66-5385146578cc",
+                inputs={
+                    "scorer_output": {"src": "hda", "id": "59ace41fc068d3ad"},
+                    "top_tracks_per_variant": 5,
+                },
+            )
+        """
+        with _mcp_error_handler("run_user_tool"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.run_user_tool(history_id, tool_uuid, inputs)
+
     mcp_app = mcp.http_app(path="/")
     mcp_app.state.mcp_server = mcp
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -73,12 +73,14 @@ from galaxy.schema.schema import (
     AsyncTaskResultSummary,
     ClaimLandingPayload,
     CreateWorkflowLandingRequestPayload,
+    InvocationIndexPayload,
     InvocationSortByEnum,
     InvocationsStateCounts,
     SetSlugPayload,
     ShareWithPayload,
     ShareWithStatus,
     SharingStatus,
+    WorkflowIndexPayload,
     WorkflowJobMetric,
     WorkflowLandingRequest,
     WorkflowSortByEnum,
@@ -120,15 +122,11 @@ from galaxy.webapps.galaxy.services.base import (
     ServesExportStores,
 )
 from galaxy.webapps.galaxy.services.invocations import (
-    InvocationIndexPayload,
     InvocationsService,
     PrepareStoreDownloadPayload,
     WriteInvocationStoreToPayload,
 )
-from galaxy.webapps.galaxy.services.workflows import (
-    WorkflowIndexPayload,
-    WorkflowsService,
-)
+from galaxy.webapps.galaxy.services.workflows import WorkflowsService
 from galaxy.workflow.extract import extract_workflow
 from galaxy.workflow.modules import module_factory
 

--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -4,8 +4,6 @@ from typing import (
     Any,
 )
 
-from pydantic import Field
-
 from galaxy.celery.helpers import async_task_summary
 from galaxy.celery.tasks import (
     prepare_invocation_download,
@@ -51,7 +49,7 @@ from galaxy.schema.schema import (
     AsyncTaskResultSummary,
     BcoGenerationParametersMixin,
     ExportObjectType,
-    InvocationIndexQueryPayload,
+    InvocationIndexPayload,
     StoreExportPayload,
     WriteStoreToPayload,
 )
@@ -69,10 +67,6 @@ from galaxy.webapps.galaxy.services.base import (
 )
 
 log = logging.getLogger(__name__)
-
-
-class InvocationIndexPayload(InvocationIndexQueryPayload):
-    instance: bool = Field(default=False, description="Is provided workflow id for Workflow instead of StoredWorkflow?")
 
 
 class PrepareStoreDownloadPayload(StoreExportPayload, BcoGenerationParametersMixin):

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -29,7 +29,7 @@ from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.invocation import WorkflowInvocationResponse
 from galaxy.schema.schema import (
     InvocationsStateCounts,
-    WorkflowIndexQueryPayload,
+    WorkflowIndexPayload,
 )
 from galaxy.schema.workflows import (
     InvokeWorkflowPayload,
@@ -43,10 +43,6 @@ from galaxy.workflow.run import queue_invoke
 from galaxy.workflow.run_request import build_workflow_run_configs
 
 log = logging.getLogger(__name__)
-
-
-class WorkflowIndexPayload(WorkflowIndexQueryPayload):
-    missing_tools: bool = False
 
 
 class WorkflowsService(ServiceBase):

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -344,6 +344,7 @@ class TestMCPServerSmoke(IntegrationTestCase):
             "list_user_tools",
             "create_user_tool",
             "delete_user_tool",
+            "run_user_tool",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -474,3 +475,38 @@ class TestMCPServerSmoke(IntegrationTestCase):
         uuid, listed = self._run_async(_flow())
         uuids_after = {t["uuid"] for t in listed.data["tools"]}
         assert uuid not in uuids_after
+
+    def test_mcp_run_user_tool(self):
+        """run_user_tool() executes a UDT against an HDA input and produces an output."""
+        from fastmcp import Client
+        from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
+
+        mcp_server = self._get_mcp_server()
+        _, api_key = self._setup_udt_user("udt_run_user@test.com")
+
+        populator = DatasetPopulator(self.galaxy_interactor)
+        history_id = populator.new_history()
+        dataset = populator.new_dataset(history_id=history_id, content="abc")
+
+        async def _flow():
+            async with Client(mcp_server) as client:
+                create = await client.call_tool(
+                    "create_user_tool",
+                    {"api_key": api_key, "representation": TOOL_WITH_SHELL_COMMAND},
+                )
+                uuid = create.data["uuid"]
+                return await client.call_tool(
+                    "run_user_tool",
+                    {
+                        "api_key": api_key,
+                        "history_id": history_id,
+                        "tool_uuid": uuid,
+                        "inputs": {"input": {"src": "hda", "id": dataset["id"]}},
+                    },
+                )
+
+        result = self._run_async(_flow())
+        assert not result.is_error, result
+        populator.wait_for_history(history_id, assert_ok=True)
+        output = populator.get_history_dataset_content(history_id)
+        assert output == "abc\n"

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -435,6 +435,7 @@ class TestMCPServerSmoke(IntegrationTestCase):
     def test_mcp_create_user_tool(self):
         """create_user_tool() persists a UDT and returns its uuid."""
         from fastmcp import Client
+
         from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
 
         mcp_server = self._get_mcp_server()
@@ -456,10 +457,13 @@ class TestMCPServerSmoke(IntegrationTestCase):
     def test_mcp_delete_user_tool(self):
         """delete_user_tool() deactivates a UDT so list_user_tools no longer returns it."""
         from fastmcp import Client
+
         from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
 
         mcp_server = self._get_mcp_server()
         _, api_key = self._setup_udt_user("udt_delete_user@test.com")
+        populator = DatasetPopulator(self._get_interactor(api_key=api_key))
+        history_id = populator.new_history()
 
         async def _flow():
             async with Client(mcp_server) as client:
@@ -470,21 +474,34 @@ class TestMCPServerSmoke(IntegrationTestCase):
                 uuid = create.data["uuid"]
                 await client.call_tool("delete_user_tool", {"api_key": api_key, "uuid": uuid})
                 listed = await client.call_tool("list_user_tools", {"api_key": api_key})
-                return uuid, listed
+                deleted_run = await client.call_tool(
+                    "run_user_tool",
+                    {
+                        "api_key": api_key,
+                        "history_id": history_id,
+                        "tool_uuid": uuid,
+                        "inputs": {},
+                    },
+                    raise_on_error=False,
+                )
+                return uuid, listed, deleted_run
 
-        uuid, listed = self._run_async(_flow())
+        uuid, listed, deleted_run = self._run_async(_flow())
         uuids_after = {t["uuid"] for t in listed.data["tools"]}
         assert uuid not in uuids_after
+        assert deleted_run.is_error
+        assert "deactivated" in deleted_run.content[0].text
 
     def test_mcp_run_user_tool(self):
         """run_user_tool() executes a UDT against an HDA input and produces an output."""
         from fastmcp import Client
+
         from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
 
         mcp_server = self._get_mcp_server()
         _, api_key = self._setup_udt_user("udt_run_user@test.com")
 
-        populator = DatasetPopulator(self.galaxy_interactor)
+        populator = DatasetPopulator(self._get_interactor(api_key=api_key))
         history_id = populator.new_history()
         dataset = populator.new_dataset(history_id=history_id, content="abc")
 
@@ -507,6 +524,10 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
         result = self._run_async(_flow())
         assert not result.is_error, result
+        data = result.data
+        assert data["jobs"][0]["tool_id"] == TOOL_WITH_SHELL_COMMAND["id"]
+        assert data["jobs"][0]["history_id"] == history_id
+        assert data["outputs"][0]["output_name"] == "output"
         populator.wait_for_history(history_id, assert_ok=True)
         output = populator.get_history_dataset_content(history_id)
         assert output == "abc\n"

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -342,6 +342,7 @@ class TestMCPServerSmoke(IntegrationTestCase):
             "invoke_workflow",
             "get_job_status",
             "list_user_tools",
+            "create_user_tool",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -428,3 +429,24 @@ class TestMCPServerSmoke(IntegrationTestCase):
         data = result.data
         assert data["tools"] == []
         assert data["count"] == 0
+
+    def test_mcp_create_user_tool(self):
+        """create_user_tool() persists a UDT and returns its uuid."""
+        from fastmcp import Client
+        from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
+
+        mcp_server = self._get_mcp_server()
+        _, api_key = self._setup_udt_user("udt_create_user@test.com")
+
+        async def _create():
+            async with Client(mcp_server) as client:
+                return await client.call_tool(
+                    "create_user_tool",
+                    {"api_key": api_key, "representation": TOOL_WITH_SHELL_COMMAND},
+                )
+
+        result = self._run_async(_create())
+        assert not result.is_error, result
+        data = result.data
+        assert "uuid" in data
+        assert data["representation"]["name"] == TOOL_WITH_SHELL_COMMAND["name"]

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -343,6 +343,7 @@ class TestMCPServerSmoke(IntegrationTestCase):
             "get_job_status",
             "list_user_tools",
             "create_user_tool",
+            "delete_user_tool",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -450,3 +451,26 @@ class TestMCPServerSmoke(IntegrationTestCase):
         data = result.data
         assert "uuid" in data
         assert data["representation"]["name"] == TOOL_WITH_SHELL_COMMAND["name"]
+
+    def test_mcp_delete_user_tool(self):
+        """delete_user_tool() deactivates a UDT so list_user_tools no longer returns it."""
+        from fastmcp import Client
+        from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
+
+        mcp_server = self._get_mcp_server()
+        _, api_key = self._setup_udt_user("udt_delete_user@test.com")
+
+        async def _flow():
+            async with Client(mcp_server) as client:
+                create = await client.call_tool(
+                    "create_user_tool",
+                    {"api_key": api_key, "representation": TOOL_WITH_SHELL_COMMAND},
+                )
+                uuid = create.data["uuid"]
+                await client.call_tool("delete_user_tool", {"api_key": api_key, "uuid": uuid})
+                listed = await client.call_tool("list_user_tools", {"api_key": api_key})
+                return uuid, listed
+
+        uuid, listed = self._run_async(_flow())
+        uuids_after = {t["uuid"] for t in listed.data["tools"]}
+        assert uuid not in uuids_after

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -282,6 +282,7 @@ class TestMCPServerSmoke(IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["enable_mcp_server"] = True
+        config["enable_beta_tool_formats"] = True
 
     def _get_mcp_server(self):
         from galaxy.webapps.galaxy.api.mcp import get_mcp_app
@@ -292,6 +293,13 @@ class TestMCPServerSmoke(IntegrationTestCase):
     def _get_api_key(self):
         _, api_key = self._setup_user_get_key("mcp_test_user@test.com")
         return api_key
+
+    def _setup_udt_user(self, email: str):
+        """Create a user, grant USER_TOOL_EXECUTE, return (user, api_key)."""
+        user, api_key = self._setup_user_get_key(email)
+        populator = DatasetPopulator(self.galaxy_interactor)
+        populator.create_role([user["id"]], role_type="user_tool_execute")
+        return user, api_key
 
     def _run_async(self, coro):
         import asyncio
@@ -333,6 +341,7 @@ class TestMCPServerSmoke(IntegrationTestCase):
             "upload_file_from_url",
             "invoke_workflow",
             "get_job_status",
+            "list_user_tools",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -402,3 +411,20 @@ class TestMCPServerSmoke(IntegrationTestCase):
         assert "query" in data
         assert "count" in data
         assert isinstance(data["tools"], list)
+
+    def test_mcp_list_user_tools_empty(self):
+        """list_user_tools() returns an empty list for a user with the role and no UDTs."""
+        from fastmcp import Client
+
+        mcp_server = self._get_mcp_server()
+        _, api_key = self._setup_udt_user("udt_list_user@test.com")
+
+        async def _list():
+            async with Client(mcp_server) as client:
+                return await client.call_tool("list_user_tools", {"api_key": api_key})
+
+        result = self._run_async(_list())
+        assert not result.is_error, result
+        data = result.data
+        assert data["tools"] == []
+        assert data["count"] == 0

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -11,12 +11,24 @@ For deterministic tests without LLM, see test_static_agent_backend.py.
     pytest test/integration/test_agents.py -v
 """
 
+import asyncio
 import logging
 import os
 
+import pytest
+from fastmcp import (
+    Client,
+    FastMCP,
+)
+from fastmcp.exceptions import ToolError
+
+from galaxy.agents.operations import AgentOperationsManager
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.util.unittest_utils import pytestmark_live_llm
+from galaxy.webapps.galaxy.api.mcp import get_mcp_app
 from galaxy_test.base.populators import (
     DatasetPopulator,
+    TOOL_WITH_SHELL_COMMAND,
     WorkflowPopulator,
 )
 from galaxy_test.driver.integration_util import IntegrationTestCase
@@ -180,9 +192,6 @@ class TestAgentOperationsManagerEncoding(AgentIntegrationTestCase):
     """
 
     def _make_ops(self):
-        from galaxy.agents.operations import AgentOperationsManager
-        from galaxy.managers.context import ProvidesUserContext
-
         class MinimalTrans(ProvidesUserContext):
             def __init__(self, app):
                 self._app = app
@@ -285,8 +294,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
         config["enable_beta_tool_formats"] = True
 
     def _get_mcp_server(self):
-        from galaxy.webapps.galaxy.api.mcp import get_mcp_app
-
         http_app = get_mcp_app(self._app)
         return http_app.state.mcp_server
 
@@ -302,8 +309,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
         return user, api_key
 
     def _run_async(self, coro):
-        import asyncio
-
         loop = asyncio.new_event_loop()
         try:
             return loop.run_until_complete(coro)
@@ -312,15 +317,11 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_server_initializes(self):
         """MCP server creates a FastMCP instance when enabled."""
-        from fastmcp import FastMCP
-
         mcp_server = self._get_mcp_server()
         assert isinstance(mcp_server, FastMCP)
 
     def test_mcp_tools_registered(self):
         """MCP server advertises all expected tools."""
-        from fastmcp import Client
-
         mcp_server = self._get_mcp_server()
 
         async def _list():
@@ -350,8 +351,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_connect_with_valid_key(self):
         """connect() succeeds with a valid API key and returns user + server info."""
-        from fastmcp import Client
-
         mcp_server = self._get_mcp_server()
         api_key = self._get_api_key()
 
@@ -367,10 +366,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_connect_with_invalid_key(self):
         """connect() rejects an invalid API key."""
-        import pytest
-        from fastmcp import Client
-        from fastmcp.exceptions import ToolError
-
         mcp_server = self._get_mcp_server()
 
         async def _connect():
@@ -382,8 +377,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_list_histories(self):
         """list_histories() returns a valid response."""
-        from fastmcp import Client
-
         mcp_server = self._get_mcp_server()
         api_key = self._get_api_key()
 
@@ -398,8 +391,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_search_tools(self):
         """search_tools() executes and returns a well-formed response."""
-        from fastmcp import Client
-
         mcp_server = self._get_mcp_server()
         api_key = self._get_api_key()
 
@@ -417,8 +408,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_list_user_tools_empty(self):
         """list_user_tools() returns an empty list for a user with the role and no UDTs."""
-        from fastmcp import Client
-
         mcp_server = self._get_mcp_server()
         _, api_key = self._setup_udt_user("udt_list_user@test.com")
 
@@ -434,10 +423,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_create_user_tool(self):
         """create_user_tool() persists a UDT and returns its uuid."""
-        from fastmcp import Client
-
-        from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
-
         mcp_server = self._get_mcp_server()
         _, api_key = self._setup_udt_user("udt_create_user@test.com")
 
@@ -456,10 +441,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_delete_user_tool(self):
         """delete_user_tool() deactivates a UDT so list_user_tools no longer returns it."""
-        from fastmcp import Client
-
-        from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
-
         mcp_server = self._get_mcp_server()
         _, api_key = self._setup_udt_user("udt_delete_user@test.com")
         populator = DatasetPopulator(self._get_interactor(api_key=api_key))
@@ -494,10 +475,6 @@ class TestMCPServerSmoke(IntegrationTestCase):
 
     def test_mcp_run_user_tool(self):
         """run_user_tool() executes a UDT against an HDA input and produces an output."""
-        from fastmcp import Client
-
-        from galaxy_test.base.populators import TOOL_WITH_SHELL_COMMAND
-
         mcp_server = self._get_mcp_server()
         _, api_key = self._setup_udt_user("udt_run_user@test.com")
 


### PR DESCRIPTION
## Summary

The standalone galaxy-mcp server has grown four user-defined-tool (UDT)
tools -- create, list, delete, run -- that the in-process MCP server
exposed at /api/mcp didn't have. This adds them, so an agent talking
to the built-in MCP can manage UDTs through the same surface as the
external server.

The implementation is thin -- each operation is a wrapper over the
existing DynamicToolManager (for create/list/delete) and
tools_service._create (for run, which already accepts tool_uuid in its
payload and routes to the toolbox's unprivileged-tool resolver). No
new infrastructure or config; the existing /api/unprivileged_tools
endpoints are the reference for shape and semantics.

The MCP-wrapper docstrings carry agent-facing UX detail: required-field
schemas for create_user_tool (including the common "container must be
a string, not a dict" mistake), worked examples, and NEXT STEPS
pointers. Tool descriptions are how an LLM picks tools and fills
arguments, so this is functional rather than decorative.

## A deactivation question for review

While wiring up run_user_tool I noticed that a UDT deactivated through
DELETE /api/unprivileged_tools/{uuid} can still be resolved and run
by UUID via tools_service._create -- because
deactivate_unprivileged_tool only flips the per-user
UserDynamicToolAssociation.active, leaving DynamicTool.active intact,
and get_unprivileged_tool_by_uuid doesn't filter by
association.active.

Reading the original split between deactivate() (admin path, flips
DynamicTool.active) and deactivate_unprivileged_tool() (user path,
flips only the association), and the fact that the schema permits
many-to-many UserDynamicToolAssociation -> DynamicTool, that asymmetry
looks deliberate -- "deactivated" is a per-user UI-facing state, not
a hard runtime gate, so we don't break other users sharing the
underlying tool.

So I left the manager alone and added a per-user runtime guard inside
run_user_tool only (checks both DynamicTool.active and the calling
user's association.active). That fixes the agent-operations entry
point without touching shared state.

The broader question -- whether get_unprivileged_tool_by_uuid should
also filter by association.active so the standard tools API run path
respects per-user deactivation -- is out of scope for this PR but
worth a separate look.

## Out of scope

- IWC tool re-introduction (will be its own PR)
- Code-mode discovery (FastMCP transform, opt-in deployment mode
  rather than parity work)
- A docstring sweep over the existing MCP tools (mechanical, low-risk,
  can land separately)

## Test plan

- [ ] `pytest test/integration/test_agents.py::TestMCPServerSmoke -v`
- [ ] `pytest lib/galaxy_test/api/test_unprivileged_tools.py -v`
- [ ] Manual: start Galaxy with `enable_mcp_server=true` and
  `enable_beta_tool_formats=true`, confirm the four `*_user_tool`
  entries appear in `tools/list` over MCP and that create -> run ->
  delete -> attempt-run-after-delete behaves as expected