### PR TITLE
[26.0] Fix missing scripts in built wheels

### DIFF
--- a/packages/app/pyproject.toml
+++ b/packages/app/pyproject.toml
@@ -14,3 +14,7 @@ dynamic = [
     "version",
 ]
 name = "galaxy-app"
+
+[project.scripts]
+galaxy-main = "galaxy.main:main"
+galaxy-dependencies = "galaxy.dependencies.script:main"

--- a/packages/config/pyproject.toml
+++ b/packages/config/pyproject.toml
@@ -14,3 +14,6 @@ dynamic = [
     "version",
 ]
 name = "galaxy-config"
+
+[project.scripts]
+galaxy-config = "galaxy.config.script:main"

--- a/packages/data/pyproject.toml
+++ b/packages/data/pyproject.toml
@@ -14,3 +14,11 @@ dynamic = [
     "version",
 ]
 name = "galaxy-data"
+
+[project.scripts]
+galaxy-build-objects = "galaxy.model.store.build_objects:main"
+galaxy-load-objects = "galaxy.model.store.load_objects:main"
+galaxy-manage-db = "galaxy.model.orm.scripts:manage_db"
+galaxy-prune-histories = "galaxy.model.scripts:prune_history_table"
+galaxy-delete-sessions = "galaxy.model.scripts:delete_galaxy_sessions"
+galaxy-delete-job-metrics = "galaxy.model.scripts:delete_job_metrics"

--- a/packages/files/pyproject.toml
+++ b/packages/files/pyproject.toml
@@ -14,3 +14,6 @@ dynamic = [
     "version",
 ]
 name = "galaxy-files"
+
+[project.scripts]
+galaxy-file-sources-conf-validation = "galaxy.files.validate.script:main"

--- a/packages/job_execution/pyproject.toml
+++ b/packages/job_execution/pyproject.toml
@@ -14,3 +14,7 @@ dynamic = [
     "version",
 ]
 name = "galaxy-job-execution"
+
+[project.scripts]
+galaxy-set-metadata = "galaxy.metadata.set_metadata:set_metadata"
+galaxy-container-monitor = "galaxy.job_execution.container_monitor:main"

--- a/packages/selenium/pyproject.toml
+++ b/packages/selenium/pyproject.toml
@@ -14,3 +14,6 @@ dynamic = [
     "version",
 ]
 name = "galaxy-selenium"
+
+[project.scripts]
+gx-dump-tour = "galaxy.selenium.scripts.dump_tour:main"

--- a/packages/tool_util/pyproject.toml
+++ b/packages/tool_util/pyproject.toml
@@ -14,3 +14,15 @@ dynamic = [
     "version",
 ]
 name = "galaxy-tool-util"
+
+[project.scripts]
+galaxy-tool-test = "galaxy.tool_util.verify.script:main"
+galaxy-tool-test-case-validation = "galaxy.tool_util.parameters.scripts.validate_test_cases:main"
+galaxy-tool-upgrade-advisor = "galaxy.tool_util.upgrade.script:main"
+validate-test-format = "galaxy.tool_util.validate_test_format:main"
+mulled-build = "galaxy.tool_util.deps.mulled.mulled_build:main"
+mulled-build-channel = "galaxy.tool_util.deps.mulled.mulled_build_channel:main"
+mulled-build-files = "galaxy.tool_util.deps.mulled.mulled_build_files:main"
+mulled-build-tool = "galaxy.tool_util.deps.mulled.mulled_build_tool:main"
+mulled-hash = "galaxy.tool_util.deps.mulled.mulled_hash:main"
+mulled-list = "galaxy.tool_util.deps.mulled.mulled_list:main"

--- a/packages/tours/pyproject.toml
+++ b/packages/tours/pyproject.toml
@@ -14,3 +14,6 @@ dynamic = [
     "version",
 ]
 name = "galaxy-tours"
+
+[project.scripts]
+gx-validate-tours = "galaxy.tours.validate:main"

--- a/packages/web_apps/pyproject.toml
+++ b/packages/web_apps/pyproject.toml
@@ -14,3 +14,6 @@ dynamic = [
     "version",
 ]
 name = "galaxy-web-apps"
+
+[project.scripts]
+galaxy-web = "galaxy.webapps.galaxy.script:main"

--- a/packages/web_client/pyproject.toml
+++ b/packages/web_client/pyproject.toml
@@ -14,3 +14,6 @@ dynamic = [
     "version",
 ]
 name = "galaxy-web-client"
+
+[project.scripts]
+galaxy-web-client-install = "galaxy.web_client.install:main"


### PR DESCRIPTION
When `[project]` is defined in `pyproject.toml`, setuptools does not include `[options.entry_points]` from `setup.cfg` in the built wheel. As a result, none of the galaxy binaries are included in the job execution venv.

Solution: move console script definitions to [project.scripts] in pyproject.toml for all affected packages.

Discovered after upgrade to 26.0 on the CFDE instance.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
