### PR TITLE
Migrate Dropbox file source to fsspec

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -254,7 +254,7 @@ class ConditionalDependencies:
     def check_python_irodsclient(self):
         return "irods" in self.object_stores
 
-    def check_fs_dropboxfs(self):
+    def check_dropboxdrivefs(self):
         return "dropbox" in self.file_sources
 
     def check_webdav4(self):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -22,7 +22,7 @@ redis>=5.3.0,<6
 
 # For file sources plugins
 webdav4[fsspec]  # type: webdav
-fs.dropboxfs>=1.0.3  # type: dropbox
+dropboxdrivefs>=1.4.1  # type: dropbox
 fs.sshfs  # type: ssh
 fs.anvilfs # type: anvil
 fs.googledrivefs # type: googledrive

--- a/lib/galaxy/files/sources/dropbox.py
+++ b/lib/galaxy/files/sources/dropbox.py
@@ -1,11 +1,13 @@
 try:
-    from fs.dropboxfs.dropboxfs import DropboxFS
+    from dropboxdrivefs import DropboxDriveFileSystem
 except ImportError:
-    DropboxFS = None
+    DropboxDriveFileSystem = None
 
 
+import posixpath
 from typing import (
     Annotated,
+    Optional,
     Union,
 )
 
@@ -19,12 +21,15 @@ from galaxy.exceptions import (
     MessageException,
 )
 from galaxy.files.models import (
-    BaseFileSourceConfiguration,
-    BaseFileSourceTemplateConfiguration,
     FilesSourceRuntimeContext,
 )
 from galaxy.util.config_templates import TemplateExpansion
-from ._pyfilesystem2 import PyFilesystem2FilesSource
+from ._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
 
 AccessTokenField = Field(
     ...,
@@ -34,38 +39,78 @@ AccessTokenField = Field(
 )
 
 
-class DropboxFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
+class DropboxFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
     access_token: Annotated[Union[str, TemplateExpansion], AccessTokenField]
 
 
-class DropboxFilesSourceConfiguration(BaseFileSourceConfiguration):
+class DropboxFilesSourceConfiguration(FsspecBaseFileSourceConfiguration):
     access_token: Annotated[str, AccessTokenField]
 
 
-class DropboxFilesSource(
-    PyFilesystem2FilesSource[DropboxFileSourceTemplateConfiguration, DropboxFilesSourceConfiguration]
-):
+class DropboxFilesSource(FsspecFilesSource[DropboxFileSourceTemplateConfiguration, DropboxFilesSourceConfiguration]):
     plugin_type = "dropbox"
-    required_module = DropboxFS
-    required_package = "fs.dropboxfs"
+    required_module = DropboxDriveFileSystem
+    required_package = "dropboxdrivefs"
 
     template_config_class = DropboxFileSourceTemplateConfiguration
     resolved_config_class = DropboxFilesSourceConfiguration
 
-    def _open_fs(self, context: FilesSourceRuntimeContext[DropboxFilesSourceConfiguration]):
-        if DropboxFS is None:
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[DropboxFilesSourceConfiguration],
+        _cache_options: CacheOptionsDictType,
+    ):
+        if DropboxDriveFileSystem is None:
             raise self.required_package_exception
 
         try:
-            return DropboxFS(access_token=context.config.access_token)
+            return DropboxDriveFileSystem(token=context.config.access_token)
         except Exception as e:
-            # This plugin might raise dropbox.dropbox_client.BadInputException
-            # which is not a subclass of fs.errors.FSError
             if "OAuth2" in str(e):
                 raise AuthenticationRequired(
                     f"Permission Denied. Reason: {e}. Please check your credentials in your preferences for {self.label}."
                 )
             raise MessageException(f"Error connecting to Dropbox. Reason: {e}")
+
+    def _to_filesystem_path(self, path: str, config: DropboxFilesSourceConfiguration) -> str:
+        if path in ("", "/"):
+            return ""
+        return f"/{path.lstrip('/')}"
+
+    def _adapt_entry_path(self, filesystem_path: str, config: DropboxFilesSourceConfiguration) -> str:
+        if not filesystem_path or filesystem_path == "/":
+            return "/"
+        return filesystem_path if filesystem_path.startswith("/") else f"/{filesystem_path}"
+
+    def _extract_timestamp(self, info: dict) -> Optional[str]:
+        return info.get("server_modified") or info.get("client_modified") or super()._extract_timestamp(info)
+
+    def _write_from(
+        self,
+        target_path: str,
+        native_path: str,
+        context: FilesSourceRuntimeContext[DropboxFilesSourceConfiguration],
+    ):
+        cache_options = self._get_cache_options(context.config)
+        fs = self._open_fs(context, cache_options)
+        target_path = self._to_filesystem_path(target_path, context.config)
+        dirname = posixpath.dirname(target_path)
+        if dirname and dirname != "/":
+            self._ensure_directory(fs, dirname)
+        fs.put_file(native_path, target_path)
+
+    def _ensure_directory(self, fs, dirname: str):
+        current = ""
+        for part in dirname.strip("/").split("/"):
+            current = f"{current}/{part}"
+            if not self._is_directory(fs, current):
+                fs.mkdir(current)
+
+    def _is_directory(self, fs, path: str) -> bool:
+        try:
+            return fs.info(path).get("type") == "directory"
+        except Exception:
+            return False
 
 
 __all__ = ("DropboxFilesSource",)

--- a/test/unit/app/dependencies/test_deps.py
+++ b/test/unit/app/dependencies/test_deps.py
@@ -74,7 +74,7 @@ def test_azure_objectstore_nested_yaml():
 def test_fs_default():
     with _config_context() as cc:
         cds = cc.get_cond_deps()
-        assert not cds.check_fs_dropboxfs()
+        assert not cds.check_dropboxdrivefs()
         assert not cds.check_webdav4()
 
 
@@ -85,7 +85,7 @@ def test_fs_configured():
             "file_sources_config_file": file_sources_conf,
         }
         cds = cc.get_cond_deps(config=config)
-        assert cds.check_fs_dropboxfs()
+        assert cds.check_dropboxdrivefs()
         assert cds.check_webdav4()
 
 

--- a/test/unit/app/managers/test_user_file_sources.py
+++ b/test/unit/app/managers/test_user_file_sources.py
@@ -3,16 +3,9 @@ from typing import (
     cast,
     Optional,
 )
-from unittest import SkipTest
 from uuid import uuid4
 
 import pytest
-from fs.osfs import OSFS
-
-try:
-    from fs.dropboxfs import DropboxFS
-except ImportError:
-    DropboxFS = None
 from requests.exceptions import HTTPError
 from yaml import safe_load
 
@@ -290,8 +283,6 @@ class TestFileSourcesTestCase(BaseTestCase):
         assert get_uuid(user_object.uuid) == get_uuid(uuid)
 
     def test_oauth2_access_token_injection_during_verify(self, tmp_path, monkeypatch):
-        if DropboxFS is None:
-            raise SkipTest("Optional dropbpox dependency not available")
         self._init_dropbox_env(tmp_path, monkeypatch)
 
         uuid = uuid4().hex
@@ -315,24 +306,25 @@ class TestFileSourcesTestCase(BaseTestCase):
         def mock_get_token_from_refresh_raw(refresh_token, client_pair, config):
             return MockResponse(json)
 
-        pyfilesystem_fs_init_kwd = {}
+        fsspec_fs_init_kwd = {}
 
-        class MockDropboxFS(OSFS):
+        class MockDropboxDriveFileSystem:
 
             def __init__(self, **kwd):
-                pyfilesystem_fs_init_kwd.update(kwd)
-                root = tmp_path / "foobar"
-                root.mkdir()
-                super().__init__(root)
+                fsspec_fs_init_kwd.update(kwd)
+
+            def ls(self, path, detail=True):
+                return []
 
         monkeypatch.setattr(config_templates, "get_token_from_refresh_raw", mock_get_token_from_refresh_raw)
-        monkeypatch.setattr(dropbox, "DropboxFS", MockDropboxFS)
+        monkeypatch.setattr(dropbox, "DropboxDriveFileSystem", MockDropboxDriveFileSystem)
+        monkeypatch.setattr(dropbox.DropboxFilesSource, "required_module", MockDropboxDriveFileSystem)
         status = self.manager.plugin_status(self.trans, create_payload)
         assert status.oauth2_access_token_generation
         assert not status.oauth2_access_token_generation.is_not_ok
         assert status.connection
         assert not status.connection.is_not_ok
-        assert pyfilesystem_fs_init_kwd["access_token"] == "my_test_access_token"
+        assert fsspec_fs_init_kwd["token"] == "my_test_access_token"
 
     def test_onedrive_oauth2_flow(self, tmp_path, monkeypatch):
         json = {


### PR DESCRIPTION
Migrates the Galaxy Dropbox file source from the deprecated PyFilesystem2 fs.dropboxfs backend to the fsspec-based dropboxdrivefs.DropboxDriveFileSystem.

The Dropbox file source now inherits from FsspecFilesSource, uses fsspec configuration models, and preserves the existing Galaxy-facing configuration keys and OAuth token aliases. Existing templates and yaml configs that provide oauth2_access_token, accessToken, or access_token continue to work.

Migration sub-issue https://github.com/galaxyproject/galaxy/issues/21865

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
