### PR TITLE
[25.1] Do not resolve symlinks at tool load time

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1025,7 +1025,7 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
         tool_dir: Optional[StrPath] = None,
     ):
         """Load a tool from the config named by `config_file`"""
-        self.config_file = os.path.realpath(config_file) if config_file else None
+        self.config_file = config_file
         # Determine the full path of the directory where the tool config is
         if self.config_file is not None:
             tool_dir = tool_dir or os.path.dirname(self.config_file)

--- a/test/functional/tools/for_tours/filtering.py
+++ b/test/functional/tools/for_tours/filtering.py
@@ -1,0 +1,1 @@
+../../../../tools/stats/filtering.py


### PR DESCRIPTION
Galaxy is now constructing the tool config path with `os.path.realpath` at load time, which freezes `${__tool_directory__}` to the resolved physical directory and breaks for admins who deploy tool updates via atomic symlink swaps. They needed to reboot Galaxy otherwise the symlink target change had no effect. If pulsar needs canonical paths, we should resolve it on the pulsar side, not in the Galaxy tool layer.

Restores prior behavior by reverting: https://github.com/galaxyproject/galaxy/commit/20b691b7cd#diff-17974c8048767aa536063088ba97dbc9c4475e7589002c3b2335f9e8490fc920L1019

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
