### PR TITLE
[26.1] Add handler for URL source type in workflow card indicators

### DIFF
--- a/client/src/components/Workflow/List/useWorkflowCardIndicators.ts
+++ b/client/src/components/Workflow/List/useWorkflowCardIndicators.ts
@@ -85,6 +85,7 @@ export function useWorkflowCardIndicators(
             label: "",
             title: sourceTitle.value,
             icon: faFileImport,
+            handler: onCopyLink,
             visible: sourceType.value == "url",
         },
     ];


### PR DESCRIPTION
This PR fixes the copy URL to clipboard for the imported workflow from URL.
 
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Import a workflow using a URL
  2. Go to the Workflows list
  3. Click on the file indicator to copy the URL

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
