### PR TITLE
[26.1] Fix BreadcrumbHeading imposing a minimum width on parent components

### DIFF
--- a/client/src/components/Common/BreadcrumbHeading.vue
+++ b/client/src/components/Common/BreadcrumbHeading.vue
@@ -48,7 +48,7 @@ function isPathActive(path: RawLocation): boolean {
                     </sup>
                 </template>
 
-                <template v-if="index < items.length - 1"> / </template>
+                <span v-if="index < items.length - 1" :key="'sep-' + index" class="breadcrumb-separator"> / </span>
             </template>
         </Heading>
 
@@ -62,11 +62,22 @@ function isPathActive(path: RawLocation): boolean {
 
     .breadcrumb-heading-header {
         flex-grow: 1;
+        min-width: 0;
+
+        :deep(.separator) {
+            grid-template-columns: 1rem 1fr 1rem;
+        }
+
+        :deep(h1) {
+            overflow: hidden;
+        }
 
         .breadcrumb-heading-header-active {
+            min-width: 0;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
+            flex-shrink: 1;
 
             &:hover {
                 cursor: pointer;
@@ -74,13 +85,18 @@ function isPathActive(path: RawLocation): boolean {
         }
 
         .breadcrumb-heading-header-inactive {
+            white-space: nowrap;
             flex-shrink: 0;
-            margin-left: auto;
+        }
+
+        .breadcrumb-separator {
+            flex-shrink: 0;
         }
 
         .breadcrumb-heading-header-beta {
             color: var(--color-grey-500);
             white-space: nowrap;
+            flex-shrink: 0;
         }
     }
 }


### PR DESCRIPTION
| Before | After |
| ---- | ---- |
| <img height="300" alt="firefox_nMaOVwMxYe" src="https://github.com/user-attachments/assets/29ff9750-8241-44e0-9e10-2810051312ea" /> | <img height="300" alt="firefox_GvHoD9E6ta" src="https://github.com/user-attachments/assets/4b8d5562-21ff-4097-8264-2026f6fa71a1" /> |

The heading's flex item lacked `min-width: 0`, which is the standard fix for preventing flex children from overflowing their container — without it, a flex item will not shrink below its content size regardless of available space. This caused BreadcrumbHeading to force a minimum width on any panel or layout it was placed in, breaking resizable split-panel views (e.g. the analysis layout) where users could drag the panel to a point where it would stop shrinking and instead overflow to the right.

The separator's internal CSS grid also used an `auto` track for the heading element, which sizes to max-content and bypasses the flex constraint. This is changed to a `1fr` track so the heading is bounded by the available space.

Individual breadcrumb link items now truncate with ellipsis independently as flex items (`min-width: 0`, `flex-shrink: 1`), while the final inactive segment (current page) never truncates (`flex-shrink: 0`). The `/` separator is wrapped in a `<span>` so it can be styled as a non-shrinking flex item.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
