### PR TITLE
[26.0] Move classifiers and keywords from setup.cfg to pyproject.toml

### DIFF
--- a/packages/app/pyproject.toml
+++ b/packages/app/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-app"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-main = "galaxy.main:main"

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy application (backend)
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/auth/pyproject.toml
+++ b/packages/auth/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-auth"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/auth/setup.cfg
+++ b/packages/auth/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy auth framework and implementations
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/config/pyproject.toml
+++ b/packages/config/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-config"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-config = "galaxy.config.script:main"

--- a/packages/config/setup.cfg
+++ b/packages/config/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy configuration
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/data/pyproject.toml
+++ b/packages/data/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-data"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-build-objects = "galaxy.model.store.build_objects:main"

--- a/packages/data/setup.cfg
+++ b/packages/data/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy datatype framework and datatypes
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/files/pyproject.toml
+++ b/packages/files/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-files"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-file-sources-conf-validation = "galaxy.files.validate.script:main"

--- a/packages/files/setup.cfg
+++ b/packages/files/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy file source framework and default plugins
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/job_execution/pyproject.toml
+++ b/packages/job_execution/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-job-execution"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-set-metadata = "galaxy.metadata.set_metadata:set_metadata"

--- a/packages/job_execution/setup.cfg
+++ b/packages/job_execution/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy job execution runtime utilities
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/job_metrics/pyproject.toml
+++ b/packages/job_metrics/pyproject.toml
@@ -14,3 +14,22 @@ dynamic = [
     "version",
 ]
 name = "galaxy-job-metrics"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/job_metrics/setup.cfg
+++ b/packages/job_metrics/setup.cfg
@@ -1,26 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy job metrics
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/meta/pyproject.toml
+++ b/packages/meta/pyproject.toml
@@ -14,3 +14,22 @@ dynamic = [
     "version",
 ]
 name = "galaxy"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/meta/setup.cfg
+++ b/packages/meta/setup.cfg
@@ -1,26 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Intended Audience :: Science/Research
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Scientific/Engineering :: Bio-Informatics
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy server metapackage
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/navigation/pyproject.toml
+++ b/packages/navigation/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-navigation"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/navigation/setup.cfg
+++ b/packages/navigation/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy client DOM navigation framework
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/objectstore/pyproject.toml
+++ b/packages/objectstore/pyproject.toml
@@ -14,3 +14,22 @@ dynamic = [
     "version",
 ]
 name = "galaxy-objectstore"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/objectstore/setup.cfg
+++ b/packages/objectstore/setup.cfg
@@ -1,26 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy objectstore framework and plugins
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/schema/pyproject.toml
+++ b/packages/schema/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-schema"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/schema/setup.cfg
+++ b/packages/schema/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Pydantic models for Galaxy
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/selenium/pyproject.toml
+++ b/packages/selenium/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-selenium"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 gx-dump-tour = "galaxy.selenium.scripts.dump_tour:main"

--- a/packages/selenium/setup.cfg
+++ b/packages/selenium/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy Selenium interaction framework
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/test_api/pyproject.toml
+++ b/packages/test_api/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-test-api"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/test_api/setup.cfg
+++ b/packages/test_api/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy API tests
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/test_base/pyproject.toml
+++ b/packages/test_base/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-test-base"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy testing utilities
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/test_driver/pyproject.toml
+++ b/packages/test_driver/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-test-driver"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/test_driver/setup.cfg
+++ b/packages/test_driver/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy test driver
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/test_selenium/pyproject.toml
+++ b/packages/test_selenium/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-test-selenium"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/test_selenium/setup.cfg
+++ b/packages/test_selenium/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy Selenium tests
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/tool_shed/pyproject.toml
+++ b/packages/tool_shed/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-tool-shed"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/tool_shed/setup.cfg
+++ b/packages/tool_shed/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy Tool Shed
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/tool_shed_schema/pyproject.toml
+++ b/packages/tool_shed_schema/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-tool-shed-schema"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/tool_shed_schema/setup.cfg
+++ b/packages/tool_shed_schema/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Pydantic models for the Galaxy Tool Shed
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/tool_util/pyproject.toml
+++ b/packages/tool_util/pyproject.toml
@@ -14,6 +14,25 @@ dynamic = [
     "version",
 ]
 name = "galaxy-tool-util"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-tool-test = "galaxy.tool_util.verify.script:main"

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -1,26 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy tool and tool dependency utilities
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/tool_util_models/pyproject.toml
+++ b/packages/tool_util_models/pyproject.toml
@@ -14,3 +14,22 @@ dynamic = [
     "version",
 ]
 name = "galaxy-tool-util-models"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/tool_util_models/setup.cfg
+++ b/packages/tool_util_models/setup.cfg
@@ -1,26 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Pydantic models for Galaxy tools
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/tours/pyproject.toml
+++ b/packages/tours/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-tours"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 gx-validate-tours = "galaxy.tours.validate:main"

--- a/packages/tours/setup.cfg
+++ b/packages/tours/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy tours backend framework
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/util/pyproject.toml
+++ b/packages/util/pyproject.toml
@@ -14,3 +14,22 @@ dynamic = [
     "version",
 ]
 name = "galaxy-util"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -1,26 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy generic utilities
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/web_apps/pyproject.toml
+++ b/packages/web_apps/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-web-apps"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-web = "galaxy.webapps.galaxy.script:main"

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy web apps
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/web_client/pyproject.toml
+++ b/packages/web_client/pyproject.toml
@@ -14,6 +14,23 @@ dynamic = [
     "version",
 ]
 name = "galaxy-web-client"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]
 
 [project.scripts]
 galaxy-web-client-install = "galaxy.web_client.install:main"

--- a/packages/web_client/setup.cfg
+++ b/packages/web_client/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy web client (frontend)
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/web_framework/pyproject.toml
+++ b/packages/web_framework/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-web-framework"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/web_framework/setup.cfg
+++ b/packages/web_framework/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy web framework
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE

--- a/packages/web_stack/pyproject.toml
+++ b/packages/web_stack/pyproject.toml
@@ -14,3 +14,20 @@ dynamic = [
     "version",
 ]
 name = "galaxy-web-stack"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
+keywords = ["Galaxy"]

--- a/packages/web_stack/setup.cfg
+++ b/packages/web_stack/setup.cfg
@@ -1,24 +1,7 @@
 [metadata]
 author = Galaxy Project and Community
 author_email = galaxy-committers@lists.galaxyproject.org
-classifiers =
-    Development Status :: 5 - Production/Stable
-    Environment :: Console
-    Intended Audience :: Developers
-    Natural Language :: English
-    Operating System :: POSIX
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
-    Programming Language :: Python :: 3.13
-    Programming Language :: Python :: 3.14
-    Topic :: Software Development
-    Topic :: Software Development :: Code Generators
-    Topic :: Software Development :: Testing
 description = Galaxy web stack abstraction
-keywords =
-    Galaxy
 license = MIT
 license_files =
     LICENSE


### PR DESCRIPTION
A follow-up to #22832 and #22825

When a [project] table is present in `pyproject.toml`, setuptools ignores fields in `setup.cfg` unless they are listed in the dynamic array.  This applies to classifiers and keywords: the build was silently dropping them from the wheel metadata.

Fix: define classifiers and keywords as static values directly in the [project] section of each package's `pyproject.toml`, and remove them from `setup.cfg`.

Alternate fix: add both to the dynamic list, keeping the definitions in `setup.cfg`. However, I think the first is better since that keeps `pyproject.toml` as the single source of truth.

Discovered during local package build:
```writing manifest file 'galaxy.egg-info/SOURCES.txt'                                                                                                                                                                                                                                                                                                                                         
/home/john/.cache/uv/builds-v0/.tmpxoaSmZ/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:75: _MissingDynamic: `keywords` defined outside of `pyproject.toml` is ignored.                                                                                                                                                                                            
!!                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                            
        ********************************************************************************                                                                                                                                                                                                                                                                                                    
        The following seems to be defined outside of `pyproject.toml`:                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                            
        `keywords = ['Galaxy']`                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                            
        According to the spec (see the link below), however, setuptools CANNOT                                                                                                                                                                                                                                                                                                              
        consider this value unless `keywords` is listed as `dynamic`.                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                            
        https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                            
        To prevent this problem, you can list `keywords` under `dynamic` or alternatively                                                                                                                                                                                                                                                                                                   
        remove the `[project]` table from your file and rely entirely on other means of                                                                                                                                                                                                                                                                                                     
        configuration.                                                                                                                                                                                                                                                                                                                                                                      
        ********************************************************************************                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                            
!!                                                                                                                                                                                                                                                                                                                                                                                          
  _handle_missing_dynamic(dist, project_table)                                                                                                                                                                                                                                                                                                                                              
/home/john/.cache/uv/builds-v0/.tmpxoaSmZ/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:75: _MissingDynamic: `classifiers` defined outside of `pyproject.toml` is ignored.                                                                                                                                                                                         
!!                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                            
        ********************************************************************************                                                                                                                                                                                                                                                                                                    
        The following seems to be defined outside of `pyproject.toml`:                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                            
        `classifiers = ['Development Status :: 5 - Production/Stable', 'Environment :: Console', 'Intended Audience :: Developers', 'Intended Audience :: Science/Research', 'Natural Language :: English', 'Operating System :: POSIX', 'Programming Language :: Python :: 3', 'Programming Language :: Python :: 3.10', 'Programming Language :: Python :: 3.11', 'Programming Language ::
 Python :: 3.12', 'Programming Language :: Python :: 3.13', 'Programming Language :: Python :: 3.14', 'Topic :: Scientific/Engineering :: Bio-Informatics', 'Topic :: Software Development', 'Topic :: Software Development :: Code Generators', 'Topic :: Software Development :: Testing']`                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                            
        According to the spec (see the link below), however, setuptools CANNOT                                                                                                                                                                                                                                                                                                              
        consider this value unless `classifiers` is listed as `dynamic`.                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                            
        https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                            
        To prevent this problem, you can list `classifiers` under `dynamic` or alternatively                                                                                                                                                                                                                                                                                                
        remove the `[project]` table from your file and rely entirely on other means of                                                                                                                                                                                                                                                                                                     
        configuration.                                                                                                                                                                                                                                                                                                                                                                      
        ********************************************************************************
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
