### PR TITLE
Harden access control for user-defined tools

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -761,9 +761,12 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer[T], 
         """
         dataset = item
         if dataset.creating_job:
-            tool = self.app.toolbox.tool_for_job(
-                dataset.creating_job, exact=False, check_access=True, user=context.get("user")
-            )
+            try:
+                tool = self.app.toolbox.tool_for_job(
+                    dataset.creating_job, exact=False, check_access=True, user=context.get("user")
+                )
+            except (exceptions.ItemAccessibilityException, exceptions.InsufficientPermissionsException):
+                return False
             if tool and tool.is_workflow_compatible:
                 return True
         return False

--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -141,7 +141,12 @@ class DynamicToolManager(ModelManager[DynamicTool]):
             if not tool_format:
                 raise exceptions.ObjectAttributeMissingException("Current tool representations require 'class'.")
 
-        if tool_format in ("GalaxyTool", "GalaxyUserTool"):
+        if tool_format == "GalaxyUserTool":
+            raise exceptions.RequestParameterInvalidException(
+                "GalaxyUserTool is reserved for user-defined tools created via "
+                "/api/unprivileged_tools; use GalaxyTool for admin-installed dynamic tools."
+            )
+        if tool_format == "GalaxyTool":
             tool_id = representation.get("id")
             if not tool_id:
                 tool_id = str(uuid)

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -416,6 +416,9 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
             return None
 
         tool = self.create_dynamic_tool(dynamic_tool)
+        if dynamic_tool.tool_format == "GalaxyUserTool":
+            # UDTs are resolved per-request via DynamicToolManager; never cache.
+            return tool
         self.register_tool(tool)
         assert isinstance(dynamic_tool.uuid, UUID)
         self._tools_by_uuid[dynamic_tool.uuid] = tool

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -680,6 +680,12 @@ class ToolBox(AbstractToolBox):
             raise Exception(f"Unknown tool representation format [{tool_format}].")
         tool = create_tool_from_source(self.app, tool_source=tool_source, tool_dir=None, dynamic=True)
         tool.dynamic_tool = dynamic_tool
+        # Snapshot while the ORM row is session-attached; later reads would raise
+        # DetachedInstanceError.
+        tool.dynamic_tool_id = dynamic_tool.id
+        tool.dynamic_tool_uuid = dynamic_tool.uuid if isinstance(dynamic_tool.uuid, UUID) else None
+        tool.is_unprivileged_tool = not bool(dynamic_tool.public)
+        tool.dynamic_tool_active = bool(dynamic_tool.active)
         return tool
 
     def tool_for_job(
@@ -691,14 +697,15 @@ class ToolBox(AbstractToolBox):
         tool_version: Optional[str] = None,
     ) -> Optional["Tool"]:
         if (dynamic_tool := job.dynamic_tool) is not None:
-            if check_access:
-                if not user:
-                    return None
-                if not dynamic_tool.public:
-                    self.app.dynamic_tool_manager.ensure_can_use_unprivileged_tool(user)
+            if check_access and not dynamic_tool.public:
+                if user is None or dynamic_tool.uuid is None:
+                    raise exceptions.ItemAccessibilityException("Tool not accessible.")
+                tool = self.get_unprivileged_tool(user, tool_uuid=dynamic_tool.uuid)
+                if tool is None:
+                    raise exceptions.ItemAccessibilityException("Tool not accessible.")
+                return tool
             return self.dynamic_tool_to_tool(dynamic_tool)
-        else:
-            return self.get_tool(job.tool_id, tool_version=tool_version or job.tool_version, exact=exact)
+        return self.get_tool(job.tool_id, tool_version=tool_version or job.tool_version, exact=exact)
 
     def create_dynamic_tool(self, dynamic_tool: "DynamicTool") -> "Tool":
         tool = self.dynamic_tool_to_tool(dynamic_tool)
@@ -1051,6 +1058,12 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         self.rerun = False
         # This will be non-None for tools loaded from the database (DynamicTool objects).
         self.dynamic_tool: Optional[DynamicTool] = None
+        # Primitives snapshotted from DynamicTool so allow_user_access never
+        # touches a possibly-detached ORM row.
+        self.dynamic_tool_id: Optional[int] = None
+        self.dynamic_tool_uuid: Optional[UUID] = None
+        self.is_unprivileged_tool: bool = False
+        self.dynamic_tool_active: bool = True
         # Define a place to keep track of all input   These
         # differ from the inputs dictionary in that inputs can be page
         # elements like conditionals, but input_params are basic form
@@ -1299,26 +1312,21 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
     def get_panel_section(self) -> Union[tuple[str, str], tuple[None, None]]:
         return self.app.toolbox.get_section_for_tool(self)
 
-    def allow_user_access(self, user, attempting_access=True):
+    def allow_user_access(self, user, attempting_access: bool = True) -> bool:
         """
         :returns: bool -- Whether the user is allowed to access the tool.
         """
         if self.require_login and user is None:
             return False
-        if self.dynamic_tool:
-            try:
-                is_public = self.dynamic_tool.public
-            except Exception:
-                # DynamicTool not bound to session, access was validated at load time
-                is_public = True
-            if not is_public:
-                if user is None:
-                    return False
-                try:
-                    self.app.dynamic_tool_manager.ensure_can_use_unprivileged_tool(user)
-                except Exception:
-                    return False
-        return True
+        if not self.is_unprivileged_tool:
+            return True
+        if user is None or not self.dynamic_tool_active or self.dynamic_tool_uuid is None:
+            return False
+        try:
+            owned = self.app.dynamic_tool_manager.get_unprivileged_tool_by_uuid(user, self.dynamic_tool_uuid)
+        except exceptions.InsufficientPermissionsException:
+            return False
+        return owned is not None
 
     def parse(self, tool_source: ToolSource, guid: Optional[str] = None, dynamic: bool = False) -> None:
         """

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -70,7 +70,10 @@ from galaxy.tool_util.parser.output_objects import (
     ToolOutput,
     ToolOutputCollection,
 )
-from galaxy.tool_util_models.dynamic_tool_models import DynamicToolCreatePayload
+from galaxy.tool_util_models.dynamic_tool_models import (
+    DynamicToolCreatePayload,
+    DynamicUnprivilegedToolCreatePayload,
+)
 from galaxy.tools import (
     DatabaseOperationTool,
     DefaultToolState,
@@ -2326,10 +2329,24 @@ class ToolModule(WorkflowModule):
         if tool_id is None and tool_uuid is None:
             tool_representation = d.get("tool_representation")
             if tool_representation:
-                create_request = DynamicToolCreatePayload(src="representation", representation=tool_representation)
-                if not trans.user_is_admin:
-                    raise exceptions.AdminRequiredException("Only admin users can create tools dynamically.")
-                dynamic_tool = trans.app.dynamic_tool_manager.create_tool(create_request)
+                if tool_representation.get("class") == "GalaxyUserTool":
+                    # User-defined tool embedded in the workflow: create it as a
+                    # private UDT owned by the importing user. Requires
+                    # USER_TOOL_EXECUTE; create_unprivileged_tool raises
+                    # InsufficientPermissionsException otherwise.
+                    if trans.user is None:
+                        raise exceptions.InsufficientPermissionsException(
+                            "User is not allowed to run unprivileged tools"
+                        )
+                    unprivileged_request = DynamicUnprivilegedToolCreatePayload(representation=tool_representation)
+                    dynamic_tool = trans.app.dynamic_tool_manager.create_unprivileged_tool(
+                        trans.user, unprivileged_request
+                    )
+                else:
+                    if not trans.user_is_admin:
+                        raise exceptions.AdminRequiredException("Only admin users can create tools dynamically.")
+                    create_request = DynamicToolCreatePayload(src="representation", representation=tool_representation)
+                    dynamic_tool = trans.app.dynamic_tool_manager.create_tool(create_request)
                 tool_uuid = dynamic_tool.uuid
         if tool_id is None and tool_uuid is None:
             raise exceptions.RequestParameterInvalidException(f"No content id could be located for for step [{d}]")

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2120,7 +2120,8 @@ class TestToolsApi(ApiTestCase, TestsTools):
     #     assert output_content == "abc\n"
 
     def test_dynamic_tool_shell_command(self):
-        tool_response = self.dataset_populator.create_tool(TOOL_WITH_SHELL_COMMAND)
+        shell_command_tool = dict(TOOL_WITH_SHELL_COMMAND, **{"class": "GalaxyTool"})
+        tool_response = self.dataset_populator.create_tool(shell_command_tool)
         self._assert_has_keys(tool_response, "uuid")
 
         # Run tool.

--- a/lib/galaxy_test/api/test_unprivileged_tools.py
+++ b/lib/galaxy_test/api/test_unprivileged_tools.py
@@ -1,4 +1,6 @@
 # Test tools API.
+from uuid import uuid4
+
 from galaxy.tool_util_models import UserToolSource
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
@@ -15,6 +17,13 @@ class TestUnprivilegedToolsApi(ApiTestCase, TestsTools):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+
+    def test_admin_cannot_create_public_galaxy_user_tool(self):
+        # GalaxyUserTool would land as public=True and bypass role+ownership.
+        payload = {"representation": TOOL_WITH_SHELL_COMMAND}
+        response = self.dataset_populator._post("dynamic_tools", data=payload, admin=True, json=True)
+        assert response.status_code == 400, response.text
+        assert "GalaxyUserTool" in response.text
 
     def test_create_unprivileged_requires_execute_role(self):
         dynamic_tool = self.dataset_populator.create_unprivileged_tool(
@@ -87,6 +96,63 @@ class TestUnprivilegedToolsApi(ApiTestCase, TestsTools):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             output_content = self.dataset_populator.get_history_dataset_content(history_id)
             assert output_content == "abc\n"
+
+    def test_rerun_private_udt_denied_for_non_owner_with_execute_role(self):
+        with (
+            self.dataset_populator.test_history() as history_id,
+            self.dataset_populator.user_tool_execute_permissions(),
+        ):
+            dynamic_tool = self.dataset_populator.create_unprivileged_tool(UserToolSource(**TOOL_WITH_SHELL_COMMAND))
+            dataset = self.dataset_populator.new_dataset(history_id=history_id, content="abc")
+            run_response = self._run(
+                history_id=history_id,
+                tool_uuid=dynamic_tool["uuid"],
+                inputs={"input": {"src": "hda", "id": dataset["id"]}},
+            )
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            job_id = run_response.json()["jobs"][0]["id"]
+            tool_uuid = dynamic_tool["uuid"]
+            self.dataset_populator.make_public(history_id)
+
+            other_email = f"udt_non_owner_{uuid4()}@bx.psu.edu"
+            with self._different_user(email=other_email):
+                with self.dataset_populator.user_tool_execute_permissions():
+                    # Import A's published history into B's account so B holds a
+                    # legitimate copy of the data; rerun must still be denied.
+                    copy_response = self.dataset_populator.copy_history(history_id)
+                    copy_response.raise_for_status()
+
+                    rerun_response = self.dataset_populator._get(f"jobs/{job_id}/build_for_rerun")
+                    assert rerun_response.status_code == 403, rerun_response.text
+
+                    tool_response = self.dataset_populator._get(f"tools/{tool_uuid}")
+                    assert tool_response.status_code in (403, 404), tool_response.text
+
+    def test_rerun_private_udt_denied_for_user_without_execute_role(self):
+        with (
+            self.dataset_populator.test_history() as history_id,
+            self.dataset_populator.user_tool_execute_permissions(),
+        ):
+            dynamic_tool = self.dataset_populator.create_unprivileged_tool(UserToolSource(**TOOL_WITH_SHELL_COMMAND))
+            dataset = self.dataset_populator.new_dataset(history_id=history_id, content="abc")
+            run_response = self._run(
+                history_id=history_id,
+                tool_uuid=dynamic_tool["uuid"],
+                inputs={"input": {"src": "hda", "id": dataset["id"]}},
+            )
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            job_id = run_response.json()["jobs"][0]["id"]
+            self.dataset_populator.make_public(history_id)
+
+            other_email = f"udt_no_role_{uuid4()}@bx.psu.edu"
+            with self._different_user(email=other_email):
+                # Import A's published history into B's account so B holds a
+                # legitimate copy of the data; rerun must still be denied.
+                copy_response = self.dataset_populator.copy_history(history_id)
+                copy_response.raise_for_status()
+
+                rerun_response = self.dataset_populator._get(f"jobs/{job_id}/build_for_rerun")
+                assert rerun_response.status_code == 403, rerun_response.text
 
     def test_deactivate(self):
         with self.dataset_populator.user_tool_execute_permissions():

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -10055,6 +10055,56 @@ outer_input:
             workflow = self.workflow_populator.download_workflow(workflow_id)
             assert workflow["steps"]["0"]["tool_representation"]["class"] == "GalaxyUserTool"
 
+    def _build_user_defined_workflow_dict(self) -> dict[str, Any]:
+        return {
+            "a_galaxy_workflow": "true",
+            "name": "wf with embedded UDT",
+            "annotation": "",
+            "format-version": "0.1",
+            "steps": {
+                "0": {
+                    "id": 0,
+                    "type": "tool",
+                    "name": "Embedded user tool",
+                    "tool_representation": TOOL_WITH_SHELL_COMMAND,
+                    "input_connections": {},
+                    "inputs": [],
+                    "outputs": [],
+                    "workflow_outputs": [],
+                    "post_job_actions": {},
+                    "tool_state": "{}",
+                    "label": None,
+                    "uuid": str(uuid4()),
+                },
+            },
+        }
+
+    def test_import_workflow_with_user_defined_tool_representation_requires_role(self):
+        # Non-admin without USER_TOOL_EXECUTE must not be able to import a
+        # workflow that embeds a GalaxyUserTool representation.
+        wf = self._build_user_defined_workflow_dict()
+        response = self._post("workflows", data={"workflow": json.dumps(wf)})
+        assert response.status_code == 403, response.text
+        assert "not allowed to run unprivileged tools" in response.text
+
+    def test_import_workflow_with_user_defined_tool_representation(self):
+        # Non-admin with USER_TOOL_EXECUTE can import a workflow that embeds a
+        # GalaxyUserTool representation; a private UDT is created in their account.
+        with self.dataset_populator.user_tool_execute_permissions():
+            wf = self._build_user_defined_workflow_dict()
+            response = self._post("workflows", data={"workflow": json.dumps(wf)})
+            assert response.status_code == 200, response.text
+            workflow_id = response.json()["id"]
+            downloaded = self.workflow_populator.download_workflow(workflow_id)
+            step_dict = downloaded["steps"]["0"]
+            assert step_dict["tool_representation"]["class"] == "GalaxyUserTool"
+
+            # The importer now owns a private UDT matching the embedded representation.
+            owned = self.dataset_populator.get_unprivileged_tools()
+            assert any(
+                t["representation"]["name"] == TOOL_WITH_SHELL_COMMAND["name"] for t in owned
+            ), f"Expected an owned UDT after workflow import: {owned}"
+
     def _invoke_paused_workflow(self, history_id):
         workflow = self.workflow_populator.load_workflow_from_resource("test_workflow_pause")
         workflow_id = self.workflow_populator.create_workflow(workflow)

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -1,18 +1,29 @@
 import logging
 import time
+from typing import (
+    Optional,
+    TYPE_CHECKING,
+)
 from unittest.mock import MagicMock
+from uuid import (
+    UUID,
+    uuid4,
+)
 
 import pytest
 import routes
 
 from galaxy import model
 from galaxy.app_unittest_utils.toolbox_support import BaseToolBoxTestCase
-from galaxy.exceptions import InsufficientPermissionsException
+from galaxy.managers.tools import DynamicToolManager
 from galaxy.tool_util.unittest_utils import mock_trans
 from galaxy.tool_util.unittest_utils.sample_data import (
     SIMPLE_MACRO,
     SIMPLE_TOOL_WITH_MACRO,
 )
+
+if TYPE_CHECKING:
+    from galaxy.tools import Tool
 
 log = logging.getLogger(__name__)
 
@@ -158,43 +169,112 @@ class TestToolBox(BaseToolBoxTestCase):
         as_dict = self.toolbox.to_dict(mock_trans(), in_panel=False)
         assert len(as_dict) == 0, as_dict
 
-    def test_allow_user_access_non_public_dynamic_tool(self):
+    def _setup_dynamic_tool_test(self) -> "Tool":
         self._init_tool()
         self._add_config("""<toolbox><tool file="tool.xml" /></toolbox>""")
         tool = self.toolbox.get_tool("test_tool")
+        tool.app.dynamic_tool_manager = DynamicToolManager(self.app)
+        return tool
 
-        # Regular tool allows access without a user
-        assert tool.allow_user_access(None) is True
+    def _persist_user(self, with_user_tool_execute_role: bool = False) -> model.User:
+        session = self.app.model.context
+        user = model.User(email=f"u_{uuid4().hex}@example.com", password="pw")
+        session.add(user)
+        if with_user_tool_execute_role:
+            role = model.Role(
+                name=f"udt_exec_{uuid4().hex[:8]}",
+                description="user tool execute",
+                type=model.Role.types.USER_TOOL_EXECUTE,
+                deleted=False,
+            )
+            session.add(role)
+            session.add(model.UserRoleAssociation(user, role))
+        session.commit()
+        return user
 
-        # Simulate a non-public dynamic tool
-        dynamic_tool = MagicMock()
-        dynamic_tool.public = False
-        tool.dynamic_tool = dynamic_tool
-
-        # Mock the dynamic tool manager to reject the user
-        mock_manager = MagicMock()
-        mock_manager.ensure_can_use_unprivileged_tool.side_effect = InsufficientPermissionsException(
-            "User is not allowed to run unprivileged tools"
+    def _persist_dynamic_tool(
+        self, public: bool, active: bool = True, owner: Optional[model.User] = None
+    ) -> model.DynamicTool:
+        session = self.app.model.context
+        dyn = model.DynamicTool(
+            tool_format="GalaxyUserTool",
+            tool_id=f"udt_{uuid4().hex[:8]}",
+            tool_version="0.1",
+            uuid=uuid4(),
+            value={"name": "test", "class": "GalaxyUserTool", "version": "0.1"},
+            public=public,
+            active=active,
         )
-        tool.app.dynamic_tool_manager = mock_manager
+        session.add(dyn)
+        session.flush()
+        if owner is not None:
+            session.add(model.UserDynamicToolAssociation(user_id=owner.id, dynamic_tool_id=dyn.id))
+        session.commit()
+        return dyn
 
-        # Non-public dynamic tool denies access without a user
+    def _snapshot(self, tool: "Tool", dyn: model.DynamicTool) -> None:
+        tool.dynamic_tool_id = dyn.id
+        tool.dynamic_tool_uuid = dyn.uuid if isinstance(dyn.uuid, UUID) else None
+        tool.is_unprivileged_tool = not bool(dyn.public)
+        tool.dynamic_tool_active = bool(dyn.active)
+
+    def test_allow_user_access_non_dynamic_tool(self):
+        tool = self._setup_dynamic_tool_test()
+        some_user = self._persist_user()
+        assert tool.allow_user_access(None) is True
+        assert tool.allow_user_access(some_user) is True
+
+    def test_allow_user_access_for_non_unprivileged_tool(self):
+        tool = self._setup_dynamic_tool_test()
+        dyn = self._persist_dynamic_tool(public=True)
+        self._snapshot(tool, dyn)
+        some_user = self._persist_user()
+
+        assert tool.is_unprivileged_tool is False
+        assert tool.allow_user_access(None) is True
+        assert tool.allow_user_access(some_user) is True
+
+    def test_allow_user_access_denies_anonymous_for_unprivileged_tool(self):
+        tool = self._setup_dynamic_tool_test()
+        dyn = self._persist_dynamic_tool(public=False)
+        self._snapshot(tool, dyn)
+
+        assert tool.is_unprivileged_tool is True
         assert tool.allow_user_access(None) is False
 
-        # Non-public dynamic tool denies access for user without execute role
-        mock_user = MagicMock()
-        assert tool.allow_user_access(mock_user) is False
-        mock_manager.ensure_can_use_unprivileged_tool.assert_called_with(mock_user)
+    def test_allow_user_access_unprivileged_tool_grants_only_to_owner_with_role(self):
+        tool = self._setup_dynamic_tool_test()
+        owner = self._persist_user(with_user_tool_execute_role=True)
+        dyn = self._persist_dynamic_tool(public=False, owner=owner)
+        self._snapshot(tool, dyn)
 
-        # Non-public dynamic tool allows access for user with execute role
-        mock_manager.ensure_can_use_unprivileged_tool.side_effect = None
-        assert tool.allow_user_access(mock_user) is True
+        assert tool.allow_user_access(owner) is True
 
-        # Detached dynamic tool allows access (validated at load time)
-        detached_dynamic_tool = MagicMock()
-        type(detached_dynamic_tool).public = property(lambda self: (_ for _ in ()).throw(Exception("not bound")))
-        tool.dynamic_tool = detached_dynamic_tool
-        assert tool.allow_user_access(None) is True
+        other_with_role = self._persist_user(with_user_tool_execute_role=True)
+        assert tool.allow_user_access(other_with_role) is False
+
+        other_no_role = self._persist_user(with_user_tool_execute_role=False)
+        assert tool.allow_user_access(other_no_role) is False
+
+        tool.dynamic_tool_active = False
+        assert tool.allow_user_access(owner) is False
+
+    def test_allow_user_access_with_detached_dynamic_tool_does_not_raise(self):
+        """Regression: booby-trap the ORM row so any read raises; allow_user_access
+        must rely on the snapshot only."""
+        tool = self._setup_dynamic_tool_test()
+
+        detached = MagicMock()
+        type(detached).public = property(lambda self: (_ for _ in ()).throw(Exception("not bound")))
+        type(detached).active = property(lambda self: (_ for _ in ()).throw(Exception("not bound")))
+        tool.dynamic_tool = detached
+
+        dyn = self._persist_dynamic_tool(public=False)
+        self._snapshot(tool, dyn)
+
+        assert tool.allow_user_access(None) is False
+        some_user = self._persist_user(with_user_tool_execute_role=True)
+        assert tool.allow_user_access(some_user) is False
 
     def _find_section(self, as_dict, section_id):
         for elem in as_dict:


### PR DESCRIPTION
## Summary

Closes three authorization gaps in the user-defined tool (UDT) flow that exist on 26.0:

1. **Admin `POST /api/dynamic_tools` accepts `class: GalaxyUserTool`.** The resulting row is written with `public=True`, enters the long-lived toolbox cache via `load_dynamic_tool`, and becomes reachable from `/api/tools/{uuid}` by any authenticated user — bypassing the role + ownership gate that `/api/unprivileged_tools` enforces.

2. **The same publish-as-public path is reachable via workflow import.** `ToolModule.from_dict` routes every embedded `tool_representation` through `DynamicToolManager.create_tool` and is admin-only. So importing admins silently turn embedded `GalaxyUserTool` representations into public toolbox entries, and non-admin users with `USER_TOOL_EXECUTE` are blocked from a legitimate flow that should create a private UDT in their own account.

3. **`Tool.allow_user_access` and `Toolbox.tool_for_job` enforce only the global `USER_TOOL_EXECUTE` role, never `UserDynamicToolAssociation` ownership.** This is information disclosure, not execution: on 26.0 actual `/api/tools` execution is already ownership-gated at the API entry via `DynamicToolManager.get_unprivileged_tool_by_uuid` (`owned_unprivileged_statement`). The two Tool-layer methods are reached from display / form-rendering paths:
   - `Toolbox.tool_for_job` from `/api/jobs/{id}/build_for_rerun` (renders the rerun form) and from `serialize_rerunnable` in dataset serialization (controls whether the rerun button is offered).
   - `Tool.allow_user_access` from `Toolbox.to_dict` / panel filtering (controls visibility in the user's toolbox listing).

   On 26.0 a non-owner who legitimately holds the data (e.g., via shared-history import) can therefore read a private UDT's tool definition / form parameters via the rerun form, and see the UDT in incidental listings. The form-disclosure case is partially masked by an unrelated history-ownership check in `Tool.to_json`, but the dedicated gate at the *tool* layer is missing in both places. The fix also closes the gap defensively against any future caller that routes execution through `allow_user_access` (e.g. workflow scheduling, agent tool execution).

## Changes

- **`DynamicToolManager.create_tool` rejects `tool_format == "GalaxyUserTool"`.** The format is now reserved for the user-facing `/api/unprivileged_tools` flow (writes `public=False`, creates the ownership association).
- **`ToolModule.from_dict` dispatches by class on embedded `tool_representation`:** `GalaxyUserTool` goes through `create_unprivileged_tool` (gated by `USER_TOOL_EXECUTE`), so non-admin users with the role can legitimately import UDT-bearing workflows; other classes (`GalaxyTool`, CWL) stay admin-only via `create_tool`.
- **`Toolbox.tool_for_job` routes non-public dynamic-tool lookups through `Toolbox.get_unprivileged_tool` → `DynamicToolManager.get_unprivileged_tool_by_uuid`** — the same path `/api/tools/{uuid}` already uses. One authoritative SQL query (`owned_unprivileged_statement`) enforces role + ownership. Closes the form-disclosure gap on the rerun path.
- **Snapshot `DynamicTool` columns onto `Tool` at load time** and expose them as `is_unprivileged_tool` / `dynamic_tool_active` / `dynamic_tool_uuid`. `Tool.allow_user_access` reads the snapshot and delegates to `get_unprivileged_tool_by_uuid`; it never touches the (possibly-detached) ORM row. Catches only `InsufficientPermissionsException` so other failures still surface. Replaces a `try/except` on dev that defaulted `is_public` to `True` on `DetachedInstanceError` — latently incorrect. Closes the listing-disclosure gap and brings the Tool-layer gate in line with the API-entry gate (defense in depth).
- **`AbstractToolBox.load_dynamic_tool` short-circuits for `tool_format == "GalaxyUserTool"`** so UDTs cannot enter the long-lived toolbox cache even if a future code path tries to publish one.
- **`_UnflattenedMetadataDatasetAssociationSerializer.serialize_rerunnable` catches the precise authorization exceptions** (`ItemAccessibilityException` / `InsufficientPermissionsException`) instead of a broad `MessageException`, so unrelated failures still surface.

## Tests

Regression tests land in a **separate first commit** so they can be run against 26.0 to verify the gaps reproduce before the fixes:

- `test_admin_cannot_create_public_galaxy_user_tool` — admin `POST /api/dynamic_tools` with `class=GalaxyUserTool` returns 400.
- `test_rerun_private_udt_denied_for_non_owner_with_execute_role` / `..._for_user_without_execute_role` — User B imports User A's published history into their own account; fetching the rerun form (`/api/jobs/{id}/build_for_rerun`) and `/api/tools/{uuid}` both return 403, regardless of B's role. (These are disclosure paths; actual execution via `POST /api/tools` is already ownership-gated on 26.0.)
- `test_import_workflow_with_user_defined_tool_representation` / `..._requires_role` — a workflow embedding `tool_representation: GalaxyUserTool` succeeds for non-admin users with `USER_TOOL_EXECUTE` (creates a private UDT they own) and returns 403 without the role.

Unit tests in `test/unit/app/tools/test_toolbox.py`: `test_allow_user_access_non_public_dynamic_tool` (which was asserting on a `MagicMock` and proved nothing) is replaced with five tests against a real `DynamicToolManager` + in-memory SQLite, including a regression test that booby-traps the ORM row to pin the snapshot-only contract of `allow_user_access`.

## Test plan

- [ ] `./run_tests.sh -api lib/galaxy_test/api/test_unprivileged_tools.py`
- [ ] `./run_tests.sh -api lib/galaxy_test/api/test_workflows.py -- -k "test_import_workflow_with_user_defined_tool_representation or test_user_defined_workflow_update"`
- [ ] `./run_tests.sh -api lib/galaxy_test/api/test_tools.py -- -k "test_dynamic_tool or test_show_dynamic_tools or test_tool_deactivate"`
- [ ] `pytest test/unit/app/tools/test_toolbox.py`
- [ ] `pytest test/integration/test_agents.py -k "test_mcp_list_user_tools_empty or test_mcp_create_user_tool or test_mcp_delete_user_tool or test_mcp_run_user_tool"`
- [ ] Verify regression-test commit fails on `release_26.0` and passes on this branch
- [ ] `tox -e lint,format,mypy`

## Backward compatibility

- Existing rows with `public=True` and `tool_format == "GalaxyUserTool"` (created by the old admin path) **continue to load and execute**. The rejection in `create_tool` is a precondition on the endpoint, not a data migration. Operators who relied on the old admin path should recreate the tool via `/api/unprivileged_tools` (with `USER_TOOL_EXECUTE`) or as `tool_format: GalaxyTool` via `/api/dynamic_tools`.
- The `load_dynamic_tool` cache short-circuit means UDT-class rows no longer enter `_tools_by_uuid` / `_tools_by_id`; lookups for them now go through the per-request `DynamicToolManager` path. The relevant endpoints (`/api/tools/{uuid}`, rerun, workflow execution) already use that path. No client-visible change for legitimate flows.