### PR TITLE
[26.0] Fix Zenodo/Invenio browsing of own records

### DIFF
--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -267,10 +267,12 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         """Gets the records in the repository and returns the total count of records."""
         params: dict[str, Any] = {}
         request_url = self.records_url
+        if self.plugin.get_authorization_token(context) or write_intent:
+            # Authenticated users should browse only their own records.
+            request_url = self.user_records_url
         if write_intent:
             # Only draft records owned by the user can be written to.
             params["is_published"] = "false"
-            request_url = self.user_records_url
         size, page = self._to_size_page(limit, offset)
         params["size"] = size
         params["page"] = page

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -297,7 +297,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         writeable: bool,
         query: Optional[str] = None,
     ) -> list[RemoteFile]:
-        conditionally_draft = "/draft" if writeable else ""
+        conditionally_draft = "/draft" if writeable or self._is_draft_record(container_id, context) else ""
         request_url = f"{self.records_url}/{container_id}{conditionally_draft}/files"
         response_data = self._get_response(context, request_url)
         return self._get_record_files_from_response(container_id, response_data)

--- a/lib/galaxy/files/templates/examples/production_zenodo.yml
+++ b/lib/galaxy/files/templates/examples/production_zenodo.yml
@@ -32,7 +32,9 @@
               The personal access token to use to connect to Zenodo. Go to your Account Settings and then go to Applications
               here https://zenodo.org/account/settings/applications/. You can generate a new `Personal Access Token` if you don't have one yet.
               This will allow Galaxy to display your draft records and upload files to them. If you enabled the option to export data
-                from Galaxy to Zenodo, make sure to enable the `deposit:write` scope when creating the token.
+              from Galaxy to Zenodo, make sure to enable the `deposit:write` scope when creating the token.
+
+              **Note**: If you provide a token, you will be able to browse **only your own records**, if you don't provide a token, you will be able to browse all public records in Zenodo.
 
   configuration:
       type: zenodo


### PR DESCRIPTION
This fixes 2 usability issues when you create a Zenodo or Invenio file source and provide an API token.
- Providing an API token will only display your own records when browsing. Displaying all the public records was causing confusion to users, and it was difficult to navigate and find their own records among millions of other public records.
- Browsing draft records in read mode will now correctly display the contents of the draft record and let you upload its contents to Galaxy instead of returning an error (404).

If you want to browse all public records, you can either create a new instance of the template without providing the API token or use the system-defined plugin for Zenodo (set up by an admin).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
