### PR TITLE
Unify remove button icons across upload methods

### DIFF
--- a/client/src/components/Panels/Upload/methods/CompositeSlotRow.vue
+++ b/client/src/components/Panels/Upload/methods/CompositeSlotRow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faCheck, faCloud, faEdit, faExclamation, faLaptop, faLink, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faCloud, faEdit, faExclamation, faLaptop, faLink, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BDropdown, BDropdownItem, BFormInput, BFormTextarea } from "bootstrap-vue";
 import { computed, ref } from "vue";
@@ -253,7 +253,7 @@ const display = computed(() => {
                 title="Clear this slot"
                 class="flex-shrink-0"
                 @click="clearSlot">
-                <FontAwesomeIcon :icon="faTimes" fixed-width />
+                <FontAwesomeIcon :icon="faTrash" fixed-width />
             </GButton>
             <!-- Spacer to keep layout stable when no clear button -->
             <span v-else class="slot-clear-placeholder" />

--- a/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
+++ b/client/src/components/Panels/Upload/methods/DataLibraryUpload.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faDatabase, faFile, faFolder, faLock, faPlus, faShieldAlt, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faDatabase, faFile, faFolder, faLock, faPlus, faShieldAlt, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BFormCheckbox, BPagination } from "bootstrap-vue";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
@@ -911,12 +911,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                         <GButton
                             v-g-tooltip.hover
                             class="remove-btn"
-                            color="red"
                             outline
                             transparent
                             title="Remove dataset from list"
                             @click="removeItem(item.id)">
-                            <FontAwesomeIcon :icon="faTimes" />
+                            <FontAwesomeIcon :icon="faTrash" />
                         </GButton>
                     </template>
                 </GTable>

--- a/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
+++ b/client/src/components/Panels/Upload/methods/LocalFileUpload.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faCloudUploadAlt, faLaptop, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faCloudUploadAlt, faLaptop, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, ref, watch } from "vue";
 
@@ -313,12 +313,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                                 v-g-tooltip.hover
                                 class="remove-btn"
                                 :data-test-id="`upload-row-${index + 1}-remove`"
-                                color="red"
                                 outline
                                 transparent
                                 title="Remove file from list"
                                 @click="removeFile(index)">
-                                <FontAwesomeIcon :icon="faTimes" />
+                                <FontAwesomeIcon :icon="faTrash" />
                             </GButton>
                         </template>
                     </GTable>

--- a/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteContentUpload.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faChevronDown, faChevronRight, faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faChevronRight, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
 
@@ -445,12 +445,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             v-g-tooltip.hover
                             class="remove-btn"
                             :data-test-id="`upload-row-${index + 1}-remove`"
-                            color="red"
                             outline
                             transparent
                             title="Remove dataset from list"
                             @click="removeItem(item.id)">
-                            <FontAwesomeIcon :icon="faTimes" />
+                            <FontAwesomeIcon :icon="faTrash" />
                         </GButton>
                     </template>
 

--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faLink, faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faLink, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BFormInput } from "bootstrap-vue";
 import { computed, nextTick, ref, watch } from "vue";
@@ -361,12 +361,11 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                             v-g-tooltip.hover
                             class="remove-btn"
                             :data-test-id="`upload-row-${index + 1}-remove`"
-                            color="red"
                             outline
                             transparent
                             title="Remove URL from list"
                             @click="removeItem(item.id)">
-                            <FontAwesomeIcon :icon="faTimes" />
+                            <FontAwesomeIcon :icon="faTrash" />
                         </GButton>
                     </template>
                 </GTable>

--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faFolder, faGlobe, faPlus, faTimes, faUser } from "@fortawesome/free-solid-svg-icons";
+import { faFolder, faGlobe, faPlus, faTrash, faUser } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { BAlert, BFormCheckbox, BFormInput, BPagination } from "bootstrap-vue";
 import { computed, nextTick, onMounted, ref, watch } from "vue";
@@ -863,13 +863,15 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
 
                     <!-- Actions column -->
                     <template v-slot:cell(actions)="{ item }">
-                        <button
+                        <GButton
                             v-g-tooltip.hover
-                            class="btn btn-link text-danger remove-btn"
+                            class="remove-btn"
+                            outline
+                            transparent
                             title="Remove file from list"
                             @click="removeItem(item.id)">
-                            <FontAwesomeIcon :icon="faTimes" />
-                        </button>
+                            <FontAwesomeIcon :icon="faTrash" />
+                        </GButton>
                     </template>
                 </GTable>
             </div>


### PR DESCRIPTION
Addresses https://github.com/galaxyproject/galaxy/pull/22711#issuecomment-4478226035

Replaced the red cross icon that could be confused with an error with the widely used "trash" icon for clarity.

<img width="1435" height="664" alt="image" src="https://github.com/user-attachments/assets/97b7aaf3-9e18-4b20-9116-b0309fae2fae" />


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
