### PR TITLE
[26.0] Prevent crash on pgcleanup script when attempting to delete files in user-defined object stores

### DIFF
--- a/scripts/cleanup_datasets/pgcleanup.py
+++ b/scripts/cleanup_datasets/pgcleanup.py
@@ -28,7 +28,10 @@ sys.path.insert(1, os.path.join(galaxy_root, "lib"))
 import galaxy.config
 from galaxy.exceptions import ObjectNotFound
 from galaxy.model import calculate_user_disk_usage_statements
-from galaxy.objectstore import build_object_store_from_config
+from galaxy.objectstore import (
+    build_object_store_from_config,
+    is_user_object_store,
+)
 from galaxy.util.script import (
     app_properties_from_args,
     populate_config_args,
@@ -271,10 +274,21 @@ class RemovesObjects:
     def collect_removed_object_info(self, row):
         object_id = getattr(row, self.id_column, None)
         object_uuid = getattr(row, self.uuid_column, None)
+        object_store_id = row.object_store_id
+        if is_user_object_store(object_store_id):
+            self.log.warning(
+                "Skipping removal of %s (id: %s): object is stored in user-defined object store (%s) "
+                "which cannot be resolved by this script. The database record has been updated "
+                "but the physical file has not been removed.",
+                self.object_class.__name__,
+                object_id,
+                object_store_id,
+            )
+            return
         if object_uuid:
             object_uuid = str(uuid.UUID(object_uuid))
         if object_id:
-            self.objects_to_remove.add(self.object_class(object_id, row.object_store_id, object_uuid))
+            self.objects_to_remove.add(self.object_class(object_id, object_store_id, object_uuid))
 
     def remove_objects(self):
         for object_to_remove in sorted(self.objects_to_remove):

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -58,6 +58,24 @@ class BaseScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
 
         return path
 
+    def _pgcleanup_check_output(self, extra_args: list[str]) -> str:
+        config_file = self.write_config_file()
+        output = self._scripts_check_output("cleanup_datasets/pgcleanup.py", ["-c", config_file] + extra_args)
+        print(output)
+        return output
+
+    def is_purged(self, history_id: str, dataset) -> bool:
+        # set wait=False to prevent errored dataset from erroring out
+        if isinstance(dataset, str):
+            details_response = self.dataset_populator.get_history_dataset_details(
+                history_id, dataset_id=dataset, wait=False
+            )
+        else:
+            details_response = self.dataset_populator.get_history_dataset_details(
+                history_id, dataset=dataset, wait=False
+            )
+        return details_response["purged"]
+
 
 class TestScriptsIntegration(BaseScriptsIntegrationTestCase):
     def test_helper(self):

--- a/test/integration/test_scripts_pgcleanup.py
+++ b/test/integration/test_scripts_pgcleanup.py
@@ -1,5 +1,32 @@
+import string
+
 from galaxy_test.base.populators import skip_without_tool
+from galaxy_test.driver import integration_util
 from .test_scripts import BaseScriptsIntegrationTestCase
+
+DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""
+type: distributed
+backends:
+  - type: disk
+    id: default
+    weight: 1
+    name: Default Store
+    files_dir: "${temp_directory}/files_default"
+    extra_dirs:
+      - type: temp
+        path: "${temp_directory}/tmp_default"
+      - type: job_work
+        path: "${temp_directory}/job_working_directory_default"
+""")
+
+USER_OBJECT_STORE_CATALOG = """
+- id: general_disk
+  name: General Disk
+  description: General Disk Bound to You
+  configuration:
+    type: disk
+    files_dir: '/data/general/{{ user.username }}'
+"""
 
 SCRIPT = "cleanup_datasets/pgcleanup.py"
 
@@ -213,20 +240,104 @@ class TestScriptsPgCleanupIntegration(BaseScriptsIntegrationTestCase):
 
         assert not self.is_purged(history_id, hda)
 
-    def is_purged(self, history_id: str, dataset) -> bool:
-        # set wait=False to prevent errored dataset from erroring out
-        if isinstance(dataset, str):
-            details_response = self.dataset_populator.get_history_dataset_details(
-                history_id, dataset_id=dataset, wait=False
-            )
-        else:
-            details_response = self.dataset_populator.get_history_dataset_details(
-                history_id, dataset=dataset, wait=False
-            )
-        return details_response["purged"]
 
-    def _pgcleanup_check_output(self, extra_args: list[str]) -> str:
-        config_file = self.write_config_file()
-        output = self._scripts_check_output(SCRIPT, ["-c", config_file] + extra_args)
-        print(output)
-        return output
+class TestPgCleanupUserObjectStoreIntegration(
+    BaseScriptsIntegrationTestCase,
+    integration_util.ConfiguresObjectStores,
+):
+    """Test that pgcleanup handles datasets in user-defined object stores gracefully.
+
+    When a dataset is stored in a user-defined object store (object_store_id starting
+    with "user_objects://"), the pgcleanup script cannot resolve the object store backend
+    since it doesn't have access to the UserObjectStoreResolver. The script should skip
+    physical file removal for such objects while still updating the database records.
+    """
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config, format="yml")
+        config["object_store_store_by"] = "uuid"
+        cls._configure_object_store_template_catalog(USER_OBJECT_STORE_CATALOG, config)
+
+    def _create_user_object_store(self) -> str:
+        """Create a user-defined object store via the API and return its object_store_id."""
+        body = {
+            "name": "My Test Disk",
+            "template_id": "general_disk",
+            "template_version": 0,
+            "secrets": {},
+            "variables": {},
+        }
+        object_store_json = self.dataset_populator.create_object_store(body)
+        object_store_id = object_store_json["object_store_id"]
+        assert object_store_id.startswith("user_objects://")
+        return object_store_id
+
+    def test_purge_deleted_histories_with_user_object_store_dataset(self):
+        """Test that purging histories containing datasets in user object stores doesn't crash.
+
+        This verifies the fix for the KeyError that occurred when pgcleanup tried to call
+        get_store_by() on objects stored in user-defined object stores, which cannot be
+        resolved without a UserObjectStoreResolver (not available in the cleanup script).
+        """
+        self._skip_unless_postgres()
+
+        # Create a user-defined object store
+        object_store_id = self._create_user_object_store()
+
+        # Set the user's preferred object store to the user-defined one
+        self.dataset_populator.set_user_preferred_object_store_id(object_store_id)
+
+        # Create a history and upload a dataset (it should go to the user object store)
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="test data for user object store", wait=True)
+
+        # Verify the dataset is in the user object store
+        storage_info = self.dataset_populator.dataset_storage_info(hda["id"])
+        assert (
+            storage_info["object_store_id"] == object_store_id
+        ), f"Expected dataset in user object store {object_store_id}, but got {storage_info['object_store_id']}"
+
+        # Reset user preference so subsequent datasets don't use it
+        self.dataset_populator.set_user_preferred_object_store_id(None)
+
+        # Delete the history
+        delete_response = self.dataset_populator._delete(f"histories/{history_id}")
+        assert delete_response.status_code == 200
+        assert delete_response.json()["purged"] is False
+
+        # Run pgcleanup - this should NOT crash with a KeyError
+        # Before the fix, this would raise:
+        #   KeyError: 'user_objects://...' in _resolve_backend
+        self._pgcleanup_check_output(["--older-than", "0", "--sequence", "purge_deleted_histories"])
+
+        # The history should be purged in the database even though the physical
+        # file in the user object store could not be removed
+        history_response = self.dataset_populator._get(f"histories/{history_id}")
+        assert history_response.status_code == 200
+        assert history_response.json()["purged"] is True, history_response.json()
+
+    def test_purge_old_hdas_with_user_object_store_dataset(self):
+        """Test that purging HDAs in user object stores doesn't crash pgcleanup."""
+        self._skip_unless_postgres()
+
+        object_store_id = self._create_user_object_store()
+        self.dataset_populator.set_user_preferred_object_store_id(object_store_id)
+
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="test data", wait=True)
+
+        # Verify the dataset is in the user object store
+        storage_info = self.dataset_populator.dataset_storage_info(hda["id"])
+        assert storage_info["object_store_id"] == object_store_id
+
+        self.dataset_populator.set_user_preferred_object_store_id(None)
+
+        # Run pgcleanup - should not crash
+        self._pgcleanup_check_output(["--older-than", "0", "--sequence", "purge_old_hdas"])
+
+        # The HDA should be purged in the database
+        assert self.is_purged(history_id, hda)


### PR DESCRIPTION
Fixes #22819

Skips the physical file removal process for datasets stored in user-defined object stores. These storage locations cannot be resolved by the cleanup script, so the database records are updated while the external files remain intact to prevent potential errors or data loss.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
