### PR TITLE
[26.0] Fix client linting

### DIFF
--- a/client/src/entry/analysis/modules/Home.vue
+++ b/client/src/entry/analysis/modules/Home.vue
@@ -32,19 +32,6 @@ export default {
             required: true,
         },
     },
-    mounted() {
-        // Data source tools redirect back to the SPA after a server-side
-        // import; surface a toast and strip the param so a reload doesn't
-        // re-fire it.
-        if (this.query.notification === "tool-submitted") {
-            this.$nextTick(() => {
-                Toast.info("Check your history panel for progress.", "Data import queued");
-            });
-            const newQuery = { ...this.$route.query };
-            delete newQuery.notification;
-            this.$router.replace({ query: newQuery });
-        }
-    },
     computed: {
         isController() {
             return this.query.m_c && this.query.m_a;
@@ -92,6 +79,19 @@ export default {
                 simpleFormUseJobCache,
             };
         },
+    },
+    mounted() {
+        // Data source tools redirect back to the SPA after a server-side
+        // import; surface a toast and strip the param so a reload doesn't
+        // re-fire it.
+        if (this.query.notification === "tool-submitted") {
+            this.$nextTick(() => {
+                Toast.info("Check your history panel for progress.", "Data import queued");
+            });
+            const newQuery = { ...this.$route.query };
+            delete newQuery.notification;
+            this.$router.replace({ query: newQuery });
+        }
     },
 };
 </script>


### PR DESCRIPTION
Fix:

```
/home/runner/work/galaxy/galaxy/client/src/entry/analysis/modules/Home.vue
Warning:    1:1  warning  Component name "Home" should always be multi-word                          vue/multi-word-component-names
Error:   48:5  error    The "computed" property should be above the "mounted" property on line 35  vue/order-in-components
```

Broken in https://github.com/galaxyproject/galaxy/pull/22720 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
