### PR TITLE
[26.0] Fix webdav file download

### DIFF
--- a/lib/galaxy/files/sources/webdav.py
+++ b/lib/galaxy/files/sources/webdav.py
@@ -6,6 +6,7 @@ except ImportError:
 import tempfile
 from typing import (
     Annotated,
+    Any,
     Optional,
     Union,
 )
@@ -64,6 +65,16 @@ class WebDavFilesSource(PyFilesystem2FilesSource[WebDavFileSourceTemplateConfigu
 
     template_config_class = WebDavFileSourceTemplateConfiguration
     resolved_config_class = WebDavFileSourceConfiguration
+
+    def _serialize_config(self, config: WebDavFileSourceConfiguration) -> dict[str, Any]:
+        result = super()._serialize_config(config)
+        # 'url' is in COMMON_FILE_SOURCE_PROP_NAMES so it is excluded by the base class
+        # _serialize_config. For WebDAV, 'url' is the server endpoint (not a display URL),
+        # so it must be preserved in the serialized form used to reconstruct the plugin on
+        # job runners. Without it, url defaults to None and WebDAVFS raises AttributeError.
+        if config.url is not None:
+            result["url"] = config.url
+        return result
 
     def _open_fs(self, context: FilesSourceRuntimeContext[WebDavFileSourceConfiguration]):
         if WebDAVFS is None:

--- a/test/unit/files/test_webdav.py
+++ b/test/unit/files/test_webdav.py
@@ -120,3 +120,20 @@ def test_serialization_user():
     file_sources = serialize_and_recover(file_sources_o, user_context=user_context)
     res = list_root(file_sources, "gxfiles://test1", recursive=True, user_context=None)
     assert find_file_a(res)
+
+
+@skip_if_no_webdav
+def test_url_preserved_in_serialization():
+    # Regression test: 'url' is in COMMON_FILE_SOURCE_PROP_NAMES and was excluded from
+    # _serialize_config, causing WebDAVFS to be initialized with url=None, which led to
+    # AttributeError: 'NoneType' object has no attribute 'rstrip' when fetching files.
+    file_sources = configured_file_sources(FILE_SOURCES_CONF)
+    fs = file_source_as_webdav(file_sources._file_sources[0])
+
+    serialized = fs.to_dict(for_serialization=True)
+    assert "url" in serialized, "WebDAV url must be preserved in serialized form for job runner reconstruction"
+    assert serialized["url"] == "http://127.0.0.1:7083"
+
+    recovered = serialize_and_recover(file_sources)
+    recovered_fs = file_source_as_webdav(recovered._file_sources[0])
+    assert recovered_fs._get_runtime_context().config.url == "http://127.0.0.1:7083"


### PR DESCRIPTION
Fixes #22681
Forgot to upstream this fix from EU.
This can be dropped when merging forward, since the webdav file source was refactored and migrated to fsspec in #22477

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
