### PR TITLE
[26.0] Add missing TLS support for FTP configurations in templates

### DIFF
--- a/lib/galaxy/files/templates/examples/production_ftp.yml
+++ b/lib/galaxy/files/templates/examples/production_ftp.yml
@@ -41,3 +41,58 @@
       help: |
         Password to connect to FTP server with. Leave this blank to connect
         to the server anonymously (if allowed by target server).
+
+- id: ftp
+  version: 1
+  name: FTP Server
+  description: |
+    Setup connections to FTP and FTPS servers to download and upload files.
+    Enable TLS to secure the connection with encryption (FTPS).
+  configuration:
+    type: ftp
+    host: "{{ variables.host }}"
+    user: "{{ variables.user }}"
+    port: "{{ variables.port }}"
+    passwd: "{{ secrets.password }}"
+    writable: "{{ variables.writable }}"
+    tls: "{{ variables.tls }}"
+  variables:
+    host:
+      label: FTP Host
+      type: string
+      help: Host of FTP Server to connect to.
+    user:
+      label: FTP User
+      type: string
+      optional: true
+      help: |
+        Username to connect with. Leave this blank to connect to the server
+        anonymously (if allowed by target server).
+    writable:
+      label: Writable?
+      type: boolean
+      optional: true
+      default: false
+      help: Is this an FTP server you have permission to write to?
+    port:
+      label: FTP Port
+      type: integer
+      help: Port used to connect to the FTP server.
+      optional: true
+      default: 21
+    tls:
+      label: Use TLS (FTPS)?
+      type: boolean
+      optional: true
+      default: false
+      help: |
+        Enable TLS encryption for the FTP connection (FTPS). When enabled,
+        the connection will be secured using explicit TLS. If your server
+        uses implicit FTPS, you may also need to change the port to 990.
+  secrets:
+    password:
+      label: FTP Password
+      optional: true
+      help: |
+        Password to connect to FTP server with. Leave this blank to connect
+        to the server anonymously (if allowed by target server).

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -142,6 +142,7 @@ class FtpFileSourceTemplateConfiguration(StrictModel):
     user: Optional[Union[str, TemplateExpansion]] = None
     passwd: Optional[Union[str, TemplateExpansion]] = None
     writable: Union[bool, TemplateExpansion] = False
+    tls: Union[bool, TemplateExpansion] = False
     template_start: Optional[str] = None
     template_end: Optional[str] = None
 
@@ -153,6 +154,7 @@ class FtpFileSourceConfiguration(StrictModel):
     user: Optional[str] = None
     passwd: Optional[str] = None
     writable: bool = False
+    tls: bool = False
 
 
 class AzureFileSourceTemplateConfiguration(StrictModel):


### PR DESCRIPTION
The FTP file source supports SFTP by enabling TLS, but the config option was not available in the template.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Use the new template and enable TLS

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
