### PR TITLE
Migrate the Google Drive file source to fsspec

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -267,7 +267,7 @@ class ConditionalDependencies:
     def check_fs_sshfs(self):
         return "ssh" in self.file_sources
 
-    def check_fs_googledrivefs(self):
+    def check_gdrive_fsspec(self):
         return "googledrive" in self.file_sources
 
     def check_gcsfs(self):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -25,7 +25,7 @@ webdav4[fsspec]  # type: webdav
 fs.dropboxfs>=1.0.3  # type: dropbox
 fs.sshfs  # type: ssh
 fs.anvilfs # type: anvil
-fs.googledrivefs # type: googledrive
+gdrive_fsspec # type: googledrive
 gcsfs # type: googlecloudstorage
 fs.onedatarestfs==21.2.5.2 # type: onedata, depends on onedatafilerestclient
 fs-basespace # type: basespace

--- a/lib/galaxy/files/sources/googledrive.py
+++ b/lib/galaxy/files/sources/googledrive.py
@@ -1,58 +1,109 @@
 try:
-    from fs.googledrivefs.googledrivefs import GoogleDriveFS
+    from gdrive_fsspec import GoogleDriveFileSystem
     from google.oauth2.credentials import Credentials
+    from googleapiclient.discovery import build
 except ImportError:
-    GoogleDriveFS = None
+    GoogleDriveFileSystem = None
 
 
+from datetime import datetime
 from typing import (
     Annotated,
+    Optional,
     Union,
 )
 
+from fsspec import AbstractFileSystem
 from pydantic import (
     AliasChoices,
     Field,
 )
 
-from galaxy.files.models import (
-    BaseFileSourceConfiguration,
-    BaseFileSourceTemplateConfiguration,
-    FilesSourceRuntimeContext,
-)
+from galaxy.files.models import FilesSourceRuntimeContext
 from galaxy.util.config_templates import TemplateExpansion
-from ._pyfilesystem2 import PyFilesystem2FilesSource
+from ._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+
+GalaxyGoogleDriveFileSystem: Optional[type[AbstractFileSystem]]
+
+if GoogleDriveFileSystem is not None:
+
+    class _GalaxyGoogleDriveFileSystem(GoogleDriveFileSystem):
+        def __init__(self, access_token: str, **kwargs):
+            self._galaxy_credentials = Credentials(token=access_token)
+            super().__init__(token="galaxy", **kwargs)
+
+        def connect(self, method=None):
+            if method == "galaxy":
+                srv = build("drive", "v3", credentials=self._galaxy_credentials)
+                self.srv = srv
+                self.files = srv.files()
+            else:
+                super().connect(method=method)
+
+        def put_file(self, lpath, rpath, *args, **kwargs):
+            parent = self._parent(str(rpath))
+            if parent not in self.dircache:
+                self.dircache[parent] = []
+            return super().put_file(lpath, rpath, *args, **kwargs)
+
+    GalaxyGoogleDriveFileSystem = _GalaxyGoogleDriveFileSystem
+
+else:
+    GalaxyGoogleDriveFileSystem = None
 
 AccessTokenField = Field(
     ...,
-    validation_alias=AliasChoices("oauth2_access_token", "accessToken", "access_token"),
+    validation_alias=AliasChoices("oauth2_access_token", "accessToken", "access_token", "token"),
 )
 
 
-class GoogleDriveFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
+class GoogleDriveFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
     access_token: Annotated[Union[str, TemplateExpansion], AccessTokenField]
 
 
-class GoogleDriveFilesSourceConfiguration(BaseFileSourceConfiguration):
+class GoogleDriveFilesSourceConfiguration(FsspecBaseFileSourceConfiguration):
     access_token: Annotated[str, AccessTokenField]
 
 
 class GoogleDriveFilesSource(
-    PyFilesystem2FilesSource[GoogleDriveFileSourceTemplateConfiguration, GoogleDriveFilesSourceConfiguration]
+    FsspecFilesSource[GoogleDriveFileSourceTemplateConfiguration, GoogleDriveFilesSourceConfiguration]
 ):
     plugin_type = "googledrive"
-    required_module = GoogleDriveFS
-    required_package = "fs.googledrivefs"
+    required_module = GalaxyGoogleDriveFileSystem
+    required_package = "gdrive_fsspec"
 
     template_config_class = GoogleDriveFileSourceTemplateConfiguration
     resolved_config_class = GoogleDriveFilesSourceConfiguration
 
-    def _open_fs(self, context: FilesSourceRuntimeContext[GoogleDriveFilesSourceConfiguration]):
-        if GoogleDriveFS is None:
+    def _open_fs(
+        self,
+        context: FilesSourceRuntimeContext[GoogleDriveFilesSourceConfiguration],
+        cache_options: CacheOptionsDictType,
+    ):
+        if GalaxyGoogleDriveFileSystem is None:
             raise self.required_package_exception
-        credentials = Credentials(token=context.config.access_token)
-        handle = GoogleDriveFS(credentials)
-        return handle
+        return GalaxyGoogleDriveFileSystem(access_token=context.config.access_token, **cache_options)
+
+    def _to_filesystem_path(self, path: str, config: GoogleDriveFilesSourceConfiguration) -> str:
+        if path in ("", "/"):
+            return ""
+        return path.lstrip("/")
+
+    def _adapt_entry_path(self, filesystem_path: str, config: GoogleDriveFilesSourceConfiguration) -> str:
+        if not filesystem_path or filesystem_path == "/":
+            return "/"
+        return filesystem_path if filesystem_path.startswith("/") else f"/{filesystem_path}"
+
+    def _extract_timestamp(self, info: dict):
+        timestamp = info.get("modifiedTime") or info.get("createdTime") or super()._extract_timestamp(info)
+        if isinstance(timestamp, str):
+            return datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        return timestamp
 
 
 __all__ = ("GoogleDriveFilesSource",)

--- a/test/unit/app/dependencies/test_deps.py
+++ b/test/unit/app/dependencies/test_deps.py
@@ -21,9 +21,10 @@ backends:
    - id: files1
      type: azure_blob
 """
-FILES_SOURCES_DROPBOX = """
+FILES_SOURCES_CONFIG = """
 - type: webdav
 - type: dropbox
+- type: googledrive
 """
 JOB_CONF_YAML = """
 runners:
@@ -75,17 +76,19 @@ def test_fs_default():
     with _config_context() as cc:
         cds = cc.get_cond_deps()
         assert not cds.check_fs_dropboxfs()
+        assert not cds.check_gdrive_fsspec()
         assert not cds.check_webdav4()
 
 
 def test_fs_configured():
     with _config_context() as cc:
-        file_sources_conf = cc.write_config("file_sources.yml", FILES_SOURCES_DROPBOX)
+        file_sources_conf = cc.write_config("file_sources.yml", FILES_SOURCES_CONFIG)
         config = {
             "file_sources_config_file": file_sources_conf,
         }
         cds = cc.get_cond_deps(config=config)
         assert cds.check_fs_dropboxfs()
+        assert cds.check_gdrive_fsspec()
         assert cds.check_webdav4()
 
 

--- a/test/unit/files/googledrive_file_sources_conf.yml
+++ b/test/unit/files/googledrive_file_sources_conf.yml
@@ -2,7 +2,3 @@
   id: test1
   doc: Test access to a Google drive.
   token: ${user.preferences['googledrive|access_token']}
-  refresh_token: ${user.preferences['googledrive|refresh_token']}
-  token_uri: "https://www.googleapis.com/oauth2/v4/token"
-  client_id: ${user.preferences['googledrive|client_id']}
-  client_secret: ${user.preferences['googledrive|client_secret']}

--- a/test/unit/files/test_googledrive.py
+++ b/test/unit/files/test_googledrive.py
@@ -8,9 +8,8 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "googledrive_file_sources_conf.yml")
 
 skip_if_no_google_drive_access_token = pytest.mark.skipif(
-    not os.environ.get("GALAXY_TEST_GOOGLE_DRIVE_ACCESS_TOKEN")
-    or not os.environ.get("GALAXY_TEST_GOOGLE_DRIVE_REFRESH_TOKEN"),
-    reason="GALAXY_TEST_GOOGLE_DRIVE_ACCESS_TOKEN and related vars not set",
+    not os.environ.get("GALAXY_TEST_GOOGLE_DRIVE_ACCESS_TOKEN"),
+    reason="GALAXY_TEST_GOOGLE_DRIVE_ACCESS_TOKEN not set",
 )
 
 


### PR DESCRIPTION
Migrates the Galaxy Google Drive file source from the deprecated PyFilesystem2 fs.googledrivefs backend to the fsspec-based gdrive_fsspec.GoogleDriveFileSystem.

The Google Drive file source now inherits from FsspecFilesSource, uses fsspec configuration models, and preserves the existing Galaxy-facing configuration keys and OAuth token aliases. Existing templates and yaml configs continue to work.

Migration sub-issue https://github.com/galaxyproject/galaxy/issues/21868
This PR fixes https://github.com/galaxyproject/galaxy/issues/22695

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
