### PR TITLE
[26.0] Fix `FlexPanel` drag handle gets stuck when dragging over iframe

### DIFF
--- a/client/src/components/Panels/FlexPanel.vue
+++ b/client/src/components/Panels/FlexPanel.vue
@@ -100,7 +100,8 @@ defineExpose({
             :min="props.minWidth"
             :max="props.maxWidth"
             @positionChanged="(v) => (panelWidth = v)"
-            @visibilityChanged="(v) => (isHoveringDragHandle = v)"></DraggableSeparator>
+            @visibilityChanged="(v) => (isHoveringDragHandle = v)"
+            @dragging="(v) => (isDragging = v)" />
 
         <button
             v-if="props.collapsible"


### PR DESCRIPTION
We just needed to update the `isDragging` variable when the `DraggableSeparator` is being dragged. This ensures the `interaction-overlay` is in sync with the dragging operation.

Fixes https://github.com/galaxyproject/galaxy/issues/20349

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. When on the home page of the Galaxy server, try dragging either left or right side panels to resize them.
  2. Note that unlike in the past, the drag handle doesn't "stick" to the cursor.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
