### PR TITLE
[25.1] Backport FastAPI/Starlette upgrade for BadHost (CVE-2026-48710)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ variables:
 jobs:
   get_code:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
     <<: *set_workdir
     steps:
       # Replace standard code checkout with shallow clone to speed things up.
@@ -73,7 +73,7 @@ jobs:
             - ~/repo
   validate_test_tools:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
     <<: *set_workdir
     steps:
       - *restore_repo_cache

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         chunk: [0, 1]
     services:
       postgres:

--- a/.github/workflows/bioblend.yaml
+++ b/.github/workflows/bioblend.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         tox_env: [py313]
-        galaxy_python_version: ['3.9']
+        galaxy_python_version: ['3.10']
     steps:
       - name: Checkout Galaxy
         uses: actions/checkout@v5

--- a/.github/workflows/check_test_class_names.yaml
+++ b/.github/workflows/check_test_class_names.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     steps:
       - if: github.event_name == 'schedule'
         run: |

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         marker: ['green', 'red and required', 'red and not required']
         conformance-version: ['cwl_conformance_v1_0'] #, 'cwl_conformance_v1_1', 'cwl_conformance_v1_2']
     services:

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -26,11 +26,11 @@ jobs:
       matrix:
         db: ['postgresql', 'sqlite']
         postgresql-version: ['17']
-        python-version: ['3.9']
+        python-version: ['3.10']
         include:
           - db: postgresql
             postgresql-version: '9.6'
-            python-version: '3.9'
+            python-version: '3.10'
     services:
       postgres:
         image: postgres:${{ matrix.postgresql-version }}

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Update dependencies
         run: make update-dependencies
       - name: Create pull request

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     steps:
       - name: Get target branch name (push)
         if: github.event_name == 'push'

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         chunk: ['0', '1', '2', '3']
     steps:
       - if: github.event_name == 'schedule'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
     env:
       LINT_PATH: 'lib/galaxy/dependencies/pinned-lint-requirements.txt'
       TYPE_PATH: 'lib/galaxy/dependencies/pinned-typecheck-requirements.txt'

--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            python-version: ['3.9']
+            python-version: ['3.10']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
         chunk: [0, 1, 2]
     services:
       postgres:

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
         shed-api: ['v1', 'v2']
         test-install-client: ['galaxy_api', 'standalone']
     services:

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgres:17

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
     steps:
       - uses: actions/checkout@v5
         with:

--- a/README.rst
+++ b/README.rst
@@ -24,12 +24,12 @@ Community support is available at `Galaxy Help <https://help.galaxyproject.org/>
 Galaxy Quickstart
 =================
 
-Galaxy requires Python 3.9 or higher. To check your Python version, run:
+Galaxy requires Python 3.10 or higher. To check your Python version, run:
 
 .. code:: console
 
     $ python -V
-    Python 3.9.21
+    Python 3.10.18
 
 Start Galaxy:
 

--- a/doc/source/admin/python.md
+++ b/doc/source/admin/python.md
@@ -1,6 +1,6 @@
 # Supported Python versions
 
-Galaxy's core functionality is currently supported on Python **>=3.9** .
+Galaxy's core functionality is currently supported on Python **>=3.10** .
 
 If Galaxy complains about the version of Python you are using:
 

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -10,6 +10,7 @@ aioitertools==0.12.0
 aiosignal==1.4.0
 alembic==1.16.5
 amqp==5.3.1
+annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.11.0
 apispec==6.8.4
@@ -67,7 +68,7 @@ edam-ontology==1.25.2
 email-validator==2.3.0
 et-xmlfile==2.0.0
 exceptiongroup==1.3.0 ; python_full_version < '3.11'
-fastapi==0.118.0
+fastapi==0.136.3
 filelock==3.19.1
 fissix==24.4.24
 frozenlist==1.7.0
@@ -170,7 +171,7 @@ pyreadline3==3.5.4 ; sys_platform == 'win32'
 pysam==0.23.3
 python-dateutil==2.9.0.post0
 python-magic==0.4.27
-python-multipart==0.0.20
+python-multipart==0.0.29
 python-slugify==8.0.4
 python3-openid==3.2.0
 pytz==2025.2
@@ -204,8 +205,8 @@ sortedcontainers==2.4.0
 spython==0.3.14
 sqlalchemy==2.0.43
 sqlparse==0.5.3
-starlette==0.48.0
-starlette-context==0.4.0
+starlette==1.1.0
+starlette-context==0.5.1
 supervisor==4.3.0
 svgwrite==1.4.3
 tenacity==9.1.2

--- a/lib/galaxy/schema/generics.py
+++ b/lib/galaxy/schema/generics.py
@@ -6,7 +6,6 @@ from typing import (
 )
 
 from pydantic import BaseModel
-from pydantic.json_schema import GenerateJsonSchema
 from typing_extensions import override
 
 from galaxy.schema.fields import (
@@ -40,17 +39,6 @@ class GenericModel(BaseModel):
         elif params[0] is DecodedDatabaseIdField:
             suffix = "Request"
         return suffix
-
-
-class CustomJsonSchema(GenerateJsonSchema):
-    def get_defs_ref(self, core_mode_ref):
-        full_def = super().get_defs_ref(core_mode_ref)
-        choices = self._prioritized_defsref_choices[full_def]
-        ref, mode = core_mode_ref
-        if ref in ref_to_name:
-            for i, choice in enumerate(choices):
-                choices[i] = choice.replace(choices[0], ref_to_name[ref])  # type: ignore[call-overload]
-        return full_def
 
 
 class PatchGenericPickle:

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -88,11 +88,17 @@ class GalaxyFileResponse(FileResponse):
         background: Optional["BackgroundTask"] = None,
         filename: Optional[str] = None,
         stat_result: Optional[os.stat_result] = None,
-        method: Optional[str] = None,
         content_disposition_type: str = "attachment",
     ) -> None:
         super().__init__(
-            path, status_code, headers, media_type, background, filename, stat_result, method, content_disposition_type
+            path=path,
+            status_code=status_code,
+            headers=headers,
+            media_type=media_type,
+            background=background,
+            filename=filename,
+            stat_result=stat_result,
+            content_disposition_type=content_disposition_type,
         )
         self.headers["accept-ranges"] = "bytes"
         self.xsendfile = self.nginx_x_accel_redirect_base or self.apache_xsendfile

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -290,7 +290,7 @@ class FastAPIDatasets:
         assert isinstance(display_data, IOBase)
         file_name = getattr(display_data, "name", None)
         assert file_name
-        return GalaxyFileResponse(file_name, headers=headers, method=request.method)
+        return GalaxyFileResponse(file_name, headers=headers)
 
     @router.get(
         "/api/histories/{history_id}/contents/{history_content_id}/display",
@@ -374,7 +374,7 @@ class FastAPIDatasets:
         if isinstance(display_data, IOBase):
             file_name = getattr(display_data, "name", None)
             if file_name:
-                return GalaxyFileResponse(file_name, headers=headers, method=request.method)
+                return GalaxyFileResponse(file_name, headers=headers)
         elif isinstance(display_data, ZipstreamWrapper):
             return StreamingResponse(display_data.response(), headers=headers)
         elif isinstance(display_data, bytes):

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -1,16 +1,15 @@
 from typing import (
     Any,
+    TYPE_CHECKING,
 )
 
 from a2wsgi import WSGIMiddleware
-from fastapi import (
-    FastAPI,
-    Request,
-)
+from fastapi import FastAPI
 from fastapi.openapi.constants import REF_TEMPLATE
+from starlette.datastructures import MutableHeaders
 from starlette.middleware.cors import CORSMiddleware
 
-from galaxy.schema.generics import CustomJsonSchema
+from galaxy.schema.generics import ref_to_name
 from galaxy.version import VERSION
 from galaxy.webapps.base.api import (
     add_exception_handler,
@@ -20,7 +19,14 @@ from galaxy.webapps.base.api import (
     include_all_package_routers,
 )
 from galaxy.webapps.base.webapp import config_allows_origin
+from galaxy.webapps.openapi._compat.v2 import GenerateJsonSchema
 from galaxy.webapps.openapi.utils import get_openapi
+
+if TYPE_CHECKING:
+    from pydantic.json_schema import (
+        CoreModeRef,
+        DefsRef,
+    )
 
 # https://fastapi.tiangolo.com/tutorial/metadata/#metadata-for-tags
 api_tags_metadata = [
@@ -99,14 +105,28 @@ class GalaxyCORSMiddleware(CORSMiddleware):
         return config_allows_origin(origin, self.config)
 
 
+class XFrameOptionsMiddleware:
+    def __init__(self, app, x_frame_options: str):
+        self.app = app
+        self.x_frame_options = x_frame_options
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers.append("X-Frame-Options", self.x_frame_options)
+            await send(message)
+
+        await self.app(scope, receive, send_with_header)
+
+
 def add_galaxy_middleware(app: FastAPI, gx_app):
     if x_frame_options := gx_app.config.x_frame_options:
-
-        @app.middleware("http")
-        async def add_x_frame_options(request: Request, call_next):
-            response = await call_next(request)
-            response.headers["X-Frame-Options"] = x_frame_options
-            return response
+        app.add_middleware(XFrameOptionsMiddleware, x_frame_options=x_frame_options)
 
     GalaxyFileResponse.nginx_x_accel_redirect_base = gx_app.config.nginx_x_accel_redirect_base
     GalaxyFileResponse.apache_xsendfile = gx_app.config.apache_xsendfile
@@ -146,6 +166,17 @@ def get_fastapi_instance(root_path="") -> FastAPI:
         license_info={"name": "MIT", "url": "https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt"},
         root_path=root_path,
     )
+
+
+class CustomJsonSchema(GenerateJsonSchema):
+    def get_defs_ref(self, core_mode_ref: "CoreModeRef") -> "DefsRef":
+        full_def = super().get_defs_ref(core_mode_ref)
+        choices = self._prioritized_defsref_choices[full_def]
+        ref, mode = core_mode_ref
+        if ref in ref_to_name:
+            for i, choice in enumerate(choices):
+                choices[i] = choice.replace(choices[0], ref_to_name[ref])  # type: ignore[call-overload]
+        return full_def
 
 
 def get_openapi_schema() -> dict[str, Any]:

--- a/lib/galaxy/webapps/openapi/_compat/v2.py
+++ b/lib/galaxy/webapps/openapi/_compat/v2.py
@@ -1,33 +1,75 @@
+from collections.abc import Sequence
 from typing import (
     Any,
     cast,
+    Literal,
     Union,
 )
 
-from fastapi._compat import ModelField
-from fastapi.types import ModelNameMap
-from pydantic.json_schema import (
+from fastapi._compat.v2 import (
+    _has_computed_fields,
     GenerateJsonSchema as GenerateJsonSchema,
+    get_flat_models_from_fields,
+    ModelField,
+)
+from fastapi.openapi.constants import REF_TEMPLATE
+from fastapi.types import ModelNameMap
+from pydantic.fields import FieldInfo as FieldInfo
+from pydantic.json_schema import (
     JsonSchemaValue as JsonSchemaValue,
 )
-from typing_extensions import Literal
 
 
 def get_definitions(
     *,
-    fields: list[ModelField],
-    schema_generator: GenerateJsonSchema,
+    fields: Sequence[ModelField],
     model_name_map: ModelNameMap,
     separate_input_output_schemas: bool = True,
+    schema_generator: Union[GenerateJsonSchema, None] = None,
 ) -> tuple[
     dict[tuple[ModelField, Literal["validation", "serialization"]], JsonSchemaValue],
     dict[str, dict[str, Any]],
 ]:
-    override_mode: Union[Literal["validation"], None] = None if separate_input_output_schemas else "validation"
-    inputs = [(field, override_mode or field.mode, field._type_adapter.core_schema) for field in fields]
+    schema_generator = schema_generator or GenerateJsonSchema(ref_template=REF_TEMPLATE)
+    validation_fields = [field for field in fields if field.mode == "validation"]
+    serialization_fields = [field for field in fields if field.mode == "serialization"]
+    flat_validation_models = get_flat_models_from_fields(validation_fields, known_models=set())
+    flat_serialization_models = get_flat_models_from_fields(serialization_fields, known_models=set())
+    flat_validation_model_fields = [
+        ModelField(
+            field_info=FieldInfo(annotation=model),
+            name=model.__name__,
+            mode="validation",
+        )
+        for model in flat_validation_models
+    ]
+    flat_serialization_model_fields = [
+        ModelField(
+            field_info=FieldInfo(annotation=model),
+            name=model.__name__,
+            mode="serialization",
+        )
+        for model in flat_serialization_models
+    ]
+    flat_model_fields = flat_validation_model_fields + flat_serialization_model_fields
+    input_types = {f.field_info.annotation for f in fields}
+    unique_flat_model_fields = {f for f in flat_model_fields if f.field_info.annotation not in input_types}
+    inputs = [
+        (
+            field,
+            (field.mode if (separate_input_output_schemas or _has_computed_fields(field)) else "validation"),
+            field._type_adapter.core_schema,
+        )
+        for field in list(fields) + list(unique_flat_model_fields)
+    ]
     field_mapping, definitions = schema_generator.generate_definitions(inputs=inputs)
     for item_def in cast(dict[str, dict[str, Any]], definitions).values():
         if "description" in item_def:
             item_description = cast(str, item_def["description"]).split("\f")[0]
             item_def["description"] = item_description
-    return field_mapping, definitions  # type: ignore[return-value]
+    # definitions: dict[DefsRef, dict[str, Any]]
+    # but mypy complains about general str in other places that are not declared as
+    # DefsRef, although DefsRef is just str:
+    # DefsRef = NewType('DefsRef', str)
+    # So, a cast to simplify the types here
+    return field_mapping, cast(dict[str, dict[str, Any]], definitions)

--- a/lib/galaxy/webapps/openapi/utils.py
+++ b/lib/galaxy/webapps/openapi/utils.py
@@ -11,17 +11,10 @@ from typing import (
 )
 
 from fastapi import routing
-
-try:
-    from fastapi._compat import (  # type: ignore[attr-defined]
-        get_flat_models_from_fields,
-        get_model_name_map,
-    )
-except ImportError:
-    # FastAPI <0.128.4
-    get_flat_models_from_fields = None
-    from fastapi._compat import get_compat_model_name_map
-
+from fastapi._compat import (  # type: ignore[attr-defined,unused-ignore]
+    get_flat_models_from_fields,
+    get_model_name_map,
+)
 from fastapi.encoders import jsonable_encoder
 from fastapi.openapi.constants import REF_TEMPLATE
 from fastapi.openapi.models import OpenAPI
@@ -29,10 +22,10 @@ from fastapi.openapi.utils import (
     get_fields_from_routes,
     get_openapi_path,
 )
-from pydantic.json_schema import GenerateJsonSchema
 from starlette.routing import BaseRoute
 
 from ._compat import get_definitions
+from ._compat.v2 import GenerateJsonSchema
 
 
 def get_openapi(
@@ -72,17 +65,14 @@ def get_openapi(
     webhook_paths: dict[str, dict[str, Any]] = {}
     operation_ids: set[str] = set()
     all_fields = get_fields_from_routes(list(routes or []) + list(webhooks or []))
-    if get_flat_models_from_fields:
-        flat_models = get_flat_models_from_fields(all_fields, known_models=set())
-        model_name_map = get_model_name_map(flat_models)
-    else:
-        model_name_map = get_compat_model_name_map(all_fields)
+    flat_models = get_flat_models_from_fields(all_fields, known_models=set())
+    model_name_map = get_model_name_map(flat_models)
     schema_generator = schema_generator or GenerateJsonSchema(ref_template=REF_TEMPLATE)
     field_mapping, definitions = get_definitions(
         fields=all_fields,
-        schema_generator=schema_generator,
         model_name_map=model_name_map,
         separate_input_output_schemas=separate_input_output_schemas,
+        schema_generator=schema_generator,
     )
     get_openapi_path_args = {}
     if "schema_generator" in signature(get_openapi_path).parameters:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -21,7 +21,6 @@ from requests import (
     delete,
     get,
     post,
-    put,
 )
 
 from galaxy.exceptions import error_codes
@@ -8870,11 +8869,11 @@ outer_input:
         invocation_step_details = invocation_step_response.json()
         return invocation_step_details
 
-    def _execute_invocation_step_action(self, workflow_id, invocation_id, step_id, action):
+    def _execute_invocation_step_action(self, workflow_id: str, invocation_id: str, step_id: str, action: bool):
         raw_url = f"workflows/{workflow_id}/usage/{invocation_id}/steps/{step_id}"
         url = self._api_url(raw_url, use_key=True)
-        payload = dumps(dict(action=action))
-        action_response = put(url, data=payload)
+        payload = {"action": action}
+        action_response = self._put(url, data=payload, json=True)
         self._assert_status_code_is(action_response, 200)
         invocation_step_details = action_response.json()
         return invocation_step_details
@@ -8910,7 +8909,9 @@ outer_input:
         )
         return workflow_request, history_id, uploaded_workflow_id
 
-    def __review_paused_steps(self, uploaded_workflow_id, invocation_id, order_index, action=True):
+    def __review_paused_steps(
+        self, uploaded_workflow_id: str, invocation_id: str, order_index: int, action: bool = True
+    ) -> None:
         invocation = self._invocation_details(uploaded_workflow_id, invocation_id)
         invocation_steps = invocation["steps"]
         pause_steps = [s for s in invocation_steps if s["order_index"] == order_index]

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -81,7 +80,7 @@ install_requires =
     WebOb>=1.8.9
     Whoosh
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/auth/setup.cfg
+++ b/packages/auth/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -35,7 +34,7 @@ install_requires =
     galaxy-data
     galaxy-util
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/packages/config/setup.cfg
+++ b/packages/config/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -38,7 +37,7 @@ install_requires =
     pykwalify
     PyYAML
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -65,7 +64,7 @@ install_requires =
     tifffile
     typing-extensions
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/files/setup.cfg
+++ b/packages/files/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -39,7 +38,7 @@ install_requires =
     typing-extensions
     fsspec
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/job_execution/setup.cfg
+++ b/packages/job_execution/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -40,7 +39,7 @@ install_requires =
     MarkupSafe
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/meta/setup.cfg
+++ b/packages/meta/setup.cfg
@@ -10,7 +10,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -34,7 +33,7 @@ version = 25.1.3.dev0
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires = file: requirements.txt
 
 [options.extras_require]

--- a/packages/navigation/setup.cfg
+++ b/packages/navigation/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -36,7 +35,7 @@ install_requires =
     PyYAML
     seletools
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/packages/schema/setup.cfg
+++ b/packages/schema/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -35,7 +34,7 @@ install_requires =
     galaxy-util
     pydantic[email]>=2.7.4
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/packages/selenium/setup.cfg
+++ b/packages/selenium/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -39,7 +38,7 @@ install_requires =
     requests
     selenium!=4.11.0,!=4.11.1,!=4.11.2
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/test_api/setup.cfg
+++ b/packages/test_api/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -38,7 +37,7 @@ install_requires =
     requests
     tuspy
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.extras_require]
 driver =

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -41,7 +40,7 @@ install_requires =
     PyYAML
     requests
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/packages/test_driver/setup.cfg
+++ b/packages/test_driver/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -41,7 +40,7 @@ install_requires =
     galaxy-web-apps
     pytest
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/packages/test_selenium/setup.cfg
+++ b/packages/test_selenium/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -43,7 +42,7 @@ install_requires =
     requests
     selenium!=4.11.0,!=4.11.1,!=4.11.2
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.extras_require]
 driver =

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -42,7 +41,7 @@ install_requires =
     galaxy-web-apps
     a2wsgi
     alembic
-    fastapi>=0.101.0
+    fastapi>=0.133.0
     Mako
     MarkupSafe
     mercurial>=6.8.2
@@ -51,13 +50,13 @@ install_requires =
     Routes
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
     slowapi
-    starlette
+    starlette>=1.0.1
     starlette-context
     typing-extensions
     WebOb
     Whoosh
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/packages/tool_shed_schema/setup.cfg
+++ b/packages/tool_shed_schema/setup.cfg
@@ -9,8 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -37,7 +35,7 @@ install_requires =
     pydantic>=2.7.4
     typing-extensions
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/tours/setup.cfg
+++ b/packages/tours/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -36,7 +35,7 @@ install_requires =
     pydantic>=2.7.4
     PyYAML
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -43,7 +42,7 @@ install_requires =
     apispec
     Babel
     CT3>=3.3.3
-    fastapi>=0.101.0
+    fastapi>=0.133.0
     gunicorn
     httpx
     gxformat2
@@ -58,7 +57,7 @@ install_requires =
     requests
     Routes
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
-    starlette
+    starlette>=1.0.1
     starlette-context
     tuswsgi
     typing-extensions
@@ -66,7 +65,7 @@ install_requires =
     uvloop>=0.21.0
     WebOb>=1.8.9
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/web_client/setup.cfg
+++ b/packages/web_client/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -32,7 +31,7 @@ version = 25.1.3.dev0
 [options]
 include_package_data = True
 packages = galaxy.web_client
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/packages/web_framework/setup.cfg
+++ b/packages/web_framework/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -44,7 +43,7 @@ install_requires =
     WebOb
 
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/packages/web_stack/setup.cfg
+++ b/packages/web_stack/setup.cfg
@@ -9,7 +9,6 @@ classifiers =
     Natural Language :: English
     Operating System :: POSIX
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -36,7 +35,7 @@ install_requires =
     galaxy-util
     SQLAlchemy>=2.0.37,<2.1,!=2.0.41
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
 ]
 license = {file = "LICENSE.txt"}
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "a2wsgi",
     "aiofiles",
@@ -37,7 +37,7 @@ dependencies = [
     "docutils!=0.17,!=0.17.1",
     "dparse",
     "edam-ontology",
-    "fastapi>=0.111.0",
+    "fastapi>=0.133.0",  # First version compatible with starlette>=1.0.0
     "fissix",
     "fs",
     "future>=1.0.0",  # Python 3.12 support
@@ -98,7 +98,7 @@ dependencies = [
     "sortedcontainers",
     "SQLAlchemy>=2.0.37,<2.1,!=2.0.41",  # https://github.com/sqlalchemy/sqlalchemy/issues/12019 , https://github.com/sqlalchemy/sqlalchemy/issues/12600
     "sqlparse",
-    "starlette",
+    "starlette>=1.0.1",  # CVE-2026-48710 BadHost
     "starlette-context",
     "svgwrite",
     "tifffile",
@@ -187,7 +187,6 @@ typecheck = [
 
 [tool.black]
 line-length = 120
-target-version = ['py39']
 include = '\.pyi?$'
 extend-exclude = '''
 ^/(
@@ -200,7 +199,6 @@ extend-exclude = '''
 isort = true
 
 [tool.ruff]
-target-version = "py39"
 exclude = [
     "lib/tool_shed/test/test_data/repos"
 ]
@@ -217,7 +215,9 @@ select = ["E", "F", "B", "C4", "G", "ISC", "NPY", "UP"]
 # E501 is line length (delegated to black)
 # G* are TODOs
 # UP006 and UP035 are PEP 585 type annotations
-ignore = ["B008", "B9", "E402", "E501", "G001", "G002", "G004", "UP006", "UP035"]
+# UP006, UP007, UP035, UP036, UP041, UP045: Python >=3.10 improvements;
+# keep the code 3.9-syntax-compatible for now, to be revisited later.
+ignore = ["B008", "B9", "E402", "E501", "G001", "G002", "G004", "UP006", "UP007", "UP035", "UP036", "UP041", "UP045"]
 
 [tool.ruff.lint.flake8-comprehensions]
 allow-dict-calls-with-keyword-arguments = true

--- a/scripts/check_python.py
+++ b/scripts/check_python.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 
 import sys
 
-MIN_VERSION_TUPLE = (3, 9)
+MIN_VERSION_TUPLE = (3, 10)
 
 
 def check_python():

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -12,7 +12,7 @@ SET_VENV=1
 SKIP_CLIENT_BUILD=${GALAXY_SKIP_CLIENT_BUILD:-0}
 INSTALL_PREBUILT_CLIENT=${GALAXY_INSTALL_PREBUILT_CLIENT:-0}
 : "${YARN_INSTALL_OPTS:=--network-timeout 300000 --check-files}"
-: "${GALAXY_CONDA_PYTHON_VERSION:=3.9}"
+: "${GALAXY_CONDA_PYTHON_VERSION:=3.10}"
 
 for arg in "$@"; do
     if [ "$arg" = "--skip-venv" ]; then
@@ -37,7 +37,7 @@ RMFILES="
     lib/pkg_resources.pyc
 "
 
-MIN_PYTHON_VERSION=3.9
+MIN_PYTHON_VERSION=3.10
 MIN_PIP_VERSION=20.3
 
 # return true if $1 is in $2 else false


### PR DESCRIPTION
Updates the pinned FastAPI/Starlette versions on release_25.1 to match upstream/dev, closing CVE-2026-48710 ("BadHost"). The vulnerability lets an attacker inject a path into the HTTP Host header and have ``request.url.path`` reflect that path, bypassing path-based access control in middleware. Starlette 1.0.1+ rejects Host headers with invalid characters; we pin starlette==1.1.0 to match dev.

Actual exposure on release_25.1 (pre-fix)
-----------------------------------------

Galaxy was running a vulnerable starlette but is **not exploitable for the headline auth-bypass scenario**. Auth runs through FastAPI dependencies (``get_user``, ``get_trans``, ``AdminUserRequired``), not through path-string checks in middleware. ``AccessLoggingMiddleware`` already uses ``scope["path"]``; ``add_galaxy_middleware`` / ``GalaxyCORSMiddleware`` / ``RawContextMiddleware`` / ``SentryAsgiMiddleware`` do not branch on ``request.url.path``.

Lower-severity findings that this upgrade also closes:

- ``lib/galaxy/webapps/base/api.py`` ``get_error_response_for_request`` picks an error schema with ``"ga4gh"/"drs"/"trs" in request.url.path`` -- spoofable Host nudges error payload shape (info-disclosure / shape confusion only).
- ``lib/galaxy/webapps/galaxy/api/drs.py`` and ``lib/galaxy/webapps/galaxy/services/datasets.py`` derive DRS ``service_info`` / ``self_uri`` from ``request.url`` -- spoofable Host poisons the advertised DRS identity and client-visible URIs, not access.
- ``lib/tool_shed/webapp/api2/tools.py`` -- same shape, TRS service info.

Bumping the pin closes the parser flaw at source and downgrades all of the above to non-issues, so no separate ``request.url.path -> scope["path"]`` sweep is needed.

Pin bumps (cherry-picks the relevant ranges from PRs #21526, #22206, #22754):

- fastapi 0.118.0 -> 0.136.3
- starlette 0.48.0 -> 1.1.0
- starlette-context 0.4.0 -> 0.5.1
- python-multipart 0.0.20 -> 0.0.29
- anyio 4.11.0 -> 4.13.0

Required code changes backported from upstream/dev:

- ``lib/galaxy/webapps/openapi/_compat/v2.py``: import ``GenerateJsonSchema`` and ``get_flat_models_from_fields`` from ``fastapi._compat.v2`` and adopt the new ``get_definitions()`` implementation for FastAPI 0.128.8+ (PRs #21384, dev commits 0800c025ce9, c8ccc7f44d8, b3bfb458846).
- ``lib/galaxy/webapps/openapi/utils.py``: route ``GenerateJsonSchema`` through ``_compat.v2``; switch the ImportError fallback to a flag variable (dev commit b3bfb458846).
- ``lib/galaxy/schema/generics.py``: drop ``CustomJsonSchema`` here (moved to fast_app.py so it can use the patched ``GenerateJsonSchema`` from ``_compat.v2``).
- ``lib/galaxy/webapps/galaxy/fast_app.py``: relocate ``CustomJsonSchema`` and switch its base to the ``_compat.v2`` ``GenerateJsonSchema``; replace the @app.middleware("http") X-Frame Options handler with a pure ASGI ``XFrameOptionsMiddleware`` class (dev commit 67eea395ab6) since ``BaseHTTPMiddleware`` semantics changed in starlette 1.0.
- ``lib/galaxy/webapps/base/api.py`` and ``lib/galaxy/webapps/galaxy/api/datasets.py``: drop the ``method`` argument of ``FileResponse`` which starlette 1.0 removed (dev commit 63954cb42e5).

Also bumps the minimum FastAPI requirement in pyproject.toml and the ``packages/web_apps`` / ``packages/tool_shed`` setup.cfg files to ``>=0.124.0`` so source installs cannot downgrade past the supported range.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
