### PR TITLE
Update test workflows to respect gxformat2 0.26.0 syntax (part 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,10 @@ lib/galaxy/web/framework/meta.json
 *.lock
 *.log
 *.pid
-celerybeat-schedule
 
 # Celery state files
-celerybeat-schedule.*
+celerybeat-schedule
+celerybeat-schedule.db
 
 # Tool Shed runtime files
 tool_shed_webapp.lock
@@ -111,6 +111,7 @@ test-data-cache
 run_api_tests.html
 run_cwl_tests.html
 run_framework_tests.html
+run_framework_workflows_tests.html
 run_functional_tests.html
 run_integration_tests.html
 run_playwright_tests.html

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -666,8 +666,6 @@ tool_form:
     parameter_data_input_collection: 'div.ui-form-element[id="form-element-${parameter}"] button[title="Dataset collection"]'
     parameter_data_label: 'div.ui-form-element[id="form-element-${parameter}"] [data-description="form data label"]'
     parameter_data_select: 'div.ui-form-element[id="form-element-${parameter}"] .multiselect'
-
-    parameter_checkbox_input: 'div.ui-form-element[id="form-element-${parameter}"] input[type="checkbox"]'
     parameter_color_input: 'div.ui-form-element[id="form-element-${parameter}"] input[type="color"]'
     parameter_text_input: 'div.ui-form-element[id="form-element-${parameter}"] input'
     parameter_form_selection: 'div.ui-form-element[id="form-element-${parameter}"] .form-selection'

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -646,7 +646,7 @@ steps:
 inputs: []
 steps:
   - tool_id: multiple_versions
-    tool_version: 0.1
+    tool_version: "0.1"
     label: multiple_versions
     state:
       foo: bar
@@ -780,7 +780,7 @@ inputs: []
 steps:
   - tool_id: create_2
     label: create_2
-    outputs:
+    out:
       out_file1:
         change_datatype: bam
   - tool_id: metadata_bam
@@ -807,7 +807,7 @@ steps:
         steps:
           - tool_id: create_2
             label: create_2
-            outputs:
+            out:
               out_file1:
                 change_datatype: bam
         outputs:
@@ -906,7 +906,7 @@ inputs:
     collection_type: "list"
 steps:
   - tool_id: multiple_versions
-    tool_version: 0.1
+    tool_version: "0.1"
     label: multiple_versions
     state:
       foo: bar

--- a/lib/galaxy_test/workflow/map_over_expression.gxwf.yml
+++ b/lib/galaxy_test/workflow/map_over_expression.gxwf.yml
@@ -13,6 +13,3 @@ steps:
     tool_id: validation_default
     in:
       input1: param_out/text_param
-    outputs:
-      out_file1:
-        rename: "replaced_param_collection"

--- a/lib/galaxy_test/workflow/optional_param_default_value.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_param_default_value.gxwf.yml
@@ -19,6 +19,6 @@ steps:
     in:
       input1:
         source: required_input
-    outputs:
+    out:
       out_file1:
         rename: "prefix_${optional_text}_suffix"

--- a/lib/galaxy_test/workflow/rename_based_on_input_collection.gxwf.yml
+++ b/lib/galaxy_test/workflow/rename_based_on_input_collection.gxwf.yml
@@ -15,6 +15,6 @@ steps:
           $link: fastq_inputs
       reference:
         $link: fasta_input
-    outputs:
+    out:
       out_file1:
         rename: "#{fastq_input.fastq_input1 | basename} suffix"

--- a/lib/galaxy_test/workflow/replacement_parameters_legacy.gxwf.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_legacy.gxwf.yml
@@ -10,7 +10,7 @@ steps:
     tool_id: create_2
     state:
       sleep_time: 0
-    outputs:
+    out:
       out_file1:
         rename: "${replaceme} name"
       out_file2:

--- a/lib/galaxy_test/workflow/replacement_parameters_nested.gxwf.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_nested.gxwf.yml
@@ -22,7 +22,7 @@ steps:
           tool_id: create_2
           state:
             sleep_time: 0
-          outputs:
+          out:
             out_file1:
               rename: "${replacemeinner} name"
             out_file2:

--- a/lib/galaxy_test/workflow/replacement_parameters_text.gxwf.yml
+++ b/lib/galaxy_test/workflow/replacement_parameters_text.gxwf.yml
@@ -11,7 +11,7 @@ steps:
     tool_id: create_2
     state:
       sleep_time: 0
-    outputs:
+    out:
       out_file1:
         rename: "${replaceme} name"
       out_file2:

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -444,7 +444,7 @@ steps:
     tool_id: cat
     in:
       input1: test_input
-    outputs:
+    out:
       out_file1:
         rename: "${pja_only_param} name"
 """)
@@ -465,7 +465,7 @@ steps:
     tool_id: cat
     in:
       input1: test_input
-    outputs:
+    out:
       out_file1:
         rename: "${pja_only_param} name"
 """)
@@ -489,7 +489,7 @@ steps:
     tool_id: cat
     in:
       input1: test_input
-    outputs:
+    out:
       out_file1:
         rename: "${pja_only_param} name"
 """)


### PR DESCRIPTION
Also:
- Remove duplicated key from bad merge which breaks 5 client unit tests

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
