### PR TITLE
Remove leftover debug print statement

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -2004,7 +2004,6 @@ class DeviceSourceMap:
         if object_store_id in self.backends:
             device_map = self.backends.get(object_store_id)
             if device_map:
-                print(device_map)
                 return device_map.get_device_id(object_store_id)
 
         return self.default_device_id


### PR DESCRIPTION
Discovered during #22606 testing

This seems to be a debug leftover since it only prints a bunch of `<galaxy.objectstore.DeviceSourceMap object at 0x7d5a3af578d0>` in the logs when moving datasets around in #22606.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
