### PR TITLE
Fix shed install column mismatch from synthesized name alias

### DIFF
--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -30,10 +30,12 @@ RequiredAppT = Union["BasicSharedApp", InstallationTarget]
 
 
 def _parse_table_columns(table_elem: Element) -> dict[str, int]:
-    """Parse a ``<table>`` element's column spec into a name->index mapping."""
+    """Parse a ``<table>`` element's column spec into a name->index mapping.
+
+    Mirrors ``TabularToolDataTable.parse_column_spec`` so the dict matches what an
+    already-registered table exposes on ``.columns`` — no implicit ``name`` alias.
+    """
     columns, _, _ = TabularToolDataTable.parse_column_spec_element(table_elem)
-    if "value" in columns and "name" not in columns:
-        columns["name"] = columns["value"]
     return columns
 
 

--- a/test/unit/tool_shed/test_data_table_manager.py
+++ b/test/unit/tool_shed/test_data_table_manager.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from galaxy.tool_shed.tools.data_table_manager import (
+    _parse_table_columns,
     DataTableColumnMismatch,
     ShedToolDataTableManager,
 )
@@ -269,11 +270,10 @@ def test_merge_skipped_for_non_tabular_table_types(tmp_path):
     existing.append_entries_with_attribution.assert_not_called()
 
 
-def test_parse_table_columns_aliases_name_to_value():
-    from galaxy.tool_shed.tools.data_table_manager import _parse_table_columns
-
+def test_parse_table_columns_matches_parse_column_spec():
+    """Ensure the dict matches what a registered TabularToolDataTable exposes."""
     elem = Element("table")
     cols = SubElement(elem, "columns")
     cols.text = "value, path"
     parsed = _parse_table_columns(elem)
-    assert parsed == {"value": 0, "path": 1, "name": 0}
+    assert parsed == {"value": 0, "path": 1}


### PR DESCRIPTION
## Summary
- Fallout from #22679 (job log: https://github.com/galaxyproject/galaxy/actions/runs/26209587316/job/77117081870).
- `_parse_table_columns` in `lib/galaxy/tool_shed/tools/data_table_manager.py` synthesizes `name = value` for the incoming dict, but `TabularToolDataTable.parse_column_spec` no longer does that for the in-memory table (since #21008 "Attempt to not require name column"). `assert_data_table_consistency` then compares e.g. `{'line_type': 0, 'value': 1, 'path': 2}` (existing) vs `{'line_type': 0, 'value': 1, 'path': 2, 'name': 1}` (incoming) and aborts the install with `DataTableColumnMismatch` — reproduced on `test_1050_circular_dependencies_4_levels.py::test_0075_install_freebayes_repository[chromium]` and `test_1300_reset_all_metadata.py::test_9905_reset_metadata_on_all_repositories[chromium]`, where `sam_fa_indexes` declares `line_type, value, path` with no explicit `name`.
- Drop the alias so both sides reflect what's actually declared in the XML, and update the unit test that pinned the old behavior.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- Toolshed tests `test_1050_circular_dependencies_4_levels` and `test_1300_reset_all_metadata` should now pass on PRs that include #22679.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).