### PR TITLE
[26.1] Reconnect SSE live updates on wake, network restore, and click

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -55,7 +55,11 @@ const router = useRouter();
 const { pushToFrameOrPage } = useWindowAwareNavigation();
 const { currentUser, isAnonymous } = storeToRefs(useUserStore());
 const { config } = useConfig();
-const { connected: sseConnected, hasEverConnected: sseHasEverConnected } = useSSEConnectionStatus();
+const {
+    connected: sseConnected,
+    hasEverConnected: sseHasEverConnected,
+    reconnect: reconnectSSE,
+} = useSSEConnectionStatus();
 const { historySize, numItemsActive, numItemsDeleted, numItemsHidden } = useHistoryContentStats(
     toRef(props, "history"),
 );
@@ -134,6 +138,12 @@ function updateTime() {
 }
 
 async function reloadContents() {
+    // When live updates have dropped, the click should re-establish the SSE
+    // pipeline — not just pull a one-shot REST refresh — so subsequent updates
+    // resume on their own. The emit below still re-fetches contents now.
+    if (sseLost.value) {
+        reconnectSSE();
+    }
     emit("reloadContents");
     reloadButtonLoading.value = true;
     setTimeout(() => {

--- a/client/src/composables/useNotificationSSE.test.ts
+++ b/client/src/composables/useNotificationSSE.test.ts
@@ -18,6 +18,7 @@ import {
     _resetHistoryViewerSubscriptionsForTest,
     _resetSSESharedSourceForTest,
     addHistoryViewerSubscription,
+    reconnectSSE,
     removeHistoryViewerSubscription,
     useSSE,
 } from "./useNotificationSSE";
@@ -255,5 +256,137 @@ describe("useNotificationSSE managed reconnect", () => {
         reopened.onerror?.();
         vi.advanceTimersByTime(2000);
         expect(FakeEventSource.instances).toHaveLength(beforeReset + 2);
+    });
+});
+
+/**
+ * Forced-reconnect tests.
+ *
+ * Background tabs throttle/suspend the timers both the browser's native retry
+ * and the managed backoff depend on, so a drop while hidden can sit
+ * un-recovered. ``reconnectSSE`` (the "click to refresh" affordance) and the
+ * wake/online listeners must reopen immediately, ignoring the backoff
+ * schedule, and only when a connection is actually wanted/lost.
+ */
+describe("useNotificationSSE forced reconnect", () => {
+    let originalEventSource: typeof EventSource | undefined;
+    let scope: EffectScope;
+
+    beforeEach(() => {
+        FakeEventSource.reset();
+        originalEventSource = (globalThis as unknown as { EventSource?: typeof EventSource }).EventSource;
+        (globalThis as unknown as { EventSource: unknown }).EventSource = FakeEventSource;
+        vi.useFakeTimers();
+        _resetSSESharedSourceForTest();
+        scope = effectScope();
+    });
+
+    afterEach(() => {
+        scope.stop();
+        vi.useRealTimers();
+        _resetSSESharedSourceForTest();
+        if (originalEventSource) {
+            (globalThis as unknown as { EventSource: typeof EventSource }).EventSource = originalEventSource;
+        } else {
+            delete (globalThis as unknown as { EventSource?: unknown }).EventSource;
+        }
+    });
+
+    it("reconnectSSE reopens immediately without waiting for backoff", () => {
+        scope.run(() => {
+            const { connect } = useSSE(() => {});
+            connect();
+        });
+        expect(FakeEventSource.instances).toHaveLength(1);
+
+        const first = FakeEventSource.instances[0]!;
+        first.readyState = FakeEventSource.CLOSED;
+        first.onerror?.();
+        // A managed reopen is now armed, but reconnectSSE should not wait for it.
+        reconnectSSE();
+        expect(FakeEventSource.instances).toHaveLength(2);
+
+        // The armed backoff timer was cancelled, so advancing time does not
+        // spawn a third instance.
+        vi.advanceTimersByTime(60_000);
+        expect(FakeEventSource.instances).toHaveLength(2);
+    });
+
+    it("reconnectSSE resets the backoff so the next failure starts at the base envelope", () => {
+        scope.run(() => {
+            const { connect } = useSSE(() => {});
+            connect();
+        });
+
+        // Stack failures to drive the unjittered delay to the 30s cap.
+        const STACKED = 5;
+        for (let i = 0; i < STACKED; i++) {
+            const current = FakeEventSource.instances.at(-1)!;
+            current.readyState = FakeEventSource.CLOSED;
+            current.onerror?.();
+            vi.advanceTimersByTime(45_001);
+        }
+        const beforeReconnect = FakeEventSource.instances.length;
+
+        // Forced reconnect opens now and zeroes the counter.
+        reconnectSSE();
+        expect(FakeEventSource.instances).toHaveLength(beforeReconnect + 1);
+
+        // Next failure must fire on the base [500, 1500) envelope — a 2s
+        // advance proves the counter reset (the capped path would need ~15s).
+        const reopened = FakeEventSource.instances.at(-1)!;
+        reopened.readyState = FakeEventSource.CLOSED;
+        reopened.onerror?.();
+        vi.advanceTimersByTime(2000);
+        expect(FakeEventSource.instances).toHaveLength(beforeReconnect + 2);
+    });
+
+    it("reconnectSSE is a no-op when there are no subscribers", () => {
+        // No connect() — the subscriber map is empty.
+        reconnectSSE();
+        expect(FakeEventSource.instances).toHaveLength(0);
+    });
+
+    it("reconnects when the tab becomes visible again while disconnected", () => {
+        scope.run(() => {
+            const { connect } = useSSE(() => {});
+            connect();
+        });
+        const first = FakeEventSource.instances[0]!;
+        first.onopen?.();
+        // Connection drops while backgrounded.
+        first.readyState = FakeEventSource.CLOSED;
+        first.onerror?.();
+
+        document.dispatchEvent(new Event("visibilitychange"));
+        // jsdom reports ``document.visibilityState === "visible"`` by default,
+        // so the wake handler should fire an immediate reopen.
+        expect(FakeEventSource.instances).toHaveLength(2);
+    });
+
+    it("does not reconnect on visibilitychange while the connection is healthy", () => {
+        scope.run(() => {
+            const { connect } = useSSE(() => {});
+            connect();
+        });
+        const first = FakeEventSource.instances[0]!;
+        first.onopen?.();
+
+        document.dispatchEvent(new Event("visibilitychange"));
+        expect(FakeEventSource.instances).toHaveLength(1);
+    });
+
+    it("reconnects when network connectivity returns while disconnected", () => {
+        scope.run(() => {
+            const { connect } = useSSE(() => {});
+            connect();
+        });
+        const first = FakeEventSource.instances[0]!;
+        first.onopen?.();
+        first.readyState = FakeEventSource.CLOSED;
+        first.onerror?.();
+
+        window.dispatchEvent(new Event("online"));
+        expect(FakeEventSource.instances).toHaveLength(2);
     });
 });

--- a/client/src/composables/useNotificationSSE.ts
+++ b/client/src/composables/useNotificationSSE.ts
@@ -133,7 +133,33 @@ function openSourceIfNeeded() {
     // tab-close, unlike ``beforeunload``) to close that window.
     if (typeof window !== "undefined") {
         window.addEventListener("pagehide", closeSource);
+        // Background tabs throttle/suspend the timers that both the browser's
+        // native EventSource retry and our ``scheduleReconnect`` backoff rely
+        // on, so a drop while the tab is hidden can sit un-recovered until the
+        // user comes back. Force an immediate reopen when the tab is
+        // refocused or connectivity returns. This only cycles the SSE socket —
+        // it never starts polling — so it stays consistent with the SSE-mode
+        // design decision documented in ``historyStore.ts``. Re-adding the
+        // same function reference is idempotent, so calling this on every
+        // reopen does not stack listeners.
+        window.addEventListener("online", handleWakeReconnect);
     }
+    if (typeof document !== "undefined") {
+        document.addEventListener("visibilitychange", handleWakeReconnect);
+    }
+}
+
+// Force an immediate reconnect when the tab wakes up (refocus) or the network
+// comes back, but only when we're actually disconnected so we never tear down
+// a healthy stream.
+function handleWakeReconnect() {
+    if (typeof document !== "undefined" && document.visibilityState !== "visible") {
+        return;
+    }
+    if (sharedConnected.value) {
+        return;
+    }
+    reconnectSSE();
 }
 
 function closeSource() {
@@ -158,6 +184,10 @@ function closeSource() {
     reconnectAttempts = 0;
     if (typeof window !== "undefined") {
         window.removeEventListener("pagehide", closeSource);
+        window.removeEventListener("online", handleWakeReconnect);
+    }
+    if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", handleWakeReconnect);
     }
 }
 
@@ -210,6 +240,38 @@ function scheduleReconnect() {
             openSourceIfNeeded();
         }
     }, delay);
+}
+
+/**
+ * Force an immediate reconnect, bypassing the backoff schedule. Used by the
+ * "Live updates disconnected. Click to refresh." button and by the
+ * wake/online listeners — situations where the user (or a regained-focus
+ * signal) wants the stream back *now* rather than on the next backed-off
+ * ``setTimeout`` tick, which a backgrounded tab may have suspended.
+ */
+export function reconnectSSE(): void {
+    // Nothing wants events; leave the source closed.
+    let hasSubscribers = false;
+    for (const subs of subscribers.values()) {
+        if (subs.size > 0) {
+            hasSubscribers = true;
+            break;
+        }
+    }
+    if (!hasSubscribers) {
+        return;
+    }
+    // Drop any pending managed reopen and zero the backoff so this reopen
+    // happens immediately and the next failure starts at the base delay.
+    if (reconnectTimer !== null) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+    }
+    reconnectAttempts = 0;
+    // Cycle the socket while keeping the subscriber map intact — covers both a
+    // source stuck in CONNECTING and one already CLOSED.
+    closeSourceForReconnect();
+    openSourceIfNeeded();
 }
 
 function addSubscriber(onEvent: Handler, eventTypes: readonly SSEEventType[]) {
@@ -298,12 +360,14 @@ export const useNotificationSSE = useSSE;
  * Read-only handle on the shared SSE connection state. ``connected`` flips
  * with the EventSource lifecycle; ``hasEverConnected`` latches true on the
  * first successful open so callers can ignore the initial-connect window
- * when surfacing a "connection lost" warning.
+ * when surfacing a "connection lost" warning. ``reconnect`` forces an
+ * immediate reopen for "click to refresh" affordances.
  */
 export function useSSEConnectionStatus() {
     return {
         connected: readonly(sharedConnected),
         hasEverConnected: readonly(sseEverConnected),
+        reconnect: reconnectSSE,
     };
 }
 


### PR DESCRIPTION
The "Live updates disconnected" badge could stay red indefinitely after a tab had been inactive: the browser's native EventSource retry and the managed backoff both run on timers that background tabs throttle/suspend, so a drop while hidden was not recovered on its own. Clicking the refresh button also did not help -- it only triggered a one-shot REST refetch and never touched the EventSource.

Add an immediate reconnect path that bypasses the backoff schedule:
- reconnectSSE() cycles the shared socket now (cancels pending backoff, resets the attempt counter), guarded to no-op without subscribers.
- visibilitychange/online listeners force a reconnect when the tab is refocused or connectivity returns, only while disconnected, so a healthy stream is never torn down. This cycles the SSE socket only and never starts polling, consistent with the SSE-mode design.
- The refresh button calls reconnectSSE() when live updates are lost, in addition to the existing REST refetch.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
