### PR TITLE
Add GAlert component and replace BAlert in exemplar usages

### DIFF
--- a/client/src/components/BaseComponents/GAlert.vue
+++ b/client/src/components/BaseComponents/GAlert.vue
@@ -5,7 +5,7 @@
  * `<div class="alert alert-{variant}">` markup the existing bootstrap CSS expects.
  */
 
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 
 type AlertVariant = "info" | "warning" | "danger" | "success" | "primary" | "secondary" | "light" | "dark";
 
@@ -37,7 +37,20 @@ const emit = defineEmits<{
 
 const variantClass = computed(() => `alert-${props.variant}`);
 
+// Mirror BAlert's localShow behavior so `dismissible` works without a parent
+// handler -- the close button hides the alert locally, and a subsequent
+// `show` prop change re-syncs.
+const localShow = ref<boolean>(props.show);
+
+watch(
+    () => props.show,
+    (next) => {
+        localShow.value = next;
+    },
+);
+
 function onDismiss() {
+    localShow.value = false;
     emit("update:show", false);
     emit("dismissed");
 }
@@ -46,7 +59,7 @@ function onDismiss() {
 <template>
     <Transition v-if="fade" name="g-alert-fade">
         <div
-            v-if="show"
+            v-if="localShow"
             class="alert"
             :class="[variantClass, { 'alert-dismissible': dismissible }]"
             role="alert"
@@ -59,7 +72,7 @@ function onDismiss() {
         </div>
     </Transition>
     <div
-        v-else-if="show"
+        v-else-if="localShow"
         class="alert"
         :class="[variantClass, { 'alert-dismissible': dismissible }]"
         role="alert"

--- a/client/src/components/BaseComponents/GAlert.vue
+++ b/client/src/components/BaseComponents/GAlert.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+/**
+ * Alert component that renders a bootstrap-styled alert div.
+ * Replaces bootstrap-vue's BAlert with a Vue 3-friendly SFC that emits the same
+ * `<div class="alert alert-{variant}">` markup the existing bootstrap CSS expects.
+ */
+
+import { computed } from "vue";
+
+type AlertVariant = "info" | "warning" | "danger" | "success" | "primary" | "secondary" | "light" | "dark";
+
+interface Props {
+    /** Controls alert visibility */
+    show?: boolean;
+    /** Bootstrap contextual variant */
+    variant?: AlertVariant;
+    /** Render a close button */
+    dismissible?: boolean;
+    /** Aria label for the dismiss button */
+    dismissLabel?: string;
+    /** Apply a fade transition on enter/leave */
+    fade?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    show: true,
+    variant: "info",
+    dismissible: false,
+    dismissLabel: "Close",
+    fade: false,
+});
+
+const emit = defineEmits<{
+    (e: "dismissed"): void;
+    (e: "update:show", show: boolean): void;
+}>();
+
+const variantClass = computed(() => `alert-${props.variant}`);
+
+function onDismiss() {
+    emit("update:show", false);
+    emit("dismissed");
+}
+</script>
+
+<template>
+    <Transition v-if="fade" name="g-alert-fade">
+        <div
+            v-if="show"
+            class="alert"
+            :class="[variantClass, { 'alert-dismissible': dismissible }]"
+            role="alert"
+            aria-live="polite"
+            aria-atomic="true">
+            <slot />
+            <button v-if="dismissible" type="button" class="close" :aria-label="dismissLabel" @click="onDismiss">
+                <span aria-hidden="true">&times;</span>
+            </button>
+        </div>
+    </Transition>
+    <div
+        v-else-if="show"
+        class="alert"
+        :class="[variantClass, { 'alert-dismissible': dismissible }]"
+        role="alert"
+        aria-live="polite"
+        aria-atomic="true">
+        <slot />
+        <button v-if="dismissible" type="button" class="close" :aria-label="dismissLabel" @click="onDismiss">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+</template>
+
+<style scoped lang="scss">
+.g-alert-fade-enter-active,
+.g-alert-fade-leave-active {
+    transition: opacity 0.15s linear;
+}
+.g-alert-fade-enter,
+.g-alert-fade-enter-from,
+.g-alert-fade-leave-to {
+    opacity: 0;
+}
+</style>

--- a/client/src/components/Citation/CitationsList.vue
+++ b/client/src/components/Citation/CitationsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faCopy, faDownload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BButton, BCard, BNav, BNavItem } from "bootstrap-vue";
+import { BButton, BCard, BNav, BNavItem } from "bootstrap-vue";
 import { computed, onMounted, onUpdated, ref, toRef } from "vue";
 
 import { getCitations } from "@/components/Citation/services";
@@ -12,6 +12,7 @@ import { copy } from "@/utils/clipboard";
 import type { Citation } from ".";
 import { Cite } from "./cite";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GCollapse from "@/components/BaseComponents/GCollapse.vue";
 import CitationItem from "@/components/Citation/CitationItem.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
@@ -187,11 +188,11 @@ function citationsToBibtexAsText() {
                     <div v-html="config?.citations_export_message_html"></div>
                 </div>
 
-                <BAlert v-if="warnings.length > 0" variant="warning" show>
+                <GAlert v-if="warnings.length > 0" variant="warning" show>
                     <ul class="mb-0">
                         <li v-for="(warning, idx) in warnings" :key="idx">{{ warning }}</li>
                     </ul>
-                </BAlert>
+                </GAlert>
 
                 <div class="citations-formatted">
                     <CitationItem

--- a/client/src/components/ConfirmDialog.vue
+++ b/client/src/components/ConfirmDialog.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert } from "bootstrap-vue";
 import { ref } from "vue";
 
 import { type ConfirmDialogOptions, DEFAULT_CONFIRM_OPTIONS } from "@/composables/confirmDialog";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GModal from "@/components/BaseComponents/GModal.vue";
 
@@ -50,9 +50,9 @@ defineExpose({ confirm });
         size="small"
         :title="currentOptions.title"
         @close="handleResponse(null)">
-        <BAlert class="mb-0" data-description="confirm dialog message" variant="info" show>
+        <GAlert class="mb-0" data-description="confirm dialog message" variant="info" show>
             {{ message }}
-        </BAlert>
+        </GAlert>
         <template v-slot:footer>
             <div class="confirm-dialog-button-container">
                 <GButton data-description="confirm dialog cancel" @click="handleResponse(false)">

--- a/client/src/components/Form/Elements/FormRadio.vue
+++ b/client/src/components/Form/Elements/FormRadio.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { computed } from "vue";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
+
 const emit = defineEmits(["input"]);
 const props = defineProps({
     value: {
@@ -32,5 +34,5 @@ const hasOptions = computed(() => {
             {{ option.label }}
         </b-form-radio>
     </b-form-radio-group>
-    <b-alert v-else v-localize variant="warning" show> No options available. </b-alert>
+    <GAlert v-else v-localize variant="warning" show> No options available. </GAlert>
 </template>

--- a/client/src/components/Form/FormCardSticky.test.js
+++ b/client/src/components/Form/FormCardSticky.test.js
@@ -33,7 +33,8 @@ describe("FormCardSticky.vue", () => {
 
     it("renders error alert when errorMessage is present", () => {
         const wrapper = mountComponent({ errorMessage: "Something went wrong" });
-        expect(wrapper.findComponent({ name: "BAlert" }).exists()).toBe(true);
+        const alert = wrapper.find(".alert.alert-danger");
+        expect(alert.exists()).toBe(true);
         expect(wrapper.text()).toContain("Something went wrong");
     });
 

--- a/client/src/components/Form/FormCardSticky.vue
+++ b/client/src/components/Form/FormCardSticky.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { faWrench, type IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert } from "bootstrap-vue";
 
 import { absPath } from "@/utils/redirect";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import Heading from "@/components/Common/Heading.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -25,7 +25,7 @@ withDefaults(
 </script>
 
 <template>
-    <BAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</BAlert>
+    <GAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</GAlert>
     <LoadingSpan v-else-if="isLoading" />
     <div v-else>
         <div class="position-relative pb-4">

--- a/client/src/components/HistoryImport.vue
+++ b/client/src/components/HistoryImport.vue
@@ -4,14 +4,14 @@
             Import {{ identifierText === "invocation" ? "an" : "a" }} {{ identifierText }} from an archive
         </h1>
 
-        <b-alert v-if="errorMessage" variant="danger" dismissible show @dismissed="errorMessage = null">
+        <GAlert v-if="errorMessage" variant="danger" dismissible show @dismissed="errorMessage = null">
             {{ errorMessage }}
             <JobError
                 v-if="jobError"
                 style="margin-top: 15px"
                 :header="`${identifierTextCapitalized} import job ended in error`"
                 :job="jobError" />
-        </b-alert>
+        </GAlert>
 
         <div v-if="initializing">
             <LoadingSpan message="Loading server configuration." />
@@ -62,14 +62,14 @@
                 </b-form-group>
 
                 <b-form-group v-if="importType === 'externalUrl'" :label="urlLabel">
-                    <b-alert v-if="showImportUrlWarning" variant="warning" show>
+                    <GAlert v-if="showImportUrlWarning" variant="warning" show>
                         It looks like you are trying to import a published history from another galaxy instance. You can
                         only import histories via an archive URL.
                         <ExternalLink
                             href="https://training.galaxyproject.org/training-material/faqs/galaxy/histories_transfer_entire_histories_from_one_galaxy_server_to_another.html">
                             Read more on the GTN
                         </ExternalLink>
-                    </b-alert>
+                    </GAlert>
 
                     <b-form-input v-model="sourceURL" type="url" />
                 </b-form-group>
@@ -103,6 +103,7 @@ import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString } from "@/utils/simple-error";
 import { capitalizeFirstLetter } from "@/utils/strings";
 
+import GAlert from "./BaseComponents/GAlert.vue";
 import GButton from "./BaseComponents/GButton.vue";
 import ExternalLink from "./ExternalLink.vue";
 import FilesInput from "@/components/FilesDialog/FilesInput.vue";
@@ -113,7 +114,16 @@ import LoadingSpan from "@/components/LoadingSpan.vue";
 Vue.use(BootstrapVue);
 
 export default {
-    components: { FilesInput, FontAwesomeIcon, ImportSuccess, JobError, LoadingSpan, ExternalLink, GButton },
+    components: {
+        FilesInput,
+        FontAwesomeIcon,
+        ImportSuccess,
+        JobError,
+        LoadingSpan,
+        ExternalLink,
+        GAlert,
+        GButton,
+    },
     props: {
         invocationImport: {
             type: Boolean,

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { BAlert } from "bootstrap-vue";
 import { ref } from "vue";
 
 import { GalaxyApi } from "@/api";
 import type { TourSummary } from "@/api/tours";
 import { withPrefix } from "@/utils/redirect";
 
+import GAlert from "../BaseComponents/GAlert.vue";
 import GLink from "../BaseComponents/GLink.vue";
 import DelayedInput from "@/components/Common/DelayedInput.vue";
 
@@ -47,7 +47,7 @@ loadTours();
             started (and remember, you can click 'End Tour' at any time).
         </p>
         <h2 class="h-sm">Tours</h2>
-        <BAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</BAlert>
+        <GAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</GAlert>
         <div v-else>
             <DelayedInput class="mb-3" :value="searchQuery" placeholder="search tours" :delay="0" @change="onSearch" />
             <div v-for="tour in tours" :key="tour.id">

--- a/client/src/components/User/UserDeletion.vue
+++ b/client/src/components/User/UserDeletion.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
@@ -12,6 +11,7 @@ import { userLogoutClient } from "@/utils/logout";
 import GForm from "../BaseComponents/Form/GForm.vue";
 import GFormInput from "../BaseComponents/Form/GFormInput.vue";
 import GFormLabel from "../BaseComponents/Form/GFormLabel.vue";
+import GAlert from "../BaseComponents/GAlert.vue";
 import GModal from "../BaseComponents/GModal.vue";
 import LoadingSpan from "../LoadingSpan.vue";
 
@@ -80,18 +80,18 @@ async function handleSubmit() {
         :close-on-ok="false"
         @close="resetModal"
         @ok="handleSubmit">
-        <BAlert variant="danger" :show="showDeleteError">{{ deleteError }}</BAlert>
-        <BAlert variant="warning" show>
+        <GAlert variant="danger" :show="showDeleteError">{{ deleteError }}</GAlert>
+        <GAlert variant="warning" show>
             <b>
                 <FontAwesomeIcon :icon="faExclamationTriangle" />
                 This action cannot be undone. Your account will be PERMANENTLY deleted, along with the data contained in
                 it.
             </b>
-        </BAlert>
+        </GAlert>
 
-        <BAlert v-if="deleting" variant="info" show>
+        <GAlert v-if="deleting" variant="info" show>
             <LoadingSpan message="Deleting user account" />
-        </BAlert>
+        </GAlert>
         <GForm v-else @submit.native.prevent>
             <GFormLabel
                 title="Enter your email address to confirm deletion"

--- a/client/src/components/admin/Notifications/BroadcastsList.vue
+++ b/client/src/components/admin/Notifications/BroadcastsList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faCheck, faClock, faHourglassHalf, faRedo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BCol, BRow } from "bootstrap-vue";
+import { BCol, BRow } from "bootstrap-vue";
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
@@ -10,6 +10,7 @@ import { Toast } from "@/composables/toast";
 import type { BroadcastNotification } from "@/stores/broadcastsStore";
 
 import BroadcastCard from "./BroadcastCard.vue";
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
 import GOverlay from "@/components/BaseComponents/GOverlay.vue";
@@ -153,14 +154,14 @@ loadBroadcastsList();
             </BRow>
         </div>
 
-        <BAlert v-if="loading" variant="info" show>
+        <GAlert v-if="loading" variant="info" show>
             <LoadingSpan message="Loading broadcasts" />
-        </BAlert>
+        </GAlert>
 
-        <BAlert v-else-if="filteredBroadcasts.length === 0" id="empty-broadcast-list-alert" variant="info" show>
+        <GAlert v-else-if="filteredBroadcasts.length === 0" id="empty-broadcast-list-alert" variant="info" show>
             There are no broadcast notifications to show. Use the button above to create a new broadcast notification or
             change the filters.
-        </BAlert>
+        </GAlert>
         <GOverlay v-else :show="overlay">
             <BroadcastCard
                 v-for="notification in filteredBroadcasts"


### PR DESCRIPTION
## Summary

Adds a small Vue 3-friendly `GAlert` SFC at `client/src/components/BaseComponents/GAlert.vue` and replaces `<BAlert>` with `<GAlert>` at twelve call sites across eight components. Part of the bootstrap-vue scoped-slot replacement effort tracked in #21956.

The motivation is concrete: `BAlert` "works" through `@vue/compat` for production rendering, but in tests bootstrap-vue's compat shim renders it as a bare `<__compat__transition>` element with no slot content. On the Vue 3 migration branch (#20787) that shows up as 92 failing test files whose selectors look for `.alert` or specific alert IDs and find nothing. `GAlert` emits the same `<div class="alert alert-{variant}">` markup the existing bootstrap CSS expects, so the rendered DOM matches what real and test selectors are looking for.

## What's in the component

`GAlert` is intentionally a subset of `BAlert`, not a full API clone:

- **Props:** `show`, `variant`, `dismissible`, `dismissLabel`, `fade`
- **Emits:** `dismissed`, `update:show`
- **Slot:** default only
- **Self-dismiss:** mirrors `BAlert` -- clicking the close button on a `dismissible` alert hides it locally without requiring a parent handler; a subsequent `show` prop change re-syncs

Dropped from `BAlert`: numeric `show` countdown (one production usage in `InteractiveTools.vue`), the `dismiss` named slot (zero usages), and the `dismissCountDown` event (zero usages). These can be added back if a future call site needs them.

## The exemplar swaps

I intentionally did not do a sweeping replacement. `BAlert` has ~200 remaining production usages and a single mega-PR would be hard to review. Instead this PR swaps twelve alerts across eight components that exercise the common API patterns -- info/warning/danger, plain `show`, reactive `:show`, dismissible with `@dismissed`, `v-localize`, and rich slot content (lists, icons, `LoadingSpan`):

`ConfirmDialog`, `HistoryImport` (2), `Citation/CitationsList`, `Tour/TourList`, `Form/Elements/FormRadio`, `admin/Notifications/BroadcastsList` (2), `User/UserDeletion` (3), and `Form/FormCardSticky`. The `FormCardSticky.test.js` selector was updated from a `BAlert` component-name lookup to a DOM-level `.alert.alert-danger` assertion, which is the migration pattern future swaps will follow.

Subsequent PRs will pick up the remaining `BAlert` call sites incrementally, similar to how the `BTable` migration was split across many PRs.

## Test plan

- [ ] `pnpm eslint --quiet` clean on changed files
- [ ] `pnpm type-check` clean
- [ ] `pnpm test` for affected component areas (FormCardSticky, FormRadio, BroadcastsList) green
- [ ] Manual smoke: render `BroadcastsList`, `HistoryImport`, `UserDeletion` in dev server and verify alerts render and dismiss correctly