### PR TITLE
[26.0] Ensure workflow editor always inserts latest tool version

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1145,7 +1145,17 @@ export default {
             const stepData = action.getNewStepData();
 
             const response = await getModule(
-                { name, type, content_id: contentId, tool_state: state, tool_uuid: toolUuid },
+                {
+                    name,
+                    type,
+                    content_id: contentId,
+                    tool_state: state,
+                    tool_uuid: toolUuid,
+                    // Request the latest version, mirroring what `routeToTool` does with `&version=latest`.
+                    // Without this, toolshed tools whose GUID includes the version would resolve to
+                    // that specific (possibly old) version rather than the latest.
+                    tool_version: type === "tool" && !toolUuid ? "latest" : undefined,
+                },
                 stepData.id,
                 this.stateStore.setLoadingState,
             );
@@ -1157,6 +1167,10 @@ export default {
                 inputs: response.inputs,
                 outputs: response.outputs,
                 config_form: response.config_form,
+                // Use the resolved content_id and tool_version from the response which
+                // references the latest tool version, rather than what comes from the GUID
+                content_id: response.content_id || stepData.content_id,
+                tool_version: response.tool_version || stepData.tool_version,
             };
 
             this.stepStore.updateStep(updatedStep);

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -127,6 +127,7 @@ from galaxy.util.json import safe_loads
 from galaxy.util.rules_dsl import RuleSet
 from galaxy.util.template import fill_template
 from galaxy.util.tool_shed.common_util import get_tool_shed_url_from_tool_shed_registry
+from galaxy.util.tool_version import remove_version_from_guid
 from galaxy.workflow.workflow_parameter_input_definitions import (
     get_default_parameter,
     INPUT_PARAMETER_TYPES,
@@ -1993,6 +1994,13 @@ class ToolModule(WorkflowModule):
         if tool_version:
             tool_version = str(tool_version)
         tool_uuid = d.get("tool_uuid", None)
+        if tool_version == "latest":
+            # Resolve to the actual latest installed version via lineage rather than matching the exact GUID.
+            # This mirrors what &version=latest does in the tool form.
+            tool_version = None
+            if tool_id:
+                tool_id = remove_version_from_guid(tool_id) or tool_id
+            kwds = dict(kwds, exact_tools=False)
         if tool_id is None and tool_uuid is None:
             tool_representation = d.get("tool_representation")
             if tool_representation:

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -130,6 +130,33 @@ def test_cannot_create_tool_modules_for_missing_tools():
     assert not module.tool
 
 
+def test_tool_version_latest_resolves_toolshed_guid():
+    # Toolshed GUIDs embed the version as the last segment. When tool_version="latest"
+    # is requested (as the WF editor does on insert), from_dict should strip the version
+    # from the GUID and resolve to the latest installed version via the versionless key.
+    trans = MockTrans()
+    old_guid = "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.68+galaxy1"
+    versionless_guid = "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc"
+    latest_tool = __mock_tool(
+        id="toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1", version="0.74+galaxy1"
+    )
+    trans.app.toolbox.tools[versionless_guid] = latest_tool
+    module = modules.module_factory.from_dict(trans, {"type": "tool", "content_id": old_guid, "tool_version": "latest"})
+    assert module.tool is not None
+    assert module.tool.version == "0.74+galaxy1"
+
+
+def test_tool_version_latest_resolves_builtin_tool():
+    # Built-in tool IDs have no version segment; remove_version_from_guid returns None
+    # so the ID is unchanged. tool_version="latest" should still resolve correctly.
+    trans = MockTrans()
+    latest_tool = __mock_tool(id="cat1", version="2.0")
+    trans.app.toolbox.tools["cat1"] = latest_tool
+    module = modules.module_factory.from_dict(trans, {"type": "tool", "content_id": "cat1", "tool_version": "latest"})
+    assert module.tool is not None
+    assert module.tool.version == "2.0"
+
+
 def test_updated_tool_version():
     trans = MockTrans()
     mock_tool = __mock_tool(id="cat1", version="0.9")


### PR DESCRIPTION
This is done by passing `tool_version: latest` to `POST api/workflows/build_module`, which is then on the backend resolved by removing the version from the tool's GUID, unless we explicitly pass a `tool_uuid` (for UDTs for e.g.).

Fixes https://github.com/galaxyproject/galaxy/issues/22646

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
