### PR TITLE
Fix collection state in history graph

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -13567,6 +13567,10 @@ export interface components {
             hid?: number | null;
             /** Id */
             id: string;
+            /** Job State Summary */
+            job_state_summary?: {
+                [key: string]: number;
+            } | null;
             /** Name */
             name?: string | null;
             /**

--- a/client/src/components/History/Content/model/states.ts
+++ b/client/src/components/History/Content/model/states.ts
@@ -203,13 +203,36 @@ export const HIERARCHICAL_COLLECTION_DATASET_STATES = [
     "discarded" as const,
 ] as const satisfies readonly DatasetState[];
 
+/** populated_state values that surface as a terminal collection display state. */
+export function stateFromPopulatedState(populatedState: string | null | undefined): State | null {
+    if (populatedState === "failed") {
+        return "failed_populated_state";
+    }
+    if (populatedState === "new") {
+        return "new_populated_state";
+    }
+    return null;
+}
+
+/** Highest-priority non-zero state from a job_state_summary, or null. */
+export function stateFromJobSummary(jobStateSummary: Record<string, number> | null | undefined): State | null {
+    if (!jobStateSummary) {
+        return null;
+    }
+    for (const jobState of HIERARCHICAL_COLLECTION_JOB_STATES) {
+        if ((jobStateSummary[jobState] ?? 0) > 0) {
+            return jobState;
+        }
+    }
+    return null;
+}
+
 export function getContentItemState(item: HistoryContentItem | HDADetailed | HDCADetailed): State {
     if (isHDCAItem(item) || isDCEWithCollection(item)) {
-        if ("populated_state" in item && item.populated_state === "failed") {
-            return "failed_populated_state";
-        }
-        if ("populated_state" in item && item.populated_state === "new") {
-            return "new_populated_state";
+        const hdca = item as HDCADetailed;
+        const popState = stateFromPopulatedState(hdca.populated_state);
+        if (popState) {
+            return popState;
         }
 
         // Check dataset states first (higher priority for actual data states)
@@ -228,14 +251,9 @@ export function getContentItemState(item: HistoryContentItem | HDADetailed | HDC
             }
         }
 
-        // Fall back to job states if no dataset states
-        if ("job_state_summary" in item && item.job_state_summary) {
-            const jobStateSummary = item.job_state_summary as Record<string, number>;
-            for (const jobState of HIERARCHICAL_COLLECTION_JOB_STATES) {
-                if ((jobStateSummary[jobState] || 0) > 0) {
-                    return jobState;
-                }
-            }
+        const jobState = stateFromJobSummary(hdca.job_state_summary);
+        if (jobState) {
+            return jobState;
         }
     } else if ("accessible" in item && item.accessible === false) {
         return "inaccessible";

--- a/client/src/components/History/Graph/historyGraphMapper.ts
+++ b/client/src/components/History/Graph/historyGraphMapper.ts
@@ -136,7 +136,7 @@ function resolveDisplayState(node: ApiGraphNode): string | null {
                 stateFromPopulatedState(node.state) ?? stateFromJobSummary(node.job_state_summary) ?? node.state ?? null
             );
         case "tool_request":
-            return stateFromJobSummary(node.job_state_summary) ?? null;
+            return null;
     }
 }
 

--- a/client/src/components/History/Graph/historyGraphMapper.ts
+++ b/client/src/components/History/Graph/historyGraphMapper.ts
@@ -3,7 +3,8 @@ import { faBolt, faFile, faLayerGroup } from "@fortawesome/free-solid-svg-icons"
 import type { components } from "@/api/schema";
 import type { ConnectorVariant, GraphEdge, GraphNode } from "@/components/Graph/types";
 import {
-    HIERARCHICAL_COLLECTION_JOB_STATES,
+    stateFromJobSummary,
+    stateFromPopulatedState,
     type StateRepresentation,
     STATES,
 } from "@/components/History/Content/model/states";
@@ -124,17 +125,19 @@ function mergedConnectorVariant(variants: ConnectorVariant[]): ConnectorVariant 
     return variants.some((variant) => variant === "multiple") ? "multiple" : "single";
 }
 
-/** Highest-priority non-zero state from a job_state_summary, or null. */
-function displayStateFromSummary(summary: Record<string, number> | null | undefined): string | null {
-    if (!summary) {
-        return null;
+/** Display state for a node, per src type. */
+function resolveDisplayState(node: ApiGraphNode): string | null {
+    switch (node.src) {
+        case "hda":
+            return node.state ?? null;
+        case "hdca":
+            // node.state carries populated_state for collections.
+            return (
+                stateFromPopulatedState(node.state) ?? stateFromJobSummary(node.job_state_summary) ?? node.state ?? null
+            );
+        case "tool_request":
+            return stateFromJobSummary(node.job_state_summary) ?? null;
     }
-    for (const state of HIERARCHICAL_COLLECTION_JOB_STATES) {
-        if ((summary[state] ?? 0) > 0) {
-            return state;
-        }
-    }
-    return null;
 }
 
 /** Connection summary shown in a tool node's body, e.g. "3 inputs, 2 outputs". */
@@ -196,8 +199,7 @@ export function mapNodes(apiNodes: ApiGraphNode[], apiEdges: ApiGraphEdge[]): Hi
         const inputs = inputVariants.get(key) ?? [];
         const outputs = outputVariants.get(key) ?? [];
 
-        // Fall back to job_state_summary when the row has no state of its own.
-        const rawState = node.state ?? displayStateFromSummary(node.job_state_summary);
+        const rawState = resolveDisplayState(node);
         const displayState = rawState === "failed" ? "error" : rawState;
         const stateKey = displayState as keyof typeof STATES | undefined;
         const stateRep: StateRepresentation | null = stateKey && stateKey in STATES ? STATES[stateKey] : null;

--- a/client/src/components/History/Graph/historyGraphMapper.ts
+++ b/client/src/components/History/Graph/historyGraphMapper.ts
@@ -200,8 +200,7 @@ export function mapNodes(apiNodes: ApiGraphNode[], apiEdges: ApiGraphEdge[]): Hi
         const rawState = node.state ?? displayStateFromSummary(node.job_state_summary);
         const displayState = rawState === "failed" ? "error" : rawState;
         const stateKey = displayState as keyof typeof STATES | undefined;
-        const stateRep: StateRepresentation | null =
-            stateKey && stateKey in STATES ? STATES[stateKey] : null;
+        const stateRep: StateRepresentation | null = stateKey && stateKey in STATES ? STATES[stateKey] : null;
 
         // Tool nodes summarise their connections; data nodes show their state text.
         const bodyText = isToolRequest

--- a/client/src/components/History/Graph/historyGraphMapper.ts
+++ b/client/src/components/History/Graph/historyGraphMapper.ts
@@ -2,7 +2,11 @@ import { faBolt, faFile, faLayerGroup } from "@fortawesome/free-solid-svg-icons"
 
 import type { components } from "@/api/schema";
 import type { ConnectorVariant, GraphEdge, GraphNode } from "@/components/Graph/types";
-import { type StateRepresentation, STATES } from "@/components/History/Content/model/states";
+import {
+    HIERARCHICAL_COLLECTION_JOB_STATES,
+    type StateRepresentation,
+    STATES,
+} from "@/components/History/Content/model/states";
 
 type ApiGraphNode = components["schemas"]["GraphNode"];
 type ApiGraphEdge = components["schemas"]["GraphEdge"];
@@ -120,6 +124,19 @@ function mergedConnectorVariant(variants: ConnectorVariant[]): ConnectorVariant 
     return variants.some((variant) => variant === "multiple") ? "multiple" : "single";
 }
 
+/** Highest-priority non-zero state from a job_state_summary, or null. */
+function displayStateFromSummary(summary: Record<string, number> | null | undefined): string | null {
+    if (!summary) {
+        return null;
+    }
+    for (const state of HIERARCHICAL_COLLECTION_JOB_STATES) {
+        if ((summary[state] ?? 0) > 0) {
+            return state;
+        }
+    }
+    return null;
+}
+
 /** Connection summary shown in a tool node's body, e.g. "3 inputs, 2 outputs". */
 function toolConnectionSummary(inputCount: number, outputCount: number): string {
     const parts: string[] = [];
@@ -179,12 +196,12 @@ export function mapNodes(apiNodes: ApiGraphNode[], apiEdges: ApiGraphEdge[]): Hi
         const inputs = inputVariants.get(key) ?? [];
         const outputs = outputVariants.get(key) ?? [];
 
-        // Dataset/collection nodes carry a state (drives header colour + state text);
-        // map "failed" → "error" to match the dataset state vocabulary.
-        const displayState = node.state === "failed" ? "error" : node.state;
+        // Fall back to job_state_summary when the row has no state of its own.
+        const rawState = node.state ?? displayStateFromSummary(node.job_state_summary);
+        const displayState = rawState === "failed" ? "error" : rawState;
         const stateKey = displayState as keyof typeof STATES | undefined;
         const stateRep: StateRepresentation | null =
-            !isToolRequest && stateKey && stateKey in STATES ? STATES[stateKey] : null;
+            stateKey && stateKey in STATES ? STATES[stateKey] : null;
 
         // Tool nodes summarise their connections; data nodes show their state text.
         const bodyText = isToolRequest

--- a/client/src/components/History/Graph/historyNodeColor.ts
+++ b/client/src/components/History/Graph/historyNodeColor.ts
@@ -13,14 +13,8 @@ function stateColor(state: string): string {
     return stateColors[state]!;
 }
 
-/**
- * Minimap fill color for a history graph node. Dataset/collection nodes use
- * their state color; tool nodes return null so the minimap applies its default.
- */
+/** Minimap fill color for a history graph node, keyed off its display state. */
 export function historyNodeColor(node: HistoryGraphNode): string | null {
-    if (node.data?.src === "tool_request") {
-        return null;
-    }
     const state = node.data?.state;
     return (state && stateColor(state)) || null;
 }

--- a/client/src/components/History/Graph/historyNodeColor.ts
+++ b/client/src/components/History/Graph/historyNodeColor.ts
@@ -15,6 +15,9 @@ function stateColor(state: string): string {
 
 /** Minimap fill color for a history graph node, keyed off its display state. */
 export function historyNodeColor(node: HistoryGraphNode): string | null {
+    if (node.data?.src === "tool_request") {
+        return null;
+    }
     const state = node.data?.state;
     return (state && stateColor(state)) || null;
 }

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -139,6 +139,7 @@ $galaxy-state-border: (
     "hidden": $state-default-border,
     "setting_metadata": $state-warning-border,
     "inaccessible": darken($state-default-border, 10%),
+    "paused": $state-info-border,
 );
 
 $galaxy-state-bg: (

--- a/lib/galaxy/managers/history_graph.py
+++ b/lib/galaxy/managers/history_graph.py
@@ -73,9 +73,7 @@ SYNTHETIC_TOOL_IDS: tuple[str, ...] = ("__DATA_FETCH__",)
 
 
 def _summary_dict(summary) -> Optional[dict[str, int]]:
-    """Lift ``JobStateSummary`` (a NamedTuple) to the wire-shaped dict, or
-    None. Matches the shape ``HDCA.job_state_summary_dict`` already emits, so
-    the client treats both node types uniformly."""
+    """Lift JobStateSummary (a NamedTuple) to a dict, or None."""
     return None if summary is None else summary._asdict()
 
 

--- a/lib/galaxy/managers/history_graph.py
+++ b/lib/galaxy/managers/history_graph.py
@@ -26,6 +26,8 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
 from galaxy.model import (
+    batch_fetch_job_state_summaries,
+    batch_fetch_tool_request_job_state_summaries,
     Dataset,
     DatasetCollection,
     DatasetCollectionElement,
@@ -68,6 +70,13 @@ MAX_LIMIT = 1000
 # etc.) rather than user-level lineage steps. Jobs with these tool_ids are
 # excluded from producer lookups so they do not appear as nodes or edges.
 SYNTHETIC_TOOL_IDS: tuple[str, ...] = ("__DATA_FETCH__",)
+
+
+def _summary_dict(summary) -> Optional[dict[str, int]]:
+    """Lift ``JobStateSummary`` (a NamedTuple) to the wire-shaped dict, or
+    None. Matches the shape ``HDCA.job_state_summary_dict`` already emits, so
+    the client treats both node types uniformly."""
+    return None if summary is None else summary._asdict()
 
 
 class HistoryGraphManager:
@@ -578,6 +587,7 @@ class HistoryGraphBuilder:
             .join(DatasetCollection, HistoryDatasetCollectionAssociation.collection_id == DatasetCollection.id)
             .where(HistoryDatasetCollectionAssociation.id.in_(db_ids))
         )
+        summaries = batch_fetch_job_state_summaries(self.sa_session, list(db_ids))
         return [
             self._node(
                 "collection",
@@ -585,6 +595,7 @@ class HistoryGraphBuilder:
                 name=row.name,
                 hid=row.hid,
                 state=row.populated_state,
+                job_state_summary=_summary_dict(summaries.get(row.id)),
                 collection_type=row.collection_type,
                 deleted=row.deleted,
                 visible=row.visible,
@@ -593,7 +604,18 @@ class HistoryGraphBuilder:
         ]
 
     def _tr_nodes(self, tr_map: dict[int, Optional[str]]) -> list[GraphNode]:
-        return [self._node("tool_request", tr_id, tool_id=tool_id) for tr_id, tool_id in tr_map.items()]
+        if not tr_map:
+            return []
+        summaries = batch_fetch_tool_request_job_state_summaries(self.sa_session, list(tr_map))
+        return [
+            self._node(
+                "tool_request",
+                tr_id,
+                tool_id=tool_id,
+                job_state_summary=_summary_dict(summaries.get(tr_id)),
+            )
+            for tr_id, tool_id in tr_map.items()
+        ]
 
     def _resolve_tool_names(self, nodes: list[GraphNode]) -> None:
         toolbox = self.toolbox

--- a/lib/galaxy/managers/history_graph.py
+++ b/lib/galaxy/managers/history_graph.py
@@ -603,10 +603,7 @@ class HistoryGraphBuilder:
     def _tr_nodes(self, tr_map: dict[int, Optional[str]]) -> list[GraphNode]:
         if not tr_map:
             return []
-        return [
-            self._node("tool_request", tr_id, tool_id=tool_id)
-            for tr_id, tool_id in tr_map.items()
-        ]
+        return [self._node("tool_request", tr_id, tool_id=tool_id) for tr_id, tool_id in tr_map.items()]
 
     def _resolve_tool_names(self, nodes: list[GraphNode]) -> None:
         toolbox = self.toolbox

--- a/lib/galaxy/managers/history_graph.py
+++ b/lib/galaxy/managers/history_graph.py
@@ -27,7 +27,6 @@ from galaxy.exceptions import (
 )
 from galaxy.model import (
     batch_fetch_job_state_summaries,
-    batch_fetch_tool_request_job_state_summaries,
     Dataset,
     DatasetCollection,
     DatasetCollectionElement,
@@ -604,14 +603,8 @@ class HistoryGraphBuilder:
     def _tr_nodes(self, tr_map: dict[int, Optional[str]]) -> list[GraphNode]:
         if not tr_map:
             return []
-        summaries = batch_fetch_tool_request_job_state_summaries(self.sa_session, list(tr_map))
         return [
-            self._node(
-                "tool_request",
-                tr_id,
-                tool_id=tool_id,
-                job_state_summary=_summary_dict(summaries.get(tr_id)),
-            )
+            self._node("tool_request", tr_id, tool_id=tool_id)
             for tr_id, tool_id in tr_map.items()
         ]
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -13451,24 +13451,3 @@ def batch_fetch_job_state_summaries(session, hdca_ids: list[int]) -> dict[int, "
             result[hdca_id] = _ZERO_JOB_STATE_SUMMARY
 
     return result
-
-
-def batch_fetch_tool_request_job_state_summaries(
-    session, tool_request_ids: list[int]
-) -> dict[int, "JobStateSummary"]:
-    """Batch-fetch job state summaries for multiple ToolRequests in a single query."""
-    if not tool_request_ids:
-        return {}
-
-    stm: Select = (
-        select(Job.tool_request_id).where(Job.tool_request_id.in_(tool_request_ids)).group_by(Job.tool_request_id)
-    )
-    for state in enum_values(Job.states):
-        stm = stm.add_columns(func.sum(case((Job.state == state, 1), else_=0)).label(state))
-    stm = stm.add_columns(func.count().label("all_jobs"))
-
-    result = {int(row[0]): JobStateSummary._make(row[1:]) for row in session.execute(stm)}
-    for tr_id in tool_request_ids:
-        if tr_id not in result:
-            result[tr_id] = _ZERO_JOB_STATE_SUMMARY
-    return result

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -13456,20 +13456,10 @@ def batch_fetch_job_state_summaries(session, hdca_ids: list[int]) -> dict[int, "
 def batch_fetch_tool_request_job_state_summaries(
     session, tool_request_ids: list[int]
 ) -> dict[int, "JobStateSummary"]:
-    """Batch-fetch job state summaries for multiple ToolRequests in a single query.
-
-    Returns a dict mapping tool_request_id to JobStateSummary for every
-    requested ID. ToolRequests with no associated jobs get a zero-filled
-    summary. Bounded payload (one row per tool_request, ~12 ints each),
-    single aggregating SQL — never linear in job count.
-    """
+    """Batch-fetch job state summaries for multiple ToolRequests in a single query."""
     if not tool_request_ids:
         return {}
 
-    state_label = "state"
-
-    # Job has a direct ``tool_request_id`` FK, so no union needed; aggregate
-    # by tool_request_id in one pass.
     stm: Select = (
         select(Job.tool_request_id).where(Job.tool_request_id.in_(tool_request_ids)).group_by(Job.tool_request_id)
     )
@@ -13478,10 +13468,7 @@ def batch_fetch_tool_request_job_state_summaries(
     stm = stm.add_columns(func.count().label("all_jobs"))
 
     result = {int(row[0]): JobStateSummary._make(row[1:]) for row in session.execute(stm)}
-
-    # Fill in zero summaries for ToolRequests with no jobs.
     for tr_id in tool_request_ids:
         if tr_id not in result:
             result[tr_id] = _ZERO_JOB_STATE_SUMMARY
-
     return result

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -13451,3 +13451,37 @@ def batch_fetch_job_state_summaries(session, hdca_ids: list[int]) -> dict[int, "
             result[hdca_id] = _ZERO_JOB_STATE_SUMMARY
 
     return result
+
+
+def batch_fetch_tool_request_job_state_summaries(
+    session, tool_request_ids: list[int]
+) -> dict[int, "JobStateSummary"]:
+    """Batch-fetch job state summaries for multiple ToolRequests in a single query.
+
+    Returns a dict mapping tool_request_id to JobStateSummary for every
+    requested ID. ToolRequests with no associated jobs get a zero-filled
+    summary. Bounded payload (one row per tool_request, ~12 ints each),
+    single aggregating SQL — never linear in job count.
+    """
+    if not tool_request_ids:
+        return {}
+
+    state_label = "state"
+
+    # Job has a direct ``tool_request_id`` FK, so no union needed; aggregate
+    # by tool_request_id in one pass.
+    stm: Select = (
+        select(Job.tool_request_id).where(Job.tool_request_id.in_(tool_request_ids)).group_by(Job.tool_request_id)
+    )
+    for state in enum_values(Job.states):
+        stm = stm.add_columns(func.sum(case((Job.state == state, 1), else_=0)).label(state))
+    stm = stm.add_columns(func.count().label("all_jobs"))
+
+    result = {int(row[0]): JobStateSummary._make(row[1:]) for row in session.execute(stm)}
+
+    # Fill in zero summaries for ToolRequests with no jobs.
+    for tr_id in tool_request_ids:
+        if tr_id not in result:
+            result[tr_id] = _ZERO_JOB_STATE_SUMMARY
+
+    return result

--- a/lib/galaxy/schema/history_graph.py
+++ b/lib/galaxy/schema/history_graph.py
@@ -37,11 +37,6 @@ class GraphNode(BaseModel):
     visible: Optional[bool] = None
     tool_id: Optional[str] = None
     tool_name: Optional[str] = None
-    # Counts by Job state for nodes whose displayed status derives from job
-    # outcomes (HDCAs from implicit collections, tool_request nodes from
-    # workflow execution). Same shape as ``HDCA.job_state_summary_dict``;
-    # client picks the display state with the same precedence the history
-    # list view uses. ``None`` when no producing jobs are linked.
     job_state_summary: Optional[dict[str, int]] = None
 
     @property

--- a/lib/galaxy/schema/history_graph.py
+++ b/lib/galaxy/schema/history_graph.py
@@ -37,6 +37,12 @@ class GraphNode(BaseModel):
     visible: Optional[bool] = None
     tool_id: Optional[str] = None
     tool_name: Optional[str] = None
+    # Counts by Job state for nodes whose displayed status derives from job
+    # outcomes (HDCAs from implicit collections, tool_request nodes from
+    # workflow execution). Same shape as ``HDCA.job_state_summary_dict``;
+    # client picks the display state with the same precedence the history
+    # list view uses. ``None`` when no producing jobs are linked.
+    job_state_summary: Optional[dict[str, int]] = None
 
     @property
     def ref(self) -> NodeRef:

--- a/test/unit/app/managers/test_HistoryGraphBuilder.py
+++ b/test/unit/app/managers/test_HistoryGraphBuilder.py
@@ -280,6 +280,87 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         assert len(collection_nodes) == 1
         assert collection_nodes[0].collection_type == "list"
 
+    def test_hdca_job_state_summary_direct_job(self):
+        """HDCA produced by a single job carries that job's state in job_state_summary."""
+        history, _ = self._create_history()
+        input_hda = self._create_hda(history, name="in")
+        element_hda = self._create_hda(history, name="el")
+        element_identifiers = self.build_element_identifiers([element_hda])
+        hdca = self.collection_manager.create(
+            self.trans, history, "direct out", "list", element_identifiers=element_identifiers
+        )
+        tr = self._create_tool_request(history)
+        job = self._create_job(tool_request=tr, tool_id="tool")
+        self._link_job_input_hda(job, input_hda)
+        self._link_job_output_hdca(job, hdca)
+        job.state = "error"
+        hdca.job_id = job.id
+        self.trans.sa_session.flush()
+
+        graph = self._build_graph(history)
+        hdca_node = next(n for n in graph.nodes if n.src == "hdca" and n.id == self._encode("c", hdca.id).id)
+        assert hdca_node.job_state_summary is not None
+        assert hdca_node.job_state_summary["error"] == 1
+        assert hdca_node.job_state_summary["all_jobs"] == 1
+        assert hdca_node.job_state_summary["ok"] == 0
+
+    def test_hdca_job_state_summary_implicit_jobs_mixed_states(self):
+        """HDCA produced by an ImplicitCollectionJobs aggregates each member job's state."""
+        history, _ = self._create_history()
+        input_hda = self._create_hda(history, name="in")
+        element_hda = self._create_hda(history, name="el")
+        element_identifiers = self.build_element_identifiers([element_hda])
+        hdca = self.collection_manager.create(
+            self.trans, history, "implicit out", "list", element_identifiers=element_identifiers
+        )
+
+        tr = self._create_tool_request(history)
+        icj = model.ImplicitCollectionJobs(populated_state="ok")
+        self.trans.sa_session.add(icj)
+        self.trans.sa_session.flush()
+
+        for idx, state in enumerate(["ok", "error", "paused"]):
+            job = self._create_job(tool_request=tr, tool_id=f"tool_{idx}")
+            self._link_job_input_hda(job, input_hda)
+            self._link_job_output_hdca(job, hdca)
+            job.state = state
+            icja = model.ImplicitCollectionJobsJobAssociation()
+            icja.implicit_collection_jobs_id = icj.id
+            icja.job_id = job.id
+            icja.order_index = idx
+            self.trans.sa_session.add(icja)
+        hdca.implicit_collection_jobs_id = icj.id
+        self.trans.sa_session.flush()
+
+        graph = self._build_graph(history)
+        hdca_node = next(n for n in graph.nodes if n.src == "hdca" and n.id == self._encode("c", hdca.id).id)
+        assert hdca_node.job_state_summary is not None
+        assert hdca_node.job_state_summary["ok"] == 1
+        assert hdca_node.job_state_summary["error"] == 1
+        assert hdca_node.job_state_summary["paused"] == 1
+        assert hdca_node.job_state_summary["all_jobs"] == 3
+
+    def test_tool_request_job_state_summary_aggregates_linked_jobs(self):
+        """ToolRequest node carries a summary of every job that points at it."""
+        history, _ = self._create_history()
+        input_hda = self._create_hda(history, name="in")
+        output_hda = self._create_hda(history, name="out")
+        tr = self._create_tool_request(history)
+        for state in ["ok", "error", "paused"]:
+            job = self._create_job(tool_request=tr, tool_id="tool")
+            self._link_job_input_hda(job, input_hda)
+            self._link_job_output_hda(job, output_hda)
+            job.state = state
+        self.trans.sa_session.flush()
+
+        graph = self._build_graph(history)
+        tr_node = next(n for n in graph.nodes if n.src == "tool_request" and n.id == self._encode("r", tr.id).id)
+        assert tr_node.job_state_summary is not None
+        assert tr_node.job_state_summary["ok"] == 1
+        assert tr_node.job_state_summary["error"] == 1
+        assert tr_node.job_state_summary["paused"] == 1
+        assert tr_node.job_state_summary["all_jobs"] == 3
+
     def test_element_input_resolves_to_top_level_item(self):
         """When a tool consumes an element HDA that is also a top-level history
         item, the input edge points to the dataset (not the collection)."""

--- a/test/unit/app/managers/test_HistoryGraphBuilder.py
+++ b/test/unit/app/managers/test_HistoryGraphBuilder.py
@@ -340,27 +340,6 @@ class TestHistoryGraphBuilder(BaseTestCase, CreatesCollectionsMixin):
         assert hdca_node.job_state_summary["paused"] == 1
         assert hdca_node.job_state_summary["all_jobs"] == 3
 
-    def test_tool_request_job_state_summary_aggregates_linked_jobs(self):
-        """ToolRequest node carries a summary of every job that points at it."""
-        history, _ = self._create_history()
-        input_hda = self._create_hda(history, name="in")
-        output_hda = self._create_hda(history, name="out")
-        tr = self._create_tool_request(history)
-        for state in ["ok", "error", "paused"]:
-            job = self._create_job(tool_request=tr, tool_id="tool")
-            self._link_job_input_hda(job, input_hda)
-            self._link_job_output_hda(job, output_hda)
-            job.state = state
-        self.trans.sa_session.flush()
-
-        graph = self._build_graph(history)
-        tr_node = next(n for n in graph.nodes if n.src == "tool_request" and n.id == self._encode("r", tr.id).id)
-        assert tr_node.job_state_summary is not None
-        assert tr_node.job_state_summary["ok"] == 1
-        assert tr_node.job_state_summary["error"] == 1
-        assert tr_node.job_state_summary["paused"] == 1
-        assert tr_node.job_state_summary["all_jobs"] == 3
-
     def test_element_input_resolves_to_top_level_item(self):
         """When a tool consumes an element HDA that is also a top-level history
         item, the input edge points to the dataset (not the collection)."""


### PR DESCRIPTION
Collection nodes in the history graph now reflect their underlying jobs' state, matching what the history list shows: a collection whose elements errored displays red instead of green. The graph manager attaches job_state_summary to each HDCA via the existing batch_fetch_job_state_summaries helper, and the frontend mapper derives display state from the same precedence list (HIERARCHICAL_COLLECTION_JOB_STATES) used by the history list.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
