### PR TITLE
[26.0] Fix linting of required_files in tools

### DIFF
--- a/lib/galaxy/tool_util/linters/required_files.py
+++ b/lib/galaxy/tool_util/linters/required_files.py
@@ -1,12 +1,15 @@
+import fnmatch
 import os
+import re
 from typing import TYPE_CHECKING
 
 from galaxy.tool_util.lint import Linter
-from galaxy.tool_util.parser.interface import RequiredFiles
 
 if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
     from galaxy.tool_util.parser import ToolSource
+
+WALK_MAX_DIRS = 10000
 
 
 class RequiredFilesExist(Linter):
@@ -21,16 +24,9 @@ class RequiredFilesExist(Linter):
         if required_files is None:
             return
         for include in required_files.includes:
-            per_include = RequiredFiles.from_dict(
-                {
-                    "includes": [include],
-                    "excludes": [],
-                    "extend_default_excludes": False,
-                }
-            )
-            if not per_include.find_required_files(tool_dir):
-                path = include["path"]
-                path_type = include.get("path_type", "literal")
+            path = include["path"]
+            path_type = include.get("path_type", "literal")
+            if not _include_matches_files(include, tool_dir):
                 if path_type == "literal":
                     lint_ctx.error(
                         f"Required file [{path}] does not exist",
@@ -41,3 +37,45 @@ class RequiredFilesExist(Linter):
                         f"Required files pattern [{path}] (type {path_type}) does not match any files",
                         linter=cls.name(),
                     )
+            else:
+                if path_type == "literal":
+                    lint_ctx.info(
+                        f"Required file [{path}] found",
+                        linter=cls.name(),
+                    )
+                else:
+                    lint_ctx.info(
+                        f"Required files pattern [{path}] (type {path_type}) matches files",
+                        linter=cls.name(),
+                    )
+
+
+def _include_matches_files(include: dict, tool_dir: str) -> bool:
+    """Check if an include pattern matches any files in the tool directory.
+
+    Uses os.walk and direct file existence checks instead of
+    RequiredFiles.find_required_files (which uses safe_walk), because
+    safe_walk filters out files whose realpath resolves outside the tool
+    directory. This causes false positives when linting tool directories
+    containing symlinked files (e.g. planemo shed_lint realized repositories
+    where files are symlinked into a temp directory).
+    """
+    path = include["path"]
+    path_type = include.get("path_type", "literal")
+    if path_type == "literal":
+        return os.path.exists(os.path.join(tool_dir, path))
+    for i, (dirpath, _, filenames) in enumerate(os.walk(tool_dir, followlinks=True)):
+        if i >= WALK_MAX_DIRS:
+            break
+        for filename in filenames:
+            rel_path = os.path.relpath(os.path.join(dirpath, filename), tool_dir)
+            if path_type == "prefix":
+                if rel_path.startswith(path):
+                    return True
+            elif path_type == "glob":
+                if fnmatch.fnmatch(rel_path, path):
+                    return True
+            else:
+                if re.match(path, rel_path) is not None:
+                    return True
+    return False

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -841,7 +841,7 @@ class RequiredFiles:
                         return True
             return False
 
-        excludes = self.excludes
+        excludes = list(self.excludes)
         if self.extend_default_excludes:
             excludes.append({"path": "tool-data", "path_type": "prefix"})
             excludes.append({"path": "test-data", "path_type": "prefix"})
@@ -851,7 +851,7 @@ class RequiredFiles:
         for dirpath, _, filenames in safe_walk(tool_directory):
             for filename in filenames:
                 rel_path = join(dirpath, filename).replace(tool_directory + os.path.sep, "")
-                if matches(self.includes, rel_path) and not matches(self.excludes, rel_path):
+                if matches(self.includes, rel_path) and not matches(excludes, rel_path):
                     files.append(rel_path)
         return files
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -2675,6 +2675,7 @@ def test_required_files_literal_exist(lint_ctx):
         _write_file(tool_dir, "my_script.R", "# R script")
         _load_and_run_lint(lint_ctx, tool_path, required_files)
     assert not lint_ctx.error_messages
+    assert "Required file [my_script.R] found" in lint_ctx.info_messages
 
 
 def test_required_files_literal_missing(lint_ctx):
@@ -2691,6 +2692,7 @@ def test_required_files_glob_match(lint_ctx):
         _write_file(tool_dir, "my_script.R", "# R script")
         _load_and_run_lint(lint_ctx, tool_path, required_files)
     assert not lint_ctx.error_messages
+    assert "Required files pattern [*.R] (type glob) matches files" in lint_ctx.info_messages
 
 
 def test_required_files_glob_no_match(lint_ctx):
@@ -2700,3 +2702,24 @@ def test_required_files_glob_no_match(lint_ctx):
         _load_and_run_lint(lint_ctx, tool_path, required_files)
     assert "Required files pattern [*.py] (type glob) does not match any files" in lint_ctx.error_messages
     assert len(lint_ctx.error_messages) == 1
+
+
+REQUIRED_FILES_LITERAL_SYMLINK = """
+<tool id="id" name="name">
+    <required_files>
+        <include path="my_script.R"/>
+    </required_files>
+</tool>
+"""
+
+
+def test_required_files_literal_symlinked_file(lint_ctx):
+    """Test that literal required files are found when symlinked from
+    outside the tool directory (e.g. planemo shed_lint realized repos)."""
+    with tempfile.TemporaryDirectory() as real_dir:
+        real_file = _write_file(real_dir, "my_script.R", "# R script")
+        with tempfile.TemporaryDirectory() as tool_dir:
+            tool_path = _write_file(tool_dir, "tool.xml", REQUIRED_FILES_LITERAL_SYMLINK)
+            os.symlink(real_file, os.path.join(tool_dir, "my_script.R"))
+            _load_and_run_lint(lint_ctx, tool_path, required_files)
+    assert not lint_ctx.error_messages


### PR DESCRIPTION
Should fix: https://github.com/galaxyproject/planemo/issues/1645

Seems the issues was with symlinks breaking with safe_walk.
If something like this gets in we might need a new release of the 26.0 packages.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
