### PR TITLE
Enhance workflow extraction by IDs with deduplication and UI improvements

### DIFF
--- a/client/src/api/histories.ts
+++ b/client/src/api/histories.ts
@@ -12,7 +12,7 @@ export type UpdateHistoryPayload = components["schemas"]["UpdateHistoryPayload"]
 
 export type CustomHistoryView = components["schemas"]["CustomHistoryView"];
 
-export type WorkflowExtractionPayload = components["schemas"]["WorkflowExtractionPayload"];
+export type WorkflowExtractionByIdsPayload = components["schemas"]["WorkflowExtractionByIdsPayload"];
 export type WorkflowExtractionJob = components["schemas"]["WorkflowExtractionJob"];
 type WorkflowExtractionResult = components["schemas"]["WorkflowExtractionResult"];
 export type WorkflowExtractionSummary = components["schemas"]["WorkflowExtractionSummary"];
@@ -320,14 +320,8 @@ export async function extractWorkflowFromHistory(historyId: string): Promise<Wor
     return data as WorkflowExtractionSummary;
 }
 
-export async function submitWorkflowExtraction(
-    historyId: string,
-    payload: WorkflowExtractionPayload,
-): Promise<WorkflowExtractionResult> {
-    const { data, error } = await GalaxyApi().POST("/api/histories/{history_id}/extract_workflow", {
-        params: {
-            path: { history_id: historyId },
-        },
+export async function extractWorkflowByIds(payload: WorkflowExtractionByIdsPayload): Promise<WorkflowExtractionResult> {
+    const { data, error } = await GalaxyApi().POST("/api/workflows/extract", {
         body: payload,
     });
 

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -25671,6 +25671,11 @@ export interface components {
              */
             hdca_ids?: string[];
             /**
+             * Implicit Collection Jobs IDs
+             * @description Decoded IDs of ImplicitCollectionJobs (map-over job groups) to include as mapped workflow steps. Use this for steps that ran with a map/over instead of passing a constituent job id in job_ids.
+             */
+            implicit_collection_jobs_ids?: string[];
+            /**
              * Job IDs
              * @description Decoded IDs of compatible tool jobs to include as workflow steps.
              */
@@ -25694,11 +25699,6 @@ export interface components {
              */
             id: string | null;
             /**
-             * Invalid
-             * @description Reason this job is invalid for extraction.
-             */
-            invalid?: components["schemas"]["InvalidWorkflowExtractionJobReason"] | null;
-            /**
              * Implicit Collection Jobs ID
              * @description Encoded ID of the ImplicitCollectionJobs this job belongs to, or null if the job is not part of a mapped/implicit collection. Callers should submit mapped jobs via implicit_collection_jobs_ids rather than job_ids in the extract-by-ids payload.
              */
@@ -25708,6 +25708,11 @@ export interface components {
              * @description Number of constituent jobs in the ICJ (only set when implicit_collection_jobs_id is non-null).
              */
             implicit_collection_jobs_size?: number | null;
+            /**
+             * Invalid
+             * @description Reason this job is invalid for extraction.
+             */
+            invalid?: components["schemas"]["InvalidWorkflowExtractionJobReason"] | null;
             /**
              * Outputs
              * @description The history items produced by this job.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6354,8 +6354,7 @@ export interface paths {
          * @description ID-based workflow extraction.
          *
          *     Per-item permission checks make this history-optional and allow
-         *     cross-history extraction. ``from_history_id`` in the body is UI
-         *     context only.
+         *     cross-history extraction.
          */
         post: operations["extract_by_ids_api_workflows_extract_post"];
         delete?: never;
@@ -25661,11 +25660,6 @@ export interface components {
              * @description Names for the input datasets, parallel to hda_ids.
              */
             dataset_names?: string[];
-            /**
-             * From History ID
-             * @description Optional history context (UI hint). Access decisions use per-item permission checks; not required for cross-history extraction.
-             */
-            from_history_id?: string | null;
             /**
              * HDA IDs
              * @description Decoded IDs of HistoryDatasetAssociations to treat as workflow inputs.

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -25705,6 +25705,16 @@ export interface components {
              */
             invalid?: components["schemas"]["InvalidWorkflowExtractionJobReason"] | null;
             /**
+             * Implicit Collection Jobs ID
+             * @description Encoded ID of the ImplicitCollectionJobs this job belongs to, or null if the job is not part of a mapped/implicit collection. Callers should submit mapped jobs via implicit_collection_jobs_ids rather than job_ids in the extract-by-ids payload.
+             */
+            implicit_collection_jobs_id?: string | null;
+            /**
+             * Implicit Collection Jobs Size
+             * @description Number of constituent jobs in the ICJ (only set when implicit_collection_jobs_id is non-null).
+             */
+            implicit_collection_jobs_size?: number | null;
+            /**
              * Outputs
              * @description The history items produced by this job.
              */

--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -6340,6 +6340,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workflows/extract": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Extract a workflow from selected jobs and history items by encoded IDs.
+         * @description ID-based workflow extraction.
+         *
+         *     Per-item permission checks make this history-optional and allow
+         *     cross-history extraction. ``from_history_id`` in the body is UI
+         *     context only.
+         */
+        post: operations["extract_by_ids_api_workflows_extract_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workflows/menu": {
         parameters: {
             query?: never;
@@ -25624,6 +25648,44 @@ export interface components {
              * @description An array of one or more acceptable engines versions for the `workflow_engine`
              */
             workflow_engine_version?: string[] | null;
+        };
+        /** WorkflowExtractionByIdsPayload */
+        WorkflowExtractionByIdsPayload: {
+            /**
+             * Dataset Collection Names
+             * @description Names for the input dataset collections, parallel to hdca_ids.
+             */
+            dataset_collection_names?: string[];
+            /**
+             * Dataset Names
+             * @description Names for the input datasets, parallel to hda_ids.
+             */
+            dataset_names?: string[];
+            /**
+             * From History ID
+             * @description Optional history context (UI hint). Access decisions use per-item permission checks; not required for cross-history extraction.
+             */
+            from_history_id?: string | null;
+            /**
+             * HDA IDs
+             * @description Decoded IDs of HistoryDatasetAssociations to treat as workflow inputs.
+             */
+            hda_ids?: string[];
+            /**
+             * HDCA IDs
+             * @description Decoded IDs of HistoryDatasetCollectionAssociations to treat as workflow inputs.
+             */
+            hdca_ids?: string[];
+            /**
+             * Job IDs
+             * @description Decoded IDs of compatible tool jobs to include as workflow steps.
+             */
+            job_ids?: string[];
+            /**
+             * Workflow Name
+             * @description The name for the extracted workflow.
+             */
+            workflow_name: string;
         };
         /** WorkflowExtractionJob */
         WorkflowExtractionJob: {
@@ -50208,6 +50270,51 @@ export interface operations {
                     "application/json": {
                         [key: string]: unknown;
                     }[];
+                };
+            };
+            /** @description Request Error */
+            "4XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+            /** @description Server Error */
+            "5XX": {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageExceptionModel"];
+                };
+            };
+        };
+    };
+    extract_by_ids_api_workflows_extract_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+                "run-as"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkflowExtractionByIdsPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkflowExtractionResult"];
                 };
             };
             /** @description Request Error */

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
 import { faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
-import { faBan, faExclamationTriangle, faInfoCircle, faPencilAlt, faWrench } from "@fortawesome/free-solid-svg-icons";
+import {
+    faBan,
+    faExclamationTriangle,
+    faInfoCircle,
+    faLayerGroup,
+    faPencilAlt,
+    faWrench,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed } from "vue";
 
-import type { WorkflowExtractionJob } from "@/api/histories";
 import type { CardBadge, TitleIcon } from "@/components/Common/GCard.types";
 
-import { isWorkflowExtractionInput, type WorkflowExtractionInput } from "./types";
+import { isMappedTool, isWorkflowExtractionInput, type WorkflowExtractionRow } from "./types";
 
 import DisplayedItem from "../Content/DisplayedItem.vue";
 import GCard from "@/components/Common/GCard.vue";
@@ -36,8 +42,19 @@ const STEP_TYPE_META: Record<
     },
 };
 
+function mappedBadge(size: number | null | undefined): CardBadge {
+    return {
+        id: "mapped-tool",
+        label: typeof size === "number" ? `Mapped over ${size} items` : "Mapped",
+        icon: faLayerGroup,
+        title: "This row represents a mapped tool step backed by an implicit collection job.",
+        class: "unselectable",
+        variant: "info",
+    };
+}
+
 const props = defineProps<{
-    job: WorkflowExtractionInput | WorkflowExtractionJob;
+    job: WorkflowExtractionRow;
 }>();
 
 const emit = defineEmits<{
@@ -92,6 +109,9 @@ const badges = computed<CardBadge[]>(() => {
                 class: "unselectable",
                 variant: "warning",
             });
+        }
+        if (isMappedTool(props.job)) {
+            badges.push(mappedBadge(props.job.implicit_collection_jobs_size));
         }
     } else {
         badges.push(INPUT_IS_RENAMABLE_BADGE);

--- a/client/src/components/History/WorkflowExtraction/types.ts
+++ b/client/src/components/History/WorkflowExtraction/types.ts
@@ -1,13 +1,28 @@
 import type { WorkflowExtractionJob } from "@/api/histories";
 
-export type WorkflowExtractionInput = WorkflowExtractionJob & {
+export type WorkflowExtractionToolJob = WorkflowExtractionJob & { step_type: "tool" };
+
+export type WorkflowExtractionInputJob = WorkflowExtractionJob & {
     step_type: "input_dataset" | "input_collection";
+};
+
+export type WorkflowExtractionInput = WorkflowExtractionInputJob & {
     /** The modifiable new name for the workflow input, which will be used in the generated workflow. */
     newName: string;
 };
 
+export type WorkflowExtractionRow = WorkflowExtractionToolJob | WorkflowExtractionInput;
+
+export function isWorkflowExtractionInput(job: WorkflowExtractionRow): job is WorkflowExtractionInput;
+export function isWorkflowExtractionInput(job: WorkflowExtractionJob): job is WorkflowExtractionInputJob;
 export function isWorkflowExtractionInput(
-    job: WorkflowExtractionJob | WorkflowExtractionInput,
-): job is WorkflowExtractionInput {
-    return job.step_type.startsWith("input");
+    job: WorkflowExtractionJob | WorkflowExtractionRow,
+): job is WorkflowExtractionInputJob | WorkflowExtractionInput {
+    return job.step_type === "input_dataset" || job.step_type === "input_collection";
+}
+
+export function isMappedTool(
+    job: WorkflowExtractionJob | WorkflowExtractionRow,
+): job is WorkflowExtractionToolJob & { implicit_collection_jobs_id: string } {
+    return job.step_type === "tool" && Boolean(job.implicit_collection_jobs_id);
 }

--- a/client/src/components/History/WorkflowExtractionForm.test.ts
+++ b/client/src/components/History/WorkflowExtractionForm.test.ts
@@ -246,7 +246,6 @@ describe("WorkflowExtractionForm", () => {
             expect(extractWorkflowByIds).toHaveBeenCalledWith(
                 expect.objectContaining({
                     workflow_name: "Extracted WF",
-                    from_history_id: "history-1",
                     job_ids: ["job-tool-1"],
                     implicit_collection_jobs_ids: [],
                     hda_ids: ["ds-2"],

--- a/client/src/components/History/WorkflowExtractionForm.test.ts
+++ b/client/src/components/History/WorkflowExtractionForm.test.ts
@@ -55,6 +55,18 @@ const TOOL_JOB = {
     ],
 };
 
+const MAPPED_TOOL_JOB = {
+    ...TOOL_JOB,
+    id: "job-tool-2",
+    implicit_collection_jobs_id: "icj-1",
+    implicit_collection_jobs_size: 4,
+};
+
+const MAPPED_TOOL_JOB_2 = {
+    ...MAPPED_TOOL_JOB,
+    id: "job-tool-3",
+};
+
 const INPUT_JOB = {
     id: null,
     tool_id: null,
@@ -76,6 +88,15 @@ const INPUT_JOB = {
 };
 
 const SUMMARY_WITH_JOBS = { jobs: [TOOL_JOB, INPUT_JOB], warnings: [] } as unknown as WorkflowExtractionSummary;
+const SUMMARY_WITH_MAPPED_JOB = { jobs: [MAPPED_TOOL_JOB], warnings: [] } as unknown as WorkflowExtractionSummary;
+const SUMMARY_WITH_DUPLICATE_MAPPED_JOBS = {
+    jobs: [MAPPED_TOOL_JOB, MAPPED_TOOL_JOB_2],
+    warnings: [],
+} as unknown as WorkflowExtractionSummary;
+const SUMMARY_WITH_PLAIN_AND_MAPPED_JOBS = {
+    jobs: [TOOL_JOB, MAPPED_TOOL_JOB],
+    warnings: [],
+} as unknown as WorkflowExtractionSummary;
 const SUMMARY_EMPTY = { jobs: [], warnings: [] } as unknown as WorkflowExtractionSummary;
 const SUMMARY_WITH_WARNINGS = {
     jobs: [TOOL_JOB],
@@ -238,10 +259,50 @@ describe("WorkflowExtractionForm", () => {
                     workflow_name: "Extracted WF",
                     from_history_id: "history-1",
                     job_ids: ["job-tool-1"],
+                    implicit_collection_jobs_ids: [],
                     hda_ids: ["ds-2"],
                     hdca_ids: [],
                     dataset_names: ["myfile.txt"],
                     dataset_collection_names: [],
+                }),
+            );
+        });
+
+        it("submits mapped tool job via implicit_collection_jobs_ids", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_MAPPED_JOB);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            await clickCreateButton(wrapper);
+            expect(extractWorkflowByIds).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    job_ids: [],
+                    implicit_collection_jobs_ids: ["icj-1"],
+                }),
+            );
+        });
+
+        it("dedupes ICJ ids when two cards share an ICJ", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_DUPLICATE_MAPPED_JOBS);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            await clickCreateButton(wrapper);
+            expect(extractWorkflowByIds).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    job_ids: [],
+                    implicit_collection_jobs_ids: ["icj-1"],
+                }),
+            );
+        });
+
+        it("mixes plain and mapped job buckets correctly", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_PLAIN_AND_MAPPED_JOBS);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            await clickCreateButton(wrapper);
+            expect(extractWorkflowByIds).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    job_ids: ["job-tool-1"],
+                    implicit_collection_jobs_ids: ["icj-1"],
                 }),
             );
         });
@@ -259,6 +320,34 @@ describe("WorkflowExtractionForm", () => {
             await setWorkflowName(wrapper, "Extracted WF");
             await clickCreateButton(wrapper);
             expect(wrapper.find('[variant="danger"]').exists()).toBe(true);
+        });
+
+        it("submission error keeps job list visible", async () => {
+            vi.mocked(extractWorkflowByIds).mockRejectedValue(new Error("Submit failed"));
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            await clickCreateButton(wrapper);
+            expect(wrapper.find('[variant="danger"]').exists()).toBe(true);
+            expect(wrapper.findAllComponents(WorkflowExtractionCard)).toHaveLength(2);
+        });
+
+        it("submit shows submitting state without hiding list", async () => {
+            let resolveSubmission: (value: { id: string }) => void = () => {};
+            vi.mocked(extractWorkflowByIds).mockReturnValue(
+                new Promise((resolve) => {
+                    resolveSubmission = resolve;
+                }),
+            );
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            wrapper.findComponent(GButton).vm.$emit("click");
+            await wrapper.vm.$nextTick();
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
+            expect(wrapper.text()).toContain("Creating...");
+            expect(wrapper.findComponent(LoadingSpan).exists()).toBe(false);
+            expect(wrapper.findAllComponents(WorkflowExtractionCard)).toHaveLength(2);
+            resolveSubmission({ id: "new-workflow-id" });
+            await flushPromises();
         });
 
         it("does not submit when button is disabled", async () => {

--- a/client/src/components/History/WorkflowExtractionForm.test.ts
+++ b/client/src/components/History/WorkflowExtractionForm.test.ts
@@ -3,7 +3,12 @@ import { shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { extractWorkflowByIds, extractWorkflowFromHistory, type WorkflowExtractionSummary } from "@/api/histories";
+import {
+    extractWorkflowByIds,
+    extractWorkflowFromHistory,
+    type WorkflowExtractionJob,
+    type WorkflowExtractionSummary,
+} from "@/api/histories";
 import { Toast } from "@/composables/toast";
 
 import GFormInput from "../BaseComponents/Form/GFormInput.vue";
@@ -42,66 +47,50 @@ vi.mock("@/stores/historyStore", () => ({
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
-const TOOL_JOB = {
+const TOOL_JOB: WorkflowExtractionJob = {
     id: "job-tool-1",
     tool_id: "cat1",
     tool_name: "Concatenate",
     tool_version: "1.0",
-    step_type: "tool" as const,
+    step_type: "tool",
     checked: true,
     tool_version_warning: null,
-    outputs: [
-        { id: "ds-1", hid: 1, name: "output1", history_content_type: "dataset" as const, state: "ok", deleted: false },
-    ],
+    outputs: [{ id: "ds-1", hid: 1, name: "output1", history_content_type: "dataset", state: "ok", deleted: false }],
 };
 
-const MAPPED_TOOL_JOB = {
+const MAPPED_TOOL_JOB: WorkflowExtractionJob = {
     ...TOOL_JOB,
     id: "job-tool-2",
     implicit_collection_jobs_id: "icj-1",
     implicit_collection_jobs_size: 4,
 };
 
-const MAPPED_TOOL_JOB_2 = {
+const MAPPED_TOOL_JOB_2: WorkflowExtractionJob = {
     ...MAPPED_TOOL_JOB,
     id: "job-tool-3",
 };
 
-const INPUT_JOB = {
+const INPUT_JOB: WorkflowExtractionJob = {
     id: null,
     tool_id: null,
     tool_name: "Input Dataset",
     tool_version: null,
-    step_type: "input_dataset" as const,
+    step_type: "input_dataset",
     checked: true,
     tool_version_warning: null,
-    outputs: [
-        {
-            id: "ds-2",
-            hid: 2,
-            name: "myfile.txt",
-            history_content_type: "dataset" as const,
-            state: "ok",
-            deleted: false,
-        },
-    ],
+    outputs: [{ id: "ds-2", hid: 2, name: "myfile.txt", history_content_type: "dataset", state: "ok", deleted: false }],
 };
 
-const SUMMARY_WITH_JOBS = { jobs: [TOOL_JOB, INPUT_JOB], warnings: [] } as unknown as WorkflowExtractionSummary;
-const SUMMARY_WITH_MAPPED_JOB = { jobs: [MAPPED_TOOL_JOB], warnings: [] } as unknown as WorkflowExtractionSummary;
-const SUMMARY_WITH_DUPLICATE_MAPPED_JOBS = {
-    jobs: [MAPPED_TOOL_JOB, MAPPED_TOOL_JOB_2],
-    warnings: [],
-} as unknown as WorkflowExtractionSummary;
-const SUMMARY_WITH_PLAIN_AND_MAPPED_JOBS = {
-    jobs: [TOOL_JOB, MAPPED_TOOL_JOB],
-    warnings: [],
-} as unknown as WorkflowExtractionSummary;
-const SUMMARY_EMPTY = { jobs: [], warnings: [] } as unknown as WorkflowExtractionSummary;
-const SUMMARY_WITH_WARNINGS = {
-    jobs: [TOOL_JOB],
-    warnings: ["Tool version mismatch"],
-} as unknown as WorkflowExtractionSummary;
+function summary(jobs: WorkflowExtractionJob[], warnings: string[] = []): WorkflowExtractionSummary {
+    return { history_id: "history-1", jobs, warnings };
+}
+
+const SUMMARY_WITH_JOBS = summary([TOOL_JOB, INPUT_JOB]);
+const SUMMARY_WITH_MAPPED_JOB = summary([MAPPED_TOOL_JOB]);
+const SUMMARY_WITH_DUPLICATE_MAPPED_JOBS = summary([MAPPED_TOOL_JOB, MAPPED_TOOL_JOB_2]);
+const SUMMARY_WITH_PLAIN_AND_MAPPED_JOBS = summary([TOOL_JOB, MAPPED_TOOL_JOB]);
+const SUMMARY_EMPTY = summary([]);
+const SUMMARY_WITH_WARNINGS = summary([TOOL_JOB], ["Tool version mismatch"]);
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/client/src/components/History/WorkflowExtractionForm.test.ts
+++ b/client/src/components/History/WorkflowExtractionForm.test.ts
@@ -3,7 +3,7 @@ import { shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { extractWorkflowFromHistory, submitWorkflowExtraction, type WorkflowExtractionSummary } from "@/api/histories";
+import { extractWorkflowByIds, extractWorkflowFromHistory, type WorkflowExtractionSummary } from "@/api/histories";
 import { Toast } from "@/composables/toast";
 
 import GFormInput from "../BaseComponents/Form/GFormInput.vue";
@@ -18,7 +18,7 @@ import WorkflowExtractionForm from "./WorkflowExtractionForm.vue";
 
 vi.mock("@/api/histories", () => ({
     extractWorkflowFromHistory: vi.fn(),
-    submitWorkflowExtraction: vi.fn(),
+    extractWorkflowByIds: vi.fn(),
 }));
 
 vi.mock("@/composables/toast", () => {
@@ -226,18 +226,22 @@ describe("WorkflowExtractionForm", () => {
     describe("workflow submission", () => {
         beforeEach(() => {
             vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_JOBS);
-            vi.mocked(submitWorkflowExtraction).mockResolvedValue({ id: "new-workflow-id" });
+            vi.mocked(extractWorkflowByIds).mockResolvedValue({ id: "new-workflow-id" });
         });
 
-        it("calls submitWorkflowExtraction with correct payload on button click", async () => {
+        it("calls extractWorkflowByIds with encoded-id payload on button click", async () => {
             const wrapper = await mountForm();
             await setWorkflowName(wrapper, "Extracted WF");
             await clickCreateButton(wrapper);
-            expect(submitWorkflowExtraction).toHaveBeenCalledWith(
-                "history-1",
+            expect(extractWorkflowByIds).toHaveBeenCalledWith(
                 expect.objectContaining({
                     workflow_name: "Extracted WF",
+                    from_history_id: "history-1",
                     job_ids: ["job-tool-1"],
+                    hda_ids: ["ds-2"],
+                    hdca_ids: [],
+                    dataset_names: ["myfile.txt"],
+                    dataset_collection_names: [],
                 }),
             );
         });
@@ -250,7 +254,7 @@ describe("WorkflowExtractionForm", () => {
         });
 
         it("shows error alert when submission fails", async () => {
-            vi.mocked(submitWorkflowExtraction).mockRejectedValue(new Error("Submit failed"));
+            vi.mocked(extractWorkflowByIds).mockRejectedValue(new Error("Submit failed"));
             const wrapper = await mountForm();
             await setWorkflowName(wrapper, "Extracted WF");
             await clickCreateButton(wrapper);
@@ -261,7 +265,7 @@ describe("WorkflowExtractionForm", () => {
             const wrapper = await mountForm();
             // no name set — button stays disabled
             await clickCreateButton(wrapper);
-            expect(submitWorkflowExtraction).not.toHaveBeenCalled();
+            expect(extractWorkflowByIds).not.toHaveBeenCalled();
         });
     });
 });

--- a/client/src/components/History/WorkflowExtractionForm.vue
+++ b/client/src/components/History/WorkflowExtractionForm.vue
@@ -260,7 +260,6 @@ async function submitWorkflow() {
 
         const payload: WorkflowExtractionByIdsPayload = {
             workflow_name: workflowName.value.trim(),
-            from_history_id: props.historyId,
             job_ids: selectedJobBuckets.value.job_ids,
             implicit_collection_jobs_ids: selectedJobBuckets.value.implicit_collection_jobs_ids,
             hda_ids: selectedDatasets.ids,

--- a/client/src/components/History/WorkflowExtractionForm.vue
+++ b/client/src/components/History/WorkflowExtractionForm.vue
@@ -6,10 +6,10 @@ import { computed, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import {
+    extractWorkflowByIds,
     extractWorkflowFromHistory,
-    submitWorkflowExtraction,
+    type WorkflowExtractionByIdsPayload,
     type WorkflowExtractionJob,
-    type WorkflowExtractionPayload,
 } from "@/api/histories";
 import { useToast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
@@ -98,11 +98,11 @@ const selectedJobIds = computed<Array<string>>(() => {
 });
 
 /**
- * A parallel mapping for `checked` input step type `hid`s and their `newNames`
+ * A parallel mapping for `checked` input step type encoded ids and their `newNames`.
  */
 const selectedInputs = computed<
     {
-        hid: number;
+        id: string;
         newName: string;
         history_content_type: "dataset" | "dataset_collection";
     }[]
@@ -117,7 +117,7 @@ const selectedInputs = computed<
         )
         .flatMap((job) =>
             job.outputs?.map((output) => ({
-                hid: output.hid,
+                id: output.id,
                 newName: job.newName,
                 history_content_type: output.history_content_type,
             })),
@@ -143,12 +143,12 @@ function getInputName(job: WorkflowExtractionInput): string | undefined {
     }
 }
 
-function getSelectedInputs(type: "dataset" | "dataset_collection"): { hids: number[]; names: string[] } {
+function getSelectedInputs(type: "dataset" | "dataset_collection"): { ids: string[]; names: string[] } {
     const inputs = selectedInputs.value.filter(
         (input) => input.history_content_type === type && Boolean(input.newName),
     );
     return {
-        hids: inputs.map((input) => input.hid),
+        ids: inputs.map((input) => input.id),
         names: inputs.map((input) => input.newName),
     };
 }
@@ -227,16 +227,17 @@ async function submitWorkflow() {
         const selectedDatasets = getSelectedInputs("dataset");
         const selectedDatasetCollections = getSelectedInputs("dataset_collection");
 
-        const payload: WorkflowExtractionPayload = {
+        const payload: WorkflowExtractionByIdsPayload = {
             workflow_name: workflowName.value.trim(),
+            from_history_id: props.historyId,
             job_ids: selectedJobIds.value,
-            dataset_hids: selectedDatasets.hids,
-            dataset_collection_hids: selectedDatasetCollections.hids,
+            hda_ids: selectedDatasets.ids,
+            hdca_ids: selectedDatasetCollections.ids,
             dataset_names: selectedDatasets.names,
             dataset_collection_names: selectedDatasetCollections.names,
         };
 
-        const data = await submitWorkflowExtraction(props.historyId, payload);
+        const data = await extractWorkflowByIds(payload);
 
         Toast.success("Workflow created successfully", "Success");
 

--- a/client/src/components/History/WorkflowExtractionForm.vue
+++ b/client/src/components/History/WorkflowExtractionForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert } from "bootstrap-vue";
 import { computed, ref } from "vue";
@@ -15,7 +15,12 @@ import { useToast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
-import { isWorkflowExtractionInput, type WorkflowExtractionInput } from "./WorkflowExtraction/types";
+import {
+    isMappedTool,
+    isWorkflowExtractionInput,
+    type WorkflowExtractionInput,
+    type WorkflowExtractionRow,
+} from "./WorkflowExtraction/types";
 
 import GFormInput from "../BaseComponents/Form/GFormInput.vue";
 import GButton from "../BaseComponents/GButton.vue";
@@ -49,8 +54,9 @@ const breadcrumbItems = computed(() => [
 ]);
 
 const loading = ref(true);
+const submitting = ref(false);
 const errorMessage = ref<string | null>(null);
-const jobsList = ref<(WorkflowExtractionInput | WorkflowExtractionJob)[]>([]);
+const jobsList = ref<WorkflowExtractionRow[]>([]);
 const workflowName = ref("");
 const renameIndex = ref<number | null>(null);
 const warnings = ref<string[]>([]);
@@ -70,7 +76,7 @@ const toRenameInput = computed(() => {
 });
 
 const submissionDisabled = computed(
-    () => hasUnnamedSelectedInputs.value || !workflowName.value.trim() || hasNoSelectedSteps.value,
+    () => submitting.value || hasUnnamedSelectedInputs.value || !workflowName.value.trim() || hasNoSelectedSteps.value,
 );
 
 const submissionDisabledMsg = computed(() => {
@@ -86,15 +92,29 @@ const submissionDisabledMsg = computed(() => {
     return "";
 });
 
-/** Selected job ids for workflow steps (not inputs) */
-const selectedJobIds = computed<Array<string>>(() => {
+/** Selected tool jobs partitioned by ICJ membership. Mapped jobs collapse to
+ *  their implicit_collection_jobs_id (deduped); non-mapped jobs stay as job_ids. */
+const selectedJobBuckets = computed<{ job_ids: string[]; implicit_collection_jobs_ids: string[] }>(() => {
     if (!jobsList.value?.length) {
-        return [];
+        return { job_ids: [], implicit_collection_jobs_ids: [] };
     }
-    return jobsList.value
-        .filter((job) => job.checked && job.step_type === "tool")
-        .map((job) => job.id)
-        .filter((id): id is string => Boolean(id));
+    const job_ids: string[] = [];
+    const icj_ids: string[] = [];
+    const seen_icj = new Set<string>();
+    for (const job of jobsList.value) {
+        if (!job.checked || job.step_type !== "tool" || !job.id) {
+            continue;
+        }
+        if (isMappedTool(job)) {
+            if (!seen_icj.has(job.implicit_collection_jobs_id)) {
+                seen_icj.add(job.implicit_collection_jobs_id);
+                icj_ids.push(job.implicit_collection_jobs_id);
+            }
+        } else {
+            job_ids.push(job.id);
+        }
+    }
+    return { job_ids, implicit_collection_jobs_ids: icj_ids };
 });
 
 /**
@@ -136,7 +156,25 @@ const hasUnnamedSelectedInputs = computed(() => {
 
 extractWorkflow();
 
-function getInputName(job: WorkflowExtractionInput): string | undefined {
+function toWorkflowExtractionRow(job: WorkflowExtractionJob): WorkflowExtractionRow {
+    const checked = job.checked ?? false;
+    if (job.step_type === "tool") {
+        return {
+            ...job,
+            checked,
+            step_type: "tool",
+        };
+    } else {
+        return {
+            ...job,
+            checked,
+            step_type: job.step_type,
+            newName: getInputName(job) || "",
+        };
+    }
+}
+
+function getInputName(job: WorkflowExtractionJob): string | undefined {
     if (job.outputs?.length && job.outputs[0]) {
         const output = job.outputs[0];
         return output.name || `Input ${output.hid}`;
@@ -157,15 +195,7 @@ async function extractWorkflow() {
     try {
         const result = await extractWorkflowFromHistory(props.historyId);
         if (result.jobs) {
-            jobsList.value = result.jobs.map((job) => {
-                return {
-                    ...job,
-                    checked: job.checked ?? false,
-                    ...(isWorkflowExtractionInput(job) && {
-                        newName: getInputName(job) || "",
-                    }),
-                };
-            });
+            jobsList.value = result.jobs.map(toWorkflowExtractionRow);
         }
 
         warnings.value = result.warnings || [];
@@ -222,7 +252,8 @@ async function submitWorkflow() {
             Toast.error(submissionDisabledMsg.value || "Cannot submit workflow extraction", "Submission Disabled");
             return;
         }
-        loading.value = true;
+        errorMessage.value = null;
+        submitting.value = true;
 
         const selectedDatasets = getSelectedInputs("dataset");
         const selectedDatasetCollections = getSelectedInputs("dataset_collection");
@@ -230,7 +261,8 @@ async function submitWorkflow() {
         const payload: WorkflowExtractionByIdsPayload = {
             workflow_name: workflowName.value.trim(),
             from_history_id: props.historyId,
-            job_ids: selectedJobIds.value,
+            job_ids: selectedJobBuckets.value.job_ids,
+            implicit_collection_jobs_ids: selectedJobBuckets.value.implicit_collection_jobs_ids,
             hda_ids: selectedDatasets.ids,
             hdca_ids: selectedDatasetCollections.ids,
             dataset_names: selectedDatasets.names,
@@ -245,8 +277,15 @@ async function submitWorkflow() {
     } catch (error) {
         errorMessage.value = errorMessageAsString(error);
     } finally {
-        loading.value = false;
+        submitting.value = false;
     }
+}
+
+function stepKind(job: WorkflowExtractionRow): string {
+    if (isMappedTool(job)) {
+        return "mapped-tool";
+    }
+    return job.step_type.replace("_", "-");
 }
 </script>
 
@@ -256,15 +295,16 @@ async function submitWorkflow() {
             <BreadcrumbHeading :items="breadcrumbItems" />
 
             <BAlert v-if="errorMessage" variant="danger" show>{{ errorMessage }}</BAlert>
-            <BAlert v-else-if="loading" variant="info" show>
+            <BAlert v-if="loading" variant="info" show>
                 <LoadingSpan message="Extracting workflow from history" />
             </BAlert>
-            <div v-else-if="jobsList.length" class="d-flex flex-column flex-gapy-1">
+            <div v-if="!loading && jobsList.length" class="d-flex flex-column flex-gapy-1">
                 <div class="workflow-extraction-actions">
                     <GFormInput
                         v-model="workflowName"
                         data-description="workflow-name-input"
                         placeholder="Please provide a name for the workflow"
+                        :disabled="submitting"
                         @keydown.enter.prevent="submitWorkflow" />
 
                     <GButton
@@ -275,13 +315,17 @@ async function submitWorkflow() {
                         :disabled="submissionDisabled"
                         :disabled-title="submissionDisabledMsg"
                         @click="submitWorkflow">
-                        <FontAwesomeIcon :icon="faCheck" fixed-width />
-                        Create Workflow
+                        <FontAwesomeIcon :icon="submitting ? faSpinner : faCheck" :spin="submitting" fixed-width />
+                        {{ submitting ? "Creating..." : "Create Workflow" }}
                     </GButton>
                 </div>
                 <WorkflowExtractionMessages :warnings="warnings" />
             </div>
-            <BAlert v-else data-description="no-workflow-message" variant="info" show>
+            <BAlert
+                v-if="!loading && !errorMessage && !jobsList.length"
+                data-description="no-workflow-message"
+                variant="info"
+                show>
                 No workflow could be extracted from this history.
             </BAlert>
         </div>
@@ -294,6 +338,8 @@ async function submitWorkflow() {
                 :job="job"
                 :data-step-type="job.step_type"
                 :data-job-id="job.id || undefined"
+                :data-icj-id="isMappedTool(job) ? job.implicit_collection_jobs_id : undefined"
+                :data-step-kind="stepKind(job)"
                 @rename="onJobRename(index)"
                 @select="onJobSelect(index)"
                 @view-job="onViewJob" />

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1070,9 +1070,12 @@ workflow_extract:
     create_button: '[data-description="create-workflow-button"]'
     no_workflow_message: '[data-description="no-workflow-message"]'
     tool_card: '[data-step-type="tool"]'
+    mapped_tool_card: '[data-step-kind="mapped-tool"]'
     tool_card_checkbox: '[data-step-type="tool"] input[id^="g-card-select-"]'
     tool_card_checkbox_checked: '[data-step-type="tool"] input[id^="g-card-select-"]:checked'
     card_checkbox_by_job_id: '[data-job-id="${job_id}"] input[id^="g-card-select-"]'
+    card_by_icj_id: '[data-icj-id="${icj_id}"]'
+    mapped_badge: '[id^="g-card-badge-mapped-tool-"]'
     all_card_checkboxes_checked: '[data-description="workflow-extraction-form"] input[id^="g-card-select-"]:checked'
 
 invocations:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2961,6 +2961,34 @@ class ImplicitCollectionJobs(Base, Serializable):
         )
         return session.execute(stmt)
 
+    @property
+    def representative_job(self) -> "Job":
+        """Lowest-order constituent job, used as the stand-in when this ICJ is
+        treated as a single mapped step. Ordered by association order_index
+        then job id so the choice is deterministic."""
+        return (
+            required_object_session(self)
+            .scalars(
+                select(Job)
+                .join(ImplicitCollectionJobsJobAssociation, ImplicitCollectionJobsJobAssociation.job_id == Job.id)
+                .where(ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id == self.id)
+                .order_by(ImplicitCollectionJobsJobAssociation.order_index, Job.id)
+                .limit(1)
+            )
+            .one()
+        )
+
+    @property
+    def output_dataset_collection_instances(self) -> list["HistoryDatasetCollectionAssociation"]:
+        """HDCAs produced by this implicit map (one per mapped tool output)."""
+        return list(
+            required_object_session(self).scalars(
+                select(HistoryDatasetCollectionAssociation).where(
+                    HistoryDatasetCollectionAssociation.implicit_collection_jobs_id == self.id
+                )
+            )
+        )
+
     def _serialize(self, id_encoder, serialization_options):
         rval = dict_for(
             self,

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -12,6 +12,7 @@ from pydantic import (
     AfterValidator,
     Field,
     field_validator,
+    model_validator,
     UUID4,
 )
 
@@ -442,6 +443,50 @@ class WorkflowExtractionPayload(Model):
         title="Dataset Collection Names",
         description="Names for the input dataset collections, parallel to dataset_collection_hids.",
     )
+
+
+class WorkflowExtractionByIdsPayload(Model):
+    workflow_name: str = Field(
+        ...,
+        title="Workflow Name",
+        description="The name for the extracted workflow.",
+    )
+    from_history_id: Optional[DecodedDatabaseIdField] = Field(
+        None,
+        title="From History ID",
+        description="Optional history context (UI hint). Access decisions use per-item permission checks; not required for cross-history extraction.",
+    )
+    job_ids: list[DecodedDatabaseIdField] = Field(
+        default_factory=list,
+        title="Job IDs",
+        description="Decoded IDs of compatible tool jobs to include as workflow steps.",
+    )
+    hda_ids: list[DecodedDatabaseIdField] = Field(
+        default_factory=list,
+        title="HDA IDs",
+        description="Decoded IDs of HistoryDatasetAssociations to treat as workflow inputs.",
+    )
+    hdca_ids: list[DecodedDatabaseIdField] = Field(
+        default_factory=list,
+        title="HDCA IDs",
+        description="Decoded IDs of HistoryDatasetCollectionAssociations to treat as workflow inputs.",
+    )
+    dataset_names: list[str] = Field(
+        default_factory=list,
+        title="Dataset Names",
+        description="Names for the input datasets, parallel to hda_ids.",
+    )
+    dataset_collection_names: list[str] = Field(
+        default_factory=list,
+        title="Dataset Collection Names",
+        description="Names for the input dataset collections, parallel to hdca_ids.",
+    )
+
+    @model_validator(mode="after")
+    def _at_least_one_input(self):
+        if not (self.hda_ids or self.hdca_ids or self.job_ids):
+            raise ValueError("At least one of hda_ids, hdca_ids, job_ids required")
+        return self
 
 
 class WorkflowExtractionResult(Model):

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -392,6 +392,21 @@ class WorkflowExtractionJob(Model):
         title="Invalid",
         description="Reason this job is invalid for extraction.",
     )
+    implicit_collection_jobs_id: Optional[EncodedDatabaseIdField] = Field(
+        None,
+        title="Implicit Collection Jobs ID",
+        description=(
+            "Encoded ID of the ImplicitCollectionJobs this job belongs to, "
+            "or null if the job is not part of a mapped/implicit collection. "
+            "Callers should submit mapped jobs via implicit_collection_jobs_ids "
+            "rather than job_ids in the extract-by-ids payload."
+        ),
+    )
+    implicit_collection_jobs_size: Optional[int] = Field(
+        None,
+        title="Implicit Collection Jobs Size",
+        description="Number of constituent jobs in the ICJ (only set when implicit_collection_jobs_id is non-null).",
+    )
 
 
 class WorkflowExtractionSummary(Model):
@@ -471,6 +486,15 @@ class WorkflowExtractionByIdsPayload(Model):
         title="HDCA IDs",
         description="Decoded IDs of HistoryDatasetCollectionAssociations to treat as workflow inputs.",
     )
+    implicit_collection_jobs_ids: list[DecodedDatabaseIdField] = Field(
+        default_factory=list,
+        title="Implicit Collection Jobs IDs",
+        description=(
+            "Decoded IDs of ImplicitCollectionJobs (map-over job groups) to include as mapped "
+            "workflow steps. Use this for steps that ran with a map/over instead of passing a "
+            "constituent job id in job_ids."
+        ),
+    )
     dataset_names: list[str] = Field(
         default_factory=list,
         title="Dataset Names",
@@ -484,8 +508,8 @@ class WorkflowExtractionByIdsPayload(Model):
 
     @model_validator(mode="after")
     def _at_least_one_input(self):
-        if not (self.hda_ids or self.hdca_ids or self.job_ids):
-            raise ValueError("At least one of hda_ids, hdca_ids, job_ids required")
+        if not (self.hda_ids or self.hdca_ids or self.job_ids or self.implicit_collection_jobs_ids):
+            raise ValueError("At least one of hda_ids, hdca_ids, job_ids, implicit_collection_jobs_ids required")
         return self
 
 

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -466,11 +466,6 @@ class WorkflowExtractionByIdsPayload(Model):
         title="Workflow Name",
         description="The name for the extracted workflow.",
     )
-    from_history_id: Optional[DecodedDatabaseIdField] = Field(
-        None,
-        title="From History ID",
-        description="Optional history context (UI hint). Access decisions use per-item permission checks; not required for cross-history extraction.",
-    )
     job_ids: list[DecodedDatabaseIdField] = Field(
         default_factory=list,
         title="Job IDs",

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -95,7 +95,7 @@ from galaxy.webapps.galaxy.api.common import (
     query_serialization_params,
 )
 from galaxy.webapps.galaxy.services.histories import HistoriesService
-from galaxy.workflow.extract import extract_workflow
+from galaxy.webapps.galaxy.services.workflows import WorkflowsService
 from .common import HistoryIDPathParam
 
 log = logging.getLogger(__name__)
@@ -207,6 +207,7 @@ IndexExportsResponse = Annotated[
 @router.cbv
 class FastAPIHistories:
     service: HistoriesService = depends(HistoriesService)
+    workflows_service: WorkflowsService = depends(WorkflowsService)
 
     @router.get(
         "/api/histories",
@@ -889,16 +890,4 @@ class FastAPIHistories:
         Returns the ID of the newly created workflow.
         """
         history = self.service.manager.get_accessible(history_id, trans.user, current_history=trans.history)
-
-        stored_workflow = extract_workflow(
-            trans,
-            user=trans.user,
-            history=history,
-            job_ids=payload.job_ids,
-            dataset_ids=payload.dataset_hids,
-            dataset_collection_ids=payload.dataset_collection_hids,
-            workflow_name=payload.workflow_name,
-            dataset_names=payload.dataset_names,
-            dataset_collection_names=payload.dataset_collection_names,
-        )
-        return WorkflowExtractionResult.model_validate({"id": stored_workflow.id})
+        return self.workflows_service.extract_from_history(trans, history, payload)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1105,8 +1105,7 @@ class FastAPIWorkflows:
         """ID-based workflow extraction.
 
         Per-item permission checks make this history-optional and allow
-        cross-history extraction. ``from_history_id`` in the body is UI
-        context only.
+        cross-history extraction.
         """
         return self.service.extract_by_ids(trans, payload)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -88,6 +88,8 @@ from galaxy.schema.schema import (
 from galaxy.schema.workflows import (
     InvokeWorkflowPayload,
     StoredWorkflowDetailed,
+    WorkflowExtractionByIdsPayload,
+    WorkflowExtractionResult,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -1090,6 +1092,23 @@ class FastAPIWorkflows:
     ):
         self.service.undelete(trans, workflow_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @router.post(
+        "/api/workflows/extract",
+        summary="Extract a workflow from selected jobs and history items by encoded IDs.",
+    )
+    def extract_by_ids(
+        self,
+        payload: WorkflowExtractionByIdsPayload = Body(...),
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> WorkflowExtractionResult:
+        """ID-based workflow extraction.
+
+        Per-item permission checks make this history-optional and allow
+        cross-history extraction. ``from_history_id`` in the body is UI
+        context only.
+        """
+        return self.service.extract_by_ids(trans, payload)
 
     @router.post(
         "/api/workflows/{workflow_id}/invocations",

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     select,
     true,
 )
+from sqlalchemy.orm import selectinload
 
 from galaxy import (
     exceptions as glx_exceptions,
@@ -45,6 +46,8 @@ from galaxy.managers.users import UserManager
 from galaxy.model import (
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
+    ImplicitCollectionJobs,
+    ImplicitCollectionJobsJobAssociation,
 )
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.model.store import payload_to_source_uri
@@ -807,6 +810,21 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
     ) -> WorkflowExtractionSummary:
         history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
         jobs, warnings = summarize(trans, history)
+        representative_job_ids = [job.id for job in jobs if isinstance(job, model.Job)]
+        icj_assoc_by_job_id = {}
+        if representative_job_ids:
+            stmt = (
+                select(ImplicitCollectionJobsJobAssociation)
+                .options(
+                    selectinload(ImplicitCollectionJobsJobAssociation.implicit_collection_jobs).selectinload(
+                        ImplicitCollectionJobs.jobs
+                    )
+                )
+                .where(ImplicitCollectionJobsJobAssociation.job_id.in_(representative_job_ids))
+            )
+            icj_assoc_by_job_id = {
+                icj_assoc.job_id: icj_assoc for icj_assoc in trans.sa_session.scalars(stmt).unique().all()
+            }
 
         def serialize_output(content) -> WorkflowExtractionOutput:
             return WorkflowExtractionOutput.model_validate(
@@ -897,6 +915,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                         if tool.version != job.tool_version
                         else None
                     )
+                    icj_assoc = icj_assoc_by_job_id.get(job.id)
+                    implicit_collection_jobs = icj_assoc.implicit_collection_jobs if icj_assoc is not None else None
                     jobs_list.append(
                         WorkflowExtractionJob(
                             id=job.id,
@@ -908,6 +928,12 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                             tool_version_warning=tool_version_warning,
                             outputs=outputs,
                             invalid=None,
+                            implicit_collection_jobs_id=(
+                                icj_assoc.implicit_collection_jobs_id if icj_assoc is not None else None
+                            ),
+                            implicit_collection_jobs_size=(
+                                len(implicit_collection_jobs.jobs) if implicit_collection_jobs is not None else None
+                            ),
                         )
                     )
 

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -6,6 +6,7 @@ from typing import (
 )
 
 from pydantic import UUID4
+from sqlalchemy import select
 
 from galaxy import (
     exceptions,
@@ -24,6 +25,8 @@ from galaxy.managers.workflows import (
     WorkflowsManager,
 )
 from galaxy.model import (
+    HistoryDatasetCollectionAssociation,
+    ImplicitCollectionJobs,
     LandingRequestToWorkflowInvocationAssociation,
     StoredWorkflow,
     WorkflowInvocation,
@@ -236,18 +239,70 @@ class WorkflowsService(ServiceBase):
     ) -> WorkflowExtractionResult:
         if trans.user is None:
             raise exceptions.AuthenticationRequired("Workflow extraction requires an authenticated user.")
+        self._validate_extract_by_ids_payload(trans, payload)
         stored_workflow = extract_workflow_by_ids(
             trans,
             user=trans.user,
             workflow_name=payload.workflow_name,
             job_manager=self._job_manager,
             job_ids=payload.job_ids,
+            implicit_collection_jobs_ids=payload.implicit_collection_jobs_ids,
             hda_ids=payload.hda_ids,
             hdca_ids=payload.hdca_ids,
             dataset_names=payload.dataset_names,
             dataset_collection_names=payload.dataset_collection_names,
         )
         return _to_extraction_result(stored_workflow)
+
+    def _validate_extract_by_ids_payload(
+        self,
+        trans: ProvidesHistoryContext,
+        payload: WorkflowExtractionByIdsPayload,
+    ) -> None:
+        """Cross-payload checks that need DB access. Pydantic handles per-field
+        shape; this enforces semantic rules across job_ids /
+        implicit_collection_jobs_ids that depend on the loaded Job / ICJ rows
+        so extract_workflow_by_ids can trust its input.
+        """
+        if len(set(payload.job_ids)) != len(payload.job_ids):
+            raise exceptions.RequestParameterInvalidException("job_ids contains duplicates")
+        if len(set(payload.implicit_collection_jobs_ids)) != len(payload.implicit_collection_jobs_ids):
+            raise exceptions.RequestParameterInvalidException("implicit_collection_jobs_ids contains duplicates")
+
+        for job_id in payload.job_ids:
+            job = self._job_manager.get_accessible_job(trans, job_id)
+            icj_assoc = job.implicit_collection_jobs_association
+            if icj_assoc is not None:
+                raise exceptions.RequestParameterInvalidException(
+                    f"job_ids[{job_id}] is part of implicit collection jobs "
+                    f"{icj_assoc.implicit_collection_jobs_id} - pass via "
+                    "implicit_collection_jobs_ids instead."
+                )
+
+        sa_session = trans.sa_session
+        dataset_collection_manager = trans.app.dataset_collection_manager
+        for icj_id in payload.implicit_collection_jobs_ids:
+            icj = sa_session.get(ImplicitCollectionJobs, icj_id)
+            if icj is None:
+                raise exceptions.ObjectNotFound(f"ImplicitCollectionJobs {icj_id} not found")
+            if icj.populated_state != ImplicitCollectionJobs.populated_states.OK:
+                raise exceptions.RequestParameterInvalidException(
+                    f"ImplicitCollectionJobs {icj_id} is in populated_state "
+                    f"{icj.populated_state!r}; only 'ok' is extractable"
+                )
+            output_hdcas = list(
+                sa_session.scalars(
+                    select(HistoryDatasetCollectionAssociation).where(
+                        HistoryDatasetCollectionAssociation.implicit_collection_jobs_id == icj_id
+                    )
+                )
+            )
+            if not output_hdcas:
+                raise exceptions.RequestParameterInvalidException(
+                    f"ImplicitCollectionJobs {icj_id} has no output collections to extract"
+                )
+            for hdca in output_hdcas:
+                dataset_collection_manager.get_dataset_collection_instance(trans, "history", hdca.id)
 
     def delete(self, trans, workflow_id):
         workflow_to_delete = self._workflows_manager.get_stored_workflow(trans, workflow_id)

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -6,7 +6,6 @@ from typing import (
 )
 
 from pydantic import UUID4
-from sqlalchemy import select
 
 from galaxy import (
     exceptions,
@@ -25,7 +24,6 @@ from galaxy.managers.workflows import (
     WorkflowsManager,
 )
 from galaxy.model import (
-    HistoryDatasetCollectionAssociation,
     ImplicitCollectionJobs,
     LandingRequestToWorkflowInvocationAssociation,
     StoredWorkflow,
@@ -264,10 +262,10 @@ class WorkflowsService(ServiceBase):
         implicit_collection_jobs_ids that depend on the loaded Job / ICJ rows
         so extract_workflow_by_ids can trust its input.
         """
-        if len(set(payload.job_ids)) != len(payload.job_ids):
-            raise exceptions.RequestParameterInvalidException("job_ids contains duplicates")
-        if len(set(payload.implicit_collection_jobs_ids)) != len(payload.implicit_collection_jobs_ids):
-            raise exceptions.RequestParameterInvalidException("implicit_collection_jobs_ids contains duplicates")
+        for field in ("job_ids", "implicit_collection_jobs_ids", "hda_ids", "hdca_ids"):
+            ids = getattr(payload, field)
+            if len(set(ids)) != len(ids):
+                raise exceptions.RequestParameterInvalidException(f"{field} contains duplicates")
 
         for job_id in payload.job_ids:
             job = self._job_manager.get_accessible_job(trans, job_id)
@@ -290,13 +288,7 @@ class WorkflowsService(ServiceBase):
                     f"ImplicitCollectionJobs {icj_id} is in populated_state "
                     f"{icj.populated_state!r}; only 'ok' is extractable"
                 )
-            output_hdcas = list(
-                sa_session.scalars(
-                    select(HistoryDatasetCollectionAssociation).where(
-                        HistoryDatasetCollectionAssociation.implicit_collection_jobs_id == icj_id
-                    )
-                )
-            )
+            output_hdcas = icj.output_dataset_collection_instances
             if not output_hdcas:
                 raise exceptions.RequestParameterInvalidException(
                     f"ImplicitCollectionJobs {icj_id} has no output collections to extract"

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -11,7 +11,11 @@ from galaxy import (
     exceptions,
     web,
 )
-from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.context import (
+    ProvidesHistoryContext,
+    ProvidesUserContext,
+)
+from galaxy.managers.jobs import JobManager
 from galaxy.managers.workflows import (
     RefactorRequest,
     RefactorResponse,
@@ -34,15 +38,26 @@ from galaxy.schema.schema import (
 from galaxy.schema.workflows import (
     InvokeWorkflowPayload,
     StoredWorkflowDetailed,
+    WorkflowExtractionByIdsPayload,
+    WorkflowExtractionPayload,
+    WorkflowExtractionResult,
 )
 from galaxy.util.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
+from galaxy.workflow.extract import (
+    extract_workflow,
+    extract_workflow_by_ids,
+)
 from galaxy.workflow.run import queue_invoke
 from galaxy.workflow.run_request import build_workflow_run_configs
 
 log = logging.getLogger(__name__)
+
+
+def _to_extraction_result(stored_workflow: StoredWorkflow) -> WorkflowExtractionResult:
+    return WorkflowExtractionResult.model_validate({"id": stored_workflow.id})
 
 
 class WorkflowsService(ServiceBase):
@@ -53,12 +68,14 @@ class WorkflowsService(ServiceBase):
         serializer: WorkflowSerializer,
         tool_shed_registry: Registry,
         notification_service: NotificationService,
+        job_manager: JobManager,
     ):
         self._workflows_manager = workflows_manager
         self._workflow_contents_manager = workflow_contents_manager
         self._serializer = serializer
         self.shareable_service = ShareableService(workflows_manager, serializer, notification_service)
         self._tool_shed_registry = tool_shed_registry
+        self._job_manager = job_manager
 
     def index(
         self,
@@ -190,6 +207,47 @@ class WorkflowsService(ServiceBase):
             return encoded_invocations
         else:
             return encoded_invocations[0]
+
+    def extract_from_history(
+        self,
+        trans: ProvidesHistoryContext,
+        history,
+        payload: WorkflowExtractionPayload,
+    ) -> WorkflowExtractionResult:
+        if trans.user is None:
+            raise exceptions.AuthenticationRequired("Workflow extraction requires an authenticated user.")
+        stored_workflow = extract_workflow(
+            trans,
+            user=trans.user,
+            history=history,
+            job_ids=payload.job_ids,
+            dataset_ids=payload.dataset_hids,
+            dataset_collection_ids=payload.dataset_collection_hids,
+            workflow_name=payload.workflow_name,
+            dataset_names=payload.dataset_names,
+            dataset_collection_names=payload.dataset_collection_names,
+        )
+        return _to_extraction_result(stored_workflow)
+
+    def extract_by_ids(
+        self,
+        trans: ProvidesHistoryContext,
+        payload: WorkflowExtractionByIdsPayload,
+    ) -> WorkflowExtractionResult:
+        if trans.user is None:
+            raise exceptions.AuthenticationRequired("Workflow extraction requires an authenticated user.")
+        stored_workflow = extract_workflow_by_ids(
+            trans,
+            user=trans.user,
+            workflow_name=payload.workflow_name,
+            job_manager=self._job_manager,
+            job_ids=payload.job_ids,
+            hda_ids=payload.hda_ids,
+            hdca_ids=payload.hdca_ids,
+            dataset_names=payload.dataset_names,
+            dataset_collection_names=payload.dataset_collection_names,
+        )
+        return _to_extraction_result(stored_workflow)
 
     def delete(self, trans, workflow_id):
         workflow_to_delete = self._workflows_manager.get_stored_workflow(trans, workflow_id)

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -520,6 +520,7 @@ def extract_workflow_by_ids(
     workflow_name: str,
     job_manager: JobManager,
     job_ids: Optional[list[int]] = None,
+    implicit_collection_jobs_ids: Optional[list[int]] = None,
     hda_ids: Optional[list[int]] = None,
     hdca_ids: Optional[list[int]] = None,
     dataset_names: Optional[list[str]] = None,
@@ -530,6 +531,7 @@ def extract_workflow_by_ids(
         trans,
         job_manager=job_manager,
         job_ids=job_ids,
+        implicit_collection_jobs_ids=implicit_collection_jobs_ids,
         hda_ids=hda_ids,
         hdca_ids=hdca_ids,
         dataset_names=dataset_names,
@@ -546,6 +548,7 @@ def extract_steps_by_ids(
     trans: ProvidesHistoryContext,
     job_manager: Optional[JobManager] = None,
     job_ids: Optional[list[int]] = None,
+    implicit_collection_jobs_ids: Optional[list[int]] = None,
     hda_ids: Optional[list[int]] = None,
     hdca_ids: Optional[list[int]] = None,
     dataset_names: Optional[list[str]] = None,
@@ -558,10 +561,15 @@ def extract_steps_by_ids(
     ``(content_type, db_id)`` of the resolved *original* HDA/HDCA so that
     copied datasets and cross-history items map deterministically.
 
+    Mapped (map-over) steps are passed as ``implicit_collection_jobs_ids``;
+    each ICJ becomes a single workflow step whose inputs are wired to the
+    pre-map input HDCA(s) via ``ImplicitlyCreatedDatasetCollectionInput``.
+
     ``job_manager`` may be omitted only when ``job_ids`` is empty (kept
     Optional for unit-test ergonomics).
     """
     job_ids = list(job_ids or [])
+    implicit_collection_jobs_ids = list(implicit_collection_jobs_ids or [])
     hda_ids = list(hda_ids or [])
     hdca_ids = list(hdca_ids or [])
 
@@ -605,49 +613,48 @@ def extract_steps_by_ids(
         original_hdca = _original_hdca(hdca)
         id_to_output_pair[("collection", original_hdca.id)] = (step, "output")
 
-    # Resolve and dedup jobs. Implicit-map participants collapse to a single
-    # representative job per ImplicitCollectionJobs id.
-    seen_icj_ids: set[int] = set()
-    resolved_jobs: list[Job] = []
+    # Build the list of work items: each tuple is (representative_job,
+    # output_hdcas). For plain jobs output_hdcas is empty; for ICJs it
+    # contains the ICJ's output HDCAs (used both for access checks and to
+    # drive input/output wiring without inferring map/over from job state).
+    # Service-layer validator ensures no job in job_ids has an ICJ
+    # association, so this branch handles only true plain jobs.
+    work_items: list[tuple[Job, list[HistoryDatasetCollectionAssociation]]] = []
+
     for job_id in job_ids:
         assert job_manager is not None, "job_manager required when job_ids supplied"
         job = job_manager.get_accessible_job(trans, job_id)
-        icj_assoc = job.implicit_collection_jobs_association
-        if icj_assoc is not None:
-            icj_id = icj_assoc.implicit_collection_jobs_id
-            if icj_id in seen_icj_ids:
-                continue
-            seen_icj_ids.add(icj_id)
-            representative = sa_session.execute(
-                select(Job)
-                .join(ImplicitCollectionJobsJobAssociation, ImplicitCollectionJobsJobAssociation.job_id == Job.id)
-                .where(ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id == icj_id)
-                .order_by(Job.id)
-                .limit(1)
-            ).scalar_one()
-            resolved_jobs.append(representative)
-        else:
-            resolved_jobs.append(job)
+        work_items.append((job, []))
 
-    # Process jobs in dependency order. Job.id is monotonically assigned at
-    # submission, so a job that consumes another's output always has the
-    # larger id; sorting by id is sufficient to ensure each downstream job's
-    # inputs are already registered in id_to_output_pair when we wire it.
-    resolved_jobs.sort(key=lambda j: j.id)
-
-    for job in resolved_jobs:
-        icj_assoc = job.implicit_collection_jobs_association
-        output_hdcas: list[HistoryDatasetCollectionAssociation] = []
-        if icj_assoc is not None:
-            output_hdcas = list(
-                sa_session.scalars(
-                    select(HistoryDatasetCollectionAssociation).where(
-                        HistoryDatasetCollectionAssociation.implicit_collection_jobs_id
-                        == icj_assoc.implicit_collection_jobs_id
-                    )
+    # FIXME: representative-job param read is the only remaining HID-style
+    # inference here. Swap step_inputs_by_id for a Job.tool_state /
+    # ToolRequest.request_state reader once that exists; see
+    # docs/research/Problem - YAML Tool Post-Hoc State Divergence.md.
+    for icj_id in implicit_collection_jobs_ids:
+        # Service-layer validator already checked existence, populated_state,
+        # output-HDCA presence, and per-HDCA accessibility.
+        output_hdcas_for_icj = list(
+            sa_session.scalars(
+                select(HistoryDatasetCollectionAssociation).where(
+                    HistoryDatasetCollectionAssociation.implicit_collection_jobs_id == icj_id
                 )
             )
+        )
+        representative = sa_session.scalars(
+            select(Job)
+            .join(ImplicitCollectionJobsJobAssociation, ImplicitCollectionJobsJobAssociation.job_id == Job.id)
+            .where(ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id == icj_id)
+            .order_by(ImplicitCollectionJobsJobAssociation.order_index, Job.id)
+            .limit(1)
+        ).one()
+        work_items.append((representative, output_hdcas_for_icj))
 
+    # Job.id is monotonically assigned at submission, so sorting by it
+    # produces dependency order: a downstream job always has a larger id
+    # than the jobs whose outputs it consumes.
+    work_items.sort(key=lambda item: item[0].id)
+
+    for job, output_hdcas in work_items:
         tool_inputs, associations = step_inputs_by_id(trans, job)
         step = model.WorkflowStep()
         step.type = "tool"
@@ -655,15 +662,15 @@ def extract_steps_by_ids(
         step.tool_version = job.tool_version
         step.tool_inputs = tool_inputs
 
+        mapped_inputs: dict[str, HistoryDatasetCollectionAssociation] = {}
+        if output_hdcas:
+            for icol in output_hdcas[0].implicit_input_collections:
+                if icol.name and icol.input_dataset_collection is not None:
+                    mapped_inputs[icol.name] = _original_hdca(icol.input_dataset_collection)
+
         for key, input_name in associations:
-            if output_hdcas:
-                # Implicit-map: rewrite per-job inputs to the input HDCA the
-                # mapping consumed (find_implicit_input_collection on any
-                # output HDCA returns the same answer).
-                input_collection = output_hdcas[0].find_implicit_input_collection(input_name)
-                if input_collection is not None:
-                    original_input = _original_hdca(input_collection)
-                    key = ("collection", original_input.id)
+            if input_name in mapped_inputs:
+                key = ("collection", mapped_inputs[input_name].id)
             if key in id_to_output_pair:
                 step_input = step.get_or_add_input(input_name)
                 other_step, other_name = id_to_output_pair[key]
@@ -673,12 +680,7 @@ def extract_steps_by_ids(
                 conn.output_name = other_name
         steps.append(step)
 
-        # Register outputs so downstream jobs can wire into them.
         if output_hdcas:
-            # Implicit-map: register each unique implicit output HDCA so downstream
-            # steps consume the collection (not its per-job leaves). Per-job HDAs
-            # on job.output_datasets are intentionally not registered here —
-            # downstream wiring resolves the collection via find_implicit_input_collection.
             seen_names: dict[str, HistoryDatasetCollectionAssociation] = {}
             for output_hdca in output_hdcas:
                 output_name = output_hdca.implicit_output_name

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -11,8 +11,6 @@ from typing import (
     Optional,
 )
 
-from sqlalchemy import select
-
 from galaxy import (
     exceptions,
     model,
@@ -24,7 +22,7 @@ from galaxy.model import (
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
     HistoryItem,
-    ImplicitCollectionJobsJobAssociation,
+    ImplicitCollectionJobs,
     Job,
     StoredWorkflow,
     User,
@@ -64,6 +62,17 @@ def _skip_output_assoc_name(name: str) -> bool:
     outputs (named-collection-part placeholders and discovered-primary-file
     rows). Both extraction paths skip these."""
     return ToolOutputCollectionPart.is_named_collection_part_name(name) or name.startswith("__new_primary_file")
+
+
+def _connect(step: WorkflowStep, input_name: str, source: tuple[WorkflowStep, str]) -> None:
+    """Wire ``step``'s ``input_name`` to ``source`` (output_step, output_name).
+    The source is always an earlier step - a job only consumes outputs of jobs
+    that ran before it. Shared by both extraction paths."""
+    source_step, source_name = source
+    conn = model.WorkflowStepConnection()
+    conn.input_step_input = step.get_or_add_input(input_name)
+    conn.output_step = source_step
+    conn.output_name = source_name
 
 
 def extract_workflow(
@@ -196,13 +205,7 @@ def extract_steps(
                 else:
                     log.info(f"Cannot find implicit input collection for {input_name}")
             if other_hid in hid_to_output_pair:
-                step_input = step.get_or_add_input(input_name)
-                other_step, other_name = hid_to_output_pair[other_hid]
-                conn = model.WorkflowStepConnection()
-                conn.input_step_input = step_input
-                # Should always be connected to an earlier step
-                conn.output_step = other_step
-                conn.output_name = other_name
+                _connect(step, input_name, hid_to_output_pair[other_hid])
         steps.append(step)
         # Store created dataset hids
         for assoc in job.output_datasets + job.output_dataset_collection_instances:
@@ -573,11 +576,6 @@ def extract_steps_by_ids(
     hda_ids = list(hda_ids or [])
     hdca_ids = list(hdca_ids or [])
 
-    if len(set(hda_ids)) != len(hda_ids):
-        raise exceptions.RequestParameterInvalidException("hda_ids contains duplicates")
-    if len(set(hdca_ids)) != len(hdca_ids):
-        raise exceptions.RequestParameterInvalidException("hdca_ids contains duplicates")
-
     user = getattr(trans, "user", None)
     sa_session = trans.sa_session
     hda_manager = trans.app.hda_manager
@@ -633,21 +631,9 @@ def extract_steps_by_ids(
     for icj_id in implicit_collection_jobs_ids:
         # Service-layer validator already checked existence, populated_state,
         # output-HDCA presence, and per-HDCA accessibility.
-        output_hdcas_for_icj = list(
-            sa_session.scalars(
-                select(HistoryDatasetCollectionAssociation).where(
-                    HistoryDatasetCollectionAssociation.implicit_collection_jobs_id == icj_id
-                )
-            )
-        )
-        representative = sa_session.scalars(
-            select(Job)
-            .join(ImplicitCollectionJobsJobAssociation, ImplicitCollectionJobsJobAssociation.job_id == Job.id)
-            .where(ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id == icj_id)
-            .order_by(ImplicitCollectionJobsJobAssociation.order_index, Job.id)
-            .limit(1)
-        ).one()
-        work_items.append((representative, output_hdcas_for_icj))
+        icj = sa_session.get(ImplicitCollectionJobs, icj_id)
+        assert icj is not None, f"ImplicitCollectionJobs {icj_id} not found"
+        work_items.append((icj.representative_job, icj.output_dataset_collection_instances))
 
     # Job.id is monotonically assigned at submission, so sorting by it
     # produces dependency order: a downstream job always has a larger id
@@ -672,12 +658,7 @@ def extract_steps_by_ids(
             if input_name in mapped_inputs:
                 key = ("collection", mapped_inputs[input_name].id)
             if key in id_to_output_pair:
-                step_input = step.get_or_add_input(input_name)
-                other_step, other_name = id_to_output_pair[key]
-                conn = model.WorkflowStepConnection()
-                conn.input_step_input = step_input
-                conn.output_step = other_step
-                conn.output_name = other_name
+                _connect(step, input_name, id_to_output_pair[key])
         steps.append(step)
 
         if output_hdcas:

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -3,22 +3,28 @@ histories.
 """
 
 import logging
+from collections.abc import Callable
 from typing import (
     Any,
     cast,
+    Literal,
     Optional,
 )
+
+from sqlalchemy import select
 
 from galaxy import (
     exceptions,
     model,
 )
 from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.managers.jobs import JobManager
 from galaxy.model import (
     History,
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
     HistoryItem,
+    ImplicitCollectionJobsJobAssociation,
     Job,
     StoredWorkflow,
     User,
@@ -53,6 +59,13 @@ log = logging.getLogger(__name__)
 WARNING_SOME_DATASETS_NOT_READY = "Some datasets still queued or running were ignored"
 
 
+def _skip_output_assoc_name(name: str) -> bool:
+    """True for job-output-association names that aren't workflow-visible
+    outputs (named-collection-part placeholders and discovered-primary-file
+    rows). Both extraction paths skip these."""
+    return ToolOutputCollectionPart.is_named_collection_part_name(name) or name.startswith("__new_primary_file")
+
+
 def extract_workflow(
     trans: ProvidesHistoryContext,
     user: User,
@@ -73,21 +86,25 @@ def extract_workflow(
         dataset_names=dataset_names,
         dataset_collection_names=dataset_collection_names,
     )
-    # Workflow to populate
+    return _finalize_workflow(trans, user, workflow_name, steps)
+
+
+def _finalize_workflow(
+    trans: ProvidesHistoryContext,
+    user: User,
+    workflow_name: Optional[str],
+    steps: list[WorkflowStep],
+) -> StoredWorkflow:
     workflow = model.Workflow()
     workflow.name = workflow_name
     workflow.steps = steps
-    # Order the steps if possible
     attach_ordered_steps(workflow)
-    # And let's try to set up some reasonable locations on the canvas
-    # (these are pretty arbitrary values)
     levorder = order_workflow_steps_with_levels(steps)
     base_pos = 10
     for i, steps_at_level in enumerate(levorder):
         for j, index in enumerate(steps_at_level):
             step = steps[index]
             step.position = dict(top=(base_pos + 120 * j), left=(base_pos + 220 * i))
-    # Store it
     stored = model.StoredWorkflow()
     stored.user = user
     stored.name = workflow_name
@@ -190,9 +207,7 @@ def extract_steps(
         # Store created dataset hids
         for assoc in job.output_datasets + job.output_dataset_collection_instances:
             assoc_name = assoc.name
-            if ToolOutputCollectionPart.is_named_collection_part_name(assoc_name):
-                continue
-            if assoc_name.startswith("__new_primary_file"):
+            if _skip_output_assoc_name(assoc_name):
                 continue
             if job in summary.implicit_map_jobs:
                 hid: Optional[int] = None
@@ -266,13 +281,28 @@ def summarize(
     return summary.jobs, summary.warnings
 
 
-class WorkflowSummary:
+class BaseWorkflowSummary:
+    """Shared helpers for workflow extraction summaries (HID-based and ID-based)."""
+
+    def __init__(self, trans: ProvidesHistoryContext) -> None:
+        self.trans = trans
+        self.warnings: set[str] = set()
+
+    def _check_state(self, hda: HistoryDatasetAssociation) -> Optional[HistoryDatasetAssociation]:
+        # FIXME: Create "Dataset.is_finished"
+        if hda.state in ("new", "running", "queued"):
+            self.warnings.add(WARNING_SOME_DATASETS_NOT_READY)
+            return None
+        return hda
+
+
+class WorkflowSummary(BaseWorkflowSummary):
     def __init__(self, trans: ProvidesHistoryContext, history: Optional[History]) -> None:
+        super().__init__(trans)
         if not history:
             history = trans.history
         assert history is not None
         self.history: History = history
-        self.warnings: set[str] = set()
         self.jobs: dict[Any, list[tuple[Optional[str], HistoryItem]]] = {}
         self.job_id2representative_job: dict[int, Job] = {}  # map a non-fake job id to its representative job
         self.implicit_map_jobs: list[Job] = []
@@ -324,7 +354,7 @@ class WorkflowSummary:
     def __summarize_dataset_collection(self, dataset_collection: HistoryDatasetCollectionAssociation) -> None:
         hid_in_history = dataset_collection.hid
         assert hid_in_history is not None, f"HDCA {dataset_collection.id} has no hid"
-        dataset_collection = self.__original_hdca(dataset_collection)
+        dataset_collection = _original_hdca(dataset_collection)
         self.hdca_hid_in_history[dataset_collection.id] = hid_in_history
 
         hid = dataset_collection.hid
@@ -359,12 +389,12 @@ class WorkflowSummary:
                 # TODO track this via tool request model
                 self.jobs[DatasetCollectionCreationJob(dataset_collection)] = [(None, dataset_collection)]
                 return
-            if not self.__check_state(dataset_instance):
+            if not self._check_state(dataset_instance):
                 # Just checking the state of one instance, don't need more but
                 # makes me wonder if even need this check at all?
                 return
 
-            original_hda = self.__original_hda(dataset_instance)
+            original_hda = _original_hda(dataset_instance)
             if not original_hda.creating_job_associations:
                 log.warning(
                     "An implicitly create output dataset collection doesn't have a creating_job_association, should not happen!"
@@ -383,12 +413,12 @@ class WorkflowSummary:
             self.jobs[DatasetCollectionCreationJob(dataset_collection)] = [(None, dataset_collection)]
 
     def __summarize_dataset(self, dataset: HistoryDatasetAssociation) -> None:
-        if not self.__check_state(dataset):
+        if not self._check_state(dataset):
             return
 
         hid_in_history = dataset.hid
         assert hid_in_history is not None
-        original_hda = self.__original_hda(dataset)
+        original_hda = _original_hda(dataset)
         self.hda_hid_in_history[original_hda.id] = hid_in_history
 
         if not original_hda.creating_job_associations:
@@ -402,24 +432,6 @@ class WorkflowSummary:
                 self.jobs[job] = [(assoc.name, dataset)]
                 self.job_id2representative_job[job.id] = job
 
-    def __original_hdca(self, hdca: HistoryDatasetCollectionAssociation) -> HistoryDatasetCollectionAssociation:
-        while hdca.copied_from_history_dataset_collection_association:
-            hdca = hdca.copied_from_history_dataset_collection_association
-        return hdca
-
-    def __original_hda(self, hda: HistoryDatasetAssociation) -> HistoryDatasetAssociation:
-        # if this hda was copied from another, we need to find the job that created the original hda
-        while hda.copied_from_history_dataset_association:
-            hda = hda.copied_from_history_dataset_association
-        return hda
-
-    def __check_state(self, hda: HistoryDatasetAssociation) -> Optional[HistoryDatasetAssociation]:
-        # FIXME: Create "Dataset.is_finished"
-        if hda.state in ("new", "running", "queued"):
-            self.warnings.add(WARNING_SOME_DATASETS_NOT_READY)
-            return None
-        return hda
-
 
 def step_inputs(trans: ProvidesHistoryContext, job: Job) -> tuple[ToolInputs, DataInputAssociations]:
     tool = trans.app.toolbox.tool_for_job(job, user=trans.user)
@@ -432,50 +444,46 @@ def step_inputs(trans: ProvidesHistoryContext, job: Job) -> tuple[ToolInputs, Da
     return tool_inputs, associations
 
 
-def __cleanup_param_values(inputs: ToolInputs, values: ToolInputs) -> DataInputAssociations:
+def _walk_data_param_tree(
+    inputs: ToolInputs,
+    values: ToolInputs,
+    leaf_handler: Callable[[Any, Any, str], None],
+) -> None:
+    """Walk a tool input tree, invoking ``leaf_handler`` once per
+    Data/DataCollection leaf with ``(input, value, full_key)``.
+
+    Clears the leaf's value in place and removes the deprecated metadata
+    cruft (``<key>_*`` siblings of the formal input keys) the framework
+    pushes into the root values dict. The cruft cleanup is shared because
+    both extraction variants need it; only the per-leaf association
+    emission differs.
     """
-    Remove 'Data' values from `param_values`, along with metadata cruft,
-    but track the associations.
-    """
-    associations = []
-    # dbkey is pushed in by the framework
     if "dbkey" in values:
         del values["dbkey"]
     root_values = values
     root_input_keys = inputs.keys()
 
-    # Recursively clean data inputs and dynamic selects
-    def cleanup(prefix, inputs, values):
+    def walk(prefix: str, inputs: ToolInputs, values: ToolInputs) -> None:
         for key, input in inputs.items():
-            if isinstance(input, DataToolParameter) or isinstance(input, DataCollectionToolParameter):
-                items = values[key]
+            if isinstance(input, (DataToolParameter, DataCollectionToolParameter)):
+                leaf_handler(input, values[key], prefix + key)
                 values[key] = None
-                # HACK: Nested associations are not yet working, but we
-                #       still need to clean them up so we can serialize
-                # if not( prefix ):
-                for item in listify(items):
-                    if isinstance(item, model.DatasetCollectionElement):
-                        item = item.first_dataset_instance()
-                    if item:  # this is false for a non-set optional dataset
-                        associations.append((item.hid, prefix + key))
-
-                # Cleanup the other deprecated crap associated with datasets
-                # as well. Worse, for nested datasets all the metadata is
-                # being pushed into the root. FIXME: MUST REMOVE SOON
-                key = f"{prefix + key}_"
-                for k in root_values.keys():
-                    if k not in root_input_keys and k.startswith(key):
+                # FIXME: Nested data params leak deprecated metadata into the
+                # root values dict; scrub anything starting with `<key>_` that
+                # isn't itself a formal input.
+                cruft_prefix = f"{prefix + key}_"
+                for k in list(root_values.keys()):
+                    if k not in root_input_keys and k.startswith(cruft_prefix):
                         del root_values[k]
             elif isinstance(input, Repeat):
                 if key in values:
                     group_values = values[key]
                     for i, rep_values in enumerate(group_values):
                         rep_index = rep_values["__index__"]
-                        cleanup(f"{prefix}{key}_{rep_index}|", input.inputs, group_values[i])
+                        walk(f"{prefix}{key}_{rep_index}|", input.inputs, group_values[i])
             elif isinstance(input, Conditional):
-                # Scrub dynamic resource related parameters from workflows,
-                # they cause problems and the workflow probably should include
-                # their state in workflow encoding.
+                # __job_resource is a runtime-only group; strip and stop —
+                # workflow encoding shouldn't carry resource selections.
                 if input.name == "__job_resource":
                     if input.name in values:
                         del values[input.name]
@@ -483,13 +491,288 @@ def __cleanup_param_values(inputs: ToolInputs, values: ToolInputs) -> DataInputA
                 if input.name in values:
                     group_values = values[input.name]
                     current_case = group_values["__current_case__"]
-                    cleanup(f"{prefix}{key}|", input.cases[current_case].inputs, group_values)
+                    walk(f"{prefix}{key}|", input.cases[current_case].inputs, group_values)
             elif isinstance(input, Section):
                 if input.name in values:
-                    cleanup(f"{prefix}{key}|", input.inputs, values[input.name])
+                    walk(f"{prefix}{key}|", input.inputs, values[input.name])
 
-    cleanup("", inputs, values)
+    walk("", inputs, values)
+
+
+def __cleanup_param_values(inputs: ToolInputs, values: ToolInputs) -> DataInputAssociations:
+    """HID-keyed Data-leaf scrub: emit ``(hid, key)`` associations."""
+    associations: DataInputAssociations = []
+
+    def emit(input, value, key):
+        for item in listify(value):
+            if isinstance(item, model.DatasetCollectionElement):
+                item = item.first_dataset_instance()
+            if item:  # false for a non-set optional dataset
+                associations.append((item.hid, key))
+
+    _walk_data_param_tree(inputs, values, emit)
     return associations
 
 
-__all__ = ("summarize", "extract_workflow")
+def extract_workflow_by_ids(
+    trans: ProvidesHistoryContext,
+    user: User,
+    workflow_name: str,
+    job_manager: JobManager,
+    job_ids: Optional[list[int]] = None,
+    hda_ids: Optional[list[int]] = None,
+    hdca_ids: Optional[list[int]] = None,
+    dataset_names: Optional[list[str]] = None,
+    dataset_collection_names: Optional[list[str]] = None,
+) -> StoredWorkflow:
+    """ID-based variant of :func:`extract_workflow`."""
+    steps = extract_steps_by_ids(
+        trans,
+        job_manager=job_manager,
+        job_ids=job_ids,
+        hda_ids=hda_ids,
+        hdca_ids=hdca_ids,
+        dataset_names=dataset_names,
+        dataset_collection_names=dataset_collection_names,
+    )
+    return _finalize_workflow(trans, user, workflow_name, steps)
+
+
+IdKey = tuple[Literal["dataset", "collection"], int]
+IdAssociations = list[tuple[IdKey, str]]
+
+
+def extract_steps_by_ids(
+    trans: ProvidesHistoryContext,
+    job_manager: Optional[JobManager] = None,
+    job_ids: Optional[list[int]] = None,
+    hda_ids: Optional[list[int]] = None,
+    hdca_ids: Optional[list[int]] = None,
+    dataset_names: Optional[list[str]] = None,
+    dataset_collection_names: Optional[list[str]] = None,
+) -> list[WorkflowStep]:
+    """ID-based variant of :func:`extract_steps`.
+
+    Inputs are decoded DB ids; each is fetched and access-checked against the
+    current user via the appropriate manager. Connections are keyed by
+    ``(content_type, db_id)`` of the resolved *original* HDA/HDCA so that
+    copied datasets and cross-history items map deterministically.
+
+    ``job_manager`` may be omitted only when ``job_ids`` is empty (kept
+    Optional for unit-test ergonomics).
+    """
+    job_ids = list(job_ids or [])
+    hda_ids = list(hda_ids or [])
+    hdca_ids = list(hdca_ids or [])
+
+    if len(set(hda_ids)) != len(hda_ids):
+        raise exceptions.RequestParameterInvalidException("hda_ids contains duplicates")
+    if len(set(hdca_ids)) != len(hdca_ids):
+        raise exceptions.RequestParameterInvalidException("hdca_ids contains duplicates")
+
+    user = getattr(trans, "user", None)
+    sa_session = trans.sa_session
+    hda_manager = trans.app.hda_manager
+    dataset_collection_manager = trans.app.dataset_collection_manager
+
+    steps: list[WorkflowStep] = []
+    step_labels: set[str] = set()
+    id_to_output_pair: dict[IdKey, tuple[WorkflowStep, str]] = {}
+
+    for i, hda_id in enumerate(hda_ids):
+        hda = hda_manager.get_accessible(hda_id, user)
+        step = model.WorkflowStep()
+        step.type = "data_input"
+        name = dataset_names[i] if dataset_names else "Input Dataset"
+        if name not in step_labels:
+            step.label = name
+            step_labels.add(name)
+        step.tool_inputs = dict(name=name)
+        steps.append(step)
+        original = _original_hda(hda)
+        id_to_output_pair[("dataset", original.id)] = (step, "output")
+
+    for i, hdca_id in enumerate(hdca_ids):
+        hdca = dataset_collection_manager.get_dataset_collection_instance(trans, "history", hdca_id)
+        step = model.WorkflowStep()
+        step.type = "data_collection_input"
+        name = dataset_collection_names[i] if dataset_collection_names else "Input Dataset Collection"
+        if name not in step_labels:
+            step.label = name
+            step_labels.add(name)
+        step.tool_inputs = dict(name=name, collection_type=hdca.collection.collection_type)
+        steps.append(step)
+        original_hdca = _original_hdca(hdca)
+        id_to_output_pair[("collection", original_hdca.id)] = (step, "output")
+
+    # Resolve and dedup jobs. Implicit-map participants collapse to a single
+    # representative job per ImplicitCollectionJobs id.
+    seen_icj_ids: set[int] = set()
+    resolved_jobs: list[Job] = []
+    for job_id in job_ids:
+        assert job_manager is not None, "job_manager required when job_ids supplied"
+        job = job_manager.get_accessible_job(trans, job_id)
+        icj_assoc = job.implicit_collection_jobs_association
+        if icj_assoc is not None:
+            icj_id = icj_assoc.implicit_collection_jobs_id
+            if icj_id in seen_icj_ids:
+                continue
+            seen_icj_ids.add(icj_id)
+            representative = sa_session.execute(
+                select(Job)
+                .join(ImplicitCollectionJobsJobAssociation, ImplicitCollectionJobsJobAssociation.job_id == Job.id)
+                .where(ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id == icj_id)
+                .order_by(Job.id)
+                .limit(1)
+            ).scalar_one()
+            resolved_jobs.append(representative)
+        else:
+            resolved_jobs.append(job)
+
+    # Process jobs in dependency order. Job.id is monotonically assigned at
+    # submission, so a job that consumes another's output always has the
+    # larger id; sorting by id is sufficient to ensure each downstream job's
+    # inputs are already registered in id_to_output_pair when we wire it.
+    resolved_jobs.sort(key=lambda j: j.id)
+
+    for job in resolved_jobs:
+        icj_assoc = job.implicit_collection_jobs_association
+        output_hdcas: list[HistoryDatasetCollectionAssociation] = []
+        if icj_assoc is not None:
+            output_hdcas = list(
+                sa_session.scalars(
+                    select(HistoryDatasetCollectionAssociation).where(
+                        HistoryDatasetCollectionAssociation.implicit_collection_jobs_id
+                        == icj_assoc.implicit_collection_jobs_id
+                    )
+                )
+            )
+
+        tool_inputs, associations = step_inputs_by_id(trans, job)
+        step = model.WorkflowStep()
+        step.type = "tool"
+        step.tool_id = job.tool_id
+        step.tool_version = job.tool_version
+        step.tool_inputs = tool_inputs
+
+        for key, input_name in associations:
+            if output_hdcas:
+                # Implicit-map: rewrite per-job inputs to the input HDCA the
+                # mapping consumed (find_implicit_input_collection on any
+                # output HDCA returns the same answer).
+                input_collection = output_hdcas[0].find_implicit_input_collection(input_name)
+                if input_collection is not None:
+                    original_input = _original_hdca(input_collection)
+                    key = ("collection", original_input.id)
+            if key in id_to_output_pair:
+                step_input = step.get_or_add_input(input_name)
+                other_step, other_name = id_to_output_pair[key]
+                conn = model.WorkflowStepConnection()
+                conn.input_step_input = step_input
+                conn.output_step = other_step
+                conn.output_name = other_name
+        steps.append(step)
+
+        # Register outputs so downstream jobs can wire into them.
+        if output_hdcas:
+            # Implicit-map: each output_name maps to one HDCA. Per-output `<filter>`
+            # evaluating True under mapping can leave per-job HDAs on
+            # `job.output_datasets` with no enclosing implicit HDCA — those go
+            # unregistered here. The legacy HID path raised in that case; we
+            # silently drop, which is functionally equivalent for downstream wiring.
+            seen_names: dict[str, HistoryDatasetCollectionAssociation] = {}
+            for output_hdca in output_hdcas:
+                output_name = output_hdca.implicit_output_name
+                if output_name and output_name not in seen_names:
+                    seen_names[output_name] = output_hdca
+            for output_name, output_hdca in seen_names.items():
+                original_output = _original_hdca(output_hdca)
+                id_to_output_pair[("collection", original_output.id)] = (step, output_name)
+        else:
+            for hda_assoc in job.output_datasets:
+                hda_assoc_name = hda_assoc.name
+                if _skip_output_assoc_name(hda_assoc_name):
+                    continue
+                original_hda = _original_hda(hda_assoc.dataset)
+                id_to_output_pair[("dataset", original_hda.id)] = (step, hda_assoc_name)
+            for hdca_assoc in job.output_dataset_collection_instances:
+                original_hdca = _original_hdca(hdca_assoc.dataset_collection_instance)
+                id_to_output_pair[("collection", original_hdca.id)] = (step, hdca_assoc.name)
+
+    return steps
+
+
+def step_inputs_by_id(trans: ProvidesHistoryContext, job: Job) -> tuple[ToolInputs, IdAssociations]:
+    """ID-based variant of :func:`step_inputs`.
+
+    Returns associations keyed by ``(content_type, db_id)`` tuples (against
+    the *original* HDA/HDCA after walking ``copied_from_*``). Collection
+    and DCE inputs come from ``Job.input_dataset_collections`` /
+    ``Job.input_dataset_collection_elements`` directly rather than from the
+    param-value walk, which avoids the HID path's flattening of HDCAs to
+    leaf HDAs and prevents duplicate emission for DCE-as-data-param.
+    """
+    tool = trans.app.toolbox.get_tool(job.tool_id, tool_version=job.tool_version)
+    assert tool is not None, f"Tool {job.tool_id} (version {job.tool_version}) not found"
+    param_values = tool.get_param_values(job, ignore_errors=True)
+    associations: IdAssociations = __cleanup_param_values_by_id(tool.inputs, param_values)
+    for assoc in job.input_dataset_collections:
+        original_hdca = _original_hdca(assoc.dataset_collection)
+        associations.append((("collection", original_hdca.id), assoc.name))
+    for elem_assoc in job.input_dataset_collection_elements:
+        dce = elem_assoc.dataset_collection_element
+        leaf = dce.hda or dce.first_dataset_instance()
+        if not isinstance(leaf, HistoryDatasetAssociation):
+            continue
+        original_hda = _original_hda(leaf)
+        associations.append((("dataset", original_hda.id), elem_assoc.name))
+    tool_inputs = tool.params_to_strings(param_values, trans.app)
+    return tool_inputs, associations
+
+
+def _original_hda(hda: HistoryDatasetAssociation) -> HistoryDatasetAssociation:
+    while hda.copied_from_history_dataset_association:
+        hda = hda.copied_from_history_dataset_association
+    return hda
+
+
+def _original_hdca(hdca: HistoryDatasetCollectionAssociation) -> HistoryDatasetCollectionAssociation:
+    while hdca.copied_from_history_dataset_collection_association:
+        hdca = hdca.copied_from_history_dataset_collection_association
+    return hdca
+
+
+def __cleanup_param_values_by_id(inputs: ToolInputs, values: ToolInputs) -> IdAssociations:
+    """ID-keyed Data-leaf scrub.
+
+    HDA leaves emit ``("dataset", _original_hda(hda).id)``. DCE values and
+    ``DataCollectionToolParameter`` leaves are scrubbed but emit nothing —
+    collection / DCE inputs are appended in :func:`step_inputs_by_id` from
+    typed DB rows so HDCAs aren't lost to ``first_dataset_instance()``
+    flattening and DCEs aren't double-emitted alongside their typed
+    ``input_dataset_collection_elements`` row.
+    """
+    associations: IdAssociations = []
+
+    def emit(input, value, key):
+        if isinstance(input, DataCollectionToolParameter):
+            return
+        for item in listify(value):
+            if isinstance(item, model.DatasetCollectionElement):
+                # Covered by job.input_dataset_collection_elements; skip to
+                # avoid duplicate connections.
+                continue
+            if isinstance(item, HistoryDatasetAssociation):
+                original = _original_hda(item)
+                associations.append((("dataset", original.id), key))
+
+    _walk_data_param_tree(inputs, values, emit)
+    return associations
+
+
+__all__ = (
+    "summarize",
+    "extract_workflow",
+    "extract_workflow_by_ids",
+    "extract_steps_by_ids",
+)

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -675,11 +675,10 @@ def extract_steps_by_ids(
 
         # Register outputs so downstream jobs can wire into them.
         if output_hdcas:
-            # Implicit-map: each output_name maps to one HDCA. Per-output `<filter>`
-            # evaluating True under mapping can leave per-job HDAs on
-            # `job.output_datasets` with no enclosing implicit HDCA — those go
-            # unregistered here. The legacy HID path raised in that case; we
-            # silently drop, which is functionally equivalent for downstream wiring.
+            # Implicit-map: register each unique implicit output HDCA so downstream
+            # steps consume the collection (not its per-job leaves). Per-job HDAs
+            # on job.output_datasets are intentionally not registered here —
+            # downstream wiring resolves the collection via find_implicit_input_collection.
             seen_names: dict[str, HistoryDatasetCollectionAssociation] = {}
             for output_hdca in output_hdcas:
                 output_name = output_hdca.implicit_output_name

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -1,5 +1,8 @@
 import functools
-from collections import namedtuple
+from collections import (
+    Counter,
+    namedtuple,
+)
 from json import (
     dumps,
     loads,
@@ -652,6 +655,465 @@ test_data:
         job_id = run_output1["jobs"][0]["id"]
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         return implicit_hdca, job_id
+
+
+class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructureAssertions):
+    """Tests for POST /api/workflows/extract (ID-based extraction).
+
+    Sibling of :class:`TestWorkflowExtractionApi` — same scenarios, but the
+    payload carries encoded HDA / HDCA / job ids rather than HIDs, and the
+    request goes to the new history-optional endpoint.
+    """
+
+    def _extract_and_download_workflow_by_ids(self, **payload):
+        if "workflow_name" not in payload:
+            payload["workflow_name"] = "test import from history (by id)"
+        response = self._post("workflows/extract", data=payload, json=True)
+        self._assert_status_code_is(response, 200)
+        new_workflow_id = response.json()["id"]
+        download = self._get(f"workflows/{new_workflow_id}/download")
+        self._assert_status_code_is(download, 200)
+        return download.json()
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_hda_ids(self, history_id):
+        new_dataset1 = self.dataset_populator.new_dataset(history_id, content="1 2 3\n")
+        new_dataset2 = self.dataset_populator.new_dataset(history_id, content="4 5 6\n")
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": new_dataset1["id"]},
+                "queries_0|input2": {"src": "hda", "id": new_dataset2["id"]},
+            },
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        cat1_job_id = run["jobs"][0]["id"]
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hda_ids=[new_dataset1["id"], new_dataset2["id"]],
+            job_ids=[cat1_job_id],
+        )
+        assert downloaded["name"] == "test import from history (by id)"
+        self.assert_cat1_workflow_structure(downloaded)
+
+    def _run_tool_get_collection_and_job_id(self, history_id, tool_id, inputs):
+        run_output = self.dataset_populator.run_tool(tool_id=tool_id, inputs=inputs, history_id=history_id)
+        implicit_hdca = run_output["implicit_collections"][0]
+        job_id = run_output["jobs"][0]["id"]
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        return implicit_hdca, job_id
+
+    def _run_random_lines_mapped_over_pair(self, history_id):
+        hdca = self.dataset_collection_populator.create_pair_in_history(
+            history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
+        ).json()["outputs"][0]
+        inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca["id"]}]}, "num_lines": 2}
+        implicit_hdca1, job_id1 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
+        inputs2 = {"input": {"batch": True, "values": [{"src": "hdca", "id": implicit_hdca1["id"]}]}, "num_lines": 1}
+        _, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
+        return hdca, job_id1, job_id2
+
+    @skip_without_tool("random_lines1")
+    @summarize_instance_history_on_error
+    def test_extract_mapping_workflow_by_ids(self, history_id):
+        hdca, job_id1, job_id2 = self._run_random_lines_mapped_over_pair(history_id)
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hdca_ids=[hdca["id"]],
+            job_ids=[job_id1, job_id2],
+        )
+        self.assert_randomlines_mapping_workflow_structure(downloaded)
+
+    def _copy_hda_to_history(self, history_id, hda):
+        response = self._post(
+            f"histories/{history_id}/contents/datasets",
+            dict(source="hda", content=hda["id"]),
+            json=True,
+        )
+        self._assert_status_code_is(response, 200)
+        return response.json()
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_copied_inputs_post_copy_ids(self, history_id):
+        """User passes post-copy HDA ids (in extraction history) plus the
+        original (pre-copy) job id."""
+        original_history_id = self.dataset_populator.new_history()
+        d1 = self.dataset_populator.new_dataset(original_history_id, content="1 2 3\n")
+        d2 = self.dataset_populator.new_dataset(original_history_id, content="4 5 6\n")
+        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": d1["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2["id"]},
+            },
+            history_id=original_history_id,
+        )
+        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
+        cat1_job_id = run["jobs"][0]["id"]
+
+        d1_copy = self._copy_hda_to_history(history_id, d1)
+        d2_copy = self._copy_hda_to_history(history_id, d2)
+
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hda_ids=[d1_copy["id"], d2_copy["id"]],
+            job_ids=[cat1_job_id],
+        )
+        self.assert_cat1_workflow_structure(downloaded)
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_copied_inputs_pre_copy_ids(self, history_id):
+        """User passes pre-copy HDA ids (in original history) plus the
+        original job id; copies exist in `history_id` but are not referenced.
+        Cross-history extraction — `from_history_id` not required."""
+        original_history_id = self.dataset_populator.new_history()
+        d1 = self.dataset_populator.new_dataset(original_history_id, content="1 2 3\n")
+        d2 = self.dataset_populator.new_dataset(original_history_id, content="4 5 6\n")
+        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": d1["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2["id"]},
+            },
+            history_id=original_history_id,
+        )
+        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
+        cat1_job_id = run["jobs"][0]["id"]
+
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+        )
+        self.assert_cat1_workflow_structure(downloaded)
+
+    @summarize_instance_history_on_error
+    def test_empty_payload_rejected(self, history_id):
+        response = self._post(
+            "workflows/extract",
+            data={"workflow_name": "no inputs"},
+            json=True,
+        )
+        # pydantic validator rejects empty input list -> 4xx (400 or 422).
+        assert response.status_code in (400, 422), response.text
+
+    @summarize_instance_history_on_error
+    def test_inaccessible_dataset_rejected(self, history_id):
+        """Another user's private HDA in payload should be rejected."""
+        with self._different_user("other_extract_user@bx.psu.edu"):
+            other_history_id = self.dataset_populator.new_history()
+            other_dataset = self.dataset_populator.new_dataset(other_history_id, content="secret\n")
+            self.dataset_populator.wait_for_history(other_history_id, assert_ok=True)
+            self.dataset_populator.make_private(other_history_id, other_dataset["id"])
+        response = self._post(
+            "workflows/extract",
+            data={
+                "workflow_name": "should fail",
+                "hda_ids": [other_dataset["id"]],
+            },
+            json=True,
+        )
+        assert response.status_code in (400, 403), response.text
+
+    @summarize_instance_history_on_error
+    def test_nonexistent_hda_id_rejected(self, history_id):
+        response = self._post(
+            "workflows/extract",
+            data={"workflow_name": "bad hda", "hda_ids": ["f" * 16]},
+            json=True,
+        )
+        assert response.status_code in (400, 404), response.text
+
+    @summarize_instance_history_on_error
+    def test_nonexistent_hdca_id_rejected(self, history_id):
+        response = self._post(
+            "workflows/extract",
+            data={"workflow_name": "bad hdca", "hdca_ids": ["f" * 16]},
+            json=True,
+        )
+        assert response.status_code in (400, 404), response.text
+
+    @summarize_instance_history_on_error
+    def test_duplicate_hda_ids_rejected(self, history_id):
+        new_dataset = self.dataset_populator.new_dataset(history_id, content="1 2 3\n")
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        response = self._post(
+            "workflows/extract",
+            data={
+                "workflow_name": "dup hdas",
+                "hda_ids": [new_dataset["id"], new_dataset["id"]],
+            },
+            json=True,
+        )
+        assert response.status_code in (400, 422), response.text
+
+    @summarize_instance_history_on_error
+    def test_inaccessible_collection_rejected(self, history_id):
+        """Another user's private HDCA in payload should be rejected."""
+        with self._different_user("other_extract_user_hdca@bx.psu.edu"):
+            other_history_id = self.dataset_populator.new_history()
+            create_response = self.dataset_collection_populator.create_pair_in_history(
+                other_history_id, contents=["a\n", "b\n"], wait=True
+            ).json()
+            other_hdca = create_response["outputs"][0]
+            details = self.dataset_populator.get_history_collection_details(
+                other_history_id, content_id=other_hdca["id"]
+            )
+            for element in details["elements"]:
+                self.dataset_populator.make_private(other_history_id, element["object"]["id"])
+        response = self._post(
+            "workflows/extract",
+            data={
+                "workflow_name": "should fail",
+                "hdca_ids": [other_hdca["id"]],
+            },
+            json=True,
+        )
+        assert response.status_code in (400, 403), response.text
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_dce_as_data_param_flows_through_as_leaf_hda(self, history_id):
+        """A tool job whose DataToolParameter was fed a DCE (drag-and-dropped
+        collection element) should resolve its connection via the leaf HDA's
+        id — the workflow has no DCE/HDCA reference. User passes the leaf
+        HDA id in `hda_ids`."""
+        hdca = self.dataset_collection_populator.create_pair_in_history(
+            history_id, contents=["forward content\n", "reverse content\n"], wait=True
+        ).json()["outputs"][0]
+        details = self.dataset_populator.get_history_collection_details(history_id, content_id=hdca["id"])
+        forward_element = details["elements"][0]
+        forward_hda_id = forward_element["object"]["id"]
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={"input1": {"src": "dce", "id": forward_element["id"]}},
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        cat1_job_id = run["jobs"][0]["id"]
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hda_ids=[forward_hda_id],
+            job_ids=[cat1_job_id],
+        )
+        steps = downloaded["steps"]
+        assert len(steps) == 2, steps
+        input_steps = [s for s in steps.values() if s["type"] == "data_input"]
+        tool_steps = [s for s in steps.values() if s["type"] == "tool"]
+        assert len(input_steps) == 1 and len(tool_steps) == 1
+        connection = tool_steps[0]["input_connections"]["input1"]
+        # .ga format may yield a single dict or a list of one dict.
+        connection = connection[0] if isinstance(connection, list) else connection
+        assert connection["id"] == input_steps[0]["id"]
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_after_copy_no_foreign_jobs(self, history_id):
+        """Regression for #9161: dataset copied A->B, tool run in B, extract
+        from B. With ID-based extraction the user explicitly supplies the
+        B-side job; result must not reference the A-side dataset's HDA id."""
+        history_a = self.dataset_populator.new_history()
+        d_a = self.dataset_populator.new_dataset(history_a, content="seed\n")
+        self.dataset_populator.wait_for_history(history_a, assert_ok=True)
+        d_b = self._copy_hda_to_history(history_id, d_a)
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={"input1": {"src": "hda", "id": d_b["id"]}},
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        cat1_job_id = run["jobs"][0]["id"]
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hda_ids=[d_b["id"]],
+            job_ids=[cat1_job_id],
+        )
+        # Exactly one input + one tool step; tool wires to the input step.
+        steps = downloaded["steps"]
+        assert len(steps) == 2, steps
+        input_steps = [s for s in steps.values() if s["type"] == "data_input"]
+        tool_steps = [s for s in steps.values() if s["type"] == "tool"]
+        assert len(input_steps) == 1 and len(tool_steps) == 1
+        cat1_step = tool_steps[0]
+        assert cat1_step["tool_id"] == "cat1"
+        assert cat1_step["input_connections"]["input1"]["id"] == input_steps[0]["id"]
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_cached_job_cross_history(self, history_id):
+        """Run cat1 in history A, then in B with use_cached_job=True. Extract
+        from B with hda_ids/job_ids referring to B-side rows. Workflow should
+        wire B-side input to B-side cached job, not pull A-side rows in."""
+        history_a = self.dataset_populator.new_history()
+        d_a = self.dataset_populator.new_dataset(history_a, content="cache me\n")
+        d2_a = self.dataset_populator.new_dataset(history_a, content="other\n")
+        self.dataset_populator.wait_for_history(history_a, assert_ok=True)
+        self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": d_a["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2_a["id"]},
+            },
+            history_id=history_a,
+        )
+        self.dataset_populator.wait_for_history(history_a, assert_ok=True)
+
+        d_b = self._copy_hda_to_history(history_id, d_a)
+        d2_b = self._copy_hda_to_history(history_id, d2_a)
+        cached_run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": d_b["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2_b["id"]},
+            },
+            history_id=history_id,
+            use_cached_job=True,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        cat1_job_id = cached_run["jobs"][0]["id"]
+
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hda_ids=[d_b["id"], d2_b["id"]],
+            job_ids=[cat1_job_id],
+        )
+        self.assert_cat1_workflow_structure(downloaded)
+
+    def _extract_workflow_id_by_ids(self, **payload):
+        if "workflow_name" not in payload:
+            payload["workflow_name"] = "extract roundtrip"
+        response = self._post("workflows/extract", data=payload, json=True)
+        self._assert_status_code_is(response, 200)
+        return response.json()["id"]
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_roundtrip_basic_by_ids(self, history_id):
+        """Extract a cat1 workflow via the by-ids endpoint, invoke it on a
+        fresh history, and assert it produces an output."""
+        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n")
+        d2 = self.dataset_populator.new_dataset(history_id, content="beta\n")
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": d1["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2["id"]},
+            },
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        cat1_job_id = run["jobs"][0]["id"]
+        workflow_id = self._extract_workflow_id_by_ids(
+            from_history_id=history_id,
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+        )
+
+        new_history_id = self.dataset_populator.new_history()
+        n1 = self.dataset_populator.new_dataset(new_history_id, content="gamma\n")
+        n2 = self.dataset_populator.new_dataset(new_history_id, content="delta\n")
+        self.dataset_populator.wait_for_history(new_history_id, assert_ok=True)
+        invocation_id = self.workflow_populator.invoke_workflow_and_assert_ok(
+            workflow_id,
+            history_id=new_history_id,
+            inputs={"0": {"src": "hda", "id": n1["id"]}, "1": {"src": "hda", "id": n2["id"]}},
+            inputs_by="step_index",
+        )
+        self.workflow_populator.wait_for_invocation_and_jobs(
+            history_id=new_history_id, workflow_id=workflow_id, invocation_id=invocation_id
+        )
+        content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=3)
+        assert "gamma" in content and "delta" in content, content
+
+    @skip_without_tool("random_lines1")
+    @skip_without_tool("multi_data_param")
+    @summarize_instance_history_on_error
+    def test_extract_reduction_by_ids(self, history_id):
+        hdca = self.dataset_collection_populator.create_pair_in_history(
+            history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
+        ).json()["outputs"][0]
+        inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca["id"]}]}, "num_lines": 2}
+        implicit_hdca1, job_id1 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
+        reduction_run = self.dataset_populator.run_tool(
+            tool_id="multi_data_param",
+            inputs={
+                "f1": {"src": "hdca", "id": implicit_hdca1["id"]},
+                "f2": {"src": "hdca", "id": implicit_hdca1["id"]},
+            },
+            history_id=history_id,
+        )
+        job_id2 = reduction_run["jobs"][0]["id"]
+        self.dataset_populator.wait_for_job(job_id2, assert_ok=True)
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hdca_ids=[hdca["id"]],
+            job_ids=[job_id1, job_id2],
+        )
+        assert len(downloaded["steps"]) == 3
+        collect_step_idx = self.assert_first_step_is_paired_input(downloaded)
+        tool_steps = self.assert_steps_of_type(downloaded, "tool", expected_len=2)
+        random_lines_map_step, reduction_step = tool_steps[0], tool_steps[1]
+        assert random_lines_map_step["tool_id"] == "random_lines1"
+        assert random_lines_map_step["input_connections"]["input"]["id"] == collect_step_idx
+        assert reduction_step["input_connections"]["f1"]["id"] == random_lines_map_step["id"]
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_by_ids_input_order_equivalent(self, history_id):
+        """Same hda_ids in different order produce structurally equivalent
+        workflows. Canvas layout via order_workflow_steps_with_levels may
+        differ across input orderings, but step types, tool set, and
+        connection topology must match.
+        """
+        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n")
+        d2 = self.dataset_populator.new_dataset(history_id, content="beta\n")
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": d1["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2["id"]},
+            },
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        cat1_job_id = run["jobs"][0]["id"]
+
+        wf_a = self._extract_and_download_workflow_by_ids(
+            workflow_name="ordering A",
+            from_history_id=history_id,
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+        )
+        wf_b = self._extract_and_download_workflow_by_ids(
+            workflow_name="ordering B",
+            from_history_id=history_id,
+            hda_ids=[d2["id"], d1["id"]],
+            job_ids=[cat1_job_id],
+        )
+
+        def signature(workflow):
+            steps = list(workflow["steps"].values())
+            tool_ids = sorted(s["tool_id"] for s in steps if s.get("tool_id"))
+            type_counts = Counter(s["type"] for s in steps)
+            by_id = {int(k): v for k, v in workflow["steps"].items()}
+            connections = set()
+            for step in steps:
+                target = step.get("tool_id") or step["type"]
+                for input_name, conn in (step.get("input_connections") or {}).items():
+                    src_type = by_id[conn["id"]]["type"]
+                    connections.add((target, input_name, src_type))
+            return tool_ids, type_counts, connections
+
+        assert signature(wf_a) == signature(wf_b)
 
 
 class TestWorkflowExtractionSummaryApi(BaseWorkflowsApiTestCase):

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -1,4 +1,6 @@
 import functools
+import time
+import unittest
 from collections import (
     Counter,
     namedtuple,
@@ -7,9 +9,15 @@ from json import (
     dumps,
     loads,
 )
+from typing import (
+    Any,
+    TYPE_CHECKING,
+)
 
 from galaxy.tool_util_models import UserToolSource
 from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
+    DatasetPopulator,
     skip_without_tool,
     summarize_instance_history_on_error,
     TOOL_WITH_SHELL_COMMAND,
@@ -17,8 +25,58 @@ from galaxy_test.base.populators import (
 from galaxy_test.base.workflow_assertions import WorkflowStructureAssertions
 from .test_workflows import BaseWorkflowsApiTestCase
 
+if TYPE_CHECKING:
+    from requests import Response
 
-class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAssertions):
+
+class _ExtractionHelpersMixin:
+    """Shared helpers for HID-based and ID-based workflow extraction tests."""
+
+    dataset_populator: DatasetPopulator
+    dataset_collection_populator: DatasetCollectionPopulator
+
+    if TYPE_CHECKING:
+
+        def _post(self, *args: Any, **kwds: Any) -> "Response": ...
+
+        def _assert_status_code_is(self, response: "Response", expected_status_code: int) -> None: ...
+
+    def _run_tool_get_collection_and_job_id(self, history_id, tool_id, inputs):
+        run = self.dataset_populator.run_tool(tool_id=tool_id, inputs=inputs, history_id=history_id)
+        implicit_hdca = run["implicit_collections"][0]
+        job_id = run["jobs"][0]["id"]
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        return implicit_hdca, job_id
+
+    def _run_random_lines_mapped_over_pair(self, history_id):
+        hdca = self.dataset_collection_populator.create_pair_in_history(
+            history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
+        ).json()["outputs"][0]
+        inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca["id"]}]}, "num_lines": 2}
+        implicit_hdca1, job_id1 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
+        inputs2 = {"input": {"batch": True, "values": [{"src": "hdca", "id": implicit_hdca1["id"]}]}, "num_lines": 1}
+        _, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
+        return hdca, job_id1, job_id2
+
+    def _copy_hda_to_history(self, history_id, hda):
+        response = self._post(
+            f"histories/{history_id}/contents/datasets",
+            dict(source="hda", content=hda["id"]),
+            json=True,
+        )
+        self._assert_status_code_is(response, 200)
+        return response.json()
+
+    def _copy_content_to_history(self, history_id, content):
+        if content["history_content_type"] == "dataset":
+            return self._copy_hda_to_history(history_id, content)
+        payload = dict(source="hdca", content=content["id"])
+        response = self._post(f"histories/{history_id}/contents/dataset_collections", payload, json=True)
+        self._assert_status_code_is(response, 200)
+        return response.json()
+
+
+class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCase, WorkflowStructureAssertions):
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error
     def test_extract_from_history(self, history_id):
@@ -104,13 +162,10 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
         offset = 0
         old_contents = self._history_contents(old_history_id)
         for old_dataset in old_contents:
-            self.__copy_content_to_history(history_id, old_dataset)
+            self._copy_content_to_history(history_id, old_dataset)
         new_contents = self._history_contents(history_id)
         input_hids = [c["hid"] for c in new_contents[(offset + 0) : (offset + 2)]]
         cat1_job_id = self.__job_id(history_id, new_contents[(offset + 2)]["id"])
-
-        def reimport_jobs_ids(new_history_id):
-            return [j["id"] for j in self.dataset_populator.history_jobs(new_history_id) if j["tool_id"] == "cat1"]
 
         downloaded_workflow = self._extract_and_download_workflow(
             history_id,
@@ -128,17 +183,14 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
         offset = 0
         old_contents = self._history_contents(old_history_id)
         for old_dataset in old_contents:
-            self.__copy_content_to_history(history_id, old_dataset)
+            self._copy_content_to_history(history_id, old_dataset)
         new_contents = self._history_contents(history_id)
         input_hids = [c["hid"] for c in new_contents[(offset + 0) : (offset + 2)]]
-
-        def reimport_jobs_ids(new_history_id):
-            return [j["id"] for j in self.dataset_populator.history_jobs(new_history_id) if j["tool_id"] == "cat1"]
 
         downloaded_workflow = self._extract_and_download_workflow(
             history_id,
             reimport_as="test_extract_with_copied_inputs",
-            reimport_jobs_ids=reimport_jobs_ids,
+            reimport_jobs_ids=lambda nh: self._jobs_by_tool(nh, "cat1"),
             dataset_ids=input_hids,
         )
         self.assert_cat1_workflow_structure(downloaded_workflow)
@@ -146,7 +198,7 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
     @skip_without_tool("random_lines1")
     @summarize_instance_history_on_error
     def test_extract_mapping_workflow_from_history(self, history_id):
-        hdca, job_id1, job_id2 = self.__run_random_lines_mapped_over_pair(history_id)
+        hdca, job_id1, job_id2 = self._run_random_lines_mapped_over_pair(history_id)
         downloaded_workflow = self._extract_and_download_workflow(
             history_id,
             reimport_as="extract_from_history_with_mapping",
@@ -156,7 +208,7 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
         self.assert_randomlines_mapping_workflow_structure(downloaded_workflow)
 
     def test_extract_copied_mapping_from_history(self, history_id):
-        hdca, job_id1, job_id2 = self.__run_random_lines_mapped_over_pair(history_id)
+        hdca, job_id1, job_id2 = self._run_random_lines_mapped_over_pair(history_id)
 
         new_history_id = self.dataset_populator.copy_history(history_id).json()["id"]
         # API test is somewhat contrived since there is no good way
@@ -170,8 +222,6 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
         self.assert_randomlines_mapping_workflow_structure(downloaded_workflow)
 
     def test_extract_copied_mapping_from_history_reimported(self, history_id):
-        import unittest
-
         raise unittest.SkipTest(
             "Mapping connection for copied collections not yet implemented in history import/export"
         )
@@ -181,14 +231,11 @@ class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase, WorkflowStructureAsser
 
         old_contents = self._history_contents(old_history_id)
         for old_content in old_contents:
-            self.__copy_content_to_history(history_id, old_content)
+            self._copy_content_to_history(history_id, old_content)
 
         def reimport_jobs_ids(new_history_id):
-            rval = [
-                j["id"] for j in self.dataset_populator.history_jobs(new_history_id) if j["tool_id"] == "random_lines1"
-            ]
+            rval = self._jobs_by_tool(new_history_id, "random_lines1")
             assert len(rval) == 2
-            print(rval)
             return rval
 
         # API test is somewhat contrived since there is no good way
@@ -510,17 +557,6 @@ test_data:
         #     assert False, "Found multiple jobs for tool %s" % tool_id
         return tool_jobs[-1]
 
-    def __run_random_lines_mapped_over_pair(self, history_id):
-        hdca = self.dataset_collection_populator.create_pair_in_history(
-            history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
-        ).json()["outputs"][0]
-        hdca_id = hdca["id"]
-        inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]}, "num_lines": 2}
-        implicit_hdca1, job_id1 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
-        inputs2 = {"input": {"batch": True, "values": [{"src": "hdca", "id": implicit_hdca1["id"]}]}, "num_lines": 1}
-        _, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
-        return hdca, job_id1, job_id2
-
     def __run_random_lines_mapped_over_singleton(self, history_id):
         hdca = self.dataset_collection_populator.create_list_in_history(history_id, contents=["1 2 3\n4 5 6"]).json()
         hdca_id = hdca["id"]
@@ -533,16 +569,8 @@ test_data:
     def _history_contents(self, history_id: str):
         return self._get(f"histories/{history_id}/contents").json()
 
-    def __copy_content_to_history(self, history_id, content):
-        if content["history_content_type"] == "dataset":
-            payload = dict(source="hda", content=content["id"])
-            response = self._post(f"histories/{history_id}/contents/datasets", payload, json=True)
-
-        else:
-            payload = dict(source="hdca", content=content["id"])
-            response = self._post(f"histories/{history_id}/contents/dataset_collections", payload, json=True)
-        self._assert_status_code_is(response, 200)
-        return response.json()
+    def _jobs_by_tool(self, history_id, tool_id):
+        return [j["id"] for j in self.dataset_populator.history_jobs(history_id) if j["tool_id"] == tool_id]
 
     def __setup_and_run_cat1_workflow(self, history_id):
         workflow = self.workflow_populator.load_workflow(name="test_for_extract")
@@ -576,8 +604,6 @@ test_data:
             )
             # wait a little more for those jobs, todo fix to wait for history imported false or
             # for a specific number of jobs...
-            import time
-
             time.sleep(1)
 
             if "reimport_jobs_ids" in extract_payload:
@@ -645,19 +671,8 @@ test_data:
         cat1_job_id = jobs_response.json()[0]["id"]
         return cat1_job_id
 
-    def _run_tool_get_collection_and_job_id(self, history_id: str, tool_id, inputs):
-        run_output1 = self.dataset_populator.run_tool(
-            tool_id=tool_id,
-            inputs=inputs,
-            history_id=history_id,
-        )
-        implicit_hdca = run_output1["implicit_collections"][0]
-        job_id = run_output1["jobs"][0]["id"]
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        return implicit_hdca, job_id
 
-
-class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructureAssertions):
+class TestWorkflowExtractionByIdsApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCase, WorkflowStructureAssertions):
     """Tests for POST /api/workflows/extract (ID-based extraction).
 
     Sibling of :class:`TestWorkflowExtractionApi` — same scenarios, but the
@@ -675,46 +690,57 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
         self._assert_status_code_is(download, 200)
         return download.json()
 
-    @skip_without_tool("cat1")
-    @summarize_instance_history_on_error
-    def test_extract_with_hda_ids(self, history_id):
-        new_dataset1 = self.dataset_populator.new_dataset(history_id, content="1 2 3\n")
-        new_dataset2 = self.dataset_populator.new_dataset(history_id, content="4 5 6\n")
+    def _extract_workflow_id_by_ids(self, **payload):
+        if "workflow_name" not in payload:
+            payload["workflow_name"] = "extract roundtrip"
+        response = self._post("workflows/extract", data=payload, json=True)
+        self._assert_status_code_is(response, 200)
+        return response.json()["id"]
+
+    def _seed_two_inputs_and_run_cat1(self, history_id, c1, c2, **run_kwargs):
+        d1 = self.dataset_populator.new_dataset(history_id, content=c1)
+        d2 = self.dataset_populator.new_dataset(history_id, content=c2)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         run = self.dataset_populator.run_tool(
             tool_id="cat1",
             inputs={
-                "input1": {"src": "hda", "id": new_dataset1["id"]},
-                "queries_0|input2": {"src": "hda", "id": new_dataset2["id"]},
+                "input1": {"src": "hda", "id": d1["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2["id"]},
             },
             history_id=history_id,
+            **run_kwargs,
         )
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        cat1_job_id = run["jobs"][0]["id"]
+        return d1, d2, run["jobs"][0]["id"]
+
+    def _assert_single_input_single_tool(self, workflow, expected_tool_id=None):
+        steps = workflow["steps"]
+        assert len(steps) == 2, steps
+        input_steps = [s for s in steps.values() if s["type"] == "data_input"]
+        tool_steps = [s for s in steps.values() if s["type"] == "tool"]
+        assert len(input_steps) == 1 and len(tool_steps) == 1
+        if expected_tool_id is not None:
+            assert tool_steps[0]["tool_id"] == expected_tool_id
+        connection = tool_steps[0]["input_connections"]["input1"]
+        # .ga format may yield a single dict or a list of one dict.
+        connection = connection[0] if isinstance(connection, list) else connection
+        assert connection["id"] == input_steps[0]["id"]
+
+    def _assert_extract_rejected(self, payload, allowed_codes):
+        response = self._post("workflows/extract", data=payload, json=True)
+        assert response.status_code in allowed_codes, response.text
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_hda_ids(self, history_id):
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="1 2 3\n", c2="4 5 6\n")
         downloaded = self._extract_and_download_workflow_by_ids(
             from_history_id=history_id,
-            hda_ids=[new_dataset1["id"], new_dataset2["id"]],
+            hda_ids=[d1["id"], d2["id"]],
             job_ids=[cat1_job_id],
         )
         assert downloaded["name"] == "test import from history (by id)"
         self.assert_cat1_workflow_structure(downloaded)
-
-    def _run_tool_get_collection_and_job_id(self, history_id, tool_id, inputs):
-        run_output = self.dataset_populator.run_tool(tool_id=tool_id, inputs=inputs, history_id=history_id)
-        implicit_hdca = run_output["implicit_collections"][0]
-        job_id = run_output["jobs"][0]["id"]
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        return implicit_hdca, job_id
-
-    def _run_random_lines_mapped_over_pair(self, history_id):
-        hdca = self.dataset_collection_populator.create_pair_in_history(
-            history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
-        ).json()["outputs"][0]
-        inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca["id"]}]}, "num_lines": 2}
-        implicit_hdca1, job_id1 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
-        inputs2 = {"input": {"batch": True, "values": [{"src": "hdca", "id": implicit_hdca1["id"]}]}, "num_lines": 1}
-        _, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
-        return hdca, job_id1, job_id2
 
     @skip_without_tool("random_lines1")
     @summarize_instance_history_on_error
@@ -727,38 +753,15 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
         )
         self.assert_randomlines_mapping_workflow_structure(downloaded)
 
-    def _copy_hda_to_history(self, history_id, hda):
-        response = self._post(
-            f"histories/{history_id}/contents/datasets",
-            dict(source="hda", content=hda["id"]),
-            json=True,
-        )
-        self._assert_status_code_is(response, 200)
-        return response.json()
-
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error
     def test_extract_with_copied_inputs_post_copy_ids(self, history_id):
         """User passes post-copy HDA ids (in extraction history) plus the
         original (pre-copy) job id."""
         original_history_id = self.dataset_populator.new_history()
-        d1 = self.dataset_populator.new_dataset(original_history_id, content="1 2 3\n")
-        d2 = self.dataset_populator.new_dataset(original_history_id, content="4 5 6\n")
-        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
-        run = self.dataset_populator.run_tool(
-            tool_id="cat1",
-            inputs={
-                "input1": {"src": "hda", "id": d1["id"]},
-                "queries_0|input2": {"src": "hda", "id": d2["id"]},
-            },
-            history_id=original_history_id,
-        )
-        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
-        cat1_job_id = run["jobs"][0]["id"]
-
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(original_history_id, c1="1 2 3\n", c2="4 5 6\n")
         d1_copy = self._copy_hda_to_history(history_id, d1)
         d2_copy = self._copy_hda_to_history(history_id, d2)
-
         downloaded = self._extract_and_download_workflow_by_ids(
             from_history_id=history_id,
             hda_ids=[d1_copy["id"], d2_copy["id"]],
@@ -773,20 +776,7 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
         original job id; copies exist in `history_id` but are not referenced.
         Cross-history extraction — `from_history_id` not required."""
         original_history_id = self.dataset_populator.new_history()
-        d1 = self.dataset_populator.new_dataset(original_history_id, content="1 2 3\n")
-        d2 = self.dataset_populator.new_dataset(original_history_id, content="4 5 6\n")
-        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
-        run = self.dataset_populator.run_tool(
-            tool_id="cat1",
-            inputs={
-                "input1": {"src": "hda", "id": d1["id"]},
-                "queries_0|input2": {"src": "hda", "id": d2["id"]},
-            },
-            history_id=original_history_id,
-        )
-        self.dataset_populator.wait_for_history(original_history_id, assert_ok=True)
-        cat1_job_id = run["jobs"][0]["id"]
-
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(original_history_id, c1="1 2 3\n", c2="4 5 6\n")
         downloaded = self._extract_and_download_workflow_by_ids(
             hda_ids=[d1["id"], d2["id"]],
             job_ids=[cat1_job_id],
@@ -795,13 +785,8 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
 
     @summarize_instance_history_on_error
     def test_empty_payload_rejected(self, history_id):
-        response = self._post(
-            "workflows/extract",
-            data={"workflow_name": "no inputs"},
-            json=True,
-        )
         # pydantic validator rejects empty input list -> 4xx (400 or 422).
-        assert response.status_code in (400, 422), response.text
+        self._assert_extract_rejected({"workflow_name": "no inputs"}, (400, 422))
 
     @summarize_instance_history_on_error
     def test_inaccessible_dataset_rejected(self, history_id):
@@ -811,47 +796,27 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
             other_dataset = self.dataset_populator.new_dataset(other_history_id, content="secret\n")
             self.dataset_populator.wait_for_history(other_history_id, assert_ok=True)
             self.dataset_populator.make_private(other_history_id, other_dataset["id"])
-        response = self._post(
-            "workflows/extract",
-            data={
-                "workflow_name": "should fail",
-                "hda_ids": [other_dataset["id"]],
-            },
-            json=True,
+        self._assert_extract_rejected(
+            {"workflow_name": "should fail", "hda_ids": [other_dataset["id"]]},
+            (400, 403),
         )
-        assert response.status_code in (400, 403), response.text
 
     @summarize_instance_history_on_error
     def test_nonexistent_hda_id_rejected(self, history_id):
-        response = self._post(
-            "workflows/extract",
-            data={"workflow_name": "bad hda", "hda_ids": ["f" * 16]},
-            json=True,
-        )
-        assert response.status_code in (400, 404), response.text
+        self._assert_extract_rejected({"workflow_name": "bad hda", "hda_ids": ["f" * 16]}, (400, 404))
 
     @summarize_instance_history_on_error
     def test_nonexistent_hdca_id_rejected(self, history_id):
-        response = self._post(
-            "workflows/extract",
-            data={"workflow_name": "bad hdca", "hdca_ids": ["f" * 16]},
-            json=True,
-        )
-        assert response.status_code in (400, 404), response.text
+        self._assert_extract_rejected({"workflow_name": "bad hdca", "hdca_ids": ["f" * 16]}, (400, 404))
 
     @summarize_instance_history_on_error
     def test_duplicate_hda_ids_rejected(self, history_id):
         new_dataset = self.dataset_populator.new_dataset(history_id, content="1 2 3\n")
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        response = self._post(
-            "workflows/extract",
-            data={
-                "workflow_name": "dup hdas",
-                "hda_ids": [new_dataset["id"], new_dataset["id"]],
-            },
-            json=True,
+        self._assert_extract_rejected(
+            {"workflow_name": "dup hdas", "hda_ids": [new_dataset["id"], new_dataset["id"]]},
+            (400, 422),
         )
-        assert response.status_code in (400, 422), response.text
 
     @summarize_instance_history_on_error
     def test_inaccessible_collection_rejected(self, history_id):
@@ -867,15 +832,10 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
             )
             for element in details["elements"]:
                 self.dataset_populator.make_private(other_history_id, element["object"]["id"])
-        response = self._post(
-            "workflows/extract",
-            data={
-                "workflow_name": "should fail",
-                "hdca_ids": [other_hdca["id"]],
-            },
-            json=True,
+        self._assert_extract_rejected(
+            {"workflow_name": "should fail", "hdca_ids": [other_hdca["id"]]},
+            (400, 403),
         )
-        assert response.status_code in (400, 403), response.text
 
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error
@@ -902,15 +862,7 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
             hda_ids=[forward_hda_id],
             job_ids=[cat1_job_id],
         )
-        steps = downloaded["steps"]
-        assert len(steps) == 2, steps
-        input_steps = [s for s in steps.values() if s["type"] == "data_input"]
-        tool_steps = [s for s in steps.values() if s["type"] == "tool"]
-        assert len(input_steps) == 1 and len(tool_steps) == 1
-        connection = tool_steps[0]["input_connections"]["input1"]
-        # .ga format may yield a single dict or a list of one dict.
-        connection = connection[0] if isinstance(connection, list) else connection
-        assert connection["id"] == input_steps[0]["id"]
+        self._assert_single_input_single_tool(downloaded)
 
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error
@@ -934,15 +886,7 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
             hda_ids=[d_b["id"]],
             job_ids=[cat1_job_id],
         )
-        # Exactly one input + one tool step; tool wires to the input step.
-        steps = downloaded["steps"]
-        assert len(steps) == 2, steps
-        input_steps = [s for s in steps.values() if s["type"] == "data_input"]
-        tool_steps = [s for s in steps.values() if s["type"] == "tool"]
-        assert len(input_steps) == 1 and len(tool_steps) == 1
-        cat1_step = tool_steps[0]
-        assert cat1_step["tool_id"] == "cat1"
-        assert cat1_step["input_connections"]["input1"]["id"] == input_steps[0]["id"]
+        self._assert_single_input_single_tool(downloaded, expected_tool_id="cat1")
 
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error
@@ -951,18 +895,7 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
         from B with hda_ids/job_ids referring to B-side rows. Workflow should
         wire B-side input to B-side cached job, not pull A-side rows in."""
         history_a = self.dataset_populator.new_history()
-        d_a = self.dataset_populator.new_dataset(history_a, content="cache me\n")
-        d2_a = self.dataset_populator.new_dataset(history_a, content="other\n")
-        self.dataset_populator.wait_for_history(history_a, assert_ok=True)
-        self.dataset_populator.run_tool(
-            tool_id="cat1",
-            inputs={
-                "input1": {"src": "hda", "id": d_a["id"]},
-                "queries_0|input2": {"src": "hda", "id": d2_a["id"]},
-            },
-            history_id=history_a,
-        )
-        self.dataset_populator.wait_for_history(history_a, assert_ok=True)
+        d_a, d2_a, _ = self._seed_two_inputs_and_run_cat1(history_a, c1="cache me\n", c2="other\n")
 
         d_b = self._copy_hda_to_history(history_id, d_a)
         d2_b = self._copy_hda_to_history(history_id, d2_a)
@@ -985,31 +918,12 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
         )
         self.assert_cat1_workflow_structure(downloaded)
 
-    def _extract_workflow_id_by_ids(self, **payload):
-        if "workflow_name" not in payload:
-            payload["workflow_name"] = "extract roundtrip"
-        response = self._post("workflows/extract", data=payload, json=True)
-        self._assert_status_code_is(response, 200)
-        return response.json()["id"]
-
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error
     def test_roundtrip_basic_by_ids(self, history_id):
         """Extract a cat1 workflow via the by-ids endpoint, invoke it on a
         fresh history, and assert it produces an output."""
-        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n")
-        d2 = self.dataset_populator.new_dataset(history_id, content="beta\n")
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        run = self.dataset_populator.run_tool(
-            tool_id="cat1",
-            inputs={
-                "input1": {"src": "hda", "id": d1["id"]},
-                "queries_0|input2": {"src": "hda", "id": d2["id"]},
-            },
-            history_id=history_id,
-        )
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        cat1_job_id = run["jobs"][0]["id"]
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
         workflow_id = self._extract_workflow_id_by_ids(
             from_history_id=history_id,
             hda_ids=[d1["id"], d2["id"]],
@@ -1073,19 +987,7 @@ class TestWorkflowExtractionByIdsApi(BaseWorkflowsApiTestCase, WorkflowStructure
         differ across input orderings, but step types, tool set, and
         connection topology must match.
         """
-        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n")
-        d2 = self.dataset_populator.new_dataset(history_id, content="beta\n")
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        run = self.dataset_populator.run_tool(
-            tool_id="cat1",
-            inputs={
-                "input1": {"src": "hda", "id": d1["id"]},
-                "queries_0|input2": {"src": "hda", "id": d2["id"]},
-            },
-            history_id=history_id,
-        )
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        cat1_job_id = run["jobs"][0]["id"]
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
 
         wf_a = self._extract_and_download_workflow_by_ids(
             workflow_name="ordering A",

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -51,14 +51,17 @@ class _ExtractionHelpersMixin:
         return implicit_hdca, job_id
 
     def _run_random_lines_mapped_over_pair(self, history_id):
+        """Returns (input_hdca, job_id1, job_id2, implicit_hdca1_id, implicit_hdca2_id).
+        Trailing implicit HDCA ids are useful for ID-path tests that need the
+        ICJ id behind each mapped step."""
         hdca = self.dataset_collection_populator.create_pair_in_history(
             history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
         ).json()["outputs"][0]
         inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca["id"]}]}, "num_lines": 2}
         implicit_hdca1, job_id1 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
         inputs2 = {"input": {"batch": True, "values": [{"src": "hdca", "id": implicit_hdca1["id"]}]}, "num_lines": 1}
-        _, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
-        return hdca, job_id1, job_id2
+        implicit_hdca2, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
+        return hdca, job_id1, job_id2, implicit_hdca1["id"], implicit_hdca2["id"]
 
     def _copy_hda_to_history(self, history_id, hda):
         response = self._post(
@@ -88,6 +91,30 @@ class _ExtractionHelpersMixin:
 
     def _job_id_for_tool(self, jobs, tool_id):
         return self._job_for_tool(jobs, tool_id)["id"]
+
+    def _icj_id_for_hdca(self, history_id, hdca_id):
+        """Look up the ImplicitCollectionJobs id of a map-over output HDCA.
+        Returns the encoded id from the HDCA detail view."""
+        details = self.dataset_populator.get_history_collection_details(history_id, content_id=hdca_id)
+        icj_id = details.get("implicit_collection_jobs_id")
+        assert icj_id, f"HDCA {hdca_id} has no implicit_collection_jobs_id"
+        return icj_id
+
+    def _icj_id_for_job_in_history(self, history_id, job_id):
+        """Walk implicit-output HDCAs in history and find the ICJ that owns
+        the given job. Job API does not expose implicit_collection_jobs_id
+        directly today, so this trawl is the cheapest test-side lookup."""
+        for content in self._history_contents(history_id):
+            if content["history_content_type"] != "dataset_collection":
+                continue
+            details = self.dataset_populator.get_history_collection_details(history_id, content_id=content["id"])
+            icj_id = details.get("implicit_collection_jobs_id")
+            if not icj_id:
+                continue
+            jobs_in_icj = self._get(f"jobs?implicit_collection_jobs_id={icj_id}").json()
+            if any(j["id"] == job_id for j in jobs_in_icj):
+                return icj_id
+        raise AssertionError(f"No ICJ in history {history_id} contains job {job_id}")
 
 
 class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCase, WorkflowStructureAssertions):
@@ -212,7 +239,7 @@ class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCas
     @skip_without_tool("random_lines1")
     @summarize_instance_history_on_error
     def test_extract_mapping_workflow_from_history(self, history_id):
-        hdca, job_id1, job_id2 = self._run_random_lines_mapped_over_pair(history_id)
+        hdca, job_id1, job_id2, *_ = self._run_random_lines_mapped_over_pair(history_id)
         downloaded_workflow = self._extract_and_download_workflow(
             history_id,
             reimport_as="extract_from_history_with_mapping",
@@ -222,7 +249,7 @@ class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCas
         self.assert_randomlines_mapping_workflow_structure(downloaded_workflow)
 
     def test_extract_copied_mapping_from_history(self, history_id):
-        hdca, job_id1, job_id2 = self._run_random_lines_mapped_over_pair(history_id)
+        hdca, job_id1, job_id2, *_ = self._run_random_lines_mapped_over_pair(history_id)
 
         new_history_id = self.dataset_populator.copy_history(history_id).json()["id"]
         # API test is somewhat contrived since there is no good way
@@ -745,11 +772,13 @@ class TestWorkflowExtractionByIdsApi(_ExtractionHelpersMixin, BaseWorkflowsApiTe
     @skip_without_tool("random_lines1")
     @summarize_instance_history_on_error
     def test_extract_mapping_workflow_by_ids(self, history_id):
-        hdca, job_id1, job_id2 = self._run_random_lines_mapped_over_pair(history_id)
+        hdca, _, _, implicit_hdca1_id, implicit_hdca2_id = self._run_random_lines_mapped_over_pair(history_id)
+        icj_id1 = self._icj_id_for_hdca(history_id, implicit_hdca1_id)
+        icj_id2 = self._icj_id_for_hdca(history_id, implicit_hdca2_id)
         downloaded = self._extract_and_download_workflow_by_ids(
             from_history_id=history_id,
             hdca_ids=[hdca["id"]],
-            job_ids=[job_id1, job_id2],
+            implicit_collection_jobs_ids=[icj_id1, icj_id2],
         )
         self.assert_randomlines_mapping_workflow_structure(downloaded)
 
@@ -786,10 +815,12 @@ test_data:
         input_hdca = next(
             c for c in self._history_contents(history_id) if c["history_content_type"] == "dataset_collection"
         )
+        icj_id1 = self._icj_id_for_job_in_history(history_id, job1_id)
+        icj_id2 = self._icj_id_for_job_in_history(history_id, job2_id)
         downloaded = self._extract_and_download_workflow_by_ids(
             from_history_id=history_id,
             hdca_ids=[input_hdca["id"]],
-            job_ids=[job1_id, job2_id],
+            implicit_collection_jobs_ids=[icj_id1, icj_id2],
         )
         self.check_workflow(
             downloaded,
@@ -837,6 +868,52 @@ test_data:
     def test_empty_payload_rejected(self, history_id):
         # pydantic validator rejects empty input list -> 4xx (400 or 422).
         self._assert_extract_rejected({"workflow_name": "no inputs"}, (400, 422))
+
+    @skip_without_tool("random_lines1")
+    @summarize_instance_history_on_error
+    def test_job_with_icj_via_job_ids_rejected(self, history_id):
+        """A constituent job of an implicit collection map must not be passed
+        as a plain job_id - the caller must use implicit_collection_jobs_ids
+        so the server can treat the whole map as one step."""
+        _, mapped_job_id, *_ = self._run_random_lines_mapped_over_pair(history_id)
+        self._assert_extract_rejected(
+            {"workflow_name": "icj as job_id", "job_ids": [mapped_job_id]},
+            (400,),
+        )
+
+    @skip_without_tool("random_lines1")
+    @summarize_instance_history_on_error
+    def test_mixed_icj_and_member_job_rejected(self, history_id):
+        """Passing both an ICJ and one of its constituent jobs is rejected -
+        the validator that filters job_ids fires first because the member
+        job carries an ICJ association."""
+        _, mapped_job_id, _, implicit_hdca1_id, _ = self._run_random_lines_mapped_over_pair(history_id)
+        icj_id = self._icj_id_for_hdca(history_id, implicit_hdca1_id)
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "mixed icj and member",
+                "job_ids": [mapped_job_id],
+                "implicit_collection_jobs_ids": [icj_id],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("random_lines1")
+    @summarize_instance_history_on_error
+    def test_duplicate_icj_ids_rejected(self, history_id):
+        _, _, _, implicit_hdca1_id, _ = self._run_random_lines_mapped_over_pair(history_id)
+        icj_id = self._icj_id_for_hdca(history_id, implicit_hdca1_id)
+        self._assert_extract_rejected(
+            {"workflow_name": "dup icjs", "implicit_collection_jobs_ids": [icj_id, icj_id]},
+            (400,),
+        )
+
+    @summarize_instance_history_on_error
+    def test_nonexistent_icj_id_rejected(self, history_id):
+        self._assert_extract_rejected(
+            {"workflow_name": "bad icj", "implicit_collection_jobs_ids": ["f" * 16]},
+            (400, 404),
+        )
 
     @summarize_instance_history_on_error
     def test_inaccessible_dataset_rejected(self, history_id):
@@ -1004,7 +1081,7 @@ test_data:
             history_id, contents=["1 2 3\n4 5 6", "7 8 9\n10 11 10"], wait=True
         ).json()["outputs"][0]
         inputs1 = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca["id"]}]}, "num_lines": 2}
-        implicit_hdca1, job_id1 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
+        implicit_hdca1, _ = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs1)
         reduction_run = self.dataset_populator.run_tool(
             tool_id="multi_data_param",
             inputs={
@@ -1016,10 +1093,12 @@ test_data:
         job_id2 = reduction_run["jobs"][0]["id"]
         self.dataset_populator.wait_for_job(job_id2, assert_ok=True)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        icj_id1 = self._icj_id_for_hdca(history_id, implicit_hdca1["id"])
         downloaded = self._extract_and_download_workflow_by_ids(
             from_history_id=history_id,
             hdca_ids=[hdca["id"]],
-            job_ids=[job_id1, job_id2],
+            implicit_collection_jobs_ids=[icj_id1],
+            job_ids=[job_id2],
         )
         assert len(downloaded["steps"]) == 3
         collect_step_idx = self.assert_first_step_is_paired_input(downloaded)
@@ -1068,7 +1147,7 @@ test_data:
         assert signature(wf_a) == signature(wf_b)
 
 
-class TestWorkflowExtractionSummaryApi(BaseWorkflowsApiTestCase):
+class TestWorkflowExtractionSummaryApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCase):
     """Tests for GET /api/histories/{history_id}/extraction_summary."""
 
     def _get_extraction_summary(self, history_id: str) -> dict:
@@ -1184,6 +1263,24 @@ class TestWorkflowExtractionSummaryApi(BaseWorkflowsApiTestCase):
             assert len(tool_jobs) == 1
             assert tool_jobs[0]["invalid"] == "custom_tool_inaccessible"
             assert tool_jobs[0]["checked"] is False
+
+    @skip_without_tool("random_lines1")
+    def test_extraction_summary_mapped_tool_step_icj_metadata(self):
+        with self.dataset_populator.test_history() as history_id:
+            _, _, _, implicit_hdca1_id, implicit_hdca2_id = self._run_random_lines_mapped_over_pair(history_id)
+            expected_icj_ids = {
+                self._icj_id_for_hdca(history_id, implicit_hdca1_id),
+                self._icj_id_for_hdca(history_id, implicit_hdca2_id),
+            }
+
+            summary = self._get_extraction_summary(history_id)
+            mapped_tool_jobs = [
+                j for j in summary["jobs"] if j["step_type"] == "tool" and j.get("implicit_collection_jobs_id")
+            ]
+            assert len(mapped_tool_jobs) >= 2, summary["jobs"]
+            assert {j["implicit_collection_jobs_id"] for j in mapped_tool_jobs}.issuperset(expected_icj_ids)
+            for job in mapped_tool_jobs:
+                assert job["implicit_collection_jobs_size"] == 2, job
 
     @skip_without_tool("cat1")
     def test_extraction_summary_structure(self):

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -39,6 +39,8 @@ class _ExtractionHelpersMixin:
 
         def _post(self, *args: Any, **kwds: Any) -> "Response": ...
 
+        def _get(self, *args: Any, **kwds: Any) -> "Response": ...
+
         def _assert_status_code_is(self, response: "Response", expected_status_code: int) -> None: ...
 
     def _run_tool_get_collection_and_job_id(self, history_id, tool_id, inputs):
@@ -74,6 +76,18 @@ class _ExtractionHelpersMixin:
         response = self._post(f"histories/{history_id}/contents/dataset_collections", payload, json=True)
         self._assert_status_code_is(response, 200)
         return response.json()
+
+    def _history_contents(self, history_id):
+        return self._get(f"histories/{history_id}/contents").json()
+
+    def _job_for_tool(self, jobs, tool_id):
+        tool_jobs = [j for j in jobs if j["tool_id"] == tool_id]
+        if not tool_jobs:
+            raise ValueError(f"Failed to find job for tool {tool_id}")
+        return tool_jobs[-1]
+
+    def _job_id_for_tool(self, jobs, tool_id):
+        return self._job_for_tool(jobs, tool_id)["id"]
 
 
 class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCase, WorkflowStructureAssertions):
@@ -546,17 +560,6 @@ test_data:
             tool_ids=tool_ids,
         )
 
-    def _job_id_for_tool(self, jobs, tool_id):
-        return self._job_for_tool(jobs, tool_id)["id"]
-
-    def _job_for_tool(self, jobs, tool_id):
-        tool_jobs = [j for j in jobs if j["tool_id"] == tool_id]
-        if not tool_jobs:
-            raise ValueError(f"Failed to find job for tool {tool_id}")
-        # if len( tool_jobs ) > 1:
-        #     assert False, "Found multiple jobs for tool %s" % tool_id
-        return tool_jobs[-1]
-
     def __run_random_lines_mapped_over_singleton(self, history_id):
         hdca = self.dataset_collection_populator.create_list_in_history(history_id, contents=["1 2 3\n4 5 6"]).json()
         hdca_id = hdca["id"]
@@ -565,9 +568,6 @@ test_data:
         inputs2 = {"input": {"batch": True, "values": [{"src": "hdca", "id": implicit_hdca1["id"]}]}, "num_lines": 1}
         _, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
         return hdca, job_id1, job_id2
-
-    def _history_contents(self, history_id: str):
-        return self._get(f"histories/{history_id}/contents").json()
 
     def _jobs_by_tool(self, history_id, tool_id):
         return [j["id"] for j in self.dataset_populator.history_jobs(history_id) if j["tool_id"] == tool_id]
@@ -752,6 +752,56 @@ class TestWorkflowExtractionByIdsApi(_ExtractionHelpersMixin, BaseWorkflowsApiTe
             job_ids=[job_id1, job_id2],
         )
         self.assert_randomlines_mapping_workflow_structure(downloaded)
+
+    @skip_without_tool("cat_collection")
+    @summarize_instance_history_on_error
+    def test_subcollection_mapping_by_ids(self, history_id):
+        """ID-path equivalent of HID test_subcollection_mapping. Exercises
+        a tool consuming a paired sub-collection element of a list:paired;
+        wiring goes through find_implicit_input_collection so the workflow
+        sees a single list:paired input rather than per-job leaves."""
+        jobs_summary = self._run_workflow(
+            """
+class: GalaxyWorkflow
+inputs:
+  text_input1: collection
+steps:
+  - label: noop
+    tool_id: cat1
+    state:
+      input1:
+        $link: text_input1
+  - tool_id: cat_collection
+    state:
+      input1:
+        $link: noop/out_file1
+test_data:
+  text_input1:
+    collection_type: "list:paired"
+""",
+            history_id,
+        )
+        job1_id = self._job_id_for_tool(jobs_summary.jobs, "cat1")
+        job2_id = self._job_id_for_tool(jobs_summary.jobs, "cat_collection")
+        input_hdca = next(
+            c for c in self._history_contents(history_id) if c["history_content_type"] == "dataset_collection"
+        )
+        downloaded = self._extract_and_download_workflow_by_ids(
+            from_history_id=history_id,
+            hdca_ids=[input_hdca["id"]],
+            job_ids=[job1_id, job2_id],
+        )
+        self.check_workflow(
+            downloaded,
+            step_count=3,
+            verify_connected=True,
+            data_input_count=0,
+            data_collection_input_count=1,
+            tool_ids=["cat_collection", "cat1"],
+        )
+        collection_step = self.assert_steps_of_type(downloaded, "data_collection_input", expected_len=1)[0]
+        collection_step_state = loads(collection_step["tool_state"])
+        assert collection_step_state["collection_type"] == "list:paired"
 
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -231,7 +231,7 @@ class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCas
         downloaded_workflow = self._extract_and_download_workflow(
             history_id,
             reimport_as="test_extract_with_copied_inputs",
-            reimport_jobs_ids=lambda nh: self._jobs_by_tool(nh, "cat1"),
+            reimport_jobs_ids=lambda nh: [j["id"] for j in self.dataset_populator.history_jobs_for_tool(nh, "cat1")],
             dataset_ids=input_hids,
         )
         self.assert_cat1_workflow_structure(downloaded_workflow)
@@ -275,7 +275,7 @@ class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCas
             self._copy_content_to_history(history_id, old_content)
 
         def reimport_jobs_ids(new_history_id):
-            rval = self._jobs_by_tool(new_history_id, "random_lines1")
+            rval = [j["id"] for j in self.dataset_populator.history_jobs_for_tool(new_history_id, "random_lines1")]
             assert len(rval) == 2
             return rval
 
@@ -596,9 +596,6 @@ test_data:
         _, job_id2 = self._run_tool_get_collection_and_job_id(history_id, "random_lines1", inputs2)
         return hdca, job_id1, job_id2
 
-    def _jobs_by_tool(self, history_id, tool_id):
-        return [j["id"] for j in self.dataset_populator.history_jobs(history_id) if j["tool_id"] == tool_id]
-
     def __setup_and_run_cat1_workflow(self, history_id):
         workflow = self.workflow_populator.load_workflow(name="test_for_extract")
         workflow_request, history_id, workflow_id = self._setup_workflow_run(workflow, history_id=history_id)
@@ -762,7 +759,6 @@ class TestWorkflowExtractionByIdsApi(_ExtractionHelpersMixin, BaseWorkflowsApiTe
     def test_extract_with_hda_ids(self, history_id):
         d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="1 2 3\n", c2="4 5 6\n")
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hda_ids=[d1["id"], d2["id"]],
             job_ids=[cat1_job_id],
         )
@@ -776,7 +772,6 @@ class TestWorkflowExtractionByIdsApi(_ExtractionHelpersMixin, BaseWorkflowsApiTe
         icj_id1 = self._icj_id_for_hdca(history_id, implicit_hdca1_id)
         icj_id2 = self._icj_id_for_hdca(history_id, implicit_hdca2_id)
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hdca_ids=[hdca["id"]],
             implicit_collection_jobs_ids=[icj_id1, icj_id2],
         )
@@ -818,7 +813,6 @@ test_data:
         icj_id1 = self._icj_id_for_job_in_history(history_id, job1_id)
         icj_id2 = self._icj_id_for_job_in_history(history_id, job2_id)
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hdca_ids=[input_hdca["id"]],
             implicit_collection_jobs_ids=[icj_id1, icj_id2],
         )
@@ -844,7 +838,6 @@ test_data:
         d1_copy = self._copy_hda_to_history(history_id, d1)
         d2_copy = self._copy_hda_to_history(history_id, d2)
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hda_ids=[d1_copy["id"], d2_copy["id"]],
             job_ids=[cat1_job_id],
         )
@@ -855,7 +848,7 @@ test_data:
     def test_extract_with_copied_inputs_pre_copy_ids(self, history_id):
         """User passes pre-copy HDA ids (in original history) plus the
         original job id; copies exist in `history_id` but are not referenced.
-        Cross-history extraction — `from_history_id` not required."""
+        Cross-history extraction — no history context supplied or required."""
         original_history_id = self.dataset_populator.new_history()
         d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(original_history_id, c1="1 2 3\n", c2="4 5 6\n")
         downloaded = self._extract_and_download_workflow_by_ids(
@@ -985,7 +978,6 @@ test_data:
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         cat1_job_id = run["jobs"][0]["id"]
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hda_ids=[forward_hda_id],
             job_ids=[cat1_job_id],
         )
@@ -1009,7 +1001,6 @@ test_data:
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         cat1_job_id = run["jobs"][0]["id"]
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hda_ids=[d_b["id"]],
             job_ids=[cat1_job_id],
         )
@@ -1039,7 +1030,6 @@ test_data:
         cat1_job_id = cached_run["jobs"][0]["id"]
 
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hda_ids=[d_b["id"], d2_b["id"]],
             job_ids=[cat1_job_id],
         )
@@ -1052,7 +1042,6 @@ test_data:
         fresh history, and assert it produces an output."""
         d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
         workflow_id = self._extract_workflow_id_by_ids(
-            from_history_id=history_id,
             hda_ids=[d1["id"], d2["id"]],
             job_ids=[cat1_job_id],
         )
@@ -1095,7 +1084,6 @@ test_data:
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         icj_id1 = self._icj_id_for_hdca(history_id, implicit_hdca1["id"])
         downloaded = self._extract_and_download_workflow_by_ids(
-            from_history_id=history_id,
             hdca_ids=[hdca["id"]],
             implicit_collection_jobs_ids=[icj_id1],
             job_ids=[job_id2],
@@ -1120,13 +1108,11 @@ test_data:
 
         wf_a = self._extract_and_download_workflow_by_ids(
             workflow_name="ordering A",
-            from_history_id=history_id,
             hda_ids=[d1["id"], d2["id"]],
             job_ids=[cat1_job_id],
         )
         wf_b = self._extract_and_download_workflow_by_ids(
             workflow_name="ordering B",
-            from_history_id=history_id,
             hda_ids=[d2["id"], d1["id"]],
             job_ids=[cat1_job_id],
         )

--- a/lib/galaxy_test/selenium/test_workflow_extraction.py
+++ b/lib/galaxy_test/selenium/test_workflow_extraction.py
@@ -464,6 +464,12 @@ test_data:
         # one cat1 job per list element (typically 2, but may vary).
         job_count = self.count_job_checkboxes()
         assert job_count >= 1, f"Expected at least 1 job checkbox, found {job_count}"
+        mapped_cards = self.find_elements_by_selector(self.components.workflow_extract.mapped_tool_card.selector)
+        assert len(mapped_cards) >= 1, "Expected at least one mapped-tool card on a list:paired mapped flow"
+        for card in mapped_cards:
+            assert card.get_attribute("data-icj-id"), "mapped-tool card missing data-icj-id"
+        mapped_badges = self.find_elements_by_selector(self.components.workflow_extract.mapped_badge.selector)
+        assert len(mapped_badges) >= len(mapped_cards), "Expected mapped-tool cards to show a Mapped badge"
         self.screenshot("workflow_extract_nested_collection")
 
         workflow_name = "Selenium Nested Collection"


### PR DESCRIPTION
Closes #21722. Supersedes and replaces #22675 (closed). Builds on work this cycle in https://github.com/galaxyproject/galaxy/pull/21935. 

## What

Adds a new `POST /api/workflows/extract` endpoint that extracts a workflow from explicitly-identified history items, jobs, and **implicit collection jobs (ICJs)** by encoded ID — rather than by HID inferred against a single history. This enables cross-history extraction and removes a class of HID-confusion bugs in the mapped-step case.

The unit of selection for a map-over step is the **implicit collection itself**, not its constituent jobs:

- `hda_ids` / `hdca_ids` — workflow inputs
- `job_ids` — non-mapped tool steps
- `implicit_collection_jobs_ids` — mapped (map-over) tool steps

A `job_id` that belongs to an ICJ is rejected (400) with a message directing the caller to pass the ICJ id instead.

## Why (response to #22675 review)

#22675 was a HID→ID translation that preserved the legacy path's "reverse-engineer map-over from a job id" model (dedup loop, representative `SELECT`, post-hoc connection-key rewrite, a speculative output-drop branch). @mvdbeek's review correctly flagged this as the wrong abstraction.
The caller already knows it's a map-over — it was looking at an implicit collection. This PR makes that explicit and deletes the inference:

- Removed the `seen_icj_ids` dedup + representative-job `SELECT`.
- `find_implicit_input_collection` is now an up-front input lookup, not a post-hoc rewrite interleaved with wiring.
- Deleted the "silently drop per-job HDAs / `<filter>` evaluated True" branch and comment.
- Public API is stable across the future swap from `JobParameter`-derived params to `ToolRequest`/`Job.tool_state` params (the one remaining representative-job read is isolated and FIXME-marked).

Also addresses the other two inline comments — see commit `Address PR 22675 review feedback` and the `(hid,key)` vs
`(("dataset",id),key)` split (legacy path unchanged, new path consistent).

## Code quality / abstraction reuse

- `ImplicitCollectionJobs.representative_job` and `.output_dataset_collection_instances` model properties; the service validator and `extract_steps_by_ids` reuse them (removed duplicated raw queries that previously lived in two files).
- Shared `_connect()` step-wiring helper used by both the HID and ID paths (was byte-identical duplicated logic).
- All four id-list dedup checks consolidated into the service validator.
- Dropped the unused `from_history_id` payload field — it was decoded but never read, and "scope to a history" contradicts the cross-history design these tests rely on.

## UI

`WorkflowExtractionForm.vue` now:
- surfaces map-over steps with a **"Mapped over N items"** badge,
- splits `loading` (initial fetch) from `submitting` (POST in flight) so a failed submit no longer wipes the user's selections,
- emits `data-icj-id` / `data-step-kind` for Selenium targeting.

Before / after:

<img width="3516" height="966" alt="before_after_side_by_side" src="https://github.com/user-attachments/assets/74090659-c89f-4200-b0b3-067226f4c291" />


## Relationship to #22705 (separate work)

The ID-path API tests must resolve "which ICJ owns this job" to build payloads. Today the Job API does not expose `implicit_collection_jobs_id`, so the test helper `_icj_id_for_job_in_history` trawls history collections to find it — correct but O(collections) round-trips and fragile.

#22705 proposes adding `implicit_collection_jobs_id` to the Job detail response. That would collapse the trawl to a single `get_job_details` call and let `_icj_id_for_hdca` move onto `DatasetPopulator`. It is an **additive, independently-reviewable API improvement** and **not required for the correctness of this PR** — the tests pass today via the trawl.
Tracked and intended as a follow-up; not in this PR's scope.

## Out of scope / known limitations

- **Legacy HID `extract_workflow` path is untouched** and still the default for the existing history endpoint.
- **Non-mapped paired-DCE-as-data-param** still collapses via `first_dataset_instance()` — preexisting on both paths; the common map-over case is handled declaratively here.
- **#21788 / #21789 / #13823** root causes need `ToolRequest`-based extraction (PRs 20935 / 21828 / 21842); this PR removes HID inference for mapped steps but does not fully resolve them.

## How to test the changes?

- [x] I've included automated tests:
  - `lib/galaxy_test/api/test_workflow_extraction.py` — `TestWorkflowExtractionByIdsApi` (mapping, reduction, subcollection mapping, copied/cross-history inputs, cached jobs, roundtrip, and rejection cases: mapped-job-in-`job_ids`, mixed ICJ+member, duplicate ids, inaccessible HDA/HDCA, nonexistent ids, empty payload).
  - `client/src/components/History/WorkflowExtractionForm.test.ts` — bucketing, dedup, mixed, error-keeps-list, submitting state.
  - `lib/galaxy_test/selenium/test_workflow_extraction.py` — mapped-card badge assertion.
- [x] Refactor of components with existing test coverage (legacy path).

## License

- [x] I agree to license these and all my past contributions to the core
  galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
