### PR TITLE
Add auto decompress advanced option (Beta Upload)

### DIFF
--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -12,6 +12,7 @@ import { useCollectionCreation } from "@/composables/upload/collectionCreation";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
 import { useUploadDefaults } from "@/composables/upload/uploadDefaults";
 import { useUploadItemValidation } from "@/composables/upload/uploadItemValidation";
+import { useUploadOptionBindings } from "@/composables/upload/uploadOptionBindings";
 import { useUploadReadyState } from "@/composables/upload/uploadReadyState";
 import { useUploadStaging } from "@/composables/upload/useUploadStaging";
 import { buildPreparedUpload } from "@/utils/upload";
@@ -84,6 +85,10 @@ const totalSize = computed(() => {
 const { isNameValid, restoreOriginalName } = useUploadItemValidation();
 
 const bulk = useBulkUploadOperations(selectedFiles, effectiveExtensions);
+const { headerOptionProps, headerOptionEvents, getRowOptionProps, getRowOptionEvents } = useUploadOptionBindings(
+    bulk,
+    optionVisibility,
+);
 
 const { isReadyToUpload } = useUploadReadyState(hasFiles, collectionState);
 
@@ -293,28 +298,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         </template>
 
                         <template v-slot:head(options)>
-                            <UploadTableOptionsHeader
-                                :all-space-to-tab="bulk.allSpaceToTab.value"
-                                :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                                :option-visibility="optionVisibility"
-                                :all-to-posix-lines="bulk.allToPosixLines.value"
-                                :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                                :all-auto-decompress="bulk.allAutoDecompress.value"
-                                :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
-                                @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
-                                @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
-                                @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
+                            <UploadTableOptionsHeader v-bind="headerOptionProps" v-on="headerOptionEvents" />
                         </template>
 
                         <template v-slot:cell(options)="{ item }">
-                            <UploadTableOptionsCell
-                                :space-to-tab="item.spaceToTab"
-                                :option-visibility="optionVisibility"
-                                :to-posix-lines="item.toPosixLines"
-                                :auto-decompress="item.autoDecompress"
-                                @updateSpaceToTab="item.spaceToTab = $event"
-                                @updateToPosixLines="item.toPosixLines = $event"
-                                @updateAutoDecompress="item.autoDecompress = $event" />
+                            <UploadTableOptionsCell v-bind="getRowOptionProps(item)" v-on="getRowOptionEvents(item)" />
                         </template>
 
                         <template v-slot:cell(actions)="{ index }">

--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -295,8 +295,12 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                                 :show-posix="advancedMode"
                                 :all-to-posix-lines="bulk.allToPosixLines.value"
                                 :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
+                                :show-auto-decompress="advancedMode"
+                                :all-auto-decompress="bulk.allAutoDecompress.value"
+                                :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                                 @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
-                                @toggle-to-posix-lines="bulk.toggleAllToPosixLines" />
+                                @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
+                                @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
                         </template>
 
                         <template v-slot:cell(options)="{ item }">
@@ -304,8 +308,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                                 :space-to-tab="item.spaceToTab"
                                 :show-posix="advancedMode"
                                 :to-posix-lines="item.toPosixLines"
+                                :show-auto-decompress="advancedMode"
+                                :auto-decompress="item.autoDecompress"
                                 @updateSpaceToTab="item.spaceToTab = $event"
-                                @updateToPosixLines="item.toPosixLines = $event" />
+                                @updateToPosixLines="item.toPosixLines = $event"
+                                @updateAutoDecompress="item.autoDecompress = $event" />
                         </template>
 
                         <template v-slot:cell(actions)="{ index }">

--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -4,6 +4,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, ref, watch } from "vue";
 
 import type { TableField } from "@/components/Common/GTable.types";
+import { localUploadOptionVisibility } from "@/components/Panels/Upload/shared/uploadOptionVisibility";
+import { getUploadSettingsColumnWidth } from "@/components/Panels/Upload/shared/uploadTableOptionsWidth";
 import { useFileDrop } from "@/composables/fileDrop";
 import { useBulkUploadOperations } from "@/composables/upload/bulkUploadOperations";
 import { useCollectionCreation } from "@/composables/upload/collectionCreation";
@@ -57,6 +59,8 @@ const emit = defineEmits<{
 
 const { advancedMode } = useUploadAdvancedMode();
 
+const optionVisibility = computed(() => localUploadOptionVisibility(advancedMode.value));
+
 const { effectiveExtensions, listDbKeys, configurationsReady, createItemDefaults } = useUploadDefaults(props.formats);
 
 const selectedFiles = ref<LocalFileItem[]>([]);
@@ -85,7 +89,7 @@ const { isReadyToUpload } = useUploadReadyState(hasFiles, collectionState);
 
 const showDragOverlay = computed(() => hasFiles.value && isFileOverDropZone.value);
 
-const tableFields: TableField[] = [
+const tableFields = computed<TableField[]>(() => [
     {
         key: "name",
         label: "Name",
@@ -119,7 +123,7 @@ const tableFields: TableField[] = [
         key: "options",
         label: "Upload Settings",
         sortable: false,
-        width: "140px",
+        width: getUploadSettingsColumnWidth(optionVisibility.value),
         align: "center",
     },
     {
@@ -129,7 +133,7 @@ const tableFields: TableField[] = [
         width: "50px",
         align: "center",
     },
-];
+]);
 
 watch(isReadyToUpload, (ready) => emit("ready", ready), { immediate: true });
 
@@ -292,10 +296,9 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             <UploadTableOptionsHeader
                                 :all-space-to-tab="bulk.allSpaceToTab.value"
                                 :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                                :show-posix="advancedMode"
+                                :option-visibility="optionVisibility"
                                 :all-to-posix-lines="bulk.allToPosixLines.value"
                                 :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                                :show-auto-decompress="advancedMode"
                                 :all-auto-decompress="bulk.allAutoDecompress.value"
                                 :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                                 @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
@@ -306,9 +309,8 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         <template v-slot:cell(options)="{ item }">
                             <UploadTableOptionsCell
                                 :space-to-tab="item.spaceToTab"
-                                :show-posix="advancedMode"
+                                :option-visibility="optionVisibility"
                                 :to-posix-lines="item.toPosixLines"
-                                :show-auto-decompress="advancedMode"
                                 :auto-decompress="item.autoDecompress"
                                 @updateSpaceToTab="item.spaceToTab = $event"
                                 @updateToPosixLines="item.toPosixLines = $event"

--- a/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
@@ -11,6 +11,7 @@ import { useCollectionCreation } from "@/composables/upload/collectionCreation";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
 import { useUploadDefaults } from "@/composables/upload/uploadDefaults";
 import { useUploadItemValidation } from "@/composables/upload/uploadItemValidation";
+import { useUploadOptionBindings } from "@/composables/upload/uploadOptionBindings";
 import { useUploadReadyState } from "@/composables/upload/uploadReadyState";
 import { useUploadStaging } from "@/composables/upload/useUploadStaging";
 import { buildPreparedUpload } from "@/utils/upload";
@@ -93,6 +94,10 @@ const hasItems = computed(() => pasteItems.value.some((item) => item.content.tri
 const { isNameValid, restoreOriginalName } = useUploadItemValidation();
 
 const bulk = useBulkUploadOperations(pasteItems, effectiveExtensions);
+const { headerOptionProps, headerOptionEvents, getRowOptionProps, getRowOptionEvents } = useUploadOptionBindings(
+    bulk,
+    optionVisibility,
+);
 
 const { isReadyToUpload } = useUploadReadyState(hasItems, collectionState);
 
@@ -425,28 +430,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                     <!-- Options column with bulk checkboxes -->
                     <template v-slot:head(options)>
-                        <UploadTableOptionsHeader
-                            :all-space-to-tab="bulk.allSpaceToTab.value"
-                            :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                            :option-visibility="optionVisibility"
-                            :all-to-posix-lines="bulk.allToPosixLines.value"
-                            :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                            :all-auto-decompress="bulk.allAutoDecompress.value"
-                            :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
-                            @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
-                            @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
-                            @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
+                        <UploadTableOptionsHeader v-bind="headerOptionProps" v-on="headerOptionEvents" />
                     </template>
 
                     <template v-slot:cell(options)="{ item }">
-                        <UploadTableOptionsCell
-                            :space-to-tab="item.spaceToTab"
-                            :option-visibility="optionVisibility"
-                            :to-posix-lines="item.toPosixLines"
-                            :auto-decompress="item.autoDecompress"
-                            @updateSpaceToTab="item.spaceToTab = $event"
-                            @updateToPosixLines="item.toPosixLines = $event"
-                            @updateAutoDecompress="item.autoDecompress = $event" />
+                        <UploadTableOptionsCell v-bind="getRowOptionProps(item)" v-on="getRowOptionEvents(item)" />
                     </template>
 
                     <!-- Actions column -->

--- a/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
@@ -4,6 +4,8 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import type { TableField } from "@/components/Common/GTable.types";
+import { localUploadOptionVisibility } from "@/components/Panels/Upload/shared/uploadOptionVisibility";
+import { getUploadSettingsColumnWidth } from "@/components/Panels/Upload/shared/uploadTableOptionsWidth";
 import { useBulkUploadOperations } from "@/composables/upload/bulkUploadOperations";
 import { useCollectionCreation } from "@/composables/upload/collectionCreation";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
@@ -55,6 +57,8 @@ const emit = defineEmits<{
 }>();
 
 const { advancedMode } = useUploadAdvancedMode();
+
+const optionVisibility = computed(() => localUploadOptionVisibility(advancedMode.value));
 
 const { effectiveExtensions, listDbKeys, configurationsReady, createItemDefaults } = useUploadDefaults(props.formats);
 
@@ -214,7 +218,7 @@ function toggleAllExpanded() {
 }
 
 // Table configuration
-const tableFields: TableField[] = [
+const tableFields = computed<TableField[]>(() => [
     {
         key: "expand",
         label: "",
@@ -261,6 +265,7 @@ const tableFields: TableField[] = [
         key: "options",
         label: "Upload Settings",
         sortable: false,
+        width: getUploadSettingsColumnWidth(optionVisibility.value),
         align: "center",
     },
     {
@@ -270,7 +275,7 @@ const tableFields: TableField[] = [
         width: "50px",
         align: "center",
     },
-];
+]);
 
 onMounted(() => {
     nextTick(() => {
@@ -423,10 +428,9 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         <UploadTableOptionsHeader
                             :all-space-to-tab="bulk.allSpaceToTab.value"
                             :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                            :show-posix="advancedMode"
+                            :option-visibility="optionVisibility"
                             :all-to-posix-lines="bulk.allToPosixLines.value"
                             :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                            :show-auto-decompress="advancedMode"
                             :all-auto-decompress="bulk.allAutoDecompress.value"
                             :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                             @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
@@ -437,9 +441,8 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <template v-slot:cell(options)="{ item }">
                         <UploadTableOptionsCell
                             :space-to-tab="item.spaceToTab"
-                            :show-posix="advancedMode"
+                            :option-visibility="optionVisibility"
                             :to-posix-lines="item.toPosixLines"
-                            :show-auto-decompress="advancedMode"
                             :auto-decompress="item.autoDecompress"
                             @updateSpaceToTab="item.spaceToTab = $event"
                             @updateToPosixLines="item.toPosixLines = $event"

--- a/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
@@ -426,8 +426,12 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             :show-posix="advancedMode"
                             :all-to-posix-lines="bulk.allToPosixLines.value"
                             :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
+                            :show-auto-decompress="advancedMode"
+                            :all-auto-decompress="bulk.allAutoDecompress.value"
+                            :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                             @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
-                            @toggle-to-posix-lines="bulk.toggleAllToPosixLines" />
+                            @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
+                            @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
                     </template>
 
                     <template v-slot:cell(options)="{ item }">
@@ -435,8 +439,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             :space-to-tab="item.spaceToTab"
                             :show-posix="advancedMode"
                             :to-posix-lines="item.toPosixLines"
+                            :show-auto-decompress="advancedMode"
+                            :auto-decompress="item.autoDecompress"
                             @updateSpaceToTab="item.spaceToTab = $event"
-                            @updateToPosixLines="item.toPosixLines = $event" />
+                            @updateToPosixLines="item.toPosixLines = $event"
+                            @updateAutoDecompress="item.autoDecompress = $event" />
                     </template>
 
                     <!-- Actions column -->

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -5,6 +5,8 @@ import { BFormInput } from "bootstrap-vue";
 import { computed, nextTick, ref, watch } from "vue";
 
 import type { TableField } from "@/components/Common/GTable.types";
+import { urlUploadOptionVisibility } from "@/components/Panels/Upload/shared/uploadOptionVisibility";
+import { getUploadSettingsColumnWidth } from "@/components/Panels/Upload/shared/uploadTableOptionsWidth";
 import { useBulkUploadOperations } from "@/composables/upload/bulkUploadOperations";
 import { useCollectionCreation } from "@/composables/upload/collectionCreation";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
@@ -56,6 +58,8 @@ const emit = defineEmits<{
 }>();
 
 const { advancedMode } = useUploadAdvancedMode();
+
+const optionVisibility = computed(() => urlUploadOptionVisibility(advancedMode.value));
 
 const { effectiveExtensions, listDbKeys, configurationsReady, createItemDefaults } = useUploadDefaults(props.formats);
 
@@ -164,7 +168,7 @@ function removeItem(id: number) {
     }
 }
 
-const tableFields: TableField[] = [
+const tableFields = computed<TableField[]>(() => [
     {
         key: "name",
         label: "Name",
@@ -196,6 +200,7 @@ const tableFields: TableField[] = [
         key: "options",
         label: "Upload Settings",
         sortable: false,
+        width: getUploadSettingsColumnWidth(optionVisibility.value),
         align: "center",
     },
     {
@@ -205,7 +210,7 @@ const tableFields: TableField[] = [
         width: "50px",
         align: "center",
     },
-];
+]);
 
 function reset() {
     urlItems.value = [];
@@ -332,13 +337,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         <UploadTableOptionsHeader
                             :all-space-to-tab="bulk.allSpaceToTab.value"
                             :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                            :show-posix="advancedMode"
+                            :option-visibility="optionVisibility"
                             :all-to-posix-lines="bulk.allToPosixLines.value"
                             :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                            :show-deferred="true"
                             :all-deferred="bulk.allDeferred.value"
                             :deferred-indeterminate="bulk.deferredIndeterminate.value"
-                            :show-auto-decompress="advancedMode"
                             :all-auto-decompress="bulk.allAutoDecompress.value"
                             :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                             @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
@@ -350,11 +353,9 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <template v-slot:cell(options)="{ item }">
                         <UploadTableOptionsCell
                             :space-to-tab="item.spaceToTab"
-                            :show-posix="advancedMode"
+                            :option-visibility="optionVisibility"
                             :to-posix-lines="item.toPosixLines"
-                            :show-deferred="true"
                             :deferred="item.deferred"
-                            :show-auto-decompress="advancedMode"
                             :auto-decompress="item.autoDecompress"
                             @updateSpaceToTab="item.spaceToTab = $event"
                             @updateToPosixLines="item.toPosixLines = $event"

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -12,6 +12,7 @@ import { useCollectionCreation } from "@/composables/upload/collectionCreation";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
 import { useUploadDefaults } from "@/composables/upload/uploadDefaults";
 import { useUploadItemValidation } from "@/composables/upload/uploadItemValidation";
+import { useUploadOptionBindings } from "@/composables/upload/uploadOptionBindings";
 import { useUploadReadyState } from "@/composables/upload/uploadReadyState";
 import { useUploadStaging } from "@/composables/upload/useUploadStaging";
 import { buildPreparedUpload } from "@/utils/upload";
@@ -100,6 +101,10 @@ const addMoreUrlsLabel = computed(() => (isSingleMode.value ? "Change selected U
 const { isNameValid, restoreOriginalName } = useUploadItemValidation();
 
 const bulk = useBulkUploadOperations(urlItems, effectiveExtensions);
+const { headerOptionProps, headerOptionEvents, getRowOptionProps, getRowOptionEvents } = useUploadOptionBindings(
+    bulk,
+    optionVisibility,
+);
 
 // Additional validation for URL items
 const hasInvalidUrls = computed(() => urlItems.value.some((item) => !isValidUrl(item.url)));
@@ -334,33 +339,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                     <!-- Options column with bulk checkboxes -->
                     <template v-slot:head(options)>
-                        <UploadTableOptionsHeader
-                            :all-space-to-tab="bulk.allSpaceToTab.value"
-                            :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                            :option-visibility="optionVisibility"
-                            :all-to-posix-lines="bulk.allToPosixLines.value"
-                            :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                            :all-deferred="bulk.allDeferred.value"
-                            :deferred-indeterminate="bulk.deferredIndeterminate.value"
-                            :all-auto-decompress="bulk.allAutoDecompress.value"
-                            :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
-                            @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
-                            @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
-                            @toggle-deferred="bulk.toggleAllDeferred"
-                            @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
+                        <UploadTableOptionsHeader v-bind="headerOptionProps" v-on="headerOptionEvents" />
                     </template>
 
                     <template v-slot:cell(options)="{ item }">
-                        <UploadTableOptionsCell
-                            :space-to-tab="item.spaceToTab"
-                            :option-visibility="optionVisibility"
-                            :to-posix-lines="item.toPosixLines"
-                            :deferred="item.deferred"
-                            :auto-decompress="item.autoDecompress"
-                            @updateSpaceToTab="item.spaceToTab = $event"
-                            @updateToPosixLines="item.toPosixLines = $event"
-                            @updateDeferred="item.deferred = $event"
-                            @updateAutoDecompress="item.autoDecompress = $event" />
+                        <UploadTableOptionsCell v-bind="getRowOptionProps(item)" v-on="getRowOptionEvents(item)" />
                     </template>
 
                     <!-- Actions column -->

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -338,9 +338,13 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             :show-deferred="true"
                             :all-deferred="bulk.allDeferred.value"
                             :deferred-indeterminate="bulk.deferredIndeterminate.value"
+                            :show-auto-decompress="advancedMode"
+                            :all-auto-decompress="bulk.allAutoDecompress.value"
+                            :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                             @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
                             @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
-                            @toggle-deferred="bulk.toggleAllDeferred" />
+                            @toggle-deferred="bulk.toggleAllDeferred"
+                            @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
                     </template>
 
                     <template v-slot:cell(options)="{ item }">
@@ -350,9 +354,12 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             :to-posix-lines="item.toPosixLines"
                             :show-deferred="true"
                             :deferred="item.deferred"
+                            :show-auto-decompress="advancedMode"
+                            :auto-decompress="item.autoDecompress"
                             @updateSpaceToTab="item.spaceToTab = $event"
                             @updateToPosixLines="item.toPosixLines = $event"
-                            @updateDeferred="item.deferred = $event" />
+                            @updateDeferred="item.deferred = $event"
+                            @updateAutoDecompress="item.autoDecompress = $event" />
                     </template>
 
                     <!-- Actions column -->

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -844,9 +844,13 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             :show-deferred="true"
                             :all-deferred="bulk.allDeferred.value"
                             :deferred-indeterminate="bulk.deferredIndeterminate.value"
+                            :show-auto-decompress="advancedMode"
+                            :all-auto-decompress="bulk.allAutoDecompress.value"
+                            :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                             @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
                             @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
-                            @toggle-deferred="bulk.toggleAllDeferred" />
+                            @toggle-deferred="bulk.toggleAllDeferred"
+                            @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
                     </template>
 
                     <template v-slot:cell(options)="{ item }">
@@ -856,9 +860,12 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             :to-posix-lines="item.toPosixLines"
                             :show-deferred="true"
                             :deferred="item.deferred"
+                            :show-auto-decompress="advancedMode"
+                            :auto-decompress="item.autoDecompress"
                             @updateSpaceToTab="item.spaceToTab = $event"
                             @updateToPosixLines="item.toPosixLines = $event"
-                            @updateDeferred="item.deferred = $event" />
+                            @updateDeferred="item.deferred = $event"
+                            @updateAutoDecompress="item.autoDecompress = $event" />
                     </template>
 
                     <!-- Actions column -->

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -19,6 +19,7 @@ import { useCollectionCreation } from "@/composables/upload/collectionCreation";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
 import { useUploadDefaults } from "@/composables/upload/uploadDefaults";
 import { useUploadItemValidation } from "@/composables/upload/uploadItemValidation";
+import { useUploadOptionBindings } from "@/composables/upload/uploadOptionBindings";
 import { useUploadReadyState } from "@/composables/upload/uploadReadyState";
 import { useUploadStaging } from "@/composables/upload/useUploadStaging";
 import { useUrlTracker } from "@/composables/urlTracker";
@@ -190,6 +191,10 @@ const breadcrumbs = computed(() => {
 const { isNameValid, restoreOriginalName } = useUploadItemValidation();
 
 const bulk = useBulkUploadOperations(remoteFileItems, effectiveExtensions);
+const { headerOptionProps, headerOptionEvents, getRowOptionProps, getRowOptionEvents } = useUploadOptionBindings(
+    bulk,
+    optionVisibility,
+);
 
 const { isReadyToUpload } = useUploadReadyState(hasItems, collectionState);
 
@@ -840,33 +845,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                     <!-- Options column with bulk checkboxes -->
                     <template v-slot:head(options)>
-                        <UploadTableOptionsHeader
-                            :all-space-to-tab="bulk.allSpaceToTab.value"
-                            :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                            :option-visibility="optionVisibility"
-                            :all-to-posix-lines="bulk.allToPosixLines.value"
-                            :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                            :all-deferred="bulk.allDeferred.value"
-                            :deferred-indeterminate="bulk.deferredIndeterminate.value"
-                            :all-auto-decompress="bulk.allAutoDecompress.value"
-                            :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
-                            @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
-                            @toggle-to-posix-lines="bulk.toggleAllToPosixLines"
-                            @toggle-deferred="bulk.toggleAllDeferred"
-                            @toggle-auto-decompress="bulk.toggleAllAutoDecompress" />
+                        <UploadTableOptionsHeader v-bind="headerOptionProps" v-on="headerOptionEvents" />
                     </template>
 
                     <template v-slot:cell(options)="{ item }">
-                        <UploadTableOptionsCell
-                            :space-to-tab="item.spaceToTab"
-                            :option-visibility="optionVisibility"
-                            :to-posix-lines="item.toPosixLines"
-                            :deferred="item.deferred"
-                            :auto-decompress="item.autoDecompress"
-                            @updateSpaceToTab="item.spaceToTab = $event"
-                            @updateToPosixLines="item.toPosixLines = $event"
-                            @updateDeferred="item.deferred = $event"
-                            @updateAutoDecompress="item.autoDecompress = $event" />
+                        <UploadTableOptionsCell v-bind="getRowOptionProps(item)" v-on="getRowOptionEvents(item)" />
                     </template>
 
                     <!-- Actions column -->

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -10,6 +10,8 @@ import type { BreadcrumbItem } from "@/components/Common";
 import type { TableField } from "@/components/Common/GTable.types";
 import { Model } from "@/components/FilesDialog/model";
 import { fileSourcePluginToItem, selectionToArray } from "@/components/FilesDialog/utilities";
+import { urlUploadOptionVisibility } from "@/components/Panels/Upload/shared/uploadOptionVisibility";
+import { getUploadSettingsColumnWidth } from "@/components/Panels/Upload/shared/uploadTableOptionsWidth";
 import type { SelectionItem } from "@/components/SelectionDialog/selectionTypes";
 import { useFileSources } from "@/composables/fileSources";
 import { useBulkUploadOperations } from "@/composables/upload/bulkUploadOperations";
@@ -69,6 +71,8 @@ const emit = defineEmits<{
 }>();
 
 const { advancedMode } = useUploadAdvancedMode();
+
+const optionVisibility = computed(() => urlUploadOptionVisibility(advancedMode.value));
 
 const router = useRouter();
 const filesSources = useFileSources();
@@ -480,7 +484,7 @@ const browserFields: TableField[] = [
 ];
 
 // File list table fields
-const tableFields: TableField[] = [
+const tableFields = computed<TableField[]>(() => [
     {
         key: "name",
         label: "Name",
@@ -522,6 +526,7 @@ const tableFields: TableField[] = [
         key: "options",
         label: "Upload Settings",
         sortable: false,
+        width: getUploadSettingsColumnWidth(optionVisibility.value),
         align: "center",
     },
     {
@@ -531,7 +536,7 @@ const tableFields: TableField[] = [
         width: "50px",
         align: "center",
     },
-];
+]);
 
 function reset() {
     remoteFileItems.value = [];
@@ -838,13 +843,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         <UploadTableOptionsHeader
                             :all-space-to-tab="bulk.allSpaceToTab.value"
                             :space-to-tab-indeterminate="bulk.spaceToTabIndeterminate.value"
-                            :show-posix="advancedMode"
+                            :option-visibility="optionVisibility"
                             :all-to-posix-lines="bulk.allToPosixLines.value"
                             :to-posix-lines-indeterminate="bulk.toPosixLinesIndeterminate.value"
-                            :show-deferred="true"
                             :all-deferred="bulk.allDeferred.value"
                             :deferred-indeterminate="bulk.deferredIndeterminate.value"
-                            :show-auto-decompress="advancedMode"
                             :all-auto-decompress="bulk.allAutoDecompress.value"
                             :auto-decompress-indeterminate="bulk.autoDecompressIndeterminate.value"
                             @toggle-space-to-tab="bulk.toggleAllSpaceToTab"
@@ -856,11 +859,9 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                     <template v-slot:cell(options)="{ item }">
                         <UploadTableOptionsCell
                             :space-to-tab="item.spaceToTab"
-                            :show-posix="advancedMode"
+                            :option-visibility="optionVisibility"
                             :to-posix-lines="item.toPosixLines"
-                            :show-deferred="true"
                             :deferred="item.deferred"
-                            :show-auto-decompress="advancedMode"
                             :auto-decompress="item.autoDecompress"
                             @updateSpaceToTab="item.spaceToTab = $event"
                             @updateToPosixLines="item.toPosixLines = $event"

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
@@ -12,18 +12,25 @@ interface Props {
     deferred?: boolean;
     /** Whether to show the deferred checkbox */
     showDeferred?: boolean;
+    /** Whether to auto-decompress compressed inputs */
+    autoDecompress?: boolean;
+    /** Whether to show the auto-decompress checkbox */
+    showAutoDecompress?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
     showPosix: true,
     deferred: false,
     showDeferred: false,
+    autoDecompress: true,
+    showAutoDecompress: false,
 });
 
 const emit = defineEmits<{
     (e: "updateSpaceToTab", value: boolean): void;
     (e: "updateToPosixLines", value: boolean): void;
     (e: "updateDeferred", value: boolean): void;
+    (e: "updateAutoDecompress", value: boolean): void;
 }>();
 
 function updateSpaceToTab(value: boolean) {
@@ -37,6 +44,10 @@ function updateToPosixLines(value: boolean) {
 function updateDeferred(value: boolean) {
     emit("updateDeferred", value);
 }
+
+function updateAutoDecompress(value: boolean) {
+    emit("updateAutoDecompress", value);
+}
 </script>
 
 <template>
@@ -45,7 +56,7 @@ function updateDeferred(value: boolean) {
             v-g-tooltip.hover
             :checked="spaceToTab"
             size="sm"
-            :class="{ 'mr-2': showPosix || showDeferred }"
+            :class="{ 'mr-2': showPosix || showDeferred || showAutoDecompress }"
             title="Convert spaces to tab characters"
             @change="updateSpaceToTab">
             <span class="small">Spaces→Tabs</span>
@@ -55,7 +66,7 @@ function updateDeferred(value: boolean) {
             v-g-tooltip.hover
             :checked="toPosixLines"
             size="sm"
-            :class="{ 'mr-2': showDeferred }"
+            :class="{ 'mr-2': showDeferred || showAutoDecompress }"
             title="Convert line endings to POSIX standard"
             @change="updateToPosixLines">
             <span class="small">POSIX</span>
@@ -68,6 +79,16 @@ function updateDeferred(value: boolean) {
                 title="Galaxy will store a reference and fetch data only when needed by a tool"
                 @change="updateDeferred">
                 <span class="small">Deferred</span>
+            </BFormCheckbox>
+        </div>
+        <div v-if="showAutoDecompress" data-test-id="auto-decompress-toggle">
+            <BFormCheckbox
+                v-g-tooltip.hover
+                :checked="autoDecompress"
+                size="sm"
+                title="Automatic decompression of compressed inputs after upload"
+                @change="updateAutoDecompress">
+                <span class="small">Auto-decompress</span>
             </BFormCheckbox>
         </div>
     </div>

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
@@ -1,90 +1,49 @@
 <script setup lang="ts">
 import { BFormCheckbox } from "bootstrap-vue";
 
-import type { UploadOptionVisibility } from "./uploadOptionVisibility";
-import { defaultUploadOptionVisibility } from "./uploadOptionVisibility";
+import type { RowOptionDescriptor } from "@/composables/upload/uploadOptionBindings";
+import type { UploadOptionKey } from "@/composables/upload/uploadOptionModel";
 
 interface Props {
-    /** Whether to convert spaces to tabs */
-    spaceToTab: boolean;
-    /** Whether to convert to POSIX line endings */
-    toPosixLines: boolean;
-    /** Which option toggles are visible */
-    optionVisibility?: UploadOptionVisibility;
-    /** Whether to defer data fetching (optional, for URLs) */
-    deferred?: boolean;
-    /** Whether to auto-decompress compressed inputs */
-    autoDecompress?: boolean;
+    /** Row option descriptors to render in order */
+    options: RowOptionDescriptor[];
 }
 
-withDefaults(defineProps<Props>(), {
-    optionVisibility: () => defaultUploadOptionVisibility,
-    deferred: false,
-    autoDecompress: true,
-});
+defineProps<Props>();
 
 const emit = defineEmits<{
-    (e: "updateSpaceToTab", value: boolean): void;
-    (e: "updateToPosixLines", value: boolean): void;
-    (e: "updateDeferred", value: boolean): void;
-    (e: "updateAutoDecompress", value: boolean): void;
+    (e: "update", payload: { key: UploadOptionKey; value: boolean }): void;
 }>();
 
-function updateSpaceToTab(value: boolean) {
-    emit("updateSpaceToTab", value);
+function updateOption(key: UploadOptionKey, value: boolean) {
+    emit("update", { key, value });
 }
 
-function updateToPosixLines(value: boolean) {
-    emit("updateToPosixLines", value);
-}
+function getToggleTestId(key: UploadOptionKey): string | undefined {
+    if (key === "deferred") {
+        return "deferred-toggle";
+    }
 
-function updateDeferred(value: boolean) {
-    emit("updateDeferred", value);
-}
+    if (key === "autoDecompress") {
+        return "auto-decompress-toggle";
+    }
 
-function updateAutoDecompress(value: boolean) {
-    emit("updateAutoDecompress", value);
+    return undefined;
 }
 </script>
 
 <template>
     <div class="options-cell options-controls d-inline-flex align-items-center flex-nowrap">
         <BFormCheckbox
+            v-for="option in options"
+            :key="option.key"
             v-g-tooltip.hover
-            :checked="spaceToTab"
+            :checked="option.checked"
+            :data-test-id="getToggleTestId(option.key)"
             size="sm"
-            title="Convert spaces to tab characters"
-            @change="updateSpaceToTab">
-            <span class="small">Spaces→Tabs</span>
+            :title="option.title"
+            @change="updateOption(option.key, $event)">
+            <span class="small">{{ option.label }}</span>
         </BFormCheckbox>
-        <BFormCheckbox
-            v-if="optionVisibility.posix"
-            v-g-tooltip.hover
-            :checked="toPosixLines"
-            size="sm"
-            title="Convert line endings to POSIX standard"
-            @change="updateToPosixLines">
-            <span class="small">POSIX</span>
-        </BFormCheckbox>
-        <div v-if="optionVisibility.deferred" data-test-id="deferred-toggle">
-            <BFormCheckbox
-                v-g-tooltip.hover
-                :checked="deferred"
-                size="sm"
-                title="Galaxy will store a reference and fetch data only when needed by a tool"
-                @change="updateDeferred">
-                <span class="small">Deferred</span>
-            </BFormCheckbox>
-        </div>
-        <div v-if="optionVisibility.autoDecompress" data-test-id="auto-decompress-toggle">
-            <BFormCheckbox
-                v-g-tooltip.hover
-                :checked="autoDecompress"
-                size="sm"
-                title="Automatic decompression of compressed inputs after upload"
-                @change="updateAutoDecompress">
-                <span class="small">Auto-decompress</span>
-            </BFormCheckbox>
-        </div>
     </div>
 </template>

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsCell.vue
@@ -1,29 +1,26 @@
 <script setup lang="ts">
 import { BFormCheckbox } from "bootstrap-vue";
 
+import type { UploadOptionVisibility } from "./uploadOptionVisibility";
+import { defaultUploadOptionVisibility } from "./uploadOptionVisibility";
+
 interface Props {
     /** Whether to convert spaces to tabs */
     spaceToTab: boolean;
     /** Whether to convert to POSIX line endings */
     toPosixLines: boolean;
-    /** Whether to show the POSIX checkbox (advanced mode) */
-    showPosix?: boolean;
+    /** Which option toggles are visible */
+    optionVisibility?: UploadOptionVisibility;
     /** Whether to defer data fetching (optional, for URLs) */
     deferred?: boolean;
-    /** Whether to show the deferred checkbox */
-    showDeferred?: boolean;
     /** Whether to auto-decompress compressed inputs */
     autoDecompress?: boolean;
-    /** Whether to show the auto-decompress checkbox */
-    showAutoDecompress?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
-    showPosix: true,
+    optionVisibility: () => defaultUploadOptionVisibility,
     deferred: false,
-    showDeferred: false,
     autoDecompress: true,
-    showAutoDecompress: false,
 });
 
 const emit = defineEmits<{
@@ -51,27 +48,25 @@ function updateAutoDecompress(value: boolean) {
 </script>
 
 <template>
-    <div class="d-flex align-items-center">
+    <div class="options-cell options-controls d-inline-flex align-items-center flex-nowrap">
         <BFormCheckbox
             v-g-tooltip.hover
             :checked="spaceToTab"
             size="sm"
-            :class="{ 'mr-2': showPosix || showDeferred || showAutoDecompress }"
             title="Convert spaces to tab characters"
             @change="updateSpaceToTab">
             <span class="small">Spaces→Tabs</span>
         </BFormCheckbox>
         <BFormCheckbox
-            v-if="showPosix"
+            v-if="optionVisibility.posix"
             v-g-tooltip.hover
             :checked="toPosixLines"
             size="sm"
-            :class="{ 'mr-2': showDeferred || showAutoDecompress }"
             title="Convert line endings to POSIX standard"
             @change="updateToPosixLines">
             <span class="small">POSIX</span>
         </BFormCheckbox>
-        <div v-if="showDeferred" data-test-id="deferred-toggle">
+        <div v-if="optionVisibility.deferred" data-test-id="deferred-toggle">
             <BFormCheckbox
                 v-g-tooltip.hover
                 :checked="deferred"
@@ -81,7 +76,7 @@ function updateAutoDecompress(value: boolean) {
                 <span class="small">Deferred</span>
             </BFormCheckbox>
         </div>
-        <div v-if="showAutoDecompress" data-test-id="auto-decompress-toggle">
+        <div v-if="optionVisibility.autoDecompress" data-test-id="auto-decompress-toggle">
             <BFormCheckbox
                 v-g-tooltip.hover
                 :checked="autoDecompress"

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { BFormCheckbox } from "bootstrap-vue";
 
+import type { UploadOptionVisibility } from "./uploadOptionVisibility";
+import { defaultUploadOptionVisibility } from "./uploadOptionVisibility";
+
 interface Props {
     /** All items have spaceToTab enabled */
     allSpaceToTab: boolean;
@@ -10,16 +13,12 @@ interface Props {
     allToPosixLines: boolean;
     /** Some but not all items have toPosixLines enabled */
     toPosixLinesIndeterminate: boolean;
-    /** Whether to show the POSIX checkbox (advanced mode) */
-    showPosix?: boolean;
-    /** Whether to show the deferred checkbox (for URL uploads) */
-    showDeferred?: boolean;
+    /** Which option toggles are visible */
+    optionVisibility?: UploadOptionVisibility;
     /** All items have deferred enabled */
     allDeferred?: boolean;
     /** Some but not all items have deferred enabled */
     deferredIndeterminate?: boolean;
-    /** Whether to show the auto-decompress checkbox (advanced mode) */
-    showAutoDecompress?: boolean;
     /** All items have auto-decompress enabled */
     allAutoDecompress?: boolean;
     /** Some but not all items have auto-decompress enabled */
@@ -27,11 +26,9 @@ interface Props {
 }
 
 withDefaults(defineProps<Props>(), {
-    showPosix: true,
-    showDeferred: false,
+    optionVisibility: () => defaultUploadOptionVisibility,
     allDeferred: false,
     deferredIndeterminate: false,
-    showAutoDecompress: false,
     allAutoDecompress: true,
     autoDecompressIndeterminate: false,
 });
@@ -63,30 +60,28 @@ function handleToggleAutoDecompress() {
 <template>
     <div class="options-header">
         <span class="options-title">Upload Settings</span>
-        <div class="d-flex align-items-center">
+        <div class="options-controls d-inline-flex align-items-center flex-nowrap">
             <BFormCheckbox
                 v-g-tooltip.hover
                 :checked="allSpaceToTab"
                 :indeterminate="spaceToTabIndeterminate"
                 size="sm"
-                class="mr-2"
                 title="Toggle all: Convert spaces to tab characters"
                 @change="handleToggleSpaceToTab">
                 <span class="small">Spaces→Tabs</span>
             </BFormCheckbox>
             <BFormCheckbox
-                v-if="showPosix"
+                v-if="optionVisibility.posix"
                 v-g-tooltip.hover
                 :checked="allToPosixLines"
                 :indeterminate="toPosixLinesIndeterminate"
                 size="sm"
-                :class="{ 'mr-2': showDeferred || showAutoDecompress }"
                 title="Toggle all: Convert line endings to POSIX standard"
                 @change="handleToggleToPosixLines">
                 <span class="small">POSIX</span>
             </BFormCheckbox>
             <BFormCheckbox
-                v-if="showDeferred"
+                v-if="optionVisibility.deferred"
                 v-g-tooltip.hover
                 :checked="allDeferred"
                 :indeterminate="deferredIndeterminate"
@@ -96,7 +91,7 @@ function handleToggleAutoDecompress() {
                 <span class="small">Deferred</span>
             </BFormCheckbox>
             <BFormCheckbox
-                v-if="showAutoDecompress"
+                v-if="optionVisibility.autoDecompress"
                 v-g-tooltip.hover
                 :checked="allAutoDecompress"
                 :indeterminate="autoDecompressIndeterminate"

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
@@ -18,6 +18,12 @@ interface Props {
     allDeferred?: boolean;
     /** Some but not all items have deferred enabled */
     deferredIndeterminate?: boolean;
+    /** Whether to show the auto-decompress checkbox (advanced mode) */
+    showAutoDecompress?: boolean;
+    /** All items have auto-decompress enabled */
+    allAutoDecompress?: boolean;
+    /** Some but not all items have auto-decompress enabled */
+    autoDecompressIndeterminate?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
@@ -25,12 +31,16 @@ withDefaults(defineProps<Props>(), {
     showDeferred: false,
     allDeferred: false,
     deferredIndeterminate: false,
+    showAutoDecompress: false,
+    allAutoDecompress: true,
+    autoDecompressIndeterminate: false,
 });
 
 const emit = defineEmits<{
     (e: "toggle-space-to-tab"): void;
     (e: "toggle-to-posix-lines"): void;
     (e: "toggle-deferred"): void;
+    (e: "toggle-auto-decompress"): void;
 }>();
 
 function handleToggleSpaceToTab() {
@@ -43,6 +53,10 @@ function handleToggleToPosixLines() {
 
 function handleToggleDeferred() {
     emit("toggle-deferred");
+}
+
+function handleToggleAutoDecompress() {
+    emit("toggle-auto-decompress");
 }
 </script>
 
@@ -66,7 +80,7 @@ function handleToggleDeferred() {
                 :checked="allToPosixLines"
                 :indeterminate="toPosixLinesIndeterminate"
                 size="sm"
-                :class="{ 'mr-2': showDeferred }"
+                :class="{ 'mr-2': showDeferred || showAutoDecompress }"
                 title="Toggle all: Convert line endings to POSIX standard"
                 @change="handleToggleToPosixLines">
                 <span class="small">POSIX</span>
@@ -80,6 +94,16 @@ function handleToggleDeferred() {
                 title="Toggle all: Galaxy will store a reference and fetch data only when needed by a tool"
                 @change="handleToggleDeferred">
                 <span class="small">Deferred</span>
+            </BFormCheckbox>
+            <BFormCheckbox
+                v-if="showAutoDecompress"
+                v-g-tooltip.hover
+                :checked="allAutoDecompress"
+                :indeterminate="autoDecompressIndeterminate"
+                size="sm"
+                title="Toggle all: Disable automatic decompression of compressed inputs"
+                @change="handleToggleAutoDecompress">
+                <span class="small">Auto-decompress</span>
             </BFormCheckbox>
         </div>
     </div>

--- a/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
+++ b/client/src/components/Panels/Upload/shared/UploadTableOptionsHeader.vue
@@ -1,59 +1,22 @@
 <script setup lang="ts">
 import { BFormCheckbox } from "bootstrap-vue";
 
-import type { UploadOptionVisibility } from "./uploadOptionVisibility";
-import { defaultUploadOptionVisibility } from "./uploadOptionVisibility";
+import type { HeaderOptionDescriptor } from "@/composables/upload/uploadOptionBindings";
+import type { UploadOptionKey } from "@/composables/upload/uploadOptionModel";
 
 interface Props {
-    /** All items have spaceToTab enabled */
-    allSpaceToTab: boolean;
-    /** Some but not all items have spaceToTab enabled */
-    spaceToTabIndeterminate: boolean;
-    /** All items have toPosixLines enabled */
-    allToPosixLines: boolean;
-    /** Some but not all items have toPosixLines enabled */
-    toPosixLinesIndeterminate: boolean;
-    /** Which option toggles are visible */
-    optionVisibility?: UploadOptionVisibility;
-    /** All items have deferred enabled */
-    allDeferred?: boolean;
-    /** Some but not all items have deferred enabled */
-    deferredIndeterminate?: boolean;
-    /** All items have auto-decompress enabled */
-    allAutoDecompress?: boolean;
-    /** Some but not all items have auto-decompress enabled */
-    autoDecompressIndeterminate?: boolean;
+    /** Bulk option descriptors to render in order */
+    options: HeaderOptionDescriptor[];
 }
 
-withDefaults(defineProps<Props>(), {
-    optionVisibility: () => defaultUploadOptionVisibility,
-    allDeferred: false,
-    deferredIndeterminate: false,
-    allAutoDecompress: true,
-    autoDecompressIndeterminate: false,
-});
+defineProps<Props>();
 
 const emit = defineEmits<{
-    (e: "toggle-space-to-tab"): void;
-    (e: "toggle-to-posix-lines"): void;
-    (e: "toggle-deferred"): void;
-    (e: "toggle-auto-decompress"): void;
+    (e: "toggle", key: UploadOptionKey): void;
 }>();
 
-function handleToggleSpaceToTab() {
-    emit("toggle-space-to-tab");
-}
-
-function handleToggleToPosixLines() {
-    emit("toggle-to-posix-lines");
-}
-
-function handleToggleDeferred() {
-    emit("toggle-deferred");
-}
-
-function handleToggleAutoDecompress() {
-    emit("toggle-auto-decompress");
+function handleToggle(key: UploadOptionKey) {
+    emit("toggle", key);
 }
 </script>
 
@@ -62,43 +25,15 @@ function handleToggleAutoDecompress() {
         <span class="options-title">Upload Settings</span>
         <div class="options-controls d-inline-flex align-items-center flex-nowrap">
             <BFormCheckbox
+                v-for="option in options"
+                :key="option.key"
                 v-g-tooltip.hover
-                :checked="allSpaceToTab"
-                :indeterminate="spaceToTabIndeterminate"
+                :checked="option.checked"
+                :indeterminate="option.indeterminate"
                 size="sm"
-                title="Toggle all: Convert spaces to tab characters"
-                @change="handleToggleSpaceToTab">
-                <span class="small">Spaces→Tabs</span>
-            </BFormCheckbox>
-            <BFormCheckbox
-                v-if="optionVisibility.posix"
-                v-g-tooltip.hover
-                :checked="allToPosixLines"
-                :indeterminate="toPosixLinesIndeterminate"
-                size="sm"
-                title="Toggle all: Convert line endings to POSIX standard"
-                @change="handleToggleToPosixLines">
-                <span class="small">POSIX</span>
-            </BFormCheckbox>
-            <BFormCheckbox
-                v-if="optionVisibility.deferred"
-                v-g-tooltip.hover
-                :checked="allDeferred"
-                :indeterminate="deferredIndeterminate"
-                size="sm"
-                title="Toggle all: Galaxy will store a reference and fetch data only when needed by a tool"
-                @change="handleToggleDeferred">
-                <span class="small">Deferred</span>
-            </BFormCheckbox>
-            <BFormCheckbox
-                v-if="optionVisibility.autoDecompress"
-                v-g-tooltip.hover
-                :checked="allAutoDecompress"
-                :indeterminate="autoDecompressIndeterminate"
-                size="sm"
-                title="Toggle all: Disable automatic decompression of compressed inputs"
-                @change="handleToggleAutoDecompress">
-                <span class="small">Auto-decompress</span>
+                :title="option.title"
+                @change="handleToggle(option.key)">
+                <span class="small">{{ option.label }}</span>
             </BFormCheckbox>
         </div>
     </div>

--- a/client/src/components/Panels/Upload/shared/upload-table-shared.scss
+++ b/client/src/components/Panels/Upload/shared/upload-table-shared.scss
@@ -58,6 +58,22 @@
     }
 }
 
+.options-controls {
+    gap: 0.5rem;
+}
+
+.options-header,
+.options-cell {
+    :deep(.custom-control) {
+        margin-right: 0;
+        margin-bottom: 0;
+    }
+
+    :deep(.custom-control-label) {
+        white-space: nowrap;
+    }
+}
+
 // Remove button in actions column
 .remove-btn {
     width: 30px;

--- a/client/src/components/Panels/Upload/shared/uploadOptionVisibility.ts
+++ b/client/src/components/Panels/Upload/shared/uploadOptionVisibility.ts
@@ -1,0 +1,31 @@
+export interface UploadOptionVisibility {
+    spaceToTab: boolean;
+    posix: boolean;
+    deferred: boolean;
+    autoDecompress: boolean;
+}
+
+export const defaultUploadOptionVisibility: UploadOptionVisibility = {
+    spaceToTab: false,
+    posix: false,
+    deferred: false,
+    autoDecompress: false,
+};
+
+export function localUploadOptionVisibility(advancedMode: boolean): UploadOptionVisibility {
+    return {
+        spaceToTab: true,
+        posix: advancedMode,
+        deferred: false,
+        autoDecompress: advancedMode,
+    };
+}
+
+export function urlUploadOptionVisibility(advancedMode: boolean): UploadOptionVisibility {
+    return {
+        spaceToTab: true,
+        posix: advancedMode,
+        deferred: true,
+        autoDecompress: advancedMode,
+    };
+}

--- a/client/src/components/Panels/Upload/shared/uploadTableOptionsWidth.ts
+++ b/client/src/components/Panels/Upload/shared/uploadTableOptionsWidth.ts
@@ -1,0 +1,32 @@
+import type { UploadOptionVisibility } from "./uploadOptionVisibility";
+
+const toggleWidths = {
+    spaceToTab: 84,
+    posix: 54,
+    deferred: 82,
+    autoDecompress: 102,
+};
+
+/**
+ * Returns a table column width that matches visible upload settings toggles.
+ */
+export function getUploadSettingsColumnWidth(visibility: UploadOptionVisibility): string {
+    const visibleCount = Object.values(visibility).filter(Boolean).length;
+
+    let width = 8 + Math.max(0, visibleCount - 1) * 8;
+
+    if (visibility.spaceToTab) {
+        width += toggleWidths.spaceToTab;
+    }
+    if (visibility.posix) {
+        width += toggleWidths.posix;
+    }
+    if (visibility.deferred) {
+        width += toggleWidths.deferred;
+    }
+    if (visibility.autoDecompress) {
+        width += toggleWidths.autoDecompress;
+    }
+
+    return `${Math.max(140, width)}px`;
+}

--- a/client/src/components/Panels/Upload/types/uploadItem.ts
+++ b/client/src/components/Panels/Upload/types/uploadItem.ts
@@ -15,6 +15,7 @@ export interface BaseUploadItem {
     dbkey: string;
     spaceToTab: boolean;
     toPosixLines: boolean;
+    autoDecompress: boolean;
 }
 
 /**

--- a/client/src/components/Panels/Upload/uploadState.test.ts
+++ b/client/src/components/Panels/Upload/uploadState.test.ts
@@ -20,6 +20,7 @@ function makePastedItem(name = "file.txt", content = "hello world"): NewUploadIt
         extension: "auto",
         spaceToTab: false,
         toPosixLines: false,
+        autoDecompress: true,
         deferred: false,
     };
 }

--- a/client/src/composables/upload/bulkUploadOperations.ts
+++ b/client/src/composables/upload/bulkUploadOperations.ts
@@ -13,6 +13,7 @@ export interface BulkUploadItem {
     dbkey: string;
     spaceToTab: boolean;
     toPosixLines: boolean;
+    autoDecompress: boolean;
     deferred?: boolean;
 }
 
@@ -27,11 +28,13 @@ export interface BulkUploadOperations {
     // "All" computed states
     allSpaceToTab: ComputedRef<boolean>;
     allToPosixLines: ComputedRef<boolean>;
+    allAutoDecompress: ComputedRef<boolean>;
     allDeferred: ComputedRef<boolean>;
 
     // Indeterminate states for checkboxes
     spaceToTabIndeterminate: ComputedRef<boolean>;
     toPosixLinesIndeterminate: ComputedRef<boolean>;
+    autoDecompressIndeterminate: ComputedRef<boolean>;
     deferredIndeterminate: ComputedRef<boolean>;
 
     // Extension warning functions
@@ -45,6 +48,7 @@ export interface BulkUploadOperations {
     // Toggle functions for checkboxes
     toggleAllSpaceToTab: () => void;
     toggleAllToPosixLines: () => void;
+    toggleAllAutoDecompress: () => void;
     toggleAllDeferred: () => void;
 }
 
@@ -92,6 +96,13 @@ export function useBulkUploadOperations<T extends BulkUploadItem>(
     });
 
     /**
+     * Computed property that returns true if all items have autoDecompress enabled.
+     */
+    const allAutoDecompress = computed(() => {
+        return items.value.length > 0 && items.value.every((item) => item.autoDecompress === true);
+    });
+
+    /**
      * Computed property that returns true if all items have deferred enabled.
      * Only relevant when supportDeferred option is true.
      */
@@ -118,6 +129,17 @@ export function useBulkUploadOperations<T extends BulkUploadItem>(
             items.value.length > 0 &&
             items.value.some((item) => item.toPosixLines === true) &&
             !items.value.every((item) => item.toPosixLines === true)
+        );
+    });
+
+    /**
+     * Computed property for checkbox indeterminate state (some but not all checked).
+     */
+    const autoDecompressIndeterminate = computed(() => {
+        return (
+            items.value.length > 0 &&
+            items.value.some((item) => item.autoDecompress === true) &&
+            !items.value.every((item) => item.autoDecompress === true)
         );
     });
 
@@ -187,6 +209,17 @@ export function useBulkUploadOperations<T extends BulkUploadItem>(
     }
 
     /**
+     * Toggles the autoDecompress setting for all items.
+     * If all are currently enabled, disables all; otherwise enables all.
+     */
+    function toggleAllAutoDecompress() {
+        const newValue = !allAutoDecompress.value;
+        items.value.forEach((item) => {
+            item.autoDecompress = newValue;
+        });
+    }
+
+    /**
      * Toggles the deferred setting for all items.
      * If all are currently enabled, disables all; otherwise enables all.
      * Only relevant when supportDeferred option is true.
@@ -227,9 +260,11 @@ export function useBulkUploadOperations<T extends BulkUploadItem>(
         bulkDbKey,
         allSpaceToTab,
         allToPosixLines,
+        allAutoDecompress,
         allDeferred,
         spaceToTabIndeterminate,
         toPosixLinesIndeterminate,
+        autoDecompressIndeterminate,
         deferredIndeterminate,
         getExtensionWarning,
         bulkExtensionWarning,
@@ -237,6 +272,7 @@ export function useBulkUploadOperations<T extends BulkUploadItem>(
         setAllDbKeys,
         toggleAllSpaceToTab,
         toggleAllToPosixLines,
+        toggleAllAutoDecompress,
         toggleAllDeferred,
     };
 }

--- a/client/src/composables/upload/bulkUploadOperations.ts
+++ b/client/src/composables/upload/bulkUploadOperations.ts
@@ -52,6 +52,34 @@ export interface BulkUploadOperations {
     toggleAllDeferred: () => void;
 }
 
+interface BooleanBulkOptionConfig<T extends BulkUploadItem> {
+    isEnabled: (item: T) => boolean;
+    setValue: (item: T, value: boolean) => void;
+}
+
+function createBooleanBulkOptionState<T extends BulkUploadItem>(items: Ref<T[]>, config: BooleanBulkOptionConfig<T>) {
+    const allEnabled = computed(() => {
+        return items.value.length > 0 && items.value.every((item) => config.isEnabled(item));
+    });
+
+    const indeterminate = computed(() => {
+        return items.value.length > 0 && items.value.some((item) => config.isEnabled(item)) && !allEnabled.value;
+    });
+
+    function toggleAll() {
+        const newValue = !allEnabled.value;
+        items.value.forEach((item) => {
+            config.setValue(item, newValue);
+        });
+    }
+
+    return {
+        allEnabled,
+        indeterminate,
+        toggleAll,
+    };
+}
+
 /**
  * Composable for managing bulk operations on upload items.
  * Provides functionality for bulk setting extensions, database keys, toggling
@@ -81,78 +109,45 @@ export function useBulkUploadOperations<T extends BulkUploadItem>(
     const bulkExtension = ref<string>("");
     const bulkDbKey = ref<string>("");
 
-    /**
-     * Computed property that returns true if all items have spaceToTab enabled.
-     */
-    const allSpaceToTab = computed(() => {
-        return items.value.length > 0 && items.value.every((item) => item.spaceToTab === true);
+    const spaceToTabState = createBooleanBulkOptionState(items, {
+        isEnabled: (item) => item.spaceToTab === true,
+        setValue: (item, value) => {
+            item.spaceToTab = value;
+        },
     });
 
-    /**
-     * Computed property that returns true if all items have toPosixLines enabled.
-     */
-    const allToPosixLines = computed(() => {
-        return items.value.length > 0 && items.value.every((item) => item.toPosixLines === true);
+    const toPosixLinesState = createBooleanBulkOptionState(items, {
+        isEnabled: (item) => item.toPosixLines === true,
+        setValue: (item, value) => {
+            item.toPosixLines = value;
+        },
     });
 
-    /**
-     * Computed property that returns true if all items have autoDecompress enabled.
-     */
-    const allAutoDecompress = computed(() => {
-        return items.value.length > 0 && items.value.every((item) => item.autoDecompress === true);
+    const autoDecompressState = createBooleanBulkOptionState(items, {
+        isEnabled: (item) => item.autoDecompress === true,
+        setValue: (item, value) => {
+            item.autoDecompress = value;
+        },
     });
 
-    /**
-     * Computed property that returns true if all items have deferred enabled.
-     * Only relevant when supportDeferred option is true.
-     */
-    const allDeferred = computed(() => {
-        return items.value.length > 0 && items.value.every((item) => item.deferred === true);
+    const deferredState = createBooleanBulkOptionState(items, {
+        isEnabled: (item) => item.deferred === true,
+        setValue: (item, value) => {
+            if (item.deferred !== undefined) {
+                item.deferred = value;
+            }
+        },
     });
 
-    /**
-     * Computed property for checkbox indeterminate state (some but not all checked).
-     */
-    const spaceToTabIndeterminate = computed(() => {
-        return (
-            items.value.length > 0 &&
-            items.value.some((item) => item.spaceToTab === true) &&
-            !items.value.every((item) => item.spaceToTab === true)
-        );
-    });
+    const allSpaceToTab = spaceToTabState.allEnabled;
+    const allToPosixLines = toPosixLinesState.allEnabled;
+    const allAutoDecompress = autoDecompressState.allEnabled;
+    const allDeferred = deferredState.allEnabled;
 
-    /**
-     * Computed property for checkbox indeterminate state (some but not all checked).
-     */
-    const toPosixLinesIndeterminate = computed(() => {
-        return (
-            items.value.length > 0 &&
-            items.value.some((item) => item.toPosixLines === true) &&
-            !items.value.every((item) => item.toPosixLines === true)
-        );
-    });
-
-    /**
-     * Computed property for checkbox indeterminate state (some but not all checked).
-     */
-    const autoDecompressIndeterminate = computed(() => {
-        return (
-            items.value.length > 0 &&
-            items.value.some((item) => item.autoDecompress === true) &&
-            !items.value.every((item) => item.autoDecompress === true)
-        );
-    });
-
-    /**
-     * Computed property for checkbox indeterminate state (some but not all checked).
-     */
-    const deferredIndeterminate = computed(() => {
-        return (
-            items.value.length > 0 &&
-            items.value.some((item) => item.deferred === true) &&
-            !items.value.every((item) => item.deferred === true)
-        );
-    });
+    const spaceToTabIndeterminate = spaceToTabState.indeterminate;
+    const toPosixLinesIndeterminate = toPosixLinesState.indeterminate;
+    const autoDecompressIndeterminate = autoDecompressState.indeterminate;
+    const deferredIndeterminate = deferredState.indeterminate;
 
     /**
      * Sets the extension/type for all items in the list.
@@ -186,52 +181,10 @@ export function useBulkUploadOperations<T extends BulkUploadItem>(
         });
     }
 
-    /**
-     * Toggles the spaceToTab setting for all items.
-     * If all are currently enabled, disables all; otherwise enables all.
-     */
-    function toggleAllSpaceToTab() {
-        const newValue = !allSpaceToTab.value;
-        items.value.forEach((item) => {
-            item.spaceToTab = newValue;
-        });
-    }
-
-    /**
-     * Toggles the toPosixLines setting for all items.
-     * If all are currently enabled, disables all; otherwise enables all.
-     */
-    function toggleAllToPosixLines() {
-        const newValue = !allToPosixLines.value;
-        items.value.forEach((item) => {
-            item.toPosixLines = newValue;
-        });
-    }
-
-    /**
-     * Toggles the autoDecompress setting for all items.
-     * If all are currently enabled, disables all; otherwise enables all.
-     */
-    function toggleAllAutoDecompress() {
-        const newValue = !allAutoDecompress.value;
-        items.value.forEach((item) => {
-            item.autoDecompress = newValue;
-        });
-    }
-
-    /**
-     * Toggles the deferred setting for all items.
-     * If all are currently enabled, disables all; otherwise enables all.
-     * Only relevant when supportDeferred option is true.
-     */
-    function toggleAllDeferred() {
-        const newValue = !allDeferred.value;
-        items.value.forEach((item) => {
-            if (item.deferred !== undefined) {
-                item.deferred = newValue;
-            }
-        });
-    }
+    const toggleAllSpaceToTab = spaceToTabState.toggleAll;
+    const toggleAllToPosixLines = toPosixLinesState.toggleAll;
+    const toggleAllAutoDecompress = autoDecompressState.toggleAll;
+    const toggleAllDeferred = deferredState.toggleAll;
 
     /**
      * Gets the upload warning for a specific extension ID.

--- a/client/src/composables/upload/testHelpers/uploadFixtures.ts
+++ b/client/src/composables/upload/testHelpers/uploadFixtures.ts
@@ -18,6 +18,7 @@ export function makePastedItem(overrides: Partial<PastedContentUploadItem> = {})
         extension: "auto",
         spaceToTab: false,
         toPosixLines: false,
+        autoDecompress: true,
         deferred: false,
         ...overrides,
     };
@@ -34,6 +35,7 @@ export function makeUrlItem(overrides: Partial<UrlUploadItem> = {}): UrlUploadIt
         extension: "auto",
         spaceToTab: false,
         toPosixLines: false,
+        autoDecompress: true,
         deferred: false,
         ...overrides,
     };
@@ -50,6 +52,7 @@ export function makeRemoteFilesItem(overrides: Partial<RemoteFileUploadItem> = {
         extension: "auto",
         spaceToTab: false,
         toPosixLines: false,
+        autoDecompress: true,
         deferred: false,
         ...overrides,
     };
@@ -65,6 +68,7 @@ export function makeLibraryItem(overrides: Partial<LibraryDatasetUploadItem> = {
         extension: "auto",
         spaceToTab: false,
         toPosixLines: false,
+        autoDecompress: false,
         deferred: false,
         libraryId: "lib_1",
         folderId: "folder_1",
@@ -85,6 +89,7 @@ export function makeLocalFileItem(overrides: Partial<LocalFileUploadItem> = {}):
         extension: "auto",
         spaceToTab: false,
         toPosixLines: false,
+        autoDecompress: true,
         deferred: false,
         fileData: file,
         ...overrides,

--- a/client/src/composables/upload/uploadDefaults.ts
+++ b/client/src/composables/upload/uploadDefaults.ts
@@ -24,6 +24,7 @@ export function useUploadDefaults(formats?: string[]) {
             dbkey: defaultDbKey.value,
             spaceToTab: false,
             toPosixLines: false,
+            autoDecompress: true,
         };
     }
 

--- a/client/src/composables/upload/uploadDefaults.ts
+++ b/client/src/composables/upload/uploadDefaults.ts
@@ -6,6 +6,7 @@
 import { computed } from "vue";
 
 import type { BaseUploadItem } from "@/components/Panels/Upload/types/uploadItem";
+import { uploadOptionDefaults } from "@/composables/upload/uploadOptionModel";
 import { useUploadConfigurations } from "@/composables/uploadConfigurations";
 
 export function useUploadDefaults(formats?: string[]) {
@@ -22,9 +23,9 @@ export function useUploadDefaults(formats?: string[]) {
         return {
             extension: defaultExtension.value,
             dbkey: defaultDbKey.value,
-            spaceToTab: false,
-            toPosixLines: false,
-            autoDecompress: true,
+            spaceToTab: uploadOptionDefaults.spaceToTab,
+            toPosixLines: uploadOptionDefaults.toPosixLines,
+            autoDecompress: uploadOptionDefaults.autoDecompress,
         };
     }
 

--- a/client/src/composables/upload/uploadItemTypes.test.ts
+++ b/client/src/composables/upload/uploadItemTypes.test.ts
@@ -48,6 +48,7 @@ describe("validateUploadItem", () => {
             extension: "auto",
             spaceToTab: false,
             toPosixLines: false,
+            autoDecompress: true,
             deferred: false,
         };
         expect(validateUploadItem(item)).toMatch(/No file selected/);
@@ -64,6 +65,7 @@ describe("validateUploadItem", () => {
             extension: "auto",
             spaceToTab: false,
             toPosixLines: false,
+            autoDecompress: true,
             deferred: false,
             fileData: emptyFile,
         };

--- a/client/src/composables/upload/uploadItemTypes.ts
+++ b/client/src/composables/upload/uploadItemTypes.ts
@@ -20,6 +20,7 @@ interface UploadItemCommon {
     extension: string;
     spaceToTab: boolean;
     toPosixLines: boolean;
+    autoDecompress: boolean;
     deferred: boolean;
     hashes?: FetchDatasetHash[];
 }

--- a/client/src/composables/upload/uploadOptionBindings.ts
+++ b/client/src/composables/upload/uploadOptionBindings.ts
@@ -1,0 +1,182 @@
+import { computed, type ComputedRef } from "vue";
+
+import type { UploadOptionVisibility } from "@/components/Panels/Upload/shared/uploadOptionVisibility";
+import type { BulkUploadItem, BulkUploadOperations } from "@/composables/upload/bulkUploadOperations";
+import {
+    isUploadOptionVisible,
+    uploadOptionDefinitions,
+    type UploadOptionKey,
+} from "@/composables/upload/uploadOptionModel";
+
+type HeaderOptionProps = {
+    options: HeaderOptionDescriptor[];
+};
+
+type HeaderOptionEvents = {
+    toggle: (key: UploadOptionKey) => void;
+};
+
+type RowOptionProps = {
+    options: RowOptionDescriptor[];
+};
+
+type RowOptionEvents = {
+    update: (payload: { key: UploadOptionKey; value: boolean }) => void;
+};
+
+export interface HeaderOptionDescriptor {
+    key: UploadOptionKey;
+    label: string;
+    title: string;
+    checked: boolean;
+    indeterminate: boolean;
+}
+
+export interface RowOptionDescriptor {
+    key: UploadOptionKey;
+    label: string;
+    title: string;
+    checked: boolean;
+}
+
+type BulkOptionState = {
+    checked: boolean;
+    indeterminate: boolean;
+};
+
+type OptionAdapter<T extends BulkUploadItem> = {
+    isSupported: (item: T) => boolean;
+    get: (item: T) => boolean;
+    set: (item: T, value: boolean) => void;
+    getBulkState: (bulk: BulkUploadOperations) => BulkOptionState;
+    toggleBulk: (bulk: BulkUploadOperations) => void;
+};
+
+const optionAdapters: Record<UploadOptionKey, OptionAdapter<BulkUploadItem>> = {
+    spaceToTab: {
+        isSupported: () => true,
+        get: (item) => item.spaceToTab,
+        set: (item, value) => {
+            item.spaceToTab = value;
+        },
+        getBulkState: (bulk) => ({
+            checked: bulk.allSpaceToTab.value,
+            indeterminate: bulk.spaceToTabIndeterminate.value,
+        }),
+        toggleBulk: (bulk) => {
+            bulk.toggleAllSpaceToTab();
+        },
+    },
+    toPosixLines: {
+        isSupported: () => true,
+        get: (item) => item.toPosixLines,
+        set: (item, value) => {
+            item.toPosixLines = value;
+        },
+        getBulkState: (bulk) => ({
+            checked: bulk.allToPosixLines.value,
+            indeterminate: bulk.toPosixLinesIndeterminate.value,
+        }),
+        toggleBulk: (bulk) => {
+            bulk.toggleAllToPosixLines();
+        },
+    },
+    autoDecompress: {
+        isSupported: () => true,
+        get: (item) => item.autoDecompress,
+        set: (item, value) => {
+            item.autoDecompress = value;
+        },
+        getBulkState: (bulk) => ({
+            checked: bulk.allAutoDecompress.value,
+            indeterminate: bulk.autoDecompressIndeterminate.value,
+        }),
+        toggleBulk: (bulk) => {
+            bulk.toggleAllAutoDecompress();
+        },
+    },
+    deferred: {
+        isSupported: (item) => "deferred" in item,
+        get: (item) => item.deferred ?? false,
+        set: (item, value) => {
+            if ("deferred" in item) {
+                item.deferred = value;
+            }
+        },
+        getBulkState: (bulk) => ({
+            checked: bulk.allDeferred.value,
+            indeterminate: bulk.deferredIndeterminate.value,
+        }),
+        toggleBulk: (bulk) => {
+            bulk.toggleAllDeferred();
+        },
+    },
+};
+
+export function useUploadOptionBindings<T extends BulkUploadItem>(
+    bulk: BulkUploadOperations,
+    optionVisibility: ComputedRef<UploadOptionVisibility>,
+) {
+    const headerOptions = computed<HeaderOptionDescriptor[]>(() => {
+        const visibility = optionVisibility.value;
+
+        return uploadOptionDefinitions
+            .filter((definition) => isUploadOptionVisible(definition.key, visibility))
+            .map((definition) => {
+                const state = optionAdapters[definition.key].getBulkState(bulk);
+
+                return {
+                    key: definition.key,
+                    label: definition.label,
+                    title: definition.headerTooltip,
+                    checked: state.checked,
+                    indeterminate: state.indeterminate,
+                };
+            });
+    });
+
+    const headerOptionProps = computed<HeaderOptionProps>(() => {
+        return {
+            options: headerOptions.value,
+        };
+    });
+
+    const headerOptionEvents = computed<HeaderOptionEvents>(() => {
+        return {
+            toggle: (key: UploadOptionKey) => {
+                optionAdapters[key].toggleBulk(bulk);
+            },
+        };
+    });
+
+    function getRowOptionProps(item: T): RowOptionProps {
+        const visibility = optionVisibility.value;
+
+        return {
+            options: uploadOptionDefinitions
+                .filter((definition) => isUploadOptionVisible(definition.key, visibility))
+                .filter((definition) => optionAdapters[definition.key].isSupported(item))
+                .map((definition) => ({
+                    key: definition.key,
+                    label: definition.label,
+                    title: definition.rowTooltip,
+                    checked: optionAdapters[definition.key].get(item),
+                })),
+        };
+    }
+
+    function getRowOptionEvents(item: T): RowOptionEvents {
+        return {
+            update: ({ key, value }: { key: UploadOptionKey; value: boolean }) => {
+                optionAdapters[key].set(item, value);
+            },
+        };
+    }
+
+    return {
+        headerOptionProps,
+        headerOptionEvents,
+        getRowOptionProps,
+        getRowOptionEvents,
+    };
+}

--- a/client/src/composables/upload/uploadOptionModel.ts
+++ b/client/src/composables/upload/uploadOptionModel.ts
@@ -1,0 +1,75 @@
+import type { UploadOptionVisibility } from "@/components/Panels/Upload/shared/uploadOptionVisibility";
+
+export type UploadOptionKey = "spaceToTab" | "toPosixLines" | "deferred" | "autoDecompress";
+
+export interface UploadOptionDefinition {
+    key: UploadOptionKey;
+    visibilityKey: keyof UploadOptionVisibility;
+    label: string;
+    headerTooltip: string;
+    rowTooltip: string;
+    defaultValue: boolean;
+}
+
+export const uploadOptionDefinitions: UploadOptionDefinition[] = [
+    {
+        key: "spaceToTab",
+        visibilityKey: "spaceToTab",
+        label: "Spaces→Tabs",
+        headerTooltip: "Toggle all: Convert spaces to tab characters",
+        rowTooltip: "Convert spaces to tab characters",
+        defaultValue: false,
+    },
+    {
+        key: "toPosixLines",
+        visibilityKey: "posix",
+        label: "POSIX",
+        headerTooltip: "Toggle all: Convert line endings to POSIX standard",
+        rowTooltip: "Convert line endings to POSIX standard",
+        defaultValue: false,
+    },
+    {
+        key: "deferred",
+        visibilityKey: "deferred",
+        label: "Deferred",
+        headerTooltip: "Toggle all: Galaxy will store a reference and fetch data only when needed by a tool",
+        rowTooltip: "Galaxy will store a reference and fetch data only when needed by a tool",
+        defaultValue: false,
+    },
+    {
+        key: "autoDecompress",
+        visibilityKey: "autoDecompress",
+        label: "Auto-decompress",
+        headerTooltip: "Toggle all: Disable automatic decompression of compressed inputs",
+        rowTooltip: "Automatic decompression of compressed inputs after upload",
+        defaultValue: true,
+    },
+];
+
+export const uploadOptionDefinitionByKey: Record<UploadOptionKey, UploadOptionDefinition> =
+    uploadOptionDefinitions.reduce(
+        (acc, definition) => {
+            acc[definition.key] = definition;
+            return acc;
+        },
+        {} as Record<UploadOptionKey, UploadOptionDefinition>,
+    );
+
+export function isUploadOptionVisible(key: UploadOptionKey, visibility: UploadOptionVisibility): boolean {
+    const definition = uploadOptionDefinitionByKey[key];
+    return visibility[definition.visibilityKey];
+}
+
+export const uploadOptionDefaults = {
+    spaceToTab: uploadOptionDefinitions.find((option) => option.key === "spaceToTab")?.defaultValue ?? false,
+    toPosixLines: uploadOptionDefinitions.find((option) => option.key === "toPosixLines")?.defaultValue ?? false,
+    deferred: uploadOptionDefinitions.find((option) => option.key === "deferred")?.defaultValue ?? false,
+    autoDecompress: uploadOptionDefinitions.find((option) => option.key === "autoDecompress")?.defaultValue ?? true,
+} as const;
+
+export const uploadApiOptionDefaults = {
+    space_to_tab: uploadOptionDefaults.spaceToTab,
+    to_posix_lines: uploadOptionDefaults.toPosixLines,
+    deferred: uploadOptionDefaults.deferred,
+    auto_decompress: uploadOptionDefaults.autoDecompress,
+} as const;

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -158,7 +158,7 @@ confirm_dialog:
     _: '#galaxy-confirm-dialog'
     message: '[data-description="confirm dialog message"]'
     ok_button: '[data-description="confirm dialog ok"]'
-    cancel_button: '[data-description="confirm dialog cancel"]' 
+    cancel_button: '[data-description="confirm dialog cancel"]'
 
 dataset_view:
   selectors:
@@ -1426,8 +1426,8 @@ beta_upload:
     paste_content_row_toggle_button: '[data-test-id="paste-content-toggle-${row}"]'
     paste_content_row_textarea: '[data-test-id="paste-content-textarea-${row}"]'
     row_remove_button: '[data-test-id="upload-row-${row}-remove"]'
-    paste_links_row_deferred_checkbox: '.url-table tbody tr:nth-child(${row}) [data-test-id="deferred-toggle"] input[type="checkbox"]'
-    paste_links_row_deferred_label: '.url-table tbody tr:nth-child(${row}) [data-test-id="deferred-toggle"] label'
+    paste_links_row_deferred_checkbox: '.url-table tbody tr:nth-child(${row}) [data-test-id="deferred-toggle"]'
+    paste_links_row_deferred_label: '.url-table tbody tr:nth-child(${row}) [data-test-id="deferred-toggle"] + label'
     # Target-history selectors (TargetHistorySelector inside UploadMethodView)
     target_history_change_link: '.target-history-banner .change-history-link'
     history_selector_modal: '.g-dialog'
@@ -1446,7 +1446,7 @@ beta_upload:
     # Remote-files selectors
     remote_files_browser_label: '[data-test-id="remote-files-browser-label"][data-label="${label}"]'
     remote_files_select_all: '[data-test-id="remote-files-select-all"] .custom-control-label'
-    remote_files_item_checkbox: 
+    remote_files_item_checkbox:
       type: xpath
       selector: '//span[contains(@data-test-id, "remote-files-browser-label") and normalize-space()="${label}"]/ancestor::*[contains(@class, "media") or contains(@class, "row") or contains(@role, "row")]//input[@type="checkbox"]'
     remote_files_add_selected: '[data-test-id="remote-files-add-selected"]'
@@ -1454,7 +1454,7 @@ beta_upload:
     data_library_library_label: '[data-test-id="data-library-browser-library-label"][data-label="${label}"]'
     data_library_item_label: '[data-test-id="data-library-browser-item-label"][data-label="${label}"]'
     data_library_select_all: '[data-test-id="data-library-select-all"] input[type="checkbox"]'
-    data_library_item_checkbox: 
+    data_library_item_checkbox:
       type: xpath
       selector: '//span[contains(@data-test-id, "data-library-browser-item-label") and normalize-space()="${label}"]/ancestor::*[contains(@class, "media") or contains(@class, "row") or contains(@role, "row")]//input[@type="checkbox"]'
     data_library_add_selected: '[data-test-id="data-library-add-selected"]'

--- a/client/src/utils/upload.test.ts
+++ b/client/src/utils/upload.test.ts
@@ -357,6 +357,7 @@ describe("createFileUploadItem", () => {
         expect(item.space_to_tab).toBe(uploadItemDefaults.space_to_tab);
         expect(item.to_posix_lines).toBe(uploadItemDefaults.to_posix_lines);
         expect(item.deferred).toBe(uploadItemDefaults.deferred);
+        expect(item.auto_decompress).toBe(uploadItemDefaults.auto_decompress);
     });
 
     test("creates file upload item with custom options", () => {
@@ -368,6 +369,7 @@ describe("createFileUploadItem", () => {
             space_to_tab: true,
             to_posix_lines: false,
             deferred: true,
+            auto_decompress: false,
         });
 
         expect(item.name).toBe("custom.bed");
@@ -376,6 +378,7 @@ describe("createFileUploadItem", () => {
         expect(item.space_to_tab).toBe(true);
         expect(item.to_posix_lines).toBe(false);
         expect(item.deferred).toBe(true);
+        expect(item.auto_decompress).toBe(false);
     });
 });
 
@@ -390,11 +393,17 @@ describe("createPastedUploadItem", () => {
         expect(item.size).toBe("pasted content".length);
         expect(item.dbkey).toBe(uploadItemDefaults.dbkey);
         expect(item.ext).toBe(uploadItemDefaults.ext);
+        expect(item.auto_decompress).toBe(uploadItemDefaults.auto_decompress);
     });
 
     test("creates pasted upload item with custom name", () => {
         const item = createPastedUploadItem("content", "historyId", { name: "MyPaste.txt" });
         expect(item.name).toBe("MyPaste.txt");
+    });
+
+    test("creates pasted upload item with custom auto_decompress", () => {
+        const item = createPastedUploadItem("content", "historyId", { auto_decompress: false });
+        expect(item.auto_decompress).toBe(false);
     });
 });
 
@@ -409,6 +418,7 @@ describe("createUrlUploadItem", () => {
         expect(item.size).toBe(0);
         expect(item.dbkey).toBe(uploadItemDefaults.dbkey);
         expect(item.deferred).toBe(uploadItemDefaults.deferred);
+        expect(item.auto_decompress).toBe(uploadItemDefaults.auto_decompress);
     });
 
     test("extracts filename from URL path", () => {
@@ -421,11 +431,13 @@ describe("createUrlUploadItem", () => {
             name: "custom-name.bed",
             deferred: true,
             dbkey: "hg38",
+            auto_decompress: false,
         });
 
         expect(item.name).toBe("custom-name.bed");
         expect(item.deferred).toBe(true);
         expect(item.dbkey).toBe("hg38");
+        expect(item.auto_decompress).toBe(false);
     });
 
     test("trims surrounding whitespace from URL", () => {
@@ -522,6 +534,22 @@ describe("buildUploadPayload", () => {
         expect(result.targets).toHaveLength(1);
         expect(result.targets[0]!.destination).toEqual({ type: "hdas" });
         expect(result.targets[0]!.elements).toHaveLength(1);
+
+        const element = result.targets[0]!.elements![0] as { auto_decompress: boolean };
+        expect(element.auto_decompress).toBe(true);
+    });
+
+    test("builds payload preserving item auto_decompress setting", () => {
+        const items: ApiUploadItem[] = [
+            createPastedUploadItem("content", "historyId", {
+                name: "manual.txt",
+                auto_decompress: false,
+            }),
+        ];
+
+        const result = buildUploadPayload(items);
+        const element = result.targets[0]!.elements![0] as { auto_decompress: boolean };
+        expect(element.auto_decompress).toBe(false);
     });
 
     test("builds composite payload", () => {

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -56,6 +56,7 @@ import type { PreparedUpload } from "@/components/Panels/Upload/types";
 import type { UploadRowModel } from "@/components/Upload/model";
 import type { SupportedCollectionType, UploadCollectionConfig } from "@/composables/upload/collectionTypes";
 import type { NewUploadItem } from "@/composables/upload/uploadItemTypes";
+import { uploadApiOptionDefaults } from "@/composables/upload/uploadOptionModel";
 import { getAppRoot } from "@/onload/loadConfig";
 import { errorMessageAsString } from "@/utils/simple-error";
 import { isUrl, isValidUrl } from "@/utils/url";
@@ -227,10 +228,7 @@ export interface UploadDatasetsConfig extends FetchDatasetsCallbacks, BuildPaylo
 export const uploadItemDefaults = {
     dbkey: "?",
     ext: "auto",
-    space_to_tab: false,
-    to_posix_lines: true,
-    deferred: false,
-    auto_decompress: true,
+    ...uploadApiOptionDefaults,
 } as const;
 
 // ============================================================================

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -230,6 +230,7 @@ export const uploadItemDefaults = {
     space_to_tab: false,
     to_posix_lines: true,
     deferred: false,
+    auto_decompress: true,
 } as const;
 
 // ============================================================================
@@ -351,7 +352,7 @@ export function createFileUploadItem(
         to_posix_lines: options.to_posix_lines ?? uploadItemDefaults.to_posix_lines,
         deferred: options.deferred ?? uploadItemDefaults.deferred,
         hashes: options.hashes,
-        auto_decompress: true,
+        auto_decompress: options.auto_decompress ?? uploadItemDefaults.auto_decompress ?? true,
     };
 }
 
@@ -388,7 +389,7 @@ export function createPastedUploadItem(
         to_posix_lines: options.to_posix_lines ?? uploadItemDefaults.to_posix_lines,
         deferred: options.deferred ?? uploadItemDefaults.deferred,
         hashes: options.hashes,
-        auto_decompress: true,
+        auto_decompress: options.auto_decompress ?? uploadItemDefaults.auto_decompress ?? true,
     };
 }
 
@@ -430,7 +431,7 @@ export function createUrlUploadItem(
         to_posix_lines: options.to_posix_lines ?? uploadItemDefaults.to_posix_lines,
         deferred: options.deferred ?? uploadItemDefaults.deferred,
         hashes: options.hashes,
-        auto_decompress: true,
+        auto_decompress: options.auto_decompress ?? uploadItemDefaults.auto_decompress ?? true,
     };
 }
 
@@ -455,7 +456,7 @@ export function toApiUploadItem(item: NewUploadItem): ApiUploadItem {
         to_posix_lines: item.toPosixLines,
         deferred: item.deferred,
         hashes: item.hashes,
-        auto_decompress: true,
+        auto_decompress: item.autoDecompress ?? true,
     };
 
     switch (item.uploadMode) {
@@ -543,7 +544,7 @@ function buildDataElement(item: ApiUploadItem): ApiDataElement {
         name: normalizeFileName(item.name),
         space_to_tab: item.space_to_tab,
         to_posix_lines: item.to_posix_lines,
-        auto_decompress: true,
+        auto_decompress: item.auto_decompress ?? uploadItemDefaults.auto_decompress ?? true,
         deferred: item.deferred,
     };
 

--- a/client/src/utils/upload/itemMappers.ts
+++ b/client/src/utils/upload/itemMappers.ts
@@ -34,6 +34,7 @@ export function mapToLocalFileUpload(item: LocalFileItem, targetHistoryId: strin
         extension: item.extension,
         spaceToTab: item.spaceToTab,
         toPosixLines: item.toPosixLines,
+        autoDecompress: item.autoDecompress,
         deferred: false,
         fileData: item.file,
     };
@@ -52,6 +53,7 @@ export function mapToPasteContentUpload(item: PasteContentItem, targetHistoryId:
         extension: item.extension,
         spaceToTab: item.spaceToTab,
         toPosixLines: item.toPosixLines,
+        autoDecompress: item.autoDecompress,
         deferred: false,
         content: item.content,
     };
@@ -70,6 +72,7 @@ export function mapToPasteUrlUpload(item: PasteUrlItem, targetHistoryId: string)
         extension: item.extension,
         spaceToTab: item.spaceToTab,
         toPosixLines: item.toPosixLines,
+        autoDecompress: item.autoDecompress,
         deferred: item.deferred,
         url: item.url.trim(),
     };
@@ -88,6 +91,7 @@ export function mapToRemoteFileUpload(item: RemoteFileItem, targetHistoryId: str
         extension: item.extension,
         spaceToTab: item.spaceToTab,
         toPosixLines: item.toPosixLines,
+        autoDecompress: item.autoDecompress,
         deferred: item.deferred,
         url: item.url,
         hashes: item.hashes,
@@ -107,6 +111,7 @@ export function mapToLibraryDatasetUpload(item: LibraryDatasetItem, targetHistor
         extension: item.extension,
         spaceToTab: false, // Not applicable to library imports
         toPosixLines: false, // Not applicable to library imports
+        autoDecompress: false, // Not applicable to library imports
         libraryId: item.libraryId,
         folderId: item.folderId,
         lddaId: item.lddaId,
@@ -176,6 +181,7 @@ export function mapToCompositeFileUpload(item: CompositeFileItem, targetHistoryI
         extension: item.extension,
         spaceToTab: false,
         toPosixLines: false,
+        autoDecompress: false,
         deferred: false,
         slots,
     };


### PR DESCRIPTION
Resolves #22504

Includes a refactoring to reduce duplication around upload settings handling and make it easier to add new settings in the future.

<img width="1528" height="993" alt="Screenshot from 2026-05-18 14-46-08" src="https://github.com/user-attachments/assets/61d659a4-b921-4c96-a1cb-4f7ed7804efc" />

<img width="1528" height="993" alt="Screenshot from 2026-05-18 14-46-30" src="https://github.com/user-attachments/assets/1aa357c3-c44e-47c3-88fc-452fbe602bd1" />


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
