### PR TITLE
Standardize on LoadingSpan, retire BSpinner usages

### DIFF
--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faCopy, faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BCard, BNav, BNavItem, BSpinner } from "bootstrap-vue";
+import { BAlert, BButton, BCard, BNav, BNavItem } from "bootstrap-vue";
 import { computed, onMounted, onUpdated, ref, toRef } from "vue";
 
 import { getCitations } from "@/components/Citation/services";
@@ -15,6 +15,7 @@ import { Cite } from "./cite";
 import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import CitationItem from "@/components/Citation/CitationItem.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const outputFormats = Object.freeze({
     CITATION: "bibliography",
@@ -132,8 +133,7 @@ function citationsToBibtexAsText() {
         <BreadcrumbHeading :items="breadcrumbItems" />
 
         <div v-if="isLoading" class="text-center">
-            <BSpinner />
-            <p class="ml-2">Loading references...</p>
+            <LoadingSpan message="Loading references" />
         </div>
         <div v-else>
             <BCard v-if="!simple" class="citation-card" header-tag="nav">

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -2,7 +2,7 @@
 import { faBars, faCog, faDatabase, faSave, faTable } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import axios from "axios";
-import { BAlert, BSpinner } from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
@@ -255,7 +255,7 @@ async function saveAttrs() {
 
                 <DbKeyProvider v-slot="{ item, loading }">
                     <div v-if="loading">
-                        <BSpinner label="Loading Database/Builds..." />
+                        <LoadingSpan message="Loading Database/Builds" />
                     </div>
                     <div v-else>
                         <DatabaseEditTab

--- a/client/src/components/Common/IdleLoad.vue
+++ b/client/src/components/Common/IdleLoad.vue
@@ -3,8 +3,9 @@
 // in order to not slow down the rendering of parent components,
 // or the responsiveness of the UI
 
-import { BSpinner } from "bootstrap-vue";
 import { onMounted, ref } from "vue";
+
+import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const props = defineProps<{
     spinner?: boolean;
@@ -26,7 +27,7 @@ onMounted(() => {
 <template>
     <div class="idle-load" :class="{ center: props.center && !render }">
         <slot v-if="render"></slot>
-        <BSpinner v-else-if="props.spinner"></BSpinner>
+        <LoadingSpan v-else-if="props.spinner" spinner-only />
     </div>
 </template>
 

--- a/client/src/components/ConfigTemplates/ConfigurationTestItem.vue
+++ b/client/src/components/ConfigTemplates/ConfigurationTestItem.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
 import { faCheckSquare, faSquare, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BListGroupItem, BSpinner } from "bootstrap-vue";
+import { BListGroupItem } from "bootstrap-vue";
 
 import type { PluginAspectStatus } from "@/api/configTemplates";
+
+import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Props {
     status?: PluginAspectStatus;
@@ -14,7 +16,7 @@ defineProps<Props>();
 
 <template>
     <BListGroupItem href="#" class="d-flex align-items-center">
-        <BSpinner v-if="status == undefined" class="mr-3" label="Testing...."></BSpinner>
+        <LoadingSpan v-if="status == undefined" classes="mr-3" message="Testing" />
         <FontAwesomeIcon v-else-if="status?.state == 'ok'" class="mr-3 text-success" :icon="faCheckSquare" size="lg" />
         <FontAwesomeIcon v-else-if="status?.state == 'not_ok'" class="mr-3 text-warning" :icon="faTimes" size="lg" />
         <FontAwesomeIcon v-else-if="status?.state == 'unknown'" class="mr-3 text-info" :icon="faSquare" size="lg" />

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -40,8 +40,7 @@
             @row-select="onRowSelect">
             <template v-slot:empty>
                 <div v-if="isBusy" class="text-center my-2">
-                    <BSpinner class="align-middle" />
-                    <strong>Loading...</strong>
+                    <LoadingSpan classes="align-middle" />
                 </div>
                 <div v-else class="empty-folder-message">
                     This folder is either empty or you do not have proper access permissions to see the contents. If you
@@ -228,9 +227,7 @@
             <BRow align-v="center" class="justify-content-md-center">
                 <BCol md="auto">
                     <div v-if="isBusy">
-                        <BSpinner small type="grow" />
-                        <BSpinner small type="grow" />
-                        <BSpinner small type="grow" />
+                        <LoadingSpan />
                     </div>
                     <BPagination
                         v-else
@@ -276,7 +273,7 @@ import {
     faUsers,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BButton, BCol, BContainer, BFormInput, BLink, BPagination, BRow, BSpinner } from "bootstrap-vue";
+import { BButton, BCol, BContainer, BFormInput, BLink, BPagination, BRow } from "bootstrap-vue";
 import purify from "dompurify";
 import linkifyHtml from "linkify-html";
 import { mapState } from "pinia";
@@ -293,6 +290,7 @@ import { fields } from "./table-fields";
 
 import FolderTopBar from "./TopToolbar/FolderTopBar.vue";
 import GTable from "@/components/Common/GTable.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 import UtcDate from "@/components/UtcDate.vue";
 
 function initialFolderState() {
@@ -315,10 +313,10 @@ export default {
         BLink,
         BPagination,
         BRow,
-        BSpinner,
         FolderTopBar,
         FontAwesomeIcon,
         GTable,
+        LoadingSpan,
         UtcDate,
     },
     beforeRouteUpdate(to, from, next) {

--- a/client/src/components/LoadingSpan.vue
+++ b/client/src/components/LoadingSpan.vue
@@ -1,3 +1,8 @@
+<!--
+    Galaxy's standard inline loading spinner. Use this for "this small thing is loading"
+    UI states. For full-screen overlay loaders use LoadingOverlay; for button-with-spinner
+    UI use Common/ButtonSpinner. Do not use bootstrap-vue's BSpinner -- migrate to this.
+-->
 <template>
     <span>
         <span :class="spinnerClasses" title="loading"></span>

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -3,7 +3,7 @@ import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { faCheckSquare, faMinusSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
 import { faCaretLeft, faCheck, faFolder, faSpinner, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BLink, BPagination, BSpinner, BTable } from "bootstrap-vue";
+import { BAlert, BButton, BLink, BPagination, BTable } from "bootstrap-vue";
 import { computed, ref, watch } from "vue";
 
 import { type ItemsProvider, SELECTION_STATES, type SelectionState } from "@/components/SelectionDialog/selectionTypes";
@@ -14,6 +14,7 @@ import type { FieldEntry, SelectionItem } from "./selectionTypes";
 import GModal from "../BaseComponents/GModal.vue";
 import Heading from "../Common/Heading.vue";
 import FilterMenu from "@/components/Common/FilterMenu.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
 import DataDialogSearch from "@/components/SelectionDialog/DataDialogSearch.vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
@@ -262,9 +263,7 @@ defineExpose({
                     </template>
                 </BTable>
                 <div v-if="isBusy" class="text-center">
-                    <BSpinner small type="grow" />
-                    <BSpinner small type="grow" />
-                    <BSpinner small type="grow" />
+                    <LoadingSpan />
                 </div>
                 <div v-else-if="totalItems === 0">
                     <div v-if="filter">


### PR DESCRIPTION
Galaxy already has LoadingSpan as its de-facto inline loading spinner -- 145 files use it. Six stragglers were still pulling in bootstrap-vue's BSpinner for the same job. This sweep converts those to LoadingSpan and adds a short top-of-file note in `LoadingSpan.vue` documenting it as the canonical Galaxy spinner so the next contributor reaches for it. One more bootstrap-vue dependency dropped from these files; same direction as the GAlert/GButton/GDropdown/GPopover sweeps.

## What changed

- `Citation/CitationsList.vue` -- `<BSpinner />` + sibling `<p>Loading references...</p>` collapsed into a single `<LoadingSpan message="Loading references" />`.
- `Common/IdleLoad.vue` -- `<BSpinner v-else-if=...>` becomes `<LoadingSpan v-else-if=... spinner-only />`.
- `Collections/common/CollectionEditView.vue` -- `<BSpinner label="Loading Database/Builds..." />` -> `<LoadingSpan message="Loading Database/Builds" />` (LoadingSpan adds the blinking dots).
- `ConfigTemplates/ConfigurationTestItem.vue` -- `<BSpinner class=\"mr-3\" label=\"Testing....\" />` -> `<LoadingSpan classes=\"mr-3\" message=\"Testing\" />`.
- `Libraries/LibraryFolder/LibraryFolder.vue` -- two changes: the empty-state `<BSpinner class=\"align-middle\" />` + sibling `<strong>Loading...</strong>` becomes a single `<LoadingSpan classes=\"align-middle\" />`, and the three `<BSpinner small type=\"grow\" />` pagination loaders collapse into one `<LoadingSpan />`.
- `SelectionDialog/SelectionDialog.vue` -- same three-grow-spinner pattern collapsed into one `<LoadingSpan />`.
- `LoadingSpan.vue` -- top-of-file SFC comment added pointing future contributors here and away from BSpinner.

6 files, 11 element instances. `grep -rE \"<BSpinner|BSpinner,\" --include='*.vue' client/src` is now zero.

## Visual diff note

The three-dots `type=\"grow\"` clusters in `SelectionDialog` and `LibraryFolder` become a single `fa-spinner` with blinking dots. Visually different but functionally equivalent (\"something is loading\"). Eyeball if needed -- LoadingSpan's blinking-dots affordance preserves the loading intent.

## Test plan

- [x] `pnpm eslint --quiet --fix` clean
- [x] `pnpm format` clean
- [x] `pnpm type-check` clean
- [x] `pnpm test` -- 340 files, 2013 tests, 0 failures
- [x] `grep -rE \"<BSpinner|BSpinner,\" --include='*.vue' client/src` returns 0
- [ ] Visual smoke check on `SelectionDialog` and `LibraryFolder` empty/loading states (reviewer welcome to confirm in dev server)