### PR TITLE
Fix CSV column header previews

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -533,6 +533,7 @@ class Tabular(TabularData):
 
         data_lines = 0
         comment_lines = 0
+        existing_column_names = getattr(dataset.metadata, "column_names", None)
         column_names = None
         header_sample_lines: list[str] = []
         header_candidate_seen = False
@@ -617,6 +618,8 @@ class Tabular(TabularData):
         dataset.metadata.delimiter = "\t"
         if use_column_names:
             dataset.metadata.column_names = column_names
+        elif existing_column_names:
+            dataset.metadata.column_names = existing_column_names
         elif hasattr(dataset.metadata, "column_names"):
             dataset.metadata.column_names = []
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -143,15 +143,51 @@ class TabularData(Text):
         except Exception:
             return False
 
-    def get_chunk(self, trans, dataset: HasFileName, offset: int = 0, ck_size: Optional[int] = None) -> str:
+    def get_chunk(self, trans, dataset: DatasetProtocol, offset: int = 0, ck_size: Optional[int] = None) -> str:
         ck_data, last_read = self._read_chunk(trans, dataset, offset, ck_size)
         return dumps(
             {
                 "ck_data": util.unicodify(ck_data),
                 "offset": last_read,
-                "data_line_offset": self.data_line_offset,
+                "data_line_offset": self._get_data_line_offset(dataset, offset),
             }
         )
+
+    def _get_data_line_offset(self, dataset: DatasetProtocol, offset: int = 0) -> int:
+        if offset:
+            return 0
+        data_line_offset = self.data_line_offset
+        try:
+            column_names = dataset.metadata.column_names
+            comment_lines = dataset.metadata.comment_lines
+        except AttributeError:
+            return data_line_offset
+        if not column_names:
+            return data_line_offset
+        if comment_lines is None:
+            return self._get_column_name_line_offset(dataset, column_names)
+        try:
+            return max(data_line_offset, int(comment_lines))
+        except (TypeError, ValueError):
+            return data_line_offset
+
+    def _get_column_name_line_offset(self, dataset: DatasetProtocol, column_names: list[str]) -> int:
+        try:
+            delimiter = dataset.metadata.delimiter
+        except AttributeError:
+            delimiter = "\t"
+        try:
+            with compression_utils.get_fileobj(dataset.get_file_name()) as dataset_fh:
+                for i, line in enumerate(dataset_fh):
+                    line = line.rstrip("\r\n")
+                    if not line or line.startswith("#"):
+                        continue
+                    if line.split(delimiter)[: len(column_names)] == column_names:
+                        return max(self.data_line_offset, i + 1)
+                    return self.data_line_offset
+        except Exception:
+            pass
+        return max(self.data_line_offset, 1)
 
     def _read_chunk(self, trans, dataset: HasFileName, offset: int, ck_size: Optional[int] = None):
         with compression_utils.get_fileobj(dataset.get_file_name()) as f:
@@ -250,7 +286,7 @@ class TabularData(Text):
             if columns is None:
                 columns = dataset.metadata.spec.columns.no_value
             columns = min(columns, self.max_peek_columns)
-            column_headers = [None] * columns
+            column_headers: list[Optional[str]] = [None] * columns
 
             # fill in empty headers with data from column_names
             assert column_names is not None
@@ -296,8 +332,9 @@ class TabularData(Text):
             if columns is None:
                 columns = dataset.metadata.spec.columns.no_value
             columns = min(columns, self.max_peek_columns)
+            data_line_offset = self._get_data_line_offset(dataset)
             for i, line in enumerate(peek.splitlines()):
-                if i >= self.data_line_offset:
+                if i >= data_line_offset:
                     if line.startswith(tuple(skipchars)):
                         out.append(f'<tr><td colspan="100%">{escape(line)}</td></tr>')
                     elif line:
@@ -388,7 +425,20 @@ class Tabular(TabularData):
     file_ext = "tabular"
 
     def get_column_names(self, first_line: str) -> Optional[list[str]]:
-        return None
+        column_names = first_line.split("\t")
+        if len(column_names) < 2 or not any(column_name.strip() for column_name in column_names):
+            return None
+        return column_names
+
+    def use_column_names(self, column_names: Optional[list[str]], header_sample: str) -> bool:
+        if not column_names:
+            return False
+        if len(header_sample.splitlines()) < 2:
+            return False
+        try:
+            return csv.Sniffer().has_header(header_sample)
+        except csv.Error:
+            return False
 
     def set_meta(
         self,
@@ -401,19 +451,13 @@ class Tabular(TabularData):
         **kwd,
     ) -> None:
         """
-        Tries to determine the number of columns as well as those columns that
-        contain numerical values in the dataset.  A skip parameter is used
-        because various tabular data types reuse this function, and their data
-        type classes are responsible to determine how many invalid comment
-        lines should be skipped. Using None for skip will cause skip to be
-        zero, but the first line will be processed as a header. A
-        max_data_lines parameter is used because various tabular data types
-        reuse this function, and their data type classes are responsible to
-        determine how many data lines should be processed to ensure that the
-        non-optional metadata parameters are properly set; if used, optional
-        metadata parameters will be set to None, unless the entire file has
-        already been read. Using None for max_data_lines will process all data
-        lines.
+        Determine tabular metadata including column count, column types, line
+        counts, and optional column names. Subclasses can pass ``skip`` when
+        they know how many leading lines are not data. When ``skip`` is
+        ``None``, this generic datatype may treat the first non-comment line as
+        a header. ``max_data_lines`` limits how many data lines are inspected;
+        when the limit is reached before EOF, optional line-count metadata is
+        cleared because the full counts are unknown.
 
         Items of interest:
 
@@ -490,6 +534,8 @@ class Tabular(TabularData):
         data_lines = 0
         comment_lines = 0
         column_names = None
+        header_sample_lines: list[str] = []
+        header_candidate_seen = False
         column_types: list = []
         first_line_column_types = []
         if dataset.has_data():
@@ -498,12 +544,17 @@ class Tabular(TabularData):
                 i = 0
                 for line in iter(dataset_fh.readline, ""):
                     line = line.rstrip("\r\n")
-                    if i == 0:
-                        column_names = self.get_column_names(first_line=line)
-                    if i < skip or not line or line.startswith("#"):
+                    skipped_or_comment = i < skip or not line or line.startswith("#")
+                    if skipped_or_comment:
                         # We'll call blank lines comments
                         comment_lines += 1
                     else:
+                        first_data_line = not header_candidate_seen
+                        if first_data_line:
+                            header_candidate_seen = True
+                            column_names = self.get_column_names(first_line=line)
+                        if len(header_sample_lines) < 21:
+                            header_sample_lines.append(line)
                         data_lines += 1
                         if max_guess_type_data_lines is None or data_lines <= max_guess_type_data_lines:
                             fields = line.split("\t")
@@ -515,12 +566,10 @@ class Tabular(TabularData):
                                 column_type = guess_column_type(field)
                                 if type_overrules_type(column_type, column_types[field_count]):
                                     column_types[field_count] = column_type
-                        if i == 0 and requested_skip is None:
-                            # This is our first line, people seem to like to upload files that have a header line, but do not
-                            # start with '#' (i.e. all column types would then most likely be detected as str).  We will assume
-                            # that the first line is always a header (this was previous behavior - it was always skipped).  When
-                            # the requested skip is None, we only use the data from the first line if we have no other data for
-                            # a column.  This is far from perfect, as
+                        if first_data_line and requested_skip is None:
+                            # The first non-comment line may be a header. Use its type guesses only as fallbacks once
+                            # header detection has had later rows to compare against.
+                            # This is far from perfect, as
                             # 1,2,3	1.1	2.2	qwerty
                             # 0	0		1,2,3
                             # will be detected as
@@ -553,13 +602,21 @@ class Tabular(TabularData):
                 else:
                     column_types[i] = first_line_column_types[i]
         # Set the discovered metadata values for the dataset
+        use_column_names = requested_skip is None and self.use_column_names(column_names, "\n".join(header_sample_lines))
+        if use_column_names:
+            if comment_lines is not None:
+                comment_lines += 1
+            if data_lines is not None:
+                data_lines -= 1
         dataset.metadata.data_lines = data_lines
         dataset.metadata.comment_lines = comment_lines
         dataset.metadata.column_types = column_types
         dataset.metadata.columns = len(column_types)
         dataset.metadata.delimiter = "\t"
-        if column_names is not None:
+        if use_column_names:
             dataset.metadata.column_names = column_names
+        elif hasattr(dataset.metadata, "column_names"):
+            dataset.metadata.column_names = []
 
     def as_gbrowse_display_file(self, dataset: HasFileName, **kwd) -> Union[FileObjType, str]:
         return open(dataset.get_file_name(), "rb")
@@ -580,6 +637,9 @@ class SraManifest(Tabular):
 
     def get_column_names(self, first_line: str) -> Optional[list[str]]:
         return first_line.strip().split("\t")
+
+    def use_column_names(self, column_names: Optional[list[str]], header_sample: str) -> bool:
+        return bool(column_names)
 
 
 class Taxonomy(Tabular):
@@ -1383,38 +1443,38 @@ class BaseCSV(TabularData):
     delimiter = ","
     peek_size = 1024  # File chunk used for sniffing CSV dialect
     big_peek_size = 10240  # Large File chunk used for sniffing CSV dialect
+    sniff_headerless = False
 
     def sniff(self, filename: str) -> bool:
-        """Return True if if recognizes dialect and header."""
+        """Return True if if recognizes dialect and an optional header."""
+        consistent_width = True
         # check the dialect works
         with open(filename, newline="") as f:
             reader = csv.reader(f, self.dialect)
             # Check we can read header and get columns
-            header_row = next(reader)
+            try:
+                header_row = next(reader)
+            except StopIteration:
+                return False
             if len(header_row) < 2:
                 # No columns so not separated by this dialect.
                 return False
 
-            # Check that there is a second row as it is used by set_meta and
-            # that all rows can be read
-            if self.strict_width:
-                num_columns = len(header_row)
-                found_second_line = False
-                for data_row in reader:
-                    found_second_line = True
-                    # All columns must be the same length
-                    if num_columns != len(data_row):
-                        return False
-                if not found_second_line:
-                    return False
-            else:
-                data_row = next(reader)
-                if len(data_row) < 2:
+            num_columns = len(header_row)
+            found_second_line = False
+            for data_row in reader:
+                if not found_second_line and len(data_row) < 2:
                     # No columns so not separated by this dialect.
                     return False
-                # ignore the length in the rest
-                for _ in reader:
-                    pass
+                found_second_line = True
+                # All columns must be the same length for strict datatypes and
+                # for headerless CSV sniffing.
+                if num_columns != len(data_row):
+                    if self.strict_width:
+                        return False
+                    consistent_width = False
+            if not found_second_line:
+                return False
 
         # Optional: Check Python's csv comes up with a similar dialect
         with open(filename) as f:
@@ -1432,9 +1492,13 @@ class BaseCSV(TabularData):
         # Note: No way around Python's csv calling Sniffer.sniff again.
         # Note: Without checking the dialect returned by sniff
         #       this test may be checking the wrong dialect.
-        if not csv.Sniffer().has_header(big_peek):
+        return self.has_header(big_peek) or (self.sniff_headerless and consistent_width)
+
+    def has_header(self, sample: str) -> bool:
+        try:
+            return csv.Sniffer().has_header(sample)
+        except csv.Error:
             return False
-        return True
 
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         column_types = []
@@ -1443,11 +1507,18 @@ class BaseCSV(TabularData):
         data_lines = 0
         if dataset.has_data():
             with open(dataset.get_file_name(), newline="") as csvfile:
+                sample = csvfile.read(self.big_peek_size)
+                csvfile.seek(0)
+                has_header = self.has_header(sample)
                 # Parse file with the correct dialect
                 reader = csv.reader(csvfile, self.dialect)
                 try:
-                    header_row = next(reader)
-                    data_row = next(reader)
+                    first_row = next(reader)
+                    if has_header:
+                        header_row = first_row
+                        data_row = next(reader)
+                    else:
+                        data_row = first_row
                     for _ in reader:
                         pass
                 except StopIteration:
@@ -1455,7 +1526,7 @@ class BaseCSV(TabularData):
                 except csv.Error as e:
                     raise Exception(f"CSV reader error - line {reader.line_num}: {e}")
                 else:
-                    data_lines = reader.line_num - 1
+                    data_lines = reader.line_num - int(has_header)
 
         # Guess column types
         for cell in data_row:
@@ -1480,6 +1551,7 @@ class CSV(BaseCSV):
     file_ext = "csv"
     dialect = csv.excel  # This is the default
     strict_width = False  # Previous csv type did not check column width
+    sniff_headerless = True
 
 
 @build_sniff_from_prefix
@@ -1625,7 +1697,7 @@ class ConnectivityTable(Tabular):
                 i += 1
         return False
 
-    def get_chunk(self, trans, dataset: HasFileName, offset: int = 0, ck_size: Optional[int] = None) -> str:
+    def get_chunk(self, trans, dataset: DatasetProtocol, offset: int = 0, ck_size: Optional[int] = None) -> str:
         ck_data, last_read = self._read_chunk(trans, dataset, offset, ck_size)
         try:
             # The ConnectivityTable format has several derivatives of which one is delimited by (multiple) spaces.
@@ -1642,7 +1714,7 @@ class ConnectivityTable(Tabular):
             {
                 "ck_data": util.unicodify(ck_data),
                 "offset": last_read,
-                "data_line_offset": self.data_line_offset,
+                "data_line_offset": self._get_data_line_offset(dataset, offset),
             }
         )
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -602,7 +602,9 @@ class Tabular(TabularData):
                 else:
                     column_types[i] = first_line_column_types[i]
         # Set the discovered metadata values for the dataset
-        use_column_names = requested_skip is None and self.use_column_names(column_names, "\n".join(header_sample_lines))
+        use_column_names = requested_skip is None and self.use_column_names(
+            column_names, "\n".join(header_sample_lines)
+        )
         if use_column_names:
             if comment_lines is not None:
                 comment_lines += 1

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -149,13 +149,11 @@ class TabularData(Text):
             {
                 "ck_data": util.unicodify(ck_data),
                 "offset": last_read,
-                "data_line_offset": self._get_data_line_offset(dataset, offset, ck_data),
+                "data_line_offset": self._get_data_line_offset(dataset, offset),
             }
         )
 
-    def _get_data_line_offset(
-        self, dataset: DatasetProtocol, offset: int = 0, data_sample: Optional[str] = None
-    ) -> int:
+    def _get_data_line_offset(self, dataset: DatasetProtocol, offset: int = 0) -> int:
         if offset:
             return 0
         data_line_offset = self.data_line_offset
@@ -163,27 +161,10 @@ class TabularData(Text):
         comment_lines = dataset.metadata.comment_lines
         if not column_names:
             return data_line_offset
-        if comment_lines is None:
-            return self._get_column_name_line_offset(dataset, column_names, data_sample)
         try:
             return max(data_line_offset, int(comment_lines))
         except (TypeError, ValueError):
             return data_line_offset
-
-    def _get_column_name_line_offset(
-        self, dataset: DatasetProtocol, column_names: list[str], data_sample: Optional[str]
-    ) -> int:
-        if data_sample is None:
-            return self.data_line_offset
-        delimiter = dataset.metadata.delimiter or "\t"
-        for i, line in enumerate(data_sample.splitlines()):
-            line = line.rstrip("\r\n")
-            if not line or line.startswith("#"):
-                continue
-            if line.split(delimiter)[: len(column_names)] == column_names:
-                return max(self.data_line_offset, i + 1)
-            return max(self.data_line_offset, 1)
-        return max(self.data_line_offset, 1)
 
     def _read_chunk(self, trans, dataset: HasFileName, offset: int, ck_size: Optional[int] = None):
         with compression_utils.get_fileobj(dataset.get_file_name()) as f:
@@ -328,7 +309,7 @@ class TabularData(Text):
             if columns is None:
                 columns = dataset.metadata.spec.columns.no_value
             columns = min(columns, self.max_peek_columns)
-            data_line_offset = self._get_data_line_offset(dataset, data_sample=peek)
+            data_line_offset = self._get_data_line_offset(dataset)
             for i, line in enumerate(peek.splitlines()):
                 if i >= data_line_offset:
                     if line.startswith(tuple(skipchars)):
@@ -421,20 +402,7 @@ class Tabular(TabularData):
     file_ext = "tabular"
 
     def get_column_names(self, first_line: str) -> Optional[list[str]]:
-        column_names = first_line.split("\t")
-        if len(column_names) < 2 or not any(column_name.strip() for column_name in column_names):
-            return None
-        return column_names
-
-    def use_column_names(self, column_names: Optional[list[str]], header_sample: str) -> bool:
-        if not column_names:
-            return False
-        if len(header_sample.splitlines()) < 2:
-            return False
-        try:
-            return csv.Sniffer().has_header(header_sample)
-        except csv.Error:
-            return False
+        return None
 
     def set_meta(
         self,
@@ -449,11 +417,10 @@ class Tabular(TabularData):
         """
         Determine tabular metadata including column count, column types, line
         counts, and optional column names. Subclasses can pass ``skip`` when
-        they know how many leading lines are not data. When ``skip`` is
-        ``None``, this generic datatype may treat the first non-comment line as
-        a header. ``max_data_lines`` limits how many data lines are inspected;
-        when the limit is reached before EOF, optional line-count metadata is
-        cleared because the full counts are unknown.
+        they know how many leading lines are not data. ``max_data_lines`` limits
+        how many data lines are inspected; when the limit is reached before EOF,
+        optional line-count metadata is cleared because the full counts are
+        unknown.
 
         Items of interest:
 
@@ -529,10 +496,7 @@ class Tabular(TabularData):
 
         data_lines = 0
         comment_lines = 0
-        existing_column_names = getattr(dataset.metadata, "column_names", None)
         column_names = None
-        header_sample_lines: list[str] = []
-        header_candidate_seen = False
         column_types: list = []
         first_line_column_types = []
         if dataset.has_data():
@@ -541,17 +505,12 @@ class Tabular(TabularData):
                 i = 0
                 for line in iter(dataset_fh.readline, ""):
                     line = line.rstrip("\r\n")
-                    skipped_or_comment = i < skip or not line or line.startswith("#")
-                    if skipped_or_comment:
+                    if i == 0:
+                        column_names = self.get_column_names(first_line=line)
+                    if i < skip or not line or line.startswith("#"):
                         # We'll call blank lines comments
                         comment_lines += 1
                     else:
-                        first_data_line = not header_candidate_seen
-                        if first_data_line:
-                            header_candidate_seen = True
-                            column_names = self.get_column_names(first_line=line)
-                        if len(header_sample_lines) < 21:
-                            header_sample_lines.append(line)
                         data_lines += 1
                         if max_guess_type_data_lines is None or data_lines <= max_guess_type_data_lines:
                             fields = line.split("\t")
@@ -563,9 +522,9 @@ class Tabular(TabularData):
                                 column_type = guess_column_type(field)
                                 if type_overrules_type(column_type, column_types[field_count]):
                                     column_types[field_count] = column_type
-                        if first_data_line and requested_skip is None:
-                            # The first non-comment line may be a header. Use its type guesses only as fallbacks once
-                            # header detection has had later rows to compare against.
+                        if i == 0 and requested_skip is None:
+                            # The first line may be a header. Use its type guesses only as fallbacks after checking
+                            # later rows.
                             # This is far from perfect, as
                             # 1,2,3	1.1	2.2	qwerty
                             # 0	0		1,2,3
@@ -599,25 +558,13 @@ class Tabular(TabularData):
                 else:
                     column_types[i] = first_line_column_types[i]
         # Set the discovered metadata values for the dataset
-        use_column_names = requested_skip is None and self.use_column_names(
-            column_names, "\n".join(header_sample_lines)
-        )
-        if use_column_names:
-            if comment_lines is not None:
-                comment_lines += 1
-            if data_lines is not None:
-                data_lines -= 1
         dataset.metadata.data_lines = data_lines
         dataset.metadata.comment_lines = comment_lines
         dataset.metadata.column_types = column_types
         dataset.metadata.columns = len(column_types)
         dataset.metadata.delimiter = "\t"
-        if use_column_names:
+        if column_names is not None:
             dataset.metadata.column_names = column_names
-        elif existing_column_names:
-            dataset.metadata.column_names = existing_column_names
-        elif hasattr(dataset.metadata, "column_names"):
-            dataset.metadata.column_names = []
 
     def as_gbrowse_display_file(self, dataset: HasFileName, **kwd) -> Union[FileObjType, str]:
         return open(dataset.get_file_name(), "rb")
@@ -638,9 +585,6 @@ class SraManifest(Tabular):
 
     def get_column_names(self, first_line: str) -> Optional[list[str]]:
         return first_line.strip().split("\t")
-
-    def use_column_names(self, column_names: Optional[list[str]], header_sample: str) -> bool:
-        return bool(column_names)
 
 
 class Taxonomy(Tabular):
@@ -1715,7 +1659,7 @@ class ConnectivityTable(Tabular):
             {
                 "ck_data": util.unicodify(ck_data),
                 "offset": last_read,
-                "data_line_offset": self._get_data_line_offset(dataset, offset, ck_data),
+                "data_line_offset": self._get_data_line_offset(dataset, offset),
             }
         )
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -149,11 +149,13 @@ class TabularData(Text):
             {
                 "ck_data": util.unicodify(ck_data),
                 "offset": last_read,
-                "data_line_offset": self._get_data_line_offset(dataset, offset),
+                "data_line_offset": self._get_data_line_offset(dataset, offset, ck_data),
             }
         )
 
-    def _get_data_line_offset(self, dataset: DatasetProtocol, offset: int = 0) -> int:
+    def _get_data_line_offset(
+        self, dataset: DatasetProtocol, offset: int = 0, data_sample: Optional[str] = None
+    ) -> int:
         if offset:
             return 0
         data_line_offset = self.data_line_offset
@@ -165,29 +167,29 @@ class TabularData(Text):
         if not column_names:
             return data_line_offset
         if comment_lines is None:
-            return self._get_column_name_line_offset(dataset, column_names)
+            return self._get_column_name_line_offset(dataset, column_names, data_sample)
         try:
             return max(data_line_offset, int(comment_lines))
         except (TypeError, ValueError):
             return data_line_offset
 
-    def _get_column_name_line_offset(self, dataset: DatasetProtocol, column_names: list[str]) -> int:
+    def _get_column_name_line_offset(
+        self, dataset: DatasetProtocol, column_names: list[str], data_sample: Optional[str]
+    ) -> int:
+        if data_sample is None:
+            return self.data_line_offset
         try:
             delimiter = dataset.metadata.delimiter
         except AttributeError:
             delimiter = "\t"
-        try:
-            with compression_utils.get_fileobj(dataset.get_file_name()) as dataset_fh:
-                for i, line in enumerate(dataset_fh):
-                    line = line.rstrip("\r\n")
-                    if not line or line.startswith("#"):
-                        continue
-                    if line.split(delimiter)[: len(column_names)] == column_names:
-                        return max(self.data_line_offset, i + 1)
-                    return self.data_line_offset
-        except Exception:
-            pass
-        return max(self.data_line_offset, 1)
+        for i, line in enumerate(data_sample.splitlines()):
+            line = line.rstrip("\r\n")
+            if not line or line.startswith("#"):
+                continue
+            if line.split(delimiter)[: len(column_names)] == column_names:
+                return max(self.data_line_offset, i + 1)
+            return self.data_line_offset
+        return self.data_line_offset
 
     def _read_chunk(self, trans, dataset: HasFileName, offset: int, ck_size: Optional[int] = None):
         with compression_utils.get_fileobj(dataset.get_file_name()) as f:
@@ -332,7 +334,7 @@ class TabularData(Text):
             if columns is None:
                 columns = dataset.metadata.spec.columns.no_value
             columns = min(columns, self.max_peek_columns)
-            data_line_offset = self._get_data_line_offset(dataset)
+            data_line_offset = self._get_data_line_offset(dataset, data_sample=peek)
             for i, line in enumerate(peek.splitlines()):
                 if i >= data_line_offset:
                     if line.startswith(tuple(skipchars)):

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -182,8 +182,8 @@ class TabularData(Text):
                 continue
             if line.split(delimiter)[: len(column_names)] == column_names:
                 return max(self.data_line_offset, i + 1)
-            return self.data_line_offset
-        return self.data_line_offset
+            return max(self.data_line_offset, 1)
+        return max(self.data_line_offset, 1)
 
     def _read_chunk(self, trans, dataset: HasFileName, offset: int, ck_size: Optional[int] = None):
         with compression_utils.get_fileobj(dataset.get_file_name()) as f:
@@ -1715,7 +1715,7 @@ class ConnectivityTable(Tabular):
             {
                 "ck_data": util.unicodify(ck_data),
                 "offset": last_read,
-                "data_line_offset": self._get_data_line_offset(dataset, offset),
+                "data_line_offset": self._get_data_line_offset(dataset, offset, ck_data),
             }
         )
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -159,11 +159,8 @@ class TabularData(Text):
         if offset:
             return 0
         data_line_offset = self.data_line_offset
-        try:
-            column_names = dataset.metadata.column_names
-            comment_lines = dataset.metadata.comment_lines
-        except AttributeError:
-            return data_line_offset
+        column_names = dataset.metadata.column_names
+        comment_lines = dataset.metadata.comment_lines
         if not column_names:
             return data_line_offset
         if comment_lines is None:
@@ -178,10 +175,7 @@ class TabularData(Text):
     ) -> int:
         if data_sample is None:
             return self.data_line_offset
-        try:
-            delimiter = dataset.metadata.delimiter
-        except AttributeError:
-            delimiter = "\t"
+        delimiter = dataset.metadata.delimiter or "\t"
         for i, line in enumerate(data_sample.splitlines()):
             line = line.rstrip("\r\n")
             if not line or line.startswith("#"):

--- a/test/unit/data/datatypes/test_connectivity_table.py
+++ b/test/unit/data/datatypes/test_connectivity_table.py
@@ -1,3 +1,4 @@
+import json
 import os
 from types import SimpleNamespace
 
@@ -10,9 +11,12 @@ from galaxy.util import galaxy_directory
 @pytest.fixture
 def dataset():
     class MockDataset:
-        metadata = SimpleNamespace(column_names=None, comment_lines=None, delimiter="\t")
+        def __init__(self):
+            self.metadata = SimpleNamespace(column_names=None, comment_lines=None, delimiter="\t")
+            self.file_name_calls = 0
 
         def get_file_name(self, sync_cache=True):
+            self.file_name_calls += 1
             return os.path.join(galaxy_directory(), "test-data/1.ct")
 
     return MockDataset()
@@ -51,3 +55,15 @@ def test_get_chunk_with_offset(dataset, make_trans):
     # reads chunk_size chars from offset 5 (line 1) to the end of line 2
     chunk = dt.get_chunk(trans, dataset, 5)
     assert chunk == '{"ck_data": "mRNA\\n1\\tG\\t0\\t2\\t359\\t1", "offset": 24, "data_line_offset": 0}'
+
+
+def test_get_chunk_uses_transformed_chunk_for_unset_line_count_offset(dataset, make_trans):
+    dataset.metadata.column_names = ["363", "tmRNA"]
+    dataset.metadata.comment_lines = None
+    dt = ConnectivityTable()
+    trans = make_trans(1000)
+
+    chunk = json.loads(dt.get_chunk(trans, dataset))
+
+    assert chunk["data_line_offset"] == 1
+    assert dataset.file_name_calls == 1

--- a/test/unit/data/datatypes/test_connectivity_table.py
+++ b/test/unit/data/datatypes/test_connectivity_table.py
@@ -1,4 +1,3 @@
-import json
 import os
 from types import SimpleNamespace
 
@@ -13,10 +12,8 @@ def dataset():
     class MockDataset:
         def __init__(self):
             self.metadata = SimpleNamespace(column_names=None, comment_lines=None, delimiter="\t")
-            self.file_name_calls = 0
 
         def get_file_name(self, sync_cache=True):
-            self.file_name_calls += 1
             return os.path.join(galaxy_directory(), "test-data/1.ct")
 
     return MockDataset()
@@ -55,15 +52,3 @@ def test_get_chunk_with_offset(dataset, make_trans):
     # reads chunk_size chars from offset 5 (line 1) to the end of line 2
     chunk = dt.get_chunk(trans, dataset, 5)
     assert chunk == '{"ck_data": "mRNA\\n1\\tG\\t0\\t2\\t359\\t1", "offset": 24, "data_line_offset": 0}'
-
-
-def test_get_chunk_uses_transformed_chunk_for_unset_line_count_offset(dataset, make_trans):
-    dataset.metadata.column_names = ["363", "tmRNA"]
-    dataset.metadata.comment_lines = None
-    dt = ConnectivityTable()
-    trans = make_trans(1000)
-
-    chunk = json.loads(dt.get_chunk(trans, dataset))
-
-    assert chunk["data_line_offset"] == 1
-    assert dataset.file_name_calls == 1

--- a/test/unit/data/datatypes/test_connectivity_table.py
+++ b/test/unit/data/datatypes/test_connectivity_table.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -9,6 +10,8 @@ from galaxy.util import galaxy_directory
 @pytest.fixture
 def dataset():
     class MockDataset:
+        metadata = SimpleNamespace(column_names=None, comment_lines=None, delimiter="\t")
+
         def get_file_name(self, sync_cache=True):
             return os.path.join(galaxy_directory(), "test-data/1.ct")
 

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -108,11 +108,26 @@ def test_single_row_numeric_tabular_set_meta_does_not_promote_first_row_to_heade
         assert not hasattr(dataset.metadata, "column_names")
 
 
-def test_tabular_set_meta_clears_stale_column_names_for_headerless_data():
+def test_tabular_set_meta_preserves_existing_column_names_for_headerless_data():
+    contents = "32.5\t1\t4.3\n19.3\t1\t3.8\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        metadata = cast(Any, dataset.metadata)
+        metadata.column_names = ["First", "2.tabular"]
+        Tabular().set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.data_lines == 2
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_names == ["First", "2.tabular"]
+
+
+def test_tabular_set_meta_replaces_existing_column_names_when_header_is_detected():
     with tempfile.NamedTemporaryFile(mode="w") as header_file, tempfile.NamedTemporaryFile(mode="w") as data_file:
         header_file.write("name\tvalue\nA\t1\nB\t2\n")
         header_file.flush()
-        data_file.write("32.5\t1\t4.3\n19.3\t1\t3.8\n")
+        data_file.write("sample\tcount\nC\t3\nD\t4\n")
         data_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(header_file.name)
@@ -122,8 +137,8 @@ def test_tabular_set_meta_clears_stale_column_names_for_headerless_data():
         dataset.set_file_name(data_file.name)
         datatype.set_meta(_dataset_protocol(dataset))
         assert dataset.metadata.data_lines == 2
-        assert dataset.metadata.comment_lines == 0
-        assert dataset.metadata.column_names == []
+        assert dataset.metadata.comment_lines == 1
+        assert dataset.metadata.column_names == ["sample", "count"]
 
 
 def test_tabular_set_meta_does_not_use_comment_line_as_column_names():

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -1,7 +1,10 @@
 import json
 import tempfile
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import (
+    Any,
+    cast,
+)
 
 from galaxy.datatypes.protocols import DatasetProtocol
 from galaxy.datatypes.tabular import (

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -195,6 +195,27 @@ def test_tabular_quick_view_skips_header_after_comments_when_line_counts_are_uns
         assert "<td>A</td>" in html
 
 
+def test_tabular_quick_view_uses_peek_for_unset_line_count_offset():
+    contents = "name\tvalue\nA\t1\nB\t2\nC\t3\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = Tabular()
+        datatype.set_meta(_dataset_protocol(dataset), max_data_lines=2)
+
+        def fail_get_file_name(sync_cache=True):
+            raise AssertionError("quick view should not open the dataset file")
+
+        dataset_for_peek = cast(Any, dataset)
+        dataset_for_peek.get_file_name = fail_get_file_name
+        html = _display_peek(datatype, dataset, contents)
+        assert "<th>1.name</th>" in html
+        assert "<td>name</td>" not in html
+        assert "<td>A</td>" in html
+
+
 def test_csv_quick_view_uses_column_names_only_as_headers():
     contents = "TMB,Systemic_therapy_history,Albumin\n32.5,1,4.3\n19.3,1,3.8\n"
     with tempfile.NamedTemporaryFile(mode="w") as test_file:

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -23,6 +23,8 @@ def _dataset_protocol(dataset: MockDataset) -> DatasetProtocol:
 def _display_peek(datatype: TabularData, dataset: MockDataset, contents: str) -> str:
     metadata = cast(Any, dataset.metadata)
     metadata.spec = {}
+    if not hasattr(metadata, "column_names"):
+        metadata.column_names = []
     dataset_for_peek = cast(Any, dataset)
     dataset_for_peek.peek = contents
     return datatype.display_peek(_dataset_protocol(dataset))
@@ -45,24 +47,7 @@ def test_tabular_set_meta_large_file():
         assert not hasattr(dataset.metadata, "column_names")
 
 
-def test_tabular_set_meta_with_header():
-    with tempfile.NamedTemporaryFile(mode="w") as test_file:
-        test_file.write("TMB\tSystemic_therapy_history\tAlbumin\n")
-        test_file.write("32.5\t1\t4.3\n")
-        test_file.write("19.3\t1\t3.8\n")
-        test_file.flush()
-        dataset = MockDataset(id=1)
-        dataset.set_file_name(test_file.name)
-        Tabular().set_meta(_dataset_protocol(dataset))
-        assert dataset.metadata.data_lines == 2
-        assert dataset.metadata.comment_lines == 1
-        assert dataset.metadata.column_types == ["float", "int", "float"]
-        assert dataset.metadata.columns == 3
-        assert dataset.metadata.delimiter == "\t"
-        assert dataset.metadata.column_names == ["TMB", "Systemic_therapy_history", "Albumin"]
-
-
-def test_tabular_quick_view_uses_column_names_only_as_headers():
+def test_tabular_quick_view_keeps_header_like_first_row_as_data():
     contents = "question_id\tcurator_name\nensembl-grab-q1\tLG\nbam-infer-read-length-q1\tSN\n"
     with tempfile.NamedTemporaryFile(mode="w") as test_file:
         test_file.write(contents)
@@ -71,11 +56,13 @@ def test_tabular_quick_view_uses_column_names_only_as_headers():
         dataset.set_file_name(test_file.name)
         datatype = Tabular()
         datatype.set_meta(_dataset_protocol(dataset))
+        assert not hasattr(dataset.metadata, "column_names")
         html = _display_peek(datatype, dataset, contents)
-        assert "<th>1.question_id</th>" in html
-        assert "<th>2.curator_name</th>" in html
-        assert "<td>question_id</td>" not in html
-        assert "<td>curator_name</td>" not in html
+        assert "<th>1</th>" in html
+        assert "<th>2</th>" in html
+        assert "<th>1.question_id</th>" not in html
+        assert "<td>question_id</td>" in html
+        assert "<td>curator_name</td>" in html
 
 
 def test_headerless_numeric_tabular_set_meta_does_not_promote_first_row_to_header():
@@ -123,24 +110,6 @@ def test_tabular_set_meta_preserves_existing_column_names_for_headerless_data():
         assert dataset.metadata.column_names == ["First", "2.tabular"]
 
 
-def test_tabular_set_meta_replaces_existing_column_names_when_header_is_detected():
-    with tempfile.NamedTemporaryFile(mode="w") as header_file, tempfile.NamedTemporaryFile(mode="w") as data_file:
-        header_file.write("name\tvalue\nA\t1\nB\t2\n")
-        header_file.flush()
-        data_file.write("sample\tcount\nC\t3\nD\t4\n")
-        data_file.flush()
-        dataset = MockDataset(id=1)
-        dataset.set_file_name(header_file.name)
-        datatype = Tabular()
-        datatype.set_meta(_dataset_protocol(dataset))
-        assert dataset.metadata.column_names == ["name", "value"]
-        dataset.set_file_name(data_file.name)
-        datatype.set_meta(_dataset_protocol(dataset))
-        assert dataset.metadata.data_lines == 2
-        assert dataset.metadata.comment_lines == 1
-        assert dataset.metadata.column_names == ["sample", "count"]
-
-
 def test_tabular_set_meta_does_not_use_comment_line_as_column_names():
     contents = "#comment\tthing\n1\t2\n3\t4\n"
     with tempfile.NamedTemporaryFile(mode="w") as test_file:
@@ -154,66 +123,6 @@ def test_tabular_set_meta_does_not_use_comment_line_as_column_names():
         assert dataset.metadata.column_types == ["int", "int"]
         assert dataset.metadata.columns == 2
         assert not hasattr(dataset.metadata, "column_names")
-
-
-def test_tabular_quick_view_skips_header_when_line_counts_are_unset():
-    contents = "name\tvalue\nA\t1\nB\t2\nC\t3\n"
-    with tempfile.NamedTemporaryFile(mode="w") as test_file:
-        test_file.write(contents)
-        test_file.flush()
-        dataset = MockDataset(id=1)
-        dataset.set_file_name(test_file.name)
-        datatype = Tabular()
-        datatype.set_meta(_dataset_protocol(dataset), max_data_lines=2)
-        html = _display_peek(datatype, dataset, contents)
-        assert dataset.metadata.data_lines is None
-        assert dataset.metadata.comment_lines is None
-        assert dataset.metadata.column_names == ["name", "value"]
-        assert "<th>1.name</th>" in html
-        assert "<th>2.value</th>" in html
-        assert "<td>name</td>" not in html
-        assert "<td>value</td>" not in html
-
-
-def test_tabular_quick_view_skips_header_after_comments_when_line_counts_are_unset():
-    contents = "# generated\nname\tvalue\nA\t1\nB\t2\nC\t3\n"
-    with tempfile.NamedTemporaryFile(mode="w") as test_file:
-        test_file.write(contents)
-        test_file.flush()
-        dataset = MockDataset(id=1)
-        dataset.set_file_name(test_file.name)
-        datatype = Tabular()
-        datatype.set_meta(_dataset_protocol(dataset), max_data_lines=2)
-        html = _display_peek(datatype, dataset, contents)
-        assert dataset.metadata.data_lines is None
-        assert dataset.metadata.comment_lines is None
-        assert dataset.metadata.column_names == ["name", "value"]
-        assert "<th>1.name</th>" in html
-        assert "<th>2.value</th>" in html
-        assert "<td># generated</td>" not in html
-        assert "<td>name</td>" not in html
-        assert "<td>A</td>" in html
-
-
-def test_tabular_quick_view_uses_peek_for_unset_line_count_offset():
-    contents = "name\tvalue\nA\t1\nB\t2\nC\t3\n"
-    with tempfile.NamedTemporaryFile(mode="w") as test_file:
-        test_file.write(contents)
-        test_file.flush()
-        dataset = MockDataset(id=1)
-        dataset.set_file_name(test_file.name)
-        datatype = Tabular()
-        datatype.set_meta(_dataset_protocol(dataset), max_data_lines=2)
-
-        def fail_get_file_name(sync_cache=True):
-            raise AssertionError("quick view should not open the dataset file")
-
-        dataset_for_peek = cast(Any, dataset)
-        dataset_for_peek.get_file_name = fail_get_file_name
-        html = _display_peek(datatype, dataset, contents)
-        assert "<th>1.name</th>" in html
-        assert "<td>name</td>" not in html
-        assert "<td>A</td>" in html
 
 
 def test_csv_quick_view_uses_column_names_only_as_headers():
@@ -291,22 +200,6 @@ def test_csv_chunked_view_skips_header_only_in_first_chunk():
         trans = SimpleNamespace(app=SimpleNamespace(config=SimpleNamespace(display_chunk_size=6)))
         first_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), 0, 6))
         next_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), first_chunk["offset"], 6))
-        assert first_chunk["data_line_offset"] == 1
-        assert next_chunk["data_line_offset"] == 0
-
-
-def test_tabular_chunked_view_skips_header_only_in_first_chunk():
-    contents = "TMB\tSystemic_therapy_history\n32.5\t1\n19.3\t1\n10.5\t1\n"
-    with tempfile.NamedTemporaryFile(mode="w") as test_file:
-        test_file.write(contents)
-        test_file.flush()
-        dataset = MockDataset(id=1)
-        dataset.set_file_name(test_file.name)
-        datatype = Tabular()
-        datatype.set_meta(_dataset_protocol(dataset))
-        trans = SimpleNamespace(app=SimpleNamespace(config=SimpleNamespace(display_chunk_size=18)))
-        first_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), 0, 18))
-        next_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), first_chunk["offset"], 18))
         assert first_chunk["data_line_offset"] == 1
         assert next_chunk["data_line_offset"] == 0
 

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -1,10 +1,28 @@
+import json
 import tempfile
+from types import SimpleNamespace
+from typing import Any, cast
 
+from galaxy.datatypes.protocols import DatasetProtocol
 from galaxy.datatypes.tabular import (
+    CSV,
     MAX_DATA_LINES,
     Tabular,
+    TabularData,
 )
 from .util import MockDataset
+
+
+def _dataset_protocol(dataset: MockDataset) -> DatasetProtocol:
+    return cast(DatasetProtocol, dataset)
+
+
+def _display_peek(datatype: TabularData, dataset: MockDataset, contents: str) -> str:
+    metadata = cast(Any, dataset.metadata)
+    metadata.spec = {}
+    dataset_for_peek = cast(Any, dataset)
+    dataset_for_peek.peek = contents
+    return datatype.display_peek(_dataset_protocol(dataset))
 
 
 def test_tabular_set_meta_large_file():
@@ -14,7 +32,7 @@ def test_tabular_set_meta_large_file():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)  # type: ignore [arg-type]
+        Tabular().set_meta(_dataset_protocol(dataset))
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines is None
         assert dataset.metadata.comment_lines is None
@@ -22,6 +40,236 @@ def test_tabular_set_meta_large_file():
         assert dataset.metadata.columns == 2
         assert dataset.metadata.delimiter == "\t"
         assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_set_meta_with_header():
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write("TMB\tSystemic_therapy_history\tAlbumin\n")
+        test_file.write("32.5\t1\t4.3\n")
+        test_file.write("19.3\t1\t3.8\n")
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        Tabular().set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.data_lines == 2
+        assert dataset.metadata.comment_lines == 1
+        assert dataset.metadata.column_types == ["float", "int", "float"]
+        assert dataset.metadata.columns == 3
+        assert dataset.metadata.delimiter == "\t"
+        assert dataset.metadata.column_names == ["TMB", "Systemic_therapy_history", "Albumin"]
+
+
+def test_tabular_quick_view_uses_column_names_only_as_headers():
+    contents = "question_id\tcurator_name\nensembl-grab-q1\tLG\nbam-infer-read-length-q1\tSN\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = Tabular()
+        datatype.set_meta(_dataset_protocol(dataset))
+        html = _display_peek(datatype, dataset, contents)
+        assert "<th>1.question_id</th>" in html
+        assert "<th>2.curator_name</th>" in html
+        assert "<td>question_id</td>" not in html
+        assert "<td>curator_name</td>" not in html
+
+
+def test_headerless_numeric_tabular_set_meta_does_not_promote_first_row_to_header():
+    contents = "32.5\t1\t4.3\n19.3\t1\t3.8\n10.5\t1\t4.2\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        Tabular().set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.data_lines == 3
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_types == ["float", "int", "float"]
+        assert dataset.metadata.columns == 3
+        assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_single_row_numeric_tabular_set_meta_does_not_promote_first_row_to_header():
+    contents = "32.5\t1\t4.3\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        Tabular().set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.data_lines == 1
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_types == ["float", "int", "float"]
+        assert dataset.metadata.columns == 3
+        assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_set_meta_clears_stale_column_names_for_headerless_data():
+    with tempfile.NamedTemporaryFile(mode="w") as header_file, tempfile.NamedTemporaryFile(mode="w") as data_file:
+        header_file.write("name\tvalue\nA\t1\nB\t2\n")
+        header_file.flush()
+        data_file.write("32.5\t1\t4.3\n19.3\t1\t3.8\n")
+        data_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(header_file.name)
+        datatype = Tabular()
+        datatype.set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.column_names == ["name", "value"]
+        dataset.set_file_name(data_file.name)
+        datatype.set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.data_lines == 2
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_names == []
+
+
+def test_tabular_set_meta_does_not_use_comment_line_as_column_names():
+    contents = "#comment\tthing\n1\t2\n3\t4\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        Tabular().set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.data_lines == 2
+        assert dataset.metadata.comment_lines == 1
+        assert dataset.metadata.column_types == ["int", "int"]
+        assert dataset.metadata.columns == 2
+        assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_quick_view_skips_header_when_line_counts_are_unset():
+    contents = "name\tvalue\nA\t1\nB\t2\nC\t3\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = Tabular()
+        datatype.set_meta(_dataset_protocol(dataset), max_data_lines=2)
+        html = _display_peek(datatype, dataset, contents)
+        assert dataset.metadata.data_lines is None
+        assert dataset.metadata.comment_lines is None
+        assert dataset.metadata.column_names == ["name", "value"]
+        assert "<th>1.name</th>" in html
+        assert "<th>2.value</th>" in html
+        assert "<td>name</td>" not in html
+        assert "<td>value</td>" not in html
+
+
+def test_tabular_quick_view_skips_header_after_comments_when_line_counts_are_unset():
+    contents = "# generated\nname\tvalue\nA\t1\nB\t2\nC\t3\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = Tabular()
+        datatype.set_meta(_dataset_protocol(dataset), max_data_lines=2)
+        html = _display_peek(datatype, dataset, contents)
+        assert dataset.metadata.data_lines is None
+        assert dataset.metadata.comment_lines is None
+        assert dataset.metadata.column_names == ["name", "value"]
+        assert "<th>1.name</th>" in html
+        assert "<th>2.value</th>" in html
+        assert "<td># generated</td>" not in html
+        assert "<td>name</td>" not in html
+        assert "<td>A</td>" in html
+
+
+def test_csv_quick_view_uses_column_names_only_as_headers():
+    contents = "TMB,Systemic_therapy_history,Albumin\n32.5,1,4.3\n19.3,1,3.8\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = CSV()
+        datatype.set_meta(_dataset_protocol(dataset))
+        html = _display_peek(datatype, dataset, contents)
+        assert "<th>1.TMB</th>" in html
+        assert "<th>2.Systemic_therapy_history</th>" in html
+        assert "<td>TMB</td>" not in html
+        assert "<td>Systemic_therapy_history</td>" not in html
+
+
+def test_headerless_csv_sniffs_as_csv():
+    contents = (
+        "32.5,1,4.3,1.19,67.91512663,0,0,0,1,0\n"
+        "19.3,1,3.8,1.38,62.50239562,0,0,0,0,0\n"
+        "10.5,1,4.2,2.54,52.10677618,0,0,0,0,0\n"
+    )
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        assert CSV().sniff(test_file.name)
+
+
+def test_headerless_csv_set_meta_does_not_promote_first_row_to_header():
+    contents = (
+        "32.5,1,4.3,1.19,67.91512663,0,0,0,1,0\n"
+        "19.3,1,3.8,1.38,62.50239562,0,0,0,0,0\n"
+        "10.5,1,4.2,2.54,52.10677618,0,0,0,0,0\n"
+    )
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = CSV()
+        datatype.set_meta(_dataset_protocol(dataset))
+        assert dataset.metadata.data_lines == 3
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_names == []
+        assert dataset.metadata.columns == 10
+
+
+def test_headerless_csv_quick_view_keeps_first_row_as_data():
+    contents = "32.5,1,4.3\n19.3,1,3.8\n10.5,1,4.2\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = CSV()
+        datatype.set_meta(_dataset_protocol(dataset))
+        html = _display_peek(datatype, dataset, contents)
+        assert "<th>1</th>" in html
+        assert "<th>2</th>" in html
+        assert "<td>32.5</td>" in html
+        assert "<td>4.3</td>" in html
+
+
+def test_csv_chunked_view_skips_header_only_in_first_chunk():
+    contents = "A,B\n1,2\n3,4\n5,6\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = CSV()
+        datatype.set_meta(_dataset_protocol(dataset))
+        trans = SimpleNamespace(app=SimpleNamespace(config=SimpleNamespace(display_chunk_size=6)))
+        first_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), 0, 6))
+        next_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), first_chunk["offset"], 6))
+        assert first_chunk["data_line_offset"] == 1
+        assert next_chunk["data_line_offset"] == 0
+
+
+def test_tabular_chunked_view_skips_header_only_in_first_chunk():
+    contents = "TMB\tSystemic_therapy_history\n32.5\t1\n19.3\t1\n10.5\t1\n"
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write(contents)
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        datatype = Tabular()
+        datatype.set_meta(_dataset_protocol(dataset))
+        trans = SimpleNamespace(app=SimpleNamespace(config=SimpleNamespace(display_chunk_size=18)))
+        first_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), 0, 18))
+        next_chunk = json.loads(datatype.get_chunk(trans, _dataset_protocol(dataset), first_chunk["offset"], 18))
+        assert first_chunk["data_line_offset"] == 1
+        assert next_chunk["data_line_offset"] == 0
 
 
 def test_tabular_set_meta_empty():
@@ -32,7 +280,7 @@ def test_tabular_set_meta_empty():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)  # type: ignore [arg-type]
+        Tabular().set_meta(_dataset_protocol(dataset))
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 0
         assert dataset.metadata.comment_lines == 0
@@ -52,7 +300,7 @@ def test_tabular_set_meta_nearly_empty():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)  # type: ignore [arg-type]
+        Tabular().set_meta(_dataset_protocol(dataset))
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 0
         assert dataset.metadata.comment_lines == 1
@@ -77,7 +325,7 @@ def test_tabular_column_types():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)  # type: ignore [arg-type]
+        Tabular().set_meta(_dataset_protocol(dataset))
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 2
         assert dataset.metadata.comment_lines == 0
@@ -104,7 +352,7 @@ def test_tabular_column_types_override():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)  # type: ignore [arg-type]
+        Tabular().set_meta(_dataset_protocol(dataset))
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 3
         assert dataset.metadata.comment_lines == 0


### PR DESCRIPTION
Fixes CSV preview header handling.

Before this change, CSV datasets with a header could render the column names twice: once in the table header and again as the first data row. This updates CSV metadata/display handling so detected CSV column names are shown only in the table header for both peek and chunked preview output.

This also keeps numeric/headerless CSV data recognized as `csv` when rows have a consistent comma-delimited shape. Headerless CSV keeps the first row as data and uses generic `Column 1`, `Column 2`, etc. labels.

Generic `tabular` preview header behavior is intentionally not changed in this PR. That smaller 26.1-targeted cleanup is tracked separately in #22947.

| CSV with header before | CSV with header after |
| ---- | ---- |
| The header row was duplicated as data.<br /><img width="500" alt="Before: full CSV preview duplicates the header row" src="https://github.com/user-attachments/assets/b8d90fea-7cd7-40b3-b344-d27a3993738b" /> | Column names are shown only in the table header.<br /><img width="500" alt="After: full CSV preview shows detected column names only in the header" src="https://github.com/user-attachments/assets/f7bbf7ef-50b7-444f-ad7f-11bb53b31fa1" /> |

Headerless CSV files are still detected as `csv`, keep the first numeric row as data, and display generic column labels.

<img width="500" alt="After: headerless CSV is detected as CSV with generic column labels" src="https://github.com/user-attachments/assets/add30f8f-6434-41be-93f0-6cd890ee44e3" />

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upload a CSV file with a header row and verify the history peek and full preview show column names only in the table header, not again as the first data row.
  2. Upload a headerless CSV file and verify it is detected as `csv`, keeps the first row as data, and displays generic `Column 1`, `Column 2`, etc. headers.
  3. Confirm generic `tabular` preview behavior is handled separately in #22947.
  4. Run `.venv/bin/pytest -q test/unit/data/datatypes/test_tabular.py test/unit/data/datatypes/test_connectivity_table.py`.
  5. Run `uvx tox -e format`.
  6. Run `uvx tox -e mypy`.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
