### PR TITLE
[26.0] Fix workflow rerun for unset optional data inputs

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -176,9 +176,18 @@ const formInputs = computed(() => {
                         if (stepType === "data_input" || stepType === "data_collection_input") {
                             // Note: This is different from workflow landings because `WorkflowInvocationRequestModel`
                             //       does not provide an object with `values` property.
-                            stepAsInput.value = {
-                                values: !Array.isArray(value) ? [value] : value,
-                            };
+                            // Optional data inputs left empty on the original run come back as `null` (or
+                            // arrays containing `null`). Filter those out so we don't poison FormData with
+                            // `{values: [null]}`, which crashes its `onMounted` hook on `"src" in null` and
+                            // leaves the bad wrapper in formData to be sent to the server.
+                            const valuesArray = (Array.isArray(value) ? value : [value]).filter(
+                                (v) => v !== null && v !== undefined,
+                            );
+                            if (valuesArray.length > 0) {
+                                stepAsInput.value = {
+                                    values: valuesArray,
+                                };
+                            }
                         } else {
                             stepAsInput.value = value;
                         }

--- a/lib/galaxy_test/selenium/test_workflow_rerun.py
+++ b/lib/galaxy_test/selenium/test_workflow_rerun.py
@@ -1,4 +1,7 @@
-from galaxy_test.base.workflow_fixtures import WORKFLOW_SIMPLE_CAT_TWICE
+from galaxy_test.base.workflow_fixtures import (
+    WORKFLOW_OPTIONAL_TRUE_INPUT_DATA,
+    WORKFLOW_SIMPLE_CAT_TWICE,
+)
 from .framework import (
     managed_history,
     retry_assertion_during_transitions,
@@ -135,6 +138,46 @@ class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows
         invocations.invocation_tab(label="Inputs").wait_for_and_click()
         self._assert_input_table_has_parameter("bool_param", "true")
         self.screenshot("workflow_rerun_boolean_inputs_tab")
+
+    @selenium_test
+    @managed_history
+    def test_workflow_rerun_with_unset_optional_data_input(self):
+        """Regression test for workflow rerun crashing when an optional data_input was left empty.
+
+        When a workflow has an optional ``data_input`` step that the user did
+        not provide on the original run, ``WorkflowInvocationRequestModel.inputs``
+        returns ``null`` for that step. WorkflowRunFormSimple.vue used to wrap
+        the value as ``{values: [null]}`` regardless, which crashed the
+        ``FormData`` mounted hook on ``"src" in null``. Because the mounted
+        hook never completed, the bad wrapper survived in formData and was
+        sent to the server, which rejected it with a ``DataOrCollectionRequest``
+        union ValidationError ("Extra inputs are not permitted in 'values'").
+        Reported on a "1 or 2 haplotypes" workflow where the second haplotype
+        was left empty.
+        """
+        invocations = self.components.invocations
+
+        # Upload one HDA so the history isn't empty (the workflow form needs a
+        # current history); the optional input is intentionally left unselected.
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.wait_for_history()
+        self.workflow_run_open_workflow(WORKFLOW_OPTIONAL_TRUE_INPUT_DATA)
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.workflow_run_wait_for_ok(hid=2, expand=True)
+
+        # Submitting lands us on the new invocation page; click rerun directly.
+        invocations.state_details.wait_for_visible()
+        invocations.workflow_rerun_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        # Submit the rerun without touching anything. Pre-fix this raises a
+        # "Workflow submission failed: ... 'values' not permitted ..." toast
+        # because formData carries the poisoned `{values: [null]}` wrapper.
+        self.workflow_run_submit()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.workflow_run_wait_for_ok(hid=3, expand=True)
+        self.screenshot("workflow_rerun_unset_optional_data_input_submitted")
 
     @retry_assertion_during_transitions
     def _assert_input_table_has_parameter(self, label: str, value: str):


### PR DESCRIPTION
Fixes
<img width="2480" height="698" alt="image" src="https://github.com/user-attachments/assets/28c85238-e5f8-41d5-ba7c-a1cafc586734" />


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
