### PR TITLE
Beef up MCP tool docstrings with workflow guidance

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -115,10 +115,18 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def connect(api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Verify connection to Galaxy and get server information.
+        """Verify connection to Galaxy and return server + user information.
 
-        Checks that the API key is valid and returns basic info about
-        the Galaxy server and current user.
+        Run this once per session to confirm the API key is valid and learn
+        the user's identity, the server URL, and basic capabilities.
+
+        Returns:
+            Dict with `connected`, `user` (current user info), and `url`.
+
+        NEXT STEPS:
+        - Find tools: search_tools(query) or search_tools_by_keywords(keywords)
+        - List or create a history: list_histories() / create_history(name)
+        - Browse the toolbox: get_tool_panel()
         """
         with _mcp_error_handler("connect"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -126,9 +134,26 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def search_tools(query: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Search for Galaxy tools by name or keyword.
+        """Search Galaxy tools by substring match against name, ID, or description.
 
-        Matches against tool names, IDs, and descriptions.
+        RECOMMENDED WORKFLOW:
+        1. Search for tools by name or keyword
+        2. Pick a candidate from the results
+        3. Call get_tool_details(tool_id, io_details=True) for full input schema
+        4. Run the tool with run_tool(history_id, tool_id, inputs)
+
+        Args:
+            query: Search query - matches name, ID, or description (case-insensitive).
+                Examples: "fastq", "alignment", "filter", "bwa".
+
+        Returns:
+            Dict with `tools` (list of matches with id, name, version, description)
+            and `count`.
+
+        NEXT STEPS:
+        - Inspect a tool: get_tool_details(tool_id, io_details=True)
+        - See real test inputs: get_tool_run_examples(tool_id)
+        - Multi-keyword search: search_tools_by_keywords(["rna", "alignment"])
         """
         with _mcp_error_handler("search_tools"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -136,10 +161,31 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def get_tool_details(tool_id: str, api_key: str, ctx: MCPContext, io_details: bool = False) -> dict[str, Any]:
-        """Get detailed information about a specific Galaxy tool.
+        """Get detailed information about a Galaxy tool, including input parameters.
 
-        Set io_details=true to get full input/output specifications
-        needed for running the tool.
+        RECOMMENDED WORKFLOW:
+        1. Find tools with search_tools() or get_tool_panel()
+        2. Call this with io_details=True to learn input parameter shapes
+        3. Build the inputs dict and call run_tool()
+
+        Args:
+            tool_id: Tool identifier. Common formats:
+                - Built-in: "fastqc", "Cut1", "upload1"
+                - Toolshed: "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73"
+            io_details: Set True to include full input/output parameter schemas.
+                Required to know how to call run_tool().
+
+        Returns:
+            Dict with `id`, `name`, `version`, `description`, plus `inputs` and
+            `outputs` schemas when `io_details=True`.
+
+        NEXT STEPS:
+        - Find example invocations: get_tool_run_examples(tool_id)
+        - Get citations: get_tool_citations(tool_id)
+        - Run the tool: run_tool(history_id, tool_id, inputs)
+
+        ERROR HANDLING:
+        - Tool not found: verify the ID via search_tools() or get_tool_panel()
         """
         with _mcp_error_handler("get_tool_details"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -151,8 +197,26 @@ def get_mcp_app(gx_app):
     ) -> dict[str, Any]:
         """List the current user's Galaxy histories.
 
-        Histories are containers for datasets and analysis results.
-        Optionally filter by name (substring match).
+        Histories are Galaxy's primary organizational unit -- each contains
+        datasets, collections, and the records of analyses.
+
+        RECOMMENDED WORKFLOW:
+        1. List histories to find an existing one, or call create_history() for new work
+        2. Use the history_id to upload data or run tools
+        3. Inspect contents with get_history_contents(history_id)
+
+        Args:
+            limit: Maximum histories to return (default 50). Paginate via `offset`.
+            offset: Number to skip from the beginning (default 0).
+            name: Substring filter applied to history names (case-insensitive).
+
+        Returns:
+            Dict with `histories` (list of {id, name, update_time, ...}) and `count`.
+
+        NEXT STEPS:
+        - Lighter listing of just IDs/names: list_history_ids()
+        - View a history's contents: get_history_contents(history_id)
+        - Create a new history: create_history(name)
         """
         with _mcp_error_handler("list_histories"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -162,10 +226,43 @@ def get_mcp_app(gx_app):
     def run_tool(
         history_id: str, tool_id: str, inputs: dict[str, Any], api_key: str, ctx: MCPContext
     ) -> dict[str, Any]:
-        """Execute a Galaxy tool.
+        """Execute a Galaxy tool against datasets in a history.
 
-        Use get_tool_details() with io_details=true first to learn
-        what inputs the tool requires.
+        RECOMMENDED WORKFLOW:
+        1. Pick or create a history: list_histories() / create_history()
+        2. Upload data if needed: upload_file_from_url()
+        3. Get inputs schema: get_tool_details(tool_id, io_details=True)
+        4. Call this function with properly formatted inputs
+        5. Monitor with get_job_status(job_id) or get_history_contents()
+
+        Args:
+            history_id: Galaxy history ID where outputs will be placed.
+            tool_id: Tool identifier (e.g. "fastqc" or a toolshed-qualified ID).
+            inputs: Tool input parameters. Common shapes:
+                - Dataset: {"input_name": {"src": "hda", "id": "<dataset_id>"}}
+                - Collection: {"input_name": {"src": "hdca", "id": "<collection_id>"}}
+                - Scalar: {"param_name": value}
+
+        Returns:
+            Dict with `jobs` (job objects with id/state) and `outputs` (created
+            dataset IDs and names).
+
+        Example:
+            run_tool(
+                history_id="abc123def456",
+                tool_id="fastqc",
+                inputs={"input_file": {"src": "hda", "id": "dataset123"}},
+            )
+
+        NEXT STEPS:
+        - Watch the job: get_job_status(job_id)
+        - View outputs: get_history_contents(history_id)
+        - Download results: download_dataset(dataset_id)
+
+        ERROR HANDLING:
+        - "Tool not found": verify tool_id with search_tools()
+        - "Invalid input": re-check shapes with get_tool_details(io_details=True)
+        - "Dataset not found": confirm the dataset exists in this history
         """
         with _mcp_error_handler("run_tool"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -175,8 +272,18 @@ def get_mcp_app(gx_app):
     def get_job_status(job_id: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
         """Get the status and details of a Galaxy job.
 
-        Use after run_tool() to check if the job finished and whether
-        it succeeded or failed.
+        Use this after run_tool() or invoke_workflow() to check whether the
+        job is still running, finished successfully, or failed.
+
+        Args:
+            job_id: Galaxy job ID returned by run_tool() or job listings.
+
+        Returns:
+            Dict with job state, tool ID, runtime info, and exit code (when finished).
+
+        NEXT STEPS:
+        - Inspect the job that produced a dataset: get_job_details(dataset_id)
+        - View results: get_history_contents(history_id)
         """
         with _mcp_error_handler("get_job_status"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -186,8 +293,27 @@ def get_mcp_app(gx_app):
     def create_history(name: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
         """Create a new Galaxy history.
 
-        Histories are containers for datasets and analysis results.
-        Create one before uploading files or running analyses.
+        Each project or analysis usually deserves its own history. Pick a
+        descriptive name so the user can find it later in the UI.
+
+        RECOMMENDED WORKFLOW:
+        1. Create a history with a descriptive name
+        2. Upload inputs: upload_file_from_url()
+        3. Run tools or workflows in the new history
+
+        Args:
+            name: Human-friendly history name. Examples:
+                - "RNA-seq Sample A"
+                - "ChIP-seq 2026-05"
+                - "BWA alignment of patient_001"
+
+        Returns:
+            Dict with the new history's `id`, `name`, and creation metadata.
+
+        NEXT STEPS:
+        - Upload data: upload_file_from_url(history_id, url)
+        - Run a tool: run_tool(history_id, tool_id, inputs)
+        - Run a workflow: invoke_workflow(workflow_id, history_id=...)
         """
         with _mcp_error_handler("create_history"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -195,10 +321,21 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def get_history_details(history_id: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Get detailed information about a specific history.
+        """Get history metadata and summary stats (no full dataset listing).
 
-        Returns metadata and summary stats. Use get_history_contents()
-        to get the actual datasets.
+        Lightweight overview -- it does NOT page through datasets. For the
+        actual datasets, follow up with get_history_contents().
+
+        Args:
+            history_id: Galaxy history ID.
+
+        Returns:
+            Dict with history metadata (name, state, sizes) and a `contents_summary`
+            with total item count.
+
+        NEXT STEPS:
+        - List datasets in this history: get_history_contents(history_id)
+        - Find a job that created a dataset: get_job_details(dataset_id, history_id)
         """
         with _mcp_error_handler("get_history_details"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -215,11 +352,31 @@ def get_mcp_app(gx_app):
         deleted: bool | None = None,
         visible: bool | None = None,
     ) -> dict[str, Any]:
-        """Get paginated contents (datasets and collections) from a history.
+        """List the paginated contents (datasets + collections) of a history.
 
-        Order options: 'hid-asc', 'hid-dsc', 'create_time-dsc',
-        'update_time-dsc', 'name-asc'.
-        Set deleted=true to include deleted items, visible=false to include hidden items.
+        Each item carries a `history_content_type` of `dataset` or
+        `dataset_collection`. Use the IDs in subsequent dataset/collection calls.
+
+        Args:
+            history_id: Galaxy history ID.
+            limit: Max items per page (default 100).
+            offset: Number of items to skip (default 0).
+            order: Sort order. Common values:
+                - "hid-asc" (default, oldest first)
+                - "hid-dsc" (newest first)
+                - "create_time-dsc" / "create_time-asc"
+                - "update_time-dsc"
+                - "name-asc"
+            deleted: True includes deleted items; False excludes them; None uses default.
+            visible: False includes hidden items; True excludes them; None uses default.
+
+        Returns:
+            Dict with items list, total/returned counts, and pagination info.
+
+        NEXT STEPS:
+        - Inspect a dataset: get_dataset_details(dataset_id)
+        - Inspect a collection: get_collection_details(collection_id)
+        - Download: download_dataset(dataset_id)
         """
         with _mcp_error_handler("get_history_contents"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -227,7 +384,20 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def get_dataset_details(dataset_id: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Get detailed information about a specific dataset."""
+        """Get detailed information about a single dataset.
+
+        Args:
+            dataset_id: Galaxy dataset ID (history dataset association / `hda` ID).
+
+        Returns:
+            Dict with dataset metadata: name, state, file size, extension/datatype,
+            genome build, and related links.
+
+        NEXT STEPS:
+        - Get the creating job: get_job_details(dataset_id)
+        - Download the file: download_dataset(dataset_id)
+        - For collections, use: get_collection_details(collection_id)
+        """
         with _mcp_error_handler("get_dataset_details"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_dataset_details(dataset_id)
@@ -236,10 +406,23 @@ def get_mcp_app(gx_app):
     def get_collection_details(
         collection_id: str, api_key: str, ctx: MCPContext, max_elements: int = 500
     ) -> dict[str, Any]:
-        """Get detailed information about a dataset collection including its elements.
+        """Get a dataset collection's metadata and member elements.
 
-        Dataset collections group related datasets (e.g., paired-end reads, lists of samples).
-        Use max_elements to limit the number of elements returned for large collections.
+        Dataset collections group related datasets together (e.g. paired-end
+        reads, sample lists, nested lists of pairs).
+
+        Args:
+            collection_id: Galaxy dataset collection ID (`hdca` ID).
+            max_elements: Cap on elements returned (default 500). Lower this for
+                very large collections.
+
+        Returns:
+            Dict with collection metadata (name, type, element count, populated/state)
+            and a list of normalized elements with object IDs and per-element metadata.
+
+        NEXT STEPS:
+        - Inspect a member: get_dataset_details(object_id)
+        - Use as a tool input: pass `{"src": "hdca", "id": collection_id}` to run_tool()
         """
         with _mcp_error_handler("get_collection_details"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -255,10 +438,34 @@ def get_mcp_app(gx_app):
         dbkey: str = "?",
         file_name: str | None = None,
     ) -> dict[str, Any]:
-        """Upload a file from a URL to Galaxy.
+        """Upload a file from a URL into a history.
 
-        Runs as an async job; use get_job_status() to monitor progress.
-        Common file_types: 'fasta', 'fastq', 'bam', 'vcf', 'bed', 'tabular'.
+        Galaxy fetches the URL on the server side as an async job. Use the
+        returned job/dataset IDs with get_job_status() to monitor progress.
+
+        Args:
+            history_id: Destination Galaxy history ID.
+            url: Public URL of the file to fetch (e.g. https://.../data.fasta).
+            file_type: Galaxy datatype (default "auto" detects from extension).
+                Common values: "fasta", "fastq", "bam", "vcf", "bed", "tabular".
+            dbkey: Genome build / database key (default "?"). Examples:
+                "hg38", "mm10", "dm6".
+            file_name: Optional display name; otherwise inferred from the URL.
+
+        Returns:
+            Dict with the created upload job and dataset metadata.
+
+        Example:
+            upload_file_from_url(
+                history_id="abc123",
+                url="https://zenodo.org/.../reads.fastq.gz",
+                file_type="fastqsanger.gz",
+                dbkey="hg38",
+            )
+
+        NEXT STEPS:
+        - Track the job: get_job_status(job_id)
+        - Run a tool on the new dataset: run_tool(history_id, tool_id, inputs)
         """
         with _mcp_error_handler("upload_file_from_url"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -276,7 +483,23 @@ def get_mcp_app(gx_app):
         show_shared: bool = True,
         search: str | None = None,
     ) -> dict[str, Any]:
-        """List user's workflows with optional filtering."""
+        """List the user's stored Galaxy workflows.
+
+        Args:
+            limit: Max workflows to return (default 50).
+            offset: Skip this many workflows (default 0).
+            show_published: Include workflows published by other users (default False).
+            show_shared: Include workflows shared with the user (default True).
+            search: Substring filter applied to workflow name/annotation.
+
+        Returns:
+            Dict with `workflows` (id, name, tags, update_time, ...) and `count`.
+
+        NEXT STEPS:
+        - Inspect a workflow: get_workflow_details(workflow_id)
+        - Run a workflow: invoke_workflow(workflow_id, history_id=...)
+        - Past runs: get_invocations(workflow_id=...)
+        """
         with _mcp_error_handler("list_workflows"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.list_workflows(limit, offset, show_published, show_shared, search)
@@ -285,9 +508,21 @@ def get_mcp_app(gx_app):
     def get_workflow_details(
         workflow_id: str, api_key: str, ctx: MCPContext, version: int | None = None
     ) -> dict[str, Any]:
-        """Get detailed information about a workflow including steps, inputs, and outputs.
+        """Get a workflow's full structure: steps, inputs, outputs, parameters.
 
-        Optionally specify a version number to get a specific workflow version.
+        Use this before invoke_workflow() to learn the input labels/indices and
+        the parameters that can be overridden.
+
+        Args:
+            workflow_id: Galaxy workflow ID.
+            version: Optional specific workflow version (defaults to latest).
+
+        Returns:
+            Dict with workflow metadata and full step/input/output definitions.
+
+        NEXT STEPS:
+        - Run it: invoke_workflow(workflow_id, history_id=..., inputs=...)
+        - View past runs: get_invocations(workflow_id=workflow_id)
         """
         with _mcp_error_handler("get_workflow_details"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -303,13 +538,40 @@ def get_mcp_app(gx_app):
         parameters: dict[str, Any] | None = None,
         history_name: str | None = None,
     ) -> dict[str, Any]:
-        """Invoke (run) a workflow.
+        """Invoke (run) a workflow against datasets in a history.
 
-        Use get_workflow_details() first to understand required inputs.
-        inputs maps workflow input labels/indices to dataset IDs;
-        parameters maps step IDs to parameter values.
-        Provide history_id to run in an existing history, or history_name
-        to create a new history for this invocation.
+        RECOMMENDED WORKFLOW:
+        1. List or pick a workflow: list_workflows()
+        2. Inspect the inputs: get_workflow_details(workflow_id)
+        3. Provide a history_id (or a history_name to create a new one)
+        4. Map inputs and call this function
+        5. Track progress with get_invocation_details(invocation_id)
+
+        Args:
+            workflow_id: Galaxy workflow ID.
+            history_id: Existing history ID for outputs. Mutually exclusive with
+                `history_name` -- if both are given, history_id wins.
+            inputs: Maps workflow input labels/indices to datasets. Common shape:
+                {"<input_label_or_index>": {"src": "hda", "id": "<dataset_id>"}}
+                Use "hdca" for collections, "ldda"/"ld" for library datasets.
+            parameters: Per-step parameter overrides keyed by step ID.
+            history_name: Name to use when creating a new history for this run
+                (used only when history_id is None).
+
+        Returns:
+            Dict with the new invocation: id, state, history_id, and step info.
+
+        Example:
+            invoke_workflow(
+                workflow_id="abc123",
+                history_id="def456",
+                inputs={"0": {"src": "hda", "id": "ds789"}},
+            )
+
+        NEXT STEPS:
+        - Watch the run: get_invocation_details(invocation_id)
+        - Cancel it: cancel_workflow_invocation(invocation_id)
+        - View outputs: get_history_contents(history_id)
         """
         with _mcp_error_handler("invoke_workflow"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -324,21 +586,55 @@ def get_mcp_app(gx_app):
         limit: int = 50,
         offset: int = 0,
     ) -> dict[str, Any]:
-        """List workflow invocations, optionally filtered by workflow or history."""
+        """List workflow invocations, optionally filtered by workflow or history.
+
+        Args:
+            workflow_id: Restrict to invocations of this workflow.
+            history_id: Restrict to invocations targeting this history.
+            limit: Max invocations returned (default 50).
+            offset: Skip this many invocations (default 0).
+
+        Returns:
+            Dict with `invocations` (id, state, workflow_id, history_id, ...) and `count`.
+
+        NEXT STEPS:
+        - Drill into one: get_invocation_details(invocation_id)
+        - Cancel a running one: cancel_workflow_invocation(invocation_id)
+        """
         with _mcp_error_handler("get_invocations"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_invocations(workflow_id, history_id, limit, offset)
 
     @mcp.tool()
     def get_invocation_details(invocation_id: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Get detailed information about a specific workflow invocation."""
+        """Get detailed step-level state for a single workflow invocation.
+
+        Args:
+            invocation_id: Galaxy workflow invocation ID.
+
+        Returns:
+            Dict with invocation state, per-step status, inputs, and outputs.
+
+        NEXT STEPS:
+        - Cancel a running invocation: cancel_workflow_invocation(invocation_id)
+        - View outputs in the history: get_history_contents(history_id)
+        """
         with _mcp_error_handler("get_invocation_details"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_invocation_details(invocation_id)
 
     @mcp.tool()
     def cancel_workflow_invocation(invocation_id: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Cancel a running workflow invocation."""
+        """Cancel a running workflow invocation.
+
+        Already-completed steps remain; not-yet-running steps are skipped.
+
+        Args:
+            invocation_id: Galaxy workflow invocation ID.
+
+        Returns:
+            Dict confirming cancellation with the updated invocation state.
+        """
         with _mcp_error_handler("cancel_workflow_invocation"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.cancel_workflow_invocation(invocation_id)
@@ -347,7 +643,22 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def get_tool_panel(api_key: str, ctx: MCPContext, view: str | None = None) -> dict[str, Any]:
-        """Get the tool panel (toolbox) hierarchy of sections and tools."""
+        """Get the toolbox hierarchy of sections and tools.
+
+        Mirrors the left-hand tool panel in Galaxy. Useful for browsing or
+        building a category-aware UI.
+
+        Args:
+            view: Optional named tool panel view (admin-configured). Defaults to
+                the standard panel.
+
+        Returns:
+            Dict with the nested section/tool tree.
+
+        NEXT STEPS:
+        - Inspect a tool: get_tool_details(tool_id, io_details=True)
+        - Search by name: search_tools(query)
+        """
         with _mcp_error_handler("get_tool_panel"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_tool_panel(view)
@@ -356,10 +667,20 @@ def get_mcp_app(gx_app):
     def get_tool_run_examples(
         tool_id: str, api_key: str, ctx: MCPContext, tool_version: str | None = None
     ) -> dict[str, Any]:
-        """Get test cases showing how to run a tool with real inputs.
+        """Return XML test definitions (inputs, outputs, assertions) for a tool.
 
-        Useful for learning how to properly format tool inputs.
-        Optionally specify tool_version to get examples for a specific version.
+        Galaxy tools ship with test cases that double as worked examples --
+        real, runnable input shapes. Read these to learn how to call run_tool().
+
+        Args:
+            tool_id: Tool identifier.
+            tool_version: Optional version selector (use "*" for all versions).
+
+        Returns:
+            Dict with `tool_id`, `requested_version`, and `test_cases`.
+
+        NEXT STEPS:
+        - Build a real call: run_tool(history_id, tool_id, inputs)
         """
         with _mcp_error_handler("get_tool_run_examples"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -367,17 +688,38 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def get_tool_citations(tool_id: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Get citation information (DOIs, BibTeX) for a tool."""
+        """Get citation information (DOIs, BibTeX) for a Galaxy tool.
+
+        Args:
+            tool_id: Tool identifier.
+
+        Returns:
+            Dict with `tool_name`, `tool_version`, and `citations` (list of citation
+            dicts with type and content).
+        """
         with _mcp_error_handler("get_tool_citations"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_tool_citations(tool_id)
 
     @mcp.tool()
     def search_tools_by_keywords(keywords: list[str], api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Search for tools matching multiple keywords, ranked by relevance.
+        """Recommend tools by matching multiple keywords across name, description,
+        and accepted input formats.
 
-        More flexible than search_tools: provide multiple keywords and get
-        tools matching any of them.
+        More flexible than search_tools(): pass several keywords and get tools
+        whose name, description, or input format extensions match any of them.
+
+        Args:
+            keywords: Keywords or phrases describing what you need. Examples:
+                ["csv", "rna", "alignment"], ["fastq", "trim"], ["vcf", "filter"].
+
+        Returns:
+            Dict with `tools` (list of slim tool dicts: id, name, description,
+            versions) and `count`.
+
+        NEXT STEPS:
+        - Inspect a candidate: get_tool_details(tool_id, io_details=True)
+        - See real test inputs: get_tool_run_examples(tool_id)
         """
         with _mcp_error_handler("search_tools_by_keywords"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -387,7 +729,17 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def list_history_ids(api_key: str, ctx: MCPContext, limit: int = 100) -> dict[str, Any]:
-        """Get a simplified list of history IDs and names (lighter than list_histories)."""
+        """Get a simplified list of history IDs and names.
+
+        Lighter than list_histories() -- returns only id/name pairs. Useful when
+        you just need to map a history name to an ID.
+
+        Args:
+            limit: Max histories to return (default 100).
+
+        Returns:
+            Dict with `histories` (list of {id, name}) and `count`.
+        """
         with _mcp_error_handler("list_history_ids"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.list_history_ids(limit)
@@ -398,8 +750,20 @@ def get_mcp_app(gx_app):
     ) -> dict[str, Any]:
         """Get details about the job that created a specific dataset.
 
-        Useful for understanding how a dataset was generated and the
-        job's execution status.
+        Use this when a dataset state is `error` or you want to know exactly
+        which tool/parameters produced an output.
+
+        Args:
+            dataset_id: Galaxy dataset ID (`hda` ID).
+            history_id: Optional history ID to speed up provenance lookup.
+
+        Returns:
+            Dict with `job` (full job metadata: tool_id, state, params, runtime),
+            plus `dataset_id` and `job_id`.
+
+        NEXT STEPS:
+        - Re-run the tool: run_tool(history_id, tool_id, inputs)
+        - Inspect dataset details: get_dataset_details(dataset_id)
         """
         with _mcp_error_handler("get_job_details"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -407,9 +771,21 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def download_dataset(dataset_id: str, api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Get download URL and metadata for a dataset.
+        """Get a dataset's download URL plus basic metadata.
 
-        The dataset must be in 'ok' state to be downloadable.
+        Returns a signed/qualified URL the client can fetch. The dataset must be
+        in `ok` state to be downloadable.
+
+        Args:
+            dataset_id: Galaxy dataset ID (`hda` ID).
+
+        Returns:
+            Dict with `download_url`, `file_name`, `file_size`, `extension`, and
+            related dataset metadata.
+
+        ERROR HANDLING:
+        - Dataset not in `ok` state: wait for the producing job to finish
+          (use get_job_details(dataset_id) or get_job_status(job_id)).
         """
         with _mcp_error_handler("download_dataset"):
             ops_manager = get_operations_manager(api_key, ctx)
@@ -417,14 +793,23 @@ def get_mcp_app(gx_app):
 
     @mcp.tool()
     def get_server_info(api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Get Galaxy server version, configuration, and capabilities."""
+        """Get the Galaxy server's version, URL, and selected configuration values.
+
+        Returns:
+            Dict with `version`, `url`, and a curated subset of public config flags
+            (e.g. enabled features, brand, support links).
+        """
         with _mcp_error_handler("get_server_info"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_server_info()
 
     @mcp.tool()
     def get_user(api_key: str, ctx: MCPContext) -> dict[str, Any]:
-        """Get current authenticated user information."""
+        """Get information about the user behind the supplied API key.
+
+        Returns:
+            Dict with the user's `id`, `username`, `email`, and quota info.
+        """
         with _mcp_error_handler("get_user"):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.get_user()


### PR DESCRIPTION
## Summary

The MCP tool docstrings in `lib/galaxy/webapps/galaxy/api/mcp.py` had been written as terse one-liners that work fine when you're reading the code but leave LLM-side MCP clients without enough context to chain tools together. The external [galaxy-mcp](https://github.com/galaxyproject/galaxy-mcp) project carries much richer descriptions -- recommended workflows, argument shapes, return field hints, and "NEXT STEPS" pointers to the next likely call.

This PR brings our in-tree wrappers up to that bar. For each tool I:

- Led with one sentence on what the tool actually does
- Documented arguments and the return shape
- Added a `RECOMMENDED WORKFLOW` block to the workhorse tools (`search_tools`, `get_tool_details`, `run_tool`, `create_history`, `invoke_workflow`) describing the typical call chain
- Added `NEXT STEPS` pointers to the next likely call (`get_tool_details` after `search_tools`, `get_invocation_details` after `invoke_workflow`, etc.)
- Added `Example:` blocks where the input shape is non-obvious (`run_tool`, `invoke_workflow`, `upload_file_from_url`)
- Added `ERROR HANDLING:` notes where there's a clear "if you hit X, do Y" recovery path (`run_tool`, `download_dataset`)

There are zero behavior changes -- these are still thin wrappers around `AgentOperationsManager`. Just the doc strings move.

UDT tools (`create_user_tool` / `list_user_tools` / `delete_user_tool` / `run_user_tool`) and the IWC tools land via separate branches and aren't part of this PR; they already carry comparable docstrings.

## Test plan

- [x] `ruff check lib/galaxy/webapps/galaxy/api/mcp.py` passes
- [x] `black --check lib/galaxy/webapps/galaxy/api/mcp.py` passes
- [x] Pre-commit hooks (black, ruff, flake8, prettier) pass on commit
- [x] Python AST parses cleanly
- [ ] Manual: hit a real MCP client (Claude Desktop, etc.) and confirm tool descriptions render as expected