### PR TITLE
Allow starring and labelling outputs during workflow extraction

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -19790,6 +19790,26 @@ export interface components {
          * @enum {string}
          */
         OutputCompareType: "diff" | "re_match" | "sim_size" | "re_match_multiline" | "contains" | "image_diff";
+        /** OutputLabelHint */
+        OutputLabelHint: {
+            /**
+             * ID
+             * @description Decoded ID of the concrete HDA/HDCA output to expose.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Kind
+             * @description Whether the output ID identifies an HDA or an HDCA.
+             * @enum {string}
+             */
+            kind: "hda" | "hdca";
+            /**
+             * Label
+             * @description Workflow output label to assign to the exposed output.
+             */
+            label: string;
+        };
         /** OutputReferenceByLabel */
         OutputReferenceByLabel: {
             /**
@@ -26354,6 +26374,11 @@ export interface components {
              */
             job_ids?: string[];
             /**
+             * Output Labels
+             * @description Concrete tool outputs to expose as workflow outputs, with labels.
+             */
+            output_labels?: components["schemas"]["OutputLabelHint"][];
+            /**
              * Workflow Name
              * @description The name for the extracted workflow.
              */
@@ -26426,6 +26451,12 @@ export interface components {
              */
             deleted: boolean;
             /**
+             * Exposed
+             * @description Whether this output should be preselected for exposure as a workflow output.
+             * @default false
+             */
+            exposed: boolean;
+            /**
              * HID
              * @description The history item ID (position in history).
              */
@@ -26447,10 +26478,25 @@ export interface components {
              */
             name: string;
             /**
+             * Output Name
+             * @description Workflow/tool output port name for this concrete output, when known.
+             */
+            output_name?: string | null;
+            /**
              * State
              * @description The state of the dataset or collection.
              */
             state: components["schemas"]["DatasetState"];
+            /**
+             * Suggested Name
+             * @description Suggested workflow output label for this concrete output.
+             */
+            suggested_name?: string | null;
+            /**
+             * Suggested Name Source
+             * @description Source used to derive the suggested workflow output label.
+             */
+            suggested_name_source?: ("renamed" | "rendered_label" | "bare_label" | "port_name") | null;
         };
         /** WorkflowExtractionPayload */
         WorkflowExtractionPayload: {

--- a/client/src/api/histories.ts
+++ b/client/src/api/histories.ts
@@ -16,6 +16,7 @@ export type WorkflowExtractionByIdsPayload = components["schemas"]["WorkflowExtr
 export type WorkflowExtractionJob = components["schemas"]["WorkflowExtractionJob"];
 type WorkflowExtractionResult = components["schemas"]["WorkflowExtractionResult"];
 export type WorkflowExtractionSummary = components["schemas"]["WorkflowExtractionSummary"];
+export type OutputLabelHint = components["schemas"]["OutputLabelHint"];
 
 export type HistoryCounts = Pick<CustomHistoryView, "nice_size" | "contents_active" | "contents_states">;
 

--- a/client/src/components/Common/RenameModal.vue
+++ b/client/src/components/Common/RenameModal.vue
@@ -60,6 +60,7 @@ async function onRename(newName: string) {
 
 <template>
     <GModal
+        :id="`rename-modal-${props.itemType}`"
         show
         :ok-text="localize('Rename')"
         :ok-disabled="nameInvalid || renaming"

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { faFile, faFolder } from "@fortawesome/free-regular-svg-icons";
+import { faFile, faFolder, faStar as faStarRegular } from "@fortawesome/free-regular-svg-icons";
 import {
     faBan,
     faExclamationTriangle,
     faInfoCircle,
     faLayerGroup,
     faPencilAlt,
+    faStar as faStarSolid,
     faWrench,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
@@ -13,7 +14,12 @@ import { computed } from "vue";
 
 import type { CardBadge, TitleIcon } from "@/components/Common/GCard.types";
 
-import { isMappedTool, isWorkflowExtractionInput, type WorkflowExtractionRow } from "./types";
+import {
+    isMappedTool,
+    isWorkflowExtractionInput,
+    type WorkflowExtractionOutput,
+    type WorkflowExtractionRow,
+} from "./types";
 
 import DisplayedItem from "../Content/DisplayedItem.vue";
 import GCard from "@/components/Common/GCard.vue";
@@ -60,6 +66,8 @@ const props = defineProps<{
 const emit = defineEmits<{
     (e: "rename"): void;
     (e: "select"): void;
+    (e: "toggle-output", outputIndex: number): void;
+    (e: "rename-output", outputIndex: number): void;
     (e: "view-job", jobId: string): void;
 }>();
 
@@ -130,6 +138,10 @@ const titleIcon = computed<TitleIcon>(() => {
     const { icon, label } = STEP_TYPE_META[props.job.step_type];
     return { icon, title: label };
 });
+
+function outputLabel(output: WorkflowExtractionOutput): string {
+    return output.outputLabel || output.suggested_name || output.name || output.output_name || "Output";
+}
 </script>
 
 <template>
@@ -158,7 +170,21 @@ const titleIcon = computed<TitleIcon>(() => {
         </template>
         <template v-slot:description>
             <template v-if="props.job.outputs?.length">
-                <div v-for="(output, outputIndex) in props.job.outputs" :key="outputIndex">
+                <div
+                    v-for="(output, outputIndex) in props.job.outputs"
+                    :key="outputIndex"
+                    class="workflow-extraction-output">
+                    <button
+                        v-if="props.job.step_type === 'tool' && output.output_name"
+                        type="button"
+                        class="output-star"
+                        data-output-star
+                        :class="{ active: output.exposed }"
+                        :disabled="Boolean(props.job.invalid) || output.deleted || !props.job.checked"
+                        :title="output.exposed ? 'Do not expose this output' : 'Expose this output'"
+                        @click.stop="emit('toggle-output', outputIndex)">
+                        <FontAwesomeIcon :icon="output.exposed ? faStarSolid : faStarRegular" fixed-width />
+                    </button>
                     <DisplayedItem
                         v-if="props.job.invalid === 'custom_tool_inaccessible'"
                         :item-id="output.id"
@@ -169,8 +195,19 @@ const titleIcon = computed<TitleIcon>(() => {
                         :state="output.state" />
                     <GenericHistoryItem
                         v-else
+                        class="workflow-output-item"
                         :item-id="output.id"
                         :item-src="output.history_content_type === 'dataset' ? 'hda' : 'hdca'" />
+                    <button
+                        v-if="props.job.step_type === 'tool' && output.output_name && output.exposed"
+                        type="button"
+                        class="output-label"
+                        data-output-label
+                        :title="`Rename workflow output ${outputLabel(output)}`"
+                        @click.stop="emit('rename-output', outputIndex)">
+                        <FontAwesomeIcon :icon="faPencilAlt" fixed-width />
+                        <span>{{ outputLabel(output) }}</span>
+                    </button>
                 </div>
             </template>
         </template>
@@ -188,6 +225,46 @@ const titleIcon = computed<TitleIcon>(() => {
         font-size: 0.8rem;
         padding: 0.25rem 0.5rem;
         border-radius: 0.25rem 0.25rem 0 0;
+    }
+
+    .workflow-extraction-output {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+
+    .workflow-output-item {
+        min-width: 0;
+        flex: 1 1 auto;
+    }
+
+    .output-star,
+    .output-label {
+        border: 0;
+        background: transparent;
+        color: $brand-secondary;
+        min-width: 2rem;
+        min-height: 2rem;
+    }
+
+    .output-star.active {
+        color: $brand-warning;
+    }
+
+    .output-star:disabled {
+        color: $gray-300;
+        cursor: not-allowed;
+    }
+
+    .output-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        max-width: 16rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 </style>

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -17,6 +17,7 @@ import type { CardBadge, TitleIcon } from "@/components/Common/GCard.types";
 import { type ExtractionOutput, type ExtractionRow, isInputStep, isMappedTool } from "./types";
 
 import DisplayedItem from "../Content/DisplayedItem.vue";
+import GButton from "@/components/BaseComponents/GButton.vue";
 import GCard from "@/components/Common/GCard.vue";
 import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
 
@@ -165,17 +166,21 @@ function displayLabel(output: ExtractionOutput): string {
                     v-for="(output, outputIndex) in props.job.outputs"
                     :key="outputIndex"
                     class="workflow-extraction-output">
-                    <button
+                    <GButton
                         v-if="props.job.step_type === 'tool' && output.output_name"
-                        type="button"
                         class="output-star"
                         data-output-star
                         :class="{ active: output.exposed }"
+                        :color="output.exposed ? 'orange' : 'grey'"
                         :disabled="Boolean(props.job.invalid) || output.deleted || !props.job.checked"
                         :title="output.exposed ? 'Do not expose this output' : 'Expose this output'"
+                        size="large"
+                        transparent
+                        icon-only
+                        tooltip
                         @click.stop="emit('toggle-output', outputIndex)">
                         <FontAwesomeIcon :icon="output.exposed ? faStarSolid : faStarRegular" fixed-width />
-                    </button>
+                    </GButton>
                     <DisplayedItem
                         v-if="props.job.invalid === 'custom_tool_inaccessible'"
                         :item-id="output.id"
@@ -189,16 +194,16 @@ function displayLabel(output: ExtractionOutput): string {
                         class="workflow-output-item"
                         :item-id="output.id"
                         :item-src="output.history_content_type === 'dataset' ? 'hda' : 'hdca'" />
-                    <button
+                    <GButton
                         v-if="props.job.step_type === 'tool' && output.output_name && output.exposed"
-                        type="button"
-                        class="output-label"
+                        class="output-label-button"
                         data-output-label
                         :title="`Rename workflow output ${displayLabel(output)}`"
+                        transparent
                         @click.stop="emit('rename-output', outputIndex)">
                         <FontAwesomeIcon :icon="faPencilAlt" fixed-width />
-                        <span>{{ displayLabel(output) }}</span>
-                    </button>
+                        <span class="output-label-button-text">{{ displayLabel(output) }}</span>
+                    </GButton>
                 </div>
             </template>
         </template>
@@ -230,32 +235,15 @@ function displayLabel(output: ExtractionOutput): string {
         flex: 1 1 auto;
     }
 
-    .output-star,
-    .output-label {
-        border: 0;
-        background: transparent;
-        color: $brand-secondary;
-        min-width: 2rem;
-        min-height: 2rem;
-    }
-
-    .output-star.active {
-        color: $brand-warning;
-    }
-
-    .output-star:disabled {
-        color: $gray-300;
-        cursor: not-allowed;
-    }
-
-    .output-label {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25rem;
+    .output-label-button {
         max-width: 16rem;
+        min-width: 0;
+
+        .output-label-button-text {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        }
     }
 }
 </style>

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -24,9 +24,18 @@ import GenericHistoryItem from "@/components/History/Content/GenericItem.vue";
 /** Badge for renamable workflow inputs. Only applied to workflow inputs, never tool steps. */
 const INPUT_IS_RENAMABLE_BADGE: CardBadge = {
     id: "is-renamable-input",
-    label: "Renamable",
+    label: "Renamable Input",
     icon: faPencilAlt,
     title: "Click the pencil icon next to the step title to rename this workflow input",
+    class: "unselectable",
+};
+
+/** Badge for renamable workflow outputs. Only applied to tool steps with at least one exposed output. */
+const OUTPUT_IS_RENAMABLE_BADGE: CardBadge = {
+    id: "is-renamable-output",
+    label: "Renamable Output",
+    icon: faPencilAlt,
+    title: "Click the pencil icon next to an exposed output to rename it",
     class: "unselectable",
 };
 
@@ -51,7 +60,6 @@ function mappedBadge(size: number | null | undefined): CardBadge {
         icon: faLayerGroup,
         title: "This row represents a mapped tool step backed by an implicit collection job.",
         class: "unselectable",
-        variant: "info",
     };
 }
 
@@ -116,6 +124,9 @@ const badges = computed<CardBadge[]>(() => {
         }
         if (isMappedTool(props.job)) {
             badges.push(mappedBadge(props.job.implicit_collection_jobs_size));
+        }
+        if (props.job.outputs.some((o) => o.output_name && o.exposed)) {
+            badges.push(OUTPUT_IS_RENAMABLE_BADGE);
         }
     } else {
         badges.push(INPUT_IS_RENAMABLE_BADGE);
@@ -240,9 +251,9 @@ function displayLabel(output: ExtractionOutput): string {
         min-width: 0;
 
         .output-label-button-text {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
     }
 }

--- a/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
+++ b/client/src/components/History/WorkflowExtraction/WorkflowExtractionCard.vue
@@ -14,12 +14,7 @@ import { computed } from "vue";
 
 import type { CardBadge, TitleIcon } from "@/components/Common/GCard.types";
 
-import {
-    isMappedTool,
-    isWorkflowExtractionInput,
-    type WorkflowExtractionOutput,
-    type WorkflowExtractionRow,
-} from "./types";
+import { type ExtractionOutput, type ExtractionRow, isInputStep, isMappedTool } from "./types";
 
 import DisplayedItem from "../Content/DisplayedItem.vue";
 import GCard from "@/components/Common/GCard.vue";
@@ -60,7 +55,7 @@ function mappedBadge(size: number | null | undefined): CardBadge {
 }
 
 const props = defineProps<{
-    job: WorkflowExtractionRow;
+    job: ExtractionRow;
 }>();
 
 const emit = defineEmits<{
@@ -139,8 +134,8 @@ const titleIcon = computed<TitleIcon>(() => {
     return { icon, title: label };
 });
 
-function outputLabel(output: WorkflowExtractionOutput): string {
-    return output.outputLabel || output.suggested_name || output.name || output.output_name || "Output";
+function displayLabel(output: ExtractionOutput): string {
+    return output.label || output.suggested_name || output.name || output.output_name || "Output";
 }
 </script>
 
@@ -148,11 +143,7 @@ function outputLabel(output: WorkflowExtractionOutput): string {
     <GCard
         :class="{ disabled: Boolean(props.job.invalid) }"
         :badges="badges"
-        :title="
-            isWorkflowExtractionInput(props.job)
-                ? props.job.newName
-                : props.job.tool_name || props.job.tool_id || 'Unnamed Step'
-        "
+        :title="isInputStep(props.job) ? props.job.newName : props.job.tool_name || props.job.tool_id || 'Unnamed Step'"
         :title-icon="titleIcon"
         :can-rename-title="props.job.step_type !== 'tool' && props.job.checked"
         selectable
@@ -169,7 +160,7 @@ function outputLabel(output: WorkflowExtractionOutput): string {
                 fixed-width />
         </template>
         <template v-slot:description>
-            <template v-if="props.job.outputs?.length">
+            <template v-if="props.job.outputs.length">
                 <div
                     v-for="(output, outputIndex) in props.job.outputs"
                     :key="outputIndex"
@@ -203,10 +194,10 @@ function outputLabel(output: WorkflowExtractionOutput): string {
                         type="button"
                         class="output-label"
                         data-output-label
-                        :title="`Rename workflow output ${outputLabel(output)}`"
+                        :title="`Rename workflow output ${displayLabel(output)}`"
                         @click.stop="emit('rename-output', outputIndex)">
                         <FontAwesomeIcon :icon="faPencilAlt" fixed-width />
-                        <span>{{ outputLabel(output) }}</span>
+                        <span>{{ displayLabel(output) }}</span>
                     </button>
                 </div>
             </template>

--- a/client/src/components/History/WorkflowExtraction/types.ts
+++ b/client/src/components/History/WorkflowExtraction/types.ts
@@ -1,36 +1,102 @@
+import type { components } from "@/api";
 import type { WorkflowExtractionJob } from "@/api/histories";
 
-export type WorkflowExtractionOutput = NonNullable<WorkflowExtractionJob["outputs"]>[number] & {
-    /** UI-local working label for the rename modal; not part of the API payload. */
-    outputLabel?: string;
-};
+type InvalidReason = components["schemas"]["InvalidWorkflowExtractionJobReason"];
+type HistoryContentType = components["schemas"]["HistoryContentType"];
+type DatasetState = components["schemas"]["DatasetState"];
+type ApiOutput = components["schemas"]["WorkflowExtractionOutput"];
 
-export type WorkflowExtractionToolJob = Omit<WorkflowExtractionJob, "outputs"> & {
-    step_type: "tool";
-    outputs?: WorkflowExtractionOutput[];
-};
-
-export type WorkflowExtractionInputJob = WorkflowExtractionJob & {
-    step_type: "input_dataset" | "input_collection";
-};
-
-export type WorkflowExtractionInput = WorkflowExtractionInputJob & {
-    /** The modifiable new name for the workflow input, which will be used in the generated workflow. */
-    newName: string;
-};
-
-export type WorkflowExtractionRow = WorkflowExtractionToolJob | WorkflowExtractionInput;
-
-export function isWorkflowExtractionInput(job: WorkflowExtractionRow): job is WorkflowExtractionInput;
-export function isWorkflowExtractionInput(job: WorkflowExtractionJob): job is WorkflowExtractionInputJob;
-export function isWorkflowExtractionInput(
-    job: WorkflowExtractionJob | WorkflowExtractionRow,
-): job is WorkflowExtractionInputJob | WorkflowExtractionInput {
-    return job.step_type === "input_dataset" || job.step_type === "input_collection";
+export interface ExtractionOutput {
+    id: string;
+    hid: number;
+    name: string;
+    output_name?: string | null;
+    suggested_name?: string | null;
+    history_content_type: HistoryContentType;
+    state: DatasetState;
+    deleted: boolean;
+    exposed: boolean;
+    /** UI-local working label for the rename modal; empty string = no override. */
+    label: string;
 }
 
-export function isMappedTool(
-    job: WorkflowExtractionJob | WorkflowExtractionRow,
-): job is WorkflowExtractionToolJob & { implicit_collection_jobs_id: string } {
-    return job.step_type === "tool" && Boolean(job.implicit_collection_jobs_id);
+interface RowBase {
+    id: string | null;
+    checked: boolean;
+    invalid?: InvalidReason | null;
+    outputs: ExtractionOutput[];
+}
+
+export interface ToolStep extends RowBase {
+    step_type: "tool";
+    tool_id?: string | null;
+    tool_name?: string | null;
+    tool_version_warning?: string | null;
+    implicit_collection_jobs_id?: string | null;
+    implicit_collection_jobs_size?: number | null;
+}
+
+export interface InputStep extends RowBase {
+    step_type: "input_dataset" | "input_collection";
+    /** Modifiable name used for the workflow input in the generated workflow. */
+    newName: string;
+}
+
+export type ExtractionRow = ToolStep | InputStep;
+
+export function isInputStep(row: ExtractionRow): row is InputStep {
+    return row.step_type !== "tool";
+}
+
+export function isMappedTool(row: ExtractionRow): row is ToolStep & { implicit_collection_jobs_id: string } {
+    return row.step_type === "tool" && Boolean(row.implicit_collection_jobs_id);
+}
+
+export function toExtractionRow(job: WorkflowExtractionJob): ExtractionRow {
+    const outputs = (job.outputs ?? []).map(toExtractionOutput);
+    if (job.step_type === "tool") {
+        return {
+            id: job.id,
+            checked: job.checked,
+            invalid: job.invalid,
+            outputs,
+            step_type: "tool",
+            tool_id: job.tool_id,
+            tool_name: job.tool_name,
+            tool_version_warning: job.tool_version_warning,
+            implicit_collection_jobs_id: job.implicit_collection_jobs_id,
+            implicit_collection_jobs_size: job.implicit_collection_jobs_size,
+        };
+    }
+    return {
+        id: job.id,
+        checked: job.checked,
+        invalid: job.invalid,
+        outputs,
+        step_type: job.step_type,
+        newName: defaultInputName(outputs),
+    };
+}
+
+function toExtractionOutput(output: ApiOutput): ExtractionOutput {
+    return {
+        id: output.id,
+        hid: output.hid,
+        name: output.name,
+        output_name: output.output_name,
+        suggested_name: output.suggested_name,
+        history_content_type: output.history_content_type,
+        state: output.state,
+        deleted: output.deleted,
+        exposed: output.exposed ?? false,
+        label: output.suggested_name || output.name || output.output_name || "",
+    };
+}
+
+function defaultInputName(outputs: ExtractionOutput[]): string {
+    const first = outputs[0];
+    if (!first) {
+        return "";
+    }
+    return first.name || `Input ${first.hid}`;
 }

--- a/client/src/components/History/WorkflowExtraction/types.ts
+++ b/client/src/components/History/WorkflowExtraction/types.ts
@@ -1,6 +1,14 @@
 import type { WorkflowExtractionJob } from "@/api/histories";
 
-export type WorkflowExtractionToolJob = WorkflowExtractionJob & { step_type: "tool" };
+export type WorkflowExtractionOutput = NonNullable<WorkflowExtractionJob["outputs"]>[number] & {
+    /** UI-local working label for the rename modal; not part of the API payload. */
+    outputLabel?: string;
+};
+
+export type WorkflowExtractionToolJob = Omit<WorkflowExtractionJob, "outputs"> & {
+    step_type: "tool";
+    outputs?: WorkflowExtractionOutput[];
+};
 
 export type WorkflowExtractionInputJob = WorkflowExtractionJob & {
     step_type: "input_dataset" | "input_collection";

--- a/client/src/components/History/WorkflowExtractionForm.test.ts
+++ b/client/src/components/History/WorkflowExtractionForm.test.ts
@@ -47,6 +47,17 @@ vi.mock("@/stores/historyStore", () => ({
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
+const TOOL_OUTPUT = {
+    id: "ds-1",
+    hid: 1,
+    name: "output1",
+    history_content_type: "dataset",
+    state: "ok",
+    deleted: false,
+    exposed: false,
+    output_name: "out_file1",
+} as NonNullable<WorkflowExtractionJob["outputs"]>[number];
+
 const TOOL_JOB: WorkflowExtractionJob = {
     id: "job-tool-1",
     tool_id: "cat1",
@@ -55,7 +66,7 @@ const TOOL_JOB: WorkflowExtractionJob = {
     step_type: "tool",
     checked: true,
     tool_version_warning: null,
-    outputs: [{ id: "ds-1", hid: 1, name: "output1", history_content_type: "dataset", state: "ok", deleted: false }],
+    outputs: [TOOL_OUTPUT],
 };
 
 const MAPPED_TOOL_JOB: WorkflowExtractionJob = {
@@ -70,6 +81,11 @@ const MAPPED_TOOL_JOB_2: WorkflowExtractionJob = {
     id: "job-tool-3",
 };
 
+const TOOL_JOB_WITH_NON_WORKFLOW_OUTPUT: WorkflowExtractionJob = {
+    ...TOOL_JOB,
+    outputs: [{ ...TOOL_OUTPUT, output_name: undefined } as NonNullable<WorkflowExtractionJob["outputs"]>[number]],
+};
+
 const INPUT_JOB: WorkflowExtractionJob = {
     id: null,
     tool_id: null,
@@ -78,7 +94,17 @@ const INPUT_JOB: WorkflowExtractionJob = {
     step_type: "input_dataset",
     checked: true,
     tool_version_warning: null,
-    outputs: [{ id: "ds-2", hid: 2, name: "myfile.txt", history_content_type: "dataset", state: "ok", deleted: false }],
+    outputs: [
+        {
+            id: "ds-2",
+            hid: 2,
+            name: "myfile.txt",
+            history_content_type: "dataset",
+            state: "ok",
+            deleted: false,
+            exposed: false,
+        },
+    ],
 };
 
 function summary(jobs: WorkflowExtractionJob[], warnings: string[] = []): WorkflowExtractionSummary {
@@ -243,7 +269,8 @@ describe("WorkflowExtractionForm", () => {
             const wrapper = await mountForm();
             await setWorkflowName(wrapper, "Extracted WF");
             await clickCreateButton(wrapper);
-            expect(extractWorkflowByIds).toHaveBeenCalledWith(
+            const payload = vi.mocked(extractWorkflowByIds).mock.calls[0]?.[0] as Record<string, unknown>;
+            expect(payload).toEqual(
                 expect.objectContaining({
                     workflow_name: "Extracted WF",
                     job_ids: ["job-tool-1"],
@@ -254,6 +281,58 @@ describe("WorkflowExtractionForm", () => {
                     dataset_collection_names: [],
                 }),
             );
+            expect(payload).not.toHaveProperty("output_labels");
+        });
+
+        it("submits output_labels only after an output is starred", async () => {
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            wrapper.findAllComponents(WorkflowExtractionCard).at(0).vm.$emit("toggle-output", 0);
+            await wrapper.vm.$nextTick();
+            await clickCreateButton(wrapper);
+            expect(extractWorkflowByIds).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    output_labels: [{ id: "ds-1", kind: "hda", label: "output1" }],
+                }),
+            );
+        });
+
+        it("does not submit starred outputs from unchecked tool rows", async () => {
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            const toolCard = wrapper.findAllComponents(WorkflowExtractionCard).at(0);
+            toolCard.vm.$emit("toggle-output", 0);
+            toolCard.vm.$emit("select");
+            await wrapper.vm.$nextTick();
+            await clickCreateButton(wrapper);
+            const payload = vi.mocked(extractWorkflowByIds).mock.calls[0]?.[0] as Record<string, unknown>;
+            expect(payload).not.toHaveProperty("output_labels");
+            expect(payload).toEqual(expect.objectContaining({ job_ids: [] }));
+        });
+
+        it("does not submit output labels for outputs without a workflow-visible output name", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(summary([TOOL_JOB_WITH_NON_WORKFLOW_OUTPUT]));
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            wrapper.findAllComponents(WorkflowExtractionCard).at(0).vm.$emit("toggle-output", 0);
+            await wrapper.vm.$nextTick();
+            await clickCreateButton(wrapper);
+            const payload = vi.mocked(extractWorkflowByIds).mock.calls[0]?.[0] as Record<string, unknown>;
+            expect(payload).not.toHaveProperty("output_labels");
+        });
+
+        it("does not submit a starred output with an empty label", async () => {
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            const toolCard = wrapper.findAllComponents(WorkflowExtractionCard).at(0);
+            toolCard.vm.$emit("toggle-output", 0);
+            toolCard.vm.$emit("rename-output", 0);
+            await flushPromises();
+            const renameAction = wrapper.findComponent(RenameModal).props("renameAction") as (name: string) => void;
+            renameAction("");
+            await wrapper.vm.$nextTick();
+            await clickCreateButton(wrapper);
+            expect(extractWorkflowByIds).not.toHaveBeenCalled();
         });
 
         it("submits mapped tool job via implicit_collection_jobs_ids", async () => {

--- a/client/src/components/History/WorkflowExtractionForm.vue
+++ b/client/src/components/History/WorkflowExtractionForm.vue
@@ -8,6 +8,7 @@ import { useRouter } from "vue-router/composables";
 import {
     extractWorkflowByIds,
     extractWorkflowFromHistory,
+    type OutputLabelHint,
     type WorkflowExtractionByIdsPayload,
     type WorkflowExtractionJob,
 } from "@/api/histories";
@@ -19,6 +20,7 @@ import {
     isMappedTool,
     isWorkflowExtractionInput,
     type WorkflowExtractionInput,
+    type WorkflowExtractionOutput,
     type WorkflowExtractionRow,
 } from "./WorkflowExtraction/types";
 
@@ -59,6 +61,7 @@ const errorMessage = ref<string | null>(null);
 const jobsList = ref<WorkflowExtractionRow[]>([]);
 const workflowName = ref("");
 const renameIndex = ref<number | null>(null);
+const outputRenameTarget = ref<{ jobIndex: number; outputIndex: number } | null>(null);
 const warnings = ref<string[]>([]);
 const showJobModal = ref(false);
 const viewedJobId = ref<string | null>(null);
@@ -75,8 +78,25 @@ const toRenameInput = computed(() => {
     return null;
 });
 
+const toRenameOutput = computed(() => {
+    const target = outputRenameTarget.value;
+    if (!target || !jobsList.value?.length) {
+        return null;
+    }
+    const job = jobsList.value[target.jobIndex];
+    if (!job || job.step_type !== "tool") {
+        return null;
+    }
+    return job.outputs?.[target.outputIndex] || null;
+});
+
 const submissionDisabled = computed(
-    () => submitting.value || hasUnnamedSelectedInputs.value || !workflowName.value.trim() || hasNoSelectedSteps.value,
+    () =>
+        submitting.value ||
+        hasUnnamedSelectedInputs.value ||
+        hasUnnamedSelectedOutputs.value ||
+        !workflowName.value.trim() ||
+        hasNoSelectedSteps.value,
 );
 
 const submissionDisabledMsg = computed(() => {
@@ -85,6 +105,9 @@ const submissionDisabledMsg = computed(() => {
     }
     if (hasUnnamedSelectedInputs.value) {
         return "All selected inputs must have a name";
+    }
+    if (hasUnnamedSelectedOutputs.value) {
+        return "All exposed outputs must have a label";
     }
     if (hasNoSelectedSteps.value) {
         return "At least one workflow step must be selected";
@@ -146,12 +169,50 @@ const selectedInputs = computed<
     return retVal;
 });
 
+const selectedOutputLabels = computed<OutputLabelHint[]>(() => {
+    if (!jobsList.value?.length) {
+        return [];
+    }
+    const outputLabels: OutputLabelHint[] = [];
+    for (const job of jobsList.value) {
+        if (!job.checked || job.step_type !== "tool") {
+            continue;
+        }
+        for (const output of job.outputs || []) {
+            if (!output.exposed || !output.output_name) {
+                continue;
+            }
+            const label = (output.outputLabel || "").trim();
+            if (!label) {
+                continue;
+            }
+            outputLabels.push({
+                id: output.id,
+                kind: output.history_content_type === "dataset" ? "hda" : "hdca",
+                label,
+            });
+        }
+    }
+    return outputLabels;
+});
+
 /** No workflow steps are selected: the workflow would have no steps */
 const hasNoSelectedSteps = computed(() => !jobsList.value?.some((job) => job.checked));
 
 /** For any inputs selected for inclusion as workflow steps, check if any are missing a name/label */
 const hasUnnamedSelectedInputs = computed(() => {
     return selectedInputs.value.some((input) => !input.newName);
+});
+
+const hasUnnamedSelectedOutputs = computed(() => {
+    return jobsList.value.some((job) => {
+        if (!job.checked || job.step_type !== "tool") {
+            return false;
+        }
+        return (job.outputs || []).some(
+            (output) => output.exposed && Boolean(output.output_name) && !(output.outputLabel || "").trim(),
+        );
+    });
 });
 
 extractWorkflow();
@@ -163,6 +224,7 @@ function toWorkflowExtractionRow(job: WorkflowExtractionJob): WorkflowExtraction
             ...job,
             checked,
             step_type: "tool",
+            outputs: (job.outputs || []).map(toWorkflowExtractionOutput),
         };
     } else {
         return {
@@ -172,6 +234,22 @@ function toWorkflowExtractionRow(job: WorkflowExtractionJob): WorkflowExtraction
             newName: getInputName(job) || "",
         };
     }
+}
+
+function toWorkflowExtractionOutput(
+    output: NonNullable<WorkflowExtractionJob["outputs"]>[number],
+): WorkflowExtractionOutput {
+    const outputWithMetadata = output as WorkflowExtractionOutput;
+    return {
+        ...outputWithMetadata,
+        exposed: outputWithMetadata.exposed ?? false,
+        outputLabel:
+            outputWithMetadata.outputLabel ||
+            outputWithMetadata.suggested_name ||
+            outputWithMetadata.name ||
+            outputWithMetadata.output_name ||
+            "",
+    };
 }
 
 function getInputName(job: WorkflowExtractionJob): string | undefined {
@@ -221,7 +299,31 @@ function onJobSelect(index: number) {
     const job = jobsList.value[index];
     if (job) {
         job.checked = !job.checked;
+        if (!job.checked && job.step_type === "tool") {
+            (job.outputs || []).forEach((output) => {
+                output.exposed = false;
+            });
+        }
     }
+}
+
+function onOutputToggle(jobIndex: number, outputIndex: number) {
+    const job = jobsList.value[jobIndex];
+    if (!job || job.step_type !== "tool" || !job.checked || job.invalid) {
+        return;
+    }
+    const output = job.outputs?.[outputIndex];
+    if (!output || output.deleted || !output.output_name) {
+        return;
+    }
+    output.exposed = !output.exposed;
+    if (output.exposed && !(output.outputLabel || "").trim()) {
+        output.outputLabel = output.suggested_name || output.name || output.output_name || "";
+    }
+}
+
+function onOutputRename(jobIndex: number, outputIndex: number) {
+    outputRenameTarget.value = { jobIndex, outputIndex };
 }
 
 function onViewJob(jobId: string) {
@@ -246,6 +348,22 @@ async function renameInput(newName: string) {
     (jobsList.value[renameIndex.value] as WorkflowExtractionInput).newName = newName;
 }
 
+async function renameOutput(newName: string) {
+    const target = outputRenameTarget.value;
+    if (!target) {
+        throw new Error("Invalid output rename target");
+    }
+    const job = jobsList.value[target.jobIndex];
+    if (!job || job.step_type !== "tool") {
+        throw new Error("Job not found or is not a tool");
+    }
+    const output = job.outputs?.[target.outputIndex];
+    if (!output) {
+        throw new Error("Output not found");
+    }
+    output.outputLabel = newName;
+}
+
 async function submitWorkflow() {
     try {
         if (submissionDisabled.value) {
@@ -267,6 +385,9 @@ async function submitWorkflow() {
             dataset_names: selectedDatasets.names,
             dataset_collection_names: selectedDatasetCollections.names,
         };
+        if (selectedOutputLabels.value.length) {
+            payload.output_labels = selectedOutputLabels.value;
+        }
 
         const data = await extractWorkflowByIds(payload);
 
@@ -340,6 +461,8 @@ function stepKind(job: WorkflowExtractionRow): string {
                 :data-icj-id="isMappedTool(job) ? job.implicit_collection_jobs_id : undefined"
                 :data-step-kind="stepKind(job)"
                 @rename="onJobRename(index)"
+                @toggle-output="(outputIndex) => onOutputToggle(index, outputIndex)"
+                @rename-output="(outputIndex) => onOutputRename(index, outputIndex)"
                 @select="onJobSelect(index)"
                 @view-job="onViewJob" />
         </div>
@@ -350,6 +473,13 @@ function stepKind(job: WorkflowExtractionRow): string {
             :name="toRenameInput.newName"
             :rename-action="renameInput"
             @close="renameIndex = null" />
+
+        <RenameModal
+            v-if="toRenameOutput"
+            item-type="output"
+            :name="toRenameOutput.outputLabel || ''"
+            :rename-action="renameOutput"
+            @close="outputRenameTarget = null" />
 
         <GModal :show.sync="showJobModal" title="View Job" fixed-height size="medium" @close="viewedJobId = null">
             <JobDetails v-if="viewedJobId" :job-id="viewedJobId" />

--- a/client/src/components/History/WorkflowExtractionForm.vue
+++ b/client/src/components/History/WorkflowExtractionForm.vue
@@ -10,18 +10,17 @@ import {
     extractWorkflowFromHistory,
     type OutputLabelHint,
     type WorkflowExtractionByIdsPayload,
-    type WorkflowExtractionJob,
 } from "@/api/histories";
 import { useToast } from "@/composables/toast";
 import { useHistoryStore } from "@/stores/historyStore";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import {
+    type ExtractionRow,
+    type InputStep,
+    isInputStep,
     isMappedTool,
-    isWorkflowExtractionInput,
-    type WorkflowExtractionInput,
-    type WorkflowExtractionOutput,
-    type WorkflowExtractionRow,
+    toExtractionRow,
 } from "./WorkflowExtraction/types";
 
 import GFormInput from "../BaseComponents/Form/GFormInput.vue";
@@ -58,7 +57,7 @@ const breadcrumbItems = computed(() => [
 const loading = ref(true);
 const submitting = ref(false);
 const errorMessage = ref<string | null>(null);
-const jobsList = ref<WorkflowExtractionRow[]>([]);
+const jobsList = ref<ExtractionRow[]>([]);
 const workflowName = ref("");
 const renameIndex = ref<number | null>(null);
 const outputRenameTarget = ref<{ jobIndex: number; outputIndex: number } | null>(null);
@@ -72,7 +71,7 @@ const toRenameInput = computed(() => {
         return null;
     }
     const job = jobsList.value[renameIndex.value];
-    if (job && isWorkflowExtractionInput(job)) {
+    if (job && isInputStep(job)) {
         return job;
     }
     return null;
@@ -87,7 +86,7 @@ const toRenameOutput = computed(() => {
     if (!job || job.step_type !== "tool") {
         return null;
     }
-    return job.outputs?.[target.outputIndex] || null;
+    return job.outputs[target.outputIndex] || null;
 });
 
 const submissionDisabled = computed(
@@ -153,20 +152,15 @@ const selectedInputs = computed<
     if (!jobsList.value?.length) {
         return [];
     }
-    const retVal = jobsList.value
-        .filter(
-            (job): job is WorkflowExtractionInput =>
-                job.checked && isWorkflowExtractionInput(job) && (job.outputs?.length ?? 0) > 0,
-        )
+    return jobsList.value
+        .filter((job): job is InputStep => job.checked && isInputStep(job) && job.outputs.length > 0)
         .flatMap((job) =>
-            job.outputs?.map((output) => ({
+            job.outputs.map((output) => ({
                 id: output.id,
                 newName: job.newName,
                 history_content_type: output.history_content_type,
             })),
-        )
-        .filter((item) => item !== undefined);
-    return retVal;
+        );
 });
 
 const selectedOutputLabels = computed<OutputLabelHint[]>(() => {
@@ -178,11 +172,11 @@ const selectedOutputLabels = computed<OutputLabelHint[]>(() => {
         if (!job.checked || job.step_type !== "tool") {
             continue;
         }
-        for (const output of job.outputs || []) {
+        for (const output of job.outputs) {
             if (!output.exposed || !output.output_name) {
                 continue;
             }
-            const label = (output.outputLabel || "").trim();
+            const label = output.label.trim();
             if (!label) {
                 continue;
             }
@@ -209,55 +203,11 @@ const hasUnnamedSelectedOutputs = computed(() => {
         if (!job.checked || job.step_type !== "tool") {
             return false;
         }
-        return (job.outputs || []).some(
-            (output) => output.exposed && Boolean(output.output_name) && !(output.outputLabel || "").trim(),
-        );
+        return job.outputs.some((output) => output.exposed && Boolean(output.output_name) && !output.label.trim());
     });
 });
 
 extractWorkflow();
-
-function toWorkflowExtractionRow(job: WorkflowExtractionJob): WorkflowExtractionRow {
-    const checked = job.checked ?? false;
-    if (job.step_type === "tool") {
-        return {
-            ...job,
-            checked,
-            step_type: "tool",
-            outputs: (job.outputs || []).map(toWorkflowExtractionOutput),
-        };
-    } else {
-        return {
-            ...job,
-            checked,
-            step_type: job.step_type,
-            newName: getInputName(job) || "",
-        };
-    }
-}
-
-function toWorkflowExtractionOutput(
-    output: NonNullable<WorkflowExtractionJob["outputs"]>[number],
-): WorkflowExtractionOutput {
-    const outputWithMetadata = output as WorkflowExtractionOutput;
-    return {
-        ...outputWithMetadata,
-        exposed: outputWithMetadata.exposed ?? false,
-        outputLabel:
-            outputWithMetadata.outputLabel ||
-            outputWithMetadata.suggested_name ||
-            outputWithMetadata.name ||
-            outputWithMetadata.output_name ||
-            "",
-    };
-}
-
-function getInputName(job: WorkflowExtractionJob): string | undefined {
-    if (job.outputs?.length && job.outputs[0]) {
-        const output = job.outputs[0];
-        return output.name || `Input ${output.hid}`;
-    }
-}
 
 function getSelectedInputs(type: "dataset" | "dataset_collection"): { ids: string[]; names: string[] } {
     const inputs = selectedInputs.value.filter(
@@ -273,7 +223,7 @@ async function extractWorkflow() {
     try {
         const result = await extractWorkflowFromHistory(props.historyId);
         if (result.jobs) {
-            jobsList.value = result.jobs.map(toWorkflowExtractionRow);
+            jobsList.value = result.jobs.map(toExtractionRow);
         }
 
         warnings.value = result.warnings || [];
@@ -300,7 +250,7 @@ function onJobSelect(index: number) {
     if (job) {
         job.checked = !job.checked;
         if (!job.checked && job.step_type === "tool") {
-            (job.outputs || []).forEach((output) => {
+            job.outputs.forEach((output) => {
                 output.exposed = false;
             });
         }
@@ -312,13 +262,13 @@ function onOutputToggle(jobIndex: number, outputIndex: number) {
     if (!job || job.step_type !== "tool" || !job.checked || job.invalid) {
         return;
     }
-    const output = job.outputs?.[outputIndex];
+    const output = job.outputs[outputIndex];
     if (!output || output.deleted || !output.output_name) {
         return;
     }
     output.exposed = !output.exposed;
-    if (output.exposed && !(output.outputLabel || "").trim()) {
-        output.outputLabel = output.suggested_name || output.name || output.output_name || "";
+    if (output.exposed && !output.label.trim()) {
+        output.label = output.suggested_name || output.name || output.output_name || "";
     }
 }
 
@@ -345,7 +295,7 @@ async function renameInput(newName: string) {
 
     // Instead of using the computed `toRenameInput`, we directly update the `newName` in the `jobsList`
     // to ensure reactivity and that the change is reflected in the UI immediately.
-    (jobsList.value[renameIndex.value] as WorkflowExtractionInput).newName = newName;
+    (jobsList.value[renameIndex.value] as InputStep).newName = newName;
 }
 
 async function renameOutput(newName: string) {
@@ -357,11 +307,11 @@ async function renameOutput(newName: string) {
     if (!job || job.step_type !== "tool") {
         throw new Error("Job not found or is not a tool");
     }
-    const output = job.outputs?.[target.outputIndex];
+    const output = job.outputs[target.outputIndex];
     if (!output) {
         throw new Error("Output not found");
     }
-    output.outputLabel = newName;
+    output.label = newName;
 }
 
 async function submitWorkflow() {
@@ -401,7 +351,7 @@ async function submitWorkflow() {
     }
 }
 
-function stepKind(job: WorkflowExtractionRow): string {
+function stepKind(job: ExtractionRow): string {
     if (isMappedTool(job)) {
         return "mapped-tool";
     }
@@ -477,7 +427,7 @@ function stepKind(job: WorkflowExtractionRow): string {
         <RenameModal
             v-if="toRenameOutput"
             item-type="output"
-            :name="toRenameOutput.outputLabel || ''"
+            :name="toRenameOutput.label"
             :rename-action="renameOutput"
             @close="outputRenameTarget = null" />
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1193,6 +1193,7 @@ workflow_extract:
     create_button: '[data-description="create-workflow-button"]'
     no_workflow_message: '[data-description="no-workflow-message"]'
     tool_card: '[data-step-type="tool"]'
+    tool_card_with_job_id: '[data-step-type="tool"][data-job-id]'
     mapped_tool_card: '[data-step-kind="mapped-tool"]'
     tool_card_checkbox: '[data-step-type="tool"] input[id^="g-card-select-"]'
     tool_card_checkbox_checked: '[data-step-type="tool"] input[id^="g-card-select-"]:checked'
@@ -1200,6 +1201,13 @@ workflow_extract:
     card_by_icj_id: '[data-icj-id="${icj_id}"]'
     mapped_badge: '[id^="g-card-badge-mapped-tool-"]'
     all_card_checkboxes_checked: '[data-description="workflow-extraction-form"] input[id^="g-card-select-"]:checked'
+    output_star_for_job: '[data-job-id="${job_id}"] [data-output-star]'
+    output_star_active_for_job: '[data-job-id="${job_id}"] [data-output-star].active'
+    output_label_for_job: '[data-job-id="${job_id}"] [data-output-label]'
+    all_active_output_stars: '[data-description="workflow-extraction-form"] [data-output-star].active'
+    output_rename_input: '#output-name-input'
+    output_rename_confirm: '#rename-modal-output .g-modal-confirm-buttons button:last-of-type'
+    output_rename_cancel: '#rename-modal-output .g-modal-confirm-buttons button:first-of-type'
 
 invocations:
   selectors:

--- a/lib/galaxy/managers/workflow_extraction_naming.py
+++ b/lib/galaxy/managers/workflow_extraction_naming.py
@@ -1,0 +1,142 @@
+"""Helpers for suggesting workflow output labels during extraction."""
+
+from dataclasses import dataclass
+from typing import (
+    Literal,
+    Optional,
+)
+
+from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.managers.jobs import get_output_name
+from galaxy.model import (
+    HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
+    Job,
+)
+from galaxy.tool_util.parser.output_objects import ToolOutputBase
+from galaxy.workflow.extract import (
+    _original_hda,
+    _original_hdca,
+    _skip_output_assoc_name,
+)
+
+SuggestedNameSource = Literal["renamed", "rendered_label", "bare_label", "port_name"]
+OutputContentKind = Literal["hda", "hdca"]
+
+
+@dataclass(frozen=True)
+class SuggestedName:
+    name: str
+    source: SuggestedNameSource
+
+
+def suggested_output_name(
+    trans: ProvidesHistoryContext, content_id: int, content_kind: OutputContentKind
+) -> Optional[SuggestedName]:
+    """Return a best-effort workflow output label suggestion for an HDA/HDCA."""
+    if content_kind == "hda":
+        hda = trans.sa_session.get(HistoryDatasetAssociation, content_id)
+        if hda is None:
+            return None
+        return _suggested_hda_output_name(trans, _original_hda(hda))
+    hdca = trans.sa_session.get(HistoryDatasetCollectionAssociation, content_id)
+    if hdca is None:
+        return None
+    return _suggested_hdca_output_name(trans, _original_hdca(hdca))
+
+
+def _suggested_hda_output_name(
+    trans: ProvidesHistoryContext, hda: HistoryDatasetAssociation
+) -> Optional[SuggestedName]:
+    assoc = next(
+        (assoc for assoc in hda.creating_job_associations if not _skip_output_assoc_name(assoc.name)),
+        None,
+    )
+    if assoc is None:
+        return _content_name(hda)
+    job = assoc.job
+    tool = _tool_for_job(trans, job)
+    tool_output = tool.outputs.get(assoc.name) if tool is not None else None
+    params = _params_for_job(tool, job)
+    return _apply_chain(content_name=hda.name, tool_output=tool_output, port_name=assoc.name, params=params, tool=tool)
+
+
+def _suggested_hdca_output_name(
+    trans: ProvidesHistoryContext, hdca: HistoryDatasetCollectionAssociation
+) -> Optional[SuggestedName]:
+    output_name = hdca.implicit_output_name
+    job: Optional[Job] = None
+    if output_name and hdca.implicit_collection_jobs is not None:
+        job = hdca.implicit_collection_jobs.representative_job
+    else:
+        assoc = next(iter(hdca.creating_job_associations), None)
+        if assoc is not None:
+            job = assoc.job
+            output_name = assoc.name
+
+    if not output_name:
+        return _content_name(hdca)
+
+    tool = _tool_for_job(trans, job) if job is not None else None
+    tool_output = None
+    if tool is not None:
+        tool_output = tool.output_collections.get(output_name) or tool.outputs.get(output_name)
+    params = _params_for_job(tool, job)
+    return _apply_chain(
+        content_name=hdca.name,
+        tool_output=tool_output,
+        port_name=output_name,
+        params=params,
+        tool=tool,
+    )
+
+
+def _tool_for_job(trans: ProvidesHistoryContext, job: Optional[Job]):
+    if job is None:
+        return None
+    try:
+        return trans.app.toolbox.tool_for_job(job, user=trans.user)
+    except Exception:
+        return None
+
+
+def _params_for_job(tool, job: Optional[Job]):
+    if tool is None or job is None:
+        return None
+    try:
+        return tool.get_param_values(job, ignore_errors=True)
+    except Exception:
+        return None
+
+
+def _apply_chain(
+    *,
+    content_name: Optional[str],
+    tool_output: Optional[ToolOutputBase],
+    port_name: Optional[str],
+    params: Optional[dict],
+    tool,
+) -> Optional[SuggestedName]:
+    rendered_name = None
+    if tool is not None and tool_output is not None and params is not None:
+        rendered_name = get_output_name(tool=tool, output=tool_output, params=dict(params))
+
+    if rendered_name and content_name and content_name != rendered_name:
+        return SuggestedName(content_name, "renamed")
+    if tool_output is not None and tool_output.label:
+        if rendered_name:
+            return SuggestedName(rendered_name, "rendered_label")
+        return SuggestedName(tool_output.label, "bare_label")
+    if port_name:
+        return SuggestedName(port_name, "port_name")
+    return _content_name_from_string(content_name)
+
+
+def _content_name(content) -> Optional[SuggestedName]:
+    return _content_name_from_string(getattr(content, "name", None))
+
+
+def _content_name_from_string(content_name: Optional[str]) -> Optional[SuggestedName]:
+    if content_name:
+        return SuggestedName(content_name, "renamed")
+    return None

--- a/lib/galaxy/schema/workflows.py
+++ b/lib/galaxy/schema/workflows.py
@@ -337,6 +337,44 @@ class WorkflowExtractionOutput(Model):
         title="History Content Type",
         description="Whether this is a dataset or dataset_collection.",
     )
+    output_name: Optional[str] = Field(
+        None,
+        title="Output Name",
+        description="Workflow/tool output port name for this concrete output, when known.",
+    )
+    suggested_name: Optional[str] = Field(
+        None,
+        title="Suggested Name",
+        description="Suggested workflow output label for this concrete output.",
+    )
+    suggested_name_source: Optional[Literal["renamed", "rendered_label", "bare_label", "port_name"]] = Field(
+        None,
+        title="Suggested Name Source",
+        description="Source used to derive the suggested workflow output label.",
+    )
+    exposed: bool = Field(
+        False,
+        title="Exposed",
+        description="Whether this output should be preselected for exposure as a workflow output.",
+    )
+
+
+class OutputLabelHint(Model):
+    id: DecodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="Decoded ID of the concrete HDA/HDCA output to expose.",
+    )
+    kind: Literal["hda", "hdca"] = Field(
+        ...,
+        title="Kind",
+        description="Whether the output ID identifies an HDA or an HDCA.",
+    )
+    label: str = Field(
+        ...,
+        title="Label",
+        description="Workflow output label to assign to the exposed output.",
+    )
 
 
 class InvalidWorkflowExtractionJobReason(str, Enum):
@@ -499,6 +537,11 @@ class WorkflowExtractionByIdsPayload(Model):
         default_factory=list,
         title="Dataset Collection Names",
         description="Names for the input dataset collections, parallel to hdca_ids.",
+    )
+    output_labels: list[OutputLabelHint] = Field(
+        default_factory=list,
+        title="Output Labels",
+        description="Concrete tool outputs to expose as workflow outputs, with labels.",
     )
 
     @model_validator(mode="after")

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -2382,6 +2382,20 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         self.sleep_for(self.wait_types.UX_TRANSITION)
         self.components.workflow_extract._.wait_for_visible()
 
+    def extract_workflow_set_name(self, name: str):
+        """Set the workflow name in the extraction form."""
+        self.components.workflow_extract.workflow_name_input.wait_for_and_clear_and_send_keys(name)
+
+    def extract_workflow_submit(self):
+        """Submit the extraction form."""
+        self.components.workflow_extract.create_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+    def extract_workflow_name_and_submit(self, name: str):
+        """Set the workflow name and submit the extraction form."""
+        self.extract_workflow_set_name(name)
+        self.extract_workflow_submit()
+
     def click_history_option(self, option_label_or_component):
         # Open menu
         self.click_history_options()

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -43,6 +43,7 @@ from galaxy.managers.histories import (
 )
 from galaxy.managers.history_graph import HistoryGraphManager
 from galaxy.managers.users import UserManager
+from galaxy.managers.workflow_extraction_naming import suggested_output_name
 from galaxy.model import (
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
@@ -109,7 +110,10 @@ from galaxy.webapps.galaxy.services.base import (
 )
 from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
-from galaxy.workflow.extract import summarize
+from galaxy.workflow.extract import (
+    _skip_output_assoc_name,
+    summarize,
+)
 
 log = logging.getLogger(__name__)
 
@@ -844,7 +848,15 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                 icj_assoc.job_id: icj_assoc for icj_assoc in trans.sa_session.scalars(stmt).unique().all()
             }
 
-        def serialize_output(content) -> WorkflowExtractionOutput:
+        def serialize_output(
+            content, output_name: Optional[str] = None, expose_outputs: bool = False
+        ) -> WorkflowExtractionOutput:
+            suggested = None
+            if output_name is not None:
+                content_kind: Literal["hda", "hdca"] = (
+                    "hdca" if content.history_content_type == "dataset_collection" else "hda"
+                )
+                suggested = suggested_output_name(trans, content.id, content_kind)
             return WorkflowExtractionOutput.model_validate(
                 {
                     "id": content.id,
@@ -853,6 +865,10 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                     "state": content.state,
                     "deleted": content.deleted,
                     "history_content_type": content.history_content_type,
+                    "output_name": output_name,
+                    "suggested_name": suggested.name if suggested else None,
+                    "suggested_name_source": suggested.source if suggested else None,
+                    "exposed": expose_outputs,
                 }
             )
 
@@ -861,10 +877,20 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                 return "input_collection"
             return "input_dataset"
 
+        def workflow_output_name(content, output_name: Optional[str]) -> Optional[str]:
+            if output_name and _skip_output_assoc_name(output_name):
+                return None
+            if content.history_content_type == "dataset_collection":
+                return getattr(content, "implicit_output_name", None) or output_name
+            return output_name
+
         jobs_list = []
         for job, datasets in jobs.items():
             is_fake = getattr(job, "is_fake", False)
-            outputs = [serialize_output(data) for _, data in datasets]
+            input_outputs = [serialize_output(data) for _, data in datasets]
+            tool_outputs = [
+                serialize_output(data, workflow_output_name(data, output_name)) for output_name, data in datasets
+            ]
             checked = any(not data.deleted for _, data in datasets)
 
             if is_fake:
@@ -872,13 +898,13 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                 jobs_list.append(
                     WorkflowExtractionJob(
                         id=None,
-                        step_type=input_step_type(outputs),
+                        step_type=input_step_type(input_outputs),
                         tool_name=getattr(job, "name", None),
                         tool_id=None,
                         tool_version=None,
                         checked=checked,
                         tool_version_warning=None,
-                        outputs=outputs,
+                        outputs=input_outputs,
                         invalid=None,
                     )
                 )
@@ -905,7 +931,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                             tool_version=job.tool_version,
                             checked=False,
                             tool_version_warning=None,
-                            outputs=outputs,
+                            outputs=tool_outputs,
                             invalid=invalid_reason,
                         )
                     )
@@ -914,13 +940,13 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                     jobs_list.append(
                         WorkflowExtractionJob(
                             id=None,
-                            step_type=input_step_type(outputs),
+                            step_type=input_step_type(input_outputs),
                             tool_name=tool.name,
                             tool_id=None,
                             tool_version=None,
                             checked=checked,
                             tool_version_warning=None,
-                            outputs=outputs,
+                            outputs=input_outputs,
                             invalid=None,
                         )
                     )
@@ -944,7 +970,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                             tool_version=job.tool_version,
                             checked=checked,
                             tool_version_warning=tool_version_warning,
-                            outputs=outputs,
+                            outputs=tool_outputs,
                             invalid=None,
                             implicit_collection_jobs_id=(
                                 icj_assoc.implicit_collection_jobs_id if icj_assoc is not None else None

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import (
     Any,
     Optional,
@@ -48,8 +49,10 @@ from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.notifications import NotificationService
 from galaxy.webapps.galaxy.services.sharable import ShareableService
 from galaxy.workflow.extract import (
+    collect_output_label_targets,
     extract_workflow,
     extract_workflow_by_ids,
+    normalize_output_label_key,
 )
 from galaxy.workflow.run import queue_invoke
 from galaxy.workflow.run_request import build_workflow_run_configs
@@ -59,6 +62,13 @@ log = logging.getLogger(__name__)
 
 def _to_extraction_result(stored_workflow: StoredWorkflow) -> WorkflowExtractionResult:
     return WorkflowExtractionResult.model_validate({"id": stored_workflow.id})
+
+
+def _sanitize_output_label(label: str) -> str:
+    label = re.sub(r"\s+", " ", label.strip())
+    if not label:
+        raise exceptions.RequestParameterInvalidException("output_labels contains an empty label")
+    return label[:255]
 
 
 class WorkflowsService(ServiceBase):
@@ -249,6 +259,7 @@ class WorkflowsService(ServiceBase):
             hdca_ids=payload.hdca_ids,
             dataset_names=payload.dataset_names,
             dataset_collection_names=payload.dataset_collection_names,
+            output_labels=payload.output_labels,
         )
         return _to_extraction_result(stored_workflow)
 
@@ -295,6 +306,44 @@ class WorkflowsService(ServiceBase):
                 )
             for hdca in output_hdcas:
                 dataset_collection_manager.get_dataset_collection_instance(trans, "history", hdca.id)
+
+        output_targets = collect_output_label_targets(
+            trans,
+            job_manager=self._job_manager,
+            job_ids=payload.job_ids,
+            implicit_collection_jobs_ids=payload.implicit_collection_jobs_ids,
+        )
+        seen_output_ids = set()
+        seen_resolved_outputs = set()
+        seen_labels = set()
+        for output_label in payload.output_labels:
+            sanitized_label = _sanitize_output_label(output_label.label)
+            output_label.label = sanitized_label
+            output_key = normalize_output_label_key(trans, output_label.kind, output_label.id)
+            output_label.id = output_key[1]
+            if output_key in seen_output_ids:
+                raise exceptions.RequestParameterInvalidException(
+                    f"output_labels contains duplicate {output_label.kind} id {output_label.id}"
+                )
+            seen_output_ids.add(output_key)
+
+            output_target = output_targets.get(output_key)
+            if output_target is None:
+                raise exceptions.RequestParameterInvalidException(
+                    f"output_labels includes {output_label.kind} id {output_label.id} "
+                    "that is not produced by a selected extraction step"
+                )
+            if output_target.step_key in seen_resolved_outputs:
+                raise exceptions.RequestParameterInvalidException(
+                    f"output_labels contains multiple labels for output {output_target.output_name!r}"
+                )
+            seen_resolved_outputs.add(output_target.step_key)
+
+            if sanitized_label in seen_labels:
+                raise exceptions.RequestParameterInvalidException(
+                    f"output_labels contains duplicate workflow output label {sanitized_label!r}"
+                )
+            seen_labels.add(sanitized_label)
 
     def delete(self, trans, workflow_id):
         workflow_to_delete = self._workflows_manager.get_stored_workflow(trans, workflow_id)

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -4,6 +4,7 @@ histories.
 
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import (
     Any,
     cast,
@@ -528,6 +529,7 @@ def extract_workflow_by_ids(
     hdca_ids: Optional[list[int]] = None,
     dataset_names: Optional[list[str]] = None,
     dataset_collection_names: Optional[list[str]] = None,
+    output_labels: Optional[list[Any]] = None,
 ) -> StoredWorkflow:
     """ID-based variant of :func:`extract_workflow`."""
     steps = extract_steps_by_ids(
@@ -539,12 +541,84 @@ def extract_workflow_by_ids(
         hdca_ids=hdca_ids,
         dataset_names=dataset_names,
         dataset_collection_names=dataset_collection_names,
+        output_labels=output_labels,
     )
     return _finalize_workflow(trans, user, workflow_name, steps)
 
 
 IdKey = tuple[Literal["dataset", "collection"], int]
 IdAssociations = list[tuple[IdKey, str]]
+OutputLabelKind = Literal["hda", "hdca"]
+OutputLabelKey = tuple[OutputLabelKind, int]
+OutputStepKey = tuple[Literal["job", "icj"], int, str]
+
+
+@dataclass(frozen=True)
+class OutputLabelTarget:
+    key: OutputLabelKey
+    step_key: OutputStepKey
+    output_name: str
+
+
+def output_label_to_id_key(kind: OutputLabelKind, content_id: int) -> IdKey:
+    if kind == "hda":
+        return ("dataset", content_id)
+    return ("collection", content_id)
+
+
+def normalize_output_label_key(trans: ProvidesHistoryContext, kind: OutputLabelKind, content_id: int) -> OutputLabelKey:
+    """Normalize a visible HDA/HDCA output id to the original id used by extraction wiring."""
+    user = getattr(trans, "user", None)
+    if kind == "hda":
+        hda = trans.app.hda_manager.get_accessible(content_id, user)
+        return ("hda", _original_hda(hda).id)
+    hdca = trans.app.dataset_collection_manager.get_dataset_collection_instance(trans, "history", content_id)
+    return ("hdca", _original_hdca(hdca).id)
+
+
+def collect_output_label_targets(
+    trans: ProvidesHistoryContext,
+    job_manager: Optional[JobManager] = None,
+    job_ids: Optional[list[int]] = None,
+    implicit_collection_jobs_ids: Optional[list[int]] = None,
+) -> dict[OutputLabelKey, OutputLabelTarget]:
+    """Collect concrete outputs produced by the selected extraction steps."""
+    job_ids = list(job_ids or [])
+    implicit_collection_jobs_ids = list(implicit_collection_jobs_ids or [])
+    targets: dict[OutputLabelKey, OutputLabelTarget] = {}
+
+    for job_id in job_ids:
+        assert job_manager is not None, "job_manager required when job_ids supplied"
+        job = job_manager.get_accessible_job(trans, job_id)
+        for hda_assoc in job.output_datasets:
+            output_name = hda_assoc.name
+            if _skip_output_assoc_name(output_name):
+                continue
+            original_hda = _original_hda(hda_assoc.dataset)
+            key: OutputLabelKey = ("hda", original_hda.id)
+            targets[key] = OutputLabelTarget(key=key, step_key=("job", job.id, output_name), output_name=output_name)
+        for hdca_assoc in job.output_dataset_collection_instances:
+            output_name = hdca_assoc.name
+            original_hdca = _original_hdca(hdca_assoc.dataset_collection_instance)
+            key = ("hdca", original_hdca.id)
+            targets[key] = OutputLabelTarget(key=key, step_key=("job", job.id, output_name), output_name=output_name)
+
+    sa_session = trans.sa_session
+    for icj_id in implicit_collection_jobs_ids:
+        icj = sa_session.get(ImplicitCollectionJobs, icj_id)
+        if icj is None:
+            continue
+        seen_output_names: set[str] = set()
+        for output_hdca in icj.output_dataset_collection_instances:
+            output_name = output_hdca.implicit_output_name
+            if not output_name or output_name in seen_output_names:
+                continue
+            seen_output_names.add(output_name)
+            original_hdca = _original_hdca(output_hdca)
+            key = ("hdca", original_hdca.id)
+            targets[key] = OutputLabelTarget(key=key, step_key=("icj", icj.id, output_name), output_name=output_name)
+
+    return targets
 
 
 def extract_steps_by_ids(
@@ -556,6 +630,7 @@ def extract_steps_by_ids(
     hdca_ids: Optional[list[int]] = None,
     dataset_names: Optional[list[str]] = None,
     dataset_collection_names: Optional[list[str]] = None,
+    output_labels: Optional[list[Any]] = None,
 ) -> list[WorkflowStep]:
     """ID-based variant of :func:`extract_steps`.
 
@@ -575,6 +650,7 @@ def extract_steps_by_ids(
     implicit_collection_jobs_ids = list(implicit_collection_jobs_ids or [])
     hda_ids = list(hda_ids or [])
     hdca_ids = list(hdca_ids or [])
+    output_labels = list(output_labels or [])
 
     user = getattr(trans, "user", None)
     sa_session = trans.sa_session
@@ -681,6 +757,20 @@ def extract_steps_by_ids(
                 original_hdca = _original_hdca(hdca_assoc.dataset_collection_instance)
                 id_to_output_pair[("collection", original_hdca.id)] = (step, hdca_assoc.name)
 
+    for output_label in output_labels:
+        kind = output_label.kind
+        content_id = output_label.id
+        label = output_label.label
+        normalized_kind, normalized_content_id = normalize_output_label_key(trans, kind, content_id)
+        id_key = output_label_to_id_key(normalized_kind, normalized_content_id)
+        output_pair = id_to_output_pair.get(id_key)
+        if output_pair is None:
+            raise exceptions.RequestParameterInvalidException(
+                f"output_labels includes {kind} id {content_id} that was not produced by a selected extraction step"
+            )
+        step, output_name = output_pair
+        step.create_or_update_workflow_output(output_name=output_name, label=label, uuid=None)
+
     return steps
 
 
@@ -753,8 +843,11 @@ def __cleanup_param_values_by_id(inputs: ToolInputs, values: ToolInputs) -> IdAs
 
 
 __all__ = (
+    "collect_output_label_targets",
     "summarize",
     "extract_workflow",
     "extract_workflow_by_ids",
     "extract_steps_by_ids",
+    "normalize_output_label_key",
+    "output_label_to_id_key",
 )

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -1132,6 +1132,213 @@ test_data:
 
         assert signature(wf_a) == signature(wf_b)
 
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_output_labels_marks_workflow_outputs(self, history_id):
+        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n")
+        d2 = self.dataset_populator.new_dataset(history_id, content="beta\n")
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        run = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={
+                "input1": {"src": "hda", "id": d1["id"]},
+                "queries_0|input2": {"src": "hda", "id": d2["id"]},
+            },
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        output = run["outputs"][0]
+
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[run["jobs"][0]["id"]],
+            output_labels=[{"kind": "hda", "id": output["id"], "label": "merged lines"}],
+        )
+
+        tool_step = self.assert_steps_of_type(downloaded, "tool", expected_len=1)[0]
+        workflow_outputs = tool_step["workflow_outputs"]
+        assert len(workflow_outputs) == 1
+        assert workflow_outputs[0]["output_name"] == "out_file1"
+        assert workflow_outputs[0]["label"] == "merged lines"
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_output_label_for_copied_output(self, history_id):
+        original_history_id = self.dataset_populator.new_history()
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(original_history_id, c1="alpha\n", c2="beta\n")
+        output = self._history_contents(original_history_id)[-1]
+        copied_output = self._copy_hda_to_history(history_id, output)
+
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+            output_labels=[{"kind": "hda", "id": copied_output["id"], "label": "copied merged lines"}],
+        )
+
+        tool_step = self.assert_steps_of_type(downloaded, "tool", expected_len=1)[0]
+        workflow_outputs = tool_step["workflow_outputs"]
+        assert len(workflow_outputs) == 1
+        assert workflow_outputs[0]["output_name"] == "out_file1"
+        assert workflow_outputs[0]["label"] == "copied merged lines"
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_duplicate_output_label_rejected(self, history_id):
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        contents = self._history_contents(history_id)
+        output = contents[-1]
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "duplicate output labels",
+                "hda_ids": [d1["id"], d2["id"]],
+                "job_ids": [cat1_job_id],
+                "output_labels": [
+                    {"kind": "hda", "id": output["id"], "label": "duplicate"},
+                    {"kind": "hda", "id": output["id"], "label": "duplicate"},
+                ],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_distinct_outputs_with_duplicate_label_string_rejected(self, history_id):
+        """Two distinct outputs cannot share the same workflow output label
+        (duplicate-label-string guard in `WorkflowsService._validate_extract_by_ids_payload`).
+        Sibling of the same-id duplicate guard which the existing duplicate test pins."""
+        d1, _, cat1_job_id_a = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        out_a = self._history_contents(history_id)[-1]
+        run_b = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={"input1": {"src": "hda", "id": d1["id"]}},
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        out_b = run_b["outputs"][0]
+        cat1_job_id_b = run_b["jobs"][0]["id"]
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "duplicate label string",
+                "hda_ids": [d1["id"]],
+                "job_ids": [cat1_job_id_a, cat1_job_id_b],
+                "output_labels": [
+                    {"kind": "hda", "id": out_a["id"], "label": "shared"},
+                    {"kind": "hda", "id": out_b["id"], "label": "shared"},
+                ],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_with_empty_output_labels_matches_existing_behavior(self, history_id):
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+            output_labels=[],
+        )
+        tool_step = self.assert_steps_of_type(downloaded, "tool", expected_len=1)[0]
+        assert tool_step["workflow_outputs"] == []
+
+    @skip_without_tool("random_lines1")
+    @summarize_instance_history_on_error
+    def test_extract_output_label_for_icj_step(self, history_id):
+        """ICJ producer: labelling the mapped output HDCA of a map-over step
+        must attach the workflow_output to the tool step, keyed by the
+        implicit collection output name."""
+        hdca, _, _, implicit_hdca1_id, implicit_hdca2_id = self._run_random_lines_mapped_over_pair(history_id)
+        icj_id1 = self._icj_id_for_hdca(history_id, implicit_hdca1_id)
+        icj_id2 = self._icj_id_for_hdca(history_id, implicit_hdca2_id)
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hdca_ids=[hdca["id"]],
+            implicit_collection_jobs_ids=[icj_id1, icj_id2],
+            output_labels=[{"kind": "hdca", "id": implicit_hdca1_id, "label": "mapped lines"}],
+        )
+        tool_steps = self.assert_steps_of_type(downloaded, "tool", expected_len=2)
+        labelled = [s for s in tool_steps if s["workflow_outputs"]]
+        assert len(labelled) == 1, [s["workflow_outputs"] for s in tool_steps]
+        outputs = labelled[0]["workflow_outputs"]
+        assert len(outputs) == 1, outputs
+        assert outputs[0]["output_name"] == "out_file1"
+        assert outputs[0]["label"] == "mapped lines"
+        # The labelled step must be the first map-over (consumes the data_collection_input),
+        # not the chained second step that consumes the first tool's output.
+        input_step = self.assert_steps_of_type(downloaded, "data_collection_input", expected_len=1)[0]
+        connection = labelled[0]["input_connections"]["input"]
+        connection = connection[0] if isinstance(connection, list) else connection
+        assert connection["id"] == input_step["id"], (connection, input_step)
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_output_label_orphan_rejected(self, history_id):
+        """Labelling an HDA that was not produced by any selected step must
+        be rejected with a 400. Hits the orphan guard in
+        `WorkflowsService._validate_extract_by_ids_payload` (the inner
+        guard in `extract_steps` is dead for the API path because the
+        service layer fires first)."""
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        unrelated = self.dataset_populator.new_dataset(history_id, content="orphan\n", wait=True)
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "orphan label",
+                "hda_ids": [d1["id"], d2["id"]],
+                "job_ids": [cat1_job_id],
+                "output_labels": [{"kind": "hda", "id": unrelated["id"], "label": "orphan"}],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_output_label_collapses_internal_whitespace(self, history_id):
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        output = self._history_contents(history_id)[-1]
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+            output_labels=[{"kind": "hda", "id": output["id"], "label": "merged   lines\tfoo"}],
+        )
+        tool_step = self.assert_steps_of_type(downloaded, "tool", expected_len=1)[0]
+        outputs = tool_step["workflow_outputs"]
+        assert len(outputs) == 1, outputs
+        assert outputs[0]["output_name"] == "out_file1"
+        assert outputs[0]["label"] == "merged lines foo"
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_output_label_truncated_at_255(self, history_id):
+        """Sanitizer silently truncates at 255 chars (`_sanitize_output_label`)."""
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        output = self._history_contents(history_id)[-1]
+        long_label = "x" * 300
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+            output_labels=[{"kind": "hda", "id": output["id"], "label": long_label}],
+        )
+        tool_step = self.assert_steps_of_type(downloaded, "tool", expected_len=1)[0]
+        workflow_outputs = tool_step["workflow_outputs"]
+        assert len(workflow_outputs) == 1, workflow_outputs
+        assert workflow_outputs[0]["output_name"] == "out_file1"
+        assert len(workflow_outputs[0]["label"]) == 255, workflow_outputs[0]["label"]
+        assert workflow_outputs[0]["label"] == "x" * 255
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_output_label_empty_after_sanitize_rejected(self, history_id):
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        output = self._history_contents(history_id)[-1]
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "empty after strip",
+                "hda_ids": [d1["id"], d2["id"]],
+                "job_ids": [cat1_job_id],
+                "output_labels": [{"kind": "hda", "id": output["id"], "label": "   "}],
+            },
+            (400,),
+        )
+
 
 class TestWorkflowExtractionSummaryApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCase):
     """Tests for GET /api/histories/{history_id}/extraction_summary."""
@@ -1198,6 +1405,11 @@ class TestWorkflowExtractionSummaryApi(_ExtractionHelpersMixin, BaseWorkflowsApi
             assert tool_job["checked"] is True
             assert tool_job["tool_version_warning"] is None
             assert len(tool_job["outputs"]) >= 1
+            output = tool_job["outputs"][0]
+            assert output["output_name"] == "out_file1"
+            assert output["suggested_name"]
+            assert output["suggested_name_source"] in {"renamed", "rendered_label", "bare_label", "port_name"}
+            assert output["exposed"] is False
 
     def test_extraction_summary_includes_udt_step(self):
         # UDT (unprivileged/user-defined tool) jobs were silently skipped in the
@@ -1267,6 +1479,57 @@ class TestWorkflowExtractionSummaryApi(_ExtractionHelpersMixin, BaseWorkflowsApi
             assert {j["implicit_collection_jobs_id"] for j in mapped_tool_jobs}.issuperset(expected_icj_ids)
             for job in mapped_tool_jobs:
                 assert job["implicit_collection_jobs_size"] == 2, job
+
+    @skip_without_tool("cat1")
+    @skip_without_tool("random_lines1")
+    def test_extraction_summary_suggested_name_source_per_producer_kind(self):
+        """Per-kind dispatch (HDA path vs HDCA path in
+        workflow_extraction_naming): rename the cat1 HDA so its source is
+        'renamed' and its suggested_name reflects the rename. The mapped
+        ICJ HDCA — never renamed by us — must surface its own auto-generated
+        HDCA name, distinct from the cat1 rename. A regression that
+        hard-codes a single source token or returns the same name for both
+        producer kinds fails this test."""
+        sentinel_cat1_name = "renamed cat1 output sentinel"
+        with self.dataset_populator.test_history() as history_id:
+            hda1 = self.dataset_populator.new_dataset(history_id, content="foo\nbar", wait=True)
+            hda2 = self.dataset_populator.new_dataset(history_id, content="baz", wait=True)
+            cat1_run = self.dataset_populator.run_tool(
+                "cat1",
+                {
+                    "input1": {"src": "hda", "id": hda1["id"]},
+                    "queries_0|input2": {"src": "hda", "id": hda2["id"]},
+                },
+                history_id,
+            )
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            self.dataset_populator.rename_dataset(cat1_run["outputs"][0]["id"], sentinel_cat1_name)
+            self._run_random_lines_mapped_over_pair(history_id)
+
+            summary = self._get_extraction_summary(history_id)
+            cat1_jobs = [j for j in summary["jobs"] if j.get("tool_id") == "cat1"]
+            mapped_jobs = [
+                j
+                for j in summary["jobs"]
+                if j.get("tool_id") == "random_lines1" and j.get("implicit_collection_jobs_id")
+            ]
+            assert cat1_jobs, summary["jobs"]
+            assert mapped_jobs, summary["jobs"]
+
+            cat1_outputs = cat1_jobs[0]["outputs"]
+            assert len(cat1_outputs) == 1, cat1_outputs
+            assert cat1_outputs[0]["suggested_name"] == sentinel_cat1_name, cat1_outputs[0]
+            assert cat1_outputs[0]["suggested_name_source"] == "renamed", cat1_outputs[0]
+
+            mapped_outputs = mapped_jobs[0]["outputs"]
+            assert mapped_outputs, mapped_jobs[0]
+            for output in mapped_outputs:
+                assert output["suggested_name"], output
+                # HDCA path's content_name is the implicit collection's
+                # auto-generated name — must differ from the sentinel we
+                # injected on the cat1 HDA, proving the dispatch did not
+                # bleed the cat1 rename into the HDCA path.
+                assert output["suggested_name"] != sentinel_cat1_name, output
 
     @skip_without_tool("cat1")
     def test_extraction_summary_structure(self):

--- a/lib/galaxy_test/selenium/test_workflow_extraction.py
+++ b/lib/galaxy_test/selenium/test_workflow_extraction.py
@@ -153,17 +153,6 @@ test_data:
 
     # --- UI Extraction Helpers ---
 
-    def extract_workflow_set_name(self, name: str):
-        """Set the workflow name in extraction form."""
-        name_input = self.components.workflow_extract.workflow_name_input.wait_for_visible()
-        name_input.clear()
-        name_input.send_keys(name)
-
-    def extract_workflow_submit(self):
-        """Submit the extraction form."""
-        self.components.workflow_extract.create_button.wait_for_and_click()
-        self.sleep_for(self.wait_types.UX_TRANSITION)
-
     def extract_workflow_toggle_job(self, job_id: str):
         """Toggle the selection checkbox for a specific job card by job_id."""
         checkbox = self.components.workflow_extract.card_checkbox_by_job_id(job_id=job_id)
@@ -191,22 +180,55 @@ test_data:
         self.navigate_to_workflow_extraction()
         if screenshot_name:
             self.screenshot(screenshot_name)
-        self.extract_workflow_set_name(name)
-        self.extract_workflow_submit()
+        self.extract_workflow_name_and_submit(name)
         return self.get_workflow_by_name(name)
 
     def count_job_checkboxes(self) -> int:
         """Count the number of tool-step cards in the extraction form."""
-        return len(self.find_elements_by_selector(self.components.workflow_extract.tool_card_checkbox.selector))
+        return len(self.components.workflow_extract.tool_card_checkbox.all())
 
     def count_checked_job_checkboxes(self) -> int:
         """Count the number of checked tool-step cards."""
-        return len(self.find_elements_by_selector(self.components.workflow_extract.tool_card_checkbox_checked.selector))
+        return len(self.components.workflow_extract.tool_card_checkbox_checked.all())
 
     def get_job_checkbox_values(self) -> list:
         """Get job IDs from all tool-step cards."""
-        cards = self.find_elements_by_selector(self.components.workflow_extract.tool_card.selector + "[data-job-id]")
+        cards = self.components.workflow_extract.tool_card_with_job_id.all()
         return [card.get_attribute("data-job-id") for card in cards]
+
+    def extract_workflow_toggle_output_star(self, job_id: str):
+        """Star/un-star the first output of the tool card for the given job.
+        The star button in WorkflowExtractionCard.vue is disabled while
+        `!props.job.checked` — a regression that defaults cards to
+        unchecked turns the click into a silent no-op, so the test surfaces
+        the bug directly rather than via a downstream timeout."""
+        star = self.components.workflow_extract.output_star_for_job(job_id=job_id).wait_for_present()
+        assert not star.get_attribute("disabled"), f"star for job {job_id} is disabled — its card is unchecked"
+        self.execute_script_click(star)
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+    def extract_workflow_rename_output(self, job_id: str, new_label: str):
+        """Click the output label button, type a new label in the modal, and
+        click the modal OK button. Requires the output to already be starred
+        (label button is v-if=output.exposed)."""
+        label_button = self.components.workflow_extract.output_label_for_job(job_id=job_id).wait_for_present()
+        self.execute_script_click(label_button)
+        self.components.workflow_extract.output_rename_input.wait_for_and_clear_and_send_keys(new_label)
+        self.components.workflow_extract.output_rename_confirm.wait_for_and_click()
+        # Modal closes asynchronously after the rename callback resolves.
+        self.components.workflow_extract.output_rename_input.wait_for_absent()
+
+    def extract_workflow_cancel_rename_output(self, job_id: str):
+        """Open the rename modal, type some text, and dismiss without
+        confirming. Asserts the modal closes without applying the rename."""
+        label_button = self.components.workflow_extract.output_label_for_job(job_id=job_id).wait_for_present()
+        self.execute_script_click(label_button)
+        self.components.workflow_extract.output_rename_input.wait_for_and_clear_and_send_keys("discarded label")
+        self.components.workflow_extract.output_rename_cancel.wait_for_and_click()
+        self.components.workflow_extract.output_rename_input.wait_for_absent()
+
+    def count_active_output_stars(self) -> int:
+        return len(self.components.workflow_extract.all_active_output_stars.all())
 
     @selenium_test
     @managed_history
@@ -245,9 +267,7 @@ test_data:
         for job_id in rendered_job_ids:
             self.extract_workflow_toggle_job(job_id)
         # Also uncheck any remaining checked cards (e.g. input_collection / input_dataset)
-        for element in self.find_elements_by_selector(
-            self.components.workflow_extract.all_card_checkboxes_checked.selector
-        ):
+        for element in self.components.workflow_extract.all_card_checkboxes_checked.all():
             self.execute_script_click(element)
         self.sleep_for(self.wait_types.UX_RENDER)
 
@@ -293,20 +313,19 @@ test_data:
         # Toggle checkbox off
         self.extract_workflow_toggle_job(cat1_job_id)
         self.sleep_for(self.wait_types.UX_RENDER)
-        cat1_checkbox = self.find_element_by_selector(f'[data-job-id="{cat1_job_id}"] input[id^="g-card-select-"]')
+        cat1_checkbox = self.components.workflow_extract.card_checkbox_by_job_id(job_id=cat1_job_id).wait_for_present()
         assert not cat1_checkbox.is_selected(), "Expected checkbox unchecked after toggle"
 
         # Toggle back on
         self.extract_workflow_toggle_job(cat1_job_id)
         self.sleep_for(self.wait_types.UX_RENDER)
-        cat1_checkbox = self.find_element_by_selector(f'[data-job-id="{cat1_job_id}"] input[id^="g-card-select-"]')
+        cat1_checkbox = self.components.workflow_extract.card_checkbox_by_job_id(job_id=cat1_job_id).wait_for_present()
         assert cat1_checkbox.is_selected(), "Expected checkbox checked after second toggle"
         self.screenshot("workflow_extract_toggle_checkbox")
 
         # Extract workflow and verify structure
         workflow_name = "Selenium Extracted Cat1"
-        self.extract_workflow_set_name(workflow_name)
-        self.extract_workflow_submit()
+        self.extract_workflow_name_and_submit(workflow_name)
 
         workflow = self.get_workflow_by_name(workflow_name)
         self.assert_cat1_workflow_structure(workflow)
@@ -333,8 +352,8 @@ test_data:
         self.sleep_for(self.wait_types.UX_RENDER)
 
         # Verify first job unchecked, second job still checked
-        checkbox1 = self.find_element_by_selector(f'[data-job-id="{job_id_first}"] input[id^="g-card-select-"]')
-        checkbox2 = self.find_element_by_selector(f'[data-job-id="{job_id_second}"] input[id^="g-card-select-"]')
+        checkbox1 = self.components.workflow_extract.card_checkbox_by_job_id(job_id=job_id_first).wait_for_present()
+        checkbox2 = self.components.workflow_extract.card_checkbox_by_job_id(job_id=job_id_second).wait_for_present()
         assert not checkbox1.is_selected(), f"Expected job {job_id_first} unchecked"
         assert checkbox2.is_selected(), f"Expected job {job_id_second} still checked"
 
@@ -342,8 +361,7 @@ test_data:
 
         # Submit extraction
         workflow_name = "Selenium Job Subset"
-        self.extract_workflow_set_name(workflow_name)
-        self.extract_workflow_submit()
+        self.extract_workflow_name_and_submit(workflow_name)
 
         # Verify extracted workflow has 2 steps (1 input + 1 tool from second run only)
         workflow = self.get_workflow_by_name(workflow_name)
@@ -370,8 +388,7 @@ test_data:
 
         # Extract and verify structure
         workflow_name = "Selenium Copied Inputs"
-        self.extract_workflow_set_name(workflow_name)
-        self.extract_workflow_submit()
+        self.extract_workflow_name_and_submit(workflow_name)
 
         workflow = self.get_workflow_by_name(workflow_name)
         self.assert_cat1_workflow_structure(workflow)
@@ -412,8 +429,7 @@ test_data:
         self.screenshot("workflow_extract_reduce_collection")
 
         workflow_name = "Selenium Reduce Collection"
-        self.extract_workflow_set_name(workflow_name)
-        self.extract_workflow_submit()
+        self.extract_workflow_name_and_submit(workflow_name)
 
         workflow = self.get_workflow_by_name(workflow_name)
         # Should have 3 steps (1 collection input + 2 tools)
@@ -442,8 +458,7 @@ test_data:
         self.screenshot("workflow_extract_output_collections")
 
         workflow_name = "Selenium Output Collections"
-        self.extract_workflow_set_name(workflow_name)
-        self.extract_workflow_submit()
+        self.extract_workflow_name_and_submit(workflow_name)
 
         workflow = self.get_workflow_by_name(workflow_name)
         # Should have 5 steps (2 data inputs + 3 tools)
@@ -464,17 +479,16 @@ test_data:
         # one cat1 job per list element (typically 2, but may vary).
         job_count = self.count_job_checkboxes()
         assert job_count >= 1, f"Expected at least 1 job checkbox, found {job_count}"
-        mapped_cards = self.find_elements_by_selector(self.components.workflow_extract.mapped_tool_card.selector)
+        mapped_cards = self.components.workflow_extract.mapped_tool_card.all()
         assert len(mapped_cards) >= 1, "Expected at least one mapped-tool card on a list:paired mapped flow"
         for card in mapped_cards:
             assert card.get_attribute("data-icj-id"), "mapped-tool card missing data-icj-id"
-        mapped_badges = self.find_elements_by_selector(self.components.workflow_extract.mapped_badge.selector)
+        mapped_badges = self.components.workflow_extract.mapped_badge.all()
         assert len(mapped_badges) >= len(mapped_cards), "Expected mapped-tool cards to show a Mapped badge"
         self.screenshot("workflow_extract_nested_collection")
 
         workflow_name = "Selenium Nested Collection"
-        self.extract_workflow_set_name(workflow_name)
-        self.extract_workflow_submit()
+        self.extract_workflow_name_and_submit(workflow_name)
 
         workflow = self.get_workflow_by_name(workflow_name)
         # Should have 2 steps (1 collection input + 1 tool)
@@ -482,3 +496,83 @@ test_data:
 
         # Verify collection input is list:paired
         self.assert_input_step_collection_type(workflow, "list:paired")
+
+    @skip_without_tool("cat1")
+    @selenium_test
+    @managed_history
+    def test_extract_output_star_and_label_creates_workflow_output(self):
+        """Star + rename an output via the extraction UI, submit, and confirm
+        the downloaded workflow carries the renamed workflow_output."""
+        history_id = self.current_history_id()
+        cat1_job_id = self.setup_cat1_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+        assert self.count_active_output_stars() == 0, "Outputs must default to unstarred"
+
+        self.extract_workflow_toggle_output_star(cat1_job_id)
+        self.components.workflow_extract.output_star_active_for_job(job_id=cat1_job_id).wait_for_present()
+        self.screenshot("workflow_extract_output_starred")
+
+        self.extract_workflow_rename_output(cat1_job_id, "cat1 result")
+
+        workflow_name = "Selenium Star And Label"
+        self.extract_workflow_name_and_submit(workflow_name)
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        tool_steps = self.assert_steps_of_type(workflow, "tool", expected_len=1)
+        outputs = tool_steps[0]["workflow_outputs"]
+        assert len(outputs) == 1, outputs
+        assert outputs[0]["output_name"] == "out_file1"
+        assert outputs[0]["label"] == "cat1 result"
+
+    @skip_without_tool("cat1")
+    @selenium_test
+    @managed_history
+    def test_extract_default_off_creates_no_workflow_outputs(self):
+        """Regression-guards the 'stars default off' UX decision: extracting
+        without touching stars must produce a workflow with no workflow_outputs."""
+        history_id = self.current_history_id()
+        self.setup_cat1_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+        # Pin the UX default at the source: no stars active on initial render.
+        # Catches a regression that flips the default to on before the
+        # downstream workflow_outputs assertion would.
+        assert self.count_active_output_stars() == 0, "Outputs must default to unstarred"
+        self.screenshot("workflow_extract_default_no_outputs")
+
+        workflow_name = "Selenium Default No Outputs"
+        self.extract_workflow_name_and_submit(workflow_name)
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        tool_steps = self.assert_steps_of_type(workflow, "tool", expected_len=1)
+        assert tool_steps[0]["workflow_outputs"] == [], tool_steps[0]["workflow_outputs"]
+
+    @skip_without_tool("cat1")
+    @selenium_test
+    @managed_history
+    def test_extract_cancel_rename_preserves_star_and_default_label(self):
+        """Cancelling the rename modal must leave the output starred but
+        keep the default label (no workflow_output label applied)."""
+        history_id = self.current_history_id()
+        cat1_job_id = self.setup_cat1_history(history_id)
+
+        self.navigate_to_workflow_extraction()
+        self.extract_workflow_toggle_output_star(cat1_job_id)
+        self.components.workflow_extract.output_star_active_for_job(job_id=cat1_job_id).wait_for_present()
+        self.extract_workflow_cancel_rename_output(cat1_job_id)
+        # Star must remain active after cancel.
+        self.components.workflow_extract.output_star_active_for_job(job_id=cat1_job_id).wait_for_present()
+
+        workflow_name = "Selenium Cancel Rename"
+        self.extract_workflow_name_and_submit(workflow_name)
+
+        workflow = self.get_workflow_by_name(workflow_name)
+        tool_steps = self.assert_steps_of_type(workflow, "tool", expected_len=1)
+        outputs = tool_steps[0]["workflow_outputs"]
+        assert len(outputs) == 1, outputs
+        assert outputs[0]["output_name"] == "out_file1"
+        # WorkflowExtractionForm's onOutputToggle auto-fills the label from
+        # suggested_name on star, so the label is non-empty even with no
+        # rename; the only invariant is that the cancelled rename did NOT apply.
+        assert outputs[0]["label"] != "discarded label", outputs[0]


### PR DESCRIPTION
API + UI w/API and Selenium tests. In review I asked Claude to simplify some existing typing that was a little akward and I felt was made only more awkward with these changes with the commit "[Simplify WorkflowExtraction client types](https://github.com/galaxyproject/galaxy/commit/27fdd4bec92f8789cc744772591871e4e75d8f2b)". I think it cleans up complicated call sites and reads better - but it is more code and more indirection so I'm happy to remove it if we don't like that change.

This functionality is an important prerequisite of #22709 and notebook extraction even if it doesn't go through the graph view and a useful feature in its own right I think. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
