### PR TITLE
Add upload storage selector

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -8228,6 +8228,8 @@ export interface components {
             history_id: unknown;
             /** Landing Uuid */
             landing_uuid?: unknown;
+            /** Preferred Object Store Id */
+            preferred_object_store_id?: unknown;
             /** Targets */
             targets: unknown;
         };
@@ -12737,6 +12739,11 @@ export interface components {
             history_id: string;
             /** Landing Uuid */
             landing_uuid?: string | null;
+            /**
+             * Preferred Object Store Id
+             * @description Optional preferred storage location id used when creating fetched datasets.
+             */
+            preferred_object_store_id?: string | null;
             /** Targets */
             targets: (
                 | components["schemas"]["DataElementsTarget"]

--- a/client/src/components/History/TargetHistorySelector.vue
+++ b/client/src/components/History/TargetHistorySelector.vue
@@ -56,8 +56,11 @@ function handleHistorySelected(history: { id: string }) {
 
 <template>
     <div>
-        <div class="d-flex align-items-center">
-            <TargetHistoryLink :target-history-id="targetHistoryId" :target-history-caption="historyCaption" />
+        <div class="target-history-selector-row d-flex align-items-center">
+            <TargetHistoryLink
+                class="target-history-selector-link"
+                :target-history-id="targetHistoryId"
+                :target-history-caption="historyCaption" />
             <a
                 v-if="canChangeHistory"
                 v-g-tooltip.hover
@@ -90,5 +93,14 @@ function handleHistorySelected(history: { id: string }) {
         text-decoration: underline;
         color: $brand-primary;
     }
+}
+
+.target-history-selector-row {
+    min-width: 0;
+}
+
+.target-history-selector-link {
+    flex: 1 1 auto;
+    min-width: 0;
 }
 </style>

--- a/client/src/components/History/TargetHistorySelector.vue
+++ b/client/src/components/History/TargetHistorySelector.vue
@@ -94,13 +94,4 @@ function handleHistorySelected(history: { id: string }) {
         color: $brand-primary;
     }
 }
-
-.target-history-selector-row {
-    min-width: 0;
-}
-
-.target-history-selector-link {
-    flex: 1 1 auto;
-    min-width: 0;
-}
 </style>

--- a/client/src/components/History/TargetObjectStoreSelector.test.ts
+++ b/client/src/components/History/TargetObjectStoreSelector.test.ts
@@ -70,11 +70,6 @@ async function mountSelector(targetObjectStoreId = PRIVATE_STORE.object_store_id
         },
         localVue,
         pinia,
-        stubs: {
-            BModal: true,
-            SelectObjectStore: true,
-            FontAwesomeIcon: true,
-        },
     });
 
     await flushPromises();

--- a/client/src/components/History/TargetObjectStoreSelector.test.ts
+++ b/client/src/components/History/TargetObjectStoreSelector.test.ts
@@ -1,0 +1,98 @@
+import { createTestingPinia } from "@pinia/testing";
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { setActivePinia } from "pinia";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UserConcreteObjectStoreModel } from "@/api";
+import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
+
+import TargetObjectStoreSelector from "./TargetObjectStoreSelector.vue";
+
+const localVue = getLocalVue(true);
+const { server, http } = useServerMock();
+
+const PRIVATE_STORE: UserConcreteObjectStoreModel = {
+    object_store_id: "object_store_private",
+    name: "Private Store",
+    description: "Private storage",
+    badges: [],
+    private: true,
+    quota: { enabled: false },
+    active: true,
+    hidden: false,
+    purged: false,
+    secrets: [],
+    template_id: "",
+    template_version: 0,
+    type: "disk",
+    uuid: "private-uuid",
+    variables: null,
+};
+
+const SHARABLE_STORE: UserConcreteObjectStoreModel = {
+    ...PRIVATE_STORE,
+    object_store_id: "object_store_public",
+    name: "Sharable Store",
+    private: false,
+};
+
+async function mountSelector(targetObjectStoreId = PRIVATE_STORE.object_store_id) {
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    setActivePinia(pinia);
+
+    const objectStoreStore = useObjectStoreStore();
+    objectStoreStore.selectableObjectStores = [PRIVATE_STORE, SHARABLE_STORE];
+
+    server.use(
+        http.get("/api/configuration", ({ response }) => {
+            return response(200).json({});
+        }),
+        http.get("/api/object_stores", ({ response }) => {
+            return response(200).json([PRIVATE_STORE, SHARABLE_STORE]);
+        }),
+        http.untyped.get("/history/permissions", () => {
+            return HttpResponse.json({
+                inputs: [
+                    { name: "DATASET_MANAGE_PERMISSIONS", value: [1] },
+                    { name: "DATASET_ACCESS", value: [] },
+                ],
+            });
+        }),
+    );
+
+    const wrapper = mount(TargetObjectStoreSelector as object, {
+        propsData: {
+            targetHistoryId: "history-1",
+            targetObjectStoreId,
+        },
+        localVue,
+        pinia,
+        stubs: {
+            BModal: true,
+            SelectObjectStore: true,
+            FontAwesomeIcon: true,
+        },
+    });
+
+    await flushPromises();
+    return wrapper;
+}
+
+describe("TargetObjectStoreSelector", () => {
+    it("shows a warning when a private store is selected for a public history", async () => {
+        const wrapper = await mountSelector();
+
+        expect(wrapper.text()).toContain(
+            "Selected storage location is private while this history still allows sharable datasets.",
+        );
+    });
+
+    it("does not show the privacy warning for a sharable store", async () => {
+        const wrapper = await mountSelector(SHARABLE_STORE.object_store_id);
+
+        expect(wrapper.text()).not.toContain("still allows sharable datasets");
+    });
+});

--- a/client/src/components/History/TargetObjectStoreSelector.vue
+++ b/client/src/components/History/TargetObjectStoreSelector.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { faDatabase } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert, BModal } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
+import { computed, ref } from "vue";
+
+import { useTargetObjectStoreUploadState } from "@/composables/upload/useTargetObjectStoreUploadState";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
+
+import SelectObjectStore from "@/components/ObjectStore/SelectObjectStore.vue";
+
+interface Props {
+    targetObjectStoreId: string | null;
+    targetHistoryId: string;
+    storeCaption?: string;
+    changeLinkText?: string;
+    changeLinkTooltip?: string;
+    modalTitle?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    storeCaption: "Target storage",
+    changeLinkText: "change",
+    changeLinkTooltip: "Change target storage location",
+    modalTitle: "Select storage location",
+});
+
+const emit = defineEmits<{
+    (e: "select-store", selection: { object_store_id: string | null; private: boolean }): void;
+}>();
+
+const showModal = ref(false);
+
+const objectStoreStore = useObjectStoreStore();
+const { selectableObjectStores } = storeToRefs(objectStoreStore);
+
+const canChangeStore = computed(() => (selectableObjectStores.value?.length ?? 0) > 1);
+
+const { storeName, storeDescription, warningMessage } = useTargetObjectStoreUploadState(
+    computed(() => props.targetObjectStoreId),
+    computed(() => props.targetHistoryId),
+);
+
+function openStoreSelector() {
+    showModal.value = true;
+}
+
+function handleStoreSelected(objectStoreId: string | null, isPrivate: boolean) {
+    showModal.value = false;
+    emit("select-store", {
+        object_store_id: objectStoreId,
+        private: isPrivate,
+    });
+}
+</script>
+
+<template>
+    <div>
+        <div class="d-flex align-items-center">
+            <span class="d-flex flex-gapx-1 align-items-center">
+                <span v-g-tooltip.hover title="The storage location where these datasets will be uploaded.">
+                    <FontAwesomeIcon class="mr-1" :icon="faDatabase" />{{ storeCaption }}:
+                </span>
+                <span v-g-tooltip.hover :title="storeDescription">
+                    <b>{{ storeName }}</b>
+                </span>
+            </span>
+            <a
+                v-if="canChangeStore"
+                v-g-tooltip.hover
+                href="#"
+                class="change-store-link ml-2"
+                :title="changeLinkTooltip"
+                @click.prevent="openStoreSelector">
+                {{ changeLinkText }}
+            </a>
+        </div>
+
+        <BAlert v-if="warningMessage" show variant="warning" class="mb-2 py-1">
+            {{ warningMessage }}
+        </BAlert>
+
+        <BModal
+            v-model="showModal"
+            centered
+            scrollable
+            size="lg"
+            :title="modalTitle"
+            title-class="h-sm"
+            title-tag="h3"
+            ok-only
+            ok-title="Close">
+            <SelectObjectStore
+                for-what="New datasets uploaded in this history"
+                :selected-object-store-id="targetObjectStoreId"
+                default-option-title="Use history preference"
+                default-option-description="Uploads will follow the selected history storage preference."
+                @onSubmit="handleStoreSelected" />
+        </BModal>
+    </div>
+</template>
+
+<style scoped lang="scss">
+@import "@/style/scss/theme/blue.scss";
+
+.change-store-link {
+    &:hover {
+        text-decoration: underline;
+        color: $brand-primary;
+    }
+}
+</style>

--- a/client/src/components/History/TargetObjectStoreSelector.vue
+++ b/client/src/components/History/TargetObjectStoreSelector.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { faDatabase } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed } from "vue";
 import Multiselect from "vue-multiselect";
@@ -9,6 +8,7 @@ import Multiselect from "vue-multiselect";
 import { useTargetObjectStoreUploadState } from "@/composables/upload/useTargetObjectStoreUploadState";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import ObjectStoreBadges from "@/components/ObjectStore/ObjectStoreBadges.vue";
 
 interface Props {
@@ -141,8 +141,8 @@ function handleStoreSelected(selectedOption: SelectorOption | null) {
             </div>
         </div>
 
-        <BAlert v-if="warningMessage" show variant="warning" class="mb-2 py-1">
+        <GAlert v-if="warningMessage" show variant="warning" class="mb-2 py-1">
             {{ warningMessage }}
-        </BAlert>
+        </GAlert>
     </div>
 </template>

--- a/client/src/components/History/TargetObjectStoreSelector.vue
+++ b/client/src/components/History/TargetObjectStoreSelector.vue
@@ -16,11 +16,15 @@ interface Props {
     targetHistoryId: string;
     storeCaption?: string;
     changeLinkTooltip?: string;
+    disabled?: boolean;
+    disabledMessage?: string | null;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     storeCaption: "Target storage",
     changeLinkTooltip: "Change target storage location",
+    disabled: false,
+    disabledMessage: null,
 });
 
 const emit = defineEmits<{
@@ -69,7 +73,7 @@ const storeOptions = computed<SelectorOption[]>(() => {
     ];
 });
 
-const canChangeStore = computed(() => storeOptions.value.length > 1);
+const canChangeStore = computed(() => storeOptions.value.length > 1 && !props.disabled);
 
 const currentStoreOption = computed<SelectorOption>(() => {
     return (
@@ -105,7 +109,7 @@ function handleStoreSelected(selectedOption: SelectorOption | null) {
                 v-g-tooltip.hover
                 class="flex-grow-1 ml-2"
                 data-test-id="upload-target-object-store-selector"
-                :title="changeLinkTooltip">
+                :title="disabledMessage ?? changeLinkTooltip">
                 <Multiselect
                     :value="currentStoreOption"
                     :options="storeOptions"

--- a/client/src/components/History/TargetObjectStoreSelector.vue
+++ b/client/src/components/History/TargetObjectStoreSelector.vue
@@ -1,113 +1,148 @@
 <script setup lang="ts">
 import { faDatabase } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BAlert, BModal } from "bootstrap-vue";
+import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
-import { computed, ref } from "vue";
+import { computed } from "vue";
+import Multiselect from "vue-multiselect";
 
 import { useTargetObjectStoreUploadState } from "@/composables/upload/useTargetObjectStoreUploadState";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
-import SelectObjectStore from "@/components/ObjectStore/SelectObjectStore.vue";
+import ObjectStoreBadges from "@/components/ObjectStore/ObjectStoreBadges.vue";
 
 interface Props {
     targetObjectStoreId: string | null;
     targetHistoryId: string;
     storeCaption?: string;
-    changeLinkText?: string;
     changeLinkTooltip?: string;
-    modalTitle?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     storeCaption: "Target storage",
-    changeLinkText: "change",
     changeLinkTooltip: "Change target storage location",
-    modalTitle: "Select storage location",
 });
 
 const emit = defineEmits<{
     (e: "select-store", selection: { object_store_id: string | null; private: boolean }): void;
 }>();
 
-const showModal = ref(false);
-
 const objectStoreStore = useObjectStoreStore();
 const { selectableObjectStores } = storeToRefs(objectStoreStore);
 
-const canChangeStore = computed(() => (selectableObjectStores.value?.length ?? 0) > 1);
+type SelectorOption = {
+    id: string;
+    name: string;
+    description: string;
+    object_store_id: string | null;
+    private: boolean;
+    badges: unknown[];
+};
 
-const { storeName, storeDescription, warningMessage } = useTargetObjectStoreUploadState(
+const defaultStoreOption: SelectorOption = {
+    id: "__null__",
+    name: "Use history preference",
+    description: "Uploads will follow the selected history storage preference.",
+    object_store_id: null,
+    private: false,
+    badges: [],
+};
+
+const storeOptions = computed<SelectorOption[]>(() => {
+    const stores = selectableObjectStores.value ?? [];
+    const visibleStores = stores.filter(
+        (store) => ("hidden" in store ? !store.hidden : true) && !!store.object_store_id,
+    );
+    return [
+        defaultStoreOption,
+        ...visibleStores.map((store) => {
+            const objectStoreId = store.object_store_id as string;
+            return {
+                id: objectStoreId,
+                name: store.name ?? "Unknown storage location",
+                description: store.description ?? "",
+                object_store_id: objectStoreId,
+                private: store.private,
+                badges: store.badges ?? [],
+            };
+        }),
+    ];
+});
+
+const canChangeStore = computed(() => storeOptions.value.length > 1);
+
+const currentStoreOption = computed<SelectorOption>(() => {
+    return (
+        storeOptions.value.find((option) => option.object_store_id === props.targetObjectStoreId) ?? defaultStoreOption
+    );
+});
+
+const { warningMessage } = useTargetObjectStoreUploadState(
     computed(() => props.targetObjectStoreId),
     computed(() => props.targetHistoryId),
 );
 
-function openStoreSelector() {
-    showModal.value = true;
-}
-
-function handleStoreSelected(objectStoreId: string | null, isPrivate: boolean) {
-    showModal.value = false;
+function handleStoreSelected(selectedOption: SelectorOption | null) {
+    if (!selectedOption) {
+        return;
+    }
     emit("select-store", {
-        object_store_id: objectStoreId,
-        private: isPrivate,
+        object_store_id: selectedOption.object_store_id,
+        private: selectedOption.private,
     });
 }
 </script>
 
 <template>
     <div>
-        <div class="d-flex align-items-center">
-            <span class="d-flex flex-gapx-1 align-items-center">
+        <div class="d-flex align-items-center flex-nowrap w-100">
+            <span class="d-flex align-items-center text-nowrap flex-shrink-0">
                 <span v-g-tooltip.hover title="The storage location where these datasets will be uploaded.">
                     <FontAwesomeIcon class="mr-1" :icon="faDatabase" />{{ storeCaption }}:
                 </span>
-                <span v-g-tooltip.hover :title="storeDescription">
-                    <b>{{ storeName }}</b>
-                </span>
             </span>
-            <a
-                v-if="canChangeStore"
+            <div
                 v-g-tooltip.hover
-                href="#"
-                class="change-store-link ml-2"
-                :title="changeLinkTooltip"
-                @click.prevent="openStoreSelector">
-                {{ changeLinkText }}
-            </a>
+                class="flex-grow-1 ml-2"
+                data-test-id="upload-target-object-store-selector"
+                :title="changeLinkTooltip">
+                <Multiselect
+                    :value="currentStoreOption"
+                    :options="storeOptions"
+                    :allow-empty="false"
+                    :searchable="false"
+                    :show-labels="false"
+                    :disabled="!canChangeStore"
+                    class="w-100 target-object-store-multiselect multiselect--soft-option-highlight"
+                    label="name"
+                    track-by="id"
+                    @input="handleStoreSelected">
+                    <template v-slot:singleLabel="{ option }">
+                        <span class="d-flex align-items-center justify-content-between">
+                            <span class="text-truncate mr-2">{{ option.name ?? "Unknown storage location" }}</span>
+                            <ObjectStoreBadges :badges="option.badges" size="lg" class="flex-shrink-0" />
+                        </span>
+                    </template>
+                    <template v-slot:option="{ option }">
+                        <div
+                            data-test-id="target-object-store-option"
+                            :data-id="option.id"
+                            class="w-100 text-wrap py-1">
+                            <div class="d-flex align-items-start justify-content-between">
+                                <span class="font-weight-bold">{{ option.name ?? "Unknown storage location" }}</span>
+                                <ObjectStoreBadges :badges="option.badges" size="lg" class="ml-2 flex-shrink-0" />
+                            </div>
+                            <div v-if="option.description" class="small text-muted mt-1 text-break">
+                                {{ option.description }}
+                            </div>
+                        </div>
+                    </template>
+                </Multiselect>
+            </div>
         </div>
 
         <BAlert v-if="warningMessage" show variant="warning" class="mb-2 py-1">
             {{ warningMessage }}
         </BAlert>
-
-        <BModal
-            v-model="showModal"
-            centered
-            scrollable
-            size="lg"
-            :title="modalTitle"
-            title-class="h-sm"
-            title-tag="h3"
-            ok-only
-            ok-title="Close">
-            <SelectObjectStore
-                for-what="New datasets uploaded in this history"
-                :selected-object-store-id="targetObjectStoreId"
-                default-option-title="Use history preference"
-                default-option-description="Uploads will follow the selected history storage preference."
-                @onSubmit="handleStoreSelected" />
-        </BModal>
     </div>
 </template>
-
-<style scoped lang="scss">
-@import "@/style/scss/theme/blue.scss";
-
-.change-store-link {
-    &:hover {
-        text-decoration: underline;
-        color: $brand-primary;
-    }
-}
-</style>

--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
@@ -16,6 +15,7 @@ import type { UploadMethod, UploadMethodComponent } from "./types";
 import { getUploadRootBreadcrumb } from "./uploadBreadcrumb";
 import { getUploadMethod } from "./uploadMethodRegistry";
 
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GTip from "@/components/BaseComponents/GTip.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
@@ -156,9 +156,9 @@ function handleReadyStateChange(ready: boolean) {
                     </div>
                 </div>
 
-                <BAlert v-if="objectStoreWarningMessage" show variant="warning" class="mb-0 mt-2 py-1">
+                <GAlert v-if="objectStoreWarningMessage" show variant="warning" class="mb-0 mt-2 py-1">
                     {{ objectStoreWarningMessage }}
-                </BAlert>
+                </GAlert>
             </div>
 
             <!-- Upload Method Content (scrollable) -->

--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -45,11 +45,16 @@ const targetHistoryId = ref<string>(currentHistoryId.value || "");
 const objectStoreStore = useObjectStoreStore();
 const { selectableObjectStores } = storeToRefs(objectStoreStore);
 
-const { targetObjectStoreId, shouldShowObjectStoreSelector, objectStoreUploadBlockReason, handleObjectStoreSelected } =
-    useTargetObjectStoreSelectionState(
-        targetHistoryId,
-        computed(() => advancedMode.value),
-    );
+const {
+    targetObjectStoreId,
+    shouldShowObjectStoreSelector,
+    objectStoreUploadBlockReason,
+    objectStoreDisabledReason,
+    handleObjectStoreSelected,
+} = useTargetObjectStoreSelectionState(
+    targetHistoryId,
+    computed(() => advancedMode.value),
+);
 
 const { warningMessage: objectStoreWarningMessage, handlePrivateStoreSelection } = usePrivateObjectStoreConfirmation();
 
@@ -163,6 +168,8 @@ function handleReadyStateChange(ready: boolean) {
                             :target-history-id="targetHistoryId"
                             store-caption="Target storage"
                             change-link-tooltip="Change storage location for this upload"
+                            :disabled="!!objectStoreDisabledReason"
+                            :disabled-message="objectStoreDisabledReason"
                             @select-store="handleObjectStoreSelection" />
                     </div>
                 </div>

--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
+import { BAlert } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import { useTargetHistoryUploadState } from "@/composables/history/useTargetHistoryUploadState";
+import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
+import { usePrivateObjectStoreConfirmation } from "@/composables/upload/usePrivateObjectStoreConfirmation";
+import { useTargetObjectStoreSelectionState } from "@/composables/upload/useTargetObjectStoreSelectionState";
 import { useUploadSubmission } from "@/composables/upload/useUploadSubmission";
 import { useHistoryStore } from "@/stores/historyStore";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
 import type { UploadMethod, UploadMethodComponent } from "./types";
 import { getUploadRootBreadcrumb } from "./uploadBreadcrumb";
@@ -15,6 +20,7 @@ import GButton from "@/components/BaseComponents/GButton.vue";
 import GTip from "@/components/BaseComponents/GTip.vue";
 import BreadcrumbHeading from "@/components/Common/BreadcrumbHeading.vue";
 import TargetHistorySelector from "@/components/History/TargetHistorySelector.vue";
+import TargetObjectStoreSelector from "@/components/History/TargetObjectStoreSelector.vue";
 
 interface Props {
     methodId: UploadMethod;
@@ -31,7 +37,20 @@ const { submitPreparedUpload } = useUploadSubmission();
 const historyStore = useHistoryStore();
 const { currentHistoryId } = storeToRefs(historyStore);
 
+const { advancedMode } = useUploadAdvancedMode();
+
 const targetHistoryId = ref<string>(currentHistoryId.value || "");
+
+const objectStoreStore = useObjectStoreStore();
+const { selectableObjectStores } = storeToRefs(objectStoreStore);
+
+const { targetObjectStoreId, shouldShowObjectStoreSelector, objectStoreUploadBlockReason, handleObjectStoreSelected } =
+    useTargetObjectStoreSelectionState(
+        targetHistoryId,
+        computed(() => advancedMode.value),
+    );
+
+const { warningMessage: objectStoreWarningMessage, handlePrivateStoreSelection } = usePrivateObjectStoreConfirmation();
 
 // Keep targetHistoryId in sync with currentHistoryId
 watch(
@@ -50,11 +69,16 @@ const method = computed(() => {
 
 const { uploadBlockReason, warningMessage } = useTargetHistoryUploadState(computed(() => targetHistoryId.value));
 
-const canStartUpload = computed(() => !uploadBlockReason.value && canUpload.value);
+const canStartUpload = computed(
+    () => !uploadBlockReason.value && !objectStoreUploadBlockReason.value && canUpload.value,
+);
 
 const startButtonTitle = computed(() => {
     if (uploadBlockReason.value) {
         return warningMessage.value;
+    }
+    if (objectStoreUploadBlockReason.value) {
+        return objectStoreUploadBlockReason.value;
     }
     return canUpload.value ? "Start uploading to Galaxy" : "Configure upload options first";
 });
@@ -70,6 +94,15 @@ function handleHistorySelected(history: { id: string }) {
     targetHistoryId.value = history.id;
 }
 
+async function handleObjectStoreSelection(selection: { object_store_id: string | null; private: boolean }) {
+    const selectedStore = selection.object_store_id
+        ? selectableObjectStores.value?.find((store) => store.object_store_id === selection.object_store_id)
+        : null;
+
+    handleObjectStoreSelected(selectedStore ?? null);
+    await handlePrivateStoreSelection(selectedStore ?? null, targetHistoryId.value);
+}
+
 function handleCancel() {
     router.push("/upload");
 }
@@ -83,7 +116,7 @@ function handleStart() {
         return;
     }
     // Fire-and-forget: progress is tracked in uploadState, visible in the progress view
-    void submitPreparedUpload(targetHistoryId.value, prepared);
+    void submitPreparedUpload(targetHistoryId.value, prepared, undefined, targetObjectStoreId.value ?? undefined);
     uploadMethodRef.value?.reset?.();
     router.push("/upload/progress");
 }
@@ -102,13 +135,31 @@ function handleReadyStateChange(ready: boolean) {
 
             <!-- Target History Display -->
             <div v-if="method.requiresTargetHistory" class="target-history-banner px-3 py-2">
-                <TargetHistorySelector
-                    :target-history-id="targetHistoryId"
-                    history-caption="Target history"
-                    change-link-text="Choose another"
-                    change-link-tooltip="Change target history for this upload"
-                    modal-title="Select a history for upload"
-                    @select-history="handleHistorySelected" />
+                <div class="target-destination-grid">
+                    <div class="target-destination-item">
+                        <TargetHistorySelector
+                            :target-history-id="targetHistoryId"
+                            history-caption="Target history"
+                            change-link-text="Choose another"
+                            change-link-tooltip="Change target history for this upload"
+                            modal-title="Select a history for upload"
+                            @select-history="handleHistorySelected" />
+                    </div>
+                    <div v-if="shouldShowObjectStoreSelector" class="target-destination-item">
+                        <TargetObjectStoreSelector
+                            :target-object-store-id="targetObjectStoreId"
+                            :target-history-id="targetHistoryId"
+                            store-caption="Target storage"
+                            change-link-text="Choose another"
+                            change-link-tooltip="Change storage location for this upload"
+                            modal-title="Select storage location for upload"
+                            @select-store="handleObjectStoreSelection" />
+                    </div>
+                </div>
+
+                <BAlert v-if="objectStoreWarningMessage" show variant="warning" class="mb-0 mt-2 py-1">
+                    {{ objectStoreWarningMessage }}
+                </BAlert>
             </div>
 
             <!-- Upload Method Content (scrollable) -->
@@ -118,6 +169,7 @@ function handleReadyStateChange(ready: boolean) {
                     ref="uploadMethodRef"
                     :method="method"
                     :target-history-id="targetHistoryId"
+                    :target-object-store-id="targetObjectStoreId"
                     @ready="handleReadyStateChange" />
             </div>
         </div>
@@ -156,6 +208,17 @@ function handleReadyStateChange(ready: boolean) {
     background-color: $gray-100;
     border-bottom: 1px solid $border-color;
     flex-shrink: 0;
+}
+
+.target-destination-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 1rem;
+}
+
+.target-destination-item {
+    flex: 1 1 20rem;
+    min-width: 16rem;
 }
 
 .target-history-name {

--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -147,12 +147,11 @@ function handleReadyStateChange(ready: boolean) {
                     </div>
                     <div v-if="shouldShowObjectStoreSelector" class="target-destination-item">
                         <TargetObjectStoreSelector
+                            class="ml-4"
                             :target-object-store-id="targetObjectStoreId"
                             :target-history-id="targetHistoryId"
                             store-caption="Target storage"
-                            change-link-text="Choose another"
                             change-link-tooltip="Change storage location for this upload"
-                            modal-title="Select storage location for upload"
                             @select-store="handleObjectStoreSelection" />
                     </div>
                 </div>
@@ -213,12 +212,19 @@ function handleReadyStateChange(ready: boolean) {
 .target-destination-grid {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.25rem 1rem;
+    align-items: center;
 }
 
 .target-destination-item {
-    flex: 1 1 20rem;
-    min-width: 16rem;
+    flex: 1 1 22rem;
+    min-width: min(100%, 18rem);
+}
+
+@media (max-width: 768px) {
+    .target-destination-item {
+        flex-basis: 100%;
+        min-width: 0;
+    }
 }
 
 .target-history-name {

--- a/client/src/components/Panels/Upload/UploadMethodView.vue
+++ b/client/src/components/Panels/Upload/UploadMethodView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BFormCheckbox } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router/composables";
@@ -128,7 +129,17 @@ function handleReadyStateChange(ready: boolean) {
 
 <template>
     <div class="upload-method-view d-flex flex-column h-100">
-        <BreadcrumbHeading :items="breadcrumbItems" />
+        <BreadcrumbHeading :items="breadcrumbItems">
+            <BFormCheckbox
+                v-model="advancedMode"
+                v-g-tooltip.hover
+                data-test-id="upload-advanced-mode-toggle"
+                switch
+                class="ml-auto align-self-center"
+                title="Show advanced upload options">
+                <span>Advanced</span>
+            </BFormCheckbox>
+        </BreadcrumbHeading>
 
         <div v-if="method" class="upload-method-content flex-grow-1 d-flex flex-column overflow-hidden">
             <GTip v-if="method.tips" :tips="method.tips" variant="info" class="mb-1" />

--- a/client/src/components/Panels/Upload/UploadPanel.vue
+++ b/client/src/components/Panels/Upload/UploadPanel.vue
@@ -36,6 +36,7 @@ function showProgressDetails() {
             <BFormCheckbox
                 v-model="advancedMode"
                 v-g-tooltip.hover
+                data-test-id="upload-advanced-mode-toggle"
                 size="sm"
                 switch
                 class="mx-2"

--- a/client/src/composables/upload/usePrivateObjectStoreConfirmation.ts
+++ b/client/src/composables/upload/usePrivateObjectStoreConfirmation.ts
@@ -1,0 +1,56 @@
+import { type Ref, ref } from "vue";
+
+import type { UserConcreteObjectStoreModel } from "@/api";
+import { getPermissions, isHistoryPrivate, makePrivate, type PermissionsResponse } from "@/components/History/services";
+import { useConfirmDialog } from "@/composables/confirmDialog";
+
+interface PrivateObjectStoreConfirmationState {
+    warningMessage: Ref<string>;
+    handlePrivateStoreSelection: (store: UserConcreteObjectStoreModel | null, historyId: string) => Promise<void>;
+}
+
+export function usePrivateObjectStoreConfirmation(): PrivateObjectStoreConfirmationState {
+    const { confirm } = useConfirmDialog();
+    const warningMessage = ref("");
+
+    async function handlePrivateStoreSelection(
+        store: UserConcreteObjectStoreModel | null,
+        historyId: string,
+    ): Promise<void> {
+        warningMessage.value = "";
+
+        if (!store?.private || !historyId) {
+            return;
+        }
+
+        try {
+            const { data } = await getPermissions(historyId);
+            const permissionResponse = data as PermissionsResponse;
+            const historyPrivate = await isHistoryPrivate(permissionResponse);
+
+            if (historyPrivate) {
+                return;
+            }
+
+            const confirmed = await confirm(
+                "Your history currently creates sharable datasets, but the selected storage location is private. Make new datasets private in this history by default?",
+                {
+                    okText: "Private new datasets",
+                    cancelText: "Keep datasets public",
+                },
+            );
+
+            if (confirmed) {
+                await makePrivate(historyId, permissionResponse);
+            }
+        } catch {
+            warningMessage.value =
+                "Could not verify history privacy settings for the selected private storage location.";
+        }
+    }
+
+    return {
+        warningMessage,
+        handlePrivateStoreSelection,
+    };
+}

--- a/client/src/composables/upload/useTargetObjectStoreSelectionState.ts
+++ b/client/src/composables/upload/useTargetObjectStoreSelectionState.ts
@@ -3,11 +3,13 @@ import { computed, type ComputedRef, type Ref, ref, watch } from "vue";
 
 import type { UserConcreteObjectStoreModel } from "@/api";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
+import { useUserStore } from "@/stores/userStore";
 
 interface TargetObjectStoreSelectionState {
     targetObjectStoreId: Ref<string | null>;
     shouldShowObjectStoreSelector: ComputedRef<boolean>;
     objectStoreUploadBlockReason: ComputedRef<string | null>;
+    objectStoreDisabledReason: ComputedRef<string | null>;
     handleObjectStoreSelected: (store: UserConcreteObjectStoreModel | null) => void;
 }
 
@@ -17,12 +19,20 @@ export function useTargetObjectStoreSelectionState(
 ): TargetObjectStoreSelectionState {
     const objectStoreStore = useObjectStoreStore();
     const { selectableObjectStores } = storeToRefs(objectStoreStore);
+    const userStore = useUserStore();
 
     const targetObjectStoreId = ref<string | null>(null);
     const userManuallySelectedStore = ref(false);
 
     const shouldShowObjectStoreSelector = computed(() => {
         return advancedMode.value && (selectableObjectStores.value?.length ?? 0) > 1;
+    });
+
+    const objectStoreDisabledReason = computed(() => {
+        if (userStore.isAnonymous) {
+            return "Please log in or register to select a storage location.";
+        }
+        return null;
     });
 
     const objectStoreUploadBlockReason = computed(() => {
@@ -57,6 +67,7 @@ export function useTargetObjectStoreSelectionState(
         targetObjectStoreId,
         shouldShowObjectStoreSelector,
         objectStoreUploadBlockReason,
+        objectStoreDisabledReason,
         handleObjectStoreSelected,
     };
 }

--- a/client/src/composables/upload/useTargetObjectStoreSelectionState.ts
+++ b/client/src/composables/upload/useTargetObjectStoreSelectionState.ts
@@ -1,0 +1,71 @@
+import { storeToRefs } from "pinia";
+import { computed, type ComputedRef, type Ref, ref, watch } from "vue";
+
+import type { UserConcreteObjectStoreModel } from "@/api";
+import { useHistoryStore } from "@/stores/historyStore";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
+
+interface TargetObjectStoreSelectionState {
+    targetObjectStoreId: Ref<string | null>;
+    shouldShowObjectStoreSelector: ComputedRef<boolean>;
+    objectStoreUploadBlockReason: ComputedRef<string | null>;
+    handleObjectStoreSelected: (store: UserConcreteObjectStoreModel | null) => void;
+}
+
+export function useTargetObjectStoreSelectionState(
+    targetHistoryId: Ref<string>,
+    advancedMode: ComputedRef<boolean>,
+): TargetObjectStoreSelectionState {
+    const historyStore = useHistoryStore();
+    const objectStoreStore = useObjectStoreStore();
+    const { selectableObjectStores } = storeToRefs(objectStoreStore);
+
+    const targetObjectStoreId = ref<string | null>(null);
+    const userManuallySelectedStore = ref(false);
+
+    const shouldShowObjectStoreSelector = computed(() => {
+        return advancedMode.value && (selectableObjectStores.value?.length ?? 0) > 1;
+    });
+
+    const objectStoreUploadBlockReason = computed(() => {
+        if (!targetObjectStoreId.value || !selectableObjectStores.value) {
+            return null;
+        }
+
+        return selectableObjectStores.value.some((store) => store.object_store_id === targetObjectStoreId.value)
+            ? null
+            : "Selected storage location is no longer available.";
+    });
+
+    watch(
+        [targetHistoryId, selectableObjectStores],
+        ([newHistoryId, stores]) => {
+            if (!newHistoryId || userManuallySelectedStore.value) {
+                return;
+            }
+
+            const history = historyStore.getHistoryById(newHistoryId);
+            const preferredObjectStoreId = history?.preferred_object_store_id ?? null;
+
+            if (preferredObjectStoreId && stores?.some((store) => store.object_store_id === preferredObjectStoreId)) {
+                targetObjectStoreId.value = preferredObjectStoreId;
+                return;
+            }
+
+            targetObjectStoreId.value = stores?.[0]?.object_store_id ?? preferredObjectStoreId;
+        },
+        { immediate: true },
+    );
+
+    function handleObjectStoreSelected(store: UserConcreteObjectStoreModel | null) {
+        userManuallySelectedStore.value = true;
+        targetObjectStoreId.value = store?.object_store_id ?? null;
+    }
+
+    return {
+        targetObjectStoreId,
+        shouldShowObjectStoreSelector,
+        objectStoreUploadBlockReason,
+        handleObjectStoreSelected,
+    };
+}

--- a/client/src/composables/upload/useTargetObjectStoreSelectionState.ts
+++ b/client/src/composables/upload/useTargetObjectStoreSelectionState.ts
@@ -2,7 +2,6 @@ import { storeToRefs } from "pinia";
 import { computed, type ComputedRef, type Ref, ref, watch } from "vue";
 
 import type { UserConcreteObjectStoreModel } from "@/api";
-import { useHistoryStore } from "@/stores/historyStore";
 import { useObjectStoreStore } from "@/stores/objectStoreStore";
 
 interface TargetObjectStoreSelectionState {
@@ -16,7 +15,6 @@ export function useTargetObjectStoreSelectionState(
     targetHistoryId: Ref<string>,
     advancedMode: ComputedRef<boolean>,
 ): TargetObjectStoreSelectionState {
-    const historyStore = useHistoryStore();
     const objectStoreStore = useObjectStoreStore();
     const { selectableObjectStores } = storeToRefs(objectStoreStore);
 
@@ -39,20 +37,13 @@ export function useTargetObjectStoreSelectionState(
 
     watch(
         [targetHistoryId, selectableObjectStores],
-        ([newHistoryId, stores]) => {
+        ([newHistoryId]) => {
             if (!newHistoryId || userManuallySelectedStore.value) {
                 return;
             }
 
-            const history = historyStore.getHistoryById(newHistoryId);
-            const preferredObjectStoreId = history?.preferred_object_store_id ?? null;
-
-            if (preferredObjectStoreId && stores?.some((store) => store.object_store_id === preferredObjectStoreId)) {
-                targetObjectStoreId.value = preferredObjectStoreId;
-                return;
-            }
-
-            targetObjectStoreId.value = stores?.[0]?.object_store_id ?? preferredObjectStoreId;
+            // Keep null to represent "Use history preference" until the user picks a concrete store.
+            targetObjectStoreId.value = null;
         },
         { immediate: true },
     );

--- a/client/src/composables/upload/useTargetObjectStoreUploadState.ts
+++ b/client/src/composables/upload/useTargetObjectStoreUploadState.ts
@@ -1,0 +1,117 @@
+import { storeToRefs } from "pinia";
+import { computed, type ComputedRef, ref, watch } from "vue";
+
+import type { UserConcreteObjectStoreModel } from "@/api";
+import { getPermissions, isHistoryPrivate, type PermissionsResponse } from "@/components/History/services";
+import { useObjectStoreStore } from "@/stores/objectStoreStore";
+
+interface TargetObjectStoreUploadState {
+    selectedStore: ComputedRef<UserConcreteObjectStoreModel | null>;
+    storeName: ComputedRef<string>;
+    storeDescription: ComputedRef<string>;
+    uploadBlockReason: ComputedRef<string | null>;
+    warningMessage: ComputedRef<string>;
+}
+
+export function useTargetObjectStoreUploadState(
+    targetObjectStoreId: ComputedRef<string | null | undefined>,
+    targetHistoryId?: ComputedRef<string | null | undefined>,
+): TargetObjectStoreUploadState {
+    const objectStoreStore = useObjectStoreStore();
+    const { selectableObjectStores } = storeToRefs(objectStoreStore);
+    const historyIsPrivate = ref<boolean | null>(null);
+    const historyPrivacyError = ref(false);
+
+    watch(
+        targetHistoryId ?? computed(() => null),
+        async (historyId, _previousHistoryId, onCleanup) => {
+            historyIsPrivate.value = null;
+            historyPrivacyError.value = false;
+
+            if (!historyId) {
+                return;
+            }
+
+            let isActive = true;
+            onCleanup(() => {
+                isActive = false;
+            });
+
+            try {
+                const { data } = await getPermissions(historyId);
+                if (!isActive) {
+                    return;
+                }
+                historyIsPrivate.value = await isHistoryPrivate(data as PermissionsResponse);
+            } catch {
+                if (!isActive) {
+                    return;
+                }
+                historyPrivacyError.value = true;
+            }
+        },
+        { immediate: true },
+    );
+
+    const selectedStore = computed(() => {
+        const objectStoreId = targetObjectStoreId.value;
+        if (!objectStoreId) {
+            return null;
+        }
+
+        const stores = selectableObjectStores.value;
+        if (!stores) {
+            return null;
+        }
+
+        return stores.find((store) => store.object_store_id === objectStoreId) ?? null;
+    });
+
+    const uploadBlockReason = computed(() => {
+        const objectStoreId = targetObjectStoreId.value;
+        const stores = selectableObjectStores.value;
+
+        if (!objectStoreId || !stores) {
+            return null;
+        }
+
+        return selectedStore.value ? null : "Selected storage location is no longer available.";
+    });
+
+    const warningMessage = computed(() => uploadBlockReason.value ?? "");
+
+    const privacyWarningMessage = computed(() => {
+        if (!selectedStore.value?.private) {
+            return "";
+        }
+        if (historyPrivacyError.value) {
+            return "Could not verify history privacy settings for the selected private storage location.";
+        }
+        if (historyIsPrivate.value === false) {
+            return "Selected storage location is private while this history still allows sharable datasets.";
+        }
+        return "";
+    });
+
+    const storeName = computed(() => {
+        if (selectedStore.value?.name) {
+            return selectedStore.value.name;
+        }
+        return "History preference";
+    });
+
+    const storeDescription = computed(() => {
+        if (selectedStore.value?.description) {
+            return selectedStore.value.description;
+        }
+        return "Uploads will use the target history storage preference.";
+    });
+
+    return {
+        selectedStore,
+        storeName,
+        storeDescription,
+        uploadBlockReason,
+        warningMessage: computed(() => warningMessage.value || privacyWarningMessage.value),
+    };
+}

--- a/client/src/composables/upload/useUploadSubmission.test.ts
+++ b/client/src/composables/upload/useUploadSubmission.test.ts
@@ -23,7 +23,7 @@ const SELECTORS = {
 const localVue = getLocalVue();
 const { server } = useServerMock();
 
-function mountHarness(prepared: PreparedUpload) {
+function mountHarness(prepared: PreparedUpload, targetObjectStoreId?: string) {
     const Harness = defineComponent({
         setup() {
             const { submitPreparedUpload } = useUploadSubmission();
@@ -32,7 +32,7 @@ function mountHarness(prepared: PreparedUpload) {
 
             async function run() {
                 try {
-                    const uploaded = await submitPreparedUpload("hist_1", prepared);
+                    const uploaded = await submitPreparedUpload("hist_1", prepared, undefined, targetObjectStoreId);
                     result.value = JSON.stringify(uploaded);
                 } catch (err) {
                     error.value = String(err);
@@ -218,6 +218,32 @@ describe("useUploadSubmission", () => {
         expect(state.standaloneUploads.value).toHaveLength(0);
         expect(state.orderedUploadItems.value[0]?.type).toBe("batch");
         expect(state.activeItems.value.every((item) => item.batchId === batch?.id)).toBe(true);
+    });
+
+    it("forwards the selected preferred object store id to fetch uploads", async () => {
+        server.use(
+            http.post("/api/tools/fetch", async ({ request }) => {
+                const body = await request.json();
+                expect(body).toMatchObject({
+                    history_id: "hist_1",
+                    preferred_object_store_id: "object_store_2",
+                });
+
+                return HttpResponse.json({
+                    jobs: [{ id: "job_1" }],
+                    outputs: [{ id: "hda_store_1", name: "stored.txt", hid: 1, src: "hda" }],
+                });
+            }),
+        );
+
+        const apiItem = makeUrlItem({ name: "stored.txt", url: "https://example.org/stored.txt" });
+        const wrapper = mountHarness(buildPreparedUpload([apiItem]), "object_store_2");
+        await flushPromises();
+
+        await wrapper.find(SELECTORS.RUN).trigger("click");
+        await flushPromises();
+
+        expect(wrapper.find(SELECTORS.RESULT).text()).toContain('"id":"hda_store_1"');
     });
 
     it("creates a two-step collection for library-only uploads", async () => {

--- a/client/src/composables/upload/useUploadSubmission.ts
+++ b/client/src/composables/upload/useUploadSubmission.ts
@@ -62,6 +62,7 @@ export function useUploadSubmission() {
         batchId?: string,
         directCollectionCreation?: boolean,
         onProgress?: (percentage: number) => void,
+        targetObjectStoreId?: string,
     ): Promise<void> {
         if (prepared.apiItems.length === 0) {
             return;
@@ -70,6 +71,7 @@ export function useUploadSubmission() {
         return new Promise<void>((resolve, reject) => {
             const config: UploadDatasetsConfig = {
                 chunkSize: galaxyConfig.value.chunk_upload_size as number,
+                preferredObjectStoreId: targetObjectStoreId,
                 success: (response) => {
                     const uploadedDatasets = datasetsFromFetchResponse(response);
 
@@ -178,6 +180,7 @@ export function useUploadSubmission() {
         historyId: string,
         prepared: PreparedUpload,
         onProgress?: (percentage: number) => void,
+        targetObjectStoreId?: string,
     ): Promise<UploadedDataset[]> {
         const datasets: UploadedDataset[] = [];
         const directCollectionCreation = isDirectCollectionCreation(prepared);
@@ -192,6 +195,7 @@ export function useUploadSubmission() {
             batchId,
             directCollectionCreation,
             onProgress,
+            targetObjectStoreId,
         );
         await processLibraryUploads(libraryUploads, historyId, datasets, batchId);
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -1566,6 +1566,11 @@ beta_upload:
     target_history_change_link: '.target-history-banner .change-history-link'
     history_selector_modal: '.g-dialog'
     history_selector_modal_item: '.g-dialog [data-pk="${history_id}"]'
+    # Upload panel advanced mode switch
+    advanced_mode_toggle_checkbox: '[data-test-id="upload-advanced-mode-toggle"]'
+    # Target-object-store selectors (TargetObjectStoreSelector inside UploadMethodView)
+    target_object_store_selector_dropdown: '.target-destination-item [data-test-id="upload-target-object-store-selector"] .target-object-store-multiselect .multiselect__select'
+    target_object_store_selector_option: '.target-destination-item [data-test-id="upload-target-object-store-selector"] .target-object-store-multiselect.multiselect--active [data-test-id="target-object-store-option"][data-id="${object_store_id}"]'
     # Composite-file selectors
     composite_slot_mode_dropdown: '.composite-file-upload .composite-slot-row:nth-of-type(${row}) [data-test-id="composite-slot-mode-dropdown"] .dropdown-toggle'
     composite_slot_enter_local_action: '.composite-file-upload .composite-slot-row:nth-of-type(${row}) [data-test-id="composite-slot-enter-local"]'

--- a/client/src/utils/upload.ts
+++ b/client/src/utils/upload.ts
@@ -171,6 +171,8 @@ export interface UploadPayload {
     targets: (HdasUploadTarget | HdcaUploadTarget)[];
     /** Whether to auto-decompress uploads */
     auto_decompress: boolean;
+    /** Optional preferred object store id for all created datasets. */
+    preferred_object_store_id?: string;
     /** Local files to upload via TUS (not part of API, processed by submitUpload) */
     files: UploadableFile[];
 }
@@ -216,6 +218,8 @@ export interface UploadSubmitConfig extends FetchDatasetsCallbacks {
 export interface UploadDatasetsConfig extends FetchDatasetsCallbacks, BuildPayloadOptions {
     /** Chunk size for TUS uploads in bytes (default: 10MB) */
     chunkSize?: number;
+    /** Optional preferred object store id for uploaded datasets. */
+    preferredObjectStoreId?: string;
 }
 
 // ============================================================================
@@ -824,11 +828,17 @@ export function buildCollectionUploadPayload(items: ApiUploadItem[], options: Co
  * Converts UploadPayload to FetchDataPayload for API submission.
  */
 function toApiPayload(data: UploadPayload): FetchDataPayload {
-    return {
+    const payload: FetchDataPayload = {
         history_id: data.history_id,
         targets: data.targets,
         auto_decompress: data.auto_decompress,
     };
+
+    if (data.preferred_object_store_id) {
+        payload.preferred_object_store_id = data.preferred_object_store_id;
+    }
+
+    return payload;
 }
 
 /**
@@ -848,6 +858,10 @@ async function uploadFilesViaTus(
         targets: data.targets,
         auto_decompress: data.auto_decompress,
     };
+
+    if (data.preferred_object_store_id) {
+        apiPayload.preferred_object_store_id = data.preferred_object_store_id;
+    }
 
     try {
         // Upload each file sequentially via TUS
@@ -983,7 +997,16 @@ export async function submitUpload(config: UploadSubmitConfig): Promise<void> {
  * ```
  */
 export async function uploadDatasets(items: ApiUploadItem[], config: UploadDatasetsConfig = {}): Promise<void> {
-    const { composite = false, compositeName, chunkSize, success, error, warning, progress } = config;
+    const {
+        composite = false,
+        compositeName,
+        chunkSize,
+        success,
+        error,
+        warning,
+        progress,
+        preferredObjectStoreId,
+    } = config;
 
     try {
         // Build the API-ready payload from upload items
@@ -994,6 +1017,7 @@ export async function uploadDatasets(items: ApiUploadItem[], config: UploadDatas
             history_id: payload.history_id,
             targets: payload.targets,
             auto_decompress: payload.auto_decompress,
+            preferred_object_store_id: preferredObjectStoreId,
             files: payload.files,
         };
 
@@ -1071,7 +1095,7 @@ export async function uploadCollectionDatasets(
     collectionOptions: CollectionUploadOptions,
     config: UploadDatasetsConfig = {},
 ): Promise<void> {
-    const { chunkSize, success, error, warning, progress } = config;
+    const { chunkSize, success, error, warning, progress, preferredObjectStoreId } = config;
 
     try {
         const payload = buildCollectionUploadPayload(items, collectionOptions);
@@ -1080,6 +1104,7 @@ export async function uploadCollectionDatasets(
             history_id: payload.history_id,
             targets: payload.targets,
             auto_decompress: payload.auto_decompress,
+            preferred_object_store_id: preferredObjectStoreId,
             files: payload.files,
         };
 

--- a/lib/galaxy/schema/fetch_data.py
+++ b/lib/galaxy/schema/fetch_data.py
@@ -273,6 +273,10 @@ class FilesPayload(Model):
 
 class BaseDataPayload(FetchBaseModel):
     history_id: DecodedDatabaseIdField
+    preferred_object_store_id: Optional[str] = Field(
+        None,
+        description="Optional preferred storage location id used when creating fetched datasets.",
+    )
     model_config = ConfigDict(extra="allow")
     landing_uuid: Optional[UUID4] = None
 

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -67,10 +67,10 @@ class BaseUploadToolAction(ToolAction):
         persisting_uploads_timer = ExecutionTimer()
         incoming = upload_common.persist_uploads(incoming, trans)
         log.debug(f"Persisted uploads {persisting_uploads_timer}")
-        rval = self._setup_job(tool, trans, incoming, dataset_upload_inputs, history)
+        rval = self._setup_job(tool, trans, incoming, dataset_upload_inputs, history, preferred_object_store_id)
         return rval
 
-    def _setup_job(self, tool, trans, incoming, dataset_upload_inputs, history):
+    def _setup_job(self, tool, trans, incoming, dataset_upload_inputs, history, preferred_object_store_id):
         """Take persisted uploads and create a job for given tool."""
 
     def _create_job(self, *args, **kwds):
@@ -82,7 +82,7 @@ class BaseUploadToolAction(ToolAction):
 
 
 class UploadToolAction(BaseUploadToolAction):
-    def _setup_job(self, tool, trans, incoming, dataset_upload_inputs, history):
+    def _setup_job(self, tool, trans, incoming, dataset_upload_inputs, history, preferred_object_store_id):
         check_timer = ExecutionTimer()
         uploaded_datasets = upload_common.get_uploaded_datasets(
             trans, "", incoming, dataset_upload_inputs, history=history
@@ -94,11 +94,19 @@ class UploadToolAction(BaseUploadToolAction):
         json_file_path = upload_common.create_paramfile(trans, uploaded_datasets)
         data_list = [ud.data for ud in uploaded_datasets]
         log.debug(f"Checked uploads {check_timer}")
-        return self._create_job(trans, incoming, tool, json_file_path, data_list, history=history)
+        return self._create_job(
+            trans,
+            incoming,
+            tool,
+            json_file_path,
+            data_list,
+            history=history,
+            preferred_object_store_id=preferred_object_store_id,
+        )
 
 
 class FetchUploadToolAction(BaseUploadToolAction):
-    def _setup_job(self, tool, trans, incoming, dataset_upload_inputs, history):
+    def _setup_job(self, tool, trans, incoming, dataset_upload_inputs, history, preferred_object_store_id):
         # Now replace references in requests with these.
         files = incoming.get("files", [])
         files_iter = iter(files)
@@ -143,7 +151,15 @@ class FetchUploadToolAction(BaseUploadToolAction):
                 _precreate_fetched_collection_instance(trans, history, target, outputs)
 
         incoming["request_json"] = json.dumps(request)
-        return self._create_job(trans, incoming, tool, None, outputs, history=history)
+        return self._create_job(
+            trans,
+            incoming,
+            tool,
+            None,
+            outputs,
+            history=history,
+            preferred_object_store_id=preferred_object_store_id,
+        )
 
 
 def _precreate_fetched_hdas(trans, history, target, outputs):

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -381,7 +381,17 @@ def create_paramfile(trans, uploaded_datasets):
     return json_file_path
 
 
-def create_job(trans, params, tool, json_file_path, outputs, folder=None, history=None, job_params=None):
+def create_job(
+    trans,
+    params,
+    tool,
+    json_file_path,
+    outputs,
+    folder=None,
+    history=None,
+    job_params=None,
+    preferred_object_store_id=None,
+):
     """
     Create the upload job.
     """
@@ -393,6 +403,7 @@ def create_job(trans, params, tool, json_file_path, outputs, folder=None, histor
         job.session_id = galaxy_session.id
     if trans.user is not None:
         job.user_id = trans.user.id
+    job.preferred_object_store_id = preferred_object_store_id
     if folder:
         job.library_folder_id = folder.id
     else:

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -307,6 +307,14 @@ class ToolsService(ServiceBase):
             clean_payload[key] = value
         clean_payload["check_content"] = self.config.check_upload_content
         validate_and_normalize_targets(trans, clean_payload)
+        preferred_object_store_id = clean_payload.get("preferred_object_store_id")
+        if preferred_object_store_id is not None:
+            validation_error = trans.app.object_store.validate_selected_object_store_id(
+                trans.user,
+                preferred_object_store_id,
+            )
+            if validation_error:
+                raise RequestParameterInvalidException(validation_error)
         request = dumps(clean_payload)
         create_payload: ToolRunPayload = {
             "tool_id": "__DATA_FETCH__",
@@ -317,6 +325,8 @@ class ToolsService(ServiceBase):
                 "file_count": str(len(files_payload)),
             },
         }
+        if preferred_object_store_id is not None:
+            create_payload["preferred_object_store_id"] = preferred_object_store_id
         create_payload.update(files_payload)
         return self._create(trans, create_payload)
 

--- a/lib/galaxy_test/selenium/upload_activity_helpers.py
+++ b/lib/galaxy_test/selenium/upload_activity_helpers.py
@@ -33,6 +33,7 @@ from typing import (
 from .framework import NavigatesGalaxyMixin
 
 T = TypeVar("T", bound="UploadItem")
+TUploadContext = TypeVar("TUploadContext", bound="BaseUploadContext")
 
 UploadMethodId = Literal[
     "local-file",
@@ -508,27 +509,27 @@ class BaseUploadContext:
         """Cancel all staged items without uploading."""
         self._context.cancel()
 
-    def select_target_history(self, history_id: str) -> "BaseUploadContext":
+    def select_target_history(self: TUploadContext, history_id: str) -> TUploadContext:
         """Change the upload target history using the TargetHistorySelector UI."""
         self._context.select_target_history(history_id)
         return self
 
-    def activate_advanced_mode(self) -> "BaseUploadContext":
+    def activate_advanced_mode(self: TUploadContext) -> TUploadContext:
         """Backward-compatible alias for enabling advanced mode via the UI switch."""
         self._context.activate_advanced_mode()
         return self
 
-    def set_advanced_mode(self, enabled: bool) -> "BaseUploadContext":
+    def set_advanced_mode(self: TUploadContext, enabled: bool) -> TUploadContext:
         """Set advanced mode state using the real upload panel switch control."""
         self._context.set_advanced_mode(enabled)
         return self
 
-    def toggle_advanced_mode(self) -> "BaseUploadContext":
+    def toggle_advanced_mode(self: TUploadContext) -> TUploadContext:
         """Toggle advanced mode using the real upload panel switch control."""
         self._context.toggle_advanced_mode()
         return self
 
-    def select_target_object_store(self, object_store_id: str) -> "BaseUploadContext":
+    def select_target_object_store(self: TUploadContext, object_store_id: str) -> TUploadContext:
         """Select a target object store for this upload.
 
         Note: Advanced mode must be activated first for this selector to be visible.
@@ -542,67 +543,11 @@ class LocalFileContext(BaseUploadContext):
     def stage_local_file(self, test_path: str, metadata: Optional["UploadMetadata"] = None) -> LocalUploadItem:
         return self._context.stage_local_file(test_path, metadata)
 
-    def select_target_history(self, history_id: str) -> "LocalFileContext":
-
-        self._context.select_target_history(history_id)
-        return self
-
-    def activate_advanced_mode(self) -> "LocalFileContext":
-        """Activate advanced mode for upload options (including target object store selector)."""
-        self._context.activate_advanced_mode()
-        return self
-
-    def set_advanced_mode(self, enabled: bool) -> "LocalFileContext":
-        """Set advanced mode state using the real upload panel switch control."""
-        self._context.set_advanced_mode(enabled)
-        return self
-
-    def toggle_advanced_mode(self) -> "LocalFileContext":
-        """Toggle advanced mode using the real upload panel switch control."""
-        self._context.toggle_advanced_mode()
-        return self
-
-    def select_target_object_store(self, object_store_id: str) -> "LocalFileContext":
-        """Select a target object store for this upload.
-
-        Note: Advanced mode must be activated first for this selector to be visible.
-        """
-        self._context.select_target_object_store(object_store_id)
-        return self
-
 
 class PasteContentContext(BaseUploadContext):
 
     def stage_paste_content(self, content: str, metadata: Optional["UploadMetadata"] = None) -> PasteContentUploadItem:
         return self._context.stage_paste_content(content, metadata)
-
-    def select_target_history(self, history_id: str) -> "PasteContentContext":
-        """Change the upload target history using the TargetHistorySelector UI."""
-        self._context.select_target_history(history_id)
-        return self
-
-    def activate_advanced_mode(self) -> "PasteContentContext":
-        """Activate advanced mode for upload options (including target object store selector)."""
-        self._context.activate_advanced_mode()
-        return self
-
-    def set_advanced_mode(self, enabled: bool) -> "PasteContentContext":
-        """Set advanced mode state using the real upload panel switch control."""
-        self._context.set_advanced_mode(enabled)
-        return self
-
-    def toggle_advanced_mode(self) -> "PasteContentContext":
-        """Toggle advanced mode using the real upload panel switch control."""
-        self._context.toggle_advanced_mode()
-        return self
-
-    def select_target_object_store(self, object_store_id: str) -> "PasteContentContext":
-        """Select a target object store for this upload.
-
-        Note: Advanced mode must be activated first for this selector to be visible.
-        """
-        self._context.select_target_object_store(object_store_id)
-        return self
 
 
 class PasteLinksContext(BaseUploadContext):
@@ -630,34 +575,6 @@ class PasteLinksContext(BaseUploadContext):
         self._context.stage_paste_links(url_metadata_pairs)
         return self
 
-    def select_target_history(self, history_id: str) -> "PasteLinksContext":
-        """Change the upload target history using the TargetHistorySelector UI."""
-        self._context.select_target_history(history_id)
-        return self
-
-    def activate_advanced_mode(self) -> "PasteLinksContext":
-        """Activate advanced mode for upload options (including target object store selector)."""
-        self._context.activate_advanced_mode()
-        return self
-
-    def set_advanced_mode(self, enabled: bool) -> "PasteLinksContext":
-        """Set advanced mode state using the real upload panel switch control."""
-        self._context.set_advanced_mode(enabled)
-        return self
-
-    def toggle_advanced_mode(self) -> "PasteLinksContext":
-        """Toggle advanced mode using the real upload panel switch control."""
-        self._context.toggle_advanced_mode()
-        return self
-
-    def select_target_object_store(self, object_store_id: str) -> "PasteLinksContext":
-        """Select a target object store for this upload.
-
-        Note: Advanced mode must be activated first for this selector to be visible.
-        """
-        self._context.select_target_object_store(object_store_id)
-        return self
-
 
 class RemoteFilesContext(BaseUploadContext):
 
@@ -665,34 +582,6 @@ class RemoteFilesContext(BaseUploadContext):
         self, source_label: str, file_label: str, metadata: Optional["UploadMetadata"] = None
     ) -> RemoteFileUploadItem:
         return self._context.stage_remote_file(source_label, file_label, metadata)
-
-    def select_target_history(self, history_id: str) -> "RemoteFilesContext":
-        """Change the upload target history using the TargetHistorySelector UI."""
-        self._context.select_target_history(history_id)
-        return self
-
-    def activate_advanced_mode(self) -> "RemoteFilesContext":
-        """Activate advanced mode for upload options (including target object store selector)."""
-        self._context.activate_advanced_mode()
-        return self
-
-    def set_advanced_mode(self, enabled: bool) -> "RemoteFilesContext":
-        """Set advanced mode state using the real upload panel switch control."""
-        self._context.set_advanced_mode(enabled)
-        return self
-
-    def toggle_advanced_mode(self) -> "RemoteFilesContext":
-        """Toggle advanced mode using the real upload panel switch control."""
-        self._context.toggle_advanced_mode()
-        return self
-
-    def select_target_object_store(self, object_store_id: str) -> "RemoteFilesContext":
-        """Select a target object store for this upload.
-
-        Note: Advanced mode must be activated first for this selector to be visible.
-        """
-        self._context.select_target_object_store(object_store_id)
-        return self
 
 
 class CompositeFileContext(BaseUploadContext):
@@ -717,67 +606,11 @@ class CompositeFileContext(BaseUploadContext):
         self._context.stage_composite_file_slot(slot, file_path)
         return self
 
-    def select_target_history(self, history_id: str) -> "CompositeFileContext":
-        """Change the upload target history using the TargetHistorySelector UI."""
-        self._context.select_target_history(history_id)
-        return self
-
-    def activate_advanced_mode(self) -> "CompositeFileContext":
-        """Activate advanced mode for upload options (including target object store selector)."""
-        self._context.activate_advanced_mode()
-        return self
-
-    def set_advanced_mode(self, enabled: bool) -> "CompositeFileContext":
-        """Set advanced mode state using the real upload panel switch control."""
-        self._context.set_advanced_mode(enabled)
-        return self
-
-    def toggle_advanced_mode(self) -> "CompositeFileContext":
-        """Toggle advanced mode using the real upload panel switch control."""
-        self._context.toggle_advanced_mode()
-        return self
-
-    def select_target_object_store(self, object_store_id: str) -> "CompositeFileContext":
-        """Select a target object store for this upload.
-
-        Note: Advanced mode must be activated first for this selector to be visible.
-        """
-        self._context.select_target_object_store(object_store_id)
-        return self
-
 
 class DataLibraryContext(BaseUploadContext):
 
     def stage_data_library_dataset(self, library_label: str, dataset_label: str) -> DataLibraryUploadItem:
         return self._context.stage_data_library_dataset(library_label, dataset_label)
-
-    def select_target_history(self, history_id: str) -> "DataLibraryContext":
-        """Change the upload target history using the TargetHistorySelector UI."""
-        self._context.select_target_history(history_id)
-        return self
-
-    def activate_advanced_mode(self) -> "DataLibraryContext":
-        """Activate advanced mode for upload options (including target object store selector)."""
-        self._context.activate_advanced_mode()
-        return self
-
-    def set_advanced_mode(self, enabled: bool) -> "DataLibraryContext":
-        """Set advanced mode state using the real upload panel switch control."""
-        self._context.set_advanced_mode(enabled)
-        return self
-
-    def toggle_advanced_mode(self) -> "DataLibraryContext":
-        """Toggle advanced mode using the real upload panel switch control."""
-        self._context.toggle_advanced_mode()
-        return self
-
-    def select_target_object_store(self, object_store_id: str) -> "DataLibraryContext":
-        """Select a target object store for this upload.
-
-        Note: Advanced mode must be activated first for this selector to be visible.
-        """
-        self._context.select_target_object_store(object_store_id)
-        return self
 
 
 # Mapping of upload method IDs to their corresponding context classes

--- a/lib/galaxy_test/selenium/upload_activity_helpers.py
+++ b/lib/galaxy_test/selenium/upload_activity_helpers.py
@@ -427,6 +427,35 @@ class UploadContext:
         self.components.beta_upload.history_selector_modal.wait_for_absent_or_hidden()
         return self
 
+    def activate_advanced_mode(self) -> "UploadContext":
+        """Backward-compatible alias for enabling advanced mode via the UI switch."""
+        return self.set_advanced_mode(True)
+
+    def set_advanced_mode(self, enabled: bool) -> "UploadContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        checkbox = self.components.beta_upload.advanced_mode_toggle_checkbox.wait_for_present()
+        if checkbox.is_selected() != enabled:
+            # Match existing framework checkbox handling via JS click on the input.
+            self.driver_wrapper.execute_script("arguments[0].click();", checkbox)
+        return self
+
+    def toggle_advanced_mode(self) -> "UploadContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        checkbox = self.components.beta_upload.advanced_mode_toggle_checkbox.wait_for_present()
+        self.driver_wrapper.execute_script("arguments[0].click();", checkbox)
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "UploadContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be enabled first for this selector to be visible.
+        """
+        self.components.beta_upload.target_object_store_selector_dropdown.wait_for_and_click()
+        self.components.beta_upload.target_object_store_selector_option(
+            object_store_id=object_store_id
+        ).wait_for_and_click()
+        return self
+
     def _select_method(self, method_id: UploadMethodId) -> None:
         if self._current_method_id == method_id:
             return
@@ -484,6 +513,29 @@ class BaseUploadContext:
         self._context.select_target_history(history_id)
         return self
 
+    def activate_advanced_mode(self) -> "BaseUploadContext":
+        """Backward-compatible alias for enabling advanced mode via the UI switch."""
+        self._context.activate_advanced_mode()
+        return self
+
+    def set_advanced_mode(self, enabled: bool) -> "BaseUploadContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        self._context.set_advanced_mode(enabled)
+        return self
+
+    def toggle_advanced_mode(self) -> "BaseUploadContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        self._context.toggle_advanced_mode()
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "BaseUploadContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be activated first for this selector to be visible.
+        """
+        self._context.select_target_object_store(object_store_id)
+        return self
+
 
 class LocalFileContext(BaseUploadContext):
 
@@ -495,6 +547,29 @@ class LocalFileContext(BaseUploadContext):
         self._context.select_target_history(history_id)
         return self
 
+    def activate_advanced_mode(self) -> "LocalFileContext":
+        """Activate advanced mode for upload options (including target object store selector)."""
+        self._context.activate_advanced_mode()
+        return self
+
+    def set_advanced_mode(self, enabled: bool) -> "LocalFileContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        self._context.set_advanced_mode(enabled)
+        return self
+
+    def toggle_advanced_mode(self) -> "LocalFileContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        self._context.toggle_advanced_mode()
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "LocalFileContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be activated first for this selector to be visible.
+        """
+        self._context.select_target_object_store(object_store_id)
+        return self
+
 
 class PasteContentContext(BaseUploadContext):
 
@@ -504,6 +579,29 @@ class PasteContentContext(BaseUploadContext):
     def select_target_history(self, history_id: str) -> "PasteContentContext":
         """Change the upload target history using the TargetHistorySelector UI."""
         self._context.select_target_history(history_id)
+        return self
+
+    def activate_advanced_mode(self) -> "PasteContentContext":
+        """Activate advanced mode for upload options (including target object store selector)."""
+        self._context.activate_advanced_mode()
+        return self
+
+    def set_advanced_mode(self, enabled: bool) -> "PasteContentContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        self._context.set_advanced_mode(enabled)
+        return self
+
+    def toggle_advanced_mode(self) -> "PasteContentContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        self._context.toggle_advanced_mode()
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "PasteContentContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be activated first for this selector to be visible.
+        """
+        self._context.select_target_object_store(object_store_id)
         return self
 
 
@@ -537,6 +635,29 @@ class PasteLinksContext(BaseUploadContext):
         self._context.select_target_history(history_id)
         return self
 
+    def activate_advanced_mode(self) -> "PasteLinksContext":
+        """Activate advanced mode for upload options (including target object store selector)."""
+        self._context.activate_advanced_mode()
+        return self
+
+    def set_advanced_mode(self, enabled: bool) -> "PasteLinksContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        self._context.set_advanced_mode(enabled)
+        return self
+
+    def toggle_advanced_mode(self) -> "PasteLinksContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        self._context.toggle_advanced_mode()
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "PasteLinksContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be activated first for this selector to be visible.
+        """
+        self._context.select_target_object_store(object_store_id)
+        return self
+
 
 class RemoteFilesContext(BaseUploadContext):
 
@@ -548,6 +669,29 @@ class RemoteFilesContext(BaseUploadContext):
     def select_target_history(self, history_id: str) -> "RemoteFilesContext":
         """Change the upload target history using the TargetHistorySelector UI."""
         self._context.select_target_history(history_id)
+        return self
+
+    def activate_advanced_mode(self) -> "RemoteFilesContext":
+        """Activate advanced mode for upload options (including target object store selector)."""
+        self._context.activate_advanced_mode()
+        return self
+
+    def set_advanced_mode(self, enabled: bool) -> "RemoteFilesContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        self._context.set_advanced_mode(enabled)
+        return self
+
+    def toggle_advanced_mode(self) -> "RemoteFilesContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        self._context.toggle_advanced_mode()
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "RemoteFilesContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be activated first for this selector to be visible.
+        """
+        self._context.select_target_object_store(object_store_id)
         return self
 
 
@@ -578,6 +722,29 @@ class CompositeFileContext(BaseUploadContext):
         self._context.select_target_history(history_id)
         return self
 
+    def activate_advanced_mode(self) -> "CompositeFileContext":
+        """Activate advanced mode for upload options (including target object store selector)."""
+        self._context.activate_advanced_mode()
+        return self
+
+    def set_advanced_mode(self, enabled: bool) -> "CompositeFileContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        self._context.set_advanced_mode(enabled)
+        return self
+
+    def toggle_advanced_mode(self) -> "CompositeFileContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        self._context.toggle_advanced_mode()
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "CompositeFileContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be activated first for this selector to be visible.
+        """
+        self._context.select_target_object_store(object_store_id)
+        return self
+
 
 class DataLibraryContext(BaseUploadContext):
 
@@ -587,6 +754,29 @@ class DataLibraryContext(BaseUploadContext):
     def select_target_history(self, history_id: str) -> "DataLibraryContext":
         """Change the upload target history using the TargetHistorySelector UI."""
         self._context.select_target_history(history_id)
+        return self
+
+    def activate_advanced_mode(self) -> "DataLibraryContext":
+        """Activate advanced mode for upload options (including target object store selector)."""
+        self._context.activate_advanced_mode()
+        return self
+
+    def set_advanced_mode(self, enabled: bool) -> "DataLibraryContext":
+        """Set advanced mode state using the real upload panel switch control."""
+        self._context.set_advanced_mode(enabled)
+        return self
+
+    def toggle_advanced_mode(self) -> "DataLibraryContext":
+        """Toggle advanced mode using the real upload panel switch control."""
+        self._context.toggle_advanced_mode()
+        return self
+
+    def select_target_object_store(self, object_store_id: str) -> "DataLibraryContext":
+        """Select a target object store for this upload.
+
+        Note: Advanced mode must be activated first for this selector to be visible.
+        """
+        self._context.select_target_object_store(object_store_id)
         return self
 
 

--- a/test/integration_selenium/test_upload_target_object_store_selection.py
+++ b/test/integration_selenium/test_upload_target_object_store_selection.py
@@ -1,0 +1,75 @@
+from typing import TYPE_CHECKING
+
+from galaxy_test.driver.integration_util import ConfiguresObjectStores
+from galaxy_test.selenium.upload_activity_helpers import UsesUploadActivity
+from .framework import (
+    managed_history,
+    selenium_test,
+    SeleniumIntegrationTestCase,
+)
+from .test_objectstore_selection import MSI_EXAMPLE_OBJECT_STORE_CONFIG_TEMPLATE
+
+if TYPE_CHECKING:
+    from galaxy_test.selenium.framework import SeleniumSessionDatasetPopulator
+
+
+class TestUploadTargetObjectStoreSelectionSeleniumIntegration(
+    SeleniumIntegrationTestCase,
+    ConfiguresObjectStores,
+    UsesUploadActivity,
+):
+    ensure_registered = True
+    dataset_populator: "SeleniumSessionDatasetPopulator"
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls._configure_object_store(MSI_EXAMPLE_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    @selenium_test
+    @managed_history
+    def test_uploads_can_target_different_object_stores(self):
+        """Test that users can select different object stores for uploads using the TargetObjectStoreSelector.
+
+        This test verifies the new upload advanced mode feature that allows selecting a target
+        object store during upload, rather than relying on history preferences. It exercises
+        both directions: an explicit store selection and the default (history preference) path,
+        then verifies each dataset landed in the correct store.
+        """
+        selectable_object_store_ids = self.dataset_populator.selectable_object_store_ids()
+        assert "second" in selectable_object_store_ids, selectable_object_store_ids
+        custom_store_id = "second"
+        default_store_id = "high_performance"
+        first_file_path = self.test_data_resolver.get_filename("1.txt")
+        second_file_path = self.test_data_resolver.get_filename("2.txt")
+
+        # Upload first file with explicit (non-default) store selection
+        local_upload = self.upload_context("local-file")
+
+        # Switch on advanced mode to reveal the TargetObjectStoreSelector and make an explicit store selection
+        local_upload.set_advanced_mode(True)
+
+        local_upload.select_target_object_store(custom_store_id)
+        local_upload.stage_local_file(first_file_path, {"name": "custom-store-dataset"}).start()
+        self.history_panel_wait_for_hid_ok(1)
+
+        # Upload second file with default store (no explicit selection)
+        self.upload_context("local-file").stage_local_file(second_file_path, {"name": "default-store-dataset"}).start()
+        self.history_panel_wait_for_hid_ok(2)
+
+        # Verify both datasets are in the history
+        history_id = self.current_history_id()
+        history_contents = self.dataset_populator.get_history_contents(history_id)
+        datasets_by_name = {
+            content["name"]: content
+            for content in history_contents
+            if content.get("history_content_type") == "dataset"
+            and content.get("name") in ["custom-store-dataset", "default-store-dataset"]
+        }
+        assert "custom-store-dataset" in datasets_by_name, history_contents
+        assert "default-store-dataset" in datasets_by_name, history_contents
+
+        # Verify each dataset landed in the expected store
+        custom_storage = self.dataset_populator.dataset_storage_info(datasets_by_name["custom-store-dataset"]["id"])
+        default_storage = self.dataset_populator.dataset_storage_info(datasets_by_name["default-store-dataset"]["id"])
+        assert custom_storage["object_store_id"] == custom_store_id, custom_storage
+        assert default_storage["object_store_id"] == default_store_id, default_storage


### PR DESCRIPTION
Resolves #22672

After activating the **Advanced mode** in the upload activity, you can now select the target storage location right before uploading your files from any source. **Note:** You also need to have some selectable object stores available in your Galaxy instance.

Includes some backend changes to pass the optional `preferred_object_store_id` to the fetch tool.

<img width="1521" height="705" alt="image" src="https://github.com/user-attachments/assets/f8612cd7-b766-4742-a3aa-7d443ef4a004" />


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
