### PR TITLE
[26.0] Fix ConnectedValue leak for omitted optional inputs inside groups

### DIFF
--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -228,6 +228,7 @@ def visit_input_values(
     payload = {
         "context": context,
         "no_replacement_value": no_replacement_value,
+        "replace_optional_connections": replace_optional_connections,
         "allow_case_inference": allow_case_inference,
         "unset_value": unset_value,
     }

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2215,6 +2215,12 @@ class DataToolParameter(BaseDataToolParameter):
                     ),
                 ):
                     rval.append(single_value)
+                elif single_value in (None, "None", ""):
+                    # An unset optional data input (e.g. connected to a multiple
+                    # data parameter) arrives as a null list element. Tolerate it
+                    # as "no dataset" the way to_python() filters it, rather than
+                    # treating null as a malformed id (regression from #22617).
+                    continue
                 else:
                     pk = _decode_dataset_id(single_value, trans.security, self.name)
                     rval.append(trans.sa_session.get(HistoryDatasetAssociation, pk))

--- a/lib/galaxy_test/workflow/optional_param_into_conditional.gxwf-tests.yml
+++ b/lib/galaxy_test/workflow/optional_param_into_conditional.gxwf-tests.yml
@@ -1,0 +1,12 @@
+- doc: |
+    Omitting the optional parameter_input connected to a conditional inner
+    parameter must use that parameter's own default ("p1used") and must NOT
+    leak a ConnectedValue sentinel into the command line.
+  job: {}
+  outputs:
+    out:
+      asserts:
+        has_text:
+          text: "p1used"
+        not_has_text:
+          text: "ConnectedValue"

--- a/lib/galaxy_test/workflow/optional_param_into_conditional.gxwf.yml
+++ b/lib/galaxy_test/workflow/optional_param_into_conditional.gxwf.yml
@@ -1,0 +1,21 @@
+class: GalaxyWorkflow
+doc: |
+  Reproduce galaxyproject/galaxy-skills PR #20: an omitted optional
+  parameter_input connected to a tool parameter that lives INSIDE a
+  conditional must not leak a ConnectedValue sentinel into the templated
+  command line; the tool parameter's own default should apply instead.
+inputs:
+  optional_text:
+    type: text
+    optional: true
+outputs:
+  out:
+    outputSource: boolean_conditional/out_file1
+steps:
+  boolean_conditional:
+    tool_id: boolean_conditional
+    state:
+      p1:
+        p1use: true
+        p1val:
+          $link: optional_text

--- a/test/unit/app/tools/test_data_parameters.py
+++ b/test/unit/app/tools/test_data_parameters.py
@@ -45,6 +45,16 @@ class TestDataToolParameter(BaseParameterTestCase):
         with pytest.raises(ParameterValueError, match="invalid dataset id"):
             self.param.from_json("not-an-id", self.trans)
 
+    def test_from_json_multi_tolerates_none(self):
+        # An unset optional data input connected to a multiple data parameter
+        # arrives as a null list element; it must be filtered out rather than
+        # rejected as a malformed id (regression from #22617, surfaced as a
+        # workflow run erroring on an unset optional data input).
+        self.multiple = True
+        self.optional = True
+        assert self.param.from_json([None], self.trans) == []
+        assert self.param.from_json(["None"], self.trans) == []
+
     def test_field_filter_on_types(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)
         hda2 = MockHistoryDatasetAssociation(name="hda2", id=2)


### PR DESCRIPTION
When an optional parameter_input is omitted from a workflow invocation and connected to a tool parameter nested inside a conditional/repeat/section, the unresolved ConnectedValue sentinel leaked into the templated command line, e.g. `-adapter_sequence '<galaxy.tools.parameters.workflow_utils.ConnectedValue object at 0x...>'`.

visit_input_values forwards a `payload` dict to its recursive calls for grouped inputs, but that payload omitted `replace_optional_connections`, so nested params fell back to the default `False` and the sentinel-replacement branch in callback_helper never ran for them. Propagate the flag through recursion so nested optional connections are resolved to the tool parameter's own default, preserving the not-provided/explicit-null distinction (top-level data params still receive None as before).

Add a framework workflow regression test that connects an omitted optional text parameter_input to a text param inside a conditional (boolean_conditional) and asserts the tool's own default is used with no ConnectedValue leak.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
