### PR TITLE
[26.1] Relax legacy doi:-prefixed citation handling (#22795)

### DIFF
--- a/lib/galaxy/tool_util/linters/citations.py
+++ b/lib/galaxy/tool_util/linters/citations.py
@@ -6,7 +6,15 @@ of the tool publish results.
 
 from typing import TYPE_CHECKING
 
+from pydantic import ValidationError
+
 from galaxy.tool_util.lint import Linter
+from galaxy.tool_util.version import parse_version
+from galaxy.tool_util_models.tool_source import Citation
+
+# Profile at which invalid citations stop loading fatally rather than being
+# dropped; see galaxyproject/galaxy#22795.
+CITATION_FATAL_PROFILE = parse_version("26.1")
 
 if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
@@ -55,6 +63,53 @@ class CitationsFound(Linter):
 
         if citations is not None and len(citations) > 0:
             lint_ctx.valid(f"Found {len(citations)} citations.", linter=cls.name(), node=root)
+
+
+class CitationsInvalid(Linter):
+    """Surface citations that the ``Citation`` model would reject at tool load.
+
+    Reuses the same pydantic validation the parser uses so the linter reports
+    exactly what fails to load, plus the legacy ``doi:`` prefix that is accepted
+    but normalized. For tools targeting profile >= 26.1 these are errors (an
+    invalid citation prevents loading and the legacy prefix is no longer
+    tolerated); for older profiles they are warnings (the citation is dropped).
+    """
+
+    @classmethod
+    def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
+        tool_xml = getattr(tool_source, "xml_tree", None)
+        if not tool_xml:
+            return
+        citations = tool_xml.find("citations")
+        if citations is None:
+            return
+        report = (
+            lint_ctx.error if parse_version(tool_source.parse_profile()) >= CITATION_FATAL_PROFILE else lint_ctx.warn
+        )
+        for citation in citations:
+            content = (citation.text or "").strip()
+            if not content:
+                # Empty citations are reported by CitationsNoText.
+                continue
+            # An absent type routes to the model's content-shape check (a useful
+            # message) rather than failing on the required str field.
+            citation_type = citation.attrib.get("type") or ""
+            try:
+                parsed = Citation(type=citation_type, content=content)
+            except ValidationError as e:
+                report(
+                    f"Citation '{content}' is invalid and will not load for tools with profile >= 26.1 "
+                    f"(and is dropped for older profiles): {e.errors()[0]['msg']}",
+                    linter=cls.name(),
+                    node=citation,
+                )
+                continue
+            if parsed.content != content:
+                report(
+                    f"Citation '{content}' uses the legacy 'doi:' prefix; use the bare DOI '{parsed.content}' instead.",
+                    linter=cls.name(),
+                    node=citation,
+                )
 
 
 class CitationsNoValid(Linter):

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -739,8 +739,16 @@ class XmlToolSource(ToolSource):
         for citation_elem in citations_elem:
             try:
                 citation = parse_citation_elem(citation_elem)
-            except Exception:
-                if Version(self.parse_profile()) < Version("24.2"):
+            except Exception as e:
+                # Only fail to load fatally for tools targeting 26.1+. Older tools
+                # skip the offending citation, but log it so the drop is visible
+                # rather than silent.
+                if Version(self.parse_profile()) < Version("26.1"):
+                    log.warning(
+                        "Tool '%s' has an invalid citation that will be skipped: %s",
+                        self._source_path or self.parse_id(),
+                        e,
+                    )
                     continue
                 else:
                     raise

--- a/lib/galaxy/tool_util_models/tool_source.py
+++ b/lib/galaxy/tool_util_models/tool_source.py
@@ -150,6 +150,10 @@ class YamlTemplateConfigFile(TemplateConfigFile):
 
 # DOI: '10.<registrant>/<suffix>' per Crossref's published shape.
 DOI_RE = re.compile(r"^10\.\d{4,9}/.+$")
+# Legacy W3C/RFC form prefixes a bare DOI with 'doi:' (optionally with whitespace
+# after the colon). Tools written before 26.1 routinely used this form, so we
+# normalize it away to the bare DOI rather than rejecting it.
+DOI_PREFIX_RE = re.compile(r"^doi:\s*", re.IGNORECASE)
 # BibTeX entries open with '@<type>{' -- e.g. '@article{', '@inproceedings{'.
 BIBTEX_RE = re.compile(r"^@[a-zA-Z]+\s*\{", re.MULTILINE)
 
@@ -166,6 +170,12 @@ class Citation(ToolSourceBaseModel):
                 "dynamic_tool.citation_empty",
                 "citation content must not be empty",
             )
+        # Normalize the legacy 'doi:' prefix to a bare DOI so older tools load and
+        # so downstream DOI resolution (https://doi.org/<doi>) gets a clean value.
+        normalized = DOI_PREFIX_RE.sub("", content, count=1)
+        if normalized != content:
+            content = normalized
+            self.content = normalized
         citation_type = (self.type or "").strip().lower()
         if citation_type == "doi":
             if not DOI_RE.match(content):

--- a/test/unit/tool_util/doi_prefixed_citation.xml
+++ b/test/unit/tool_util/doi_prefixed_citation.xml
@@ -1,0 +1,17 @@
+<tool id="doi_prefixed_citation" name="doi_prefixed_citation" version="1.0.0" profile="24.2">
+    <command>
+        cat $input1 > $out_file1
+    </command>
+    <inputs>
+        <param name="input1" type="data" label="Concatenate Dataset"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="input" metadata_source="input1"/>
+    </outputs>
+    <!-- Legacy W3C/RFC 'doi:'-prefixed citation; see https://github.com/galaxyproject/galaxy/issues/22795 -->
+    <citations>
+        <citation type="doi">doi:10.1186/1471-2105-11-485</citation>
+    </citations>
+    <help>
+    </help>
+</tool>

--- a/test/unit/tool_util/invalid_citation_26.1.xml
+++ b/test/unit/tool_util/invalid_citation_26.1.xml
@@ -1,4 +1,4 @@
-<tool id="invalid_citation" name="invalid_citation" version="1.0.0" profile="24.2">
+<tool id="invalid_citation" name="invalid_citation" version="1.0.0" profile="26.1">
     <command>
         cat $input1 > $out_file1
     </command>

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -1060,7 +1060,7 @@ def test_old_invalid_citation_dont_cause_failure_to_load():
 
 
 def test_invalid_citation_not_allowed_in_modern_tools():
-    with as_file(resource_path(__name__, "invalid_citation_24.2.xml")) as tool_path:
+    with as_file(resource_path(__name__, "invalid_citation_26.1.xml")) as tool_path:
         tool_source = get_tool_source(tool_path)
     exc = None
     try:
@@ -1068,6 +1068,17 @@ def test_invalid_citation_not_allowed_in_modern_tools():
     except Exception as e:
         exc = e
     assert exc is not None
+
+
+def test_legacy_doi_prefix_citation_is_normalized():
+    # Legacy 'doi:'-prefixed citations load and are normalized to the bare DOI
+    # so downstream resolution (https://doi.org/<doi>) works (see issue #22795).
+    with as_file(resource_path(__name__, "doi_prefixed_citation.xml")) as tool_path:
+        tool_source = get_tool_source(tool_path)
+    citations = tool_source.parse_citations()
+    assert len(citations) == 1
+    assert citations[0].type == "doi"
+    assert citations[0].content == "10.1186/1471-2105-11-485"
 
 
 class TestToolProvidedMetadata2(FunctionalTestToolTestCase):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -62,7 +62,31 @@ CITATIONS_ERRORS = """
 CITATIONS_VALID = """
 <tool id="id" name="name">
     <citations>
-        <citation type="doi">DOI</citation>
+        <citation type="doi">10.1186/1471-2105-11-485</citation>
+    </citations>
+</tool>
+"""
+
+CITATIONS_LEGACY_DOI_PREFIX = """
+<tool id="id" name="name">
+    <citations>
+        <citation type="doi">doi:10.1186/1471-2105-11-485</citation>
+    </citations>
+</tool>
+"""
+
+CITATIONS_INVALID = """
+<tool id="id" name="name">
+    <citations>
+        <citation type="doi">not-a-doi</citation>
+    </citations>
+</tool>
+"""
+
+CITATIONS_LEGACY_DOI_PREFIX_MODERN = """
+<tool id="id" name="name" profile="26.1">
+    <citations>
+        <citation type="doi">doi:10.1186/1471-2105-11-485</citation>
     </citations>
 </tool>
 """
@@ -1208,7 +1232,36 @@ def test_citations_valid(lint_ctx):
     assert "Found 1 citations." in lint_ctx.valid_messages
     assert len(lint_ctx.valid_messages) == 1
     assert not lint_ctx.info_messages
+    assert not lint_ctx.warn_messages
     assert not lint_ctx.error_messages
+
+
+def test_citations_legacy_doi_prefix(lint_ctx):
+    tool_source = get_xml_tool_source(CITATIONS_LEGACY_DOI_PREFIX)
+    run_lint_module(lint_ctx, citations, tool_source)
+    assert lint_ctx.warn_messages == [
+        "Citation 'doi:10.1186/1471-2105-11-485' uses the legacy 'doi:' prefix; "
+        "use the bare DOI '10.1186/1471-2105-11-485' instead."
+    ]
+    assert not lint_ctx.error_messages
+
+
+def test_citations_invalid(lint_ctx):
+    tool_source = get_xml_tool_source(CITATIONS_INVALID)
+    run_lint_module(lint_ctx, citations, tool_source)
+    assert len(lint_ctx.warn_messages) == 1
+    assert "is invalid and will not load for tools with profile >= 26.1" in str(lint_ctx.warn_messages[0])
+    assert not lint_ctx.error_messages
+
+
+def test_citations_legacy_doi_prefix_error_on_modern_profile(lint_ctx):
+    tool_source = get_xml_tool_source(CITATIONS_LEGACY_DOI_PREFIX_MODERN)
+    run_lint_module(lint_ctx, citations, tool_source)
+    assert lint_ctx.error_messages == [
+        "Citation 'doi:10.1186/1471-2105-11-485' uses the legacy 'doi:' prefix; "
+        "use the bare DOI '10.1186/1471-2105-11-485' instead."
+    ]
+    assert not lint_ctx.warn_messages
 
 
 def test_command_multiple(lint_ctx):
@@ -2543,7 +2596,7 @@ def test_skip_by_module(lint_ctx):
 def test_list_linters():
     linter_names = Linter.list_listers()
     # make sure to add/remove a test for new/removed linters if this number changes
-    assert len(linter_names) == 146
+    assert len(linter_names) == 147
     assert "Linter" not in linter_names
     # make sure that linters from all modules are available
     for prefix in [

--- a/test/unit/tool_util/user_tool_source_validation_cases.yml
+++ b/test/unit/tool_util/user_tool_source_validation_cases.yml
@@ -182,6 +182,14 @@ cases:
         - {type: reference, content: 10.1234/abc.def}
     valid: true
 
+  - name: legacy_doi_prefix_citation_accepted
+    # Legacy W3C/RFC 'doi:'-prefixed DOIs are normalized to the bare DOI rather
+    # than rejected (see issue #22795).
+    doc:
+      citations:
+        - {type: doi, content: "doi:10.1186/1471-2105-11-485"}
+    valid: true
+
   - name: no_citations_accepted
     doc:
       citations: null


### PR DESCRIPTION
Fixes #22795 — a 26.1 regression where tools declaring `profile >= 24.2` with a legacy `doi:`-prefixed citation (e.g. `<citation type="doi">doi:10.1186/1471-2105-11-485</citation>`) fail to load fatally and are **silently dropped from the toolbox**.

### What happened

26.1 introduced a strict pydantic validator on citations (`Citation` in `tool_util_models/tool_source.py`) that checks `type="doi"` content against `^10\.\d{4,9}/.+$`. The legacy W3C/RFC `doi:` prefix fails that regex, raising a `ValidationError`. `XmlToolSource.parse_citations` re-raised for any `profile >= 24.2`, so the whole tool failed to parse and disappeared from the toolbox with no admin-visible warning.

Two `tools-iuc` tools (`abyss-pe`, `ena_upload`) vanished from 26.1 test runs; nine more were spared only by older profiles. Any privately-maintained tool upgraded to `profile >= 24.2` with a legacy DOI citation breaks on upgrade.

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Citation
  declared as DOI but 'doi:10.1186/1471-2105-11-485' does not match DOI shape (^10\.\d{4,9}/.+$)
```

### What this does

1. **Normalize the legacy prefix** — the shared `Citation` model now strips a leading `doi:` (case-insensitive, optional whitespace) and stores the bare DOI. This fixes loading for all sources (XML/YAML/user tools) **and** fixes downstream resolution: `DoiCitation` builds `https://doi.org/{content}`, which was previously producing a broken `https://doi.org/doi:10...`.

2. **Only fail fatally for `profile >= 26.1`** — older profiles now skip the offending citation and **log a warning** (tool path + reason) instead of silently dropping the entire tool. New tools (26.1+) still fail loudly, so the strict contract is preserved going forward.

3. **Add a linter** (`CitationsInvalid`) so tool authors are told about the problem instead of discovering it at load time — it was previously **not** a lint error. It reuses the same `Citation` model the parser uses (no duplicated regex), so it reports exactly what fails to load. Severity tracks the load behavior: **warning** for `profile < 26.1` (citation dropped), **error** for `profile >= 26.1` (prevents loading); the legacy `doi:` prefix is flagged as a deprecated form (error on 26.1+, warning otherwise).

### How to test the changes?
- [x] I've included appropriate automated tests.
  - `Citation` model: legacy `doi:` prefix normalized & accepted; malformed DOI/BibTeX still rejected (`user_tool_source_validation_cases.yml`).
  - `parse_citations`: `profile < 26.1` skips invalid citations; `profile >= 26.1` raises; legacy-prefix tool loads with normalized content (`test_parsing.py`).
  - Linter: warn vs. error by profile for legacy prefix and invalid citations (`test_tool_linters.py`).

### License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
