### PR TITLE
chore: make mulled more architecture agnostic

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -37,6 +37,7 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.commands import argv_to_str
+from .mulled_build import conda_platform
 from .util import (
     CondaInDockerContext,
     get_files_from_conda_package,
@@ -102,12 +103,14 @@ def get_run_test(file: str) -> Dict[str, Any]:
     return package_tests
 
 
-def get_anaconda_url(container, anaconda_channel="bioconda"):
+def get_anaconda_url(container, anaconda_channel="bioconda", conda_platform_str=None):
     """
     Download tarball from anaconda for test
     """
-    name = split_container_name(container)  # list consisting of [name, version, (build, if present)]
-    return f"https://anaconda.org/{anaconda_channel}/{name[0]}/{name[1]}/download/linux-64/{'-'.join(name)}.tar.bz2"
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
+    name = split_container_name(container)
+    return f"https://anaconda.org/{anaconda_channel}/{name[0]}/{name[1]}/download/{conda_platform_str}/{'-'.join(name)}.tar.bz2"
 
 
 def get_test_from_anaconda(url: str) -> Optional[Dict[str, Any]]:
@@ -128,11 +131,17 @@ def get_test_from_anaconda(url: str) -> Optional[Dict[str, Any]]:
 
 
 def find_anaconda_download_url(
-    name: str, version: str, build: Optional[str] = None, anaconda_channel: str = "bioconda"
+    name: str,
+    version: str,
+    build: Optional[str] = None,
+    anaconda_channel: str = "bioconda",
+    conda_platform_str: Optional[str] = None,
 ) -> Optional[str]:
     """
     Find the anaconda download url for a given package.
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     r = requests.get(
         f"https://api.anaconda.org/package/{anaconda_channel}/{name}/files",
         timeout=MULLED_SOCKET_TIMEOUT,
@@ -143,7 +152,7 @@ def find_anaconda_download_url(
         if (
             package_file["version"] == version
             and (build is None or package_file["attrs"]["build"] == build)
-            and package_file["attrs"]["subdir"] in ["linux-64", "noarch"]
+            and package_file["attrs"]["subdir"] in [conda_platform_str, "noarch"]
         ):
             return f"https:{package_file['download_url']}"
     return None
@@ -207,11 +216,17 @@ def try_a_func(func1, func2, param, container):
 
 
 def deep_test_search(
-    container, recipes_path=None, anaconda_channel="bioconda", github_repo="bioconda/bioconda-recipes"
+    container,
+    recipes_path=None,
+    anaconda_channel="bioconda",
+    github_repo="bioconda/bioconda-recipes",
+    conda_platform_str=None,
 ):
     """
     Look in bioconda-recipes repo as well as anaconda for the tests, checking in multiple possible locations. If no test is found for the specified version, search if other package versions have a test available.
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     name_tuple = split_container_name(container)
     assert len(name_tuple) in (2, 3)
     name = name_tuple[0]
@@ -237,7 +252,7 @@ def deep_test_search(
             container,
         ),
         (get_run_test, open_recipe_file, (f"recipes/{name}/run_test.sh", recipes_path, github_repo), container),
-        (get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel), container),
+        (get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel, conda_platform_str), container),
     ]:
         result = try_a_func(*f)
         if result:
@@ -257,7 +272,9 @@ def deep_test_search(
         if result:
             return result
 
-    url = find_anaconda_download_url(name, version, build=build, anaconda_channel=anaconda_channel)
+    url = find_anaconda_download_url(
+        name, version, build=build, anaconda_channel=anaconda_channel, conda_platform_str=conda_platform_str
+    )
     result = try_a_func(get_test_from_anaconda, lambda x: x, (url,), container)
     if result:
         return result
@@ -267,15 +284,24 @@ def deep_test_search(
 
 
 def main_test_search(
-    container, recipes_path=None, deep=False, anaconda_channel="bioconda", github_repo="bioconda/bioconda-recipes"
+    container,
+    recipes_path=None,
+    deep=False,
+    anaconda_channel="bioconda",
+    github_repo="bioconda/bioconda-recipes",
+    conda_platform_str=None,
 ):
     """
     Download tarball from anaconda for test
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     if deep:  # do a deep search
-        return deep_test_search(container, recipes_path, anaconda_channel, github_repo)
+        return deep_test_search(container, recipes_path, anaconda_channel, github_repo, conda_platform_str)
     # else shallow
-    result = try_a_func(get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel), container)
+    result = try_a_func(
+        get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel, conda_platform_str), container
+    )
     if result:
         return result
     return {"container": container}
@@ -291,11 +317,18 @@ def import_test_to_command_list(import_lang: str, import_: str) -> List[str]:
 
 
 def hashed_test_search(
-    container: str, recipes_path=None, deep=False, anaconda_channel="bioconda", github_repo="bioconda/bioconda-recipes"
+    container: str,
+    recipes_path=None,
+    deep=False,
+    anaconda_channel="bioconda",
+    github_repo="bioconda/bioconda-recipes",
+    conda_platform_str=None,
 ) -> Dict[str, Any]:
     """
     Get test for hashed containers
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     package_tests: Dict[str, Any] = {"commands": [], "imports": [], "container": container, "import_lang": "python -c"}
 
     response = requests.get(
@@ -314,8 +347,7 @@ def hashed_test_search(
     containers = []
     for package_name, package_version in packages:
         conda_target = CondaTarget(package_name, package_version)
-        # include only linux-64 builds since that is hardcoded in get_anaconda_url and the only target for container builds
-        hit, exact = best_search_result(conda_target, conda_context, platform="linux-64")
+        hit, exact = best_search_result(conda_target, conda_context, platform=conda_platform_str)
         if not hit or not exact:
             raise Exception(f"Could not find {conda_target}")
         build = hit["build"]
@@ -325,7 +357,7 @@ def hashed_test_search(
             containers.append(f"{package_name}:{package_version}")
 
     for container in containers:
-        tests = main_test_search(container, recipes_path, deep, anaconda_channel, github_repo)
+        tests = main_test_search(container, recipes_path, deep, anaconda_channel, github_repo, conda_platform_str)
         package_tests["commands"] += tests.get("commands", [])  # not a very nice solution but probably the simplest
         # Given that this could be a mix of Python and Perl packages, translate imports to commands
         for imp in tests.get("imports", []):

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -103,7 +103,7 @@ def get_run_test(file: str) -> Dict[str, Any]:
     return package_tests
 
 
-def get_anaconda_url(container, anaconda_channel="bioconda", conda_platform_str=None):
+def get_anaconda_url(container: str, anaconda_channel: str = "bioconda", conda_platform_str: Optional[str] = None) -> str:
     """
     Download tarball from anaconda for test
     """
@@ -216,12 +216,12 @@ def try_a_func(func1, func2, param, container):
 
 
 def deep_test_search(
-    container,
-    recipes_path=None,
-    anaconda_channel="bioconda",
-    github_repo="bioconda/bioconda-recipes",
-    conda_platform_str=None,
-):
+    container: str,
+    recipes_path: Optional[str] = None,
+    anaconda_channel: str = "bioconda",
+    github_repo: str = "bioconda/bioconda-recipes",
+    conda_platform_str: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Look in bioconda-recipes repo as well as anaconda for the tests, checking in multiple possible locations. If no test is found for the specified version, search if other package versions have a test available.
     """
@@ -284,13 +284,13 @@ def deep_test_search(
 
 
 def main_test_search(
-    container,
-    recipes_path=None,
-    deep=False,
-    anaconda_channel="bioconda",
-    github_repo="bioconda/bioconda-recipes",
-    conda_platform_str=None,
-):
+    container: str,
+    recipes_path: Optional[str] = None,
+    deep: bool = False,
+    anaconda_channel: str = "bioconda",
+    github_repo: str = "bioconda/bioconda-recipes",
+    conda_platform_str: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Download tarball from anaconda for test
     """
@@ -318,11 +318,11 @@ def import_test_to_command_list(import_lang: str, import_: str) -> List[str]:
 
 def hashed_test_search(
     container: str,
-    recipes_path=None,
-    deep=False,
-    anaconda_channel="bioconda",
-    github_repo="bioconda/bioconda-recipes",
-    conda_platform_str=None,
+    recipes_path: Optional[str] = None,
+    deep: bool = False,
+    anaconda_channel: str = "bioconda",
+    github_repo: str = "bioconda/bioconda-recipes",
+    conda_platform_str: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Get test for hashed containers

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -103,7 +103,9 @@ def get_run_test(file: str) -> Dict[str, Any]:
     return package_tests
 
 
-def get_anaconda_url(container: str, anaconda_channel: str = "bioconda", conda_platform_str: Optional[str] = None) -> str:
+def get_anaconda_url(
+    container: str, anaconda_channel: str = "bioconda", conda_platform_str: Optional[str] = None
+) -> str:
     """
     Download tarball from anaconda for test
     """

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -100,9 +100,9 @@ From: %(base_image)s
 
 
 def involucro_link():
-    repo = "https://github.com/involucro/involucro/releases/download"
+    url_start = f"https://github.com/involucro/involucro/releases/download/v{INVOLUCRO_VERSION}/"
     if IS_OS_X:
-        url = f"{repo}/v{INVOLUCRO_VERSION}/involucro.darwin"
+        url = f"{url_start}involucro.darwin"
     else:
         machine = _platform_module.machine()
         arch_map = {
@@ -113,7 +113,7 @@ def involucro_link():
             "armv7l": "involucro.linux-armv7",
         }
         asset = arch_map.get(machine, "involucro")
-        url = f"{repo}/v{INVOLUCRO_VERSION}/{asset}"
+        url = f"{url_start}{asset}"
     return url
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -177,12 +177,13 @@ def conda_versions(pkg_name, file_name):
 
 
 def conda_platform() -> str:
-    machine = _platform_module.machine()
+    machine = _platform_module.machine().lower()
     if IS_OS_X:
         conda_arch_map = {
             "x86_64": "osx-64",
             "arm64": "osx-arm64",
         }
+        default_platform = "osx-64"
     else:
         conda_arch_map = {
             "x86_64": "linux-64",
@@ -191,7 +192,8 @@ def conda_platform() -> str:
             "arm64": "linux-aarch64",
             "armv7l": "linux-armv7l",
         }
-    return conda_arch_map.get(machine, "linux-64")
+        default_platform = "linux-64"
+    return conda_arch_map.get(machine, default_platform)
 
 
 def get_conda_hits_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> List[Dict[str, Any]]:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -176,8 +176,27 @@ def conda_versions(pkg_name, file_name):
     return ret
 
 
+def _conda_platform() -> str:
+    machine = _platform_module.machine()
+    if IS_OS_X:
+        conda_arch_map = {
+            "x86_64": "osx-64",
+            "arm64": "osx-arm64",
+        }
+    else:
+        conda_arch_map = {
+            "x86_64": "linux-64",
+            "amd64": "linux-64",
+            "aarch64": "linux-aarch64",
+            "arm64": "linux-aarch64",
+            "armv7l": "linux-armv7l",
+        }
+    return conda_arch_map.get(machine, "linux-64")
+
+
 def get_conda_hits_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> List[Dict[str, Any]]:
-    search_results = (best_search_result(t, conda_context, platform="linux-64")[0] for t in targets)
+    platform = _conda_platform()
+    search_results = (best_search_result(t, conda_context, platform=platform)[0] for t in targets)
     return [r for r in search_results if r]
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -12,12 +12,12 @@ Build a mulled image with:
 import json
 import logging
 import os
+import platform as _platform_module
 import shutil
 import stat
 import string
 import subprocess
 import sys
-import platform as _platform_module
 from sys import platform as _platform
 from typing import (
     Any,
@@ -176,7 +176,7 @@ def conda_versions(pkg_name, file_name):
     return ret
 
 
-def _conda_platform() -> str:
+def conda_platform() -> str:
     machine = _platform_module.machine()
     if IS_OS_X:
         conda_arch_map = {
@@ -195,7 +195,7 @@ def _conda_platform() -> str:
 
 
 def get_conda_hits_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> List[Dict[str, Any]]:
-    platform = _conda_platform()
+    platform = conda_platform()
     search_results = (best_search_result(t, conda_context, platform=platform)[0] for t in targets)
     return [r for r in search_results if r]
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -17,6 +17,7 @@ import stat
 import string
 import subprocess
 import sys
+import platform as _platform_module
 from sys import platform as _platform
 from typing import (
     Any,
@@ -76,7 +77,7 @@ DEFAULT_REPOSITORY_TEMPLATE = "quay.io/${namespace}/${image}"
 DEFAULT_BINDS = ["build/dist:/usr/local/"]
 DEFAULT_WORKING_DIR = "/source/"
 IS_OS_X = _platform == "darwin"
-INVOLUCRO_VERSION = "1.1.2"
+INVOLUCRO_VERSION = "1.2.0"
 DEST_BASE_IMAGE = os.environ.get("DEST_BASE_IMAGE", None)
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker
@@ -99,10 +100,20 @@ From: %(base_image)s
 
 
 def involucro_link():
+    repo = "https://github.com/involucro/involucro/releases/download"
     if IS_OS_X:
-        url = f"https://github.com/mvdbeek/involucro/releases/download/v{INVOLUCRO_VERSION}/involucro.darwin"
+        url = f"{repo}/v{INVOLUCRO_VERSION}/involucro.darwin"
     else:
-        url = f"https://github.com/involucro/involucro/releases/download/v{INVOLUCRO_VERSION}/involucro"
+        machine = _platform_module.machine()
+        arch_map = {
+            "x86_64": "involucro.linux-amd64",
+            "amd64": "involucro.linux-amd64",
+            "aarch64": "involucro.linux-arm64",
+            "arm64": "involucro.linux-arm64",
+            "armv7l": "involucro.linux-armv7",
+        }
+        asset = arch_map.get(machine, "involucro")
+        url = f"{repo}/v{INVOLUCRO_VERSION}/{asset}"
     return url
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
@@ -19,7 +19,6 @@ See recent changes that would be built with:
 
 import os
 import subprocess
-import sys
 import time
 
 from galaxy.util import requests
@@ -28,6 +27,7 @@ from .mulled_build import (
     add_build_arguments,
     args_to_mull_targets_kwds,
     build_target,
+    conda_platform,
     conda_versions,
     get_affected_packages,
     mull_targets,
@@ -42,7 +42,7 @@ def _fetch_repo_data(args):
     repo_data = args.repo_data
     channel = args.channel
     if not os.path.exists(repo_data):
-        platform_tag = "osx-64" if sys.platform == "darwin" else "linux-64"
+        platform_tag = conda_platform()
         subprocess.check_call(
             [
                 "wget",

--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -1,5 +1,8 @@
 import os.path
-from unittest import SkipTest, mock
+from unittest import (
+    mock,
+    SkipTest,
+)
 
 from galaxy.tool_util.deps.mulled.get_tests import (
     deep_test_search,

--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -1,5 +1,5 @@
 import os.path
-from unittest import SkipTest
+from unittest import SkipTest, mock
 
 from galaxy.tool_util.deps.mulled.get_tests import (
     deep_test_search,
@@ -47,8 +47,14 @@ def test_get_run_test():
 
 
 def test_get_anaconda_url():
-    url = get_anaconda_url("samtools:1.7--1")
+    url = get_anaconda_url("samtools:1.7--1", conda_platform_str="linux-64")
     assert url == "https://anaconda.org/bioconda/samtools/1.7/download/linux-64/samtools-1.7-1.tar.bz2"
+
+
+def test_get_anaconda_url_delegates_to_conda_platform():
+    with mock.patch("galaxy.tool_util.deps.mulled.get_tests.conda_platform", return_value="linux-aarch64"):
+        url = get_anaconda_url("samtools:1.7--1")
+    assert url == "https://anaconda.org/bioconda/samtools/1.7/download/linux-aarch64/samtools-1.7-1.tar.bz2"
 
 
 @external_dependency_management

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -1,10 +1,12 @@
 import os.path
+from unittest import mock
 
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_build import (
     base_image_for_targets,
     build_target,
+    conda_platform,
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
     InvolucroContext,
@@ -54,3 +56,10 @@ def test_target_str_to_targets():
     targets = target_str_to_targets(target_str)
     assert (targets[0].package, targets[0].version, targets[0].build) == ("samtools", "1.3.1", "4")
     assert (targets[1].package, targets[1].version, targets[1].build) == ("bedtools", "2.22", None)
+
+
+@mock.patch("galaxy.tool_util.deps.mulled.mulled_build._platform_module.machine")
+def test_conda_platform_fallback_to_linux64(mock_machine):
+    mock_machine.return_value = "riscv64"
+    with mock.patch("galaxy.tool_util.deps.mulled.mulled_build.IS_OS_X", False):
+        assert conda_platform() == "linux-64"


### PR DESCRIPTION
## What
look up the actual architecture instead of hardcoding linux-64 (which is x86) or OSX everywhere. I updated involucro to have ARM support, which is why this contains an involucro version bump. 

## Why

bioconda-utils uses mulled-build to build its biocontainers. There is a demand for ARM biocontainers, mulled needs to become more architecture agnostic to support that. 
This PR also serves as a first step towards supporting some kind of platform argument in mulled so that containers for foreign architectures can be built regardless of the architecture of the host. 

querying the host architecture is a fallback if no architecture is provided, since when building for foreign architectures, we will override that. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
