### PR TITLE
Fix workflow extraction not including user-defined tool steps

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -16066,6 +16066,12 @@ export interface components {
             /** Value */
             value?: number | null;
         };
+        /**
+         * InvalidWorkflowExtractionJobReason
+         * @description Reasons a workflow extraction job may be invalid and disabled for extraction.
+         * @enum {string}
+         */
+        InvalidWorkflowExtractionJobReason: "tool_missing_or_inaccessible" | "custom_tool_inaccessible";
         /** InvocationCancellationHistoryDeletedResponse */
         InvocationCancellationHistoryDeletedResponse: {
             /**
@@ -25556,6 +25562,11 @@ export interface components {
              * @description Encoded job ID, or null for fake input dataset entries.
              */
             id: string | null;
+            /**
+             * Invalid
+             * @description Reason this job is invalid for extraction.
+             */
+            invalid?: components["schemas"]["InvalidWorkflowExtractionJobReason"] | null;
             /**
              * Outputs
              * @description The history items produced by this job.

--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -79,7 +79,8 @@ function isPathActive(path: RawLocation): boolean {
         }
 
         .breadcrumb-heading-header-beta {
-            color: #717273;
+            color: var(--color-grey-500);
+            white-space: nowrap;
         }
     }
 }

--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -719,6 +719,11 @@ function onKeyDown(event: KeyboardEvent) {
             opacity 0.15s ease;
     }
 
+    &.g-card-dim:hover .g-card-content {
+        filter: none;
+        opacity: 1;
+    }
+
     &.g-card-current .g-card-content {
         background-color: $brand-light;
         border-width: 2px;

--- a/client/src/components/History/Content/DisplayedItem.vue
+++ b/client/src/components/History/Content/DisplayedItem.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import type { HistoryContentType } from "@/api/datasets";
+
+import type { State } from "./model/states";
+
+const props = defineProps<{
+    deleted: boolean;
+    hid: number;
+    historyContentType: HistoryContentType;
+    itemId: string;
+    name: string;
+    state: State;
+}>();
+
+const contentId = computed(() => `${props.historyContentType}-${props.itemId}`);
+</script>
+
+<template>
+    <div :id="contentId" class="content-item rounded" :data-hid="props.hid" :data-state="props.state">
+        <div class="p-1">
+            <div class="d-flex">
+                <span class="p-1" data-description="content item header info">
+                    <span class="id hid">{{ props.hid }}: </span>
+                    <span class="content-title name font-weight-bold">{{ props.name }}</span>
+                </span>
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -116,7 +116,11 @@ const titleIcon = computed<TitleIcon>(() => {
     <GCard
         :class="{ disabled: Boolean(props.job.invalid) }"
         :badges="badges"
-        :title="isWorkflowExtractionInput(props.job) ? props.job.newName : props.job.tool_name || 'Unnamed Step'"
+        :title="
+            isWorkflowExtractionInput(props.job)
+                ? props.job.newName
+                : props.job.tool_name || props.job.tool_id || 'Unnamed Step'
+        "
         :title-icon="titleIcon"
         :can-rename-title="props.job.step_type !== 'tool' && props.job.checked"
         selectable

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
-import { faExclamationTriangle, faInfoCircle, faPencilAlt, faWrench } from "@fortawesome/free-solid-svg-icons";
+import { faBan, faExclamationTriangle, faInfoCircle, faPencilAlt, faWrench } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 
 import type { WorkflowExtractionJob } from "@/api/histories";
@@ -8,6 +9,7 @@ import type { CardBadge, TitleIcon } from "@/components/Common/GCard.types";
 
 import { isWorkflowExtractionInput, type WorkflowExtractionInput } from "./types";
 
+import DisplayedItem from "../Content/DisplayedItem.vue";
 import GCard from "@/components/Common/GCard.vue";
 import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
 
@@ -48,7 +50,7 @@ const badges = computed<CardBadge[]>(() => {
     const badges: CardBadge[] = [];
     const meta = STEP_TYPE_META[props.job.step_type];
     if (props.job.step_type === "tool") {
-        if (props.job.id) {
+        if (props.job.id && props.job.invalid !== "custom_tool_inaccessible") {
             badges.push({
                 id: "view-job-details",
                 label: "View Job",
@@ -60,6 +62,27 @@ const badges = computed<CardBadge[]>(() => {
                 variant: "info",
             });
         }
+
+        if (props.job.invalid === "custom_tool_inaccessible") {
+            badges.push({
+                id: "custom-tool-inaccessible",
+                label: "Custom Tool Inaccessible",
+                icon: faBan,
+                title: "This history item was produced by a User Defined Tool that is not accessible for you. Hence, this step cannot be included in the workflow.",
+                class: "unselectable",
+                variant: "danger",
+            });
+        } else if (props.job.invalid === "tool_missing_or_inaccessible") {
+            badges.push({
+                id: "tool-missing-or-inaccessible",
+                label: "Tool Missing or Inaccessible",
+                icon: faExclamationTriangle,
+                title: "This history item was produced by a tool that is either missing or inaccessible for you. Hence, this step cannot be included in the workflow.",
+                class: "unselectable",
+                variant: "danger",
+            });
+        }
+
         if (props.job.tool_version_warning) {
             badges.push({
                 id: "tool-version-warning",
@@ -91,6 +114,7 @@ const titleIcon = computed<TitleIcon>(() => {
 
 <template>
     <GCard
+        :class="{ disabled: Boolean(props.job.invalid) }"
         :badges="badges"
         :title="isWorkflowExtractionInput(props.job) ? props.job.newName : props.job.tool_name || 'Unnamed Step'"
         :title-icon="titleIcon"
@@ -101,12 +125,30 @@ const titleIcon = computed<TitleIcon>(() => {
         dim-when-unselected
         @rename="emit('rename')"
         @select="emit('select')">
-        <template v-if="props.job.outputs?.length" v-slot:description>
-            <div v-for="(output, outputIndex) in props.job.outputs" :key="outputIndex">
-                <GenericHistoryItem
-                    :item-id="output.id"
-                    :item-src="output.history_content_type === 'dataset' ? 'hda' : 'hdca'" />
-            </div>
+        <template v-slot:select>
+            <FontAwesomeIcon
+                v-if="Boolean(props.job.invalid)"
+                :icon="faExclamationTriangle"
+                class="text-danger mr-1"
+                fixed-width />
+        </template>
+        <template v-slot:description>
+            <template v-if="props.job.outputs?.length">
+                <div v-for="(output, outputIndex) in props.job.outputs" :key="outputIndex">
+                    <DisplayedItem
+                        v-if="props.job.invalid === 'custom_tool_inaccessible'"
+                        :item-id="output.id"
+                        :deleted="output.deleted"
+                        :hid="output.hid"
+                        :history-content-type="output.history_content_type"
+                        :name="output.name"
+                        :state="output.state" />
+                    <GenericHistoryItem
+                        v-else
+                        :item-id="output.id"
+                        :item-src="output.history_content_type === 'dataset' ? 'hda' : 'hdca'" />
+                </div>
+            </template>
         </template>
     </GCard>
 </template>

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
-import { faExclamationTriangle, faExternalLinkAlt, faPencilAlt, faWrench } from "@fortawesome/free-solid-svg-icons";
+import { faExclamationTriangle, faInfoCircle, faPencilAlt, faWrench } from "@fortawesome/free-solid-svg-icons";
 import { computed } from "vue";
 
 import type { WorkflowExtractionJob } from "@/api/histories";
@@ -41,6 +41,7 @@ const props = defineProps<{
 const emit = defineEmits<{
     (e: "rename"): void;
     (e: "select"): void;
+    (e: "view-job", jobId: string): void;
 }>();
 
 const badges = computed<CardBadge[]>(() => {
@@ -51,10 +52,10 @@ const badges = computed<CardBadge[]>(() => {
             badges.push({
                 id: "view-job-details",
                 label: "View Job",
-                icon: faExternalLinkAlt,
+                icon: faInfoCircle,
                 title: "View details for the job that ran this tool",
                 handler: () => {
-                    window.open(`/jobs/${props.job.id}/view`, "_blank");
+                    emit("view-job", props.job.id!);
                 },
                 variant: "info",
             });

--- a/client/src/components/History/WorkflowExtractionForm.vue
+++ b/client/src/components/History/WorkflowExtractionForm.vue
@@ -19,8 +19,10 @@ import { isWorkflowExtractionInput, type WorkflowExtractionInput } from "./Workf
 
 import GFormInput from "../BaseComponents/Form/GFormInput.vue";
 import GButton from "../BaseComponents/GButton.vue";
+import GModal from "../BaseComponents/GModal.vue";
 import BreadcrumbHeading from "../Common/BreadcrumbHeading.vue";
 import RenameModal from "../Common/RenameModal.vue";
+import JobDetails from "../JobInformation/JobDetails.vue";
 import LoadingSpan from "../LoadingSpan.vue";
 import WorkflowExtractionCard from "./WorkflowExtraction/WorkflowExtractionCard.vue";
 import WorkflowExtractionMessages from "./WorkflowExtraction/WorkflowExtractionMessages.vue";
@@ -52,6 +54,8 @@ const jobsList = ref<(WorkflowExtractionInput | WorkflowExtractionJob)[]>([]);
 const workflowName = ref("");
 const renameIndex = ref<number | null>(null);
 const warnings = ref<string[]>([]);
+const showJobModal = ref(false);
+const viewedJobId = ref<string | null>(null);
 
 /** The job (input step) to rename based on the current `renameIndex`. */
 const toRenameInput = computed(() => {
@@ -190,6 +194,11 @@ function onJobSelect(index: number) {
     }
 }
 
+function onViewJob(jobId: string) {
+    viewedJobId.value = jobId;
+    showJobModal.value = true;
+}
+
 async function renameInput(newName: string) {
     if (!jobsList.value?.length) {
         throw new Error("No jobs available to rename");
@@ -285,7 +294,8 @@ async function submitWorkflow() {
                 :data-step-type="job.step_type"
                 :data-job-id="job.id || undefined"
                 @rename="onJobRename(index)"
-                @select="onJobSelect(index)" />
+                @select="onJobSelect(index)"
+                @view-job="onViewJob" />
         </div>
 
         <RenameModal
@@ -294,6 +304,10 @@ async function submitWorkflow() {
             :name="toRenameInput.newName"
             :rename-action="renameInput"
             @close="renameIndex = null" />
+
+        <GModal :show.sync="showJobModal" title="View Job" fixed-height size="medium" @close="viewedJobId = null">
+            <JobDetails v-if="viewedJobId" :job-id="viewedJobId" />
+        </GModal>
     </div>
 </template>
 

--- a/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissionsCalculations.vue
+++ b/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissionsCalculations.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+import { computed, ref, watch } from "vue";
+
+import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
+import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
+
 import { worldwideCarbonIntensity, worldwidePowerUsageEffectiveness } from "./carbonEmissionConstants.js";
 
 import Abbreviation from "@/components/Common/Abbreviation.vue";
@@ -33,11 +38,31 @@ const epaUrl = "https://www.epa.gov/energy/greenhouse-gas-equivalencies-calculat
 const epaCalculationsUrl =
     "https://www.epa.gov/energy/greenhouse-gases-equivalencies-calculator-calculations-and-references";
 const greenAlgorithmsUrl = "https://www.green-algorithms.org/";
+
+const isScrollable = ref(false);
+const scrollableDiv = ref<HTMLElement | null>(null);
+// check if we have scrolled to the bottom of the scrollable div
+const { arrived } = useAnimationFrameScroll(scrollableDiv);
+useAnimationFrameResizeObserver(scrollableDiv, ({ clientSize, scrollSize }) => {
+    isScrollable.value = scrollSize.height >= clientSize.height + 1;
+});
+const scrolledBottom = computed(() => !isScrollable.value || arrived.bottom);
+
+const footerToggled = ref(false);
+
+watch(
+    () => [scrolledBottom.value, isScrollable.value],
+    ([scrolledBottomValue, isScrollableValue]) => {
+        if (scrolledBottomValue || !isScrollableValue) {
+            footerToggled.value = true;
+        }
+    },
+);
 </script>
 
 <template>
-    <article class="mt-4">
-        <header>
+    <article class="d-flex flex-column h-100">
+        <header class="position-sticky">
             <Heading h1 separator bold size="lg">Carbon Emissions Calculations</Heading>
 
             <p>
@@ -52,114 +77,151 @@ const greenAlgorithmsUrl = "https://www.green-algorithms.org/";
             </p>
         </header>
 
-        <section>
-            <Heading h2 separator bold size="sm">How we calculate carbon emissions</Heading>
+        <div ref="scrollableDiv" class="content-area">
+            <section>
+                <Heading h2 separator bold size="sm">How we calculate carbon emissions</Heading>
 
-            <p>
-                For each job, the carbon emissions are based off of the job runtime (in hours) and the memory allocated
-                to it (in MB). Additionally, we require information about the CPU model of the server that ran the job.
-                In particular, we consider the CPU
-                <Abbreviation :explanation="'Thermal Design Power'">TDP</Abbreviation>, its core count and the number of
-                cores allocated to the job. We assume that 100% of each allocated core's resources are used.
-            </p>
+                <p>
+                    For each job, the carbon emissions are based off of the job runtime (in hours) and the memory
+                    allocated to it (in MB). Additionally, we require information about the CPU model of the server that
+                    ran the job. In particular, we consider the CPU
+                    <Abbreviation :explanation="'Thermal Design Power'">TDP</Abbreviation>, its core count and the
+                    number of cores allocated to the job. We assume that 100% of each allocated core's resources are
+                    used.
+                </p>
 
-            <p>
-                Given that CPU specifications can vary greatly and that Galaxy does not support fetching this
-                information dynamically, we estimate the server's hardware configuration by matching your job's CPU
-                and/or memory usage to a comparable general purpose
-                <Abbreviation :explanation="'Amazon Web Services Elastic Compute Cloud'">AWS EC2</Abbreviation>
-                instance. EC2 was chosen because the service provides various hardware configurations allowing us to
-                cover more real-world situations.
-                <ExternalLink :href="'https://aws.amazon.com/ec2/instance-types/'">
-                    (Click here to read further about general purpose EC2 machines)
-                </ExternalLink>
-            </p>
+                <p>
+                    Given that CPU specifications can vary greatly and that Galaxy does not support fetching this
+                    information dynamically, we estimate the server's hardware configuration by matching your job's CPU
+                    and/or memory usage to a comparable general purpose
+                    <Abbreviation :explanation="'Amazon Web Services Elastic Compute Cloud'">AWS EC2</Abbreviation>
+                    instance. EC2 was chosen because the service provides various hardware configurations allowing us to
+                    cover more real-world situations.
+                    <ExternalLink :href="'https://aws.amazon.com/ec2/instance-types/'">
+                        (Click here to read further about general purpose EC2 machines)
+                    </ExternalLink>
+                </p>
 
-            <p>
-                Once we have the information needed, we calculate your job's CPU and memory power usage in watts. The
-                power usage is the product of allocated resources amount, a
-                <Abbreviation :explanation="'Power Usage Effectiveness'">PUE</Abbreviation> value and a power usage
-                factor. For CPUs, the power usage factor is its TDP per core and, for memory, we use a reference of
-                0.375 W/GiB from the "carbon footprint calculator". Administrators can set a custom PUE value, otherwise
-                a default PUE value of {{ worldwidePowerUsageEffectiveness }} is used.
-            </p>
+                <p>
+                    Once we have the information needed, we calculate your job's CPU and memory power usage in watts.
+                    The power usage is the product of allocated resources amount, a
+                    <Abbreviation :explanation="'Power Usage Effectiveness'">PUE</Abbreviation> value and a power usage
+                    factor. For CPUs, the power usage factor is its TDP per core and, for memory, we use a reference of
+                    0.375 W/GiB from the "carbon footprint calculator". Administrators can set a custom PUE value,
+                    otherwise a default PUE value of {{ worldwidePowerUsageEffectiveness }} is used.
+                </p>
 
-            <pre>
-                memory_allocated_in_gibibyte = memory_allocated_in_mebibyte / 1024
-                tdp_per_core = cpu_TDP / cpu_core_count
-                normalized_tdp_per_core = tdp_per_core * cores_allocated_to_job
+                <pre>
+                    memory_allocated_in_gibibyte = memory_allocated_in_mebibyte / 1024
+                    tdp_per_core = cpu_TDP / cpu_core_count
+                    normalized_tdp_per_core = tdp_per_core * cores_allocated_to_job
 
-                power_needed_cpu = pue * normalized_tdp_per_core
-                power_needed_memory = pue * memory_allocated_in_gibibyte * memory_power_usage_constant
-                total_power_needed = power_needed_cpu + power_needed_memory
-            </pre>
+                    power_needed_cpu = pue * normalized_tdp_per_core
+                    power_needed_memory = pue * memory_allocated_in_gibibyte * memory_power_usage_constant
+                    total_power_needed = power_needed_cpu + power_needed_memory
+                </pre>
 
-            <p>
-                The power usage is then converted into energy usage (in kWh) by factoring in the job runtime (in hours):
-            </p>
+                <p>
+                    The power usage is then converted into energy usage (in kWh) by factoring in the job runtime (in
+                    hours):
+                </p>
 
-            <pre>
-                energy_needed_cpu = runtime * power_needed_cpu / 1000
-                energy_needed_memory = runtime * power_needed_memory / 1000
-                total_energy_needed = runtime * total_power_needed / 1000
-            </pre>
+                <pre>
+                    energy_needed_cpu = runtime * power_needed_cpu / 1000
+                    energy_needed_memory = runtime * power_needed_memory / 1000
+                    total_energy_needed = runtime * total_power_needed / 1000
+                </pre>
 
-            <p>
-                Finally, we convert the energy usage into estimated carbon emissions (in metric units CO2e) by
-                multiplying the carbon intensity value corresponding to the geographical server location configured by
-                administrators. If no value was set or the location is not supported, the calculation uses a global
-                average carbon intensity value of {{ worldwideCarbonIntensity }} gCO2/kWh.
-            </p>
+                <p>
+                    Finally, we convert the energy usage into estimated carbon emissions (in metric units CO2e) by
+                    multiplying the carbon intensity value corresponding to the geographical server location configured
+                    by administrators. If no value was set or the location is not supported, the calculation uses a
+                    global average carbon intensity value of {{ worldwideCarbonIntensity }} gCO2/kWh.
+                </p>
 
-            <pre>
-                cpu_carbon_emissions = energy_needed_cpu * carbon_intensity
-                memory_carbon_emissions = energy_needed_memory * carbon_intensity
-                total_carbon_emissions = total_energy_needed * carbon_intensity
-            </pre>
-        </section>
+                <pre>
+                    cpu_carbon_emissions = energy_needed_cpu * carbon_intensity
+                    memory_carbon_emissions = energy_needed_memory * carbon_intensity
+                    total_carbon_emissions = total_energy_needed * carbon_intensity
+                </pre>
+            </section>
 
-        <section>
-            <Heading h2 separator bold size="sm">How we compare carbon emissions</Heading>
+            <section>
+                <Heading h2 separator bold size="sm">How we compare carbon emissions</Heading>
 
-            <p>
-                To make the estimates more relatable, we compare your job's carbon emissions and energy usage to
-                <ExternalLink :href="epaCalculationsUrl">values calculated by the EPA</ExternalLink>. We use the same
-                reference values from the Green Algorithms Project's "Carbon emissions Calculator" tool when calculating
-                the equivalent distance driven.
-            </p>
+                <p>
+                    To make the estimates more relatable, we compare your job's carbon emissions and energy usage to
+                    <ExternalLink :href="epaCalculationsUrl">values calculated by the EPA</ExternalLink>. We use the
+                    same reference values from the Green Algorithms Project's "Carbon emissions Calculator" tool when
+                    calculating the equivalent distance driven.
+                </p>
 
-            <pre>
-                gasoline_consumed = total_carbon_emissions / gasoline_emissions_as_per_epa
-                carbon_carbon_savings_by_using_leds = total_carbon_emissions / led_carbon_savings_as_per_epa
-                equivalent_km_in_eu = total_carbon_emissions / average_passenger_car_emissions_eu
-                equivalent_km_in_us = total_carbon_emissions / average_passenger_car_emissions_us
-                smartphones_charged = total_carbon_emissions / smartphone_charged_emissions_as_per_epa
-                tree_months = total_carbon_emissions / tree_year * 12
-            </pre>
-        </section>
+                <pre>
+                    gasoline_consumed = total_carbon_emissions / gasoline_emissions_as_per_epa
+                    carbon_carbon_savings_by_using_leds = total_carbon_emissions / led_carbon_savings_as_per_epa
+                    equivalent_km_in_eu = total_carbon_emissions / average_passenger_car_emissions_eu
+                    equivalent_km_in_us = total_carbon_emissions / average_passenger_car_emissions_us
+                    smartphones_charged = total_carbon_emissions / smartphone_charged_emissions_as_per_epa
+                    tree_months = total_carbon_emissions / tree_year * 12
+                </pre>
+            </section>
 
-        <footer class="py-4">
-            <Heading h2 separator bold size="sm">Glossary</Heading>
+            <footer class="glossary-footer">
+                <Heading
+                    class="py-2"
+                    h2
+                    separator
+                    bold
+                    size="sm"
+                    :collapse="!footerToggled ? 'closed' : 'open'"
+                    @click="footerToggled = !footerToggled"
+                    >Glossary</Heading
+                >
 
-            <table class="tabletip info_data_table">
-                <thead>
-                    <th>Term</th>
-                    <th>Definition</th>
-                </thead>
+                <transition name="slide-up">
+                    <table v-show="footerToggled" class="tabletip info_data_table">
+                        <thead>
+                            <th>Term</th>
+                            <th>Definition</th>
+                        </thead>
 
-                <tbody>
-                    <tr v-for="{ term, definition } in dictionary" :key="term">
-                        <td>{{ term }}</td>
-                        <td>{{ definition }}</td>
-                    </tr>
-                </tbody>
-            </table>
-        </footer>
+                        <tbody>
+                            <tr v-for="{ term, definition } in dictionary" :key="term">
+                                <td>{{ term }}</td>
+                                <td>{{ definition }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </transition>
+            </footer>
+        </div>
     </article>
 </template>
 
 <style lang="scss" scoped>
 @import "@/style/scss/theme/blue.scss";
+
+article {
+    height: 100%;
+}
+
+.content-area {
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: auto;
+}
+
+.glossary-footer {
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    background-color: $white;
+
+    // flip the arrow icon since this is an inverted collapse
+    :deep(svg) {
+        transform: scaleY(-1);
+    }
+}
 
 pre {
     font-weight: bold;
@@ -171,7 +233,17 @@ pre {
     padding: 1rem;
 }
 
-section {
-    margin-top: 4rem;
+.slide-up-enter-active {
+    transition:
+        max-height 0.35s ease,
+        opacity 0.25s ease;
+    overflow: hidden;
+    opacity: 1;
+}
+
+// TODO(vue3): rename .slide-up-enter to .slide-up-enter-from
+.slide-up-enter {
+    max-height: 0;
+    opacity: 0;
 }
 </style>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -559,6 +559,7 @@ async function onCancel() {
         transform 0.25s ease;
 }
 
+// TODO(vue3): rename .header-collapse-enter to .header-collapse-enter-from
 .header-collapse-enter,
 .header-collapse-leave-to {
     max-height: 0;

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from typing import (
     Annotated,
     Any,
@@ -337,6 +338,13 @@ class WorkflowExtractionOutput(Model):
     )
 
 
+class InvalidWorkflowExtractionJobReason(str, Enum):
+    """Reasons a workflow extraction job may be invalid and disabled for extraction."""
+
+    TOOL_MISSING_OR_INACCESSIBLE = "tool_missing_or_inaccessible"
+    CUSTOM_TOOL_INACCESSIBLE = "custom_tool_inaccessible"
+
+
 class WorkflowExtractionJob(Model):
     id: Optional[EncodedDatabaseIdField] = Field(
         ...,
@@ -377,6 +385,11 @@ class WorkflowExtractionJob(Model):
         default_factory=list,
         title="Outputs",
         description="The history items produced by this job.",
+    )
+    invalid: Optional[InvalidWorkflowExtractionJobReason] = Field(
+        None,
+        title="Invalid",
+        description="Reason this job is invalid for extraction.",
     )
 
 

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -85,6 +85,7 @@ from galaxy.schema.tasks import (
 )
 from galaxy.schema.types import LatestLiteral
 from galaxy.schema.workflows import (
+    InvalidWorkflowExtractionJobReason,
     WorkflowExtractionJob,
     WorkflowExtractionOutput,
     WorkflowExtractionSummary,
@@ -842,17 +843,37 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                         checked=checked,
                         tool_version_warning=None,
                         outputs=outputs,
+                        invalid=None,
                     )
                 )
             else:
+                custom_tools_inaccessible = False
                 try:
                     tool = trans.app.toolbox.tool_for_job(job, user=trans.user)
                 except glx_exceptions.InsufficientPermissionsException:
                     tool = None
+                    custom_tools_inaccessible = True
                 if tool is None:
                     # Tool missing or inaccessible
-                    continue
-                if not tool.is_workflow_compatible:
+                    invalid_reason = (
+                        InvalidWorkflowExtractionJobReason.CUSTOM_TOOL_INACCESSIBLE
+                        if custom_tools_inaccessible
+                        else InvalidWorkflowExtractionJobReason.TOOL_MISSING_OR_INACCESSIBLE
+                    )
+                    jobs_list.append(
+                        WorkflowExtractionJob(
+                            id=job.id,
+                            step_type="tool",
+                            tool_name=getattr(job, "tool_id", None),
+                            tool_id=job.tool_id,
+                            tool_version=job.tool_version,
+                            checked=False,
+                            tool_version_warning=None,
+                            outputs=outputs,
+                            invalid=invalid_reason,
+                        )
+                    )
+                elif not tool.is_workflow_compatible:
                     # Not a workflow step (e.g. upload, data fetch) — treat as input.
                     jobs_list.append(
                         WorkflowExtractionJob(
@@ -864,6 +885,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                             checked=checked,
                             tool_version_warning=None,
                             outputs=outputs,
+                            invalid=None,
                         )
                     )
                 else:
@@ -876,17 +898,16 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                         else None
                     )
                     jobs_list.append(
-                        WorkflowExtractionJob.model_validate(
-                            {
-                                "id": job.id,
-                                "step_type": "tool",
-                                "tool_name": tool.name,
-                                "tool_id": job.tool_id,
-                                "tool_version": job.tool_version,
-                                "checked": checked,
-                                "tool_version_warning": tool_version_warning,
-                                "outputs": outputs,
-                            }
+                        WorkflowExtractionJob(
+                            id=job.id,
+                            step_type="tool",
+                            tool_name=tool.name,
+                            tool_id=job.tool_id,
+                            tool_version=job.tool_version,
+                            checked=checked,
+                            tool_version_warning=tool_version_warning,
+                            outputs=outputs,
+                            invalid=None,
                         )
                     )
 

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -845,9 +845,12 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                     )
                 )
             else:
-                tool = trans.app.toolbox.get_tool(job.tool_id, tool_version=job.tool_version)
+                try:
+                    tool = trans.app.toolbox.tool_for_job(job, user=trans.user)
+                except glx_exceptions.InsufficientPermissionsException:
+                    tool = None
                 if tool is None:
-                    # Tool missing
+                    # Tool missing or inaccessible
                     continue
                 if not tool.is_workflow_compatible:
                     # Not a workflow step (e.g. upload, data fetch) — treat as input.

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -864,7 +864,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                         WorkflowExtractionJob(
                             id=job.id,
                             step_type="tool",
-                            tool_name=getattr(job, "tool_id", None),
+                            tool_name=None,
                             tool_id=job.tool_id,
                             tool_version=job.tool_version,
                             checked=False,

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -165,6 +165,8 @@ def extract_steps(
         step.tool_id = job.tool_id
         step.tool_version = job.tool_version
         step.tool_inputs = tool_inputs
+        if job.dynamic_tool_id:
+            step.dynamic_tool_id = job.dynamic_tool_id
         # NOTE: We shouldn't need to do two passes here since only
         #       an earlier job can be used as an input to a later
         #       job.
@@ -420,7 +422,7 @@ class WorkflowSummary:
 
 
 def step_inputs(trans: ProvidesHistoryContext, job: Job) -> tuple[ToolInputs, DataInputAssociations]:
-    tool = trans.app.toolbox.get_tool(job.tool_id, tool_version=job.tool_version)
+    tool = trans.app.toolbox.tool_for_job(job, user=trans.user)
     assert tool is not None, f"Tool {job.tool_id} (version {job.tool_version}) not found"
     param_values = tool.get_param_values(
         job, ignore_errors=True

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -53,7 +53,7 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
                 history_id=history_id,
             )
             payload["tool_uuid"] = dynamic_tool["uuid"]
-            run_response = self._post("tools", data=payload, json=True)
+            run_response = self.dataset_populator.tools_post(payload)
             self._assert_status_code_is(run_response, 200)
             udt_job_id = run_response.json()["jobs"][0]["id"]
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
@@ -736,8 +736,7 @@ class TestWorkflowExtractionSummaryApi(BaseWorkflowsApiTestCase):
                 history_id=history_id,
             )
             payload["tool_uuid"] = dynamic_tool["uuid"]
-            run_response = self._post("tools", data=payload, json=True)
-            self._assert_status_code_is(run_response, 200)
+            self._assert_status_code_is(self.dataset_populator.tools_post(payload), 200)
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
             summary = self._get_extraction_summary(history_id)
@@ -746,6 +745,31 @@ class TestWorkflowExtractionSummaryApi(BaseWorkflowsApiTestCase):
             udt_job = tool_jobs[0]
             assert udt_job["id"] is not None
             assert udt_job["tool_id"] == dynamic_tool["tool_id"]
+
+    def test_extraction_summary_udt_step_invalid_after_role_revoked(self):
+        # After the execute role is revoked the UDT step must be marked invalid
+        # with reason "custom_tool_inaccessible" and checked=False.
+        with self.dataset_populator.test_history() as history_id:
+            with self.dataset_populator.user_tool_execute_permissions():
+                dynamic_tool = self.dataset_populator.create_unprivileged_tool(
+                    UserToolSource(**TOOL_WITH_SHELL_COMMAND)
+                )
+                hda = self.dataset_populator.new_dataset(history_id, content="hello", wait=True)
+                payload = self.dataset_populator.run_tool_payload(
+                    tool_id=None,
+                    inputs={"input": {"src": "hda", "id": hda["id"]}},
+                    history_id=history_id,
+                )
+                payload["tool_uuid"] = dynamic_tool["uuid"]
+                self._assert_status_code_is(self.dataset_populator.tools_post(payload), 200)
+                self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+
+            # Role revoked — UDT is inaccessible; step must be invalid.
+            summary = self._get_extraction_summary(history_id)
+            tool_jobs = [j for j in summary["jobs"] if j["step_type"] == "tool"]
+            assert len(tool_jobs) == 1
+            assert tool_jobs[0]["invalid"] == "custom_tool_inaccessible"
+            assert tool_jobs[0]["checked"] is False
 
     @skip_without_tool("cat1")
     def test_extraction_summary_structure(self):

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -5,9 +5,11 @@ from json import (
     loads,
 )
 
+from galaxy.tool_util_models import UserToolSource
 from galaxy_test.base.populators import (
     skip_without_tool,
     summarize_instance_history_on_error,
+    TOOL_WITH_SHELL_COMMAND,
 )
 from galaxy_test.base.workflow_assertions import WorkflowStructureAssertions
 from .test_workflows import BaseWorkflowsApiTestCase
@@ -29,6 +31,60 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
         )
         assert downloaded_workflow["name"] == "test import from history"
         self.assert_cat1_workflow_structure(downloaded_workflow)
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_udt_step_with_downstream_tool(self, history_id):
+        # A UDT job used to be silently dropped from the extraction because
+        # get_tool(job.tool_id) returned None for UUID-based tool IDs. The fix
+        # uses tool_for_job() instead, which looks up UDTs via job.dynamic_tool.
+        # This test verifies that:
+        # 1. The UDT step itself appears in the extracted workflow.
+        # 2. The downstream tool step that consumes the UDT output is also present
+        #    and carries an input_connection back to the UDT step.
+        with self.dataset_populator.user_tool_execute_permissions():
+            dynamic_tool = self.dataset_populator.create_unprivileged_tool(UserToolSource(**TOOL_WITH_SHELL_COMMAND))
+
+            # Run the UDT on an uploaded dataset.
+            hda = self.dataset_populator.new_dataset(history_id, content="hello world", wait=True)
+            payload = self.dataset_populator.run_tool_payload(
+                tool_id=None,
+                inputs={"input": {"src": "hda", "id": hda["id"]}},
+                history_id=history_id,
+            )
+            payload["tool_uuid"] = dynamic_tool["uuid"]
+            run_response = self._post("tools", data=payload, json=True)
+            self._assert_status_code_is(run_response, 200)
+            udt_job_id = run_response.json()["jobs"][0]["id"]
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+
+            # Run cat1 on the UDT output so there is a downstream tool step.
+            udt_output = run_response.json()["outputs"][0]
+            cat1_inputs = {"input1": {"src": "hda", "id": udt_output["id"]}}
+            cat1_run = self.dataset_populator.run_tool("cat1", cat1_inputs, history_id)
+            cat1_job_id = cat1_run["jobs"][0]["id"]
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+
+            downloaded_workflow = self._extract_and_download_workflow(
+                history_id,
+                dataset_ids=[hda["hid"]],
+                job_ids=[udt_job_id, cat1_job_id],
+            )
+
+        steps = downloaded_workflow["steps"]
+        assert len(steps) == 3, f"Expected 3 steps (1 input + UDT + cat1), got {len(steps)}: {list(steps.values())}"
+
+        tool_steps = self.assert_steps_of_type(downloaded_workflow, "tool", expected_len=2)
+        udt_step = next(s for s in tool_steps if s.get("tool_id") == dynamic_tool["tool_id"])
+        cat1_step = next(s for s in tool_steps if s.get("tool_id") == "cat1")
+
+        # The UDT step must be linked to its dynamic tool.
+        assert udt_step.get("tool_uuid") is not None, udt_step
+
+        # The cat1 step must have an input connection pointing back to the UDT step.
+        assert "input_connections" in cat1_step, cat1_step
+        assert "input1" in cat1_step["input_connections"], cat1_step
+        assert cat1_step["input_connections"]["input1"]["id"] == udt_step["id"], cat1_step
 
     @summarize_instance_history_on_error
     def test_extract_with_copied_inputs(self, history_id):
@@ -663,6 +719,33 @@ class TestWorkflowExtractionSummaryApi(BaseWorkflowsApiTestCase):
             assert tool_job["checked"] is True
             assert tool_job["tool_version_warning"] is None
             assert len(tool_job["outputs"]) >= 1
+
+    def test_extraction_summary_includes_udt_step(self):
+        # UDT (unprivileged/user-defined tool) jobs were silently skipped in the
+        # extraction summary because get_tool(job.tool_id) returned None for UUID-based
+        # tool IDs. After the fix they must appear as "tool" steps.
+        with (
+            self.dataset_populator.test_history() as history_id,
+            self.dataset_populator.user_tool_execute_permissions(),
+        ):
+            dynamic_tool = self.dataset_populator.create_unprivileged_tool(UserToolSource(**TOOL_WITH_SHELL_COMMAND))
+            hda = self.dataset_populator.new_dataset(history_id, content="hello", wait=True)
+            payload = self.dataset_populator.run_tool_payload(
+                tool_id=None,
+                inputs={"input": {"src": "hda", "id": hda["id"]}},
+                history_id=history_id,
+            )
+            payload["tool_uuid"] = dynamic_tool["uuid"]
+            run_response = self._post("tools", data=payload, json=True)
+            self._assert_status_code_is(run_response, 200)
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+
+            summary = self._get_extraction_summary(history_id)
+            tool_jobs = [j for j in summary["jobs"] if j["step_type"] == "tool"]
+            assert len(tool_jobs) == 1, f"Expected UDT job to appear as a tool step, got: {summary['jobs']}"
+            udt_job = tool_jobs[0]
+            assert udt_job["id"] is not None
+            assert udt_job["tool_id"] == dynamic_tool["tool_id"]
 
     @skip_without_tool("cat1")
     def test_extraction_summary_structure(self):


### PR DESCRIPTION
We needed to consider the case where a job can have a `dynamic_tool_id`, when extracting steps from the history.

We also add an `invalid` property to `WorkflowExtractionJob`s, which indicates if the job cannot be converted into a step if its tool is inaccessible.

<img width="1595" height="816" alt="image" src="https://github.com/user-attachments/assets/db153a28-755f-4167-9ecb-84b34e940613" />

Fixes https://github.com/galaxyproject/galaxy/issues/22659

This also includes minor fixes and enhancements such as:
- We now view workflow extraction job in a modal instead of in new tab
- Breadcrumb headings' supertext used to wrap weirdly (think the `current` indicator on history views); that is now fixed
- Improves styling and layout on the carbon emissions page

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
