### PR TITLE
Fix SQL compatibility in kombu message pruning

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -621,7 +621,7 @@ def prune_kombu_sqla_transport(config: GalaxyAppConfiguration):
     engine = create_engine(sa_url)
     try:
         with engine.begin() as conn:
-            result = conn.execute(text("DELETE FROM kombu_message WHERE visible = false"))
+            result = conn.execute(text("DELETE FROM kombu_message WHERE visible IS FALSE"))
             log.info("kombu cleanup: deleted %s consumed messages", result.rowcount)
     except Exception:
         log.exception("kombu cleanup: failed to prune kombu_message")

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -621,7 +621,7 @@ def prune_kombu_sqla_transport(config: GalaxyAppConfiguration):
     engine = create_engine(sa_url)
     try:
         with engine.begin() as conn:
-            result = conn.execute(text("DELETE FROM kombu_message WHERE visible = 0"))
+            result = conn.execute(text("DELETE FROM kombu_message WHERE visible = false"))
             log.info("kombu cleanup: deleted %s consumed messages", result.rowcount)
     except Exception:
         log.exception("kombu cleanup: failed to prune kombu_message")


### PR DESCRIPTION
Should fix:
```
[2026-05-07 18:45:09,241: ERROR/main] kombu cleanup: failed to prune kombu_message
Traceback (most recent call last):
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
    self.dialect.do_execute(
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 952, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UndefinedFunction: operator does not exist: boolean = integer
LINE 1: DELETE FROM kombu_message WHERE visible = 0
                                                ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dlopez/dev/galaxy/lib/galaxy/celery/tasks.py", line 668, in prune_kombu_sqla_transport
    result = conn.execute(text("DELETE FROM kombu_message WHERE visible = 0"))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1419, in execute
    return meth(
           ^^^^^
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 527, in _execute_on_connection
    return connection._execute_clauseelement(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1641, in _execute_clauseelement
    ret = self._execute_context(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
    return self._exec_single_context(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1986, in _exec_single_context
    self._handle_dbapi_exception(
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 2363, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
    self.dialect.do_execute(
  File "/home/dlopez/dev/galaxy/.venv/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 952, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedFunction) operator does not exist: boolean = integer
LINE 1: DELETE FROM kombu_message WHERE visible = 0
                                                ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.

[SQL: DELETE FROM kombu_message WHERE visible = 0]
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
