### PR TITLE
Drop dead history_id kwarg from QueueJobs construction

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -286,7 +286,6 @@ class JobsService(ServiceBase):
         )
         task_request = QueueJobs(
             user=trans.async_request_user,
-            history_id=target_history and target_history.id,
             tool_source=tool_source,
             tool_request_id=tool_request_id,
             use_cached_jobs=job_request.use_cached_jobs or False,


### PR DESCRIPTION
QueueJobs has no history_id field; pydantic silently ignored it. The celery flow takes history from tool_request.history (set on the ToolRequest model at request creation), not from the message.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
