### PR TITLE
[26.0] Stop workflow editor leaking UI metadata into Apply Rules tool_state

### DIFF
--- a/client/src/components/RuleCollectionBuilder.test.js
+++ b/client/src/components/RuleCollectionBuilder.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import RuleCollectionBuilder, { UI_ONLY_RULE_KEYS } from "./RuleCollectionBuilder.vue";
+
+// A rule and a mapping entry, each polluted with all six UI-only keys plus real DSL keys.
+function leakedModel() {
+    return {
+        rules: [
+            {
+                type: "add_column_metadata",
+                value: "identifier0",
+                collapsible_value: { __class__: "RuntimeValue" },
+                connectable: true,
+                is_workflow: false,
+                editing: true,
+                error: null,
+                warn: "some warning",
+            },
+        ],
+        mapping: [
+            {
+                type: "list_identifiers",
+                columns: [1],
+                collapsible_value: { __class__: "RuntimeValue" },
+                connectable: true,
+                is_workflow: false,
+                editing: false,
+                error: null,
+                warn: null,
+            },
+        ],
+    };
+}
+
+// resetSource builds the canonical serialization (ruleSourceJson -> tool_state / saved
+// sessions, ruleSource -> view-source + localStorage). Exercise it directly against a
+// minimal context to avoid rendering the (unrelated, render-brittle) full component.
+const resetSource = RuleCollectionBuilder.methods.resetSource;
+
+describe("RuleCollectionBuilder.resetSource serialization", () => {
+    it("strips UI-only keys from the serialized output while leaving the live model intact", () => {
+        const model = leakedModel();
+        const ctx = {
+            rules: model.rules,
+            mapping: model.mapping,
+            exisistingDatasets: true, // skip extension/genome handling
+        };
+
+        resetSource.call(ctx);
+
+        // Serialized object (-> tool_state / saved sessions) carries only DSL keys.
+        const serializedRule = ctx.ruleSourceJson.rules[0];
+        const serializedMapping = ctx.ruleSourceJson.mapping[0];
+        for (const key of UI_ONLY_RULE_KEYS) {
+            expect(serializedRule).not.toHaveProperty(key);
+            expect(serializedMapping).not.toHaveProperty(key);
+        }
+        expect(serializedRule).toEqual({ type: "add_column_metadata", value: "identifier0" });
+        expect(serializedMapping).toEqual({ type: "list_identifiers", columns: [1] });
+
+        // The string form (-> view-source panel + localStorage) is scrubbed too.
+        const parsed = JSON.parse(ctx.ruleSource);
+        expect(parsed.rules[0]).toEqual({ type: "add_column_metadata", value: "identifier0" });
+        expect(parsed.mapping[0]).toEqual({ type: "list_identifiers", columns: [1] });
+
+        // The live model keeps validation/edit state so the builder UI still renders it.
+        expect(ctx.rules[0].warn).toBe("some warning");
+        expect(ctx.rules[0].editing).toBe(true);
+        expect(ctx.rules[0]).toHaveProperty("collapsible_value");
+        expect(ctx.mapping[0]).toHaveProperty("error");
+    });
+});

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -643,6 +643,17 @@ Vue.use(BootstrapVue);
 const RULES = RuleDefs.RULES;
 const MAPPING_TARGETS = RuleDefs.MAPPING_TARGETS;
 
+// UI-only keys the rule builder / tool form stamp onto live rule & mapping entries.
+// The server never reads them; they must not be persisted into tool_state or saved sessions.
+export const UI_ONLY_RULE_KEYS = ["collapsible_value", "connectable", "is_workflow", "editing", "error", "warn"];
+const stripUiKeys = function (entry) {
+    const clean = { ...entry };
+    for (const key of UI_ONLY_RULE_KEYS) {
+        delete clean[key];
+    }
+    return clean;
+};
+
 export default {
     components: {
         TooltipOnHover,
@@ -1373,15 +1384,11 @@ export default {
             this.ruleView = "source";
         },
         resetSource() {
-            const replacer = function (key, value) {
-                if (key == "error" || key == "warn") {
-                    return undefined;
-                }
-                return value;
-            };
             const asJson = {
-                rules: this.rules,
-                mapping: this.mapping,
+                // Serialize DSL-only copies; leave this.rules/this.mapping live so the
+                // builder UI keeps rendering validation/edit state (error/warn/editing).
+                rules: this.rules.map(stripUiKeys),
+                mapping: this.mapping.map(stripUiKeys),
             };
             if (!this.exisistingDatasets) {
                 if (this.extension !== UploadUtils.DEFAULT_EXTENSION) {
@@ -1392,7 +1399,7 @@ export default {
                 }
             }
             this.ruleSourceJson = asJson;
-            this.ruleSource = JSON.stringify(asJson, replacer, "  ");
+            this.ruleSource = JSON.stringify(asJson, null, "  ");
             this.ruleSourceError = null;
         },
         attemptRulePreview() {
@@ -1499,8 +1506,10 @@ export default {
         },
         async createCollection() {
             const asJson = {
-                rules: this.rules,
-                mapping: this.mapping,
+                // DSL-only copies — this is stringified into a localStorage saved session
+                // below; strip UI-only keys so they are not persisted.
+                rules: this.rules.map(stripUiKeys),
+                mapping: this.mapping.map(stripUiKeys),
             };
             var arrayOfColumns = this.mapping.flatMap((m) => m.columns);
             if (arrayOfColumns.some((m) => m >= this.colHeaders.length)) {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -33,7 +33,7 @@ describe("FormTool", () => {
         );
     });
 
-    function mountTarget() {
+    function mountTarget(inputs = [{ name: "input", label: "input", type: "text", value: "value" }]) {
         return mount(FormTool, {
             propsData: {
                 id: "input",
@@ -45,7 +45,7 @@ describe("FormTool", () => {
                         name: "tool_name",
                         version: "1.0",
                         description: "description",
-                        inputs: [{ name: "input", label: "input", type: "text", value: "value" }],
+                        inputs,
                         help: "help_text",
                         help_format: "restructuredtext",
                         versions: ["1.0", "2.0", "3.0"],
@@ -85,5 +85,39 @@ describe("FormTool", () => {
         expect(state.tool_version).toEqual("3.0");
         expect(state.tool_id).toEqual("tool_id+3.0");
         await flushPromises();
+    });
+
+    it("does not stamp UI metadata into a rules input payload", () => {
+        const inputs = mountTarget([
+            { name: "input", label: "input", type: "text", value: "value" },
+            {
+                name: "rules",
+                label: "rules",
+                type: "rules",
+                value: {
+                    mapping: [{ type: "list_identifiers", columns: [1] }],
+                    rules: [{ type: "add_column_metadata", value: "identifier0" }],
+                },
+            },
+        ]).vm.inputs;
+
+        const rulesInput = inputs[1];
+        const nestedEntries = [rulesInput.value.mapping[0], rulesInput.value.rules[0]];
+
+        // Leak fixed: nested rule/mapping entries carry no UI-only keys.
+        for (const entry of nestedEntries) {
+            expect(entry).not.toHaveProperty("collapsible_value");
+            expect(entry).not.toHaveProperty("connectable");
+            expect(entry).not.toHaveProperty("is_workflow");
+        }
+
+        // #18741 preserved: the top-level rules input is runtime-editable / not connectable.
+        expect(rulesInput.collapsible_value).toBeUndefined();
+        expect(rulesInput.connectable).toBe(false);
+
+        // Regression guard: sibling scalar inputs are still stamped as before.
+        const textInput = inputs[0];
+        expect(textInput.collapsible_value.__class__).toBe("RuntimeValue");
+        expect(textInput.connectable).toBe(true);
     });
 });

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -163,10 +163,20 @@ export default {
                         input.is_workflow =
                             (input.options && input.options.length === 0) ||
                             ["integer", "float"].indexOf(input.type) != -1;
+
+                        if (isRules) {
+                            // Do not descend into the rule-builder payload; its nested
+                            // mapping/rules entries carry a `.type` and would otherwise be
+                            // stamped with UI-only metadata that leaks into tool_state.
+                            return false;
+                        }
                     }
                 }
             });
             Utils.deepEach(inputs, (input) => {
+                if (input.type === "rules") {
+                    return false;
+                }
                 if (input.type === "conditional") {
                     input.connectable = false;
                     input.test_param.collapsible_value = undefined;

--- a/client/src/utils/utils.test.ts
+++ b/client/src/utils/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { deepEach } from "./utils";
+
+describe("deepEach", () => {
+    it("recurses into every nested object by default", () => {
+        const tree = { a: { b: { c: {} } } };
+        const seen: object[] = [];
+        deepEach(tree, (node) => {
+            seen.push(node);
+        });
+        // a, b, c => 3 nested objects visited
+        expect(seen).toHaveLength(3);
+    });
+
+    it("halts recursion into a subtree when the callback returns false", () => {
+        const tree = { a: { skip: true, child: { grandchild: {} } }, b: {} };
+        const visited: object[] = [];
+        deepEach(tree, (node: any) => {
+            visited.push(node);
+            if (node.skip) {
+                return false;
+            }
+        });
+        // a's `child`/`grandchild` are never walked; only a and b are visited
+        expect(visited).toHaveLength(2);
+        expect(visited.some((n: any) => n.grandchild)).toBe(false);
+    });
+
+    it("treats undefined/true returns as recurse (backward compatible)", () => {
+        const tree = { a: { b: {} }, c: { d: {} } };
+        const count = { undef: 0, truthy: 0 };
+        deepEach(tree, () => {
+            count.undef++;
+        });
+        deepEach(tree, () => {
+            count.truthy++;
+            return true;
+        });
+        expect(count.undef).toBe(4);
+        expect(count.truthy).toBe(4);
+    });
+});

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -19,16 +19,19 @@ export type AnyObject = Record<string | number | symbol, any>;
  * Call callback on every object in an object recursively
  *
  * @param object object to traverse
- * @param callback ran on every nested child object
+ * @param callback ran on every nested child object; return `false` to skip
+ *                 recursion into that child's own children
  */
 export function deepEach<O extends AnyObject, V extends O[keyof O] extends AnyObject ? O[keyof O] : never>(
     object: Readonly<O>,
-    callback: (object: V | AnyObject) => void,
+    callback: (object: V | AnyObject) => void | boolean,
 ): void {
     Object.values(object).forEach((value) => {
         if (Boolean(value) && typeof value === "object") {
-            callback(value);
-            deepEach(value, callback);
+            const descend = callback(value);
+            if (descend !== false) {
+                deepEach(value, callback);
+            }
         }
     });
 }


### PR DESCRIPTION
We noticed a bunch of junk is being saved into IWC workflows around apple rules invocations. Traced the root cause to this - probably will follow up with a IWC PR to cleanup the state on that end also.

Native .ga workflows accrued UI-only keys (collapsible_value, connectable, is_workflow, editing, error, warn) inside Apply Rules `rules` payloads. Server never reads them; they bloat tool_state. Two independent leak paths:

Path A: FormTool.vue `inputs()` ran Utils.deepEach, which descended into the rules input's value and stamped every nested mapping/rules entry (each has a .type) with collapsible_value/connectable/is_workflow. Give deepEach opt-in recursion control (callback returns false to halt a subtree) and use it to stop at a rules input. Completes #18741, which only fixed the top-level rules input.

Path B: the rule builder writes error/warn/editing onto live rule objects, which ride along when serialized. Scrub UI-only keys from copies at the canonical serialization (RuleCollectionBuilder asJson in resetSource + createCollection), covering workflow tool_state and localStorage saved sessions; live model keeps validation/edit state. Drop now-redundant error/warn stringify replacer.

Tests (red->green): deepEach halt, FormTool no nested stamping (#18741 + sibling regression guards preserved), RuleCollectionBuilder serialized output DSL-only with live model intact.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
