### PR TITLE
MSP data type sniffer update and add the spectra counter in the history

### DIFF
--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -9,9 +9,11 @@ from typing import (
     Optional,
 )
 
+from galaxy import util
 from galaxy.datatypes import data
 from galaxy.datatypes.binary import Binary
 from galaxy.datatypes.data import Text
+from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.protocols import (
     DatasetHasHidProtocol,
     DatasetProtocol,
@@ -28,9 +30,6 @@ from galaxy.datatypes.tabular import (
 )
 from galaxy.datatypes.xml import GenericXml
 from galaxy.util import nice_size
-from galaxy import util
-from galaxy.datatypes.metadata import MetadataElement
-
 
 log = logging.getLogger(__name__)
 
@@ -1078,7 +1077,7 @@ class Msp(Text):
 
     def _count_spectra(self, path: str) -> int:
         count = 0
-        with open(path, 'r', encoding='utf-8') as handle:
+        with open(path, "r", encoding="utf-8") as handle:
             for line in handle:
                 stripped = line.strip()
                 lower_line = stripped.split(":", 1)[0].strip().lower()

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -1002,6 +1002,21 @@ class Msp(Text):
 
     file_ext = "msp"
 
+    identity_keys = frozenset(
+        {
+            "spectrum_id",
+            "accession",
+            "db#",
+            "spectrumid",
+            "title",
+            "record title",
+            "compound_name",
+            "ch$name",
+            "name",
+        }
+    )
+    num_peaks_keys = frozenset({"num_peaks", "pk$num_peak", "num peaks"})
+
     MetadataElement(
         name="spectra_count",
         default=0,
@@ -1013,6 +1028,7 @@ class Msp(Text):
 
     @staticmethod
     def next_line_starts_with(contents: IO, prefix: str) -> bool:
+        """Helper function to check if the next line starts with a given prefix."""
         next_line = contents.readline()
         return next_line is not None and next_line.startswith(prefix)
 
@@ -1020,28 +1036,37 @@ class Msp(Text):
         """Determines whether the file is a NIST MSP output file."""
         contents = file_prefix.string_io()
         in_block = False
+        has_identity = False
         has_num_peaks = False
 
         for line in contents:
-            lower_line = line.lower()
-            if lower_line.startswith("name:"):
-                if in_block and has_num_peaks:
+            stripped = line.strip()
+            if not stripped:
+                if in_block and has_identity and has_num_peaks:
                     return True
-                in_block = True
+                in_block = False
+                has_identity = False
                 has_num_peaks = False
                 continue
-            if in_block and lower_line.startswith("num peaks:"):
+            key = stripped.split(":", 1)[0].strip().lower()
+            if key in self.identity_keys:
+                in_block = True
+                has_identity = True
+                continue
+            if in_block and key in self.num_peaks_keys:
                 has_num_peaks = True
 
-        return in_block and has_num_peaks
-    
+        return in_block and has_identity and has_num_peaks
+
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
+        """Set the metadata elements."""
         super().set_meta(dataset=dataset, overwrite=overwrite, **kwd)
         if not dataset.has_data():
             return
         dataset.metadata.spectra_count = self._count_spectra(dataset.get_file_name())
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
+        """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.get_file_name())
             count = dataset.metadata.spectra_count
@@ -1053,10 +1078,11 @@ class Msp(Text):
 
     def _count_spectra(self, path: str) -> int:
         count = 0
-        with open(path) as handle:
+        with open(path, 'r', encoding='utf-8') as handle:
             for line in handle:
-                lower_line = line.lower()
-                if lower_line.startswith("num peaks:"):
+                stripped = line.strip()
+                lower_line = stripped.split(":", 1)[0].strip().lower()
+                if lower_line in self.num_peaks_keys:
                     count += 1
         return count
 

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -1077,7 +1077,7 @@ class Msp(Text):
 
     def _count_spectra(self, path: str) -> int:
         count = 0
-        with open(path, "r", encoding="utf-8") as handle:
+        with open(path, encoding="utf-8") as handle:
             for line in handle:
                 stripped = line.strip()
                 lower_line = stripped.split(":", 1)[0].strip().lower()

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -999,6 +999,15 @@ class Msp(Text):
 
     file_ext = "msp"
 
+    MetadataElement(
+        name="spectra_count",
+        default=0,
+        desc="Number of spectra",
+        readonly=True,
+        visible=True,
+        no_value=0,
+    )
+
     @staticmethod
     def next_line_starts_with(contents: IO, prefix: str) -> bool:
         next_line = contents.readline()
@@ -1022,7 +1031,31 @@ class Msp(Text):
                 has_num_peaks = True
 
         return in_block and has_num_peaks
+    
+    def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
+        super().set_meta(dataset=dataset, overwrite=overwrite, **kwd)
+        if not dataset.has_data():
+            return
+        dataset.metadata.spectra_count = self._count_spectra(dataset.get_file_name())
 
+    def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
+        if not dataset.dataset.purged:
+            dataset.peek = data.get_file_peek(dataset.get_file_name())
+            count = dataset.metadata.spectra_count
+            label = "spectrum" if count == 1 else "spectra"
+            dataset.blurb = f"{util.commaify(str(count))} {label}"
+        else:
+            dataset.peek = "file does not exist"
+            dataset.blurb = "file purged from disk"
+
+    def _count_spectra(self, path: str) -> int:
+        count = 0
+        with open(path, "rb") as handle:
+            for line in handle:
+                lower_line = line.lower()
+                if lower_line.startswith("num peaks:"):
+                    count += 1
+        return count
 
 class SPLibNoIndex(Text):
     """SPlib without index file"""

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -1006,13 +1006,22 @@ class Msp(Text):
 
     def sniff_prefix(self, file_prefix: FilePrefix) -> bool:
         """Determines whether the file is a NIST MSP output file."""
-        begin_contents = file_prefix.contents_header
-        if "\n" not in begin_contents:
-            return False
-        lines = begin_contents.splitlines()
-        if len(lines) < 2:
-            return False
-        return lines[0].startswith("Name:") and lines[1].startswith("MW:")
+        contents = file_prefix.string_io()
+        in_block = False
+        has_num_peaks = False
+
+        for line in contents:
+            lower_line = line.lower()
+            if lower_line.startswith("name:"):
+                if in_block and has_num_peaks:
+                    return True
+                in_block = True
+                has_num_peaks = False
+                continue
+            if in_block and lower_line.startswith("num peaks:"):
+                has_num_peaks = True
+
+        return in_block and has_num_peaks
 
 
 class SPLibNoIndex(Text):

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -28,6 +28,9 @@ from galaxy.datatypes.tabular import (
 )
 from galaxy.datatypes.xml import GenericXml
 from galaxy.util import nice_size
+from galaxy import util
+from galaxy.datatypes.metadata import MetadataElement
+
 
 log = logging.getLogger(__name__)
 
@@ -1050,12 +1053,13 @@ class Msp(Text):
 
     def _count_spectra(self, path: str) -> int:
         count = 0
-        with open(path, "rb") as handle:
+        with open(path) as handle:
             for line in handle:
                 lower_line = line.lower()
                 if lower_line.startswith("num peaks:"):
                     count += 1
         return count
+
 
 class SPLibNoIndex(Text):
     """SPlib without index file"""

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -32,6 +32,7 @@ from galaxy.datatypes.xml import GenericXml
 from galaxy.util import nice_size
 
 log = logging.getLogger(__name__)
+MAX_LINE_LEN = 100
 
 
 class Wiff(Binary):
@@ -1078,7 +1079,7 @@ class Msp(Text):
     def _count_spectra(self, path: str) -> int:
         count = 0
         with open(path, encoding="utf-8") as handle:
-            for line in handle:
+            for line in util.iter_start_of_line(handle, MAX_LINE_LEN):
                 stripped = line.strip()
                 lower_line = stripped.split(":", 1)[0].strip().lower()
                 if lower_line in self.num_peaks_keys:


### PR DESCRIPTION
## What changed:
Expanded MSP sniffing to accept multiple common identity keys plus Num Peaks within a record block, instead of relying on `Name:` and `MW:` only.
Added spectra_count metadata and populated it by counting `num peaks` records in the file.
Updated peek/blurb to show the spectra count.

## Why:
Support broader MSP variants and provide the number of spectra.
**Link the issue: https://github.com/galaxyproject/galaxy/issues/22777**

## Result Screenshot:
<img width="230" height="244" alt="image" src="https://github.com/user-attachments/assets/aa800071-8a97-4287-a334-4a0085853584" />

<img width="230" height="235" alt="image" src="https://github.com/user-attachments/assets/c298bbbc-7c26-4f19-b6c7-f30abab5cff1" />


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Prepare some example files
  https://github.com/matchms/matchms/tree/master/tests/testdata
  2. Upload the MSP datatype and check the history
  
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
