### PR TITLE
[26.0] Fix data source tool redirect back to Galaxy SPA

### DIFF
--- a/client/src/entry/analysis/modules/Home.vue
+++ b/client/src/entry/analysis/modules/Home.vue
@@ -10,6 +10,8 @@
 <script>
 import decodeUriComponent from "decode-uri-component";
 
+import { Toast } from "@/composables/toast";
+
 import ToolForm from "@/components/Tool/ToolForm.vue";
 import WorkflowRun from "@/components/Workflow/Run/WorkflowRun.vue";
 import CenterFrame from "@/entry/analysis/modules/CenterFrame.vue";
@@ -29,6 +31,19 @@ export default {
             type: Object,
             required: true,
         },
+    },
+    mounted() {
+        // Data source tools redirect back to the SPA after a server-side
+        // import; surface a toast and strip the param so a reload doesn't
+        // re-fire it.
+        if (this.query.notification === "tool-submitted") {
+            this.$nextTick(() => {
+                Toast.info("Check your history panel for progress.", "Data import queued");
+            });
+            const newQuery = { ...this.$route.query };
+            delete newQuery.notification;
+            this.$router.replace({ query: newQuery });
+        }
     },
     computed: {
         isController() {

--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -17,6 +17,7 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.hash_util import hmac_new
+from galaxy.web import url_for
 from galaxy.webapps.base.controller import BaseUIController
 
 log = logging.getLogger(__name__)
@@ -230,6 +231,6 @@ class ASync(BaseUIController):
 
             trans.sa_session.commit()
 
-        return trans.show_ok_message(
-            "A job has been successfully added to the queue. You can check the status of queued jobs in the History panel."
-        )
+        # Return the user to the Galaxy SPA; the frontend surfaces a toast
+        # based on the `notification` query parameter.
+        return trans.response.send_redirect(url_for("/?notification=tool-submitted"))

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -122,16 +122,13 @@ class ToolRunner(BaseUIController):
             error(galaxy.util.unicodify(e))
         if len(params) > 0:
             trans.log_event(f"Tool params: {str(params)}", tool_id=tool_id)
-        status_text = "You can check the status of queued jobs in the History panel."
         if job_errors := vars.get("job_errors"):
             errors = "\n".join(f"- {job_error}" for job_error in job_errors)
             message = f"There were errors setting up {len(job_errors)} submitted job(s):\n{errors}"
             return trans.show_error_message(message)
-        if (num_jobs := vars.get("num_jobs")) > 1:
-            message = f"{num_jobs} jobs have been successfully added to the queue. {status_text}"
-        else:
-            message = f"A job has been successfully added to the queue. {status_text}"
-        return trans.show_ok_message(message)
+        # Return the user to the Galaxy SPA; the frontend surfaces a toast
+        # based on the `notification` query parameter.
+        return trans.response.send_redirect(url_for("/?notification=tool-submitted"))
 
     @web.expose
     def rerun(self, trans, id=None, job_id=None, **kwd):

--- a/lib/galaxy_test/api/test_authenticate.py
+++ b/lib/galaxy_test/api/test_authenticate.py
@@ -42,13 +42,14 @@ class TestAuthenticateApi(ApiTestCase):
         tool_runner_response = get(
             urljoin(self.url, "tool_runner?tool_id=test_data_source"),
             cookies={"galaxytoolrunnersession": tool_runner_session_cookie},
+            allow_redirects=False,
         )
-        tool_runner_response.raise_for_status()
+        # On success, the controller redirects back to the SPA so the
+        # frontend can surface a "tool-submitted" toast.
+        assert tool_runner_response.status_code == 302
+        assert "notification=tool-submitted" in tool_runner_response.headers["Location"]
         # Verify that we're not returning the sessioncookie
         assert "galaxysession" not in tool_runner_response.cookies
-        # Verify text message
-        text = tool_runner_response.text
-        assert "A job has been successfully added to the queue." in text
         # Make sure history for original session received job
         current_history_json_response = get(
             urljoin(self.url, "history/current_history_json"), cookies={"galaxysession": galaxy_session_cookie}

--- a/lib/galaxy_test/selenium/test_data_source_tools.py
+++ b/lib/galaxy_test/selenium/test_data_source_tools.py
@@ -12,6 +12,7 @@ from .framework import (
 
 class TestDataSource(SeleniumTestCase, UsesHistoryItemAssertions):
     ensure_registered = True
+    framework_tool_and_types = True
 
     @pytest.mark.skip("Skipping UCSC table direct1 data source test, chromedriver fails captcha")
     @selenium_test
@@ -38,3 +39,20 @@ class TestDataSource(SeleniumTestCase, UsesHistoryItemAssertions):
         self.history_panel_wait_for_hid_ok(1, allowed_force_refreshes=2)
         # Make sure we're still logged in (xref https://github.com/galaxyproject/galaxy/issues/11374)
         self.components.masthead.logged_in_only.wait_for_visible()
+
+    @selenium_test
+    @managed_history
+    def test_tool_runner_redirects_to_spa(self):
+        """Data source tools redirect back to the Galaxy SPA after handing off control to the controller.
+
+        Regression test for https://github.com/galaxyproject/galaxy/issues/22671: the new tab opened
+        by an external data source app used to hit `/tool_runner?tool_id=...` and then JS-redirect
+        back to `/`. After the mako removal the new tab was stranded on a static "ok" page; the
+        controller now sends a 302 to `/?notification=tool-submitted` and the SPA surfaces a toast.
+        """
+        self.get("tool_runner?tool_id=test_data_source")
+        # If the redirect is broken we land on a static page with no masthead.
+        self.wait_for_masthead()
+        # Confirm the SPA queued a toast from the notification query param.
+        self.wait_for_selector_visible(".b-toast")
+        self.screenshot("tool_runner_redirect_toast")


### PR DESCRIPTION
The mako-template removal in 76341658dcc deleted the JavaScript `top.location.href = '/'` redirect that returned the user to Galaxy after an external data source import in a new tab. The replacement `show_ok_message` rendered a static page, leaving the new tab stranded on a "job queued" message instead of navigating back to the SPA.

Restore the redirect with a 302 to `/?notification=tool-submitted` from both `ToolRunner.index` and `ASync.index`, and have `Home.vue` surface a `useToast` notification on landing (then strip the query param so a reload doesn't re-fire it).

Fixes #22671

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
