### PR TITLE
[26.1] Drop full path from client_build_hash.txt exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ shed_data_manager_conf.xml
 object_store_conf.xml
 job_metrics_conf.xml
 workflow_schedulers_conf.xml
+client_build_hash.txt
 config/*
 config/plugins/interactive_environments/**/*.ini
 config/plugins/**/.cache
@@ -81,7 +82,6 @@ config/plugins/visualizations
 !config/plugins
 static/welcome.html.*
 static/welcome.html
-static/client_build_hash.txt
 lib/galaxy_test/selenium/jupyter/galaxy_selenium_context.yml
 
 # Tool data


### PR DESCRIPTION
 -- we don't want this included in packages either (and never will anywhere)

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
