### PR TITLE
Fix TypeError in regex validator for non-string values

### DIFF
--- a/lib/galaxy/tool_util_models/parameter_validators.py
+++ b/lib/galaxy/tool_util_models/parameter_validators.py
@@ -183,7 +183,7 @@ class RegexParameterValidatorModel(StaticValidatorModel):
         if not isinstance(value, list):
             value = [value]
         for val in value:
-            match = regex.match(expression, val or "")
+            match = regex.match(expression, str(val) if val else "")
             raise_error_if_validation_fails(match is not None, validator, value_to_show=val)
 
 

--- a/test/unit/app/tools/test_parameter_validation.py
+++ b/test/unit/app/tools/test_parameter_validation.py
@@ -141,6 +141,20 @@ class TestParameterValidation(BaseParameterTestCase):
             p.validate(["Fop", "foo"])
         p.validate(["Fop", "fop"])
 
+    def test_RegexValidator_non_string_value(self):
+        p = self._parameter_for(xml="""
+<param name="blah" type="integer" value="10">
+    <validator type="regex">[0-9]+</validator>
+</param>""")
+        p.validate(10)
+        with self.assertRaisesRegex(
+            ValueError, r"Parameter 'blah': Value '10' does not match regular expression '\[a-z\]\+'"
+        ):
+            self._parameter_for(xml="""
+<param name="blah" type="integer" value="10">
+    <validator type="regex">[a-z]+</validator>
+</param>""").validate(10)
+
     def test_LengthValidator(self):
         p = self._parameter_for(xml="""
 <param name="blah" type="text" value="foobar">


### PR DESCRIPTION
A regex `<validator>` crashes with `TypeError: expected string or buffer` when it receives a non-string value at runtime (for example an integer parameter value coming through a workflow), because `regex_validation` passes the raw value to `regex.match`. Coercing the value to a string first lets the validation fail (or pass) cleanly with the usual message instead of raising, matching the type-tolerant intent of the existing `val or ""` handling. Closes #22689.