### PR TITLE
Expose execution metadata in ParsedTool

### DIFF
--- a/lib/galaxy/tool_util/model_factory.py
+++ b/lib/galaxy/tool_util/model_factory.py
@@ -1,9 +1,21 @@
+import math
 from typing import (
+    Any,
+    List,
     Type,
     TypeVar,
 )
 
 from galaxy.tool_util_models import ParsedTool
+from galaxy.tool_util_models.tool_source import (
+    Container,
+    PackageRequirement,
+    ResourceRequirement,
+    SetEnvironmentRequirement,
+    Stdio,
+    StdioExitCode,
+    StdioRegex,
+)
 from .parameters import input_models_for_tool_source
 from .parser.interface import (
     ToolSource,
@@ -32,12 +44,21 @@ def parse_tool_custom(tool_source: ToolSource, model_type: Type[P]) -> P:
     edam_topics = tool_source.parse_edam_topics()
     xrefs = tool_source.parse_xrefs()
     help = tool_source.parse_help()
+    tool_requirements, container_descriptions, resource_requirements, javascript_requirements, _ = (
+        tool_source.parse_requirements()
+    )
+    requirements = _parsed_requirements(tool_requirements, resource_requirements, javascript_requirements)
+    containers = [Container(type=c.type, container_id=c.identifier) for c in container_descriptions]
+    stdio = _parsed_stdio(tool_source)
 
     return model_type(
         id=id,
         version=version,
         name=name,
         description=description,
+        requirements=requirements,
+        containers=containers,
+        stdio=stdio,
         profile=profile,
         inputs=inputs,
         outputs=outputs,
@@ -48,3 +69,53 @@ def parse_tool_custom(tool_source: ToolSource, model_type: Type[P]) -> P:
         xrefs=xrefs,
         help=help,
     )
+
+
+def _parsed_requirements(tool_requirements, resource_requirements, javascript_requirements) -> List[Any]:
+    parsed_requirements: List[Any] = []
+    for requirement in tool_requirements:
+        if requirement.type == "package":
+            parsed_requirements.append(
+                PackageRequirement(type="package", name=requirement.name, version=requirement.version)
+            )
+        elif requirement.type == "set_environment":
+            parsed_requirements.append(SetEnvironmentRequirement(type="set_environment", environment=requirement.name))
+
+    resource_requirement_kwds = {r.resource_type: r.value_or_expression for r in resource_requirements}
+    if resource_requirement_kwds:
+        resource_requirement = {"cores_min": None, "ram_min": None, **resource_requirement_kwds}
+        parsed_requirements.append(ResourceRequirement(type="resource", **resource_requirement))
+
+    parsed_requirements.extend(javascript_requirements)
+    return parsed_requirements
+
+
+def _parsed_stdio(tool_source: ToolSource) -> Stdio:
+    exit_codes, regexes = tool_source.parse_stdio()
+    return Stdio(
+        exit_codes=[
+            StdioExitCode(
+                range_start=_stdio_range_value(exit_code.range_start),
+                range_end=_stdio_range_value(exit_code.range_end),
+                error_level=exit_code.error_level,
+                desc=exit_code.desc,
+            )
+            for exit_code in exit_codes
+        ],
+        regexes=[
+            StdioRegex(
+                match=regex.match,
+                stdout_match=regex.stdout_match,
+                stderr_match=regex.stderr_match,
+                error_level=regex.error_level,
+                desc=regex.desc,
+            )
+            for regex in regexes
+        ],
+    )
+
+
+def _stdio_range_value(value):
+    if isinstance(value, float) and math.isinf(value):
+        return "-inf" if value < 0 else "inf"
+    return value

--- a/lib/galaxy/tool_util_models/__init__.py
+++ b/lib/galaxy/tool_util_models/__init__.py
@@ -43,11 +43,15 @@ from .tool_outputs import (
 )
 from .tool_source import (
     Citation,
+    Container,
     ContainerRequirement,
     HelpContent,
     JavascriptRequirement,
     OutputCompareType,
+    PackageRequirement,
     ResourceRequirement,
+    SetEnvironmentRequirement,
+    Stdio,
     XrefDict,
     YamlTemplateConfigFile,
 )
@@ -160,6 +164,11 @@ class ParsedTool(ToolSourceBaseModel):
     version: Optional[str]
     name: str
     description: Optional[str]
+    requirements: List[
+        Union[PackageRequirement, SetEnvironmentRequirement, ResourceRequirement, JavascriptRequirement]
+    ] = Field(default_factory=list)
+    containers: List[Container] = Field(default_factory=list)
+    stdio: Stdio = Field(default_factory=Stdio)
     inputs: List[ToolParameterT]
     outputs: List[ToolOutput]
     citations: List[Citation]

--- a/lib/galaxy/tool_util_models/tool_source.py
+++ b/lib/galaxy/tool_util_models/tool_source.py
@@ -37,7 +37,7 @@ class ContainerRequirement(ToolSourceBaseModel):
 class PackageRequirement(Requirement):
     type: Literal["package"]
     name: str
-    version: Optional[str]
+    version: Optional[str] = None
 
 
 class SetEnvironmentRequirement(Requirement):
@@ -55,26 +55,29 @@ ram_max_description = "Maximum reserved RAM in mebibytes (2**20)."
 ram_description = """May be a fractional value. If so, the actual RAM request is rounded up to the next whole number. The reported amount of RAM reserved for the process is a non-zero integer."""
 
 
+ResourceRequirementValue = Union[int, float, str, None]
+
+
 class ResourceRequirement(ToolSourceBaseModel):
     type: Literal["resource"]
     cores_min: Annotated[
-        Union[int, float, None], Field(description=f"{cores_min_description}\n{cores_description}")
+        ResourceRequirementValue, Field(description=f"{cores_min_description}\n{cores_description}")
     ] = 1
     cores_max: Annotated[
-        Union[int, float, None], Field(description=f"{cores_max_description}\n{cores_description}")
+        ResourceRequirementValue, Field(description=f"{cores_max_description}\n{cores_description}")
     ] = None
-    ram_min: Annotated[Union[int, float, None], Field(description=f"{ram_min_description}\n{ram_description}")] = 256
-    ram_max: Annotated[Union[int, float, None], Field(description=f"{ram_max_description}\n{ram_description}")] = None
-    tmpdir_min: Optional[Union[int, float]] = None
-    tmpdir_max: Optional[Union[int, float]] = None
-    cuda_version_min: Optional[Union[int, float]] = None
-    cuda_compute_capability: Optional[Union[int, float]] = None
-    gpu_memory_min: Optional[Union[int, float]] = None
-    cuda_device_count_min: Optional[Union[int, float]] = None
-    cuda_device_count_max: Optional[Union[int, float]] = None
-    shm_size: Optional[Union[int, float]] = None
+    ram_min: Annotated[ResourceRequirementValue, Field(description=f"{ram_min_description}\n{ram_description}")] = 256
+    ram_max: Annotated[ResourceRequirementValue, Field(description=f"{ram_max_description}\n{ram_description}")] = None
+    tmpdir_min: ResourceRequirementValue = None
+    tmpdir_max: ResourceRequirementValue = None
+    cuda_version_min: ResourceRequirementValue = None
+    cuda_compute_capability: ResourceRequirementValue = None
+    gpu_memory_min: ResourceRequirementValue = None
+    cuda_device_count_min: ResourceRequirementValue = None
+    cuda_device_count_max: ResourceRequirementValue = None
+    shm_size: ResourceRequirementValue = None
     timelimit: Annotated[
-        Union[int, float, None],
+        ResourceRequirementValue,
         Field(description="Maximum time in seconds the tool is allowed to run. Job will be terminated if exceeded."),
     ] = None
 
@@ -150,6 +153,29 @@ class Citation(ToolSourceBaseModel):
 class HelpContent(ToolSourceBaseModel):
     format: Literal["restructuredtext", "plain_text", "markdown"]
     content: str
+
+
+StdioExitCodeRangeValue = Union[int, float, Literal["-inf", "inf"]]
+
+
+class StdioExitCode(ToolSourceBaseModel):
+    range_start: StdioExitCodeRangeValue
+    range_end: StdioExitCodeRangeValue
+    error_level: Union[int, float]
+    desc: Optional[str] = None
+
+
+class StdioRegex(ToolSourceBaseModel):
+    match: str
+    stdout_match: bool
+    stderr_match: bool
+    error_level: Union[int, float]
+    desc: Optional[str] = None
+
+
+class Stdio(ToolSourceBaseModel):
+    exit_codes: List[StdioExitCode] = Field(default_factory=list)
+    regexes: List[StdioRegex] = Field(default_factory=list)
 
 
 class OutputCompareType(str, Enum):

--- a/test/unit/tool_util/test_parsed_tool_model.py
+++ b/test/unit/tool_util/test_parsed_tool_model.py
@@ -1,0 +1,105 @@
+from galaxy.tool_util.model_factory import (
+    parse_tool,
+    parse_tool_custom,
+)
+from galaxy.tool_util.parser.factory import build_xml_tool_source
+from galaxy.tool_util_models.tool_source import PackageRequirement
+from tool_shed_client.schema import ShedParsedTool
+
+
+def test_parsed_tool_exposes_package_requirements():
+    tool = parse_tool(build_xml_tool_source("""
+<tool id="parsed_req" name="Parsed Requirement" version="1.0" profile="22.05">
+    <requirements>
+        <requirement type="package" version="1.17">samtools</requirement>
+    </requirements>
+</tool>
+"""))
+
+    assert len(tool.requirements) == 1
+    requirement = tool.requirements[0]
+    assert requirement.type == "package"
+    assert requirement.name == "samtools"
+    assert requirement.version == "1.17"
+
+
+def test_parsed_tool_exposes_containers():
+    tool = parse_tool(build_xml_tool_source("""
+<tool id="parsed_container" name="Parsed Container" version="1.0" profile="22.05">
+    <requirements>
+        <container type="docker">quay.io/biocontainers/samtools:1.17--h00cdaf9_0</container>
+    </requirements>
+</tool>
+"""))
+
+    assert len(tool.containers) == 1
+    container = tool.containers[0]
+    assert container.type == "docker"
+    assert container.container_id == "quay.io/biocontainers/samtools:1.17--h00cdaf9_0"
+
+
+def test_parsed_tool_exposes_resource_requirements_without_defaults():
+    tool = parse_tool(build_xml_tool_source("""
+<tool id="parsed_resource" name="Parsed Resource" version="1.0" profile="22.05">
+    <requirements>
+        <resource type="cores_min">4</resource>
+    </requirements>
+</tool>
+"""))
+
+    assert len(tool.requirements) == 1
+    requirement = tool.requirements[0]
+    assert requirement.type == "resource"
+    assert requirement.cores_min == "4"
+    assert requirement.ram_min is None
+
+
+def test_package_requirement_version_is_optional():
+    requirement = PackageRequirement.model_validate({"type": "package", "name": "bwa"})
+
+    assert requirement.version is None
+
+
+def test_parsed_tool_exposes_stdio_rules():
+    tool = parse_tool(build_xml_tool_source("""
+<tool id="parsed_stdio" name="Parsed Stdio" version="1.0" profile="22.05">
+    <stdio>
+        <exit_code range="2:4" level="fatal" description="bad exit" />
+        <regex match="WARNING" source="stdout" level="warning" description="warn text" />
+    </stdio>
+</tool>
+"""))
+
+    assert len(tool.stdio.exit_codes) == 1
+    exit_code = tool.stdio.exit_codes[0]
+    assert exit_code.range_start == 2
+    assert exit_code.range_end == 4
+    assert exit_code.error_level == 3
+    assert exit_code.desc == "bad exit"
+
+    assert len(tool.stdio.regexes) == 1
+    regex = tool.stdio.regexes[0]
+    assert regex.match == "WARNING"
+    assert regex.stdout_match is True
+    assert regex.stderr_match is False
+    assert regex.error_level == 2
+    assert regex.desc == "warn text"
+
+
+def test_parsed_tool_and_shed_parsed_tool_serialize():
+    tool_source = build_xml_tool_source("""
+<tool id="parsed_serialized" name="Parsed Serialized" version="1.0" profile="22.05">
+    <requirements>
+        <requirement type="package" version="1.17">samtools</requirement>
+        <container type="docker">quay.io/biocontainers/samtools:1.17--h00cdaf9_0</container>
+    </requirements>
+</tool>
+""")
+
+    parsed_tool = parse_tool(tool_source)
+    shed_parsed_tool = parse_tool_custom(tool_source, ShedParsedTool)
+
+    assert parsed_tool.model_dump(mode="json")["requirements"][0]["name"] == "samtools"
+    assert shed_parsed_tool.model_dump(mode="json")["containers"][0]["type"] == "docker"
+    assert parsed_tool.model_dump_json()
+    assert shed_parsed_tool.model_dump_json()


### PR DESCRIPTION
## Summary
- Extend `ParsedTool` with normalized requirements, containers, and stdio execution metadata.
- Populate the new fields from existing `ToolSource.parse_requirements()` and `ToolSource.parse_stdio()` parser surfaces.
- Add focused tests for package, container, resource, stdio, and `ShedParsedTool` serialization behavior.

## Testing
- `.venv/bin/python -m pytest "test/unit/tool_util/test_parsed_tool_model.py"`
- `.venv/bin/python -m pytest "test/unit/tool_util/test_input_models.py" "test/unit/tool_util/test_parameter_test_cases.py" "test/unit/tool_util/test_parsed_tool_model.py"`