### PR TITLE
Dispatch container builds to galaxy-docker-k8s (externalize container CI)

### DIFF
--- a/.github/workflows/notify-container-build.yml
+++ b/.github/workflows/notify-container-build.yml
@@ -1,0 +1,52 @@
+# Lives in galaxyproject/galaxy — the ONLY container-build file that stays in the
+# main repo. It builds nothing; it just tells galaxy-docker-k8s that source moved.
+#
+# Requires an org/repo secret CONTAINER_BUILD_DISPATCH_TOKEN: a fine-grained PAT or
+# GitHub App token with "Contents: read" on galaxyproject/galaxy-docker-k8s.
+# (The built-in GITHUB_TOKEN cannot dispatch to another repository.)
+name: Notify container build repo
+
+on:
+  push:
+    branches:
+      - dev
+      - release_*
+  release:
+    types: [released, prereleased]
+
+jobs:
+  dispatch:
+    name: Dispatch build to galaxy-docker-k8s
+    if: github.repository == 'galaxyproject/galaxy'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute payload
+        id: p
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "build_type=release"                              >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.event.release.tag_name }}"        >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=${{ github.event.release.prerelease }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
+            echo "build_type=dev"   >> "$GITHUB_OUTPUT"
+            echo "ref=dev"          >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_type=release_branch"           >> "$GITHUB_OUTPUT"
+            echo "ref=${GITHUB_REF#refs/heads/}"        >> "$GITHUB_OUTPUT"
+            echo "is_prerelease=false"                  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger galaxy-docker-k8s
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CONTAINER_BUILD_DISPATCH_TOKEN }}
+          repository: galaxyproject/galaxy-docker-k8s
+          event-type: galaxy-source-changed
+          client-payload: |
+            {
+              "build_type": "${{ steps.p.outputs.build_type }}",
+              "ref": "${{ steps.p.outputs.ref }}",
+              "sha": "${{ github.sha }}",
+              "is_prerelease": "${{ steps.p.outputs.is_prerelease }}"
+            }


### PR DESCRIPTION
## What

Companion to **galaxyproject/galaxy-docker-k8s#42**, which moves the Galaxy container build/test/publish orchestration out of this repo and into `galaxy-docker-k8s` (where the ansible playbook the image is built from already lives). See galaxyproject/galaxy#22763 for the discussion.

This PR adds the **only** container-build file that needs to remain in galaxy/galaxy: a ~50-line hook that builds nothing and just notifies `galaxy-docker-k8s` (via `repository_dispatch`) when source moves on `dev`, `release_*`, or a release.

## Why this is all that stays here

The actual coupling to this repo is small — the external build needs the source tree at a ref (cloneable), event triggers, and `.k8s_ci.Dockerfile` (which stays here because it tracks the source layout). This hook supplies the one thing an external repo can't observe natively: the push/release events. A nightly cron in `galaxy-docker-k8s` is the safety net if a dispatch is ever missed.

## Draft — do not merge yet

Blocked on the `galaxy-docker-k8s` side landing **and** the secret/token wiring:

- Add `CONTAINER_BUILD_DISPATCH_TOKEN` here (fine-grained PAT or GitHub App token with `Contents: read` on `galaxyproject/galaxy-docker-k8s`). The built-in `GITHUB_TOKEN` **cannot** dispatch across repos.
- Until then this workflow would fail at the dispatch step on every `dev` push.

When this lands, `build_container_image.yaml` (and the workflows proposed in #22763) should be removed in the same change — the "off switch" becomes `git rm` rather than a manual GitHub-UI toggle.

🤖 Drafted with Claude Code.
