### PR TITLE
[26.1] Framework test for UDTs in Format 2 Workflows

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -105,7 +105,7 @@ groq==1.2.0
 grpcio==1.80.0
 grpcio-status==1.80.0
 gunicorn==26.0.0
-gxformat2==0.24.0
+gxformat2==0.27.0
 h11==0.16.0
 h5grove==4.0.0
 h5py==3.16.0

--- a/lib/galaxy_test/workflow/inline_user_defined_tool.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/inline_user_defined_tool.gxwf-tests.yml
@@ -1,0 +1,12 @@
+- doc: |
+    INLINE_UDT_BASIC: Cat through a single inline user-defined tool step.
+    Input file content round-trips to the workflow output unchanged.
+  job:
+    input1:
+      class: File
+      contents: "hello inline udt\n"
+  outputs:
+    wf_output:
+      asserts:
+        - that: has_text
+          text: "hello inline udt"

--- a/lib/galaxy_test/workflow/inline_user_defined_tool.gxwf.yml
+++ b/lib/galaxy_test/workflow/inline_user_defined_tool.gxwf.yml
@@ -1,0 +1,34 @@
+class: GalaxyWorkflow
+doc: |
+  Workflow with one inline user-defined tool (UDT) step. Exercises the
+  end-to-end path through Galaxy: format2 normalization (including
+  _expand_format2 pass-through for GalaxyUserToolStub, gxformat2 PR #218),
+  workflow import with tool_representation, on-import DynamicTool
+  registration, and execution via the YAML tool runtime.
+inputs:
+  input1:
+    type: data
+outputs:
+  wf_output:
+    outputSource: udt_cat/output1
+steps:
+  udt_cat:
+    run:
+      class: GalaxyUserTool
+      id: cat_user_defined
+      version: "0.1"
+      name: cat_user_defined
+      description: concatenates a file
+      container: busybox
+      shell_command: cat '$(inputs.input1.path)' > output.txt
+      inputs:
+        - name: input1
+          type: data
+          format: txt
+      outputs:
+        - name: output1
+          type: data
+          format: txt
+          from_work_dir: output.txt
+    in:
+      input1: input1

--- a/lib/galaxy_test/workflow/test_framework_workflows.py
+++ b/lib/galaxy_test/workflow/test_framework_workflows.py
@@ -57,6 +57,7 @@ class TestWorkflow(ApiTestCase):
         self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+        self.dataset_populator.create_role([self.dataset_populator.user_id()], role_type="user_tool_execute")
 
     @pytest.mark.workflow
     def test_workflow(self, workflow_path: Path, test_job: JobTestDict):

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     cloudauthz==0.6.0
     cwl-utils
     dparse
-    gxformat2>=0.23.0,!=0.25.0,!=0.26.0
+    gxformat2>=0.27.0
     kombu>=5.3
     lagom
     lxml!=4.2.2

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     galaxy-util
     bioblend
     cwltest>=2.5.20240906231108
-    gxformat2>=0.23.0,!=0.25.0,!=0.26.0
+    gxformat2>=0.27.0
     pytest
     pytest-celery
     PyYAML
@@ -47,7 +47,7 @@ packages = find_namespace:
 python_requires = >=3.10
 
 [options.extras_require]
-test = 
+test =
     pytest
 
 [options.packages.find]

--- a/packages/test_selenium/setup.cfg
+++ b/packages/test_selenium/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     galaxy-selenium
     galaxy-test-base
     galaxy-util
-    gxformat2>=0.23.0,!=0.25.0,!=0.26.0
+    gxformat2>=0.27.0
     pytest
     PyYAML
     requests

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     fastapi>=0.124.0
     gunicorn!=25.1.0
     httpx
-    gxformat2>=0.23.0,!=0.25.0,!=0.26.0
+    gxformat2>=0.27.0
     Mako
     MarkupSafe
     Paste
@@ -71,7 +71,7 @@ packages = find_namespace:
 python_requires = >=3.10
 
 [options.extras_require]
-test = 
+test =
     httpx
     pytest
     pytest-asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "future>=1.0.0",  # Python 3.12 support
     "gravity>=1.2.0",  # Python 3.14 support
     "gunicorn!=25.1.0",  # https://github.com/benoitc/gunicorn/discussions/3509
-    "gxformat2>=0.23.0,!=0.25.0,!=0.26.0",  # https://github.com/galaxyproject/gxformat2/issues/204
+    "gxformat2>=0.27.0",
     "h5grove>=1.2.1",
     "h5py>=3.12",  # Python 3.13 support
     "httpx",


### PR DESCRIPTION
I'll retarget release_26.1 once it lands. I think this will be red and will prove https://github.com/galaxyproject/gxformat2/pull/218 is needed and should land and belongs in 26.1.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
