### PR TITLE
[26.1] Add fallback at read location in dynamic options

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -993,9 +993,11 @@ class DynamicOptions:
             or self.missing_index_file
         ):
             options = self.get_fields(trans, other_values)
+            value_col = self.columns["value"]
+            name_col = self.columns.get("name", value_col)
             for fields in options:
-                name = fields[self.columns["name"]]
-                value = fields[self.columns["value"]]
+                name = fields[name_col]
+                value = fields[value_col]
                 hda = fields[-1] if isinstance(fields[-1], HistoryDatasetAssociation) else None
                 rval.append(ParameterOption(name, value, False, dataset=hda))
         else:

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -143,6 +143,7 @@
   <tool file="select_optional_legacy.xml" />
   <tool file="select_optional.xml" />
   <tool file="select_dynamic.xml" />
+  <tool file="select_from_data_table_no_name.xml" />
   <tool file="hidden_param.xml" />
   <tool file="special_params.xml" />
   <tool file="section.xml" />

--- a/test/functional/tools/select_from_data_table_no_name.xml
+++ b/test/functional/tools/select_from_data_table_no_name.xml
@@ -1,0 +1,26 @@
+<tool id="select_from_data_table_no_name" name="Select from data table without name column" version="1.0.0" profile="22.05">
+    <command><![CDATA[
+        echo "value $select" >> '$output1'
+    ]]></command>
+    <inputs>
+        <!-- testbeta has columns "value, path" with no "name" column. Building
+             the options list must not raise KeyError on the missing key. -->
+        <param name="select" type="select">
+            <options from_data_table="testbeta"/>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="select" value="newvalue"/>
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="value newvalue"/>
+                    <has_n_lines n="1"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/unit/app/tools/test_dynamic_options.py
+++ b/test/unit/app/tools/test_dynamic_options.py
@@ -63,17 +63,9 @@ def test_dynamic_option_cache():
 
 
 def test_get_options_handles_missing_name_column():
-    """
-    tool_util/data/__init__.py:parse_column_spec no longer silently
-    fabricates a "name" entry in self.columns when none was declared.
-    get_options must defend against the missing key by falling back to
-    the value column for the display name, mirroring the existing
-    .get("name", value_col) pattern of dynamic_options.py.
-    """
+    """Must fall back to value column if display name is missing."""
     tool_param = Bunch(tool=Bunch(app=Bunch()))
 
-    # Populate columns to simulate state arriving from the now-honest
-    # core API: "value" is present, "name" is not.
     opts = DynamicOptions(XML("<options/>"), tool_param)
     opts.columns = {"value": 0}
 

--- a/test/unit/app/tools/test_dynamic_options.py
+++ b/test/unit/app/tools/test_dynamic_options.py
@@ -60,3 +60,30 @@ def test_dynamic_option_cache():
         },
     )
     assert from_url_option.get_options(trans, {}) == [ParameterOption("chr2L", "23513712", False)]
+
+
+def test_get_options_handles_missing_name_column():
+    """
+    tool_util/data/__init__.py:parse_column_spec no longer silently
+    fabricates a "name" entry in self.columns when none was declared.
+    get_options must defend against the missing key by falling back to
+    the value column for the display name, mirroring the existing
+    .get("name", value_col) pattern of dynamic_options.py.
+    """
+    tool_param = Bunch(tool=Bunch(app=Bunch()))
+
+    # Populate columns to simulate state arriving from the now-honest
+    # core API: "value" is present, "name" is not.
+    opts = DynamicOptions(XML("<options/>"), tool_param)
+    opts.columns = {"value": 0}
+
+    opts.file_fields = [["hg38"], ["mm10"]]
+
+    trans = WorkRequestContext(app=MockApp())
+    options = opts.get_options(trans, {})
+
+    # No KeyError, and name falls back to value when no name column exists.
+    assert options == [
+        ParameterOption("hg38", "hg38", False),
+        ParameterOption("mm10", "mm10", False),
+    ]


### PR DESCRIPTION
In #21008, the implicit `self.columns["name"] = self.columns["value"]` fallback was removed from parse_column_spec in `lib/galaxy/tool_util/data/__init__.py`, requiring consumers of the affected code paths to apply their own fallback at the read site. This PR completes that work for `DynamicOptions.get_options`, which previously read `self.columns["name"]` directly and would raise `KeyError: 'name'` whenever a tool data table without a declared name column was exercised through it. The read is now defensive `name_col = self.columns.get("name", value_col)`, matching the existing pattern already used elsewhere in the same module, and a unit regression test in `test/unit/app/tools/test_dynamic_options.py` covers the missing-name case.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
