### PR TITLE
Attempt to improve HashiCorp Vault readiness check in tests

### DIFF
--- a/test/integration/test_hashicorp_vault.py
+++ b/test/integration/test_hashicorp_vault.py
@@ -48,12 +48,14 @@ class VaultClient:
             }
         )
 
-    def wait_ready(self, timeout=30):
+    def wait_ready(self, timeout=60):
         def check():
             try:
-                self.session.get(f"{self.addr}/v1/sys/health", timeout=2).raise_for_status()
+                resp = self.session.get(f"{self.addr}/v1/sys/health", timeout=2)
+                resp.raise_for_status()
                 return True
-            except Exception:
+            except Exception as exc:
+                print(f"Vault not ready yet ({self.addr}/v1/sys/health): {exc}")
                 return None
 
         wait_on(check, "Vault to become ready", timeout)


### PR DESCRIPTION
Not sure if this will really help, but this test has been pretty flaky lately:

ERROR test/integration/test_hashicorp_vault.py::TestHashicorpVaultRenewalGalaxyIntegration::test_beat_renews_token_and_secrets_survive - galaxy.util.wait.TimeoutAssertionError: Timed out after 30.25 seconds waiting on Vault to become ready.

This is what GLM 5.1 thinks:

---

The wait_ready timeout of 30 seconds is marginal for CI runners. docker run -d returns immediately after creating the container, but the Vault dev server inside still needs time to initialize and start responding to health checks. On loaded CI runners (Docker daemon contention, slow I/O, resource constraints), 30 seconds isn't always enough — hence the intermittent TimeoutAssertionError: Timed out after 30.25 seconds waiting on Vault to become ready.

Changes made:

- Increased timeout from 30s → 60s — gives CI runners enough headroom for slower container startup
- Added diagnostic logging in the check() callback — prints the exception on each failed health check attempt, so if it does time out, the CI logs will show what was happening instead of just the generic timeout message

---

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
