### PR TITLE
[26.0] Fix repository sort order so incremental tool shed search updates work

### DIFF
--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -1087,7 +1087,7 @@ def get_repository_metadata(session, repository_id):
     stmt = (
         select(RepositoryMetadata)
         .where(RepositoryMetadata.repository_id == repository_id)
-        .order_by(RepositoryMetadata.changeset_revision, RepositoryMetadata.update_time.desc())  # type: ignore[attr-defined]  # mapped attribute
+        .order_by(RepositoryMetadata.changeset_revision, RepositoryMetadata.update_time.desc())
     )
     return session.scalars(stmt)
 

--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -201,13 +201,16 @@ def load_one_dir(path):
 
 def get_repositories_for_indexing(session):
     # Do not index deleted, deprecated, or "tool_dependency_definition" type repositories.
+    # Order by last_updated_time so the build_index incremental fast path can
+    # break out as soon as it encounters an already-indexed repo with a
+    # matching full_last_updated stamp.
     Repository = model.Repository
     stmt = (
         select(Repository)
         .where(Repository.deleted == false())
         .where(Repository.deprecated == false())
         .where(Repository.type != "tool_dependency_definition")
-        .order_by(Repository.update_time.desc())
+        .order_by(Repository.last_updated_time.desc())
     )
     return session.scalars(stmt)
 

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -387,13 +387,14 @@ class Repository(Base, Dictifiable):
     user = relationship("User", back_populates="active_repositories")
     downloadable_revisions = relationship(
         "RepositoryMetadata",
-        primaryjoin=lambda: (Repository.id == RepositoryMetadata.repository_id) & (RepositoryMetadata.downloadable == true()),  # type: ignore[has-type]
+        primaryjoin=lambda: (Repository.id == RepositoryMetadata.repository_id)
+        & (RepositoryMetadata.downloadable == true()),
         viewonly=True,
-        order_by=lambda: desc(RepositoryMetadata.update_time),  # type: ignore[attr-defined]
+        order_by=lambda: desc(RepositoryMetadata.update_time),
     )
     metadata_revisions = relationship(
         "RepositoryMetadata",
-        order_by=lambda: desc(RepositoryMetadata.update_time),  # type: ignore[attr-defined]
+        order_by=lambda: desc(RepositoryMetadata.update_time),
         back_populates="repository",
     )
     roles = relationship("RepositoryRoleAssociation", back_populates="repository")
@@ -702,10 +703,26 @@ class Tag(Base):
 
 
 class RepositoryMetadata(Dictifiable):
-    repository: "Repository"
+    # Annotations only — runtime attributes are installed by
+    # mapper_registry.map_imperatively below.
+    id: Mapped[Optional[int]]
+    create_time: Mapped[Optional[datetime]]
+    update_time: Mapped[Optional[datetime]]
+    repository_id: Mapped[Optional[int]]
+    changeset_revision: Mapped[Optional[str]]
+    numeric_revision: Mapped[Optional[int]]
+    metadata: Mapped[Any]
+    tool_versions: Mapped[Any]
+    malicious: Mapped[Optional[bool]]
+    downloadable: Mapped[Optional[bool]]
+    missing_test_components: Mapped[Optional[bool]]
+    has_repository_dependencies: Mapped[Optional[bool]]
+    includes_datatypes: Mapped[Optional[bool]]
+    includes_tools: Mapped[Optional[bool]]
+    includes_tool_dependencies: Mapped[Optional[bool]]
+    includes_workflows: Mapped[Optional[bool]]
+    repository: Mapped["Repository"]
 
-    # Once the class has been mapped, all Column items in this table will be available
-    # as instrumented class attributes on RepositoryMetadata.
     table = Table(
         "repository_metadata",
         mapper_registry.metadata,

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -24,8 +24,10 @@ from sqlalchemy import (
     DateTime,
     desc,
     ForeignKey,
+    func,
     Integer,
     not_,
+    select,
     String,
     Table,
     text,
@@ -33,6 +35,7 @@ from sqlalchemy import (
     true,
     UniqueConstraint,
 )
+from sqlalchemy.ext import hybrid
 from sqlalchemy.orm import (
     Mapped,
     mapped_column,
@@ -436,11 +439,24 @@ class Repository(Base, Dictifiable):
         self.name = self.name or "Unnamed repository"
         self.user = user
 
-    @property
+    @hybrid.hybrid_property
     def last_updated_time(self):
         if downloadable_revisions := self.downloadable_revisions:
             return downloadable_revisions[0].create_time
         return self.create_time
+
+    @last_updated_time.expression  # type: ignore[no-redef]
+    def last_updated_time(cls):
+        last_revision_create_time = (
+            select(RepositoryMetadata.create_time)
+            .where(RepositoryMetadata.repository_id == cls.id)
+            .where(RepositoryMetadata.downloadable == true())
+            .order_by(RepositoryMetadata.update_time.desc())
+            .limit(1)
+            .correlate(cls)
+            .scalar_subquery()
+        )
+        return func.coalesce(last_revision_create_time, cls.create_time)
 
     @property
     def hg_repo(self):

--- a/test/unit/tool_shed/test_shed_index.py
+++ b/test/unit/tool_shed/test_shed_index.py
@@ -91,12 +91,10 @@ def test_get_repositories_for_indexing_orders_by_last_revision_create_time(shed_
     base = datetime(2026, 1, 1, 12, 0, 0)
     rm_a = RepositoryMetadata(repository_id=repo_a.id, changeset_revision="a", downloadable=True)
     rm_b = RepositoryMetadata(repository_id=repo_b.id, changeset_revision="b", downloadable=True)
-    # setattr — RepositoryMetadata is imperatively mapped, so create_time /
-    # update_time aren't visible to the static type checker.
-    setattr(rm_a, "create_time", base)
-    setattr(rm_a, "update_time", base)
-    setattr(rm_b, "create_time", base + timedelta(hours=1))
-    setattr(rm_b, "update_time", base + timedelta(hours=1))
+    rm_a.create_time = base
+    rm_a.update_time = base
+    rm_b.create_time = base + timedelta(hours=1)
+    rm_b.update_time = base + timedelta(hours=1)
     session.add_all([rm_a, rm_b])
     # Make repo_a's row look "recently updated" — under the old ORDER BY this
     # surfaced repo_a first even though repo_b has the newer downloadable

--- a/test/unit/tool_shed/test_shed_index.py
+++ b/test/unit/tool_shed/test_shed_index.py
@@ -1,11 +1,27 @@
 import os
 import shutil
 import tempfile
+from datetime import (
+    datetime,
+    timedelta,
+)
 
 import pytest
 from whoosh import index
 
-from tool_shed.util.shed_index import build_index
+from tool_shed.util.shed_index import (
+    build_index,
+    get_repositories_for_indexing,
+)
+from tool_shed.webapp.model import (
+    RepositoryMetadata,
+    User,
+)
+from ._util import (
+    random_name,
+    repository_fixture,
+    TestToolShedApp,
+)
 
 COMMUNITY_FILES_DIR = os.path.join(os.path.dirname(__file__), "data", "toolshed_community_files")
 
@@ -60,3 +76,34 @@ def test_build_index(whoosh_index_dir):
     )
     assert repos_indexed == 1
     assert tools_indexed == 1
+
+
+def test_get_repositories_for_indexing_orders_by_last_revision_create_time(shed_app: TestToolShedApp, new_user: User):
+    # Regression test: the incremental fast path in build_index breaks out of
+    # the loop as soon as it sees an already-indexed repo whose stored
+    # full_last_updated matches Repository.last_updated_time. That requires the
+    # ORDER BY to track last_updated_time, not Repository.update_time (which
+    # is bumped by unrelated row changes such as times_downloaded).
+    session = shed_app.model.session
+    repo_a = repository_fixture(shed_app, new_user, random_name())
+    repo_b = repository_fixture(shed_app, new_user, random_name())
+
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    rm_a = RepositoryMetadata(repository_id=repo_a.id, changeset_revision="a", downloadable=True)
+    rm_b = RepositoryMetadata(repository_id=repo_b.id, changeset_revision="b", downloadable=True)
+    # setattr — RepositoryMetadata is imperatively mapped, so create_time /
+    # update_time aren't visible to the static type checker.
+    setattr(rm_a, "create_time", base)
+    setattr(rm_a, "update_time", base)
+    setattr(rm_b, "create_time", base + timedelta(hours=1))
+    setattr(rm_b, "update_time", base + timedelta(hours=1))
+    session.add_all([rm_a, rm_b])
+    # Make repo_a's row look "recently updated" — under the old ORDER BY this
+    # surfaced repo_a first even though repo_b has the newer downloadable
+    # revision.
+    repo_a.update_time = base + timedelta(days=1)
+    repo_b.update_time = base
+    session.flush()
+
+    ids = [r.id for r in get_repositories_for_indexing(session)]
+    assert ids.index(repo_b.id) < ids.index(repo_a.id)


### PR DESCRIPTION
`build_index` relies on iterating repositories in descending freshness
order so it can break out of the loop as soon as it sees an
already-indexed repo whose `full_last_updated` stamp matches. The stamp
is derived from `Repository.last_updated_time` (the create_time of the
most-recently-updated downloadable RepositoryMetadata, falling back to
the repo's own create_time), but the ORDER BY was on
`Repository.update_time`, which is bumped by unrelated row changes such
as `times_downloaded`. Any download bump on an indexed repo would float
it to the top, match its stamp, and silently truncate the rest of the
incremental index pass.

Promote `Repository.last_updated_time` to a `hybrid_property` with a SQL
expression that mirrors the Python branch, and order by it directly so
sort key and comparison key can't drift apart.

Thanks for the diagnosis (https://github.com/galaxyproject/galaxy/pull/22650) @bgruening

6f8e001853ff89e099db774fbda75c683ed5a6c6 adds type hints so we avoid the type ignores.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
