### PR TITLE
[26.1] Fix on_string containing redundant datasets

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -941,7 +941,11 @@ class DefaultToolAction(ToolAction):
 
         for input_name in inp_data:
             data = inp_data[input_name]
+            # Skip collection inputs and any suffixed dataset names derived from them (e.g., "datasets1", "datasets2")
             if input_name in inp_dataset_collections:
+                continue
+            # Also skip if the name starts with a collection input key and the remainder is a numeric suffix
+            if any(input_name.startswith(key) and input_name[len(key) :].isdigit() for key in inp_dataset_collections):
                 continue
             if getattr(data, "hid", None):
                 input_hids.append(data.hid)

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -51,6 +51,18 @@ TWO_OUTPUTS = """<tool id="test_tool" name="Test Tool">
 </tool>
 """
 
+# Tool with a multiple="true" data parameter – used to test on_string handling for collections.
+MULTIPLE_DATA_TOOL = """<tool id="test_tool" name="Test Tool" version="1.0" profile="26.1">
+    <command>cat "$param1" &lt; $out1</command>
+    <inputs>
+        <param type="data" format="tabular" name="param1" multiple="true" value="" />
+    </inputs>
+    <outputs>
+        <data name="out1" format="data" />
+    </outputs>
+</tool>
+"""
+
 
 def test_on_text_for_numeric_ids():
     def assert_on_text_is(expected, hids):
@@ -83,6 +95,27 @@ def test_on_text_for_dataset_and_collections():
 
 
 class TestDefaultToolAction(TestCase, tools_support.UsesTools):
+    def test_on_text_multiple_true_collection(self):
+        # Create a collection with three datasets
+        hdca = model.HistoryDatasetCollectionAssociation()
+        hdca.id = 999
+        hdca.hid = 55
+        collection = model.DatasetCollection()
+        hdca.collection = collection
+        # add three datasets to the collection
+        hda1 = self.__add_dataset()
+        hda2 = self.__add_dataset()
+        hda3 = self.__add_dataset()
+        model.DatasetCollectionElement(collection=collection, element=hda1)
+        model.DatasetCollectionElement(collection=collection, element=hda2)
+        model.DatasetCollectionElement(collection=collection, element=hda3)
+        collection.collection_type = "list"
+        self.history.dataset_collections.append(hdca)
+        # incoming param with the collection
+        incoming = {"param1": hdca}
+        job, output = self._simple_execute(contents=MULTIPLE_DATA_TOOL, incoming=incoming)
+        assert output["out1"].name == f"Test Tool on collection {hdca.hid}"
+
     def setUp(self):
         self.setup_app()
         history = model.History()


### PR DESCRIPTION
For parameters with `multiple="true"` collection input yields an `on_string` containing the collection as well as the datasets in the collection.

Fixes https://github.com/galaxyproject/galaxy/issues/22722

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
