### PR TITLE
[26.1] Fix composite uploads ignoring substitute_name_with_metadata

### DIFF
--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -190,15 +190,21 @@ def _fetch_target(upload_config: "UploadConfig", target: dict[str, Any]):
             # get_composite_dataset_name finds dataset name from basename of contents
             # and such but we're not implementing that here yet. yagni?
             # also need name...
-            metadata = item.get("metadata") or {
+            # Substitution keys (e.g. base_name) default from the datatype, with any
+            # provided metadata layered on top.
+            metadata = {
                 composite_file.substitute_name_with_metadata: datatype.metadata_spec[
                     composite_file.substitute_name_with_metadata
                 ].default
                 for composite_file in datatype.composite_files.values()
                 if composite_file.substitute_name_with_metadata
             }
+            metadata.update(item.get("metadata") or {})
+            # History display name: respect an explicitly provided name, then fall back to
+            # base_name. Do NOT write this back into metadata["base_name"] -- base_name drives
+            # the canonical "%s" -> base_name substitution for composite filenames and must keep
+            # its provided/default value (e.g. "RgeneticsData"), independent of the display name.
             name = item.get("name") or metadata.get("base_name") or "Composite Dataset"
-            metadata["base_name"] = name
             dataset = Bunch(
                 name=name,
                 metadata=metadata,

--- a/test/functional/tools/composite_pbed.xml
+++ b/test/functional/tools/composite_pbed.xml
@@ -1,0 +1,26 @@
+<tool id="composite_pbed" name="composite_pbed" version="1.0.0">
+    <command><![CDATA[
+cat '$input.extra_files_path/RgeneticsData.bed' > '$out_bed' &&
+cat '$input.extra_files_path/RgeneticsData.bim' > '$out_bim' &&
+cat '$input.extra_files_path/RgeneticsData.fam' > '$out_fam'
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="pbed" label="Plink pbed dataset"/>
+    </inputs>
+    <outputs>
+        <data name="out_bed" format="txt"/>
+        <data name="out_bim" format="txt"/>
+        <data name="out_fam" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="" ftype="pbed">
+                <composite_data value="rgenetics.bim"/>
+                <composite_data value="rgenetics.bed"/>
+                <composite_data value="rgenetics.fam"/>
+            </param>
+            <output name="out_bim" file="rgenetics.bim" compare="diff"/>
+            <output name="out_fam" file="rgenetics.fam" compare="diff"/>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -17,6 +17,7 @@
   <tool file="inheritance_simple.xml" />
   <tool file="boolean_conditional.xml" />
   <tool file="composite.xml" />
+  <tool file="composite_pbed.xml" />
   <tool file="environment_variables.xml" />
   <tool file="environment_variables_inject.xml" />
   <tool file="code_file.xml" />


### PR DESCRIPTION
Composite datatypes (e.g. pbed/Rgenetics) name their extra files via a "%s" -> base_name substitution, so tools can reference canonical paths like $input.extra_files_path/RgeneticsData.bed. In _fetch_target the resolved display name was written back into metadata["base_name"], which since the name-precedence change clobbered base_name with the dataset display name (for tool tests, a generated _COMPOSITE_RENAMED_* string). Composite files were then staged under the wrong names and tools relying on the canonical name failed with dangling symlinks.

Decouple the two: keep respecting an explicitly provided display name, but leave base_name at its provided/default value so the canonical substitution is preserved. Also layer provided metadata over the datatype defaults instead of using one or the other.

Adds a composite_pbed framework tool that references the canonical RgeneticsData.* names as a regression test.

Fixes #22786

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
