### PR TITLE
Don't install data table entries for non-DM tool installs

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -191,9 +191,7 @@ class InstallRepositoryManager:
             # so they're separated from admin-configured loc files at tool_data_path root.
             shed_loc_dir = os.path.join(self.app.config.tool_data_path, "shed")
             os.makedirs(shed_loc_dir, exist_ok=True)
-            tool_util.copy_sample_files(
-                shed_loc_dir, tool_index_sample_files, tool_path=tool_path
-            )
+            tool_util.copy_sample_files(shed_loc_dir, tool_index_sample_files, tool_path=tool_path)
             sample_files_copied = [str(s) for s in tool_index_sample_files]
             repository_tools_tups = irmm.get_repository_tools_tups()
             if repository_tools_tups:

--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -170,7 +170,8 @@ class InstallRepositoryManager:
         session.add(tool_shed_repository)
         session.commit()
 
-        if "sample_files" in irmm_metadata_dict:
+        is_data_manager = "data_manager" in irmm_metadata_dict
+        if is_data_manager and "sample_files" in irmm_metadata_dict:
             sample_files = irmm_metadata_dict.get("sample_files", [])
             tool_index_sample_files = stdtm.get_tool_index_sample_files(sample_files)
             tool_data_table_conf_filename, tool_data_table_elems = stdtm.install_tool_data_tables(
@@ -191,10 +192,11 @@ class InstallRepositoryManager:
             sample_files_copied = [str(s) for s in tool_index_sample_files]
             repository_tools_tups = irmm.get_repository_tools_tups()
             if repository_tools_tups:
-                # Handle missing data table entries for tool parameters that are dynamically generated select lists.
-                repository_tools_tups = stdtm.handle_missing_data_table_entry(
-                    relative_install_dir, tool_path, repository_tools_tups
-                )
+                if is_data_manager:
+                    # Only Data Manager repos register data tables on install.
+                    repository_tools_tups = stdtm.handle_missing_data_table_entry(
+                        relative_install_dir, tool_path, repository_tools_tups
+                    )
                 # Handle missing index files for tool parameters that are dynamically generated select lists.
                 repository_tools_tups, sample_files_copied = tool_util.handle_missing_index_file(
                     self.app, tool_path, sample_files, repository_tools_tups, sample_files_copied

--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -171,7 +171,7 @@ class InstallRepositoryManager:
         session.commit()
 
         is_data_manager = "data_manager" in irmm_metadata_dict
-        if is_data_manager and "sample_files" in irmm_metadata_dict:
+        if "sample_files" in irmm_metadata_dict:
             sample_files = irmm_metadata_dict.get("sample_files", [])
             tool_index_sample_files = stdtm.get_tool_index_sample_files(sample_files)
             tool_data_table_conf_filename, tool_data_table_elems = stdtm.install_tool_data_tables(

--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -188,6 +188,8 @@ class InstallRepositoryManager:
             sample_files = irmm_metadata_dict.get("sample_files", [])
             tool_index_sample_files = stdtm.get_tool_index_sample_files(sample_files)
             tool_data_path = self.app.config.tool_data_path
+            # Used to be created as a side effect of install_tool_data_tables; that no longer runs for non-DM repos.
+            os.makedirs(tool_data_path, exist_ok=True)
             tool_util.copy_sample_files(tool_data_path, tool_index_sample_files, tool_path=tool_path)
             sample_files_copied = [str(s) for s in tool_index_sample_files]
             repository_tools_tups = irmm.get_repository_tools_tups()

--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -187,10 +187,13 @@ class InstallRepositoryManager:
             )
             sample_files = irmm_metadata_dict.get("sample_files", [])
             tool_index_sample_files = stdtm.get_tool_index_sample_files(sample_files)
-            tool_data_path = self.app.config.tool_data_path
-            # Used to be created as a side effect of install_tool_data_tables; that no longer runs for non-DM repos.
-            os.makedirs(tool_data_path, exist_ok=True)
-            tool_util.copy_sample_files(tool_data_path, tool_index_sample_files, tool_path=tool_path)
+            # Galaxy-managed loc files for shed-installed tools live under tool_data_path/shed/
+            # so they're separated from admin-configured loc files at tool_data_path root.
+            shed_loc_dir = os.path.join(self.app.config.tool_data_path, "shed")
+            os.makedirs(shed_loc_dir, exist_ok=True)
+            tool_util.copy_sample_files(
+                shed_loc_dir, tool_index_sample_files, tool_path=tool_path
+            )
             sample_files_copied = [str(s) for s in tool_index_sample_files]
             repository_tools_tups = irmm.get_repository_tools_tups()
             if repository_tools_tups:
@@ -203,10 +206,9 @@ class InstallRepositoryManager:
                 repository_tools_tups, sample_files_copied = tool_util.handle_missing_index_file(
                     self.app, tool_path, sample_files, repository_tools_tups, sample_files_copied
                 )
-                # Copy remaining sample files included in the repository to the ~/tool-data directory of the
-                # local Galaxy instance.
+                # Copy remaining sample files included in the repository to the shed loc dir.
                 tool_util.copy_sample_files(
-                    tool_data_path, sample_files, tool_path=tool_path, sample_files_copied=sample_files_copied
+                    shed_loc_dir, sample_files, tool_path=tool_path, sample_files_copied=sample_files_copied
                 )
                 self.tpm.add_to_tool_panel(
                     repository_name=tool_shed_repository.name,

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -8,10 +8,7 @@ from typing import (
 
 from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.util import hg_util
-from galaxy.tool_util.data import (
-    DataTableColumnMismatch,
-    DataTableFileConflict,
-)
+from galaxy.tool_util.data import DataTableColumnMismatch
 from galaxy.util import (
     Element,
     SubElement,
@@ -219,16 +216,14 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             if elem.tag != "table":
                 kept_elems.append(elem)
                 continue
-            candidate_file_paths: list[str] = []
             for file_elem in elem.findall("file"):
                 path = file_elem.get("path", None)
                 if path:
                     new_path = os.path.normpath(os.path.join(shared_loc_dir, os.path.split(path)[1]))
                     file_elem.set("path", new_path)
-                    candidate_file_paths.append(new_path)
             table_name = elem.get("name") or ""
             incoming_columns = _parse_table_columns(elem)
-            self.app.tool_data_tables.assert_data_table_consistency(table_name, incoming_columns, candidate_file_paths)
+            self.app.tool_data_tables.assert_data_table_consistency(table_name, incoming_columns)
             existing = registered_tables.get(table_name) if table_name else None
             if existing is not None and getattr(existing, "columns", None) is not None:
                 # Already registered with matching columns; skip to avoid duplicate <table> entry.
@@ -251,7 +246,6 @@ ToolDataTableManager = ShedToolDataTableManager
 
 __all__ = (
     "DataTableColumnMismatch",
-    "DataTableFileConflict",
     "ToolDataTableManager",
     "ShedToolDataTableManager",
 )

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -171,14 +171,41 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
         )
         for file_elem in elem.findall("file"):
             shared_path = file_elem.get("path")
-            basename = os.path.basename(shared_path) if shared_path else None
-            source_loc_sample = loc_basename_to_source.get(basename) if basename else None
+            if not shared_path:
+                continue
+            self._register_shared_loc_with_existing_table(existing_table, shared_path, elem)
+            basename = os.path.basename(shared_path)
+            source_loc_sample = loc_basename_to_source.get(basename)
             if not source_loc_sample or not os.path.exists(source_loc_sample):
                 continue
             # Keep `${__HERE__}` literal so the appended rows match the shared loc's existing format.
             new_rows = existing_table.parse_file_fields(source_loc_sample, here="${__HERE__}")
             if new_rows:
                 existing_table.append_entries_with_attribution(new_rows, attribution)
+
+    def _register_shared_loc_with_existing_table(
+        self,
+        existing_table: TabularToolDataTable,
+        shared_path: str,
+        elem: Element,
+    ) -> None:
+        """Make the shared loc file path known to the existing table's ``filenames``.
+
+        Without this, Data Manager persist calls can't locate a destination loc file
+        when the table was first registered from a shipped or refgenie config that has
+        no tabular ``<file>`` entry (e.g. ``__dbkeys__``).
+        """
+        if shared_path in existing_table.filenames:
+            return
+        existing_table.filenames[shared_path] = dict(
+            found=os.path.exists(shared_path),
+            filename=shared_path,
+            from_shed_config=True,
+            tool_data_path=self.app.config.tool_data_path,
+            config_element=elem,
+            tool_shed_repository=None,
+            errors=[],
+        )
 
     def install_tool_data_tables(self, tool_shed_repository: "ToolShedRepository", tool_index_sample_files):
         TOOL_DATA_TABLE_FILE_NAME = "tool_data_table_conf.xml"

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -8,6 +8,10 @@ from typing import (
 
 from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.util import hg_util
+from galaxy.tool_util.data import (
+    DataTableColumnMismatch,
+    DataTableFileConflict,
+)
 from galaxy.util import (
     Element,
     SubElement,
@@ -23,6 +27,16 @@ log = logging.getLogger(__name__)
 
 
 RequiredAppT = Union["BasicSharedApp", InstallationTarget]
+
+
+def _parse_table_columns(table_elem: Element) -> dict[str, int]:
+    """Parse a ``<table>`` element's column spec into a name->index mapping."""
+    from galaxy.tool_util.data import TabularToolDataTable
+
+    columns, _, _ = TabularToolDataTable.parse_column_spec_element(table_elem)
+    if "value" in columns and "name" not in columns:
+        columns["name"] = columns["value"]
+    return columns
 
 
 class BaseShedToolDataTableManager:
@@ -151,28 +165,36 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
         TOOL_DATA_TABLE_FILE_SAMPLE_NAME = f"{TOOL_DATA_TABLE_FILE_NAME}.sample"
         SAMPLE_SUFFIX = ".sample"
         SAMPLE_SUFFIX_OFFSET = -len(SAMPLE_SUFFIX)
+        LOC_SAMPLE_SUFFIX = ".loc.sample"
         target_dir, tool_path, relative_target_dir = self.get_target_install_dir(tool_shed_repository)
+        # .loc files are shared across DM revisions: install at the root of tool_data_path.
+        shared_loc_dir = self.app.config.tool_data_path
         for sample_file in tool_index_sample_files:
             path, filename = os.path.split(sample_file)
             target_filename = filename
             if target_filename.endswith(SAMPLE_SUFFIX):
                 target_filename = target_filename[:SAMPLE_SUFFIX_OFFSET]
             source_file = os.path.join(tool_path, sample_file)
+            if filename.endswith(LOC_SAMPLE_SUFFIX):
+                target_path_filename = os.path.join(shared_loc_dir, target_filename)
+                install_dest_dir = shared_loc_dir
+            else:
+                target_path_filename = os.path.join(target_dir, target_filename)
+                install_dest_dir = target_dir
             # We're not currently uninstalling index files, do not overwrite existing files.
-            target_path_filename = os.path.join(target_dir, target_filename)
             if not os.path.exists(target_path_filename) or target_filename == TOOL_DATA_TABLE_FILE_NAME:
                 shutil.copy2(source_file, target_path_filename)
             else:
                 log.debug(
                     "Did not copy sample file '%s' to install directory '%s' because file already exists.",
                     filename,
-                    target_dir,
+                    install_dest_dir,
                 )
             # For provenance and to simplify introspection, let's keep the original data table sample file around.
             if filename == TOOL_DATA_TABLE_FILE_SAMPLE_NAME:
                 shutil.copy2(source_file, os.path.join(target_dir, filename))
         tool_data_table_conf_filename = os.path.join(target_dir, TOOL_DATA_TABLE_FILE_NAME)
-        elems = []
+        elems: list = []
         if os.path.exists(tool_data_table_conf_filename):
             tree, error_message = xml_util.parse_xml(tool_data_table_conf_filename)
             if tree:
@@ -191,20 +213,36 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
                 tool_data_table_conf_filename,
                 TOOL_DATA_TABLE_FILE_SAMPLE_NAME,
             )
+        registered_tables = self.app.tool_data_tables.data_tables
+        kept_elems: list = []
         for elem in elems:
-            if elem.tag == "table":
-                for file_elem in elem.findall("file"):
-                    path = file_elem.get("path", None)
-                    if path:
-                        file_elem.set("path", os.path.normpath(os.path.join(target_dir, os.path.split(path)[1])))
-                # Store repository info in the table tag set for trace-ability.
-                self.generate_repository_info_elem_from_repository(tool_shed_repository, parent_elem=elem)
-        if elems:
+            if elem.tag != "table":
+                kept_elems.append(elem)
+                continue
+            candidate_file_paths: list[str] = []
+            for file_elem in elem.findall("file"):
+                path = file_elem.get("path", None)
+                if path:
+                    new_path = os.path.normpath(os.path.join(shared_loc_dir, os.path.split(path)[1]))
+                    file_elem.set("path", new_path)
+                    candidate_file_paths.append(new_path)
+            table_name = elem.get("name") or ""
+            incoming_columns = _parse_table_columns(elem)
+            self.app.tool_data_tables.assert_data_table_consistency(table_name, incoming_columns, candidate_file_paths)
+            existing = registered_tables.get(table_name) if table_name else None
+            if existing is not None and getattr(existing, "columns", None) is not None:
+                # Already registered with matching columns; skip to avoid duplicate <table> entry.
+                continue
+            # Store repository info in the table tag set for trace-ability.
+            self.generate_repository_info_elem_from_repository(tool_shed_repository, parent_elem=elem)
+            kept_elems.append(elem)
+        if kept_elems:
             # Remove old data_table
-            os.unlink(tool_data_table_conf_filename)
+            if os.path.exists(tool_data_table_conf_filename):
+                os.unlink(tool_data_table_conf_filename)
             # Persist new data_table content.
-            self.app.tool_data_tables.to_xml_file(tool_data_table_conf_filename, elems)
-        return tool_data_table_conf_filename, elems
+            self.app.tool_data_tables.to_xml_file(tool_data_table_conf_filename, kept_elems)
+        return tool_data_table_conf_filename, kept_elems
 
 
 # For backwards compatibility with exisiting data managers
@@ -212,6 +250,8 @@ ToolDataTableManager = ShedToolDataTableManager
 
 
 __all__ = (
+    "DataTableColumnMismatch",
+    "DataTableFileConflict",
     "ToolDataTableManager",
     "ShedToolDataTableManager",
 )

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -8,7 +8,10 @@ from typing import (
 
 from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.util import hg_util
-from galaxy.tool_util.data import DataTableColumnMismatch
+from galaxy.tool_util.data import (
+    DataTableColumnMismatch,
+    TabularToolDataTable,
+)
 from galaxy.util import (
     Element,
     SubElement,
@@ -28,8 +31,6 @@ RequiredAppT = Union["BasicSharedApp", InstallationTarget]
 
 def _parse_table_columns(table_elem: Element) -> dict[str, int]:
     """Parse a ``<table>`` element's column spec into a name->index mapping."""
-    from galaxy.tool_util.data import TabularToolDataTable
-
     columns, _, _ = TabularToolDataTable.parse_column_spec_element(table_elem)
     if "value" in columns and "name" not in columns:
         columns["name"] = columns["value"]
@@ -157,6 +158,28 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             os.makedirs(target_dir)
         return target_dir, tool_path, relative_target_dir
 
+    def _merge_loc_sample_entries(
+        self,
+        existing_table: TabularToolDataTable,
+        elem: Element,
+        loc_basename_to_source: dict,
+        tool_shed_repository: "ToolShedRepository",
+    ) -> None:
+        attribution = (
+            f"Added by {tool_shed_repository.owner}/{tool_shed_repository.name}"
+            f"@{tool_shed_repository.installed_changeset_revision}"
+        )
+        for file_elem in elem.findall("file"):
+            shared_path = file_elem.get("path")
+            basename = os.path.basename(shared_path) if shared_path else None
+            source_loc_sample = loc_basename_to_source.get(basename) if basename else None
+            if not source_loc_sample or not os.path.exists(source_loc_sample):
+                continue
+            # Keep `${__HERE__}` literal so the appended rows match the shared loc's existing format.
+            new_rows = existing_table.parse_file_fields(source_loc_sample, here="${__HERE__}")
+            if new_rows:
+                existing_table.append_entries_with_attribution(new_rows, attribution)
+
     def install_tool_data_tables(self, tool_shed_repository: "ToolShedRepository", tool_index_sample_files):
         TOOL_DATA_TABLE_FILE_NAME = "tool_data_table_conf.xml"
         TOOL_DATA_TABLE_FILE_SAMPLE_NAME = f"{TOOL_DATA_TABLE_FILE_NAME}.sample"
@@ -164,8 +187,10 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
         SAMPLE_SUFFIX_OFFSET = -len(SAMPLE_SUFFIX)
         LOC_SAMPLE_SUFFIX = ".loc.sample"
         target_dir, tool_path, relative_target_dir = self.get_target_install_dir(tool_shed_repository)
-        # .loc files are shared across DM revisions: install at the root of tool_data_path.
+        # .loc files are shared across repository installations: install at the root of tool_data_path.
         shared_loc_dir = self.app.config.tool_data_path
+        # Map shared loc basename -> source .loc.sample, used to merge entries when a table is reinstalled.
+        loc_basename_to_source: dict[str, str] = {}
         for sample_file in tool_index_sample_files:
             path, filename = os.path.split(sample_file)
             target_filename = filename
@@ -175,6 +200,7 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             if filename.endswith(LOC_SAMPLE_SUFFIX):
                 target_path_filename = os.path.join(shared_loc_dir, target_filename)
                 install_dest_dir = shared_loc_dir
+                loc_basename_to_source[target_filename] = source_file
             else:
                 target_path_filename = os.path.join(target_dir, target_filename)
                 install_dest_dir = target_dir
@@ -225,11 +251,11 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             incoming_columns = _parse_table_columns(elem)
             self.app.tool_data_tables.assert_data_table_consistency(table_name, incoming_columns)
             existing = registered_tables.get(table_name) if table_name else None
-            if existing is not None and getattr(existing, "columns", None) is not None:
-                # Already registered with matching columns; skip to avoid duplicate <table> entry.
+            if isinstance(existing, TabularToolDataTable) and existing.columns is not None:
+                # Already registered with matching columns. Merge any rows from this install's
+                # .loc.sample(s) into the shared loc file, then skip adding a duplicate <table>.
+                self._merge_loc_sample_entries(existing, elem, loc_basename_to_source, tool_shed_repository)
                 continue
-            # Store repository info in the table tag set for trace-ability.
-            self.generate_repository_info_elem_from_repository(tool_shed_repository, parent_elem=elem)
             kept_elems.append(elem)
         if kept_elems:
             # Remove old data_table

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -165,6 +165,15 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
         loc_basename_to_source: dict,
         tool_shed_repository: "ToolShedRepository",
     ) -> None:
+        """Append any non-comment rows from this install's .loc.sample files to the shared loc file,
+        attributing them to the installing repository. 99% of .loc.sample files are empty/comments,
+        in which case this is a no-op.
+
+        Skipped for non-tabular table types (e.g. ``RefgenieToolDataTable``) whose
+        ``parse_file_fields`` is not designed to read a ``.loc.sample``.
+        """
+        if getattr(existing_table, "type_key", "tabular") != "tabular":
+            return
         attribution = (
             f"Added by {tool_shed_repository.owner}/{tool_shed_repository.name}"
             f"@{tool_shed_repository.installed_changeset_revision}"
@@ -173,7 +182,6 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             shared_path = file_elem.get("path")
             if not shared_path:
                 continue
-            self._register_shared_loc_with_existing_table(existing_table, shared_path, elem)
             basename = os.path.basename(shared_path)
             source_loc_sample = loc_basename_to_source.get(basename)
             if not source_loc_sample or not os.path.exists(source_loc_sample):
@@ -183,29 +191,33 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             if new_rows:
                 existing_table.append_entries_with_attribution(new_rows, attribution)
 
-    def _register_shared_loc_with_existing_table(
-        self,
-        existing_table: TabularToolDataTable,
-        shared_path: str,
-        elem: Element,
-    ) -> None:
-        """Make the shared loc file path known to the existing table's ``filenames``.
+    def _shed_config_has_matching_entry(self, table_name: str, elem: Element) -> bool:
+        """Return True if ``shed_tool_data_table_config`` already has a ``<table>`` with the same
+        ``name`` and identical set of ``<file path>`` entries as ``elem``.
 
-        Without this, Data Manager persist calls can't locate a destination loc file
-        when the table was first registered from a shipped or refgenie config that has
-        no tabular ``<file>`` entry (e.g. ``__dbkeys__``).
+        Used to avoid writing duplicate ``<table>`` entries for tables that have already been
+        registered by a prior install. The shed config remains the persistent source of the
+        shared loc file's association with the data table name — on reload, ``merge_tool_data_table``
+        re-applies the filename info to the in-memory table.
         """
-        if shared_path in existing_table.filenames:
-            return
-        existing_table.filenames[shared_path] = dict(
-            found=os.path.exists(shared_path),
-            filename=shared_path,
-            from_shed_config=True,
-            tool_data_path=self.app.config.tool_data_path,
-            config_element=elem,
-            tool_shed_repository=None,
-            errors=[],
-        )
+        config = self.app.config.shed_tool_data_table_config
+        if not config or not os.path.exists(config):
+            return False
+        try:
+            tree, _ = xml_util.parse_xml(config)
+        except OSError as e:
+            log.warning("Could not read shed_tool_data_table_config '%s' for dedup check: %s", config, e)
+            return False
+        if tree is None:
+            return False
+        elem_paths = {fe.get("path") for fe in elem.findall("file") if fe.get("path")}
+        for existing_elem in tree.getroot().findall("table"):
+            if existing_elem.get("name") != table_name:
+                continue
+            existing_paths = {fe.get("path") for fe in existing_elem.findall("file") if fe.get("path")}
+            if elem_paths == existing_paths:
+                return True
+        return False
 
     def install_tool_data_tables(self, tool_shed_repository: "ToolShedRepository", tool_index_sample_files):
         TOOL_DATA_TABLE_FILE_NAME = "tool_data_table_conf.xml"
@@ -214,8 +226,11 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
         SAMPLE_SUFFIX_OFFSET = -len(SAMPLE_SUFFIX)
         LOC_SAMPLE_SUFFIX = ".loc.sample"
         target_dir, tool_path, relative_target_dir = self.get_target_install_dir(tool_shed_repository)
-        # .loc files are shared across repository installations: install at the root of tool_data_path.
-        shared_loc_dir = self.app.config.tool_data_path
+        # Galaxy-managed loc files for shed-installed tools live under tool_data_path/shed/ so they
+        # are clearly separated from admin-configured loc files in tool_data_path and from any
+        # entries shipped via tool_data_table_conf.xml.sample.
+        shared_loc_dir = os.path.join(self.app.config.tool_data_path, "shed")
+        os.makedirs(shared_loc_dir, exist_ok=True)
         # Map shared loc basename -> source .loc.sample, used to merge entries when a table is reinstalled.
         loc_basename_to_source: dict[str, str] = {}
         for sample_file in tool_index_sample_files:
@@ -280,9 +295,12 @@ class ShedToolDataTableManager(BaseShedToolDataTableManager):
             existing = registered_tables.get(table_name) if table_name else None
             if isinstance(existing, TabularToolDataTable) and existing.columns is not None:
                 # Already registered with matching columns. Merge any rows from this install's
-                # .loc.sample(s) into the shared loc file, then skip adding a duplicate <table>.
+                # .loc.sample(s) into the shared loc file.
                 self._merge_loc_sample_entries(existing, elem, loc_basename_to_source, tool_shed_repository)
-                continue
+                if self._shed_config_has_matching_entry(table_name, elem):
+                    # An identical <table> entry already exists in shed_tool_data_table_config.
+                    # Don't write another one (it would just duplicate the shared loc reference).
+                    continue
             kept_elems.append(elem)
         if kept_elems:
             # Remove old data_table

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -684,6 +684,7 @@ class TabularToolDataTable(ToolDataTable):
                     source_repo_info_model = source.repo_info
                 source_repo_info = source_repo_info_model.model_dump() if source_repo_info_model else None
         filename = default
+        shared_fallback: Optional[str] = None
         for name, value in self.filenames.items():
             repo_info = value.get("tool_shed_repository")
             if (not source_repo_info and not repo_info) or (
@@ -691,6 +692,14 @@ class TabularToolDataTable(ToolDataTable):
             ):
                 filename = name
                 break
+            if source_repo_info and not repo_info and shared_fallback is None:
+                # Loc file registered without repo_info (shared install) — use as fallback
+                # when a tool-shed source has no exact match. Preserves legacy behavior where
+                # a `<tool_shed_repository>`-tagged filename matches exactly.
+                shared_fallback = name
+        else:
+            if shared_fallback is not None:
+                filename = shared_fallback
         return filename
 
     def _add_entry(
@@ -761,6 +770,62 @@ class TabularToolDataTable(ToolDataTable):
                         raise
                 fields_collapsed = f"{self.separator.join(fields)}\n"
                 data_table_fh.write(fields_collapsed.encode("utf-8"))
+
+    def append_entries_with_attribution(
+        self,
+        entries: List[List[str]],
+        attribution: str,
+        allow_duplicates: bool = False,
+    ) -> int:
+        """Append ``entries`` to this table's loc file with an attribution comment line.
+
+        When ``allow_duplicates`` is False, dedupes entries by the ``value`` column
+        (the table's primary key) against existing in-memory rows and the pending
+        batch. Writes a single ``{comment_char} {attribution}`` line before the first
+        new row. No-op if no rows survive the dedup.
+        """
+        filename: Optional[str] = self.get_filename_for_source(None)
+        if filename is None:
+            for name in self.filenames:
+                filename = name
+                break
+        if filename is None:
+            raise MessageException(f"Unable to determine filename for appending entries to data table '{self.name}'.")
+        value_index = self.columns.get("value", 0)
+        existing_values: Optional[Set[str]] = None
+        if not allow_duplicates:
+            existing_values = {row[value_index] for row in self.data if value_index < len(row)}
+        new_rows: List[List[str]] = []
+        for entry in entries:
+            fields = self._replace_field_separators(list(entry))
+            if self.largest_index >= len(fields):
+                log.warning(
+                    "Skipping fields (%s) for data table '%s': only %d field(s) provided.",
+                    fields,
+                    self.name,
+                    len(fields),
+                )
+                continue
+            if existing_values is not None and fields[value_index] in existing_values:
+                continue
+            new_rows.append(fields)
+            if existing_values is not None:
+                existing_values.add(fields[value_index])
+        if not new_rows:
+            return self._loaded_content_version
+        with FileLock(filename):
+            if os.path.exists(filename) and os.stat(filename).st_size > 0:
+                with open(filename, "rb+") as fh:
+                    fh.seek(-1, 2)
+                    if fh.read(1) not in (b"\n", b"\r"):
+                        fh.write(b"\n")
+            with open(filename, "ab") as fh:
+                fh.write(f"{self.comment_char} {attribution}\n".encode())
+                for fields in new_rows:
+                    fh.write(f"{self.separator.join(fields)}\n".encode())
+        for fields in new_rows:
+            self.data.append(fields)
+        return self._update_version()
 
     def _locate_filename(self, tool_data_file_path, entry_source, bundle_mode):
         if tool_data_file_path is not None:

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -23,7 +23,6 @@ from typing import (
     BinaryIO,
     Callable,
     Dict,
-    Iterable,
     List,
     Optional,
     overload,
@@ -151,28 +150,6 @@ class DataTableColumnMismatch(Exception):
         super().__init__(
             f"Data table {table_name!r} is already registered with columns {existing_columns}, "
             f"refusing to register conflicting columns {incoming_columns}."
-        )
-
-
-class DataTableFileConflict(Exception):
-    """Two data tables with different names reference the same loc file."""
-
-    def __init__(
-        self,
-        path: str,
-        candidate_name: str,
-        candidate_columns: Dict[str, int],
-        existing_name: str,
-        existing_columns: Dict[str, int],
-    ):
-        self.path = path
-        self.candidate_name = candidate_name
-        self.candidate_columns = candidate_columns
-        self.existing_name = existing_name
-        self.existing_columns = existing_columns
-        super().__init__(
-            f"Data table {candidate_name!r} declares loc file {path!r}, but that file is already "
-            f"registered to data table {existing_name!r}."
         )
 
 
@@ -1022,31 +999,13 @@ class ToolDataTableManager(Dictifiable):
         self,
         candidate_name: str,
         candidate_columns: Dict[str, int],
-        candidate_file_paths: Iterable[str],
     ) -> None:
-        """
-        Raise if registering ``candidate_name`` would conflict with current state:
-        an existing table with the same name but different columns, or any
-        ``candidate_file_paths`` already owned by a different table name.
-        """
+        """Raise if ``candidate_name`` is already registered with different columns."""
         existing = self.data_tables.get(candidate_name)
         if existing is not None:
             existing_columns = getattr(existing, "columns", None)
             if existing_columns is not None and existing_columns != candidate_columns:
                 raise DataTableColumnMismatch(candidate_name, existing_columns, candidate_columns)
-        candidate_realpaths = {os.path.realpath(p) for p in candidate_file_paths if p}
-        if not candidate_realpaths:
-            return
-        for other_name, other_table in self.data_tables.items():
-            if other_name == candidate_name:
-                continue
-            other_filenames = getattr(other_table, "filenames", None) or {}
-            for other_path in other_filenames:
-                if os.path.realpath(other_path) in candidate_realpaths:
-                    other_columns = getattr(other_table, "columns", None) or {}
-                    raise DataTableFileConflict(
-                        other_path, candidate_name, candidate_columns, other_name, other_columns
-                    )
 
     def to_dict(
         self, view: str = "collection", value_mapper: Optional[Dict[str, Callable]] = None
@@ -1085,11 +1044,6 @@ class ToolDataTableManager(Dictifiable):
                 other_config_dict=self.other_config_dict,
             )
             table_elems.append(table_elem)
-            self.assert_data_table_consistency(
-                table.name,
-                getattr(table, "columns", {}) or {},
-                getattr(table, "filenames", {}) or {},
-            )
             if table.name not in self.data_tables:
                 self.data_tables[table.name] = table
                 log.debug("Loaded tool data table '%s' from file '%s'", table.name, config_filename)

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -23,6 +23,7 @@ from typing import (
     BinaryIO,
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     overload,
@@ -138,6 +139,41 @@ class FileNameInfoT(TypedDict):
 
 
 LoadInfoT = Tuple[Tuple[Element, Optional[StrPath]], Dict[str, Any]]
+
+
+class DataTableColumnMismatch(Exception):
+    """Two data tables share a name but declare different columns."""
+
+    def __init__(self, table_name: str, existing_columns: Dict[str, int], incoming_columns: Dict[str, int]):
+        self.table_name = table_name
+        self.existing_columns = existing_columns
+        self.incoming_columns = incoming_columns
+        super().__init__(
+            f"Data table {table_name!r} is already registered with columns {existing_columns}, "
+            f"refusing to register conflicting columns {incoming_columns}."
+        )
+
+
+class DataTableFileConflict(Exception):
+    """Two data tables with different names reference the same loc file."""
+
+    def __init__(
+        self,
+        path: str,
+        candidate_name: str,
+        candidate_columns: Dict[str, int],
+        existing_name: str,
+        existing_columns: Dict[str, int],
+    ):
+        self.path = path
+        self.candidate_name = candidate_name
+        self.candidate_columns = candidate_columns
+        self.existing_name = existing_name
+        self.existing_columns = existing_columns
+        super().__init__(
+            f"Data table {candidate_name!r} declares loc file {path!r}, but that file is already "
+            f"registered to data table {existing_name!r}."
+        )
 
 
 class ToolDataTable(Dictifiable):
@@ -516,6 +552,38 @@ class TabularToolDataTable(ToolDataTable):
     def get_version_fields(self):
         return (self._loaded_content_version, self.get_fields())
 
+    @staticmethod
+    def parse_column_spec_element(
+        config_element: Element,
+    ) -> Tuple[Dict[str, int], int, Dict[str, str]]:
+        """
+        Parse column definitions into ``(columns, largest_index, empty_field_values)``.
+        Does not mutate or assert — callers layer their own validation.
+        """
+        columns: Dict[str, int] = {}
+        empty_field_values: Dict[str, str] = {}
+        largest_index = 0
+        columns_elem = config_element.find("columns")
+        if columns_elem is not None:
+            column_names = util.xml_text(columns_elem)
+            for index, name in enumerate(n.strip() for n in column_names.split(",")):
+                columns[name] = index
+                largest_index = index
+        else:
+            for column_elem in config_element.findall("column"):
+                name = column_elem.get("name")
+                index_attr = column_elem.get("index")
+                if name is None or index_attr is None:
+                    continue
+                index = int(index_attr)
+                columns[name] = index
+                if index > largest_index:
+                    largest_index = index
+                empty_field_value = column_elem.get("empty_field_value", None)
+                if empty_field_value is not None:
+                    empty_field_values[name] = empty_field_value
+        return columns, largest_index, empty_field_values
+
     def parse_column_spec(self, config_element: Element) -> None:
         """
         Parse column definitions, which can either be a set of 'column' elements
@@ -525,27 +593,12 @@ class TabularToolDataTable(ToolDataTable):
 
         A column named 'value' is required.
         """
-        self.columns: Dict[str, int] = {}
-        if config_element.find("columns") is not None:
-            column_names = util.xml_text(config_element.find("columns"))
-            column_names = [n.strip() for n in column_names.split(",")]
-            for index, name in enumerate(column_names):
-                self.columns[name] = index
-                self.largest_index = index
-        else:
-            self.largest_index = 0
+        if config_element.find("columns") is None:
             for column_elem in config_element.findall("column"):
-                name = column_elem.get("name")
-                assert name is not None, "Required 'name' attribute missing from column def"
-                index_attr = column_elem.get("index")
-                assert index_attr is not None, "Required 'index' attribute missing from column def"
-                index = int(index_attr)
-                self.columns[name] = index
-                if index > self.largest_index:
-                    self.largest_index = index
-                empty_field_value = column_elem.get("empty_field_value", None)
-                if empty_field_value is not None:
-                    self.empty_field_values[name] = empty_field_value
+                assert column_elem.get("name") is not None, "Required 'name' attribute missing from column def"
+                assert column_elem.get("index") is not None, "Required 'index' attribute missing from column def"
+        self.columns, self.largest_index, parsed_empty_field_values = self.parse_column_spec_element(config_element)
+        self.empty_field_values.update(parsed_empty_field_values)
         assert "value" in self.columns, "Required 'value' column missing from column def"
         if "name" not in self.columns:
             self.columns["name"] = self.columns["value"]
@@ -965,6 +1018,36 @@ class ToolDataTableManager(Dictifiable):
     def get_tables(self) -> Dict[str, "ToolDataTable"]:
         return self.data_tables
 
+    def assert_data_table_consistency(
+        self,
+        candidate_name: str,
+        candidate_columns: Dict[str, int],
+        candidate_file_paths: Iterable[str],
+    ) -> None:
+        """
+        Raise if registering ``candidate_name`` would conflict with current state:
+        an existing table with the same name but different columns, or any
+        ``candidate_file_paths`` already owned by a different table name.
+        """
+        existing = self.data_tables.get(candidate_name)
+        if existing is not None:
+            existing_columns = getattr(existing, "columns", None)
+            if existing_columns is not None and existing_columns != candidate_columns:
+                raise DataTableColumnMismatch(candidate_name, existing_columns, candidate_columns)
+        candidate_realpaths = {os.path.realpath(p) for p in candidate_file_paths if p}
+        if not candidate_realpaths:
+            return
+        for other_name, other_table in self.data_tables.items():
+            if other_name == candidate_name:
+                continue
+            other_filenames = getattr(other_table, "filenames", None) or {}
+            for other_path in other_filenames:
+                if os.path.realpath(other_path) in candidate_realpaths:
+                    other_columns = getattr(other_table, "columns", None) or {}
+                    raise DataTableFileConflict(
+                        other_path, candidate_name, candidate_columns, other_name, other_columns
+                    )
+
     def to_dict(
         self, view: str = "collection", value_mapper: Optional[Dict[str, Callable]] = None
     ) -> Dict[str, Dict[str, Any]]:
@@ -1002,6 +1085,11 @@ class ToolDataTableManager(Dictifiable):
                 other_config_dict=self.other_config_dict,
             )
             table_elems.append(table_elem)
+            self.assert_data_table_consistency(
+                table.name,
+                getattr(table, "columns", {}) or {},
+                getattr(table, "filenames", {}) or {},
+            )
             if table.name not in self.data_tables:
                 self.data_tables[table.name] = table
                 log.debug("Loaded tool data table '%s' from file '%s'", table.name, config_filename)

--- a/lib/tool_shed/test/base/testcase.py
+++ b/lib/tool_shed/test/base/testcase.py
@@ -1709,7 +1709,9 @@ class ShedTestCase(ShedApiTestCase):
                     ), f"The hard-coded Galaxy tool-data directory is missing for the {required_data_table_entry} entry."
                     assert os.path.exists(galaxy_tool_data_dir), "The Galaxy tool-data directory does not exist."
                     # Make sure the loc_file_name was correctly copied into the configured directory location.
-                    configured_file_location = os.path.join(self.tool_data_path, loc_file_name)
+                    # Shed-installed loc files now live under tool_data_path/shed/ to keep them
+                    # separate from admin-configured ones.
+                    configured_file_location = os.path.join(self.tool_data_path, "shed", loc_file_name)
                     assert os.path.isfile(
                         configured_file_location
                     ), f'The expected copied file "{configured_file_location}" is missing.'

--- a/lib/tool_shed/test/base/testcase.py
+++ b/lib/tool_shed/test/base/testcase.py
@@ -1655,18 +1655,6 @@ class ShedTestCase(ShedApiTestCase):
         assert self._installation_client
         self._installation_client.refresh_tool_shed_repository(repo)
 
-    def verify_no_installed_repository_data_table_entries(self, table_names):
-        """Assert that none of ``table_names`` appears in shed_tool_data_table_conf.xml."""
-        shed_tool_data_table_conf = self.shed_tool_data_table_conf
-        if not os.path.exists(shed_tool_data_table_conf):
-            return
-        data_tables, error_message = xml_util.parse_xml(shed_tool_data_table_conf)
-        assert not error_message, f"Failed to parse {shed_tool_data_table_conf}: {error_message}"
-        assert data_tables is not None
-        registered_names = {t.get("name") for t in data_tables.findall("table")}
-        for name in table_names:
-            assert name not in registered_names, f"Unexpected data table entry '{name}' in {shed_tool_data_table_conf}"
-
     def verify_installed_repository_data_table_entries(self, required_data_table_entries):
         # The value of the received required_data_table_entries will be something like: [ 'sam_fa_indexes' ]
         shed_tool_data_table_conf = self.shed_tool_data_table_conf

--- a/lib/tool_shed/test/base/testcase.py
+++ b/lib/tool_shed/test/base/testcase.py
@@ -1655,6 +1655,18 @@ class ShedTestCase(ShedApiTestCase):
         assert self._installation_client
         self._installation_client.refresh_tool_shed_repository(repo)
 
+    def verify_no_installed_repository_data_table_entries(self, table_names):
+        """Assert that none of ``table_names`` appears in shed_tool_data_table_conf.xml."""
+        shed_tool_data_table_conf = self.shed_tool_data_table_conf
+        if not os.path.exists(shed_tool_data_table_conf):
+            return
+        data_tables, error_message = xml_util.parse_xml(shed_tool_data_table_conf)
+        assert not error_message, f"Failed to parse {shed_tool_data_table_conf}: {error_message}"
+        assert data_tables is not None
+        registered_names = {t.get("name") for t in data_tables.findall("table")}
+        for name in table_names:
+            assert name not in registered_names, f"Unexpected data table entry '{name}' in {shed_tool_data_table_conf}"
+
     def verify_installed_repository_data_table_entries(self, required_data_table_entries):
         # The value of the received required_data_table_entries will be something like: [ 'sam_fa_indexes' ]
         shed_tool_data_table_conf = self.shed_tool_data_table_conf

--- a/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
@@ -63,7 +63,5 @@ class TestToolWithToolDependencies(ShedTestCase):
         self.verify_installed_repository_metadata_unchanged(repository_name, common.test_user_1_name)
 
     def test_0025_verify_sample_files(self):
-        """Non-Data-Manager repositories no longer auto-register data tables on install
-        (galaxyproject/galaxy#21448); confirm sam_fa_indexes is absent from
-        shed_tool_data_table_conf.xml."""
-        self.verify_no_installed_repository_data_table_entries(table_names=["sam_fa_indexes"])
+        """Verify that the installed repository populated shed_tool_data_table.xml and the sample files."""
+        self.verify_installed_repository_data_table_entries(required_data_table_entries=["sam_fa_indexes"])

--- a/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
@@ -63,5 +63,7 @@ class TestToolWithToolDependencies(ShedTestCase):
         self.verify_installed_repository_metadata_unchanged(repository_name, common.test_user_1_name)
 
     def test_0025_verify_sample_files(self):
-        """Verify that the installed repository populated shed_tool_data_table.xml and the sample files."""
-        self.verify_installed_repository_data_table_entries(required_data_table_entries=["sam_fa_indexes"])
+        """Non-Data-Manager repositories no longer auto-register data tables on install
+        (galaxyproject/galaxy#21448); confirm sam_fa_indexes is absent from
+        shed_tool_data_table_conf.xml."""
+        self.verify_no_installed_repository_data_table_entries(table_names=["sam_fa_indexes"])

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -68,7 +68,7 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         shipped via tool_data_table_conf.xml.sample). Any <table> entries written to
         shed_tool_data_table_conf.xml have no <tool_shed_repository> sub-element."""
         non_dm_repo = ("devteam", "bwa", "051eba708f43")
-        non_dm_loc_files = {"bwa_index.loc"}
+        non_dm_loc_files = {"bwa_mem_index.loc"}
         self.install_repository(*non_dm_repo)
         shed_loc_dir = os.path.join(self._app.config.tool_data_path, "shed")
         for loc_file in non_dm_loc_files:

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -62,15 +62,27 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         self.install_repository(*repo)
         self.uninstall_repository(*repo)
 
-    def test_non_data_manager_install_skips_data_table_registration(self):
-        """Non-Data-Manager repos must not persist data table entries in shed_tool_data_table_conf.xml."""
+    def test_non_data_manager_install_registers_data_tables_without_repo_info(self):
+        """Non-Data-Manager repos register tables in shed_tool_data_table_conf.xml without the
+        <tool_shed_repository> sub-element, and their loc files land at tool_data_path root."""
         non_dm_repo = ("devteam", "bwa", "051eba708f43")
         non_dm_table_names = {"bwa_indexes", "bwa_mem_indexes"}
         self.install_repository(*non_dm_repo)
         shed_conf = self._app.config.shed_tool_data_table_config
-        registered = {t.get("name") for t in ET.parse(shed_conf).getroot().findall("table")}
-        leaked = non_dm_table_names & registered
-        assert not leaked, f"Unexpected data tables in {shed_conf}: {sorted(leaked)}"
+        table_elems = {t.get("name"): t for t in ET.parse(shed_conf).getroot().findall("table")}
+        missing = non_dm_table_names - table_elems.keys()
+        assert not missing, f"Expected tables not registered in {shed_conf}: {sorted(missing)}"
+        for name in non_dm_table_names:
+            assert (
+                table_elems[name].find("tool_shed_repository") is None
+            ), f"Table {name!r} should not have a <tool_shed_repository> sub-element on new installs"
+            file_elems = table_elems[name].findall("file")
+            assert file_elems, f"Table {name!r} has no <file> entry"
+            for file_elem in file_elems:
+                loc_path = file_elem.get("path") or ""
+                assert loc_path.startswith(
+                    self._app.config.tool_data_path
+                ), f"Loc file for {name!r} not at tool_data_path root: {loc_path}"
 
     def test_repository_update(self):
         response = self._install_repository(revision=REVISION_4, version="0.0.3", allow_upgraded=True)[0]

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -62,27 +62,23 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         self.install_repository(*repo)
         self.uninstall_repository(*repo)
 
-    def test_non_data_manager_install_registers_data_tables_without_repo_info(self):
-        """Non-Data-Manager repos register tables in shed_tool_data_table_conf.xml without the
-        <tool_shed_repository> sub-element, and their loc files land at tool_data_path root."""
+    def test_non_data_manager_install_lands_loc_files_at_tool_data_path(self):
+        """Non-Data-Manager repos install their .loc files to tool_data_path root, and any
+        <table> entries written to shed_tool_data_table_conf.xml have no <tool_shed_repository>
+        sub-element. Tables that already exist in Galaxy's shipped tool_data_table_conf.xml.sample
+        are deduped (not re-added to shed_tool_data_table_conf.xml)."""
         non_dm_repo = ("devteam", "bwa", "051eba708f43")
-        non_dm_table_names = {"bwa_indexes", "bwa_mem_indexes"}
+        non_dm_loc_files = {"bwa_index.loc"}
         self.install_repository(*non_dm_repo)
+        for loc_file in non_dm_loc_files:
+            shared_loc = os.path.join(self._app.config.tool_data_path, loc_file)
+            assert os.path.exists(shared_loc), f"Expected shared loc file at {shared_loc}"
         shed_conf = self._app.config.shed_tool_data_table_config
-        table_elems = {t.get("name"): t for t in ET.parse(shed_conf).getroot().findall("table")}
-        missing = non_dm_table_names - table_elems.keys()
-        assert not missing, f"Expected tables not registered in {shed_conf}: {sorted(missing)}"
-        for name in non_dm_table_names:
-            assert (
-                table_elems[name].find("tool_shed_repository") is None
-            ), f"Table {name!r} should not have a <tool_shed_repository> sub-element on new installs"
-            file_elems = table_elems[name].findall("file")
-            assert file_elems, f"Table {name!r} has no <file> entry"
-            for file_elem in file_elems:
-                loc_path = file_elem.get("path") or ""
-                assert loc_path.startswith(
-                    self._app.config.tool_data_path
-                ), f"Loc file for {name!r} not at tool_data_path root: {loc_path}"
+        if os.path.exists(shed_conf):
+            for table_elem in ET.parse(shed_conf).getroot().findall("table"):
+                assert (
+                    table_elem.find("tool_shed_repository") is None
+                ), f"Table {table_elem.get('name')!r} should not have a <tool_shed_repository> sub-element"
 
     def test_repository_update(self):
         response = self._install_repository(revision=REVISION_4, version="0.0.3", allow_upgraded=True)[0]

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -1,4 +1,5 @@
 import os
+import xml.etree.ElementTree as ET
 from collections import namedtuple
 
 from sqlalchemy import select
@@ -62,13 +63,14 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         self.uninstall_repository(*repo)
 
     def test_non_data_manager_install_skips_data_table_registration(self):
-        """Non-Data-Manager repos must not register data tables on install."""
+        """Non-Data-Manager repos must not persist data table entries in shed_tool_data_table_conf.xml."""
         non_dm_repo = ("devteam", "bwa", "051eba708f43")
         non_dm_table_names = {"bwa_indexes", "bwa_mem_indexes"}
         self.install_repository(*non_dm_repo)
-        registered = set(self._app.tool_data_tables.data_tables.keys())
+        shed_conf = self._app.config.shed_tool_data_table_config
+        registered = {t.get("name") for t in ET.parse(shed_conf).getroot().findall("table")}
         leaked = non_dm_table_names & registered
-        assert not leaked, f"Unexpected data tables registered by non-DM repo: {sorted(leaked)}"
+        assert not leaked, f"Unexpected data tables in {shed_conf}: {sorted(leaked)}"
 
     def test_repository_update(self):
         response = self._install_repository(revision=REVISION_4, version="0.0.3", allow_upgraded=True)[0]

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -62,17 +62,22 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         self.install_repository(*repo)
         self.uninstall_repository(*repo)
 
-    def test_non_data_manager_install_lands_loc_files_at_tool_data_path(self):
-        """Non-Data-Manager repos install their .loc files to tool_data_path root, and any
-        <table> entries written to shed_tool_data_table_conf.xml have no <tool_shed_repository>
-        sub-element. Tables that already exist in Galaxy's shipped tool_data_table_conf.xml.sample
-        are deduped (not re-added to shed_tool_data_table_conf.xml)."""
+    def test_non_data_manager_install_lands_loc_files_under_shed_subdir(self):
+        """Non-Data-Manager repos install their .loc files under tool_data_path/shed/ (keeping them
+        separate from admin-configured loc files at the tool_data_path root and from anything
+        shipped via tool_data_table_conf.xml.sample). Any <table> entries written to
+        shed_tool_data_table_conf.xml have no <tool_shed_repository> sub-element."""
         non_dm_repo = ("devteam", "bwa", "051eba708f43")
         non_dm_loc_files = {"bwa_index.loc"}
         self.install_repository(*non_dm_repo)
+        shed_loc_dir = os.path.join(self._app.config.tool_data_path, "shed")
         for loc_file in non_dm_loc_files:
-            shared_loc = os.path.join(self._app.config.tool_data_path, loc_file)
+            shared_loc = os.path.join(shed_loc_dir, loc_file)
             assert os.path.exists(shared_loc), f"Expected shared loc file at {shared_loc}"
+            # The loc file should NOT also be written at the tool_data_path root.
+            assert not os.path.exists(
+                os.path.join(self._app.config.tool_data_path, loc_file)
+            ), f"Shed loc file should not land at tool_data_path root: {loc_file}"
         shed_conf = self._app.config.shed_tool_data_table_config
         if os.path.exists(shed_conf):
             for table_elem in ET.parse(shed_conf).getroot().findall("table"):

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -61,6 +61,15 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         self.install_repository(*repo)
         self.uninstall_repository(*repo)
 
+    def test_non_data_manager_install_skips_data_table_registration(self):
+        """Non-Data-Manager repos must not register data tables on install."""
+        non_dm_repo = ("devteam", "bwa", "051eba708f43")
+        non_dm_table_names = {"bwa_indexes", "bwa_mem_indexes"}
+        self.install_repository(*non_dm_repo)
+        registered = set(self._app.tool_data_tables.data_tables.keys())
+        leaked = non_dm_table_names & registered
+        assert not leaked, f"Unexpected data tables registered by non-DM repo: {sorted(leaked)}"
+
     def test_repository_update(self):
         response = self._install_repository(revision=REVISION_4, version="0.0.3", allow_upgraded=True)[0]
         assert int(response["ctx_rev"]) >= 4

--- a/test/unit/app/test_galaxy_install.py
+++ b/test/unit/app/test_galaxy_install.py
@@ -43,7 +43,8 @@ def test_against_production_shed(tmp_path: Path):
         assert tool_guid in f.read()
     repo_path = tmp_path / "tools" / "toolshed.g2.bx.psu.edu" / "repos" / repo_owner / repo_name / repo_revision
     assert repo_path.exists()
-    # featurecounts is not a Data Manager — install must not register a per-revision data table config.
+    # All shed installs now register data tables; the per-revision config is written for any repo
+    # with sample files, regardless of whether it's a Data Manager.
     tool_data_table_path = (
         tmp_path
         / "tool_data"
@@ -54,7 +55,7 @@ def test_against_production_shed(tmp_path: Path):
         / repo_revision
         / "tool_data_table_conf.xml"
     )
-    assert not tool_data_table_path.exists()
+    assert tool_data_table_path.exists()
 
     install_model_context = cast("install_model_scoped_session", install_target.install_model.session)
     query = install_model_context.query(ToolShedRepository).where(ToolShedRepository.name == repo_name)

--- a/test/unit/app/test_galaxy_install.py
+++ b/test/unit/app/test_galaxy_install.py
@@ -43,6 +43,7 @@ def test_against_production_shed(tmp_path: Path):
         assert tool_guid in f.read()
     repo_path = tmp_path / "tools" / "toolshed.g2.bx.psu.edu" / "repos" / repo_owner / repo_name / repo_revision
     assert repo_path.exists()
+    # featurecounts is not a Data Manager — install must not register a per-revision data table config.
     tool_data_table_path = (
         tmp_path
         / "tool_data"
@@ -53,7 +54,7 @@ def test_against_production_shed(tmp_path: Path):
         / repo_revision
         / "tool_data_table_conf.xml"
     )
-    assert tool_data_table_path.exists()
+    assert not tool_data_table_path.exists()
 
     install_model_context = cast("install_model_scoped_session", install_target.install_model.session)
     query = install_model_context.query(ToolShedRepository).where(ToolShedRepository.name == repo_name)

--- a/test/unit/tool_shed/test_data_table_manager.py
+++ b/test/unit/tool_shed/test_data_table_manager.py
@@ -205,6 +205,25 @@ def test_second_install_with_empty_loc_sample_does_not_append(tmp_path):
     existing.append_entries_with_attribution.assert_not_called()
 
 
+def test_second_install_registers_shared_loc_with_existing_table(tmp_path):
+    """When merging into an existing table whose ``filenames`` is empty (e.g. refgenie tables
+    or shipped tables whose loc resolution failed), the shared loc path must be registered so
+    Data Managers can persist entries."""
+    stdtm, repo, samples, _, tool_data_path, _, _ = _make_stdtm(tmp_path)
+    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    existing = _registered_table(matching_columns)
+    existing.parse_file_fields.return_value = []
+    stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
+
+    stdtm.install_tool_data_tables(repo, samples)
+
+    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
+    assert shared_loc in existing.filenames
+    info = existing.filenames[shared_loc]
+    assert info["tool_shed_repository"] is None
+    assert info["from_shed_config"] is True
+
+
 def test_parse_table_columns_aliases_name_to_value():
     from galaxy.tool_shed.tools.data_table_manager import _parse_table_columns
 

--- a/test/unit/tool_shed/test_data_table_manager.py
+++ b/test/unit/tool_shed/test_data_table_manager.py
@@ -9,7 +9,10 @@ from galaxy.tool_shed.tools.data_table_manager import (
     DataTableColumnMismatch,
     ShedToolDataTableManager,
 )
-from galaxy.tool_util.data import ToolDataTableManager
+from galaxy.tool_util.data import (
+    TabularToolDataTable,
+    ToolDataTableManager,
+)
 from galaxy.util import (
     Element,
     SubElement,
@@ -80,9 +83,10 @@ def _make_stdtm(tmp_path):
 
 
 def _registered_table(columns, filenames=None):
-    existing = mock.MagicMock(spec=["columns", "filenames"])
+    existing = mock.MagicMock(spec=TabularToolDataTable)
     existing.columns = columns
     existing.filenames = filenames or {}
+    existing.parse_file_fields.return_value = []
     return existing
 
 
@@ -99,6 +103,10 @@ def test_loc_file_lands_at_shared_root_not_per_revision(tmp_path):
     file_elems = list(kept_elems[0].findall("file"))
     assert len(file_elems) == 1
     assert file_elems[0].get("path") == shared_loc
+    # New installs should not stamp a <tool_shed_repository> sub-element on the <table>:
+    # the loc-file location is deterministic and DMs on legacy installs fall through to
+    # the shared-no-repo_info match in get_filename_for_source.
+    assert kept_elems[0].find("tool_shed_repository") is None
 
 
 def test_existing_loc_file_is_not_overwritten(tmp_path):
@@ -161,6 +169,40 @@ def test_column_match_with_column_elements_dedupes(tmp_path):
         ["tool_data_table_conf.xml.sample", os.path.join("tool-data", "all_fasta.loc.sample")],
     )
     assert kept_elems == []
+
+
+def test_second_install_merges_loc_sample_rows_with_attribution(tmp_path):
+    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    existing = _registered_table(matching_columns)
+    incoming_rows = [["hg19", "hg19", "human (hg19)", "/data/hg19.fa"]]
+    existing.parse_file_fields.return_value = incoming_rows
+    stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
+
+    _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
+
+    assert kept_elems == []
+    assert not captured["to_xml_calls"]
+    existing.append_entries_with_attribution.assert_called_once()
+    call_args = existing.append_entries_with_attribution.call_args
+    assert call_args.args[0] == incoming_rows
+    attribution = call_args.args[1]
+    assert "iuc/data_manager_fetch_genome_dbkeys_all_fasta" in attribution
+    assert "abc" in attribution
+
+
+def test_second_install_with_empty_loc_sample_does_not_append(tmp_path):
+    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    existing = _registered_table(matching_columns)
+    existing.parse_file_fields.return_value = []
+    stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
+
+    _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
+
+    assert kept_elems == []
+    assert not captured["to_xml_calls"]
+    existing.append_entries_with_attribution.assert_not_called()
 
 
 def test_parse_table_columns_aliases_name_to_value():

--- a/test/unit/tool_shed/test_data_table_manager.py
+++ b/test/unit/tool_shed/test_data_table_manager.py
@@ -52,6 +52,7 @@ def _make_stdtm(tmp_path):
     repo_dir = str(tmp_path / "repo")
     tool_data_path = str(tmp_path / "tool-data")
     shed_tool_data_path = str(tmp_path / "shed_tool_data")
+    shed_tool_data_table_config = str(tmp_path / "shed_data_table_conf.xml")
     relative_target_dir = "owner/name/abc"
 
     os.makedirs(tool_data_path)
@@ -62,6 +63,7 @@ def _make_stdtm(tmp_path):
     app = mock.MagicMock(name="app")
     app.config.tool_data_path = tool_data_path
     app.config.shed_tool_data_path = shed_tool_data_path
+    app.config.shed_tool_data_table_config = shed_tool_data_table_config
     registry = _FakeTableRegistry()
     app.tool_data_tables = registry
     captured = {"to_xml_calls": registry.to_xml_calls}
@@ -82,20 +84,39 @@ def _make_stdtm(tmp_path):
     return stdtm, repo, sample_files, captured, tool_data_path, shed_tool_data_path, relative_target_dir
 
 
-def _registered_table(columns, filenames=None):
+def _registered_table(columns, filenames=None, type_key="tabular"):
     existing = mock.MagicMock(spec=TabularToolDataTable)
     existing.columns = columns
     existing.filenames = filenames or {}
+    existing.type_key = type_key
     existing.parse_file_fields.return_value = []
     return existing
 
 
-def test_loc_file_lands_at_shared_root_not_per_revision(tmp_path):
+def _write_shed_config_with_entry(stdtm, table_name, file_path):
+    """Pre-populate ``shed_tool_data_table_config`` with a single ``<table>`` matching ``elem``."""
+    shed_config = stdtm.app.config.shed_tool_data_table_config
+    contents = f"""<?xml version="1.0"?>
+<tables>
+    <table name="{table_name}" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="{file_path}" />
+    </table>
+</tables>
+"""
+    with open(shed_config, "w") as fh:
+        fh.write(contents)
+
+
+def test_loc_file_lands_under_shed_subdir_not_per_revision(tmp_path):
     stdtm, repo, samples, captured, tool_data_path, shed_tool_data_path, _ = _make_stdtm(tmp_path)
     _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
 
-    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
+    shared_loc = os.path.join(tool_data_path, "shed", "all_fasta.loc")
     assert os.path.exists(shared_loc)
+    # The loc file does NOT land at the tool_data_path root (which is for admin-configured loc
+    # files) — Galaxy-managed shed loc files are isolated under tool_data_path/shed/.
+    assert not os.path.exists(os.path.join(tool_data_path, "all_fasta.loc"))
     per_rev_loc = os.path.join(shed_tool_data_path, "owner/name/abc", "all_fasta.loc")
     assert not os.path.exists(per_rev_loc)
 
@@ -111,7 +132,8 @@ def test_loc_file_lands_at_shared_root_not_per_revision(tmp_path):
 
 def test_existing_loc_file_is_not_overwritten(tmp_path):
     stdtm, repo, samples, _, tool_data_path, _, _ = _make_stdtm(tmp_path)
-    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
+    shared_loc = os.path.join(tool_data_path, "shed", "all_fasta.loc")
+    os.makedirs(os.path.dirname(shared_loc), exist_ok=True)
     _write(shared_loc, "preexisting DM-populated content\n")
 
     stdtm.install_tool_data_tables(repo, samples)
@@ -132,8 +154,11 @@ def test_column_mismatch_raises(tmp_path):
     assert not captured["to_xml_calls"]
 
 
-def test_column_match_dedupes_without_writing(tmp_path):
-    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+def test_column_match_first_install_writes_table_entry(tmp_path):
+    """When a table is already registered in memory but has not yet been written to
+    ``shed_tool_data_table_config``, we still write a (stamp-less) ``<table>`` entry so the
+    shared loc file's association with the table survives reload."""
+    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
     stdtm.app.tool_data_tables.data_tables = {
         "all_fasta": _registered_table(matching_columns),
@@ -141,12 +166,31 @@ def test_column_match_dedupes_without_writing(tmp_path):
 
     _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
 
+    assert len(kept_elems) == 1
+    file_elems = list(kept_elems[0].findall("file"))
+    assert len(file_elems) == 1
+    assert file_elems[0].get("path") == os.path.join(tool_data_path, "shed", "all_fasta.loc")
+    assert kept_elems[0].find("tool_shed_repository") is None
+
+
+def test_column_match_subsequent_install_dedupes_shed_config_entry(tmp_path):
+    """If shed_tool_data_table_config already has a ``<table>`` with the same name and same
+    ``<file path>``, don't write another one."""
+    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
+    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    stdtm.app.tool_data_tables.data_tables = {
+        "all_fasta": _registered_table(matching_columns),
+    }
+    _write_shed_config_with_entry(stdtm, "all_fasta", os.path.join(tool_data_path, "shed", "all_fasta.loc"))
+
+    _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
+
     assert kept_elems == []
     assert not captured["to_xml_calls"]
 
 
-def test_column_match_with_column_elements_dedupes(tmp_path):
-    stdtm, repo, _, captured, _, _, _ = _make_stdtm(tmp_path)
+def test_column_match_with_column_elements_writes_entry(tmp_path):
+    stdtm, repo, _, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
     column_form_conf = """\
 <tables>
     <table name="all_fasta" comment_char="#">
@@ -168,16 +212,19 @@ def test_column_match_with_column_elements_dedupes(tmp_path):
         repo,
         ["tool_data_table_conf.xml.sample", os.path.join("tool-data", "all_fasta.loc.sample")],
     )
-    assert kept_elems == []
+    assert len(kept_elems) == 1
+    assert kept_elems[0].find("tool_shed_repository") is None
 
 
 def test_second_install_merges_loc_sample_rows_with_attribution(tmp_path):
-    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
     existing = _registered_table(matching_columns)
     incoming_rows = [["hg19", "hg19", "human (hg19)", "/data/hg19.fa"]]
     existing.parse_file_fields.return_value = incoming_rows
     stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
+    # Pre-populate shed config so kept_elems stays empty — we're testing the row-merge path.
+    _write_shed_config_with_entry(stdtm, "all_fasta", os.path.join(tool_data_path, "shed", "all_fasta.loc"))
 
     _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
 
@@ -192,11 +239,12 @@ def test_second_install_merges_loc_sample_rows_with_attribution(tmp_path):
 
 
 def test_second_install_with_empty_loc_sample_does_not_append(tmp_path):
-    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
     existing = _registered_table(matching_columns)
     existing.parse_file_fields.return_value = []
     stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
+    _write_shed_config_with_entry(stdtm, "all_fasta", os.path.join(tool_data_path, "shed", "all_fasta.loc"))
 
     _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
 
@@ -205,23 +253,20 @@ def test_second_install_with_empty_loc_sample_does_not_append(tmp_path):
     existing.append_entries_with_attribution.assert_not_called()
 
 
-def test_second_install_registers_shared_loc_with_existing_table(tmp_path):
-    """When merging into an existing table whose ``filenames`` is empty (e.g. refgenie tables
-    or shipped tables whose loc resolution failed), the shared loc path must be registered so
-    Data Managers can persist entries."""
+def test_merge_skipped_for_non_tabular_table_types(tmp_path):
+    """Refgenie-backed (and other non-tabular) tables don't get their .loc.sample parsed
+    during install — refgenie's ``parse_file_fields`` expects YAML, not a .loc, so calling
+    it on a ``.loc.sample`` is incorrect."""
     stdtm, repo, samples, _, tool_data_path, _, _ = _make_stdtm(tmp_path)
     matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
-    existing = _registered_table(matching_columns)
-    existing.parse_file_fields.return_value = []
+    existing = _registered_table(matching_columns, type_key="refgenie")
     stdtm.app.tool_data_tables.data_tables = {"all_fasta": existing}
+    _write_shed_config_with_entry(stdtm, "all_fasta", os.path.join(tool_data_path, "shed", "all_fasta.loc"))
 
-    stdtm.install_tool_data_tables(repo, samples)
-
-    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
-    assert shared_loc in existing.filenames
-    info = existing.filenames[shared_loc]
-    assert info["tool_shed_repository"] is None
-    assert info["from_shed_config"] is True
+    _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
+    assert kept_elems == []
+    existing.parse_file_fields.assert_not_called()
+    existing.append_entries_with_attribution.assert_not_called()
 
 
 def test_parse_table_columns_aliases_name_to_value():

--- a/test/unit/tool_shed/test_data_table_manager.py
+++ b/test/unit/tool_shed/test_data_table_manager.py
@@ -1,0 +1,191 @@
+"""Unit tests for shed-side data table install behavior."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from galaxy.tool_shed.tools.data_table_manager import (
+    DataTableColumnMismatch,
+    DataTableFileConflict,
+    ShedToolDataTableManager,
+)
+from galaxy.tool_util.data import ToolDataTableManager
+from galaxy.util import (
+    Element,
+    SubElement,
+)
+
+
+class _FakeTableRegistry(ToolDataTableManager):
+    def __init__(self):
+        self.data_tables: dict = {}
+        self.to_xml_calls: list = []
+
+    def to_xml_file(self, shed_tool_data_table_config, new_elems=None, remove_elems=None):
+        self.to_xml_calls.append((shed_tool_data_table_config, new_elems))
+        with open(shed_tool_data_table_config, "wb") as fh:
+            fh.write(b"<tables/>")
+
+
+SAMPLE_TABLE_CONF = """\
+<tables>
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/all_fasta.loc" />
+    </table>
+</tables>
+"""
+
+LOC_SAMPLE_CONTENT = "# all_fasta.loc sample\n"
+
+
+def _write(path: str, contents: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(contents)
+
+
+def _make_stdtm(tmp_path):
+    repo_dir = str(tmp_path / "repo")
+    tool_data_path = str(tmp_path / "tool-data")
+    shed_tool_data_path = str(tmp_path / "shed_tool_data")
+    relative_target_dir = "owner/name/abc"
+
+    os.makedirs(tool_data_path)
+    os.makedirs(os.path.join(shed_tool_data_path, relative_target_dir))
+    _write(os.path.join(repo_dir, "tool_data_table_conf.xml.sample"), SAMPLE_TABLE_CONF)
+    _write(os.path.join(repo_dir, "tool-data", "all_fasta.loc.sample"), LOC_SAMPLE_CONTENT)
+
+    app = mock.MagicMock(name="app")
+    app.config.tool_data_path = tool_data_path
+    app.config.shed_tool_data_path = shed_tool_data_path
+    registry = _FakeTableRegistry()
+    app.tool_data_tables = registry
+    captured = {"to_xml_calls": registry.to_xml_calls}
+
+    stdtm = ShedToolDataTableManager(app)
+
+    repo = mock.MagicMock(name="tool_shed_repository")
+    repo.name = "data_manager_fetch_genome_dbkeys_all_fasta"
+    repo.owner = "iuc"
+    repo.installed_changeset_revision = "abc"
+    repo.tool_shed = "tool-shed"
+    repo.get_tool_relative_path.return_value = (repo_dir, relative_target_dir)
+
+    sample_files = [
+        "tool_data_table_conf.xml.sample",
+        os.path.join("tool-data", "all_fasta.loc.sample"),
+    ]
+    return stdtm, repo, sample_files, captured, tool_data_path, shed_tool_data_path, relative_target_dir
+
+
+def _registered_table(columns, filenames=None):
+    existing = mock.MagicMock(spec=["columns", "filenames"])
+    existing.columns = columns
+    existing.filenames = filenames or {}
+    return existing
+
+
+def test_loc_file_lands_at_shared_root_not_per_revision(tmp_path):
+    stdtm, repo, samples, captured, tool_data_path, shed_tool_data_path, _ = _make_stdtm(tmp_path)
+    _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
+
+    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
+    assert os.path.exists(shared_loc)
+    per_rev_loc = os.path.join(shed_tool_data_path, "owner/name/abc", "all_fasta.loc")
+    assert not os.path.exists(per_rev_loc)
+
+    assert len(kept_elems) == 1
+    file_elems = list(kept_elems[0].findall("file"))
+    assert len(file_elems) == 1
+    assert file_elems[0].get("path") == shared_loc
+
+
+def test_existing_loc_file_is_not_overwritten(tmp_path):
+    stdtm, repo, samples, _, tool_data_path, _, _ = _make_stdtm(tmp_path)
+    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
+    _write(shared_loc, "preexisting DM-populated content\n")
+
+    stdtm.install_tool_data_tables(repo, samples)
+
+    with open(shared_loc) as fh:
+        assert fh.read() == "preexisting DM-populated content\n"
+
+
+def test_column_mismatch_raises(tmp_path):
+    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+    stdtm.app.tool_data_tables.data_tables = {
+        "all_fasta": _registered_table({"value": 0, "name": 1, "path": 2}),
+    }
+
+    with pytest.raises(DataTableColumnMismatch) as exc_info:
+        stdtm.install_tool_data_tables(repo, samples)
+    assert exc_info.value.table_name == "all_fasta"
+    assert not captured["to_xml_calls"]
+
+
+def test_column_match_dedupes_without_writing(tmp_path):
+    stdtm, repo, samples, captured, _, _, _ = _make_stdtm(tmp_path)
+    matching_columns = {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    stdtm.app.tool_data_tables.data_tables = {
+        "all_fasta": _registered_table(matching_columns),
+    }
+
+    _, kept_elems = stdtm.install_tool_data_tables(repo, samples)
+
+    assert kept_elems == []
+    assert not captured["to_xml_calls"]
+
+
+def test_column_match_with_column_elements_dedupes(tmp_path):
+    stdtm, repo, _, captured, _, _, _ = _make_stdtm(tmp_path)
+    column_form_conf = """\
+<tables>
+    <table name="all_fasta" comment_char="#">
+        <column name="value" index="0" />
+        <column name="dbkey" index="1" />
+        <column name="name" index="2" />
+        <column name="path" index="3" />
+        <file path="tool-data/all_fasta.loc" />
+    </table>
+</tables>
+"""
+    repo_dir, _ = repo.get_tool_relative_path.return_value
+    _write(os.path.join(repo_dir, "tool_data_table_conf.xml.sample"), column_form_conf)
+    stdtm.app.tool_data_tables.data_tables = {
+        "all_fasta": _registered_table({"value": 0, "dbkey": 1, "name": 2, "path": 3}),
+    }
+
+    _, kept_elems = stdtm.install_tool_data_tables(
+        repo,
+        ["tool_data_table_conf.xml.sample", os.path.join("tool-data", "all_fasta.loc.sample")],
+    )
+    assert kept_elems == []
+
+
+def test_file_path_conflict_raises(tmp_path):
+    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
+    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
+    stdtm.app.tool_data_tables.data_tables = {
+        "other_table": _registered_table(
+            {"value": 0, "name": 1},
+            filenames={shared_loc: {"found": True}},
+        ),
+    }
+
+    with pytest.raises(DataTableFileConflict) as exc_info:
+        stdtm.install_tool_data_tables(repo, samples)
+    assert exc_info.value.candidate_name == "all_fasta"
+    assert exc_info.value.existing_name == "other_table"
+    assert not captured["to_xml_calls"]
+
+
+def test_parse_table_columns_aliases_name_to_value():
+    from galaxy.tool_shed.tools.data_table_manager import _parse_table_columns
+
+    elem = Element("table")
+    cols = SubElement(elem, "columns")
+    cols.text = "value, path"
+    parsed = _parse_table_columns(elem)
+    assert parsed == {"value": 0, "path": 1, "name": 0}

--- a/test/unit/tool_shed/test_data_table_manager.py
+++ b/test/unit/tool_shed/test_data_table_manager.py
@@ -7,7 +7,6 @@ import pytest
 
 from galaxy.tool_shed.tools.data_table_manager import (
     DataTableColumnMismatch,
-    DataTableFileConflict,
     ShedToolDataTableManager,
 )
 from galaxy.tool_util.data import ToolDataTableManager
@@ -162,23 +161,6 @@ def test_column_match_with_column_elements_dedupes(tmp_path):
         ["tool_data_table_conf.xml.sample", os.path.join("tool-data", "all_fasta.loc.sample")],
     )
     assert kept_elems == []
-
-
-def test_file_path_conflict_raises(tmp_path):
-    stdtm, repo, samples, captured, tool_data_path, _, _ = _make_stdtm(tmp_path)
-    shared_loc = os.path.join(tool_data_path, "all_fasta.loc")
-    stdtm.app.tool_data_tables.data_tables = {
-        "other_table": _registered_table(
-            {"value": 0, "name": 1},
-            filenames={shared_loc: {"found": True}},
-        ),
-    }
-
-    with pytest.raises(DataTableFileConflict) as exc_info:
-        stdtm.install_tool_data_tables(repo, samples)
-    assert exc_info.value.candidate_name == "all_fasta"
-    assert exc_info.value.existing_name == "other_table"
-    assert not captured["to_xml_calls"]
 
 
 def test_parse_table_columns_aliases_name_to_value():

--- a/test/unit/tool_shed/test_install_manager.py
+++ b/test/unit/tool_shed/test_install_manager.py
@@ -1,0 +1,109 @@
+"""Unit tests for install-time data table registration gating."""
+
+from typing import (
+    Any,
+)
+from unittest import mock
+
+from galaxy.tool_shed.galaxy_install import install_manager
+
+INSTALL_MANAGER_MODULE = "galaxy.tool_shed.galaxy_install.install_manager"
+
+
+def _make_install_repository_manager():
+    app = mock.MagicMock(name="app")
+    app.install_model.context = mock.MagicMock(name="session")
+    register_mock = mock.MagicMock(name="add_new_entries_from_config_file")
+    app.tool_data_tables.add_new_entries_from_config_file = register_mock
+    irm = install_manager.InstallRepositoryManager.__new__(install_manager.InstallRepositoryManager)
+    irm.app = app
+    irm.install_model = app.install_model
+    irm.tpm = mock.MagicMock(name="tpm")
+    return irm, register_mock
+
+
+def _invoke_handle(irm, metadata_dict: dict[str, Any], repository_tools_tups: list[Any]):
+    irmm_instance = mock.MagicMock(name="irmm_instance")
+    irmm_instance.get_metadata_dict.return_value = metadata_dict
+    irmm_instance.get_repository_tools_tups.return_value = repository_tools_tups
+
+    stdtm_instance = mock.MagicMock(name="stdtm_instance")
+    stdtm_instance.get_tool_index_sample_files.return_value = []
+    stdtm_instance.install_tool_data_tables.return_value = (
+        "/dev/null/tool_data_table_conf.xml",
+        [object()],
+    )
+    stdtm_instance.handle_missing_data_table_entry.side_effect = lambda *_a, **_k: repository_tools_tups
+
+    patches = [
+        mock.patch(f"{INSTALL_MANAGER_MODULE}.InstalledRepositoryMetadataManager", return_value=irmm_instance),
+        mock.patch(f"{INSTALL_MANAGER_MODULE}.ShedToolDataTableManager", return_value=stdtm_instance),
+        mock.patch(
+            f"{INSTALL_MANAGER_MODULE}.repository_util.get_tool_shed_status_for_installed_repository", return_value=None
+        ),
+        mock.patch(f"{INSTALL_MANAGER_MODULE}.tool_util.copy_sample_files"),
+        mock.patch(
+            f"{INSTALL_MANAGER_MODULE}.tool_util.handle_missing_index_file",
+            side_effect=lambda *_a, **_k: (repository_tools_tups, []),
+        ),
+        mock.patch(f"{INSTALL_MANAGER_MODULE}.data_manager.DataManagerHandler"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        repo = mock.MagicMock(name="tool_shed_repository")
+        repo.changeset_revision = "abc"
+        repo.installed_changeset_revision = "abc"
+        irm._InstallRepositoryManager__handle_repository_contents(
+            tool_shed_repository=repo,
+            tool_path="/tmp/tool_path",
+            repository_clone_url="http://tool-shed/repos/owner/name",
+            relative_install_dir="owner/name/abc",
+            tool_shed="tool-shed",
+            tool_section=None,
+            shed_tool_conf=None,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    return stdtm_instance
+
+
+def test_non_data_manager_repo_skips_sample_files_registration():
+    irm, register_mock = _make_install_repository_manager()
+    stdtm_instance = _invoke_handle(irm, {"sample_files": ["foo.loc.sample"]}, [])
+    stdtm_instance.install_tool_data_tables.assert_not_called()
+    register_mock.assert_not_called()
+
+
+def test_data_manager_repo_registers_sample_files():
+    irm, register_mock = _make_install_repository_manager()
+    metadata = {
+        "sample_files": ["foo.loc.sample"],
+        "tools": [{"id": "t"}],
+        "data_manager": {"data_managers": {}},
+    }
+    fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
+    stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
+    stdtm_instance.install_tool_data_tables.assert_called_once()
+    register_mock.assert_called_once()
+
+
+def test_non_data_manager_repo_skips_handle_missing_data_table_entry():
+    irm, _ = _make_install_repository_manager()
+    metadata = {"tools": [{"id": "t"}], "sample_files": []}
+    fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
+    stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
+    stdtm_instance.handle_missing_data_table_entry.assert_not_called()
+
+
+def test_data_manager_repo_invokes_handle_missing_data_table_entry():
+    irm, _ = _make_install_repository_manager()
+    metadata = {
+        "tools": [{"id": "t"}],
+        "sample_files": [],
+        "data_manager": {"data_managers": {}},
+    }
+    fake_tup = (mock.MagicMock(), "guid", mock.MagicMock())
+    stdtm_instance = _invoke_handle(irm, metadata, [fake_tup])
+    stdtm_instance.handle_missing_data_table_entry.assert_called_once()

--- a/test/unit/tool_shed/test_install_manager.py
+++ b/test/unit/tool_shed/test_install_manager.py
@@ -69,11 +69,11 @@ def _invoke_handle(irm, metadata_dict: dict[str, Any], repository_tools_tups: li
     return stdtm_instance
 
 
-def test_non_data_manager_repo_skips_sample_files_registration():
+def test_non_data_manager_repo_registers_sample_files():
     irm, register_mock = _make_install_repository_manager()
     stdtm_instance = _invoke_handle(irm, {"sample_files": ["foo.loc.sample"]}, [])
-    stdtm_instance.install_tool_data_tables.assert_not_called()
-    register_mock.assert_not_called()
+    stdtm_instance.install_tool_data_tables.assert_called_once()
+    register_mock.assert_called_once()
 
 
 def test_data_manager_repo_registers_sample_files():

--- a/test/unit/tool_util/data/test_tool_data.py
+++ b/test/unit/tool_util/data/test_tool_data.py
@@ -1,7 +1,30 @@
+import pytest
+
+from galaxy.tool_util.data import (
+    DataTableColumnMismatch,
+    DataTableFileConflict,
+)
+
 LOC_ALPHA_CONTENTS_V2 = """
 data1	data1name	${__HERE__}/data1/entry.txt
 data2	data2name	${__HERE__}/data2/entry.txt
 data3	data3name	${__HERE__}/data3/entry.txt
+"""
+
+CONFLICTING_TABLE_CONF_XML = """<tables>
+  <table name="other_table" comment_char="#">
+    <columns>value, name, path</columns>
+    <file path="{loc_path}" />
+  </table>
+</tables>
+"""
+
+COLUMN_DIVERGENT_TABLE_CONF_XML = """<tables>
+  <table name="testalpha" comment_char="#">
+    <columns>value, name, path, extra</columns>
+    <file path="{loc_path}" />
+  </table>
+</tables>
 """
 
 
@@ -60,3 +83,56 @@ def test_to_json(merged_tdt_manager, tmp_path):
     assert not json_path.exists()
     merged_tdt_manager.to_json(json_path)
     assert json_path.exists()
+
+
+def test_assert_data_table_consistency_accepts_new_table(tdt_manager, tmp_path):
+    tdt_manager.assert_data_table_consistency(
+        "brand_new_table",
+        {"value": 0, "name": 1, "path": 2},
+        [str(tmp_path / "brand_new_table.loc")],
+    )
+
+
+def test_assert_data_table_consistency_accepts_matching_redefinition(tdt_manager, tmp_path):
+    existing = tdt_manager["testalpha"]
+    tdt_manager.assert_data_table_consistency(
+        "testalpha",
+        existing.columns,
+        list(existing.filenames),
+    )
+
+
+def test_assert_data_table_consistency_raises_column_mismatch(tdt_manager, tmp_path):
+    with pytest.raises(DataTableColumnMismatch) as exc_info:
+        tdt_manager.assert_data_table_consistency(
+            "testalpha",
+            {"value": 0, "name": 1, "path": 2, "extra": 3},
+            [str(tmp_path / "testalpha.loc")],
+        )
+    assert exc_info.value.table_name == "testalpha"
+
+
+def test_assert_data_table_consistency_raises_file_conflict(tdt_manager, tmp_path):
+    shared_loc = str(tmp_path / "testalpha.loc")
+    with pytest.raises(DataTableFileConflict) as exc_info:
+        tdt_manager.assert_data_table_consistency(
+            "other_table",
+            {"value": 0, "name": 1, "path": 2},
+            [shared_loc],
+        )
+    assert exc_info.value.candidate_name == "other_table"
+    assert exc_info.value.existing_name == "testalpha"
+
+
+def test_load_from_config_file_raises_on_file_path_conflict(tdt_manager, tmp_path):
+    conflicting_conf = tmp_path / "conflict.xml"
+    conflicting_conf.write_text(CONFLICTING_TABLE_CONF_XML.format(loc_path=str(tmp_path / "testalpha.loc")))
+    with pytest.raises(DataTableFileConflict):
+        tdt_manager.load_from_config_file(str(conflicting_conf), str(tmp_path), from_shed_config=True)
+
+
+def test_load_from_config_file_raises_on_column_mismatch_same_name(tdt_manager, tmp_path):
+    column_conflict_conf = tmp_path / "column_conflict.xml"
+    column_conflict_conf.write_text(COLUMN_DIVERGENT_TABLE_CONF_XML.format(loc_path=str(tmp_path / "testalpha.loc")))
+    with pytest.raises(DataTableColumnMismatch):
+        tdt_manager.load_from_config_file(str(column_conflict_conf), str(tmp_path), from_shed_config=True)

--- a/test/unit/tool_util/data/test_tool_data.py
+++ b/test/unit/tool_util/data/test_tool_data.py
@@ -93,3 +93,73 @@ def test_assert_data_table_consistency_raises_column_mismatch(tdt_manager):
             {"value": 0, "name": 1, "path": 2, "extra": 3},
         )
     assert exc_info.value.table_name == "testalpha"
+
+
+def test_get_filename_for_source_falls_back_to_shared_filename(tdt_manager):
+    table = tdt_manager["testalpha"]
+    [shared_filename] = list(table.filenames)
+    assert table.filenames[shared_filename].get("tool_shed_repository") is None
+    source_with_unknown_repo = {
+        "tool_shed": "tool-shed",
+        "repository_name": "repo",
+        "repository_owner": "owner",
+        "installed_changeset_revision": "abc",
+    }
+    assert table.get_filename_for_source(source_with_unknown_repo) == shared_filename
+
+
+def test_get_filename_for_source_prefers_exact_repo_match_over_shared(tdt_manager):
+    table = tdt_manager["testalpha"]
+    [shared_filename] = list(table.filenames)
+    legacy_info = {
+        "tool_shed": "tool-shed",
+        "repository_name": "legacy",
+        "repository_owner": "owner",
+        "installed_changeset_revision": "deadbeef",
+    }
+    legacy_filename = f"{shared_filename}.legacy"
+    table.filenames[legacy_filename] = dict(
+        found=True,
+        filename=legacy_filename,
+        from_shed_config=True,
+        tool_data_path=None,
+        config_element=None,
+        tool_shed_repository=legacy_info,
+        errors=[],
+    )
+    assert table.get_filename_for_source(legacy_info) == legacy_filename
+    other_info = dict(legacy_info, repository_name="unknown")
+    assert table.get_filename_for_source(other_info) == shared_filename
+
+
+def test_append_entries_with_attribution_appends_and_dedupes(tdt_manager):
+    table = tdt_manager["testalpha"]
+    [loc_filename] = list(table.filenames)
+    initial_rows = len(table.data)
+    new_entries = [
+        ["data3", "data3name", "${__HERE__}/data3/entry.txt"],
+        ["data1", "data1name", "${__HERE__}/data1/entry.txt"],  # duplicate, must be skipped
+    ]
+    table.append_entries_with_attribution(new_entries, "added by owner/foo@rev1")
+    with open(loc_filename) as fh:
+        contents = fh.read()
+    assert "# added by owner/foo@rev1" in contents
+    assert contents.count("data3\tdata3name") == 1
+    assert contents.count("data1\tdata1name") == 1
+    assert len(table.data) == initial_rows + 1
+
+
+def test_append_entries_with_attribution_noop_when_all_duplicates(tdt_manager):
+    table = tdt_manager["testalpha"]
+    [loc_filename] = list(table.filenames)
+    with open(loc_filename) as fh:
+        before = fh.read()
+    rows_before = list(table.data)
+    table.append_entries_with_attribution(
+        [["data1", "data1name", "${__HERE__}/data1/entry.txt"]],
+        "added by owner/foo@rev1",
+    )
+    with open(loc_filename) as fh:
+        after = fh.read()
+    assert after == before
+    assert table.data == rows_before

--- a/test/unit/tool_util/data/test_tool_data.py
+++ b/test/unit/tool_util/data/test_tool_data.py
@@ -1,22 +1,11 @@
 import pytest
 
-from galaxy.tool_util.data import (
-    DataTableColumnMismatch,
-    DataTableFileConflict,
-)
+from galaxy.tool_util.data import DataTableColumnMismatch
 
 LOC_ALPHA_CONTENTS_V2 = """
 data1	data1name	${__HERE__}/data1/entry.txt
 data2	data2name	${__HERE__}/data2/entry.txt
 data3	data3name	${__HERE__}/data3/entry.txt
-"""
-
-CONFLICTING_TABLE_CONF_XML = """<tables>
-  <table name="other_table" comment_char="#">
-    <columns>value, name, path</columns>
-    <file path="{loc_path}" />
-  </table>
-</tables>
 """
 
 COLUMN_DIVERGENT_TABLE_CONF_XML = """<tables>
@@ -85,54 +74,22 @@ def test_to_json(merged_tdt_manager, tmp_path):
     assert json_path.exists()
 
 
-def test_assert_data_table_consistency_accepts_new_table(tdt_manager, tmp_path):
+def test_assert_data_table_consistency_accepts_new_table(tdt_manager):
     tdt_manager.assert_data_table_consistency(
         "brand_new_table",
         {"value": 0, "name": 1, "path": 2},
-        [str(tmp_path / "brand_new_table.loc")],
     )
 
 
-def test_assert_data_table_consistency_accepts_matching_redefinition(tdt_manager, tmp_path):
+def test_assert_data_table_consistency_accepts_matching_redefinition(tdt_manager):
     existing = tdt_manager["testalpha"]
-    tdt_manager.assert_data_table_consistency(
-        "testalpha",
-        existing.columns,
-        list(existing.filenames),
-    )
+    tdt_manager.assert_data_table_consistency("testalpha", existing.columns)
 
 
-def test_assert_data_table_consistency_raises_column_mismatch(tdt_manager, tmp_path):
+def test_assert_data_table_consistency_raises_column_mismatch(tdt_manager):
     with pytest.raises(DataTableColumnMismatch) as exc_info:
         tdt_manager.assert_data_table_consistency(
             "testalpha",
             {"value": 0, "name": 1, "path": 2, "extra": 3},
-            [str(tmp_path / "testalpha.loc")],
         )
     assert exc_info.value.table_name == "testalpha"
-
-
-def test_assert_data_table_consistency_raises_file_conflict(tdt_manager, tmp_path):
-    shared_loc = str(tmp_path / "testalpha.loc")
-    with pytest.raises(DataTableFileConflict) as exc_info:
-        tdt_manager.assert_data_table_consistency(
-            "other_table",
-            {"value": 0, "name": 1, "path": 2},
-            [shared_loc],
-        )
-    assert exc_info.value.candidate_name == "other_table"
-    assert exc_info.value.existing_name == "testalpha"
-
-
-def test_load_from_config_file_raises_on_file_path_conflict(tdt_manager, tmp_path):
-    conflicting_conf = tmp_path / "conflict.xml"
-    conflicting_conf.write_text(CONFLICTING_TABLE_CONF_XML.format(loc_path=str(tmp_path / "testalpha.loc")))
-    with pytest.raises(DataTableFileConflict):
-        tdt_manager.load_from_config_file(str(conflicting_conf), str(tmp_path), from_shed_config=True)
-
-
-def test_load_from_config_file_raises_on_column_mismatch_same_name(tdt_manager, tmp_path):
-    column_conflict_conf = tmp_path / "column_conflict.xml"
-    column_conflict_conf.write_text(COLUMN_DIVERGENT_TABLE_CONF_XML.format(loc_path=str(tmp_path / "testalpha.loc")))
-    with pytest.raises(DataTableColumnMismatch):
-        tdt_manager.load_from_config_file(str(column_conflict_conf), str(tmp_path), from_shed_config=True)


### PR DESCRIPTION
This does not make it impossible, it just disables it by default.

Fixes #21448, which also contains rationale. I'll follow up and fix the specific tool that @bernt-matthias mentioned in the issue if it hasn't already been done.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
