### PR TITLE
Bump default max_tokens for AI agents

### DIFF
--- a/doc/source/admin/ai_agents.md
+++ b/doc/source/admin/ai_agents.md
@@ -108,13 +108,13 @@ The `inference_services` dictionary allows fine-grained control over individual 
 
 Supported keys within each agent block:
 
-| Key            | Description                                                                             |
-| -------------- | --------------------------------------------------------------------------------------- |
-| `model`        | Model name with optional provider prefix (e.g. `gpt-4o`, `anthropic:claude-sonnet-4-5`) |
-| `api_key`      | API key override for this agent or default                                              |
-| `api_base_url` | Base URL override for this agent or default                                             |
-| `temperature`  | Sampling temperature (0.0 - 1.0)                                                        |
-| `max_tokens`   | Maximum tokens in the response                                                          |
+| Key            | Description                                                                                                 |
+| -------------- | ----------------------------------------------------------------------------------------------------------- |
+| `model`        | Model name with optional provider prefix (e.g. `gpt-4o`, `anthropic:claude-sonnet-4-5`)                     |
+| `api_key`      | API key override for this agent or default                                                                  |
+| `api_base_url` | Base URL override for this agent or default                                                                 |
+| `temperature`  | Sampling temperature (0.0 - 1.0)                                                                            |
+| `max_tokens`   | Maximum tokens in the response (default: 8192; 16384 for the history, orchestrator, and custom_tool agents) |
 
 ### Example: Per-Agent Overrides
 
@@ -130,11 +130,11 @@ galaxy:
         custom_tool:
             model: "openai:gpt-4o"
             temperature: 0.4
-            max_tokens: 2000
+            max_tokens: 16384
         error_analysis:
             model: "openai:gpt-4o"
             temperature: 0.2
-            max_tokens: 2000
+            max_tokens: 8192
 ```
 
 ### Example: Mixed Providers
@@ -302,10 +302,10 @@ galaxy:
             model: "openai:gpt-4o"
             api_key: "sk-..."
             temperature: 0.4
-            max_tokens: 2000
+            max_tokens: 16384
         error_analysis:
             model: "anthropic:claude-sonnet-4-5"
             api_key: "sk-ant-..."
             temperature: 0.2
-            max_tokens: 2000
+            max_tokens: 8192
 ```

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -304,6 +304,10 @@ class BaseGalaxyAgent(ABC):
     agent: Agent[GalaxyAgentDependencies, Any]
     _INTERNAL_CONTEXT_KEYS = frozenset({"run_state"})
 
+    # Fallback when no max_tokens is configured. 8k leaves headroom on every
+    # backend we currently support (smallest is Qwen3-32B at 32k context).
+    DEFAULT_MAX_TOKENS = 8192
+
     def __init__(self, deps: GalaxyAgentDependencies):
         self.deps = deps
 
@@ -686,10 +690,7 @@ class BaseGalaxyAgent(ABC):
         return self._get_agent_config("temperature", 0.7)
 
     def _get_max_tokens(self) -> int:
-        # 8192 leaves headroom on the smallest backend we point at (Qwen3-32B,
-        # 32k total) while being big enough that most agents -- history in
-        # particular -- don't get truncated mid-answer at the default.
-        return self._get_agent_config("max_tokens", 8192)
+        return self._get_agent_config("max_tokens", self.DEFAULT_MAX_TOKENS)
 
     async def _call_agent_from_tool(
         self,

--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -686,7 +686,10 @@ class BaseGalaxyAgent(ABC):
         return self._get_agent_config("temperature", 0.7)
 
     def _get_max_tokens(self) -> int:
-        return self._get_agent_config("max_tokens", 2000)
+        # 8192 leaves headroom on the smallest backend we point at (Qwen3-32B,
+        # 32k total) while being big enough that most agents -- history in
+        # particular -- don't get truncated mid-answer at the default.
+        return self._get_agent_config("max_tokens", 8192)
 
     async def _call_agent_from_tool(
         self,

--- a/lib/galaxy/agents/custom_tool.py
+++ b/lib/galaxy/agents/custom_tool.py
@@ -41,6 +41,7 @@ class CustomToolAgent(BaseGalaxyAgent):
     """
 
     agent_type = AgentType.CUSTOM_TOOL
+    DEFAULT_MAX_TOKENS = 16384
 
     def _requires_structured_output(self) -> bool:
         return True

--- a/lib/galaxy/agents/history.py
+++ b/lib/galaxy/agents/history.py
@@ -28,6 +28,7 @@ class HistoryAgent(BaseGalaxyAgent):
     """Agent for understanding and answering questions about Galaxy histories."""
 
     agent_type = AgentType.HISTORY
+    DEFAULT_MAX_TOKENS = 16384
 
     def __init__(self, deps: GalaxyAgentDependencies):
         super().__init__(deps)

--- a/lib/galaxy/agents/orchestrator.py
+++ b/lib/galaxy/agents/orchestrator.py
@@ -49,6 +49,7 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
     """Coordinates multiple specialist agents for complex tasks."""
 
     agent_type = AgentType.ORCHESTRATOR
+    DEFAULT_MAX_TOKENS = 16384
 
     def __init__(self, deps: GalaxyAgentDependencies):
         super().__init__(deps)


### PR DESCRIPTION
The 2000-token default in `_get_max_tokens()` was triggering
`Model token limit (2000) exceeded before any response was generated`
on the history agent for histories with more than a handful of
datasets. Same trap was waiting for any agent that produces longer
structured output.

This raises the baseline to 8192 and gives the heavier agents --
history, orchestrator, custom_tool -- 16384, since those generate
long structured output (history listings, multi-step plans, full
UserToolSource JSON schemas). `error_analysis`, `router`, and
`tool_recommendation` stay on the 8k default; their typical responses
sit comfortably under that.

Defaults are introduced as a `DEFAULT_MAX_TOKENS` class attribute on
`BaseGalaxyAgent`, so subclasses declare their own ceiling without
overriding the whole getter. `inference_services.<agent>.max_tokens`
config still wins.

`max_tokens` is a ceiling, not a target -- bumping it doesn't raise
token usage for unchanged responses, only allows responses that
previously truncated to finish.

## Test plan
- [x] `test/unit/app/test_agents.py` -- 35 pass / 15 skipped, no regressions
- [x] Existing per-agent overrides still take precedence (covered by `test_agent_config_fallback_chain`)