### PR TITLE
Fix for multi-select allow-empty parameter

### DIFF
--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -71,6 +71,20 @@ describe("FormSelect", () => {
         expect(unselectDefault.text()).toBe("Nothing selected");
     });
 
+    it("required multi-select emits null when fully cleared", async () => {
+        const wrapper = createTarget({
+            optional: false,
+            multiple: true,
+            options: defaultOptions,
+            value: ["value_1"],
+        });
+        const selected = wrapper.findAll(".multiselect__option--selected");
+        expect(selected.length).toBe(1);
+        selected.at(0).trigger("click");
+        const emitted = wrapper.emitted().input[0][0];
+        expect(emitted).toBe(null);
+    });
+
     it("multiple values", async () => {
         const wrapper = createTarget({
             optional: true,

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -241,7 +241,7 @@ function isSelected(item: SelectValue): boolean {
             v-if="hasOptions"
             :id="id"
             v-model="currentValue"
-            :allow-empty="optional"
+            :allow-empty="optional || multiple"
             :aria-expanded="ariaExpanded"
             :close-on-select="!multiple"
             :disabled="disabled"

--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -109,8 +109,8 @@ function onChange(refreshOnChange?: boolean): void {
     rebuildIndex();
     const params = buildFormData();
     if (JSON.stringify(params) != JSON.stringify(formData.value)) {
-        formData.value = params;
         resetErrors();
+        formData.value = params;
         emit("onChange", params, refreshOnChange);
     }
 }

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -403,7 +403,11 @@ export function validateInputs(index, values, rejectEmptyRequiredInputs = false)
             continue;
         }
         if (isRequired && inputDef.type != "hidden") {
-            if (!isDefined(inputValue) || (rejectEmptyRequiredInputs && inputValue === "")) {
+            if (
+                !isDefined(inputValue) ||
+                (rejectEmptyRequiredInputs && inputValue === "") ||
+                (Array.isArray(inputValue) && inputValue.length === 0)
+            ) {
                 return [inputId, "Please provide a value for this option."];
             }
         }

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -120,6 +120,23 @@ describe("form component utilities", () => {
         expect(JSON.stringify(result)).toEqual('["input_c","Please provide data for this input."]');
     });
 
+    it("rejects empty array for required multi-select but allows it when optional", () => {
+        const index = { multi: {} };
+
+        // Required (default) + empty array → fails
+        let result = validateInputs(index, { multi: [] });
+        expect(JSON.stringify(result)).toEqual('["multi","Please provide a value for this option."]');
+
+        // Required + non-empty array → passes
+        result = validateInputs(index, { multi: ["alpha"] });
+        expect(result).toEqual(null);
+
+        // Optional + empty array → passes
+        index.multi.optional = true;
+        result = validateInputs(index, { multi: [] });
+        expect(result).toEqual(null);
+    });
+
     it("test error matching", () => {
         const index = {
             input_a: {},

--- a/client/src/components/Tool/ToolForm.test.js
+++ b/client/src/components/Tool/ToolForm.test.js
@@ -111,4 +111,31 @@ describe("ToolForm", () => {
 
         expect(userStore.recentTools).toEqual(["tool_id"]);
     });
+
+    it("preserves client-side validation errors on input change (does not wipe formConfig.errors when only validationInternal is set)", async () => {
+        await flushPromises();
+        // Simulate steady state: no backend errors, but a client-side validation error
+        // raised by FormDisplay (e.g. a required field was cleared).
+        await wrapper.setData({
+            formConfigInitialized: true,
+            validationInternal: ["multi_required", "Please provide a value for this option."],
+        });
+        wrapper.vm.formConfig.errors = {};
+
+        wrapper.vm.onChange({ multi_required: null }, false);
+
+        // Should NOT have been assigned null — that would cascade through props.errors
+        // and wipe the client-side validation error before it can render.
+        expect(wrapper.vm.formConfig.errors).toEqual({});
+    });
+
+    it("still wipes formConfig.errors when there are actual backend errors to clear on input change", async () => {
+        await flushPromises();
+        await wrapper.setData({ formConfigInitialized: true });
+        wrapper.vm.formConfig.errors = { multi_required: "Backend rejected this value." };
+
+        wrapper.vm.onChange({ multi_required: "alpha" }, false);
+
+        expect(wrapper.vm.formConfig.errors).toBeNull();
+    });
 });

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -299,7 +299,7 @@ export default {
         hasConfigOrValErrors() {
             return (
                 (this.formConfig.errors && Object.values(this.formConfig.errors).length > 0) ||
-                this.validationInternal?.length
+                this.validationInternal?.length > 0
             );
         },
     },
@@ -342,9 +342,13 @@ export default {
             this.formData = newData;
             if (refreshRequest) {
                 this.onUpdate();
-            } else if (this.formConfigInitialized && this.hasConfigOrValErrors) {
-                // After the first manual change to a form input, for every change, if there isn't a request to refresh,
-                // we reset the errors since we haven't received a tool form update via the backend.
+            } else if (
+                this.formConfigInitialized &&
+                this.formConfig.errors &&
+                Object.values(this.formConfig.errors).length > 0
+            ) {
+                // Clear stale backend errors when the user edits. Scoped to backend errors only;
+                // client-side validation errors are not wiped here.
                 this.formConfig.errors = null;
             }
             this.formConfigInitialized = true;

--- a/client/src/style/scss/multiselect.scss
+++ b/client/src/style/scss/multiselect.scss
@@ -47,7 +47,7 @@
         }
 
         &.multiselect__option--highlight {
-            background: darken($brand-secondary, 40%);
+            background: darken($brand-secondary, 10%);
 
             &::after {
                 background: unset;


### PR DESCRIPTION
_Addresses issue #22498_

### Allow empty option (first element still pre-selected upon loading) 
_[last updated: 2026-06-01]_

<img width="722" height="269" alt="2026-06-01 07-26-44 2026-06-01 07_30_16" src="https://github.com/user-attachments/assets/08f183b4-0c7c-47cd-a96a-42443e236270" />

### Improved color contrast for select drop-down background color selected option highlighting

_before / after_

<img width="325" height="199" alt="multiselect_highlight_bg_color_BEFORE" src="https://github.com/user-attachments/assets/82cd9b10-a567-48f4-b998-ee0938ad8ede" /> <img width="325" height="199" alt="multiselect_highlight_bg_color_AFTER" src="https://github.com/user-attachments/assets/58a9f0d5-b83a-4144-b225-a1382dedaa81" />

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

1. Select one item (e.g., "breakfast")
2. Deselect it before selecting another (this was the bug!)
3. Select a different item (e.g., "lunch")

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
