### PR TITLE
Update test workflows to respect gxformat2 0.26.0 syntax

### DIFF
--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -191,9 +191,9 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
         jobs_summary = self._run_workflow(
             """
 class: GalaxyWorkflow
+inputs:
+  text_input1: collection
 steps:
-  - label: text_input1
-    type: input_collection
   - tool_id: collection_paired_test
     state:
       f1:
@@ -269,9 +269,9 @@ test_data:
         jobs_summary = self._run_workflow(
             """
 class: GalaxyWorkflow
+inputs:
+  text_input1: collection
 steps:
-  - label: text_input1
-    type: input_collection
   - label: noop
     tool_id: cat1
     state:
@@ -340,11 +340,10 @@ steps:
         jobs_summary = self._run_workflow(
             """
 class: GalaxyWorkflow
+inputs:
+  text_input1: data
+  text_input2: data
 steps:
-  - label: text_input1
-    type: input
-  - label: text_input2
-    type: input
   - label: cat_inputs
     tool_id: cat1
     state:
@@ -391,9 +390,9 @@ test_data:
         jobs_summary = self._run_workflow(
             """
 class: GalaxyWorkflow
+inputs:
+  text_input1: collection
 steps:
-  - label: text_input1
-    type: input_collection
   - label: cat_inputs
     tool_id: cat1
     state:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -283,7 +283,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         change_datatype: bed
         set_columns:
@@ -1024,7 +1024,7 @@ steps:
   subworkflow:
     in:
       dataset: dataset
-    outputs:
+    out:
       output:
         outputSource: cat1/out_file1
     run:
@@ -3016,7 +3016,7 @@ steps:
 steps:
   empty_output:
     tool_id: empty_output
-    outputs:
+    out:
       out_file1:
         change_datatype: tabular
   column_param:
@@ -3039,7 +3039,7 @@ steps:
 steps:
   empty_output:
     tool_id: empty_output
-    outputs:
+    out:
       out_file1:
         change_datatype: tabular
   column_param_list:
@@ -3064,7 +3064,7 @@ steps:
 steps:
   empty_output:
     tool_id: empty_output
-    outputs:
+    out:
       out_file1:
         change_datatype: tabular
   column_param_list:
@@ -3783,7 +3783,7 @@ steps:
     in:
       some_collection: some_collection
       should_run: should_run
-    outputs:
+    out:
       inner_out: a_tool_step/out_file1
     when: $(inputs.should_run)
 outputs:
@@ -3843,7 +3843,7 @@ steps:
     in:
       some_file: some_file
       should_run: should_run
-    outputs:
+    out:
       inner_out: a_tool_step/out_file1
     when: $(inputs.should_run)
 outputs:
@@ -5818,7 +5818,7 @@ steps:
     tool_id: random_lines1
     in:
       input: text_input1
-    outputs:
+    out:
         out_file1:
           change_datatype: csv
 """,
@@ -5848,7 +5848,7 @@ steps:
     tool_id: collection_split_on_column
     in:
       input1: input
-    outputs:
+    out:
         split_output:
           change_datatype: csv
 outputs:
@@ -6166,11 +6166,6 @@ steps:
     tool_id: create_2
     state:
       sleep_time: 0
-    outputs:
-      out_file1:
-        rename: "my new name"
-      out_file2:
-        rename: "my other new name"
   first_cat1:
     tool_id: cat
     in:
@@ -6198,11 +6193,6 @@ steps:
     tool_id: create_2
     state:
       sleep_time: 0
-    outputs:
-      out_file1:
-        rename: "my new name"
-      out_file2:
-        rename: "my other new name"
 outputs:
   main_out:
     outputSource: create_2/does_not_exist
@@ -7574,7 +7564,7 @@ steps:
         cat1:
           in:
             input1: apply/output
-          outputs:
+          out:
             out_file1:
               rename: "#{inner_text_input} suffix"
         """,
@@ -7639,7 +7629,7 @@ steps:
     tool_id: cat1
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         hide: true
 """,
@@ -7985,7 +7975,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         rename: "my new name"
 """,
@@ -8026,7 +8016,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         rename: "#{input1} suffix"
 """,
@@ -8060,7 +8050,7 @@ steps:
   - tool_id: collection_creates_pair
     in:
       input1: input1
-    outputs:
+    out:
       paired_output:
         rename: "my new name"
 """,
@@ -8095,7 +8085,7 @@ steps:
       datasets:
       - id_cond:
           id_select: id
-    outputs:
+    out:
       output:
         hide: true
 """,
@@ -8130,7 +8120,7 @@ steps:
       datasets:
       - id_cond:
           id_select: id
-    outputs:
+    out:
       output:
         delete_intermediate_datasets: true
 """,
@@ -8168,7 +8158,7 @@ steps:
       datasets:
       - id_cond:
           id_select: idx
-    outputs:
+    out:
       output:
         change_datatype: txt
   - tool_id: __BUILD_LIST__
@@ -8218,7 +8208,7 @@ steps:
     tool_id: __EXTRACT_DATASET__
     in:
       input: build_list/output
-    outputs:
+    out:
       output:
         change_datatype: vcf_bgzip
 """,
@@ -8249,7 +8239,7 @@ steps:
       datasets:
       - id_cond:
           id_select: idx
-    outputs:
+    out:
       output:
         rename: "my new name"
 """,
@@ -8280,7 +8270,7 @@ steps:
     tool_id: create_2
     state:
       sleep_time: 0
-    outputs:
+    out:
       out_file1:
         rename: "my new name"
       out_file2:
@@ -8319,14 +8309,11 @@ steps:
       failbool: true
       input1:
         $link: input1
-    outputs:
-      out_file1:
-        rename: "cat1 out"
   cat:
     tool_id: cat
     in:
       input1: first_fail/out_file1
-    outputs:
+    out:
       out_file1:
         rename: "#{input1} suffix"
 """,
@@ -8374,7 +8361,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         rename: "#{input1} #{input1 | upper} suffix"
 """,
@@ -8408,7 +8395,7 @@ steps:
       queries:
         - input2:
             $link: input2
-    outputs:
+    out:
       out_file1:
         rename: "#{queries_0.input2| basename} suffix"
 """,
@@ -8447,7 +8434,7 @@ steps:
           $link: fastq_input
       reference:
         $link: fasta_input
-    outputs:
+    out:
       out_file1:
         rename: "#{fastq_input.fastq_input1 | basename} suffix"
 """,
@@ -8488,7 +8475,7 @@ steps:
           $link: fastq_input
       reference:
         $link: fasta_input
-    outputs:
+    out:
       out_file1:
         # The fully prefixed variant test in "test_run_rename_based_on_input_conditional" should be preferred,
         # but we don't want to break old workflow renaming actions
@@ -8526,7 +8513,7 @@ steps:
     state:
       input1:
         $link: input1
-    outputs:
+    out:
       paired_output:
         hide: true
 """,
@@ -8560,7 +8547,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         hide: true
 """,
@@ -8599,7 +8586,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         add_tags:
             - "name:treated1fb"
@@ -8647,7 +8634,7 @@ steps:
     tool_id: collection_creates_pair
     in:
       input1: input1
-    outputs:
+    out:
       paired_output:
         add_tags:
             - "name:foo"
@@ -8683,7 +8670,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         add_tags:
             - "name:foo"
@@ -8721,7 +8708,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         add_tags:
           - "name:foo"
@@ -8729,7 +8716,7 @@ steps:
     tool_id: collection_creates_pair
     in:
       input1: first_cat/out_file1
-    outputs:
+    out:
       paired_output:
         remove_tags:
           - "name:foo"
@@ -8772,7 +8759,7 @@ steps:
     tool_id: __EXTRACT_DATASET__
     in:
       input: input1
-    outputs:
+    out:
       output:
         add_tags:
           - "name:foo"
@@ -8903,7 +8890,7 @@ steps:
     tool_id: cat1
     in:
       input1: second_cat/out_file1
-    outputs:
+    out:
       out_file1:
         delete_intermediate_datasets: true
 """,

--- a/lib/galaxy_test/api/test_workflows_from_yaml.py
+++ b/lib/galaxy_test/api/test_workflows_from_yaml.py
@@ -210,9 +210,9 @@ $graph:
     def test_pause(self):
         workflow_id = self._upload_yaml_workflow("""
 class: GalaxyWorkflow
+inputs:
+  test_input: data
 steps:
-  test_input:
-    type: input
   first_cat:
     tool_id: cat1
     state:

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -239,12 +239,13 @@ steps:
 
 WORKFLOW_WITH_OUTPUT_COLLECTION_MAPPING = """
 class: GalaxyWorkflow
+inputs:
+  input_collection: collection
 steps:
-  - type: input_collection
   - tool_id: collection_creates_pair
     state:
       input1:
-        $link: 0
+        $link: "0"
   - tool_id: collection_paired_test
     state:
       f1:
@@ -547,7 +548,7 @@ inputs:
 steps:
   first_cat:
     tool_id: cat1
-    outputs:
+    out:
        out_file1:
          hide: true
          rename: "the new value"
@@ -733,7 +734,7 @@ steps:
       input: required
     state:
       lineNum:
-        $link:  expression/out1
+        $link: expression/out1
   count_multi_file:
     tool_id: count_multi_file
     in:
@@ -798,7 +799,7 @@ steps:
     state:
       input1:
         $link: input1
-    outputs:
+    out:
       out_file1:
         rename: "#{input1 | basename} suffix"
 test_data:
@@ -817,7 +818,7 @@ steps:
     tool_id: cat
     in:
       input1: input1
-    outputs:
+    out:
       out_file1:
         rename: "${replaceme} suffix"
 """
@@ -843,7 +844,7 @@ steps:
           label: first_cat
           in:
             input1: inner_input
-          outputs:
+          out:
             out_file1:
               rename: "${replaceme} suffix"
     in:

--- a/lib/galaxy_test/selenium/test_workflow_extraction.py
+++ b/lib/galaxy_test/selenium/test_workflow_extraction.py
@@ -130,9 +130,9 @@ class TestWorkflowExtractionSelenium(SeleniumTestCase, WorkflowStructureAssertio
         self.workflow_populator.run_workflow(
             """
 class: GalaxyWorkflow
+inputs:
+  text_input1: collection
 steps:
-  - label: text_input1
-    type: input_collection
   - label: noop
     tool_id: cat1
     state:

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -70,9 +70,9 @@ WORKFLOW_SCHEDULER_HANDLER_PATTERN = re.compile(r"work\d")
 
 PAUSE_WORKFLOW = """
 class: GalaxyWorkflow
+inputs:
+  test_input: data
 steps:
-- label: test_input
-  type: input
 - label: the_pause
   type: pause
   connect:

--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -8,6 +8,7 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     WorkflowPopulator,
 )
+from galaxy_test.base.workflow_fixtures import WORKFLOW_WITH_OUTPUT_COLLECTION_MAPPING
 from galaxy_test.driver import integration_util
 
 
@@ -62,23 +63,7 @@ class TestMaximumWorkflowJobsPerSchedulingIteration(integration_util.Integration
         config["maximum_workflow_jobs_per_scheduling_iteration"] = 1
 
     def test_collection_explicit_and_implicit(self):
-        workflow_id = self.workflow_populator.upload_yaml_workflow("""
-class: GalaxyWorkflow
-steps:
-  - type: input_collection
-  - tool_id: collection_creates_pair
-    state:
-      input1:
-        $link: 0
-  - tool_id: collection_paired_test
-    state:
-      f1:
-        $link: 1/paired_output
-  - tool_id: cat_list
-    state:
-      input1:
-        $link: 2/out1
-""")
+        workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_WITH_OUTPUT_COLLECTION_MAPPING)
         with self.dataset_populator.test_history() as history_id:
             fetch_response = self.dataset_collection_populator.create_list_in_history(
                 history_id, contents=["a\nb\nc\nd\n", "e\nf\ng\nh\n"]


### PR DESCRIPTION
Fix most of the test failures in https://github.com/galaxyproject/galaxy/pull/22619 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
