### PR TITLE
[26.0] Fix missing router in GTN integration

### DIFF
--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -29,6 +29,7 @@ export class GalaxyApp {
         this.data = {};
         this.data.create = (...args) => create(this, ...args);
         this.data.dialog = (...args) => dialog(this, ...args);
+        this.router = null;
     }
 
     _processOptions(options) {

--- a/client/src/entry/analysis/index.ts
+++ b/client/src/entry/analysis/index.ts
@@ -26,6 +26,9 @@ window.addEventListener("load", async () => {
 
     // Build router
     const router = getRouter(Galaxy);
+    // Keep router available on the global app object for legacy integrations
+    // such as webhooks that are injected outside of Vue component context.
+    Galaxy.router = router;
 
     // Initialize globals
     await initSentry(Galaxy, router);


### PR DESCRIPTION
Fixes #22535

The router used in the GTN webhook was missing, so the tool links were broken.

We should probably follow up on dev further refactoring the GalaxyApp and related code to Typescript to catch these issues earlier.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
