### PR TITLE
chore: configure project to work with ty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,8 +279,9 @@ package = false
 [tool.ty.environment]
 # Galaxy's sources live in lib/ (not the conventional ./ or ./src/) and the
 # project is not installed into the venv (uv `package = false`), so tools
-# need to be told where first-party modules are.
-root = ["lib"]
+# need to be told where first-party modules are. `test` is also a root so
+# relative imports in the test suite (e.g. `from ..util import ...`) resolve.
+root = ["lib", "test"]
 
 [tool.ty.src]
 include = ["lib", "test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,3 +275,16 @@ default-groups = []
 extra-index-url = ["https://wheels.galaxyproject.org/simple"]
 index-strategy = "unsafe-best-match"
 package = false
+
+[tool.ty.environment]
+# Galaxy's sources live in lib/ (not the conventional ./ or ./src/) and the
+# project is not installed into the venv (uv `package = false`), so tools
+# need to be told where first-party modules are.
+root = ["lib"]
+
+[tool.ty.src]
+include = ["lib", "test"]
+exclude = [
+    "lib/tool_shed/test/test_data/repos",
+    "test/functional/tools/cwl_tools",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,17 +275,3 @@ default-groups = []
 extra-index-url = ["https://wheels.galaxyproject.org/simple"]
 index-strategy = "unsafe-best-match"
 package = false
-
-[tool.ty.environment]
-# Galaxy's sources live in lib/ (not the conventional ./ or ./src/) and the
-# project is not installed into the venv (uv `package = false`), so tools
-# need to be told where first-party modules are. `test` is also a root so
-# relative imports in the test suite (e.g. `from ..util import ...`) resolve.
-root = ["lib", "test"]
-
-[tool.ty.src]
-include = ["lib", "test"]
-exclude = [
-    "lib/tool_shed/test/test_data/repos",
-    "test/functional/tools/cwl_tools",
-]

--- a/ty.toml
+++ b/ty.toml
@@ -1,0 +1,13 @@
+[environment]
+# Galaxy's sources live in lib/ (not the conventional ./ or ./src/) and the
+# project is not installed into the venv (uv `package = false`), so tools
+# need to be told where first-party modules are. `test` is also a root so
+# relative imports in the test suite (e.g. `from ..util import ...`) resolve.
+root = ["lib", "test"]
+
+[src]
+include = ["lib", "test"]
+exclude = [
+    "lib/tool_shed/test/test_data/repos",
+    "test/functional/tools/cwl_tools",
+]


### PR DESCRIPTION
What: Configure astral ty to use the lib/ and test/ root folders

Why: Ty was unable to resolve `galaxy. [...]` modules because they are located in non-standard locations. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open any IDE with ty as its Python LSP
  2. Marvel at the reduced error count

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
