### PR TITLE
[26.1] Route ChatGXY on the current message, and ask when uncertain

### DIFF
--- a/client/src/components/GalaxyAI.vue
+++ b/client/src/components/GalaxyAI.vue
@@ -241,6 +241,13 @@ watch(busy, (isBusy) => {
     }
 });
 
+async function selectClarificationOption(option: string) {
+    // A quick-reply to a clarifying question -- send it as the next message. The router
+    // includes the clarification turn when routing, so a terse option still routes.
+    query.value = option;
+    await submitQuery();
+}
+
 async function sendFeedback(messageId: string, value: "up" | "down") {
     const message = messages.value.find((m) => m.id === messageId);
     if (message) {
@@ -438,7 +445,8 @@ watch(currentChatId, async (newId) => {
                 :render-markdown="renderMarkdown"
                 :processing-action="processingAction"
                 @feedback="sendFeedback"
-                @handle-action="handleAction" />
+                @handle-action="handleAction"
+                @select-clarification-option="selectClarificationOption" />
 
             <!-- Loading state -->
             <div v-if="busy" class="loading-entry">

--- a/client/src/components/GalaxyAI/ChatMessageCell.test.ts
+++ b/client/src/components/GalaxyAI/ChatMessageCell.test.ts
@@ -83,6 +83,58 @@ describe("ChatMessageCell", () => {
         });
     });
 
+    describe("clarification messages", () => {
+        function makeClarificationMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+            return makeAssistantMessage({
+                agentType: "clarification",
+                content: "Do you want a tool recommendation or a tutorial?",
+                agentResponse: {
+                    content: "Do you want a tool recommendation or a tutorial?",
+                    agent_type: "clarification",
+                    confidence: "medium",
+                    suggestions: [],
+                    metadata: { options: ["Tool recommendation", "Tutorial"] },
+                },
+                ...overrides,
+            });
+        }
+
+        it("renders the ClarificationCard, not the markdown content", () => {
+            const wrapper = mountCell(makeClarificationMessage());
+            expect(wrapper.find(".clarification-card").exists()).toBe(true);
+            expect(wrapper.find(".response-content").exists()).toBe(false);
+        });
+
+        it("renders one quick-reply button per option", () => {
+            const wrapper = mountCell(makeClarificationMessage());
+            expect(wrapper.findAll(".clarification-options button").length).toBe(2);
+        });
+
+        it("bubbles select-clarification-option with the chosen option", async () => {
+            const wrapper = mountCell(makeClarificationMessage());
+            await wrapper.findAll(".clarification-options button").at(0)!.trigger("click");
+            expect(wrapper.emitted("select-clarification-option")).toEqual([["Tool recommendation"]]);
+        });
+
+        it("renders the question even with no options", () => {
+            const wrapper = mountCell(
+                makeClarificationMessage({
+                    agentResponse: {
+                        content: "What would you like to do?",
+                        agent_type: "clarification",
+                        confidence: "medium",
+                        suggestions: [],
+                        metadata: {},
+                    },
+                }),
+            );
+            expect(wrapper.find(".clarification-question").text()).toBe(
+                "Do you want a tool recommendation or a tutorial?",
+            );
+            expect(wrapper.findAll(".clarification-options button").length).toBe(0);
+        });
+    });
+
     describe("system messages", () => {
         it("renders system notice", () => {
             const wrapper = mountCell(makeAssistantMessage({ isSystemMessage: true, content: "Welcome" }));

--- a/client/src/components/GalaxyAI/ChatMessageCell.vue
+++ b/client/src/components/GalaxyAI/ChatMessageCell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { faDatabase, faHistory, faThumbsDown, faThumbsUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { computed } from "vue";
 
 import type { ActionSuggestion, AgentResponse } from "@/composables/agentActions";
 import { type EntityType, MENTION_PATTERN_SOURCE } from "@/composables/useEntityMentions";
@@ -9,6 +10,7 @@ import { formatModelName, getAgentIcon, getAgentLabel, getAgentResponseOrEmpty }
 import type { ChatMessage } from "./chatTypes";
 
 import ActionCard from "./ActionCard.vue";
+import ClarificationCard from "./ClarificationCard.vue";
 
 const MENTION_RE = new RegExp(MENTION_PATTERN_SOURCE, "g");
 
@@ -41,7 +43,11 @@ const props = defineProps<{
 const emit = defineEmits<{
     (e: "feedback", messageId: string, value: "up" | "down"): void;
     (e: "handle-action", action: ActionSuggestion, agentResponse: AgentResponse): void;
+    (e: "select-clarification-option", option: string): void;
 }>();
+
+const isClarification = computed(() => props.message.agentType === "clarification");
+const clarificationOptions = computed<string[]>(() => props.message.agentResponse?.metadata?.options ?? []);
 </script>
 
 <template>
@@ -84,11 +90,16 @@ const emit = defineEmits<{
                     </span>
                 </div>
                 <div class="response-main">
+                    <ClarificationCard
+                        v-if="isClarification"
+                        :question="props.message.content"
+                        :options="clarificationOptions"
+                        @select-option="(option) => emit('select-clarification-option', option)" />
                     <!-- eslint-disable-next-line vue/no-v-html -->
-                    <div class="response-content" v-html="props.renderMarkdown(props.message.content)" />
+                    <div v-else class="response-content" v-html="props.renderMarkdown(props.message.content)" />
 
                     <ActionCard
-                        v-if="props.message.suggestions?.length"
+                        v-if="!isClarification && props.message.suggestions?.length"
                         :suggestions="props.message.suggestions"
                         :processing-action="props.processingAction"
                         @handle-action="

--- a/client/src/components/GalaxyAI/ClarificationCard.test.ts
+++ b/client/src/components/GalaxyAI/ClarificationCard.test.ts
@@ -1,0 +1,41 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import ClarificationCard from "./ClarificationCard.vue";
+
+function mountCard(props: Record<string, unknown> = {}) {
+    return mount(ClarificationCard as any, {
+        propsData: {
+            question: "Do you want a tool recommendation or a tutorial?",
+            options: ["Tool recommendation", "Tutorial"],
+            ...props,
+        },
+    });
+}
+
+describe("ClarificationCard", () => {
+    it("renders the question", () => {
+        const wrapper = mountCard();
+        expect(wrapper.find(".clarification-question").text()).toBe("Do you want a tool recommendation or a tutorial?");
+    });
+
+    it("renders one button per option", () => {
+        const wrapper = mountCard();
+        const buttons = wrapper.findAll(".clarification-options button");
+        expect(buttons.length).toBe(2);
+        expect(buttons.at(0)!.text()).toBe("Tool recommendation");
+        expect(buttons.at(1)!.text()).toBe("Tutorial");
+    });
+
+    it("emits select-option with the option text on click", async () => {
+        const wrapper = mountCard();
+        await wrapper.findAll(".clarification-options button").at(1)!.trigger("click");
+        expect(wrapper.emitted("select-option")).toEqual([["Tutorial"]]);
+    });
+
+    it("renders the question with no options and no buttons", () => {
+        const wrapper = mountCard({ options: [] });
+        expect(wrapper.find(".clarification-question").text()).toBe("Do you want a tool recommendation or a tutorial?");
+        expect(wrapper.findAll(".clarification-options button").length).toBe(0);
+    });
+});

--- a/client/src/components/GalaxyAI/ClarificationCard.vue
+++ b/client/src/components/GalaxyAI/ClarificationCard.vue
@@ -1,0 +1,48 @@
+<template>
+    <div class="clarification-card">
+        <div class="clarification-question">{{ question }}</div>
+        <div v-if="options.length > 0" class="clarification-options">
+            <GButton
+                v-for="(option, index) in options"
+                :key="`${index}-${option}`"
+                outline
+                size="small"
+                color="blue"
+                @click="$emit('select-option', option)">
+                {{ option }}
+            </GButton>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import GButton from "@/components/BaseComponents/GButton.vue";
+
+withDefaults(
+    defineProps<{
+        question: string;
+        options?: string[];
+    }>(),
+    {
+        options: () => [],
+    },
+);
+
+defineEmits<{
+    "select-option": [option: string];
+}>();
+</script>
+
+<style lang="scss" scoped>
+@import "@/style/scss/theme/blue.scss";
+
+.clarification-question {
+    margin-bottom: 0.5rem;
+}
+
+.clarification-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+</style>

--- a/client/src/components/GalaxyAI/agentTypes.ts
+++ b/client/src/components/GalaxyAI/agentTypes.ts
@@ -6,6 +6,7 @@ import {
     faGraduationCap,
     faMagic,
     faPlus,
+    faQuestionCircle,
     faRobot,
     faRoute,
 } from "@fortawesome/free-solid-svg-icons";
@@ -27,6 +28,7 @@ export const agentTypes: AgentType[] = [
     { value: "custom_tool", label: "Custom Tool", icon: faPlus, description: "Create custom tools" },
     { value: "dataset_analyzer", label: "Dataset Analyzer", icon: faChartBar, description: "Analyze datasets" },
     { value: "gtn_training", label: "GTN Training", icon: faGraduationCap, description: "Find tutorials" },
+    { value: "clarification", label: "Clarification", icon: faQuestionCircle, description: "Needs more info" },
     {
         value: "page_assistant",
         label: AGENT_LABELS.pageAssistantLabel,

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -53,7 +53,13 @@ Ask when:
 Do NOT ask when the current message is clear enough to route or answer on its own. A
 confident route or answer is always better than an unnecessary question -- over-asking is
 as harmful as mis-routing. When you do ask, name the options where you can ("Do you want a
-tool recommendation or a tutorial?") rather than a generic "can you clarify?".
+tool recommendation or a tutorial?") rather than a generic "can you clarify?". You may pass
+2-4 short `options` so the user can pick an answer directly.
+
+If the user's message is answering a clarifying question you just asked, route using that
+question together with their original request -- e.g. after you asked "tool recommendation
+or a tutorial?", a reply of "the second one" or "a tutorial" means hand off to the tutorial
+specialist. Do not ask again; commit to the route their answer indicates.
 
 ## Fast-path tools
 

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -38,6 +38,23 @@ You have access to specialist agents that you can route queries to. Choose the a
 - Scientific analysis best practices
 - Galaxy features and capabilities
 
+## When You're Not Sure -- Ask
+
+If the user's message is too ambiguous or underspecified to route or answer confidently,
+ask ONE concise clarifying question via `ask_for_clarification` instead of guessing.
+
+Ask when:
+
+- The message names no analysis, tool, dataset, or goal ("Can you help with my data?", "What should I do next?")
+- A failure is reported with no error text, exit code, or tool name ("It keeps failing", "My job isn't working")
+- The intent could plausibly mean several different things -- a tool, a tutorial, usage help, or debugging ("I need help with variant calling")
+- A follow-up's referent cannot be determined from the message itself ("Is there a better one?")
+
+Do NOT ask when the current message is clear enough to route or answer on its own. A
+confident route or answer is always better than an unnecessary question -- over-asking is
+as harmful as mis-routing. When you do ask, name the options where you can ("Do you want a
+tool recommendation or a tutorial?") rather than a generic "can you clarify?".
+
 ## Fast-path tools
 
 You also have a few read-only tools you can call directly. Use them for simple

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -74,6 +74,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
         next_step_handoff = self._create_next_step_advisor_handoff()
         orchestrator_handoff = self._create_orchestrator_handoff()
         gtn_handoff = self._create_gtn_training_handoff()
+        clarification_output = self._create_clarification_output()
 
         agent: Agent[GalaxyAgentDependencies, str] = Agent(
             self._get_model(),
@@ -86,6 +87,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
                 next_step_handoff,
                 orchestrator_handoff,
                 gtn_handoff,
+                clarification_output,
                 str,  # Default: answer directly
             ],
             system_prompt=self.get_system_prompt(),
@@ -447,6 +449,31 @@ class QueryRouterAgent(BaseGalaxyAgent):
 
         return hand_off_to_gtn_training
 
+    def _create_clarification_output(self):
+        async def ask_for_clarification(
+            ctx: RunContext[GalaxyAgentDependencies],
+            question: str,
+        ) -> str:
+            """Ask the user ONE concise clarifying question when the request is too ambiguous
+            or underspecified to route or answer confidently.
+
+            Use this ONLY when you are genuinely uncertain, e.g.:
+            - The message names no analysis, tool, dataset, or goal ("Can you help with my data?")
+            - A failure is reported with no error text, exit code, or tool name ("It keeps failing")
+            - The intent could plausibly mean several different things -- a tool, a tutorial,
+              usage help, or debugging ("I need help with variant calling")
+            - A follow-up's referent cannot be determined from the message itself
+
+            Do NOT use this when the current message is clear enough to route or answer on its
+            own -- a confident route or answer is always better than an unnecessary question.
+
+            Args:
+                question: the single concise clarifying question to ask the user
+            """
+            return json.dumps({"__clarification__": True, "question": question})
+
+        return ask_for_clarification
+
     def _routing_history(self, full_history: Optional[list]) -> Optional[list]:
         """The history the router uses for its routing decision.
 
@@ -491,20 +518,27 @@ class QueryRouterAgent(BaseGalaxyAgent):
             content = extract_result_content(result)
 
             try:
-                handoff_data = json.loads(content)
-                if handoff_data.get("__handoff__"):
-                    metadata = handoff_data.get("metadata", {})
-                    if handoff_data.get("handoff_info"):
-                        metadata["handoff_info"] = handoff_data["handoff_info"]
+                parsed = json.loads(content)
+                if parsed.get("__clarification__"):
                     return AgentResponse(
-                        content=handoff_data["content"],
-                        confidence=ConfidenceLevel(handoff_data.get("confidence", "medium")),
-                        agent_type=handoff_data.get("agent_type", self.agent_type),
-                        suggestions=handoff_data.get("suggestions", []),
+                        content=parsed.get("question", content),
+                        confidence=ConfidenceLevel.MEDIUM,
+                        agent_type="clarification",
+                        metadata={"method": "clarification"},
+                    )
+                if parsed.get("__handoff__"):
+                    metadata = parsed.get("metadata", {})
+                    if parsed.get("handoff_info"):
+                        metadata["handoff_info"] = parsed["handoff_info"]
+                    return AgentResponse(
+                        content=parsed["content"],
+                        confidence=ConfidenceLevel(parsed.get("confidence", "medium")),
+                        agent_type=parsed.get("agent_type", self.agent_type),
+                        suggestions=parsed.get("suggestions", []),
                         metadata=metadata,
                     )
             except (json.JSONDecodeError, TypeError, KeyError, ValidationError) as e:
-                log.debug(f"Router: Response not a handoff (parse failed: {e}), treating as direct response")
+                log.debug(f"Router: Response not a handoff/clarification (parse failed: {e}), treating as direct")
 
             return self._build_response(
                 content=content,

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -49,6 +49,14 @@ class QueryRouterAgent(BaseGalaxyAgent):
     agent_type = AgentType.ROUTER
     _handoff_context: Optional[dict[str, Any]] = None
 
+    # How many recent conversation turns the router sees when making its routing
+    # decision. Evals show routing accuracy degrades monotonically as more history is
+    # fed to the router -- a tool/workflow question that routes correctly on turn 1 gets
+    # answered directly deep in a conversation. Routing on the current message alone
+    # (0 turns) recovers it; specialists still receive the full conversation_history via
+    # the handoff context, so nothing downstream loses information.
+    ROUTING_HISTORY_TURNS = 0
+
     def _create_agent(self) -> Agent[GalaxyAgentDependencies, str]:
         model_name = self._get_agent_config("model", "")
 
@@ -439,15 +447,38 @@ class QueryRouterAgent(BaseGalaxyAgent):
 
         return hand_off_to_gtn_training
 
+    def _routing_history(self, full_history: Optional[list]) -> Optional[list]:
+        """The history the router uses for its routing decision.
+
+        Capped at ``ROUTING_HISTORY_TURNS`` recent turns (0 -> none). Conversation history
+        dilutes the routing signal and biases the model toward answering directly, so the
+        router routes on the current message while specialists still get the full history.
+        """
+        if not full_history or self.ROUTING_HISTORY_TURNS <= 0:
+            return None
+
+        def _is_turn_start(message: Any) -> bool:
+            return any(getattr(part, "part_kind", "") == "user-prompt" for part in getattr(message, "parts", ()))
+
+        turn_starts = [i for i, message in enumerate(full_history) if _is_turn_start(message)]
+        if len(turn_starts) <= self.ROUTING_HISTORY_TURNS:
+            return full_history
+        return full_history[turn_starts[-self.ROUTING_HISTORY_TURNS] :]
+
     async def process(self, query: str, context: Optional[dict[str, Any]] = None) -> AgentResponse:
         validation_error = self._validate_query(query)
         if validation_error:
             return self._validation_error_response(validation_error)
 
         try:
-            message_history = self._extract_message_history(context)
-            if message_history:
-                log.info(f"Router: passing {len(message_history)} prior messages as message_history")
+            full_history = self._extract_message_history(context)
+            # Route on the current message; deep history degrades the routing decision.
+            # Specialists still receive the full conversation_history via _handoff_context.
+            message_history = self._routing_history(full_history)
+            if full_history and not message_history:
+                log.info(f"Router: routing on current message, withholding {len(full_history)} history messages")
+            elif message_history:
+                log.info(f"Router: routing on {len(message_history)} recent messages")
             else:
                 log.info("Router: processing query with no conversation history")
 

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -501,7 +501,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
             return full_history
         return full_history[turn_starts[-self.ROUTING_HISTORY_TURNS] :]
 
-    def _clarification_routing_history(self, full_history: Optional[list]) -> Optional[list]:
+    def _clarification_routing_history(self, full_history: Optional[list]) -> list:
         """The last conversation turn (original request + the clarifying question we asked).
 
         A narrow exception to history-withholding: when the user is answering a clarification,
@@ -509,7 +509,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
         its own it has no referent. Specialists still receive the full history via the handoff.
         """
         if not full_history:
-            return None
+            return []
         turn_starts = self._turn_start_indices(full_history)
         if not turn_starts:
             return full_history
@@ -524,6 +524,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
             full_history = self._extract_message_history(context)
             # Route on the current message; deep history degrades the routing decision.
             # Specialists still receive the full conversation_history via _handoff_context.
+            message_history: Optional[list]
             if context and context.get("responding_to_clarification") and full_history:
                 # The previous turn asked a clarifying question -- route the answer using
                 # that one turn so an elliptical reply ("the second one") has a referent.

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -453,6 +453,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
         async def ask_for_clarification(
             ctx: RunContext[GalaxyAgentDependencies],
             question: str,
+            options: Optional[list[str]] = None,
         ) -> str:
             """Ask the user ONE concise clarifying question when the request is too ambiguous
             or underspecified to route or answer confidently.
@@ -469,10 +470,21 @@ class QueryRouterAgent(BaseGalaxyAgent):
 
             Args:
                 question: the single concise clarifying question to ask the user
+                options: optional 2-4 short answers the user can pick from (e.g.
+                    ["Tool recommendation", "Tutorial"]); rendered as quick-reply buttons
             """
-            return json.dumps({"__clarification__": True, "question": question})
+            return json.dumps({"__clarification__": True, "question": question, "options": options or []})
 
         return ask_for_clarification
+
+    @staticmethod
+    def _turn_start_indices(full_history: list) -> list[int]:
+        """Indices in ``full_history`` where a new user turn begins (a user-prompt part)."""
+
+        def _is_turn_start(message: Any) -> bool:
+            return any(getattr(part, "part_kind", "") == "user-prompt" for part in getattr(message, "parts", ()))
+
+        return [i for i, message in enumerate(full_history) if _is_turn_start(message)]
 
     def _routing_history(self, full_history: Optional[list]) -> Optional[list]:
         """The history the router uses for its routing decision.
@@ -484,13 +496,24 @@ class QueryRouterAgent(BaseGalaxyAgent):
         if not full_history or self.ROUTING_HISTORY_TURNS <= 0:
             return None
 
-        def _is_turn_start(message: Any) -> bool:
-            return any(getattr(part, "part_kind", "") == "user-prompt" for part in getattr(message, "parts", ()))
-
-        turn_starts = [i for i, message in enumerate(full_history) if _is_turn_start(message)]
+        turn_starts = self._turn_start_indices(full_history)
         if len(turn_starts) <= self.ROUTING_HISTORY_TURNS:
             return full_history
         return full_history[turn_starts[-self.ROUTING_HISTORY_TURNS] :]
+
+    def _clarification_routing_history(self, full_history: Optional[list]) -> Optional[list]:
+        """The last conversation turn (original request + the clarifying question we asked).
+
+        A narrow exception to history-withholding: when the user is answering a clarification,
+        the router needs that turn to route an elliptical answer like "the second one" -- on
+        its own it has no referent. Specialists still receive the full history via the handoff.
+        """
+        if not full_history:
+            return None
+        turn_starts = self._turn_start_indices(full_history)
+        if not turn_starts:
+            return full_history
+        return full_history[turn_starts[-1] :]
 
     async def process(self, query: str, context: Optional[dict[str, Any]] = None) -> AgentResponse:
         validation_error = self._validate_query(query)
@@ -501,13 +524,19 @@ class QueryRouterAgent(BaseGalaxyAgent):
             full_history = self._extract_message_history(context)
             # Route on the current message; deep history degrades the routing decision.
             # Specialists still receive the full conversation_history via _handoff_context.
-            message_history = self._routing_history(full_history)
-            if full_history and not message_history:
-                log.info(f"Router: routing on current message, withholding {len(full_history)} history messages")
-            elif message_history:
-                log.info(f"Router: routing on {len(message_history)} recent messages")
+            if context and context.get("responding_to_clarification") and full_history:
+                # The previous turn asked a clarifying question -- route the answer using
+                # that one turn so an elliptical reply ("the second one") has a referent.
+                message_history = self._clarification_routing_history(full_history)
+                log.info(f"Router: answering a clarification, routing on the last turn ({len(message_history)} msgs)")
             else:
-                log.info("Router: processing query with no conversation history")
+                message_history = self._routing_history(full_history)
+                if full_history and not message_history:
+                    log.info(f"Router: routing on current message, withholding {len(full_history)} history messages")
+                elif message_history:
+                    log.info(f"Router: routing on {len(message_history)} recent messages")
+                else:
+                    log.info("Router: processing query with no conversation history")
 
             previous_handoff_context = self._handoff_context
             self._handoff_context = context.copy() if context else {}
@@ -524,7 +553,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
                         content=parsed.get("question", content),
                         confidence=ConfidenceLevel.MEDIUM,
                         agent_type="clarification",
-                        metadata={"method": "clarification"},
+                        metadata={"method": "clarification", "options": parsed.get("options", [])},
                     )
                 if parsed.get("__handoff__"):
                     metadata = parsed.get("metadata", {})

--- a/lib/galaxy/managers/chat.py
+++ b/lib/galaxy/managers/chat.py
@@ -247,23 +247,6 @@ class ChatManager:
             raise InternalServerError(f"Error loading from the database: {unicodify(e)}")
         return chat_exchange
 
-    def was_last_message_clarification(self, trans: ProvidesUserContext, exchange_id: int) -> bool:
-        """Whether the most recent stored turn in this exchange asked the user a clarifying question.
-
-        The router emits ``agent_type="clarification"`` when it needs more info; the next user
-        message is the answer. The router withholds history when routing, so routing that answer
-        ("the second one") needs this one turn of context -- the API surfaces it as a flag.
-        """
-        exchange = self.get_exchange_by_id(trans, exchange_id)
-        if not exchange or not exchange.messages:
-            return False
-        try:
-            data = json.loads(exchange.messages[-1].message)
-        except (json.JSONDecodeError, TypeError):
-            return False
-        agent_response = data.get("agent_response") or {}
-        return agent_response.get("agent_type") == "clarification"
-
     def set_feedback_for_exchange(self, trans: ProvidesUserContext, exchange_id: int, feedback: int) -> ChatExchange:
         """
         Set the feedback for a chat exchange by exchange ID.
@@ -354,18 +337,49 @@ class ChatManager:
                     messages.append({"role": "assistant", "content": msg.message})
             return messages
         else:
-            # Format for pydantic-ai
-            pydantic_messages: list[ModelMessage] = []
-            for msg in chat_exchange.messages:
-                try:
-                    data = json.loads(msg.message)
-                    if "query" in data:
-                        pydantic_messages.append(ModelRequest(parts=[UserPromptPart(content=data["query"])]))
-                    if "response" in data:
-                        pydantic_messages.append(ModelResponse(parts=[TextPart(content=data["response"])]))
-                except (json.JSONDecodeError, KeyError):
-                    pydantic_messages.append(ModelResponse(parts=[TextPart(content=msg.message)]))
-            return pydantic_messages
+            return self._messages_to_pydantic_ai(chat_exchange.messages)
+
+    @staticmethod
+    def _messages_to_pydantic_ai(messages: list) -> list[ModelMessage]:
+        """Reconstruct stored exchange messages as pydantic-ai history.
+
+        Only the query/response text survives -- the stored ``agent_response`` (including
+        ``agent_type``) is intentionally dropped here. Where the router needs that signal (to
+        tell it is answering a clarification) ``get_routing_history`` reads it from storage.
+        """
+        pydantic_messages: list[ModelMessage] = []
+        for msg in messages:
+            try:
+                data = json.loads(msg.message)
+                if "query" in data:
+                    pydantic_messages.append(ModelRequest(parts=[UserPromptPart(content=data["query"])]))
+                if "response" in data:
+                    pydantic_messages.append(ModelResponse(parts=[TextPart(content=data["response"])]))
+            except (json.JSONDecodeError, KeyError):
+                pydantic_messages.append(ModelResponse(parts=[TextPart(content=msg.message)]))
+        return pydantic_messages
+
+    @staticmethod
+    def _message_is_clarification(message) -> bool:
+        """Whether a stored message's response was a clarifying question (by ``agent_type``)."""
+        try:
+            data = json.loads(message.message)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        return (data.get("agent_response") or {}).get("agent_type") == "clarification"
+
+    def get_routing_history(self, trans: ProvidesUserContext, exchange_id: int) -> tuple[list[ModelMessage], bool]:
+        """The pydantic-ai conversation history plus whether the last turn was a clarification.
+
+        Both are derived from a single exchange fetch. The router emits
+        ``agent_type="clarification"`` when it needs more info; the next user message answers it.
+        Routing withholds history, so routing that elliptical answer ("the second one") needs the
+        flag to re-include the clarification turn.
+        """
+        exchange = self.get_exchange_by_id(trans, exchange_id)
+        if not exchange or not exchange.messages:
+            return [], False
+        return self._messages_to_pydantic_ai(exchange.messages), self._message_is_clarification(exchange.messages[-1])
 
     def delete_exchange(self, trans: ProvidesUserContext, exchange_id: int) -> None:
         """Delete a single chat exchange and its messages."""

--- a/lib/galaxy/managers/chat.py
+++ b/lib/galaxy/managers/chat.py
@@ -301,44 +301,6 @@ class ChatManager:
 
         return chat_exchange
 
-    def get_chat_history(
-        self, trans: ProvidesUserContext, exchange_id: int, format_for_pydantic_ai: bool = False
-    ) -> Union[list[dict[str, Any]], list[ModelMessage]]:
-        """
-        Get the chat history for a specific exchange, optionally formatted for pydantic-ai.
-
-        :param  exchange_id: id of the chat exchange
-        :type   exchange_id: int
-        :param  format_for_pydantic_ai: whether to format the history for pydantic-ai
-        :type   format_for_pydantic_ai: bool
-        :returns: list of chat messages
-        :rtype: Union[List[Dict[str, Any]], List[ModelMessage]]
-        """
-        chat_exchange = self.get_exchange_by_id(trans, exchange_id)
-
-        if not chat_exchange:
-            return []
-
-        if not format_for_pydantic_ai:
-            # Format as simple role/content dictionaries
-            messages: list[dict[str, Any]] = []
-            for msg in chat_exchange.messages:
-                try:
-                    # Parse the JSON to get query and response
-                    data = json.loads(msg.message)
-                    # Add user message
-                    if "query" in data:
-                        messages.append({"role": "user", "content": data["query"]})
-                    # Add assistant message
-                    if "response" in data:
-                        messages.append({"role": "assistant", "content": data["response"]})
-                except (json.JSONDecodeError, KeyError):
-                    # Fallback for non-JSON messages
-                    messages.append({"role": "assistant", "content": msg.message})
-            return messages
-        else:
-            return self._messages_to_pydantic_ai(chat_exchange.messages)
-
     @staticmethod
     def _messages_to_pydantic_ai(messages: list) -> list[ModelMessage]:
         """Reconstruct stored exchange messages as pydantic-ai history.

--- a/lib/galaxy/managers/chat.py
+++ b/lib/galaxy/managers/chat.py
@@ -1,3 +1,4 @@
+import json
 from typing import (
     Any,
     Optional,
@@ -246,6 +247,23 @@ class ChatManager:
             raise InternalServerError(f"Error loading from the database: {unicodify(e)}")
         return chat_exchange
 
+    def was_last_message_clarification(self, trans: ProvidesUserContext, exchange_id: int) -> bool:
+        """Whether the most recent stored turn in this exchange asked the user a clarifying question.
+
+        The router emits ``agent_type="clarification"`` when it needs more info; the next user
+        message is the answer. The router withholds history when routing, so routing that answer
+        ("the second one") needs this one turn of context -- the API surfaces it as a flag.
+        """
+        exchange = self.get_exchange_by_id(trans, exchange_id)
+        if not exchange or not exchange.messages:
+            return False
+        try:
+            data = json.loads(exchange.messages[-1].message)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        agent_response = data.get("agent_response") or {}
+        return agent_response.get("agent_type") == "clarification"
+
     def set_feedback_for_exchange(self, trans: ProvidesUserContext, exchange_id: int, feedback: int) -> ChatExchange:
         """
         Set the feedback for a chat exchange by exchange ID.
@@ -317,8 +335,6 @@ class ChatManager:
 
         if not chat_exchange:
             return []
-
-        import json
 
         if not format_for_pydantic_ai:
             # Format as simple role/content dictionaries

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1661,6 +1661,9 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         """Ensure GalaxyAI center panel shows an empty conversation."""
         galaxyai = self.components.galaxyai
         galaxyai._.wait_for_visible()
+        # Don't reset mid-stream -- the new chat button can be transiently unclickable and the
+        # reset races with an in-flight response render.
+        galaxyai.loading.wait_for_absent_or_hidden()
         if len(galaxyai.query_cell.all()) > 0 or len(galaxyai.response_content.all()) > 0:
             galaxyai.new_chat_button.wait_for_and_click()
         self._galaxyai_assert_chat_empty()
@@ -1673,11 +1676,15 @@ class NavigatesGalaxy(HasDriverProxy[WaitType]):
         galaxyai.loading.wait_for_absent_or_hidden()
         galaxyai.response_content.wait_for_visible()
 
-    @retry_during_transitions
     def _galaxyai_assert_chat_empty(self):
         galaxyai = self.components.galaxyai
-        assert len(galaxyai.query_cell.all()) == 0
-        assert len(galaxyai.response_content.all()) == 0
+        # A reset chat renders only the welcome notice, no query/response cells. Poll for that
+        # state instead of asserting counts once: under load the prior messages clear a beat
+        # after the new-chat click, and retry_during_transitions does not retry a bare
+        # AssertionError, so a count-based assert here could fire before the DOM settled.
+        galaxyai.welcome_message.wait_for_visible()
+        galaxyai.query_cell.wait_for_absent_or_hidden()
+        galaxyai.response_content.wait_for_absent_or_hidden()
 
     def navigate_to_dataset_error(self, hid):
         """Display a dataset and click the error tab."""

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -225,18 +225,14 @@ class ChatAPI:
                 # format so the router passes it as ``message_history`` rather than
                 # flattening into a text blob.
                 if exchange_id:
-                    db_history = await anyio.to_thread.run_sync(
-                        partial(self.chat_manager.get_chat_history, trans, exchange_id, format_for_pydantic_ai=True)
+                    # One fetch yields both the history and whether the previous turn asked a
+                    # clarifying question -- when it did, the router re-includes that turn so it
+                    # can route this (otherwise elliptical) answer instead of withholding history.
+                    db_history, responding_to_clarification = await anyio.to_thread.run_sync(
+                        partial(self.chat_manager.get_routing_history, trans, exchange_id)
                     )
-                    if db_history:
-                        full_context["conversation_history"] = db_history
-                    else:
-                        full_context["conversation_history"] = []
-                    # If the previous turn asked a clarifying question, the router includes
-                    # that turn so it can route this answer (otherwise history is withheld).
-                    full_context["responding_to_clarification"] = await anyio.to_thread.run_sync(
-                        partial(self.chat_manager.was_last_message_clarification, trans, exchange_id)
-                    )
+                    full_context["conversation_history"] = db_history or []
+                    full_context["responding_to_clarification"] = responding_to_clarification
                 else:
                     full_context["conversation_history"] = []
 

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -232,6 +232,11 @@ class ChatAPI:
                         full_context["conversation_history"] = db_history
                     else:
                         full_context["conversation_history"] = []
+                    # If the previous turn asked a clarifying question, the router includes
+                    # that turn so it can route this answer (otherwise history is withheld).
+                    full_context["responding_to_clarification"] = await anyio.to_thread.run_sync(
+                        partial(self.chat_manager.was_last_message_clarification, trans, exchange_id)
+                    )
                 else:
                     full_context["conversation_history"] = []
 

--- a/test/evals/datasets/__init__.py
+++ b/test/evals/datasets/__init__.py
@@ -6,6 +6,7 @@ from .orchestrator_planning import orchestrator_planning_dataset
 from .router_tool_use import router_tool_use_dataset
 from .routing import routing_dataset
 from .routing_ambiguous import routing_ambiguous_dataset
+from .routing_clarification_followup import routing_clarification_followup_dataset
 from .routing_depth import (
     build_history,
     routing_depth_dataset,
@@ -20,6 +21,7 @@ __all__ = [
     "orchestrator_planning_dataset",
     "router_tool_use_dataset",
     "routing_ambiguous_dataset",
+    "routing_clarification_followup_dataset",
     "routing_dataset",
     "routing_depth_dataset",
     "staining_quantification_dataset",

--- a/test/evals/datasets/__init__.py
+++ b/test/evals/datasets/__init__.py
@@ -5,15 +5,23 @@ from .error_analysis import error_analysis_dataset
 from .orchestrator_planning import orchestrator_planning_dataset
 from .router_tool_use import router_tool_use_dataset
 from .routing import routing_dataset
+from .routing_ambiguous import routing_ambiguous_dataset
+from .routing_depth import (
+    build_history,
+    routing_depth_dataset,
+)
 from .staining_quantification import staining_quantification_dataset
 from .tool_recommendation import tool_recommendation_dataset
 
 __all__ = [
     "bioinformatics_workflows_dataset",
+    "build_history",
     "error_analysis_dataset",
     "orchestrator_planning_dataset",
     "router_tool_use_dataset",
+    "routing_ambiguous_dataset",
     "routing_dataset",
+    "routing_depth_dataset",
     "staining_quantification_dataset",
     "tool_recommendation_dataset",
 ]

--- a/test/evals/datasets/routing_ambiguous.py
+++ b/test/evals/datasets/routing_ambiguous.py
@@ -1,0 +1,53 @@
+"""Routing-ambiguous dataset: genuinely underspecified single-turn queries where the
+RIGHT move is to ask a clarifying question, not guess.
+
+Pairs with the routing fix to test "ask-when-uncertain" (idea 3). Each case is a vague
+message a real user might send ("Can you help with my data?", "It keeps failing", "I need
+help with variant calling") whose correct route is ``clarification`` -- a confident route
+to a specialist or a direct answer would be a guess.
+
+The point of this dataset is CALIBRATION: it only means something alongside the clear
+datasets (routing / routing_depth). A good router asks here (high) while still routing the
+clear cases without over-asking (low false-ask). Scored by HandoffMatch against the
+router's ``agent_type`` ("clarification" when it calls ask_for_clarification).
+
+Scenarios are generated data in ``routing_ambiguous_scenarios.json``.
+"""
+
+import json
+from pathlib import Path
+from typing import (
+    Any,
+    Optional,
+)
+
+from pydantic_evals import (
+    Case,
+    Dataset,
+)
+
+_SCENARIOS_PATH = Path(__file__).parent / "routing_ambiguous_scenarios.json"
+
+
+def _load_scenarios() -> list[dict[str, Any]]:
+    return json.loads(_SCENARIOS_PATH.read_text())
+
+
+def routing_ambiguous_dataset(
+    only: Optional[list[str]] = None,
+) -> Dataset[str, str, dict[str, Any]]:
+    """Build the ambiguous-routing Dataset: (vague query, expected="clarification")."""
+    cases: list[Case[str, str, dict[str, Any]]] = []
+    for scenario in _load_scenarios():
+        cases.append(
+            Case(
+                name=scenario["name"],
+                inputs=scenario["query"],
+                expected_output=scenario["expected"],
+                metadata={"ambiguity_type": scenario.get("ambiguity_type", ""), "requires_galaxy": False},
+            )
+        )
+    if only:
+        wanted = set(only)
+        cases = [c for c in cases if c.name in wanted]
+    return Dataset(name="routing_ambiguous", cases=cases)

--- a/test/evals/datasets/routing_ambiguous_scenarios.json
+++ b/test/evals/datasets/routing_ambiguous_scenarios.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "underspecified-goal-stuck-rnaseq-vague",
+    "ambiguity_type": "underspecified-goal",
+    "query": "Hey, I'm working on some RNA-seq stuff in Galaxy and I'm kind of stuck. Can you help?",
+    "expected": "clarification",
+    "good_clarifying_question": "Happy to help -- where in the RNA-seq process are you stuck: are you getting an error from a specific tool, unsure which tool to run next (e.g. alignment vs quantification vs DESeq2), or confused by a result you got?"
+  },
+  {
+    "name": "underspecified-goal-what-next",
+    "ambiguity_type": "underspecified-goal",
+    "query": "Okay, I uploaded my files. What should I do next?",
+    "expected": "clarification",
+    "good_clarifying_question": "Glad they're uploaded -- what kind of data are they (e.g. FASTQ reads, a VCF, a BAM, a tabular file) and what are you ultimately trying to produce, so I can point you to the right next step?"
+  },
+  {
+    "name": "underspecified-goal-make-it-work",
+    "ambiguity_type": "underspecified-goal",
+    "query": "Can someone just help me get this thing working? I've been at it all day and nothing's happening.",
+    "expected": "clarification",
+    "good_clarifying_question": "I'd like to help -- what specifically isn't working: a job that's stuck or failed, a workflow that won't start, an upload that won't finish, or something else? If there's a tool name or an error message, that would point me right at it."
+  },
+  {
+    "name": "vague-failure-no-details-history-red",
+    "ambiguity_type": "vague-failure-no-details",
+    "query": "Something's broken in my history, can you take a look?",
+    "expected": "clarification",
+    "good_clarifying_question": "Which dataset is the problem, and what state is it in -- red/errored, grey/queued, or green but with unexpected results? If it's a failed job, the dataset number or job id will help me dig into the error."
+  },
+  {
+    "name": "vague-failure-no-details-workflow-wont-run",
+    "ambiguity_type": "vague-failure-no-details",
+    "query": "My workflow won't run, what do I do?",
+    "expected": "clarification",
+    "good_clarifying_question": "When you try, does it fail to start (an error or missing-input message when you hit Run), or does it start and then a step turns red? The workflow name or invocation id plus any message you see would let me pinpoint it."
+  },
+  {
+    "name": "vague-failure-no-details-results-look-off",
+    "ambiguity_type": "vague-failure-no-details",
+    "query": "I ran my analysis and the results look totally off, something definitely went wrong.",
+    "expected": "clarification",
+    "good_clarifying_question": "What does 'off' look like concretely -- empty output, way more/fewer rows than expected, wrong coordinates, or a specific number that's wrong? And which tool produced it (name or dataset number)? That'll tell me whether it's a parameter/reference issue or an actual job error."
+  },
+  {
+    "name": "cross-specialist-intent-atac-seq",
+    "ambiguity_type": "cross-specialist-intent",
+    "query": "I'm working with ATAC-seq data in Galaxy and could use some help.",
+    "expected": "clarification",
+    "good_clarifying_question": "Happy to help with ATAC-seq -- are you looking to find the right tools, follow a step-by-step tutorial, get a failed step diagnosed, or interpret results you already have?"
+  },
+  {
+    "name": "cross-specialist-intent-variant-calling-stuck",
+    "ambiguity_type": "cross-specialist-intent",
+    "query": "I'm stuck on variant calling, can you help me out?",
+    "expected": "clarification",
+    "good_clarifying_question": "What's blocking you on variant calling -- a job that errored out, picking the right caller, running a specific tool, or figuring out the overall workflow?"
+  },
+  {
+    "name": "cross-specialist-intent-single-cell",
+    "ambiguity_type": "cross-specialist-intent",
+    "query": "Can you help me with single-cell RNA-seq?",
+    "expected": "clarification",
+    "good_clarifying_question": "For single-cell RNA-seq, do you want help choosing tools, a full tutorial to follow, running a specific tool, troubleshooting a failed step, or making sense of results you already have?"
+  },
+  {
+    "name": "referentless-followup-better-one",
+    "ambiguity_type": "referentless-followup",
+    "query": "is there a better one for this?",
+    "expected": "clarification",
+    "good_clarifying_question": "Happy to help find an alternative -- what are you looking to replace: a specific tool, a workflow, a reference genome, or something else, and for what kind of analysis?"
+  },
+  {
+    "name": "referentless-followup-redo-it",
+    "ambiguity_type": "referentless-followup",
+    "query": "can you just redo it, it came out wrong last time",
+    "expected": "clarification",
+    "good_clarifying_question": "Sure -- what would you like me to redo: a specific job or tool run, a workflow invocation, or an upload, and what went wrong with the previous result (an error, or unexpected output)?"
+  },
+  {
+    "name": "referentless-followup-other-approach",
+    "ambiguity_type": "referentless-followup",
+    "query": "what about the other approach instead?",
+    "expected": "clarification",
+    "good_clarifying_question": "Which two approaches are you weighing -- can you name the analysis (for example DESeq2 vs edgeR, or reference-based vs de novo assembly) so I know what the alternative is?"
+  },
+  {
+    "name": "overbroad-scope-rnaseq-end-to-end",
+    "ambiguity_type": "overbroad-scope",
+    "query": "Can you handle my RNA-seq data for me from start to finish?",
+    "expected": "clarification",
+    "good_clarifying_question": "Happy to help -- where do you want to start: raw read QC/trimming, alignment to a reference, count quantification, or differential expression? And do you have a reference genome/organism and your sample groups in mind?"
+  },
+  {
+    "name": "overbroad-scope-analyze-my-genome",
+    "ambiguity_type": "overbroad-scope",
+    "query": "I just uploaded my sequencing data, analyze my genome.",
+    "expected": "clarification",
+    "good_clarifying_question": "What's the goal -- assembling a new genome, mapping reads and calling variants against a reference, or annotating an existing assembly? And what kind of reads did you upload (Illumina short reads or long reads)?"
+  },
+  {
+    "name": "overbroad-scope-do-everything-singlecell",
+    "ambiguity_type": "overbroad-scope",
+    "query": "Do everything for my single-cell dataset.",
+    "expected": "clarification",
+    "good_clarifying_question": "Where are you starting -- raw FASTQs that still need to be turned into a count matrix, or an existing matrix/AnnData ready for QC and clustering? And which downstream steps do you actually need (filtering, clustering, marker detection, annotation)?"
+  }
+]

--- a/test/evals/datasets/routing_clarification_followup.py
+++ b/test/evals/datasets/routing_clarification_followup.py
@@ -1,0 +1,63 @@
+"""Routing clarification-followup dataset: route the user's ANSWER to a clarifying question.
+
+The router withholds conversation history when routing (route-on-current-message). That
+collides with the ask-when-uncertain feature: the answer to "tool recommendation or a
+tutorial?" is elliptical ("the second one", "a tutorial") and routes on the fragment alone.
+The seam fix includes just the last turn (original request + the question we asked) when the
+previous turn was a clarification, so the answer routes correctly.
+
+Each case reconstructs that prior turn and provides the elliptical answer as the current
+message. The task sets ``responding_to_clarification=True``. Scored by HandoffMatch on the
+router's chosen ``agent_type`` against the gold specialist.
+
+Run with the flag OFF (plain ``make_router_multiturn_task``-style, no flag) vs ON to quantify
+the seam's value: without it, referential answers fall through to a direct router answer.
+
+Scenarios are generated data in ``routing_clarification_followup_scenarios.json``.
+"""
+
+import json
+from pathlib import Path
+from typing import (
+    Any,
+    Optional,
+)
+
+from pydantic_evals import (
+    Case,
+    Dataset,
+)
+
+_SCENARIOS_PATH = Path(__file__).parent / "routing_clarification_followup_scenarios.json"
+
+
+def _load_scenarios() -> list[dict[str, Any]]:
+    return json.loads(_SCENARIOS_PATH.read_text())
+
+
+def routing_clarification_followup_dataset(
+    only: Optional[list[str]] = None,
+) -> Dataset[dict[str, Any], str, dict[str, Any]]:
+    """Build the clarification-followup Dataset.
+
+    Case input is ``{"original_query", "clarification_question", "answer"}``; the task
+    reconstructs the prior turn into conversation_history and routes the answer.
+    """
+    cases: list[Case[dict[str, Any], str, dict[str, Any]]] = []
+    for scenario in _load_scenarios():
+        cases.append(
+            Case(
+                name=scenario["name"],
+                inputs={
+                    "original_query": scenario["original_query"],
+                    "clarification_question": scenario["clarification_question"],
+                    "answer": scenario["answer"],
+                },
+                expected_output=scenario["expected"],
+                metadata={"answer_kind": scenario.get("answer_kind", ""), "requires_galaxy": False},
+            )
+        )
+    if only:
+        wanted = set(only)
+        cases = [c for c in cases if c.name in wanted]
+    return Dataset(name="routing_clarification_followup", cases=cases)

--- a/test/evals/datasets/routing_clarification_followup_scenarios.json
+++ b/test/evals/datasets/routing_clarification_followup_scenarios.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "variant_calling_tutorial_second",
+    "original_query": "I need help with variant calling",
+    "clarification_question": "Do you want a tool recommendation or a tutorial?",
+    "answer": "the second one",
+    "expected": "gtn_training",
+    "answer_kind": "referential"
+  },
+  {
+    "name": "variant_calling_tool_first",
+    "original_query": "I need help with variant calling",
+    "clarification_question": "Do you want a tool recommendation or a tutorial?",
+    "answer": "the first one",
+    "expected": "tool_recommendation",
+    "answer_kind": "referential"
+  },
+  {
+    "name": "variant_calling_tutorial_named",
+    "original_query": "I need help with variant calling",
+    "clarification_question": "Do you want a tool recommendation or a tutorial?",
+    "answer": "a tutorial please",
+    "expected": "gtn_training",
+    "answer_kind": "named"
+  },
+  {
+    "name": "rnaseq_learn_how",
+    "original_query": "help me with RNA-seq analysis",
+    "clarification_question": "Are you looking to learn how to do it (a tutorial) or to find a specific tool?",
+    "answer": "learn how to do it",
+    "expected": "gtn_training",
+    "answer_kind": "named"
+  },
+  {
+    "name": "align_reads_tool",
+    "original_query": "I want to do something with my sequencing reads",
+    "clarification_question": "Do you want to align them (a tool recommendation) or learn the workflow (a tutorial)?",
+    "answer": "align them",
+    "expected": "tool_recommendation",
+    "answer_kind": "referential"
+  },
+  {
+    "name": "find_failed_job",
+    "original_query": "something went wrong with my analysis",
+    "clarification_question": "Do you want me to find the failed job in your history, or do you already have the error details to share?",
+    "answer": "find it for me",
+    "expected": "orchestrator",
+    "answer_kind": "referential"
+  },
+  {
+    "name": "error_paste_exit_code",
+    "original_query": "my tool isn't working",
+    "clarification_question": "Can you share the error message or exit code so I can diagnose it?",
+    "answer": "exit code 137, the job was killed",
+    "expected": "error_analysis",
+    "answer_kind": "named"
+  },
+  {
+    "name": "methods_section",
+    "original_query": "I need help writing up my history",
+    "clarification_question": "Do you want a summary, a methods section, or next-step suggestions?",
+    "answer": "the methods section",
+    "expected": "history",
+    "answer_kind": "named"
+  },
+  {
+    "name": "history_what_i_did",
+    "original_query": "tell me about my work",
+    "clarification_question": "Do you want a summary of what you did, or suggestions for what to do next?",
+    "answer": "what I did",
+    "expected": "history",
+    "answer_kind": "referential"
+  },
+  {
+    "name": "next_steps_suggestions",
+    "original_query": "I finished my alignment, now what",
+    "clarification_question": "Do you want next-step suggestions, or a tutorial on what usually comes next?",
+    "answer": "suggestions for what's next",
+    "expected": "next_step_advisor",
+    "answer_kind": "named"
+  },
+  {
+    "name": "custom_tool_wrap_it",
+    "original_query": "I have a command-line script",
+    "clarification_question": "Do you want to wrap it as a Galaxy tool, or find an existing tool that does the same thing?",
+    "answer": "wrap it as a tool",
+    "expected": "custom_tool",
+    "answer_kind": "named"
+  },
+  {
+    "name": "chipseq_tutorial",
+    "original_query": "I'm new to ChIP-seq",
+    "clarification_question": "Would you like a tutorial to learn it, or a tool recommendation to start right away?",
+    "answer": "tutorial",
+    "expected": "gtn_training",
+    "answer_kind": "named"
+  },
+  {
+    "name": "proteomics_tools",
+    "original_query": "I have mass spec data",
+    "clarification_question": "Do you want tool recommendations or a tutorial?",
+    "answer": "tools",
+    "expected": "tool_recommendation",
+    "answer_kind": "named"
+  },
+  {
+    "name": "assembly_first_option",
+    "original_query": "help me with genome assembly",
+    "clarification_question": "Do you want a tool recommendation or a tutorial?",
+    "answer": "the first option",
+    "expected": "tool_recommendation",
+    "answer_kind": "referential"
+  }
+]

--- a/test/evals/datasets/routing_depth.py
+++ b/test/evals/datasets/routing_depth.py
@@ -1,0 +1,72 @@
+"""Routing-depth A/B dataset: the SAME tool/workflow-recommendation query, asked fresh
+(turn 1) vs. deep in a conversation.
+
+This is the experiment that found the routing fix. The bug (from LIVE testing): a
+tool-discovery request that correctly routes to the tool_recommendation specialist on
+turn 1 gets answered DIRECTLY by the base router by turn 4-5 -- routing degrades as the
+conversation grows. Each case is a realistic multi-turn Galaxy analysis conversation
+(prior turns) plus a final query that should clearly route to tool_recommendation, run
+under two history representations applied by the task:
+
+- ``none``  -> turn-1 baseline (no history): does the query route correctly fresh?
+- ``prose`` -> deep conversation as flattened {role, content} text
+
+The fix routes on the current message (the router withholds history), so both should
+score near the turn-1 baseline. Scored by HandoffMatch on the router's ``agent_type``.
+
+Scenarios are generated data in ``routing_depth_scenarios.json``.
+"""
+
+import json
+from pathlib import Path
+from typing import (
+    Any,
+    Optional,
+)
+
+from pydantic_evals import (
+    Case,
+    Dataset,
+)
+
+_SCENARIOS_PATH = Path(__file__).parent / "routing_depth_scenarios.json"
+
+
+def build_history(history_turns: list[dict[str, str]], representation: str) -> list[Any]:
+    """Render prior turns as a conversation_history payload.
+
+    ``none`` -> empty history (turn-1 baseline); ``prose`` -> flattened {role, content} dicts.
+    """
+    if representation == "none":
+        return []
+    if representation == "prose":
+        history: list[dict[str, str]] = []
+        for turn in history_turns:
+            history.append({"role": "user", "content": turn["user"]})
+            history.append({"role": "assistant", "content": turn.get("assistant_answer") or turn.get("answer") or ""})
+        return history
+    raise ValueError(f"unknown history representation: {representation!r}")
+
+
+def _load_scenarios() -> list[dict[str, Any]]:
+    return json.loads(_SCENARIOS_PATH.read_text())
+
+
+def routing_depth_dataset(
+    only: Optional[list[str]] = None,
+) -> Dataset[dict[str, Any], str, dict[str, Any]]:
+    """Build the routing-depth Dataset. History representation is applied by the task."""
+    cases: list[Case[dict[str, Any], str, dict[str, Any]]] = []
+    for scenario in _load_scenarios():
+        cases.append(
+            Case(
+                name=scenario["name"],
+                inputs={"history_turns": scenario["prior_turns"], "query": scenario["final_query"]},
+                expected_output=scenario["expected"],
+                metadata={"domain": scenario.get("domain", ""), "requires_galaxy": False},
+            )
+        )
+    if only:
+        wanted = set(only)
+        cases = [c for c in cases if c.name in wanted]
+    return Dataset(name="routing_depth", cases=cases)

--- a/test/evals/datasets/routing_depth_scenarios.json
+++ b/test/evals/datasets/routing_depth_scenarios.json
@@ -1,0 +1,426 @@
+[
+  {
+    "name": "rnaseq-align-then-deg-tool",
+    "domain": "RNA-seq differential expression",
+    "prior_turns": [
+      {
+        "user": "I've got paired-end Illumina FASTQ files from a mouse RNA-seq experiment. What tool should I use to align the reads to the genome?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For spliced alignment of RNA-seq reads against the mouse reference (mm10/mm39), HISAT2 and STAR are the two standard choices in Galaxy. HISAT2 is fast and memory-efficient, which makes it a good default; STAR tends to give slightly better junction sensitivity at the cost of more RAM. Both are available in the Galaxy Tool Shed and output sorted BAM files you can feed straight into counting."
+      },
+      {
+        "user": "My HISAT2 job stayed grey for a long time then turned red. The stderr mentions it couldn't find the genome index. What happened?",
+        "route": "error_analysis",
+        "assistant_answer": "That red state with a missing-index error usually means HISAT2 was pointed at a built-in reference that isn't installed on this server, or the custom index dataset in your history was deleted or in an error state. Check that the 'Source for the reference genome' is set correctly: if you selected a built-in genome, pick one actually listed in the dropdown; if you're using a history dataset, make sure that FASTA finished uploading green before you run. Re-running with a valid index should clear it."
+      },
+      {
+        "user": "Okay it ran. Now I have BAM files and a GTF annotation. What tool should I use to get a per-gene count matrix?",
+        "route": "tool_recommendation",
+        "assistant_answer": "featureCounts (from the Subread package) is the most widely used tool in Galaxy for summarizing aligned reads into per-gene counts using your GTF. Set it to count at the gene level and make sure the strandedness setting matches your library prep, since getting that wrong dramatically lowers your counts. The alternative is htseq-count, which is also available but slower; featureCounts conveniently outputs a single combined matrix when you give it all your BAMs at once."
+      }
+    ],
+    "final_query": "What tool should I use to run the differential expression analysis on my featureCounts count matrix?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "rnaseq-qc-trim-deg-viz-tool",
+    "domain": "RNA-seq differential expression",
+    "prior_turns": [
+      {
+        "user": "How do I upload several FASTQ files at once into a single Galaxy history as a collection?",
+        "route": "router",
+        "assistant_answer": "Use the Upload Data dialog from the top of the tool panel, switch to the 'Collection' tab, and drag in or select all your FASTQ files. Set the collection type to 'List' for single-end or 'List of Pairs' for paired-end data, and Galaxy will let you auto-pair by filename pattern. Once built, the whole collection moves through downstream tools as one item, which keeps your history tidy when you have many samples."
+      },
+      {
+        "user": "What tool should I use to check the quality of these raw reads before I do anything else?",
+        "route": "tool_recommendation",
+        "assistant_answer": "FastQC is the standard per-sample quality report in Galaxy, giving you per-base quality, adapter content, and duplication plots. When you have many samples, run FastQC across the collection and then aggregate everything into one report with MultiQC, which summarizes all the FastQC outputs side by side. That combination is the usual first QC step before trimming."
+      },
+      {
+        "user": "FastQC flagged adapter contamination and low-quality tails. What tool should I use to trim the reads?",
+        "route": "tool_recommendation",
+        "assistant_answer": "Trimmomatic and Cutadapt are both excellent for adapter and quality trimming in Galaxy, and Trim Galore wraps Cutadapt with sensible RNA-seq defaults if you want something simpler. For Illumina adapter removal plus quality trimming of the 3' tails, Trimmomatic with the ILLUMINACLIP and SLIDINGWINDOW steps is a reliable choice. Re-run FastQC afterward to confirm the adapters are gone before alignment."
+      }
+    ],
+    "final_query": "After DESeq2 gives me my results table, is there a tool to make a volcano plot and heatmap of the differentially expressed genes?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "rnaseq-pseudoalign-deg-enrichment-tool",
+    "domain": "RNA-seq differential expression",
+    "prior_turns": [
+      {
+        "user": "I want to skip full genome alignment and quantify transcripts directly from my human RNA-seq reads. What tool should I use?",
+        "route": "tool_recommendation",
+        "assistant_answer": "Salmon and kallisto are the two pseudo-alignment quantifiers available in Galaxy that map reads against a transcriptome index instead of the genome, which is much faster than STAR or HISAT2. Salmon also models GC and sequence bias, so it's a popular default; you'll need a transcript FASTA (for example GENCODE) to build the index. Both produce per-transcript abundance estimates in TPM and estimated counts."
+      },
+      {
+        "user": "Where do I find the GENCODE human transcriptome to use as the Salmon reference?",
+        "route": "router",
+        "assistant_answer": "You can paste the GENCODE transcript FASTA URL directly into the Upload Data dialog using the 'Paste/Fetch data' field, and Galaxy will download it into your history. GENCODE hosts the transcript sequences on their website under the human release downloads, and the 'transcripts' FASTA is the one Salmon expects. Once it's green in your history, select it as the reference when you run Salmon."
+      },
+      {
+        "user": "Salmon gives me per-transcript abundances, but I need gene-level counts for differential expression. What tool should I use to summarize transcripts to genes?",
+        "route": "tool_recommendation",
+        "assistant_answer": "tximport is the standard tool in Galaxy for aggregating Salmon or kallisto transcript-level estimates up to gene-level counts, using a transcript-to-gene mapping table. It produces a count matrix that plugs directly into DESeq2 or edgeR while correctly handling the offset from average transcript length. You'll need a tx2gene file mapping transcript IDs to gene IDs, which you can derive from the GENCODE annotation."
+      }
+    ],
+    "final_query": "I have my list of significant DE genes from DESeq2. What tool should I use to run GO term and pathway enrichment analysis on them?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "varcall-germline-gatk-tool",
+    "domain": "variant calling (DNA-seq / WGS)",
+    "prior_turns": [
+      {
+        "user": "I just got paired-end Illumina WGS reads for a human sample. What tool should I use to align them to GRCh38?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For short-read WGS alignment against GRCh38, BWA-MEM2 is the standard choice on Galaxy and is what GATK best-practices pipelines assume; the older BWA-MEM tool is also available if you prefer. Both emit a BAM you can feed downstream, and you'll want to provide read group information (sample, library, platform) at the mapping step so later GATK tools behave correctly. After alignment, sort and index the BAM with Samtools before variant calling."
+      },
+      {
+        "user": "How do I set the read group fields when I run the mapper? I'm not sure what to put.",
+        "route": "router",
+        "assistant_answer": "In the BWA-MEM2 tool form, expand the read-group section and set ID to something unique per sequencing run, SM to your sample name (this is what GATK uses to label the sample in the VCF), LB to your library prep identifier, and PL to ILLUMINA. If you have one sample sequenced in one run, simple values like ID=rg1, SM=sample1, LB=lib1 are fine. These propagate into the BAM header and are required for the duplicate-marking and base-recalibration steps."
+      },
+      {
+        "user": "What tool should I use to mark PCR duplicates before calling variants?",
+        "route": "tool_recommendation",
+        "assistant_answer": "Use MarkDuplicates from the Picard suite, which is installed on most Galaxy servers and flags duplicate read pairs in your coordinate-sorted BAM without removing them by default. This is the standard pre-processing step in the GATK germline best-practices flow and feeds directly into base quality score recalibration. After MarkDuplicates, run Samtools index again so the marked BAM is ready for the recalibration and calling steps."
+      }
+    ],
+    "final_query": "Now that I have a recalibrated, duplicate-marked BAM, what tool should I use to call germline SNPs and indels from it?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "varcall-somatic-tumor-normal-workflow",
+    "domain": "variant calling (DNA-seq / WGS)",
+    "prior_turns": [
+      {
+        "user": "I'm doing a tumor/normal cancer WGS study. What tool should I use to align both the tumor and normal FASTQ files?",
+        "route": "tool_recommendation",
+        "assistant_answer": "BWA-MEM2 is the right aligner for both your tumor and normal short-read WGS samples against the reference genome, and you'd run it separately on each sample to produce two BAMs. Make sure the read groups carry distinct SM values (e.g. SM=tumor and SM=normal) so the downstream somatic caller can tell the two samples apart. Sort and index each BAM with Samtools afterward before any duplicate marking."
+      },
+      {
+        "user": "How do I upload these FASTQ files? They're sitting in a Zenodo record.",
+        "route": "router",
+        "assistant_answer": "Galaxy supports Zenodo as a file source, so you can pull the FASTQ files in directly rather than downloading them locally first. Configure a Zenodo connection under User Preferences -> File Sources using the Zenodo template, then in the upload dialog choose 'Choose remote files' and browse to your record to import the paired-end files into your history. From there they're regular datasets you can feed to the aligner."
+      },
+      {
+        "user": "What tool should I use to estimate cross-sample contamination before somatic calling?",
+        "route": "tool_recommendation",
+        "assistant_answer": "GATK's GetPileupSummaries followed by CalculateContamination is the standard pair for this, and both are available through the GATK4 tool wrappers on Galaxy. GetPileupSummaries tabulates allele counts at common germline variant sites and CalculateContamination turns that into a contamination fraction you pass to the somatic caller. This is recommended whenever you want Mutect2 to filter out artifacts driven by sample contamination."
+      }
+    ],
+    "final_query": "Is there an end-to-end IWC workflow for somatic variant calling from tumor/normal BAMs using Mutect2?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "varcall-bacterial-freebayes-tool",
+    "domain": "variant calling (DNA-seq / WGS)",
+    "prior_turns": [
+      {
+        "user": "I have bacterial isolate WGS reads and a reference assembly. What tool should I use to map the reads to the reference?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For bacterial short-read mapping to a reference, BWA-MEM works well and is widely available on Galaxy; Bowtie2 is an equally good alternative if you prefer its tuning options. Either produces a BAM you can sort and index with Samtools before variant calling. Given the small genome size these jobs run quickly, so you don't need to worry much about resource tuning here."
+      },
+      {
+        "user": "My mapping job failed with this in the stderr: '[E::bwa_idx_load_from_disk] fail to locate the index files' and a non-zero exit code. What went wrong?",
+        "route": "error_analysis",
+        "assistant_answer": "That error means BWA couldn't find a built index for the reference you pointed it at -- it's trying to load .amb/.ann/.bwt/.pac/.sa files that don't exist for that dataset. This usually happens when the reference was selected as a plain FASTA history dataset but indexing didn't run, or a built-in index reference was mis-selected. Re-run the tool making sure you choose 'Use a genome from history and build index' with your FASTA, or pick a properly built-in reference, and the index will be generated before mapping."
+      },
+      {
+        "user": "After I get a sorted BAM, what tool should I use to check the mapping quality and coverage depth?",
+        "route": "tool_recommendation",
+        "assistant_answer": "Samtools flagstat gives you a quick summary of mapped/properly-paired read counts, and Samtools depth or the Qualimap BamQC tool will report per-base coverage depth across the reference. Qualimap in particular produces a nice HTML report with coverage histograms and mapping-quality distributions that's handy for QC on a bacterial genome. All three are commonly installed and take your sorted, indexed BAM directly."
+      }
+    ],
+    "final_query": "What's the best tool to call SNPs and small indels from my bacterial sorted BAM against the reference?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "chip-tf-peak-annotation",
+    "domain": "ChIP-seq / ATAC-seq peak analysis",
+    "prior_turns": [
+      {
+        "user": "I've got paired-end ChIP-seq FASTQ files for a CTCF pulldown in mouse. What should I use to align them to mm10?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For aligning ChIP-seq reads to a reference genome, BWA-MEM is the standard choice and is well-suited to short reads from a CTCF pulldown. Bowtie2 is the other widely-used aligner for ChIP-seq and tends to be preferred when you want fine control over end-to-end vs local alignment. Both are installed on most Galaxy servers under the mapping tools; point either at the mm10 built-in index and feed in your paired-end reads. After alignment you'll typically filter the BAM for properly-paired, high-MAPQ reads before peak calling."
+      },
+      {
+        "user": "How do I tell which mm10 reference build is actually available in the alignment tool's dropdown?",
+        "route": "router",
+        "assistant_answer": "In the tool form, the reference genome dropdown is populated from the genomes your Galaxy admin has installed as built-in indexes, so you can just open the BWA-MEM or Bowtie2 form and scroll the 'Using reference genome' selector to see if mm10 is listed. If mm10 isn't there, you can switch the source to 'history' and supply your own FASTA, or ask your admin to install the cached mm10 index. The dropdown labels usually show both the dbkey (mm10) and a human-readable name."
+      },
+      {
+        "user": "Now that I have a filtered BAM, what tool should I use to call the CTCF binding peaks?",
+        "route": "tool_recommendation",
+        "assistant_answer": "MACS2 (callpeak) is the go-to peak caller for transcription-factor ChIP-seq like CTCF -- run it in narrow-peak mode since CTCF gives sharp, punctate binding sites rather than broad domains. Provide your ChIP BAM as the treatment and, ideally, an input/IgG control BAM to model background. Set the genome size to 'mm' for mouse and keep the default q-value cutoff of 0.05 to start. The main output is a narrowPeak BED file plus summit coordinates you can carry forward to annotation."
+      }
+    ],
+    "final_query": "What's the best tool to annotate these CTCF narrowPeak regions with the nearest genes and genomic features?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "atac-nucleosome-footprint-workflow",
+    "domain": "ChIP-seq / ATAC-seq peak analysis",
+    "prior_turns": [
+      {
+        "user": "I'm starting an ATAC-seq experiment on human PBMCs. Which tool should I use to trim the Nextera adapters off my paired-end reads?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For ATAC-seq adapter trimming, Trim Galore! is a solid default because it auto-detects and removes the Nextera/Tn5 adapters and does quality trimming in one pass. Cutadapt is the more configurable alternative if you want to specify the CTGTCTCTTATA Nextera sequence explicitly and tune the overlap/error settings. Either is available in Galaxy under the FASTQ QC/manipulation tools; run it in paired mode so both mates stay in sync. Run FastQC before and after to confirm the adapter content drops."
+      },
+      {
+        "user": "My Trim Galore job stayed gray and then went red after a few minutes -- the stderr just says 'cutadapt: error: No input files given'. What went wrong?",
+        "route": "error_analysis",
+        "assistant_answer": "That error means the underlying cutadapt call received no FASTQ input, which almost always traces back to an empty or mis-assigned input dataset rather than a code bug. Check that the dataset you selected in the form is actually a fastqsanger file in the 'ok' (green) state and not a failed upload or an empty collection element. If you ran it on a paired collection, make sure both the forward and reverse elements are populated -- a collection with zero elements produces exactly this 'no input files' message. Re-pick the input and rerun once the dataset is green."
+      },
+      {
+        "user": "After alignment with Bowtie2 I want to shift the Tn5 cut sites and call accessible regions. What tool should I use for ATAC-seq peak calling?",
+        "route": "tool_recommendation",
+        "assistant_answer": "MACS2 callpeak is the most common peak caller for ATAC-seq -- many pipelines run it with the --nomodel and --shift/--extsize options to account for the Tn5 9-bp offset and to center signal on the cut sites. Genrich is a strong ATAC-specific alternative that has a dedicated ATAC-seq mode (-j) which performs the Tn5 shift internally and can handle multiple replicates jointly. Both should be available in your Galaxy tool panel; for human data set the effective genome size to 'hs'. The output is a BED/narrowPeak set of accessible chromatin regions."
+      }
+    ],
+    "final_query": "Is there an end-to-end IWC workflow for ATAC-seq that goes from raw FASTQ through nucleosome footprinting and TF motif analysis?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "chip-broad-histone-diffbind",
+    "domain": "ChIP-seq / ATAC-seq peak analysis",
+    "prior_turns": [
+      {
+        "user": "I have H3K27me3 ChIP-seq across two conditions, three replicates each. After mapping, what tool should I use to call peaks for this broad histone mark?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For a broad repressive mark like H3K27me3 you want a peak caller tuned for diffuse domains rather than sharp summits. MACS2 callpeak in --broad mode works and is widely used, but SICER (or its epic2 reimplementation) was designed specifically for broad histone domains and often performs better on marks like H3K27me3 and H3K9me3. Run whichever you pick against matched input controls for each condition, and keep the per-replicate BAMs separate so you can assess reproducibility downstream. The output broadPeak/domain BED files become the input to differential binding analysis."
+      },
+      {
+        "user": "How do I group my six BAM datasets into a collection so the downstream tools treat the replicates together?",
+        "route": "router",
+        "assistant_answer": "Use the 'Create dataset collection' option from the history panel -- click the checkbox-select icon at the top of the history, tick your six BAMs, then choose 'Build Dataset List' (or 'Build List of Pairs' if you're keeping forward/reverse mates together). Give the collection a clear name and, if your tool expects condition grouping, you can build two lists (one per condition) or a nested list:list. Once built, the collection appears as a single selectable item in tool forms and the tool will map over each element automatically."
+      },
+      {
+        "user": "I want to quantify which H3K27me3 domains change between my two conditions across the replicates. What tool should I use for differential binding analysis?",
+        "route": "tool_recommendation",
+        "assistant_answer": "DiffBind is the standard tool for differential binding analysis of ChIP-seq across conditions and replicates -- it reads in your peak sets plus the aligned BAMs, builds a consensus peak/affinity matrix, and tests for differential occupancy. Under the hood it uses DESeq2 or edgeR for the statistics, so you get fold-changes and FDR-adjusted p-values per region. It's available in Galaxy and expects a sample sheet describing condition, replicate, peak file, and bam for each sample. The output is a ranked table of differentially-bound H3K27me3 domains plus diagnostic PCA and correlation plots."
+      }
+    ],
+    "final_query": "What tool should I use to compute a correlation matrix and PCA across all my ChIP-seq BAM coverage tracks for QC before differential binding?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "meta-16s-taxonomy-classifier-tool",
+    "domain": "metagenomics / 16S amplicon",
+    "prior_turns": [
+      {
+        "user": "I've got paired-end 16S rRNA amplicon reads (V3-V4 region) from an Illumina MiSeq run. They still have the primer sequences attached. What tool should I use to trim the primers off before processing?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For removing primer sequences from amplicon reads, Cutadapt is the standard choice in Galaxy. It lets you specify your forward and reverse primer sequences (for V3-V4 that's typically the 341F/805R pair) and trim them from the 5' ends of R1 and R2 respectively. If you only need fixed-length trimming you could use Trimmomatic or Trim Galore!, but for primer-aware removal Cutadapt is the right tool because it does adapter/primer matching rather than blind positional trimming."
+      },
+      {
+        "user": "Cutadapt worked. Now I want to denoise the reads into amplicon sequence variants instead of clustering into OTUs. Which tool does that?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For generating amplicon sequence variants (ASVs) rather than OTUs, DADA2 is the tool you want. In Galaxy the DADA2 suite walks you through quality filtering (dada2: filterAndTrim), learning the error model (dada2: learnErrors), the core denoising step (dada2: dada), merging pairs, and building the sequence table with chimera removal (dada2: removeBimeraDenovo). The whole QIIME2 ecosystem is also available if you prefer that wrapper, but the standalone DADA2 tools give you finer control over each step."
+      },
+      {
+        "user": "My DADA2 filterAndTrim job finished but almost all my reads were discarded -- the output shows only about 3% of reads passed. The reverse reads have low quality near the 3' end. What went wrong?",
+        "route": "error_analysis",
+        "assistant_answer": "This is almost always a truncation-length problem rather than a real failure. Your V3-V4 reverse reads degrade in quality toward the 3' end, and if your truncLen values are set too long, DADA2 keeps low-quality tails that fail the maxEE (expected errors) filter, so reads get thrown out. Inspect the quality profile plots, then shorten truncLenR (for example to ~200) while keeping enough overlap for merging -- your forward + reverse truncated lengths need to sum to more than the ~465 bp amplicon plus ~12 bp of overlap. Relaxing maxEE on the reverse read slightly can also help."
+      }
+    ],
+    "final_query": "Now that I have my ASV sequences, what tool should I use to assign taxonomy to them against SILVA or Greengenes?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "meta-shotgun-functional-profiling-tool",
+    "domain": "metagenomics / 16S amplicon",
+    "prior_turns": [
+      {
+        "user": "How do I upload a folder of gzipped fastq files for a whole-metagenome shotgun project? There are about 40 paired-end samples.",
+        "route": "router",
+        "assistant_answer": "For 40 paired-end samples the easiest route is the Upload dialog's 'Rule-based' tab, or better yet build a paired collection so each sample's R1/R2 stay linked. Click Upload Data, switch to 'Collection', choose 'List of Pairs', and drag in your gzipped fastqs -- Galaxy will auto-detect the _R1/_R2 (or _1/_2) naming and pair them. If the files are already on a remote server or in a data library, you can also paste a list of URLs or use the FTP import to avoid uploading through the browser."
+      },
+      {
+        "user": "Great, collection is built. Before profiling I want to remove human host contamination from these shotgun reads. What tool should I use for that?",
+        "route": "tool_recommendation",
+        "assistant_answer": "To strip human host reads from shotgun metagenomes, the usual approach in Galaxy is to map against the human reference with Bowtie2 and keep only the unmapped reads, then convert those back to fastq with Samtools fastx. There's also the dedicated 'Kraken2' + filtering path, but Bowtie2 against GRCh38 (or the masked hg38 host-removal index) is the most common decontamination step. If you want an all-in-one option, the BBMap/BBDuk tool can also do reference-based host filtering in a single step."
+      },
+      {
+        "user": "Host reads removed. Now I want taxonomic profiles of what organisms are present in each clean shotgun sample. Which tool is best for that?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For taxonomic profiling of shotgun metagenomes, MetaPhlAn is the standard marker-gene-based profiler and gives you relative abundances down to species/strain level. If instead you want k-mer-based classification of every read against a full database, Kraken2 (paired with Bracken for abundance re-estimation) is the other major option. MetaPhlAn tends to be cleaner for relative-abundance community profiles, while Kraken2 + Bracken gives per-read assignments and is better when you care about absolute read counts."
+      }
+    ],
+    "final_query": "Is there a Galaxy tool that will give me the functional and metabolic pathway abundances from these shotgun samples?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "meta-amplicon-diversity-viz-tool",
+    "domain": "metagenomics / 16S amplicon",
+    "prior_turns": [
+      {
+        "user": "I imported a QIIME2-style feature table and taxonomy from my 16S run. Why does my history show the .qza files as 'qza' datatype that nothing seems to accept as input?",
+        "route": "router",
+        "assistant_answer": "That's expected -- QIIME2 artifacts (.qza) and visualizations (.qzv) are their own Galaxy datatypes, and only the QIIME2 tool suite in Galaxy accepts them as inputs, so generic tools won't list them. Make sure the datatype was detected correctly (qza for artifacts, qzv for visualizations); if a file came in as plain 'binary' or 'zip', use Edit Attributes > Datatypes to set it to qza. From there the qiime2 tools in the tool panel will pick them up, and you can open any .qzv directly in the embedded QIIME2 viewer."
+      },
+      {
+        "user": "Got it. I want to build a phylogenetic tree from my representative ASV sequences so I can compute UniFrac distances. What tool should I use to make that tree?",
+        "route": "tool_recommendation",
+        "assistant_answer": "To build a phylogeny from your representative sequences, the standard QIIME2 path in Galaxy is the 'qiime phylogeny align-to-tree-mafft-fasttree' pipeline -- it does a MAFFT alignment, masks highly variable positions, and builds the tree with FastTree, producing the rooted tree UniFrac needs. If you're working outside QIIME2, you can run MAFFT to align the ASV sequences and then FastTree (or IQ-TREE / RAxML for a more rigorous maximum-likelihood tree) as separate steps. For UniFrac you specifically need the rooted tree output, so the align-to-tree-mafft-fasttree wrapper is the convenient one-shot choice."
+      },
+      {
+        "user": "Tree is built. Now which tool runs the core alpha- and beta-diversity metrics (Shannon, Faith's PD, weighted UniFrac) all at once?",
+        "route": "tool_recommendation",
+        "assistant_answer": "The tool you want is 'qiime diversity core-metrics-phylogenetic'. You give it your feature table, the rooted tree, your sample metadata, and a rarefaction sampling depth, and it computes the full panel in one go -- alpha metrics like Shannon and Faith's phylogenetic diversity, plus beta-diversity distance matrices including weighted and unweighted UniFrac, Jaccard, and Bray-Curtis, along with PCoA results and Emperor plots. If you'd rather not phylogenetically-weight anything you can use the plain 'core-metrics' instead, but since you built a tree, the phylogenetic version is the right pick."
+      }
+    ],
+    "final_query": "What tool should I use to test whether the beta-diversity differences between my treatment groups are statistically significant?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "scrna-doublet-detection-tool",
+    "domain": "single-cell RNA-seq",
+    "prior_turns": [
+      {
+        "user": "I've got 10x Genomics droplet single-cell data. What tool should I use to align the reads and generate a count matrix in Galaxy?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For 10x droplet data, the go-to tool on Galaxy is RNA STARsolo, which handles barcode demultiplexing, UMI deduplication, and alignment in one step to produce a cell-by-gene count matrix. An alternative is Salmon Alevin (via the alevin-fry / Alevin tools) if you prefer a lightweight pseudoalignment approach. STARsolo is the most common choice for 10x v2/v3 chemistry because it mirrors Cell Ranger's behavior closely while staying fully open."
+      },
+      {
+        "user": "How do I upload the R1 and R2 FASTQ files as a paired collection so STARsolo picks them up correctly?",
+        "route": "router",
+        "assistant_answer": "Use the Upload tool, switch to the Collection tab, and choose 'List of Pairs' as the collection type. Drop your R1/R2 FASTQs in, and Galaxy will pair them by the shared sample prefix; you can also use the 'Build List of Dataset Pairs' option in the history if the files are already uploaded. STARsolo's input expects the cDNA read (R2) and the barcode+UMI read (R1) in the right order, so double-check the pairing before you run it."
+      },
+      {
+        "user": "After STARsolo I loaded the matrix into an AnnData object and ran filtering. What tool should I use to normalize and find highly variable genes?",
+        "route": "tool_recommendation",
+        "assistant_answer": "The Scanpy suite in Galaxy covers this end-to-end. Use 'Scanpy NormaliseData' for library-size normalization plus log1p, then 'Scanpy FindVariableGenes' to flag highly variable genes before scaling and PCA. These operate directly on your AnnData (.h5ad) object so you can chain them together, and they map onto the standard scanpy.pp.normalize_total / highly_variable_genes calls."
+      },
+      {
+        "user": "My Scanpy RunPCA job failed with an error about the input not being scaled. Here's the traceback: ValueError: zero-centering a sparse array is not allowed.",
+        "route": "error_analysis",
+        "assistant_answer": "That error means PCA received a sparse matrix that wasn't scaled/densified first. Scanpy's ScaleData step zero-centers the data and converts it appropriately; running RunPCA before scaling leaves a sparse matrix that can't be zero-centered. Insert a 'Scanpy ScaleData' step (optionally with max_value=10 to clip) before RunPCA, and the matrix will be in the dense, centered form PCA expects."
+      }
+    ],
+    "final_query": "What tool should I use to detect and remove doublets from my single-cell AnnData object?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "scrna-trajectory-workflow",
+    "domain": "single-cell RNA-seq",
+    "prior_turns": [
+      {
+        "user": "I have a filtered cell-by-gene count matrix from scRNA-seq. Is there a tool to cluster the cells and assign them to groups?",
+        "route": "tool_recommendation",
+        "assistant_answer": "Yes -- on Galaxy the standard path is the Scanpy clustering tools. After PCA and 'Scanpy ComputeGraph' (neighbors), run 'Scanpy FindCluster' which wraps the Leiden and Louvain community-detection algorithms to partition cells into clusters. Leiden is the recommended default these days because it produces better-connected clusters than Louvain. The output annotates each cell with a cluster label in the AnnData obs table."
+      },
+      {
+        "user": "Can I rename my history so I can find this analysis again later?",
+        "route": "router",
+        "assistant_answer": "Yes -- click the history name at the top of the history panel (it says 'Unnamed history' by default) and type a new name, then press Enter. You can also add tags and an annotation from the history options menu (the pencil/edit icon) to make it easier to search for later. Renaming doesn't affect any datasets or jobs in the history."
+      },
+      {
+        "user": "Now I want to find marker genes that distinguish each cluster. What tool does that?",
+        "route": "tool_recommendation",
+        "assistant_answer": "Use 'Scanpy FindMarkers' (the rank_genes_groups wrapper) to compute differentially expressed marker genes for each cluster. It supports several statistical methods -- Wilcoxon rank-sum is the recommended default, with t-test and logistic regression also available. The output ranks genes per cluster so you can identify cell-type markers, and you can visualize them afterward with the Scanpy plotting tools (dotplot, heatmap, or violin)."
+      }
+    ],
+    "final_query": "Is there a workflow in Galaxy for inferring a single-cell pseudotime trajectory from my clustered AnnData?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "scrna-celltype-annotation-tool",
+    "domain": "single-cell RNA-seq",
+    "prior_turns": [
+      {
+        "user": "I'm processing 10x single-cell data and need to remove ambient RNA contamination before downstream analysis. What tool should I use for that?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For ambient RNA correction on Galaxy, SoupX is the established choice -- it estimates the contamination fraction from empty droplets and subtracts the background expression profile from each cell. DropletUtils is the complementary tool you'd use first to distinguish real cells from empty droplets (emptyDrops) when you're starting from the raw, unfiltered matrix. Run DropletUtils for cell calling, then SoupX for decontamination before normalization."
+      },
+      {
+        "user": "How do I share this history with a collaborator so they can see the decontaminated matrix?",
+        "route": "router",
+        "assistant_answer": "Open the history options menu and choose 'Share or Publish'. You can share privately by entering your collaborator's Galaxy email/username, which gives them read access without making it public, or generate a shareable link. They'll be able to import a copy into their own account; sharing is read-only, so your original history stays intact."
+      },
+      {
+        "user": "I want to integrate three samples and correct for batch effects between them. Is there a tool for batch integration of scRNA-seq data?",
+        "route": "tool_recommendation",
+        "assistant_answer": "Yes -- a few options are available on Galaxy. 'Scanpy BBKNN' (batch-balanced KNN) integrates batches at the neighbor-graph step and is fast for moderate dataset sizes. For stronger correction, Harmony (via the harmonypy integration in the Scanpy tools) adjusts the PCA embedding across batches, and Scanpy's built-in scanpy.pp.combat handles linear batch correction on the expression matrix. Harmony is the common recommendation when batch effects are pronounced."
+      }
+    ],
+    "final_query": "What's the best tool to automatically annotate cell types in my integrated single-cell AnnData object?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "assembly-bacterial-longread-polish-tool",
+    "domain": "genome assembly and annotation",
+    "prior_turns": [
+      {
+        "user": "I have Oxford Nanopore long reads for a bacterial isolate. What tool should I use to assemble them de novo?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For de novo assembly of bacterial Nanopore long reads, Flye is the standard choice on Galaxy -- it's designed for noisy long reads and handles bacterial genomes and plasmids well. If you also have Illumina short reads, Unicycler can produce a hybrid assembly that's often more accurate for bacteria. Both are installed here; Flye alone is a good starting point if you only have the Nanopore data."
+      },
+      {
+        "user": "How do I upload my FASTQ files? They're about 4 GB each.",
+        "route": "router",
+        "assistant_answer": "For files that large, don't use the basic browser upload. Open the Upload dialog and choose the 'Paste/Fetch data' tab to give Galaxy a direct URL, or better, use the FTP/Rule-based upload which is built for big files. If your reads are hosted somewhere with a URL, fetching by URL is the most reliable. You can also configure a remote file source under User Preferences -> File Sources and import directly from there."
+      },
+      {
+        "user": "Before assembling, what tool should I use to check the quality of the raw Nanopore reads?",
+        "route": "tool_recommendation",
+        "assistant_answer": "NanoPlot is the go-to QC tool for Nanopore reads -- it gives you read-length distributions, quality score plots, and yield summaries that are tailored to long reads. FastQC works too but it was built for short reads, so its per-base metrics are less meaningful here. After QC, you can trim adapters and filter by length/quality with Filtlong or Porechop before feeding reads to Flye."
+      },
+      {
+        "user": "My Flye job finished but the assembly graph shows the chromosome in several contigs instead of one. Is that a problem?",
+        "route": "router",
+        "assistant_answer": "Not necessarily a failure -- fragmentation usually means coverage was uneven or there were long repeats Flye couldn't resolve. Check the assembly_info.txt for coverage per contig; very low coverage on some contigs suggests you may need more reads or less aggressive length filtering. A few contigs is normal for a first pass and can often be improved with polishing and scaffolding rather than re-assembling."
+      }
+    ],
+    "final_query": "What tool should I use to polish my Flye assembly using the Nanopore reads?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "assembly-eukaryote-annotation-tool",
+    "domain": "genome assembly and annotation",
+    "prior_turns": [
+      {
+        "user": "I just finished a draft genome assembly of a fungal species. What tool should I use to assess how complete it is?",
+        "route": "tool_recommendation",
+        "assistant_answer": "BUSCO is the standard tool for assessing genome completeness -- it searches your assembly for a lineage-specific set of single-copy orthologs and reports how many are complete, fragmented, or missing. For a fungus, use the fungi_odb10 or a more specific lineage dataset. QUAST is a useful complement for contiguity stats like N50 and total length, so running both gives you a fuller picture of assembly quality."
+      },
+      {
+        "user": "How do I set the BUSCO lineage parameter? I don't see my exact species.",
+        "route": "router",
+        "assistant_answer": "You don't need an exact species match -- BUSCO lineages are clade-level. In the tool form, set the lineage mode to pick from the available ODB datasets and choose the closest clade above your organism (e.g. fungi_odb10, or ascomycota_odb10 if your species is an ascomycete). The narrower the lineage you can justify, the more informative the completeness score. Leave auto-lineage off if you already know the clade, since specifying it directly is faster."
+      },
+      {
+        "user": "Before annotation, what tool should I use to identify and mask the repetitive elements in the assembly?",
+        "route": "tool_recommendation",
+        "assistant_answer": "RepeatMasker is the classic choice for masking known repeats, and it pairs well with RepeatModeler, which builds a de novo repeat library from your assembly first. The usual flow is RepeatModeler to model species-specific repeats, then RepeatMasker using that custom library to soft-mask the genome. Soft-masking (lowercase) rather than hard-masking is what downstream gene predictors expect."
+      }
+    ],
+    "final_query": "Is there a tool I can use to predict protein-coding genes and annotate this masked fungal assembly?",
+    "expected": "tool_recommendation"
+  },
+  {
+    "name": "assembly-hybrid-scaffold-contamination-tool",
+    "domain": "genome assembly and annotation",
+    "prior_turns": [
+      {
+        "user": "I have both Illumina and PacBio HiFi reads for a plant genome. What tool should I use to build the assembly?",
+        "route": "tool_recommendation",
+        "assistant_answer": "For PacBio HiFi data, hifiasm is the leading assembler -- it's built specifically for accurate long reads and produces highly contiguous, often phased assemblies. Your Illumina reads are best used afterward for QC and base-level validation rather than as direct input to hifiasm. If you later add Hi-C data, hifiasm can use it for haplotype-resolved scaffolding, which is valuable for a heterozygous plant genome."
+      },
+      {
+        "user": "The hifiasm job failed almost immediately. Here's the end of the stderr: '[M::ha_analyze_count] failed to open the input file' and exit code 1.",
+        "route": "error_analysis",
+        "assistant_answer": "That error means hifiasm couldn't read the input file you pointed it at -- the path resolved but the file either isn't valid FASTQ/FASTA or is empty/corrupt. The most common cause is selecting a dataset that's still in a queued or error state, or accidentally passing a non-sequence dataset (like a stats file) as the reads input. Check that the input dataset is green/ok and is actually your HiFi FASTQ, then re-run; if it's a multi-file collection, make sure the collection elements are the reads themselves."
+      },
+      {
+        "user": "Assembly worked this time. What tool should I use to scaffold the contigs into chromosome-scale sequences with my Hi-C reads?",
+        "route": "tool_recommendation",
+        "assistant_answer": "YaHS is a fast, widely-used Hi-C scaffolder that takes your contigs plus a Hi-C alignment and joins them into chromosome-scale scaffolds. The typical pipeline aligns the Hi-C reads to the contigs first (with BWA-MEM or Chromap), then feeds those alignments to YaHS. SALSA2 is an older alternative that's also available, but YaHS is generally faster and more robust for large plant genomes."
+      }
+    ],
+    "final_query": "What tool should I use to screen the scaffolded assembly for contaminant and organellar sequences before I submit it?",
+    "expected": "tool_recommendation"
+  }
+]

--- a/test/evals/evaluators.py
+++ b/test/evals/evaluators.py
@@ -1,12 +1,21 @@
 """Custom pydantic-evals evaluators for Galaxy agents."""
 
 from dataclasses import dataclass
-from typing import Any
+from typing import (
+    Any,
+    Generic,
+    TypeVar,
+)
 
 from pydantic_evals.evaluators import (
     Evaluator,
     EvaluatorContext,
 )
+
+# Routing datasets vary in their case-input shape: a plain query string, or a dict for the
+# multi-turn cases. HandoffMatch ignores the input entirely (it only compares output to
+# expected), so it is generic over the input type and adapts to whichever dataset it scores.
+HandoffInputsT = TypeVar("HandoffInputsT")
 
 
 def _output_text(output: Any) -> str:
@@ -17,13 +26,10 @@ def _output_text(output: Any) -> str:
 
 
 @dataclass
-class HandoffMatch(Evaluator[Any, str, dict]):
-    """Score 1.0 if router's chosen agent_type matches expected, 0.0 otherwise.
+class HandoffMatch(Evaluator[HandoffInputsT, str, dict], Generic[HandoffInputsT]):
+    """Score 1.0 if router's chosen agent_type matches expected, 0.0 otherwise."""
 
-    Input type is ``Any`` so this works with both string-query datasets (routing) and
-    dict-input multi-turn datasets (routing_depth, routing_clarification_followup)."""
-
-    def evaluate(self, ctx: EvaluatorContext[Any, str, dict]) -> float:
+    def evaluate(self, ctx: EvaluatorContext[HandoffInputsT, str, dict]) -> float:
         return 1.0 if ctx.output == ctx.expected_output else 0.0
 
 

--- a/test/evals/evaluators.py
+++ b/test/evals/evaluators.py
@@ -17,10 +17,13 @@ def _output_text(output: Any) -> str:
 
 
 @dataclass
-class HandoffMatch(Evaluator[str, str, dict]):
-    """Score 1.0 if router's chosen agent_type matches expected, 0.0 otherwise."""
+class HandoffMatch(Evaluator[Any, str, dict]):
+    """Score 1.0 if router's chosen agent_type matches expected, 0.0 otherwise.
 
-    def evaluate(self, ctx: EvaluatorContext[str, str, dict]) -> float:
+    Input type is ``Any`` so this works with both string-query datasets (routing) and
+    dict-input multi-turn datasets (routing_depth, routing_clarification_followup)."""
+
+    def evaluate(self, ctx: EvaluatorContext[Any, str, dict]) -> float:
         return 1.0 if ctx.output == ctx.expected_output else 0.0
 
 

--- a/test/evals/specs.py
+++ b/test/evals/specs.py
@@ -22,7 +22,9 @@ from .datasets import (
     error_analysis_dataset,
     orchestrator_planning_dataset,
     router_tool_use_dataset,
+    routing_ambiguous_dataset,
     routing_dataset,
+    routing_depth_dataset,
     staining_quantification_dataset,
     tool_recommendation_dataset,
 )
@@ -38,6 +40,7 @@ from .tasks import (
     make_orchestrator_plan_task,
     make_router_content_task,
     make_router_inspect_task,
+    make_router_multiturn_task,
     make_router_task,
     make_tool_recommendation_task,
 )
@@ -60,6 +63,61 @@ def build_routing(
     usage_buffer: Optional[list[dict[str, int]]] = None,
 ) -> BuiltDataset:
     dataset = routing_dataset(include_galaxy_required=include_galaxy_required, only=only)
+    dataset.add_evaluator(HandoffMatch())
+    return BuiltDataset(
+        dataset=dataset,
+        task=make_router_task(deps, usage_buffer=usage_buffer),
+        primary_score="HandoffMatch",
+    )
+
+
+def _build_routing_depth(
+    deps: GalaxyAgentDependencies,
+    representation: str,
+    only: Optional[list[str]],
+    usage_buffer: Optional[list[dict[str, int]]],
+) -> BuiltDataset:
+    dataset = routing_depth_dataset(only=only)
+    dataset.add_evaluator(HandoffMatch())
+    return BuiltDataset(
+        dataset=dataset,
+        task=make_router_multiturn_task(deps, representation=representation, usage_buffer=usage_buffer),
+        primary_score="HandoffMatch",
+    )
+
+
+def build_routing_depth_turn1(
+    deps: GalaxyAgentDependencies,
+    judge_model: Optional[Model] = None,
+    only: Optional[list[str]] = None,
+    include_galaxy_required: bool = False,
+    usage_buffer: Optional[list[dict[str, int]]] = None,
+) -> BuiltDataset:
+    """Turn-1 baseline: the final query with no conversation history."""
+    return _build_routing_depth(deps, "none", only, usage_buffer)
+
+
+def build_routing_depth_prose(
+    deps: GalaxyAgentDependencies,
+    judge_model: Optional[Model] = None,
+    only: Optional[list[str]] = None,
+    include_galaxy_required: bool = False,
+    usage_buffer: Optional[list[dict[str, int]]] = None,
+) -> BuiltDataset:
+    """Deep conversation as flattened prose. The router routes on the current message, so
+    this should recover to ~the turn-1 baseline rather than degrading."""
+    return _build_routing_depth(deps, "prose", only, usage_buffer)
+
+
+def build_routing_ambiguous(
+    deps: GalaxyAgentDependencies,
+    judge_model: Optional[Model] = None,
+    only: Optional[list[str]] = None,
+    include_galaxy_required: bool = False,
+    usage_buffer: Optional[list[dict[str, int]]] = None,
+) -> BuiltDataset:
+    """Genuinely-ambiguous queries; expected route is "clarification" (ask, don't guess)."""
+    dataset = routing_ambiguous_dataset(only=only)
     dataset.add_evaluator(HandoffMatch())
     return BuiltDataset(
         dataset=dataset,
@@ -168,6 +226,9 @@ def build_orchestrator_planning(
 
 SPECS: dict[str, Callable[..., BuiltDataset]] = {
     "routing": build_routing,
+    "routing_depth_turn1": build_routing_depth_turn1,
+    "routing_depth_prose": build_routing_depth_prose,
+    "routing_ambiguous": build_routing_ambiguous,
     "error_analysis": build_error_analysis,
     "tool_recommendation": build_tool_recommendation,
     "router_tool_use": build_router_tool_use,

--- a/test/evals/specs.py
+++ b/test/evals/specs.py
@@ -10,7 +10,9 @@ from collections.abc import (
 from dataclasses import dataclass
 from typing import (
     Any,
+    Generic,
     Optional,
+    TypeVar,
 )
 
 from pydantic_ai.models import Model
@@ -47,17 +49,18 @@ from .tasks import (
     make_tool_recommendation_task,
 )
 
+# A case input is either a plain query string or, for the multi-turn datasets
+# (routing_depth, routing_clarification_followup), a dict. Parameterizing BuiltDataset on it
+# keeps the dataset and its task linked: a dict-input dataset must pair with a dict-input task.
+CaseInputsT = TypeVar("CaseInputsT")
+
 
 @dataclass
-class BuiltDataset:
-    """A dataset configured with evaluators and a task ready to evaluate.
+class BuiltDataset(Generic[CaseInputsT]):
+    """A dataset configured with evaluators and a task ready to evaluate."""
 
-    Input type is ``Any``: most datasets take a string query, but the multi-turn ones
-    (routing_depth, routing_clarification_followup) take a dict case input.
-    """
-
-    dataset: Dataset[Any, Any, dict[str, Any]]
-    task: Callable[..., Awaitable[Any]]
+    dataset: Dataset[CaseInputsT, Any, dict[str, Any]]
+    task: Callable[[CaseInputsT], Awaitable[Any]]
     primary_score: str  # name of the headline scorer for the summary table
 
 

--- a/test/evals/specs.py
+++ b/test/evals/specs.py
@@ -23,6 +23,7 @@ from .datasets import (
     orchestrator_planning_dataset,
     router_tool_use_dataset,
     routing_ambiguous_dataset,
+    routing_clarification_followup_dataset,
     routing_dataset,
     routing_depth_dataset,
     staining_quantification_dataset,
@@ -38,6 +39,7 @@ from .evaluators import (
 from .tasks import (
     make_error_analysis_task,
     make_orchestrator_plan_task,
+    make_router_clarification_task,
     make_router_content_task,
     make_router_inspect_task,
     make_router_multiturn_task,
@@ -124,6 +126,48 @@ def build_routing_ambiguous(
         task=make_router_task(deps, usage_buffer=usage_buffer),
         primary_score="HandoffMatch",
     )
+
+
+def _build_routing_clarification_followup(
+    deps: GalaxyAgentDependencies,
+    responding_to_clarification: bool,
+    only: Optional[list[str]],
+    usage_buffer: Optional[list[dict[str, int]]],
+) -> BuiltDataset:
+    dataset = routing_clarification_followup_dataset(only=only)
+    dataset.add_evaluator(HandoffMatch())
+    return BuiltDataset(
+        dataset=dataset,
+        task=make_router_clarification_task(
+            deps, responding_to_clarification=responding_to_clarification, usage_buffer=usage_buffer
+        ),
+        primary_score="HandoffMatch",
+    )
+
+
+def build_routing_clarification_followup(
+    deps: GalaxyAgentDependencies,
+    judge_model: Optional[Model] = None,
+    only: Optional[list[str]] = None,
+    include_galaxy_required: bool = False,
+    usage_buffer: Optional[list[dict[str, int]]] = None,
+) -> BuiltDataset:
+    """Route the answer to a clarifying question WITH the seam fix (the shipped behavior):
+    the router sees the prior turn, so "the second one" routes to the right specialist."""
+    return _build_routing_clarification_followup(deps, True, only, usage_buffer)
+
+
+def build_routing_clarification_followup_nofix(
+    deps: GalaxyAgentDependencies,
+    judge_model: Optional[Model] = None,
+    only: Optional[list[str]] = None,
+    include_galaxy_required: bool = False,
+    usage_buffer: Optional[list[dict[str, int]]] = None,
+) -> BuiltDataset:
+    """A/B control: route the same answers WITHOUT the seam (history withheld). The elliptical
+    answers have no referent, so this should score well below the fixed variant -- that gap is
+    the seam's value."""
+    return _build_routing_clarification_followup(deps, False, only, usage_buffer)
 
 
 def build_error_analysis(
@@ -229,6 +273,8 @@ SPECS: dict[str, Callable[..., BuiltDataset]] = {
     "routing_depth_turn1": build_routing_depth_turn1,
     "routing_depth_prose": build_routing_depth_prose,
     "routing_ambiguous": build_routing_ambiguous,
+    "routing_clarification_followup": build_routing_clarification_followup,
+    "routing_clarification_followup_nofix": build_routing_clarification_followup_nofix,
     "error_analysis": build_error_analysis,
     "tool_recommendation": build_tool_recommendation,
     "router_tool_use": build_router_tool_use,

--- a/test/evals/specs.py
+++ b/test/evals/specs.py
@@ -50,10 +50,14 @@ from .tasks import (
 
 @dataclass
 class BuiltDataset:
-    """A dataset configured with evaluators and a task ready to evaluate."""
+    """A dataset configured with evaluators and a task ready to evaluate.
 
-    dataset: Dataset[str, Any, dict[str, Any]]
-    task: Callable[[str], Awaitable[Any]]
+    Input type is ``Any``: most datasets take a string query, but the multi-turn ones
+    (routing_depth, routing_clarification_followup) take a dict case input.
+    """
+
+    dataset: Dataset[Any, Any, dict[str, Any]]
+    task: Callable[..., Awaitable[Any]]
     primary_score: str  # name of the headline scorer for the summary table
 
 

--- a/test/evals/tasks.py
+++ b/test/evals/tasks.py
@@ -195,6 +195,31 @@ def make_router_task(
     return router_task
 
 
+def make_router_multiturn_task(
+    deps: GalaxyAgentDependencies,
+    representation: str,
+    usage_buffer: UsageBuffer = None,
+) -> Callable[[dict], Awaitable[str]]:
+    """Build an async callable for the routing-depth dataset.
+
+    The case input is ``{"history_turns": [...], "query": str}``. Prior turns are rendered
+    into a conversation_history in the given ``representation`` ("none" or "prose") and
+    threaded into the router; returns the router's chosen agent_type. The shipped router
+    routes on the current message, so both representations should score near the turn-1
+    baseline -- which is the point the routing-depth eval demonstrates.
+    """
+    from .datasets import build_history
+
+    async def router_multiturn_task(case_input: dict) -> str:
+        history = build_history(case_input["history_turns"], representation)
+        router = QueryRouterAgent(deps)
+        response = await router.process(case_input["query"], context={"conversation_history": history})
+        _record_response_usage(usage_buffer, response)
+        return response.agent_type
+
+    return router_multiturn_task
+
+
 def make_router_content_task(
     deps: GalaxyAgentDependencies,
     context: Optional[dict] = None,

--- a/test/evals/tasks.py
+++ b/test/evals/tasks.py
@@ -30,6 +30,7 @@ from galaxy.agents.error_analysis import ErrorAnalysisAgent
 from galaxy.agents.registry import build_default_registry
 from galaxy.agents.router import QueryRouterAgent
 from galaxy.agents.tools import ToolRecommendationAgent
+from .datasets import build_history
 
 UsageBuffer = Optional[list[dict[str, int]]]
 
@@ -208,7 +209,6 @@ def make_router_multiturn_task(
     routes on the current message, so both representations should score near the turn-1
     baseline -- which is the point the routing-depth eval demonstrates.
     """
-    from .datasets import build_history
 
     async def router_multiturn_task(case_input: dict) -> str:
         history = build_history(case_input["history_turns"], representation)

--- a/test/evals/tasks.py
+++ b/test/evals/tasks.py
@@ -220,6 +220,40 @@ def make_router_multiturn_task(
     return router_multiturn_task
 
 
+def make_router_clarification_task(
+    deps: GalaxyAgentDependencies,
+    responding_to_clarification: bool = True,
+    usage_buffer: UsageBuffer = None,
+) -> Callable[[dict], Awaitable[str]]:
+    """Build an async callable for the clarification-followup dataset.
+
+    The case input is ``{"original_query", "clarification_question", "answer"}``.
+    Reconstructs the prior turn (the ambiguous request + the question the router asked) as
+    conversation_history and routes the elliptical ``answer``. With
+    ``responding_to_clarification=True`` the router includes that turn (the seam fix); with
+    ``False`` it withholds history as usual -- the A/B that quantifies the seam's value.
+    Returns the router's chosen agent_type.
+    """
+
+    async def router_clarification_task(case_input: dict) -> str:
+        history = [
+            {"role": "user", "content": case_input["original_query"]},
+            {"role": "assistant", "content": case_input["clarification_question"]},
+        ]
+        router = QueryRouterAgent(deps)
+        response = await router.process(
+            case_input["answer"],
+            context={
+                "conversation_history": history,
+                "responding_to_clarification": responding_to_clarification,
+            },
+        )
+        _record_response_usage(usage_buffer, response)
+        return response.agent_type
+
+    return router_clarification_task
+
+
 def make_router_content_task(
     deps: GalaxyAgentDependencies,
     context: Optional[dict] = None,

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -479,8 +479,11 @@ class TestAgentUnitMocked:
         )
 
     @pytest.mark.asyncio
-    async def test_router_passes_message_history_to_run(self):
-        """Router should hand the structured history to ``agent.run`` via ``message_history``."""
+    async def test_router_withholds_history_for_routing(self):
+        """Router routes on the current message, withholding conversation history from the
+        model. Feeding history dilutes the routing signal (evals show it degrades routing
+        monotonically), so ``message_history`` is not forwarded; specialists still get the
+        full history via the handoff context."""
         router = QueryRouterAgent(self.deps)
         history: list[ModelMessage] = [
             ModelRequest(parts=[UserPromptPart(content="What histories do I have?")]),
@@ -499,8 +502,8 @@ class TestAgentUnitMocked:
 
             mock_run.assert_called_once()
             args, kwargs = mock_run.call_args
-            assert kwargs["message_history"] == history
-            # The query itself should not have history pre-pended as a text blob
+            # Routing decision is made on the current message, not the accumulated history.
+            assert kwargs["message_history"] is None
             assert args[0] == "Tell me more about the second one"
 
     @pytest.mark.asyncio

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -507,6 +507,22 @@ class TestAgentUnitMocked:
             assert args[0] == "Tell me more about the second one"
 
     @pytest.mark.asyncio
+    async def test_router_asks_for_clarification(self):
+        """When the model calls ask_for_clarification, the router surfaces it as a
+        clarification turn (agent_type="clarification") rather than guessing a route."""
+        router = QueryRouterAgent(self.deps)
+
+        with mock.patch.object(router, "_run_with_retry") as mock_run:
+            mock_result = mock.Mock(spec=["output"])
+            mock_result.output = '{"__clarification__": true, "question": "Do you want a tool or a tutorial?"}'
+            mock_run.return_value = mock_result
+
+            response = await router.process("I need help with variant calling")
+
+            assert response.agent_type == "clarification"
+            assert response.content == "Do you want a tool or a tutorial?"
+
+    @pytest.mark.asyncio
     async def test_router_runs_without_history_for_fresh_conversation(self):
         router = QueryRouterAgent(self.deps)
 

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -538,6 +538,55 @@ class TestAgentUnitMocked:
             assert kwargs["message_history"] is None
 
     @pytest.mark.asyncio
+    async def test_router_includes_last_turn_when_responding_to_clarification(self):
+        """When the previous turn asked a clarifying question, the router includes just that
+        turn (the original request + the question) in routing context so an elliptical answer
+        like "the second one" can be routed -- a narrow exception to history-withholding."""
+        router = QueryRouterAgent(self.deps)
+        history: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="What histories do I have?")]),
+            ModelResponse(parts=[TextPart(content="You have 3.")]),
+            ModelRequest(parts=[UserPromptPart(content="I need help with variant calling")]),
+            ModelResponse(parts=[TextPart(content="Do you want a tool recommendation or a tutorial?")]),
+        ]
+
+        with mock.patch.object(router, "_run_with_retry") as mock_run:
+            mock_result = mock.Mock(spec=["output"])
+            mock_result.output = "Routed."
+            mock_run.return_value = mock_result
+
+            await router.process(
+                "the second one",
+                context={"conversation_history": history, "responding_to_clarification": True},
+            )
+
+            _, kwargs = mock_run.call_args
+            forwarded = kwargs["message_history"]
+            assert forwarded is not None
+            # Only the last turn (the clarification Q&A), not the whole conversation.
+            assert len(forwarded) == 2
+            assert forwarded[0].parts[0].content == "I need help with variant calling"
+
+    @pytest.mark.asyncio
+    async def test_router_clarification_carries_options(self):
+        """ask_for_clarification can offer short options; they ride along in metadata so the
+        client can render quick-reply buttons."""
+        router = QueryRouterAgent(self.deps)
+
+        with mock.patch.object(router, "_run_with_retry") as mock_run:
+            mock_result = mock.Mock(spec=["output"])
+            mock_result.output = (
+                '{"__clarification__": true, "question": "Tool or tutorial?", '
+                '"options": ["Tool recommendation", "Tutorial"]}'
+            )
+            mock_run.return_value = mock_result
+
+            response = await router.process("I need help with variant calling")
+
+            assert response.agent_type == "clarification"
+            assert response.metadata["options"] == ["Tool recommendation", "Tutorial"]
+
+    @pytest.mark.asyncio
     async def test_custom_tool_rejects_prompt_injection_query(self):
         self.mock_config.ai_model = "gpt-4o"
         agent = CustomToolAgent(self.deps)

--- a/test/unit/app/test_chat_manager.py
+++ b/test/unit/app/test_chat_manager.py
@@ -147,3 +147,71 @@ class TestGetUserChatHistoryExcludesPage:
         mgr.get_user_chat_history(trans, include_page_chats=True)
 
         trans.sa_session.execute.assert_called_once()
+
+
+class TestWasLastMessageClarification:
+    """The router emits agent_type='clarification' when it asks the user a question.
+    The next turn's answer needs that one turn of routing context, so the API surfaces
+    'was the last turn a clarification?' as a flag -- this is the detection helper."""
+
+    @staticmethod
+    def _exchange_with(*messages):
+        exchange = _FakeChatExchange()
+        for message in messages:
+            exchange.add_message(message if isinstance(message, str) else json.dumps(message))
+        return exchange
+
+    def test_true_when_last_response_is_clarification(self):
+        mgr = ChatManager()
+        trans = _make_trans()
+        exchange = self._exchange_with(
+            {"query": "help me", "agent_type": "auto", "agent_response": {"agent_type": "clarification"}},
+        )
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=exchange):
+            assert mgr.was_last_message_clarification(trans, 1) is True
+
+    def test_false_for_normal_last_message(self):
+        mgr = ChatManager()
+        trans = _make_trans()
+        exchange = self._exchange_with(
+            {"query": "align reads", "agent_response": {"agent_type": "tool_recommendation"}},
+        )
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=exchange):
+            assert mgr.was_last_message_clarification(trans, 1) is False
+
+    def test_only_the_last_message_counts(self):
+        mgr = ChatManager()
+        trans = _make_trans()
+        # Earlier clarification, last is normal -> False
+        stale = self._exchange_with(
+            {"agent_response": {"agent_type": "clarification"}},
+            {"agent_response": {"agent_type": "router"}},
+        )
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=stale):
+            assert mgr.was_last_message_clarification(trans, 1) is False
+        # Earlier normal, last is clarification -> True
+        fresh = self._exchange_with(
+            {"agent_response": {"agent_type": "router"}},
+            {"agent_response": {"agent_type": "clarification"}},
+        )
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=fresh):
+            assert mgr.was_last_message_clarification(trans, 1) is True
+
+    def test_false_when_no_exchange(self):
+        mgr = ChatManager()
+        trans = _make_trans()
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=None):
+            assert mgr.was_last_message_clarification(trans, 999) is False
+
+    def test_false_for_empty_messages(self):
+        mgr = ChatManager()
+        trans = _make_trans()
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=_FakeChatExchange()):
+            assert mgr.was_last_message_clarification(trans, 1) is False
+
+    def test_false_for_malformed_json(self):
+        mgr = ChatManager()
+        trans = _make_trans()
+        exchange = self._exchange_with("not valid json{{{")
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=exchange):
+            assert mgr.was_last_message_clarification(trans, 1) is False

--- a/test/unit/app/test_chat_manager.py
+++ b/test/unit/app/test_chat_manager.py
@@ -149,10 +149,10 @@ class TestGetUserChatHistoryExcludesPage:
         trans.sa_session.execute.assert_called_once()
 
 
-class TestWasLastMessageClarification:
-    """The router emits agent_type='clarification' when it asks the user a question.
-    The next turn's answer needs that one turn of routing context, so the API surfaces
-    'was the last turn a clarification?' as a flag -- this is the detection helper."""
+class TestGetRoutingHistory:
+    """get_routing_history returns the pydantic-ai history plus whether the last turn asked a
+    clarifying question -- both from one fetch. The router uses the flag to re-include that turn
+    when routing an otherwise-elliptical answer ("the second one")."""
 
     @staticmethod
     def _exchange_with(*messages):
@@ -161,23 +161,29 @@ class TestWasLastMessageClarification:
             exchange.add_message(message if isinstance(message, str) else json.dumps(message))
         return exchange
 
+    def _routing_history(self, mgr, trans, exchange):
+        with mock.patch.object(mgr, "get_exchange_by_id", return_value=exchange):
+            return mgr.get_routing_history(trans, 1)
+
     def test_true_when_last_response_is_clarification(self):
         mgr = ChatManager()
         trans = _make_trans()
         exchange = self._exchange_with(
-            {"query": "help me", "agent_type": "auto", "agent_response": {"agent_type": "clarification"}},
+            {"query": "help me", "response": "Tool or tutorial?", "agent_response": {"agent_type": "clarification"}},
         )
-        with mock.patch.object(mgr, "get_exchange_by_id", return_value=exchange):
-            assert mgr.was_last_message_clarification(trans, 1) is True
+        history, responding = self._routing_history(mgr, trans, exchange)
+        assert responding is True
+        # The turn is reconstructed for routing context (user query + assistant response).
+        assert len(history) == 2
 
     def test_false_for_normal_last_message(self):
         mgr = ChatManager()
         trans = _make_trans()
         exchange = self._exchange_with(
-            {"query": "align reads", "agent_response": {"agent_type": "tool_recommendation"}},
+            {"query": "align reads", "response": "Use BWA", "agent_response": {"agent_type": "tool_recommendation"}},
         )
-        with mock.patch.object(mgr, "get_exchange_by_id", return_value=exchange):
-            assert mgr.was_last_message_clarification(trans, 1) is False
+        _, responding = self._routing_history(mgr, trans, exchange)
+        assert responding is False
 
     def test_only_the_last_message_counts(self):
         mgr = ChatManager()
@@ -187,31 +193,29 @@ class TestWasLastMessageClarification:
             {"agent_response": {"agent_type": "clarification"}},
             {"agent_response": {"agent_type": "router"}},
         )
-        with mock.patch.object(mgr, "get_exchange_by_id", return_value=stale):
-            assert mgr.was_last_message_clarification(trans, 1) is False
+        assert self._routing_history(mgr, trans, stale)[1] is False
         # Earlier normal, last is clarification -> True
         fresh = self._exchange_with(
             {"agent_response": {"agent_type": "router"}},
             {"agent_response": {"agent_type": "clarification"}},
         )
-        with mock.patch.object(mgr, "get_exchange_by_id", return_value=fresh):
-            assert mgr.was_last_message_clarification(trans, 1) is True
+        assert self._routing_history(mgr, trans, fresh)[1] is True
 
-    def test_false_when_no_exchange(self):
+    def test_empty_when_no_exchange(self):
         mgr = ChatManager()
         trans = _make_trans()
         with mock.patch.object(mgr, "get_exchange_by_id", return_value=None):
-            assert mgr.was_last_message_clarification(trans, 999) is False
+            assert mgr.get_routing_history(trans, 999) == ([], False)
 
-    def test_false_for_empty_messages(self):
+    def test_empty_for_no_messages(self):
         mgr = ChatManager()
         trans = _make_trans()
         with mock.patch.object(mgr, "get_exchange_by_id", return_value=_FakeChatExchange()):
-            assert mgr.was_last_message_clarification(trans, 1) is False
+            assert mgr.get_routing_history(trans, 1) == ([], False)
 
-    def test_false_for_malformed_json(self):
+    def test_not_clarification_for_malformed_json(self):
         mgr = ChatManager()
         trans = _make_trans()
         exchange = self._exchange_with("not valid json{{{")
-        with mock.patch.object(mgr, "get_exchange_by_id", return_value=exchange):
-            assert mgr.was_last_message_clarification(trans, 1) is False
+        _, responding = self._routing_history(mgr, trans, exchange)
+        assert responding is False


### PR DESCRIPTION
## The problem

Testing GalaxyAI live, I noticed routing degraded the deeper into a conversation you got. A request that correctly handed off to the tool- or workflow-recommendation specialist on turn 1 would get answered directly by the base router -- often with a hallucinated answer -- by turn 4 or 5. Same sentence, different turn, wrong route.

## Root cause

It's the conversation history. I'd assumed the opposite at first and built a fix that fed the router *more* structured history -- evals showed it made routing *worse*. The accumulated turns dilute the routing signal and bias the model toward answering directly instead of handing off. The router doesn't need the history to decide where a message goes; the current message is enough, and the specialist it hands off to still receives the full conversation.

So the core fix is small: route on the current message (`ROUTING_HISTORY_TURNS = 0`), and keep passing the full `conversation_history` to specialists via the handoff context. On gpt-oss-120b this recovers deep-conversation routing from ~61% back to ~87%, matching the turn-1 baseline.

## Asking when uncertain

With routing decided per-message, I added the other half: when a request is genuinely too vague to route or answer -- "I need help with variant calling", "it keeps failing", "can you help with my data?" -- the router asks one concise clarifying question (optionally with a couple of short options) instead of guessing. It's calibrated not to over-ask: a confident route is always better than an unnecessary question.

## Closing the loop

Those two changes create a seam: routing on the current message alone breaks the *answer* to a clarifying question, because the answer is usually elliptical ("the second one", "a tutorial") and has no referent on its own. So when the previous turn was a clarification, the router includes just that one turn -- the original request plus the question it asked -- when routing the answer. A narrow, deliberate exception to the history-withholding rule. An A/B eval shows the gap: clarification answers route correctly 3/14 without it, ~11/14 with it.

On the client, a clarifying question now renders as a dedicated card with the options as quick-reply pills; clicking one sends it as the next message (and the seam above makes the terse reply route correctly). Clarification also gets its own icon/label instead of the generic robot.

## Evals

This landed alongside a small pydantic-evals harness so the behavior is measurable rather than vibes:
- `routing_depth` -- the turn-1-vs-deep A/B that found the fix
- `routing_ambiguous` -- calibration: does it ask on genuinely-vague queries without over-asking on clear ones?
- `routing_clarification_followup` -- can it route the answer to its own clarifying question?

## Notes

- The clarification seam is gated on a `responding_to_clarification` flag the API sets, so the default routing path is untouched.
- Quality numbers are gpt-oss-120b; the mechanisms are model-agnostic but realized quality is model-dependent (llama-4-scout is a weaker router and barely uses clarification).
