### PR TITLE
Fix galaxy_task DI injection on Python 3.14

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -172,6 +172,16 @@ def tear_down_pool(sig, how, exitcode, **kwargs):
 def galaxy_task(*args, action=None, **celery_task_kwd):
     if "serializer" not in celery_task_kwd:
         celery_task_kwd["serializer"] = PYDANTIC_AWARE_SERIALIZER_NAME
+    # Galaxy tasks rely on ``app.magic_partial(func)`` (below) to inject
+    # DI dependencies — typically ``sa_session`` and manager instances —
+    # at task-execution time. Celery's ``apply_async`` runs
+    # ``check_arguments`` against the wrapped function's *original*
+    # signature *before* the task body fires, so any DI-injected
+    # positional shows up as missing (``TypeError: set_job_metadata()
+    # missing 1 required positional argument: 'sa_session'``). Disabling
+    # ``typing`` for every Galaxy task lets the DI flow work as designed;
+    # individual call sites still pass their non-DI args explicitly.
+    celery_task_kwd.setdefault("typing", False)
 
     def decorate(func: Callable):
         @shared_task(base=GalaxyTask, **celery_task_kwd)


### PR DESCRIPTION
Every ``@galaxy_task`` relies on ``app.magic_partial(func)`` (in the wrapper itself) to inject DI dependencies — typically ``sa_session: galaxy_scoped_session`` and manager instances declared on the function signature — at task-execution time. Celery's ``apply_async`` runs ``check_arguments(*args, **kwargs)`` against the *original* function signature before the task body fires, and that check has no visibility into magic_partial. Net effect: every Galaxy celery task that takes a DI-injected positional crashes at ``.delay()`` with ``TypeError: <task>() missing 1 required positional argument: 'sa_session'``.

The failure mode was hidden on older celery / Python combos because ``Task.typing`` (which gates the pre-call check) interacted differently with the signature ``head_from_fun`` generated. On celery 5.6.x + Python 3.14 it surfaces consistently — most visibly in
``test_run_specific_version_executes_that_version`` where ``set_job_metadata.delay(...)`` doesn't pass ``sa_session`` and the metadata-setting job fails before it runs.

Set ``typing=False`` as the default in ``galaxy_task``: every Galaxy celery task already uses DI injection, so the pre-call check would never be correct for them anyway. Individual call sites still pass their non-DI args explicitly; the DI-injected ones are populated by ``magic_partial`` at execution. Callers that want celery's typing check back can pass ``typing=True`` explicitly.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
