### PR TITLE
Fix MCP get_dataset_details crash on display-apps serialization

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -7,17 +7,26 @@ Uses Streamable HTTP transport with stateless mode for multi-worker compatibilit
 
 import logging
 from contextlib import contextmanager
-from typing import Any
+from typing import (
+    Any,
+    Optional,
+)
+from urllib.parse import urlparse
 
 from fastmcp import (
     Context as MCPContext,
     FastMCP,
     settings as fastmcp_settings,
 )
+from starlette.datastructures import URL
 
 from galaxy.agents.operations import AgentOperationsManager
 from galaxy.managers.users import UserManager
-from galaxy.work.context import WorkRequestContext
+from galaxy.work.context import (
+    GalaxyAbstractRequest,
+    GalaxyAbstractResponse,
+    SessionRequestContext,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +81,68 @@ def get_mcp_url_builder(fallback_base_url: str):
     return MCPUrlBuilder(fallback_base_url)
 
 
+class _StaticRequest(GalaxyAbstractRequest):
+    """Minimal GalaxyAbstractRequest backed by a configured base URL.
+
+    MCP tools run outside of an HTTP request, but downstream serializers
+    (notably HDASerializer.serialize_old_display_applications) read
+    ``trans.request.base`` to build absolute display-app URLs.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        # Match GalaxyASGIRequest.base shape (Starlette base_url always has trailing slash).
+        self._base = base_url if base_url.endswith("/") else f"{base_url}/"
+        self._parsed = urlparse(self._base)
+
+    @property
+    def base(self) -> str:
+        return self._base
+
+    @property
+    def url_path(self) -> str:
+        return self._base
+
+    @property
+    def host(self) -> str:
+        return self._parsed.netloc
+
+    @property
+    def is_secure(self) -> bool:
+        return self._parsed.scheme == "https"
+
+    def get_cookie(self, name: str) -> Optional[str]:
+        return None
+
+    @property
+    def url(self) -> URL:
+        return URL(self._base)
+
+
+class _StaticResponse(GalaxyAbstractResponse):
+    """No-op GalaxyAbstractResponse for MCP contexts (no HTTP response surface)."""
+
+    def __init__(self) -> None:
+        self._headers: dict = {}
+
+    @property
+    def headers(self) -> dict:
+        return self._headers
+
+    def set_cookie(
+        self,
+        key: str,
+        value: str = "",
+        max_age: Optional[int] = None,
+        expires: Optional[int] = None,
+        path: str = "/",
+        domain: Optional[str] = None,
+        secure: bool = False,
+        httponly: bool = False,
+        samesite: Optional[str] = "lax",
+    ) -> None:
+        return None
+
+
 @contextmanager
 def _mcp_error_handler(operation: str):
     """Standard error handling for MCP tool calls."""
@@ -90,7 +161,7 @@ def get_mcp_app(gx_app):
 
     mcp = FastMCP("Galaxy")
 
-    base_url = getattr(gx_app.config, "galaxy_infrastructure_url", "http://localhost:8080")
+    base_url = gx_app.config.galaxy_infrastructure_url
     user_manager = UserManager(gx_app)
 
     def get_operations_manager(api_key: str, ctx: MCPContext) -> AgentOperationsManager:
@@ -109,7 +180,13 @@ def get_mcp_app(gx_app):
             )
 
         url_builder = get_mcp_url_builder(base_url)
-        trans = WorkRequestContext(app=gx_app, user=user, url_builder=url_builder)
+        trans = SessionRequestContext(
+            app=gx_app,
+            user=user,
+            url_builder=url_builder,
+            request=_StaticRequest(base_url),
+            response=_StaticResponse(),
+        )
 
         return AgentOperationsManager(app=gx_app, trans=trans)
 

--- a/test/unit/webapps/api/test_mcp.py
+++ b/test/unit/webapps/api/test_mcp.py
@@ -1,0 +1,50 @@
+"""Unit tests for the MCP request/response stubs.
+
+Regression coverage for the bug where MCP tools constructed a bare
+``WorkRequestContext`` (no ``.request`` attribute), causing
+``HDASerializer.serialize_old_display_applications`` to raise
+``AttributeError: 'WorkRequestContext' object has no attribute 'request'``
+whenever ``enable_old_display_applications`` was set.
+"""
+
+from galaxy.webapps.galaxy.api.mcp import (
+    _StaticRequest,
+    _StaticResponse,
+)
+from galaxy.work.context import (
+    GalaxyAbstractRequest,
+    GalaxyAbstractResponse,
+)
+
+
+def test_static_request_implements_abstract_interface():
+    request = _StaticRequest("http://localhost:8080")
+    assert isinstance(request, GalaxyAbstractRequest)
+
+
+def test_static_request_base_always_has_trailing_slash():
+    # Matches GalaxyASGIRequest.base shape (Starlette base_url has trailing slash).
+    assert _StaticRequest("http://localhost:8080").base == "http://localhost:8080/"
+    assert _StaticRequest("http://localhost:8080/").base == "http://localhost:8080/"
+    assert _StaticRequest("https://example.org/galaxy").base == "https://example.org/galaxy/"
+
+
+def test_static_request_host_and_security():
+    insecure = _StaticRequest("http://localhost:8080")
+    assert insecure.host == "localhost:8080"
+    assert insecure.is_secure is False
+
+    secure = _StaticRequest("https://galaxy.example.org")
+    assert secure.host == "galaxy.example.org"
+    assert secure.is_secure is True
+
+
+def test_static_request_get_cookie_returns_none():
+    assert _StaticRequest("http://localhost:8080").get_cookie("anything") is None
+
+
+def test_static_response_implements_abstract_interface():
+    response = _StaticResponse()
+    assert isinstance(response, GalaxyAbstractResponse)
+    assert response.headers == {}
+    response.set_cookie("k", "v")


### PR DESCRIPTION
MCP tools constructed a bare WorkRequestContext, which has no .request attribute. HDASerializer.serialize_old_display_applications reads trans.request.base to build absolute display-app URLs, so any tool running detailed HDA serialization crashed with AttributeError when enable_old_display_applications was enabled.

Switch to SessionRequestContext backed by minimal _StaticRequest / _StaticResponse stubs derived from galaxy_infrastructure_url (the same base URL already used for the MCP URL builder).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
