### PR TITLE
Improve toolSectionTitle font size

### DIFF
--- a/client/src/style/scss/unsorted.scss
+++ b/client/src/style/scss/unsorted.scss
@@ -689,7 +689,7 @@ div.permissionContainer {
 
 div.toolSectionTitle {
     font-weight: 500;
-    font-size: $h4-font-size;
+    font-size: $font-size-base;
 }
 
 div.toolTitle,


### PR DESCRIPTION
The tools menu looks like a visual mess with both spacings and different font sizes. This tiny change makes it all the same size which reduces the visual mess and allows us to clearly see the tools menu in a more eye pleasing way.

| Before  | After |
| ------------- | ------------- |
| <img width="381" height="917" alt="image" src="https://github.com/user-attachments/assets/034a5c28-22fd-4b88-90a8-c1ece0dd60a0" />  | <img width="373" height="951" alt="image" src="https://github.com/user-attachments/assets/8e5315d6-18e0-401f-bf38-f10b876df61f" />  |

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open tools tab and look at the menu on the left.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
