### PR TITLE
More structured HistoryGraph API references

### DIFF
--- a/client/src/api/schema/schema.ts
+++ b/client/src/api/schema/schema.ts
@@ -13134,10 +13134,8 @@ export interface components {
         };
         /** GraphEdge */
         GraphEdge: {
-            /** Source */
-            source: string;
-            /** Target */
-            target: string;
+            source: components["schemas"]["NodeRef"];
+            target: components["schemas"]["NodeRef"];
             /**
              * Type
              * @enum {string}
@@ -13158,17 +13156,17 @@ export interface components {
             id: string;
             /** Name */
             name?: string | null;
+            /**
+             * Src
+             * @enum {string}
+             */
+            src: "hda" | "hdca" | "tool_request";
             /** State */
             state?: string | null;
             /** Tool Id */
             tool_id?: string | null;
             /** Tool Name */
             tool_name?: string | null;
-            /**
-             * Type
-             * @enum {string}
-             */
-            type: "dataset" | "collection" | "tool_request";
             /** Visible */
             visible?: boolean | null;
         };
@@ -19002,6 +19000,20 @@ export interface components {
              * @constant
              */
             type: "no_options";
+        };
+        /**
+         * NodeRef
+         * @description A (src, id) reference to a graph node. Frozen so it is hashable
+         *     and usable directly as an edge endpoint and as an internal key.
+         */
+        NodeRef: {
+            /** Id */
+            id: string;
+            /**
+             * Src
+             * @enum {string}
+             */
+            src: "hda" | "hdca" | "tool_request";
         };
         /**
          * NotificationBroadcastUpdateRequest
@@ -39246,14 +39258,18 @@ export interface operations {
                 limit?: number;
                 /** @description Include deleted datasets and collections. */
                 include_deleted?: boolean;
-                /** @description Optional: focus on subgraph reachable from this node (e.g. d<encoded_id>). */
-                seed?: string | null;
+                /** @description Optional: src of the node to focus the subgraph on. Provide with seed_id. */
+                seed_src?: ("hda" | "hdca" | "tool_request") | null;
+                /** @description Optional: encoded id of the node to focus the subgraph on. Provide with seed_src. */
+                seed_id?: string | null;
                 /** @description Direction for seed-based subgraph extraction. */
                 direction?: "backward" | "forward" | "both";
                 /** @description Max depth for seed-based subgraph extraction. */
                 depth?: number;
-                /** @description Center the selection window on this item. Format: d{encoded_id} or c{encoded_id}. */
-                seed_scope?: string | null;
+                /** @description src of the item to center the selection window on. Required with seed_scope_id. */
+                seed_scope_src?: ("hda" | "hdca") | null;
+                /** @description Center the selection window on this encoded id. Provide with seed_scope_src. */
+                seed_scope_id?: string | null;
             };
             header?: {
                 /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */

--- a/client/src/components/History/Graph/HistoryGraphDetails.vue
+++ b/client/src/components/History/Graph/HistoryGraphDetails.vue
@@ -16,16 +16,13 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const nodeType = computed(() => (props.node?.data?.type as string) ?? null);
-const encodedId = computed(() => (props.node?.data?.encodedId as string) ?? null);
+const nodeSrc = computed(() => (props.node?.data?.src as string) ?? null);
+const itemId = computed(() => (props.node?.data?.itemId as string) ?? null);
 
-/** Map graph node type to the item source GenericHistoryItem expects */
+/** src GenericHistoryItem expects, for the item node kinds it can render */
 const itemSrc = computed(() => {
-    if (nodeType.value === "dataset") {
-        return "hda";
-    }
-    if (nodeType.value === "collection") {
-        return "hdca";
+    if (nodeSrc.value === "hda" || nodeSrc.value === "hdca") {
+        return nodeSrc.value;
     }
     return null;
 });
@@ -36,11 +33,11 @@ const jobLoading = ref(false);
 const jobError = ref<string | null>(null);
 
 watch(
-    () => [nodeType.value, encodedId.value],
-    async ([type, id]) => {
+    () => [nodeSrc.value, itemId.value],
+    async ([src, id]) => {
         jobId.value = null;
         jobError.value = null;
-        if (type !== "tool_request" || !id) {
+        if (src !== "tool_request" || !id) {
             return;
         }
         jobLoading.value = true;
@@ -69,15 +66,15 @@ watch(
     <div class="history-graph-details border-left bg-white">
         <div class="details-body">
             <!-- Dataset or Collection -->
-            <div v-if="itemSrc && encodedId" :key="encodedId" class="p-2">
+            <div v-if="itemSrc && itemId" :key="itemId" class="p-2">
                 <Heading h1 separator inline size="md">
-                    {{ nodeType === "dataset" ? "Dataset Information" : "Collection Information" }}
+                    {{ nodeSrc === "hda" ? "Dataset Information" : "Collection Information" }}
                 </Heading>
-                <GenericHistoryItem :item-id="encodedId" :item-src="itemSrc" />
+                <GenericHistoryItem :item-id="itemId" :item-src="itemSrc" />
             </div>
 
             <!-- Tool request / Job details -->
-            <div v-else-if="nodeType === 'tool_request'" class="p-2">
+            <div v-else-if="nodeSrc === 'tool_request'" class="p-2">
                 <LoadingSpan v-if="jobLoading" message="Loading job details" />
                 <BAlert v-else-if="jobError" variant="info" show class="mb-0">{{ jobError }}</BAlert>
                 <JobInformation v-else-if="jobId" :job-id="jobId" :include-times="true" />

--- a/client/src/components/History/Graph/HistoryGraphView.vue
+++ b/client/src/components/History/Graph/HistoryGraphView.vue
@@ -20,7 +20,8 @@ import LoadingSpan from "@/components/LoadingSpan.vue";
 
 interface Props {
     historyId: string;
-    seedNodeId?: string;
+    seedSrc?: string;
+    seedId?: string;
 }
 
 const props = defineProps<Props>();
@@ -32,7 +33,15 @@ const historyName = computed(() => historyStore.getHistoryNameById(props.history
 // Fetch params — product decisions owned here
 const limit = ref(500);
 
-const { graphData, loading, error } = useHistoryGraphData(toRef(props, "historyId"), limit, toRef(props, "seedNodeId"));
+const { graphData, loading, error } = useHistoryGraphData(
+    toRef(props, "historyId"),
+    limit,
+    toRef(props, "seedSrc"),
+    toRef(props, "seedId"),
+);
+
+// Renderer focus key mirrors the mapper's `${src}:${id}` node key.
+const focusNodeId = computed(() => (props.seedSrc && props.seedId ? `${props.seedSrc}:${props.seedId}` : null));
 
 // Layout
 const edgeStyle = ref<EdgeStyle>("orthogonal");
@@ -88,7 +97,7 @@ const isTruncated = computed(() => graphData.value?.truncated?.item_count_capped
             <div class="history-graph-content">
                 <GraphView
                     :layout="layout"
-                    :focus-node-id="seedNodeId ?? null"
+                    :focus-node-id="focusNodeId"
                     :edge-style="edgeStyle"
                     :minimap-component="HistoryGraphMinimap"
                     @nodeSelected="onNodeSelected" />

--- a/client/src/components/History/Graph/historyGraphMapper.ts
+++ b/client/src/components/History/Graph/historyGraphMapper.ts
@@ -43,33 +43,38 @@ function computeNodeHeight(
     return headerHeight + portRows * PORT_ROW_HEIGHT + rule + BODY_PADDING + badgeRow;
 }
 
-/** User-facing type labels */
+/** User-facing labels keyed by node src */
 export const NODE_TYPE_LABELS: Record<string, string> = {
-    dataset: "Dataset",
-    collection: "Collection",
+    hda: "Dataset",
+    hdca: "Collection",
     tool_request: "Tool Execution",
 };
 
 const NODE_ICONS: Record<string, typeof faFile> = {
-    dataset: faFile,
-    collection: faLayerGroup,
+    hda: faFile,
+    hdca: faLayerGroup,
     tool_request: faWrench,
 };
 
 const NODE_CSS_CLASS: Record<string, string> = {
-    dataset: "node-dataset",
-    collection: "node-collection",
+    hda: "node-dataset",
+    hdca: "node-collection",
     tool_request: "node-tool-request",
 };
+
+/** Stable string key for the generic renderer, derived from the (src, id) ref. */
+function nodeKey(ref: { src: string; id: string }): string {
+    return `${ref.src}:${ref.id}`;
+}
 
 // ── Label resolution ──
 
 function resolveNodeLabel(node: ApiGraphNode): string {
     const hid = node.hid ? `${node.hid}: ` : "";
-    switch (node.type) {
-        case "dataset":
+    switch (node.src) {
+        case "hda":
             return `${hid}${node.name ?? node.extension ?? "Dataset"}`;
-        case "collection":
+        case "hdca":
             return `${hid}${node.name ?? node.collection_type ?? "Collection"}`;
         case "tool_request":
             return node.tool_name ?? shortenToolId(node.tool_id);
@@ -77,10 +82,10 @@ function resolveNodeLabel(node: ApiGraphNode): string {
 }
 
 function resolveNodeBadge(node: ApiGraphNode): string | null {
-    switch (node.type) {
-        case "dataset":
+    switch (node.src) {
+        case "hda":
             return node.extension ?? null;
-        case "collection":
+        case "hdca":
             return node.collection_type ?? null;
         case "tool_request":
             return null;
@@ -111,40 +116,43 @@ function isCollectionEdge(edge: ApiGraphEdge): boolean {
  * Returns nodes with dimensions, labels, icons, badges, and domain data.
  */
 export function mapNodes(apiNodes: ApiGraphNode[], apiEdges: ApiGraphEdge[]): GraphNode[] {
-    // Build a lookup for node labels by ID
+    // Build a lookup for node labels by renderer key
     const nodeLabels = new Map<string, string>();
     for (const node of apiNodes) {
-        nodeLabels.set(node.id, resolveNodeLabel(node));
+        nodeLabels.set(nodeKey(node), resolveNodeLabel(node));
     }
 
     // Build input/output port lists per node from edges
     const inputPorts = new Map<string, GraphNodePort[]>();
     const outputPorts = new Map<string, GraphNodePort[]>();
     for (const edge of apiEdges) {
-        const sourceLabel = nodeLabels.get(edge.source) ?? edge.source;
-        const targetLabel = nodeLabels.get(edge.target) ?? edge.target;
+        const sourceKey = nodeKey(edge.source);
+        const targetKey = nodeKey(edge.target);
+        const sourceLabel = nodeLabels.get(sourceKey) ?? sourceKey;
+        const targetLabel = nodeLabels.get(targetKey) ?? targetKey;
 
         // Target node gets an input port labeled by the source
-        if (!inputPorts.has(edge.target)) {
-            inputPorts.set(edge.target, []);
+        if (!inputPorts.has(targetKey)) {
+            inputPorts.set(targetKey, []);
         }
-        inputPorts.get(edge.target)!.push({ name: edge.source, label: sourceLabel });
+        inputPorts.get(targetKey)!.push({ name: sourceKey, label: sourceLabel });
 
         // Source node gets an output port labeled by the target
-        if (!outputPorts.has(edge.source)) {
-            outputPorts.set(edge.source, []);
+        if (!outputPorts.has(sourceKey)) {
+            outputPorts.set(sourceKey, []);
         }
-        outputPorts.get(edge.source)!.push({ name: edge.target, label: targetLabel });
+        outputPorts.get(sourceKey)!.push({ name: targetKey, label: targetLabel });
     }
 
     return apiNodes.map((node) => {
+        const key = nodeKey(node);
         // Only tool_request nodes show input/output port lists.
         // Dataset and collection nodes show state + badge in the body.
-        const isToolRequest = node.type === "tool_request";
-        const inputs = isToolRequest ? (inputPorts.get(node.id) ?? []) : [];
-        const outputs = isToolRequest ? (outputPorts.get(node.id) ?? []) : [];
-        const inputCount = inputPorts.get(node.id)?.length ?? 0;
-        const outputCount = outputPorts.get(node.id)?.length ?? 0;
+        const isToolRequest = node.src === "tool_request";
+        const inputs = isToolRequest ? (inputPorts.get(key) ?? []) : [];
+        const outputs = isToolRequest ? (outputPorts.get(key) ?? []) : [];
+        const inputCount = inputPorts.get(key)?.length ?? 0;
+        const outputCount = outputPorts.get(key)?.length ?? 0;
         const badge = resolveNodeBadge(node);
 
         // For datasets/collections, use state to determine icon.
@@ -157,14 +165,14 @@ export function mapNodes(apiNodes: ApiGraphNode[], apiEdges: ApiGraphEdge[]): Gr
         const stateKey = displayState as keyof typeof STATES | undefined;
         const stateRep: StateRepresentation | null =
             !isToolRequest && stateKey && stateKey in STATES ? STATES[stateKey] : null;
-        const icon = stateRep?.icon ?? NODE_ICONS[node.type] ?? faFile;
-        const cssClass = NODE_CSS_CLASS[node.type];
+        const icon = stateRep?.icon ?? NODE_ICONS[node.src] ?? faFile;
+        const cssClass = NODE_CSS_CLASS[node.src];
 
         // Data nodes always have a body (badge + state text)
         const hasBody = !isToolRequest;
-        const label = nodeLabels.get(node.id)!;
+        const label = nodeLabels.get(key)!;
         return {
-            id: node.id,
+            id: key,
             x: 0,
             y: 0,
             width: NODE_WIDTH,
@@ -176,10 +184,10 @@ export function mapNodes(apiNodes: ApiGraphNode[], apiEdges: ApiGraphEdge[]): Gr
             inputs,
             outputs,
             data: {
-                type: node.type,
-                typeLabel: NODE_TYPE_LABELS[node.type] ?? node.type,
-                /** Encoded ID without the type prefix (d/c/r) */
-                encodedId: node.id.slice(1),
+                src: node.src,
+                typeLabel: NODE_TYPE_LABELS[node.src] ?? node.src,
+                /** Encoded id of the underlying item (no prefix). */
+                itemId: node.id,
                 toolId: isToolRequest ? node.tool_id : null,
                 inputCount,
                 outputCount,
@@ -199,8 +207,8 @@ export function mapNodes(apiNodes: ApiGraphNode[], apiEdges: ApiGraphEdge[]): Gr
 export function mapEdges(apiEdges: ApiGraphEdge[]): GraphEdge[] {
     return apiEdges.map((edge, idx) => ({
         id: `e${idx}`,
-        source: edge.source,
-        target: edge.target,
+        source: nodeKey(edge.source),
+        target: nodeKey(edge.target),
         cssClass: isCollectionEdge(edge) ? "edge-collection" : "edge-dataset",
         isCollection: isCollectionEdge(edge),
         points: [],

--- a/client/src/components/History/Graph/useHistoryGraphData.ts
+++ b/client/src/components/History/Graph/useHistoryGraphData.ts
@@ -1,4 +1,4 @@
-import { type Ref, ref, watch } from "vue";
+import { type Ref, ref, watch, type WatchSource } from "vue";
 
 import { GalaxyApi } from "@/api";
 
@@ -54,7 +54,7 @@ export function useHistoryGraphData(
         }
     }
 
-    const watchSources = [historyId, limit];
+    const watchSources: WatchSource[] = [historyId, limit];
     if (seedSrc) {
         watchSources.push(seedSrc);
     }

--- a/client/src/components/History/Graph/useHistoryGraphData.ts
+++ b/client/src/components/History/Graph/useHistoryGraphData.ts
@@ -8,9 +8,14 @@ import type { HistoryGraphResponse } from "./historyGraphMapper";
  * Fetch the history-scoped graph from the API.
  *
  * The default call returns the full history graph (within bounds).
- * An optional seed parameter requests a focused subgraph.
+ * An optional (seedSrc, seedId) pair requests a focused subgraph.
  */
-export function useHistoryGraphData(historyId: Ref<string>, limit: Ref<number>, seed?: Ref<string | undefined>) {
+export function useHistoryGraphData(
+    historyId: Ref<string>,
+    limit: Ref<number>,
+    seedSrc?: Ref<string | undefined>,
+    seedId?: Ref<string | undefined>,
+) {
     const graphData = ref<HistoryGraphResponse | null>(null);
     const loading = ref(false);
     const error = ref<string | null>(null);
@@ -23,8 +28,9 @@ export function useHistoryGraphData(historyId: Ref<string>, limit: Ref<number>, 
             const query: Record<string, unknown> = {
                 limit: limit.value,
             };
-            if (seed?.value) {
-                query.seed = seed.value;
+            if (seedSrc?.value && seedId?.value) {
+                query.seed_src = seedSrc.value;
+                query.seed_id = seedId.value;
             }
 
             const { data, error: apiError } = await GalaxyApi().GET("/api/histories/{history_id}/graph", {
@@ -48,7 +54,13 @@ export function useHistoryGraphData(historyId: Ref<string>, limit: Ref<number>, 
         }
     }
 
-    const watchSources = seed ? [historyId, limit, seed] : [historyId, limit];
+    const watchSources = [historyId, limit];
+    if (seedSrc) {
+        watchSources.push(seedSrc);
+    }
+    if (seedId) {
+        watchSources.push(seedId);
+    }
     watch(watchSources, () => fetchGraph(), { immediate: true });
 
     return { graphData, loading, error };

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -432,7 +432,8 @@ export function getRouter(Galaxy) {
                         component: HistoryGraphView,
                         props: (route) => ({
                             historyId: route.params.historyId,
-                            seedNodeId: route.query.seed || undefined,
+                            seedSrc: route.query.seed_src || undefined,
+                            seedId: route.query.seed_id || undefined,
                         }),
                     },
                     {

--- a/lib/galaxy/managers/history_graph.py
+++ b/lib/galaxy/managers/history_graph.py
@@ -41,6 +41,7 @@ from galaxy.schema.history_graph import (
     GraphEdge,
     GraphNode,
     HistoryGraphResponse,
+    NodeRef,
     TruncationInfo,
 )
 from galaxy.schema.schema import DataItemSourceType
@@ -52,7 +53,10 @@ log = logging.getLogger(__name__)
 
 TYPE_RANK = {"dataset": 0, "collection": 1, "tool_request": 2}
 EDGE_TYPE_RANK = {"dataset_input": 0, "dataset_output": 1, "collection_input": 2, "collection_output": 3}
-NODE_TYPE_PREFIX = {"dataset": "d", "collection": "c", "tool_request": "r"}
+# Internal node-type token -> public src value. The internal tokens
+# ("dataset"/"collection") stay because they mirror request payload
+# content_type; only the wire boundary speaks src.
+NODE_SRC: dict[str, str] = {"dataset": "hda", "collection": "hdca", "tool_request": "tool_request"}
 MAX_LIMIT = 1000
 
 
@@ -66,7 +70,7 @@ class HistoryGraphManager:
         history_id: int,
         limit: int = 500,
         include_deleted: bool = False,
-        seed: Optional[str] = None,
+        seed: Optional[NodeRef] = None,
         direction: Literal["backward", "forward", "both"] = "both",
         depth: int = 5,
         seed_scope_hid: Optional[int] = None,
@@ -113,7 +117,7 @@ class HistoryGraphBuilder:
         limit: int = 500,
         toolbox: Optional[AbstractToolBox] = None,
         include_deleted: bool = False,
-        seed: Optional[str] = None,
+        seed: Optional[NodeRef] = None,
         direction: Literal["backward", "forward", "both"] = "both",
         depth: int = 5,
         seed_scope_hid: Optional[int] = None,
@@ -130,7 +134,7 @@ class HistoryGraphBuilder:
         self.seed_scope_hid = seed_scope_hid
         self._older_than_hid: Optional[int] = None
         self._newer_than_hid: Optional[int] = None
-        self._sort_keys: dict[str, tuple[int, int]] = {}
+        self._sort_keys: dict[NodeRef, tuple[int, int]] = {}
 
     def build(self) -> HistoryGraphResponse:
         truncation = TruncationInfo()
@@ -161,20 +165,20 @@ class HistoryGraphBuilder:
         for item_key, (tr_id, tool_id) in all_producers.items():
             item_type, item_id = item_key
             tr_nodes[tr_id] = tool_id
-            src = self._encode("tool_request", tr_id)
-            tgt = self._encode(item_type, item_id)
+            source = self._ref("tool_request", tr_id)
+            target = self._ref(item_type, item_id)
             etype = "dataset_output" if item_type == "dataset" else "collection_output"
-            edges.append(GraphEdge(source=src, target=tgt, type=etype))
+            edges.append(GraphEdge(source=source, target=target, type=etype))
 
         # Batch-fetch all payloads, parse inputs, emit input edges.
         payloads = self._fetch_payloads(set(tr_nodes.keys()))
         for tr_id, payload in payloads.items():
             input_refs = self._extract_inputs(payload)
             for ref_type, ref_id in input_refs:
-                src = self._encode(ref_type, ref_id)
-                tgt = self._encode("tool_request", tr_id)
+                source = self._ref(ref_type, ref_id)
+                target = self._ref("tool_request", tr_id)
                 etype = "dataset_input" if ref_type == "dataset" else "collection_input"
-                edges.append(GraphEdge(source=src, target=tgt, type=etype))
+                edges.append(GraphEdge(source=source, target=target, type=etype))
                 if ref_type == "dataset" and ref_id not in dataset_ids:
                     closure_dataset_ids.add(ref_id)
                 elif ref_type == "collection" and ref_id not in collection_ids:
@@ -198,7 +202,7 @@ class HistoryGraphBuilder:
         # Invariant: every edge endpoint must be a node. Edges were emitted
         # before closure deletion filtering, so drop any that now reference
         # an item that did not survive.
-        node_id_set = {n.id for n in nodes}
+        node_id_set = {n.ref for n in nodes}
         edges = [e for e in edges if e.source in node_id_set and e.target in node_id_set]
 
         # 5. Resolve tool names.
@@ -206,7 +210,7 @@ class HistoryGraphBuilder:
 
         # 6. Optional seed subgraph filter (in-memory only).
         if self.seed:
-            node_ids = {n.id for n in nodes}
+            node_ids = {n.ref for n in nodes}
             truncation.seed_in_scope = self.seed in node_ids
             nodes, edges = self._seed_filter(self.seed, nodes, edges)
 
@@ -478,9 +482,9 @@ class HistoryGraphBuilder:
             .where(HistoryDatasetAssociation.id.in_(db_ids))
         )
         return [
-            GraphNode(
-                id=self._encode("dataset", row.id),
-                type="dataset",
+            self._node(
+                "dataset",
+                row.id,
                 name=row.name,
                 hid=row.hid,
                 state=row._state if row._state else row.dataset_state,
@@ -508,9 +512,9 @@ class HistoryGraphBuilder:
             .where(HistoryDatasetCollectionAssociation.id.in_(db_ids))
         )
         return [
-            GraphNode(
-                id=self._encode("collection", row.id),
-                type="collection",
+            self._node(
+                "collection",
+                row.id,
                 name=row.name,
                 hid=row.hid,
                 state=row.populated_state,
@@ -522,20 +526,13 @@ class HistoryGraphBuilder:
         ]
 
     def _tr_nodes(self, tr_map: dict[int, Optional[str]]) -> list[GraphNode]:
-        return [
-            GraphNode(
-                id=self._encode("tool_request", tr_id),
-                type="tool_request",
-                tool_id=tool_id,
-            )
-            for tr_id, tool_id in tr_map.items()
-        ]
+        return [self._node("tool_request", tr_id, tool_id=tool_id) for tr_id, tool_id in tr_map.items()]
 
     def _resolve_tool_names(self, nodes: list[GraphNode]) -> None:
         toolbox = self.toolbox
         if toolbox is None:
             return
-        tool_ids = {n.tool_id for n in nodes if n.type == "tool_request" and n.tool_id}
+        tool_ids = {n.tool_id for n in nodes if n.src == "tool_request" and n.tool_id}
         name_map: dict[str, str] = {}
         for tool_id in tool_ids:
             try:
@@ -545,28 +542,28 @@ class HistoryGraphBuilder:
             except MessageException:
                 pass
         for node in nodes:
-            if node.type == "tool_request" and node.tool_id and node.tool_id in name_map:
+            if node.src == "tool_request" and node.tool_id and node.tool_id in name_map:
                 node.tool_name = name_map[node.tool_id]
 
     # ── Seed subgraph filter (in-memory only) ──
 
     def _seed_filter(
-        self, seed: str, nodes: list[GraphNode], edges: list[GraphEdge]
+        self, seed: NodeRef, nodes: list[GraphNode], edges: list[GraphEdge]
     ) -> tuple[list[GraphNode], list[GraphEdge]]:
-        node_ids = {n.id for n in nodes}
+        node_ids = {n.ref for n in nodes}
         if seed not in node_ids:
-            raise RequestParameterInvalidException(f"Seed {seed} not found in graph.")
+            raise RequestParameterInvalidException(f"Seed {seed.src}:{seed.id} not found in graph.")
 
-        out_map: dict[str, set[str]] = {}
-        in_map: dict[str, set[str]] = {}
+        out_map: dict[NodeRef, set[NodeRef]] = {}
+        in_map: dict[NodeRef, set[NodeRef]] = {}
         for e in edges:
             out_map.setdefault(e.source, set()).add(e.target)
             in_map.setdefault(e.target, set()).add(e.source)
 
-        reachable: set[str] = {seed}
+        reachable: set[NodeRef] = {seed}
         frontier = {seed}
         for _ in range(self.depth):
-            nxt: set[str] = set()
+            nxt: set[NodeRef] = set()
             for nid in frontier:
                 if self.direction in ("forward", "both"):
                     nxt |= out_map.get(nid, set()) - reachable
@@ -577,7 +574,7 @@ class HistoryGraphBuilder:
             reachable |= nxt
             frontier = nxt
         return (
-            [n for n in nodes if n.id in reachable],
+            [n for n in nodes if n.ref in reachable],
             [e for e in edges if e.source in reachable and e.target in reachable],
         )
 
@@ -585,7 +582,7 @@ class HistoryGraphBuilder:
 
     def _sort(self, nodes: list[GraphNode], edges: list[GraphEdge]) -> tuple[list[GraphNode], list[GraphEdge]]:
         fallback = (99, 0)
-        nodes.sort(key=lambda n: self._sort_keys.get(n.id, fallback))
+        nodes.sort(key=lambda n: self._sort_keys.get(n.ref, fallback))
         edges.sort(
             key=lambda e: (
                 self._sort_keys.get(e.source, fallback),
@@ -597,7 +594,11 @@ class HistoryGraphBuilder:
 
     # ── Utilities ──
 
-    def _encode(self, node_type: str, db_id: int) -> str:
-        encoded = f"{NODE_TYPE_PREFIX[node_type]}{self.security.encode_id(db_id)}"
-        self._sort_keys[encoded] = (TYPE_RANK[node_type], db_id)
-        return encoded
+    def _ref(self, node_type: str, db_id: int) -> NodeRef:
+        ref = NodeRef(src=NODE_SRC[node_type], id=self.security.encode_id(db_id))
+        self._sort_keys[ref] = (TYPE_RANK[node_type], db_id)
+        return ref
+
+    def _node(self, node_type: str, db_id: int, **fields) -> GraphNode:
+        ref = self._ref(node_type, db_id)
+        return GraphNode(src=ref.src, id=ref.id, **fields)

--- a/lib/galaxy/schema/history_graph.py
+++ b/lib/galaxy/schema/history_graph.py
@@ -3,12 +3,31 @@ from typing import (
     Optional,
 )
 
-from pydantic import BaseModel
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+)
+
+# Graph-local src vocabulary. Scoped to this context exactly as src is
+# scoped elsewhere in Galaxy (DataItemSourceType, src: Literal["job"],
+# etc.). "hda"/"hdca" align with the rest of the codebase; "tool_request"
+# is the graph's tool-execution node.
+NodeSrc = Literal["hda", "hdca", "tool_request"]
+
+
+class NodeRef(BaseModel):
+    """A (src, id) reference to a graph node. Frozen so it is hashable
+    and usable directly as an edge endpoint and as an internal key."""
+
+    model_config = ConfigDict(frozen=True)
+
+    src: NodeSrc
+    id: str
 
 
 class GraphNode(BaseModel):
+    src: NodeSrc
     id: str
-    type: Literal["dataset", "collection", "tool_request"]
     name: Optional[str] = None
     hid: Optional[int] = None
     state: Optional[str] = None
@@ -19,10 +38,14 @@ class GraphNode(BaseModel):
     tool_id: Optional[str] = None
     tool_name: Optional[str] = None
 
+    @property
+    def ref(self) -> NodeRef:
+        return NodeRef(src=self.src, id=self.id)
+
 
 class GraphEdge(BaseModel):
-    source: str
-    target: str
+    source: NodeRef
+    target: NodeRef
     type: Literal["dataset_input", "dataset_output", "collection_input", "collection_output"]
 
 

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -48,7 +48,10 @@ from galaxy.schema.history import (
     HistoryIndexQueryPayload,
     HistorySortByEnum,
 )
-from galaxy.schema.history_graph import HistoryGraphResponse
+from galaxy.schema.history_graph import (
+    HistoryGraphResponse,
+    NodeSrc,
+)
 from galaxy.schema.schema import (
     AnyArchivedHistoryView,
     AnyHistoryView,
@@ -375,10 +378,13 @@ class FastAPIHistories:
             default=False,
             description="Include deleted datasets and collections.",
         ),
-        seed: Optional[str] = Query(
+        seed_src: Optional[NodeSrc] = Query(
             default=None,
-            description="Optional: focus on subgraph reachable from this node (e.g. d<encoded_id>).",
-            pattern=r"^[dcr].+$",
+            description="Optional: src of the node to focus the subgraph on. Provide with seed_id.",
+        ),
+        seed_id: Optional[str] = Query(
+            default=None,
+            description="Optional: encoded id of the node to focus the subgraph on. Provide with seed_src.",
         ),
         direction: Literal["backward", "forward", "both"] = Query(
             default="both",
@@ -390,10 +396,13 @@ class FastAPIHistories:
             ge=1,
             le=20,
         ),
-        seed_scope: Optional[str] = Query(
+        seed_scope_src: Optional[Literal["hda", "hdca"]] = Query(
             default=None,
-            description="Center the selection window on this item. Format: d{encoded_id} or c{encoded_id}.",
-            pattern=r"^[dc].+$",
+            description="src of the item to center the selection window on. Required with seed_scope_id.",
+        ),
+        seed_scope_id: Optional[str] = Query(
+            default=None,
+            description="Center the selection window on this encoded id. Provide with seed_scope_src.",
         ),
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> HistoryGraphResponse:
@@ -402,10 +411,12 @@ class FastAPIHistories:
             history_id,
             limit=limit,
             include_deleted=include_deleted,
-            seed=seed,
+            seed_src=seed_src,
+            seed_id=seed_id,
             direction=direction,
             depth=depth,
-            seed_scope=seed_scope,
+            seed_scope_src=seed_scope_src,
+            seed_scope_id=seed_scope_id,
         )
 
     @router.post(

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -54,7 +54,11 @@ from galaxy.schema import (
 )
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.history import HistoryIndexQueryPayload
-from galaxy.schema.history_graph import HistoryGraphResponse
+from galaxy.schema.history_graph import (
+    HistoryGraphResponse,
+    NodeRef,
+    NodeSrc,
+)
 from galaxy.schema.schema import (
     AnyArchivedHistoryView,
     AnyHistoryView,
@@ -392,13 +396,17 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         history_id: DecodedDatabaseIdField,
         limit: int = 500,
         include_deleted: bool = False,
-        seed: Optional[str] = None,
+        seed_src: Optional[NodeSrc] = None,
+        seed_id: Optional[str] = None,
         direction: Literal["backward", "forward", "both"] = "both",
         depth: int = 20,
-        seed_scope: Optional[str] = None,
+        seed_scope_src: Optional[Literal["hda", "hdca"]] = None,
+        seed_scope_id: Optional[str] = None,
     ) -> HistoryGraphResponse:
         history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
-        seed_scope_hid = self._resolve_seed_scope_hid(trans, history.id, seed_scope) if seed_scope else None
+        seed = self._build_node_ref("seed", seed_src, seed_id)
+        seed_scope = self._build_node_ref("seed_scope", seed_scope_src, seed_scope_id)
+        seed_scope_hid = self._resolve_seed_scope_hid(trans, history.id, seed_scope) if seed_scope is not None else None
         return self.history_graph_manager.build(
             sa_session=trans.sa_session,
             history_id=history.id,
@@ -410,14 +418,24 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             seed_scope_hid=seed_scope_hid,
         )
 
-    def _resolve_seed_scope_hid(self, trans: ProvidesHistoryContext, history_id: int, seed_scope: str) -> int:
-        db_id = self.security.decode_id(seed_scope[1:])
-        model_class = HistoryDatasetAssociation if seed_scope[0] == "d" else HistoryDatasetCollectionAssociation
+    @staticmethod
+    def _build_node_ref(param: str, src: Optional[str], id: Optional[str]) -> Optional[NodeRef]:
+        if src is None and id is None:
+            return None
+        if src is None or id is None:
+            raise glx_exceptions.RequestParameterInvalidException(
+                f"{param}_src and {param}_id must be provided together."
+            )
+        return NodeRef(src=src, id=id)
+
+    def _resolve_seed_scope_hid(self, trans: ProvidesHistoryContext, history_id: int, seed_scope: NodeRef) -> int:
+        db_id = self.security.decode_id(seed_scope.id)
+        model_class = HistoryDatasetAssociation if seed_scope.src == "hda" else HistoryDatasetCollectionAssociation
         row = trans.sa_session.execute(
             select(model_class.hid).where(model_class.id == db_id, model_class.history_id == history_id)
         ).first()
         if row is None or row.hid is None:
-            raise glx_exceptions.ObjectNotFound(f"seed_scope {seed_scope} not found in history.")
+            raise glx_exceptions.ObjectNotFound(f"seed_scope {seed_scope.src}:{seed_scope.id} not found in history.")
         return row.hid
 
     def prepare_download(

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -1280,7 +1280,7 @@ class TestHistoryGraphApi(ApiTestCase, BaseHistories):
         body = self.dataset_populator.get_history_graph(history_id)
         assert len(body["nodes"]) == 2
         assert body["edges"] == []
-        assert all(n["type"] == "dataset" for n in body["nodes"])
+        assert all(n["src"] == "hda" for n in body["nodes"])
 
     def test_limit_caps_items_and_sets_truncation_flag(self):
         history_id = self.dataset_populator.new_history()
@@ -1293,19 +1293,19 @@ class TestHistoryGraphApi(ApiTestCase, BaseHistories):
     def test_seed_scope_returns_seed_centered_window(self):
         history_id = self.dataset_populator.new_history()
         dataset = self.dataset_populator.new_dataset(history_id, content="seed", wait=True)
-        seed_scope = f"d{dataset['id']}"
-        body = self.dataset_populator.get_history_graph(history_id, seed_scope=seed_scope, limit=5)
+        body = self.dataset_populator.get_history_graph(
+            history_id, seed_scope_src="hda", seed_scope_id=dataset["id"], limit=5
+        )
         assert body["truncated"]["scope_type"] == "seed_centered"
-        assert seed_scope in {n["id"] for n in body["nodes"]}
+        assert ("hda", dataset["id"]) in {(n["src"], n["id"]) for n in body["nodes"]}
 
     # ── query-parameter validation (API-layer regex and bounds) ──
 
     @pytest.mark.parametrize(
         "param,value",
         [
-            ("seed_scope", "xabc"),  # wrong prefix
-            ("seed_scope", "d"),  # prefix but empty body
-            ("seed", "z"),  # wrong prefix
+            ("seed_src", "bogus"),  # not a valid NodeSrc
+            ("seed_scope_src", "tool_request"),  # not allowed as a scope center
             ("limit", 5000),  # above max
             ("depth", 21),  # above max
         ],
@@ -1315,13 +1315,20 @@ class TestHistoryGraphApi(ApiTestCase, BaseHistories):
         response = self.dataset_populator.get_history_graph_raw(history_id, **{param: value})
         self._assert_status_code_is(response, 400)
 
+    def test_seed_src_without_seed_id_is_rejected(self):
+        history_id = self.dataset_populator.new_history()
+        response = self.dataset_populator.get_history_graph_raw(history_id, seed_src="hda")
+        self._assert_status_code_is(response, 400)
+
     # ── manager-level validation (after API regex passes) ──
 
     def test_seed_scope_not_in_target_history_is_rejected(self):
         source_history = self.dataset_populator.new_history()
         dataset = self.dataset_populator.new_dataset(source_history, content="a", wait=True)
         target_history = self.dataset_populator.new_history()
-        response = self.dataset_populator.get_history_graph_raw(target_history, seed_scope=f"d{dataset['id']}")
+        response = self.dataset_populator.get_history_graph_raw(
+            target_history, seed_scope_src="hda", seed_scope_id=dataset["id"]
+        )
         self._assert_status_code_is(response, 404)
 
     # ── auth ──

--- a/test/unit/app/managers/test_HistoryGraphBuilder.py
+++ b/test/unit/app/managers/test_HistoryGraphBuilder.py
@@ -11,6 +11,7 @@ from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.histories import HistoryManager
 from galaxy.managers.history_graph import HistoryGraphManager
+from galaxy.schema.history_graph import NodeRef
 from .base import (
     BaseTestCase,
     CreatesCollectionsMixin,
@@ -58,7 +59,8 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         )
 
     def _encode(self, prefix, db_id):
-        return f"{prefix}{self.app.security.encode_id(db_id)}"
+        src = {"d": "hda", "c": "hdca", "r": "tool_request"}[prefix]
+        return NodeRef(src=src, id=self.app.security.encode_id(db_id))
 
     def _create_history(self):
         user = self.user_manager.create(**_next_user_data())
@@ -216,8 +218,8 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         assert len(graph.nodes) == 3  # input + output + tool_request
         assert len(graph.edges) == 2  # dataset_input + dataset_output
 
-        types = {n.type for n in graph.nodes}
-        assert types == {"dataset", "tool_request"}
+        types = {n.src for n in graph.nodes}
+        assert types == {"hda", "tool_request"}
 
         edge_types = {e.type for e in graph.edges}
         assert edge_types == {"dataset_input", "dataset_output"}
@@ -255,7 +257,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         self._create_job(tool_request=tr, tool_id="__DATA_FETCH__")
 
         graph = self._build_graph(history)
-        tr_nodes = [n for n in graph.nodes if n.type == "tool_request"]
+        tr_nodes = [n for n in graph.nodes if n.src == "tool_request"]
         assert len(tr_nodes) == 0
 
     def test_collection_node(self):
@@ -272,7 +274,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         self._link_job_input_hdca(job, hdca)
 
         graph = self._build_graph(history)
-        collection_nodes = [n for n in graph.nodes if n.type == "collection"]
+        collection_nodes = [n for n in graph.nodes if n.src == "hdca"]
         assert len(collection_nodes) == 1
         assert collection_nodes[0].collection_type == "list"
 
@@ -324,7 +326,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         self._link_job_output_hda(job, hda)
 
         graph = self._build_graph(history)
-        dataset_node = [n for n in graph.nodes if n.type == "dataset" and n.name == "test.fastq"][0]
+        dataset_node = [n for n in graph.nodes if n.src == "hda" and n.name == "test.fastq"][0]
         assert dataset_node.hid is not None
         assert dataset_node.extension == "fastq"
 
@@ -345,7 +347,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
 
         graph1 = self._build_graph(history)
         graph2 = self._build_graph(history)
-        assert [n.id for n in graph1.nodes] == [n.id for n in graph2.nodes]
+        assert [n.ref for n in graph1.nodes] == [n.ref for n in graph2.nodes]
         assert [(e.source, e.target, e.type) for e in graph1.edges] == [
             (e.source, e.target, e.type) for e in graph2.edges
         ]
@@ -415,7 +417,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
 
         assert len(graph.nodes) <= 4
         # The seed item must be in scope
-        node_ids = {n.id for n in graph.nodes}
+        node_ids = {n.ref for n in graph.nodes}
         assert self._encode("d", middle.id) in node_ids
         assert graph.truncated.scope_type == "seed_centered"
 
@@ -507,7 +509,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
 
         graph = self._build_graph(history)
 
-        node_ids = {n.id for n in graph.nodes}
+        node_ids = {n.ref for n in graph.nodes}
         assert self._encode("d", execution_hda.id) not in node_ids
         assert self._encode("d", visible_copy.id) in node_ids
         assert self._encode("d", output_hda.id) in node_ids
@@ -528,7 +530,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         graph = self._build_graph(history)
 
         hidden_enc = self._encode("d", hidden_hda.id)
-        node_ids = {n.id for n in graph.nodes}
+        node_ids = {n.ref for n in graph.nodes}
         assert hidden_enc in node_ids
 
     def test_closure_completes_tool_requests_at_seed_boundary(self):
@@ -553,11 +555,11 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         # pull in the other side so the tool_request is complete.
         graph = self._build_graph(history, limit=1)
 
-        tr_nodes = [n for n in graph.nodes if n.type == "tool_request"]
+        tr_nodes = [n for n in graph.nodes if n.src == "tool_request"]
         assert len(tr_nodes) == 1
         assert graph.truncated.item_count_capped is True
 
-        node_ids = {n.id for n in graph.nodes}
+        node_ids = {n.ref for n in graph.nodes}
         assert self._encode("d", input_hda.id) in node_ids
         assert self._encode("d", output_hda.id) in node_ids
 
@@ -601,8 +603,8 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         small = self._build_graph(history, limit=4)
         large = self._build_graph(history, limit=8)
 
-        small_ids = {n.id for n in small.nodes}
-        large_ids = {n.id for n in large.nodes}
+        small_ids = {n.ref for n in small.nodes}
+        large_ids = {n.ref for n in large.nodes}
         # All nodes in the small graph should also be in the large graph
         assert small_ids.issubset(large_ids)
         assert len(large_ids) >= len(small_ids)
@@ -800,7 +802,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         graph = self._build_graph(history)
 
         # Collection is one node, not 100
-        collection_nodes = [n for n in graph.nodes if n.type == "collection"]
+        collection_nodes = [n for n in graph.nodes if n.src == "hdca"]
         assert len(collection_nodes) == 1
 
         # Total nodes: 100 element HDAs (hidden, removed as elements) +
@@ -832,7 +834,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
 
         graph = self._build_graph(history)
 
-        node_ids = {n.id for n in graph.nodes}
+        node_ids = {n.ref for n in graph.nodes}
         assert self._encode("d", copy1.id) in node_ids
         assert self._encode("d", copy2.id) in node_ids
         assert self._encode("d", copy3.id) in node_ids
@@ -1020,7 +1022,7 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         )
 
         hdca_enc = self._encode("c", hdca.id)
-        node_ids = {n.id for n in graph.nodes}
+        node_ids = {n.ref for n in graph.nodes}
         assert hdca_enc in node_ids, "Ambiguous HDCA should still be a node"
 
         # No producer edge for this HDCA.
@@ -1064,13 +1066,13 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
             counter["n"] = 0
             unseeded = self._build_graph(history)
             unseeded_count = counter["n"]
-            unseeded_ids = {n.id for n in unseeded.nodes}
+            unseeded_ids = {n.ref for n in unseeded.nodes}
 
             self.trans.sa_session.flush()
             counter["n"] = 0
             seeded = self._build_graph(history, seed=seed_enc, depth=20)
             seeded_count = counter["n"]
-            seeded_ids = {n.id for n in seeded.nodes}
+            seeded_ids = {n.ref for n in seeded.nodes}
         finally:
             event.remove(engine, "before_cursor_execute", _count)
 
@@ -1105,23 +1107,23 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         middle_hda = chain[2][0]
         graph = self._build_graph(history, seed_scope_hid=middle_hda.hid, limit=1)
 
-        node_ids = {n.id for n in graph.nodes}
-        tr_nodes = [n for n in graph.nodes if n.type == "tool_request"]
+        node_ids = {n.ref for n in graph.nodes}
+        tr_nodes = [n for n in graph.nodes if n.src == "tool_request"]
         assert len(tr_nodes) >= 1, "Expected at least one tool_request via closure"
 
         # For each tool_request in the graph, all its incident edges
         # must reference items that are also nodes in the graph.
         for tr_node in tr_nodes:
-            connected_items = {e.source for e in graph.edges if e.target == tr_node.id} | {
-                e.target for e in graph.edges if e.source == tr_node.id
+            connected_items = {e.source for e in graph.edges if e.target == tr_node.ref} | {
+                e.target for e in graph.edges if e.source == tr_node.ref
             }
             for item_id in connected_items:
                 assert item_id in node_ids, (
-                    f"Tool_request {tr_node.id} has edge referencing missing node {item_id} — "
+                    f"Tool_request {tr_node.ref} has edge referencing missing node {item_id} — "
                     "closure invariant violated"
                 )
             assert len(connected_items) >= 2, (
-                f"Tool_request {tr_node.id} has only {len(connected_items)} connected items — "
+                f"Tool_request {tr_node.ref} has only {len(connected_items)} connected items — "
                 "expected at least one input and one output after closure"
             )
 
@@ -1136,13 +1138,13 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
 
         # All 5 in scope
         graph1 = self._build_graph(history, limit=5)
-        ids1 = {n.id for n in graph1.nodes}
+        ids1 = {n.ref for n in graph1.nodes}
         assert len(ids1) == 5
 
         # Add a new item — now 6 total, limit=5 means oldest drops out
         new_hda = self._create_hda(history, name="ds_new")
         graph2 = self._build_graph(history, limit=5)
-        ids2 = {n.id for n in graph2.nodes}
+        ids2 = {n.ref for n in graph2.nodes}
         assert len(ids2) == 5
 
         # The new item is in scope
@@ -1188,7 +1190,8 @@ class TestHistoryGraphBuilderBoundedness(BaseTestCase, CreatesCollectionsMixin):
         )
 
     def _encode(self, prefix, db_id):
-        return f"{prefix}{self.app.security.encode_id(db_id)}"
+        src = {"d": "hda", "c": "hdca", "r": "tool_request"}[prefix]
+        return NodeRef(src=src, id=self.app.security.encode_id(db_id))
 
     def _create_history(self):
         user = self.user_manager.create(**_next_user_data())
@@ -1321,13 +1324,13 @@ class TestHistoryGraphBuilderBoundedness(BaseTestCase, CreatesCollectionsMixin):
 
         # Items bounded by limit + closure (payload-driven closure can pull
         # in at most one extra input per representable TR).
-        item_nodes = [nd for nd in graph.nodes if nd.type != "tool_request"]
-        tr_nodes = [nd for nd in graph.nodes if nd.type == "tool_request"]
+        item_nodes = [nd for nd in graph.nodes if nd.src != "tool_request"]
+        tr_nodes = [nd for nd in graph.nodes if nd.src == "tool_request"]
         assert len(item_nodes) <= limit + len(tr_nodes)
 
         # Each TR has at least one edge
         for tr_node in tr_nodes:
-            tr_edges = [e for e in graph.edges if e.target == tr_node.id or e.source == tr_node.id]
+            tr_edges = [e for e in graph.edges if e.target == tr_node.ref or e.source == tr_node.ref]
             assert len(tr_edges) >= 1
 
     def test_collection_heavy_map_over(self):
@@ -1392,21 +1395,21 @@ class TestHistoryGraphBuilderBoundedness(BaseTestCase, CreatesCollectionsMixin):
         graph = self._build_graph(history)
 
         # Collection nodes bounded by 2*m (input + output collections)
-        coll_nodes = [nd for nd in graph.nodes if nd.type == "collection"]
+        coll_nodes = [nd for nd in graph.nodes if nd.src == "hdca"]
         assert len(coll_nodes) <= 2 * m
 
         # No element-level dataset explosion: dataset nodes must be far fewer
         # than the total hidden elements created (m*k*2)
-        dataset_nodes = [nd for nd in graph.nodes if nd.type == "dataset"]
+        dataset_nodes = [nd for nd in graph.nodes if nd.src == "hda"]
         assert (
             len(dataset_nodes) < total_hidden_elements
         ), f"Element explosion: {len(dataset_nodes)} dataset nodes from {total_hidden_elements} hidden elements"
 
         # Collection-level edges present on representable TRs
-        tr_nodes = [nd for nd in graph.nodes if nd.type == "tool_request"]
+        tr_nodes = [nd for nd in graph.nodes if nd.src == "tool_request"]
         for tr_node in tr_nodes:
-            input_edges = [e for e in graph.edges if e.target == tr_node.id]
-            output_edges = [e for e in graph.edges if e.source == tr_node.id]
+            input_edges = [e for e in graph.edges if e.target == tr_node.ref]
+            output_edges = [e for e in graph.edges if e.source == tr_node.ref]
             for e in input_edges:
                 assert e.type == "collection_input", f"Expected collection_input, got {e.type}"
             for e in output_edges:
@@ -1433,7 +1436,7 @@ class TestHistoryGraphBuilderBoundedness(BaseTestCase, CreatesCollectionsMixin):
         graph = self._build_graph(history, seed_scope_hid=early.hid, limit=limit)
 
         # Seed item must be in scope
-        node_ids = {nd.id for nd in graph.nodes}
+        node_ids = {nd.ref for nd in graph.nodes}
         assert self._encode("d", early.id) in node_ids
 
         # Response bounded
@@ -1465,7 +1468,7 @@ class TestHistoryGraphBuilderBoundedness(BaseTestCase, CreatesCollectionsMixin):
         assert len(after.nodes) == limit
         assert after.truncated.item_count_capped is True
 
-        after_ids = {nd.id for nd in after.nodes}
+        after_ids = {nd.ref for nd in after.nodes}
         # Oldest originals should be gone
         for hda in original[:added]:
             assert self._encode("d", hda.id) not in after_ids
@@ -1501,9 +1504,9 @@ class TestHistoryGraphBuilderBoundedness(BaseTestCase, CreatesCollectionsMixin):
         graph = self._build_graph(history)
 
         # No hidden element HDAs as nodes
-        dataset_nodes = [nd for nd in graph.nodes if nd.type == "dataset"]
+        dataset_nodes = [nd for nd in graph.nodes if nd.src == "hda"]
         assert len(dataset_nodes) == 0, f"Expected 0 dataset nodes (all hidden elements), got {len(dataset_nodes)}"
 
         # Collection is present
-        coll_nodes = [nd for nd in graph.nodes if nd.type == "collection"]
+        coll_nodes = [nd for nd in graph.nodes if nd.src == "hdca"]
         assert len(coll_nodes) == 1


### PR DESCRIPTION
@guerler are you okay with this more structured (or we could say strongly typed) version of the graph API? I've always found working with the f-prefix in library folder prefixes difficult / tricky.

From claude:

Replace prefixed-string node ids ("d<enc>"/"c<enc>"/"r<enc>") with structured NodeRef {src, id}, src in {hda, hdca, tool_request}. Split seed and seed_scope query params into _src/_id pairs; service rejects partial pairs; seed_scope_src restricted to hda|hdca at the API layer. Frontend mapper builds "${src}:${id}" renderer keys; details panel and router updated accordingly. Regenerated TS schema.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
