### PR TITLE
Cleanup Markdown export: render mapped (ICJ) job directives; drop dead report data

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -16926,27 +16926,6 @@ export interface components {
              */
             generate_version?: string | null;
             /**
-             * Histories
-             * @description Histories associated with the invocation.
-             */
-            histories?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * History dataset collections
-             * @description History dataset collections associated with the invocation.
-             */
-            history_dataset_collections?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * History datasets
-             * @description History datasets associated with the invocation.
-             */
-            history_datasets?: {
-                [key: string]: unknown;
-            } | null;
-            /**
              * Workflow ID
              * @description The workflow this invocation has been triggered for.
              * @example 0123456789ABCDEF
@@ -16957,20 +16936,6 @@ export interface components {
              * @description Raw galaxy-flavored markdown contents of the report.
              */
             invocation_markdown?: string | null;
-            /**
-             * Invocations
-             * @description Other invocations associated with the invocation.
-             */
-            invocations?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Jobs
-             * @description Jobs associated with the invocation.
-             */
-            jobs?: {
-                [key: string]: unknown;
-            } | null;
             /**
              * Markdown
              * @description Raw galaxy-flavored markdown contents of the report.
@@ -16999,13 +16964,6 @@ export interface components {
              * @description The name of the user who owns this report.
              */
             username: string;
-            /**
-             * Workflows
-             * @description Workflows associated with the invocation.
-             */
-            workflows?: {
-                [key: string]: unknown;
-            } | null;
         };
         /**
          * InvocationSerializationView

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -38,7 +38,6 @@ from galaxy.exceptions import (
     ObjectNotFound,
     ServerNotConfiguredForRequest,
 )
-from galaxy.managers.hdcas import HDCASerializer
 from galaxy.managers.jobs import (
     JobManager,
     summarize_job_metrics,
@@ -46,6 +45,7 @@ from galaxy.managers.jobs import (
 )
 from galaxy.managers.licenses import LicensesManager
 from galaxy.model import (
+    ImplicitCollectionJobs,
     Job,
 )
 from galaxy.model.item_attrs import get_item_annotation_str
@@ -146,6 +146,25 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
         job_manager = JobManager(trans.app, history_manager)
         collection_manager = trans.app.dataset_collection_manager
 
+        def _job_for_job_directive(object_type, object_id):
+            """Resolve the job a job directive (stdout/stderr/metrics/parameters)
+            refers to, by either a job id or an implicit collection jobs id.
+
+            For a map-over (ICJ) the representative job stands in for the step.
+            There is no ICJ-level access accessor, so access is enforced by
+            running the representative job through ``get_accessible_job``.
+            """
+            if object_id is None:
+                return None
+            if object_type == "job_id":
+                return job_manager.get_accessible_job(trans, object_id)
+            if object_type == "implicit_collection_jobs_id":
+                icj = trans.sa_session.get(ImplicitCollectionJobs, object_id)
+                if icj is None:
+                    raise ObjectNotFound(f"ImplicitCollectionJobs [{object_id}] not found")
+                return job_manager.get_accessible_job(trans, icj.representative_job.id)
+            return None
+
         def _remap(container, line):
             line, object_type, object_id, encoded_id = self._encode_line(trans, line)
             rval = None
@@ -214,20 +233,20 @@ class GalaxyInternalMarkdownDirectiveHandler(metaclass=abc.ABCMeta):
                     hdca = collection_manager.get_dataset_collection_instance(trans, "history", encoded_id)
                     rval = self.handle_dataset_collection_display(line, hdca)
             elif container == "tool_stdout":
-                if object_id is not None and object_type == "job_id":
-                    job = job_manager.get_accessible_job(trans, object_id)
+                job = _job_for_job_directive(object_type, object_id)
+                if job is not None:
                     rval = self.handle_tool_stdout(line, job)
             elif container == "tool_stderr":
-                if object_id is not None and object_type == "job_id":
-                    job = job_manager.get_accessible_job(trans, object_id)
+                job = _job_for_job_directive(object_type, object_id)
+                if job is not None:
                     rval = self.handle_tool_stderr(line, job)
             elif container == "job_parameters":
-                if object_id is not None and object_type == "job_id":
-                    job = job_manager.get_accessible_job(trans, object_id)
+                job = _job_for_job_directive(object_type, object_id)
+                if job is not None:
                     rval = self.handle_job_parameters(line, job)
             elif container == "job_metrics":
-                if object_id is not None and object_type == "job_id":
-                    job = job_manager.get_accessible_job(trans, object_id)
+                job = _job_for_job_directive(object_type, object_id)
+                if job is not None:
                     rval = self.handle_job_metrics(line, job)
             elif container == "generate_galaxy_version":
                 version = trans.app.config.version_major
@@ -525,60 +544,46 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         self.trans = trans
         self.extra_rendering_data = extra_rendering_data
 
-    def ensure_rendering_data_for(self, object_type, obj):
-        encoded_id = self.trans.security.encode_id(obj.id)
-        if object_type not in self.extra_rendering_data:
-            self.extra_rendering_data[object_type] = {}
-        object_type_data = self.extra_rendering_data[object_type]
-        if encoded_id not in object_type_data:
-            object_type_data[encoded_id] = {}
-        return object_type_data[encoded_id]
-
-    def extend_history_dataset_rendering_data(self, obj, key, val, default_val):
-        self.ensure_rendering_data_for("history_datasets", obj)[key] = val or default_val
-
+    # Object directives are no-ops here. The interactive client resolves every
+    # referenced object live from its own store/API (datasets, collections, jobs,
+    # workflows, histories, invocations), and PDF/HTML export renders inline via
+    # ToBasicMarkdownDirectiveHandler. The export markdown carries the (encoded-id)
+    # directive, so nothing needs to be baked into extra_rendering_data. Handlers
+    # are spelled out rather than defaulted on the base class so a new directive
+    # must still be considered here explicitly.
     def handle_dataset_display(self, line, hda):
-        self.handle_dataset_name(line, hda)
-        self.handle_dataset_type(line, hda)
+        pass
 
     def handle_dataset_embedded(self, line, hda):
-        self.handle_dataset_name(line, hda)
+        pass
 
     def handle_dataset_peek(self, line, hda):
-        self.extend_history_dataset_rendering_data(hda, "peek", hda.peek, "*No Dataset Peek Available*")
+        pass
 
     def handle_dataset_info(self, line, hda):
-        self.extend_history_dataset_rendering_data(hda, "info", hda.info, "*No Dataset Info Available*")
+        pass
 
     def handle_workflow_display(self, line, stored_workflow, workflow_version: Optional[int]):
-        self.ensure_rendering_data_for("workflows", stored_workflow)["name"] = stored_workflow.name
+        pass
 
     def handle_workflow_image(self, line, stored_workflow, workflow_version: Optional[int]):
         pass
 
     def handle_workflow_license(self, line, stored_workflow):
-        self.ensure_rendering_data_for("workflows", stored_workflow)[
-            "license"
-        ] = stored_workflow.latest_workflow.license
+        pass
 
     def handle_dataset_collection_display(self, line, hdca):
-        hdca_serializer = HDCASerializer(self.trans.app)
-        hdca_view = hdca_serializer.serialize_to_view(hdca, user=self.trans.user, trans=self.trans, view="summary")
-        self.ensure_rendering_data_for("history_dataset_collections", hdca).update(hdca_view)
+        pass
 
     def handle_tool_stdout(self, line, job):
-        self.ensure_rendering_data_for("jobs", job)["tool_stdout"] = job.tool_stdout or "*No Standard Output Available*"
+        pass
 
     def handle_tool_stderr(self, line, job):
-        self.ensure_rendering_data_for("jobs", job)["tool_stderr"] = job.tool_stderr or "*No Standard Error Available*"
+        pass
 
     def handle_history_link(self, line, history):
-        self.ensure_rendering_data_for("histories", history)["name"] = history.name
+        pass
 
-    # Following three cases - the client side widgets have everything they need
-    # from the encoded ID. Don't implement a default on the base class though because
-    # it is good to force both Client and PDF/HTML export to deal with each new directive
-    # explicitly.
     def handle_dataset_as_image(self, line, hda):
         pass
 
@@ -622,7 +627,7 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         pass
 
     def handle_invocation_time(self, line, invocation):
-        self.ensure_rendering_data_for("invocations", invocation)["create_time"] = invocation.create_time.isoformat()
+        pass
 
     def handle_invocation_inputs(self, line, invocation):
         pass
@@ -634,10 +639,10 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         pass
 
     def handle_dataset_type(self, line, hda):
-        self.extend_history_dataset_rendering_data(hda, "ext", hda.ext, "*Unknown dataset type*")
+        pass
 
     def handle_dataset_name(self, line, hda):
-        self.extend_history_dataset_rendering_data(hda, "name", hda.name, "*Unknown dataset name*")
+        pass
 
     def handle_error(self, container, line, error):
         if "errors" not in self.extra_rendering_data:
@@ -801,13 +806,22 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
         markdown = f"---\n{markdown_wrapper[0]}\n---\n"
         return (markdown, True)
 
+    def _mapped_job_note(self, job):
+        """When ``job`` stands in for a map-over (ICJ) step, a note that the
+        rendered data is one representative element, not the whole map."""
+        icj_assoc = job.implicit_collection_jobs_association
+        if icj_assoc is None:
+            return ""
+        count = len(icj_assoc.implicit_collection_jobs.job_list)
+        return f"*Representative job of {count} mapped jobs.*\n\n"
+
     def handle_tool_stdout(self, line, job):
         stdout = job.tool_stdout or "*No Standard Output Available*"
-        return (f"**Standard Output:** {stdout}", True)
+        return (f"{self._mapped_job_note(job)}**Standard Output:** {stdout}", True)
 
     def handle_tool_stderr(self, line, job):
         stderr = job.tool_stderr or "*No Standard Error Available*"
-        return (f"**Standard Error:** {stderr}", True)
+        return (f"{self._mapped_job_note(job)}**Standard Error:** {stderr}", True)
 
     def handle_job_metrics(self, line, job):
         job_metrics = summarize_job_metrics(self.trans, job)
@@ -817,7 +831,7 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
             if plugin not in metrics_by_plugin:
                 metrics_by_plugin[plugin] = {}
             metrics_by_plugin[plugin][job_metric["title"]] = job_metric["value"]
-        markdown = ""
+        markdown = self._mapped_job_note(job)
         for metric_plugin, metrics_for_plugin in metrics_by_plugin.items():
             markdown += f"**{metric_plugin}**\n\n"
             markdown += "|   |   |\n|---|--|\n"
@@ -826,7 +840,8 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
         return (markdown, True)
 
     def handle_job_parameters(self, line, job: Job):
-        markdown = """
+        markdown = self._mapped_job_note(job)
+        markdown += """
 | Input Parameter | Value |
 |-----------------|-------|
 """

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -496,37 +496,6 @@ class InvocationReport(Model, WithModelClass):
         description="Errors associated with the invocation.",
     )
 
-    history_datasets: Optional[dict[str, Any]] = Field(
-        default=None,
-        title="History datasets",
-        description="History datasets associated with the invocation.",
-    )
-    workflows: Optional[dict[str, Any]] = Field(
-        default=None,
-        title="Workflows",
-        description="Workflows associated with the invocation.",
-    )
-    history_dataset_collections: Optional[dict[str, Any]] = Field(
-        default=None,
-        title="History dataset collections",
-        description="History dataset collections associated with the invocation.",
-    )
-    jobs: Optional[dict[str, Any]] = Field(
-        default=None,
-        title="Jobs",
-        description="Jobs associated with the invocation.",
-    )
-    histories: Optional[dict[str, Any]] = Field(
-        default=None,
-        title="Histories",
-        description="Histories associated with the invocation.",
-    )
-    invocations: Optional[dict[str, Any]] = Field(
-        default=None,
-        title="Invocations",
-        description="Other invocations associated with the invocation.",
-    )
-
 
 class ReportInvocationErrorPayload(Model):
     invocation_id: DecodedDatabaseIdField = Field(

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from unittest import mock
 
 from galaxy import model
+from galaxy.exceptions import ItemAccessibilityException
 from galaxy.managers.jobs import JobManager
 from galaxy.managers.markdown_util import (
     ready_galaxy_markdown_for_export,
@@ -326,12 +327,89 @@ job_metrics(job_id=1)
         assert "| Cores Allocated | 1 |\n" in result
         assert "| GALAXY_HOME | /path/to/home |\n" in result
 
+    def _mapped_job_and_icj(self, count=3):
+        """A representative job standing in for an N-element map-over (ICJ)."""
+        job = model.Job()
+        job.id = 1
+        icj = mock.MagicMock()
+        icj.representative_job = job
+        icj.job_list = [job] + [mock.MagicMock() for _ in range(count - 1)]
+        icj_assoc = mock.MagicMock()
+        icj_assoc.implicit_collection_jobs = icj
+        job.implicit_collection_jobs_association = icj_assoc
+        return job, icj
+
+    def test_tool_stdout_implicit_collection_jobs(self):
+        job, icj = self._mapped_job_and_icj(count=3)
+        job.tool_stdout = "mapped stdout"
+        example = """# Example
+```galaxy
+tool_stdout(implicit_collection_jobs_id=7)
+```
+"""
+        with mock.patch.object(self.trans, "sa_session") as sa_session:
+            sa_session.get.return_value = icj
+            with mock.patch.object(JobManager, "get_accessible_job", return_value=job):
+                result = self._to_basic(example)
+        assert "**Standard Output:** mapped stdout" in result
+        assert "Representative job of 3 mapped jobs" in result
+        assert "implicit_collection_jobs_id" not in result
+
+    def test_job_metrics_implicit_collection_jobs(self):
+        job, icj = self._mapped_job_and_icj(count=4)
+        example = """# Example
+```galaxy
+job_metrics(implicit_collection_jobs_id=7)
+```
+"""
+        metrics = [{"plugin": "core", "title": "Cores Allocated", "value": 1}]
+        with mock.patch.object(self.trans, "sa_session") as sa_session:
+            sa_session.get.return_value = icj
+            with mock.patch.object(JobManager, "get_accessible_job", return_value=job):
+                with mock.patch("galaxy.managers.markdown_util.summarize_job_metrics", return_value=metrics):
+                    result = self._to_basic(example)
+        assert "| Cores Allocated | 1 |\n" in result
+        assert "Representative job of 4 mapped jobs" in result
+        assert "implicit_collection_jobs_id" not in result
+
+    def test_job_parameters_implicit_collection_jobs(self):
+        job, icj = self._mapped_job_and_icj(count=2)
+        example = """# Example
+```galaxy
+job_parameters(implicit_collection_jobs_id=7)
+```
+"""
+        response = {"parameters": [{"text": "Num Lines", "value": "6", "depth": 1}]}
+        with mock.patch.object(self.trans, "sa_session") as sa_session:
+            sa_session.get.return_value = icj
+            with mock.patch.object(JobManager, "get_accessible_job", return_value=job):
+                with mock.patch("galaxy.managers.markdown_util.summarize_job_parameters", return_value=response):
+                    result = self._to_basic(example)
+        assert "| Num Lines |" in result
+        assert "Representative job of 2 mapped jobs" in result
+        assert "implicit_collection_jobs_id" not in result
+
+    def test_implicit_collection_jobs_access_denied_does_not_leak(self):
+        job, icj = self._mapped_job_and_icj()
+        job.tool_stdout = "SECRET stdout"
+        example = """# Example
+```galaxy
+tool_stdout(implicit_collection_jobs_id=7)
+```
+"""
+        with mock.patch.object(self.trans, "sa_session") as sa_session:
+            sa_session.get.return_value = icj
+            with mock.patch.object(JobManager, "get_accessible_job", side_effect=ItemAccessibilityException("nope")):
+                result = self._to_basic(example)
+        assert "SECRET stdout" not in result
+
     def _to_basic(self, example):
         return to_basic_markdown(self.trans, example)
 
 
 class TestReadyExport(BaseExportTestCase):
-    def test_ready_dataset_display(self):
+    def test_ready_dataset_display_not_baked(self):
+        # The client resolves datasets live; nothing is baked into the report.
         hda = self._new_hda()
         example = """
 ```galaxy
@@ -340,10 +418,9 @@ history_dataset_display(history_dataset_id=1)
 """
         with self._expect_get_hda(hda):
             _, export_markdown, extra_data = self._ready_export(example)
-        assert "history_datasets" in extra_data
-        assert len(extra_data["history_datasets"]) == 1
+        assert "history_datasets" not in extra_data
 
-    def test_ready_export_two_datasets(self):
+    def test_ready_export_two_datasets_not_baked(self):
         hda = self._new_hda()
         hda2 = self._new_hda()
         hda2.id = 2
@@ -358,10 +435,9 @@ history_dataset_display(history_dataset_id=2)
 """
         self.app.hda_manager.get_accessible.side_effect = [hda, hda2]
         _, export_markdown, extra_data = self._ready_export(example)
-        assert "history_datasets" in extra_data
-        assert len(extra_data["history_datasets"]) == 2
+        assert "history_datasets" not in extra_data
 
-    def test_export_dataset_collection_paired(self):
+    def test_export_dataset_collection_not_baked(self):
         hdca = model.HistoryDatasetCollectionAssociation()
         hdca.name = "cool name"
         hdca.collection = self._new_pair_collection()
@@ -375,19 +451,8 @@ history_dataset_display(history_dataset_id=2)
 history_dataset_collection_display(history_dataset_collection_id=1)
 ```
 """
-        # Mock the HDCASerializer to return a dummy serialized view
-        from galaxy.managers.hdcas import HDCASerializer
-
-        mock_hdca_view = {"id": "encoded_id_1", "name": "cool name", "collection_type": "paired"}
-
-        with (
-            mock.patch.object(HDCASerializer, "url_for", return_value="http://google.com"),
-            mock.patch.object(HDCASerializer, "serialize_to_view", return_value=mock_hdca_view),
-            mock.patch.object(HDCASerializer, "serialize_store_times_summary", return_value=[]),
-        ):
-            _, export, extra_data = self._ready_export(example)
-        assert "history_dataset_collections" in extra_data
-        assert len(extra_data.get("history_dataset_collections")) == 1
+        _, export, extra_data = self._ready_export(example)
+        assert "history_dataset_collections" not in extra_data
 
     def test_galaxy_version(self):
         example = """# Example
@@ -408,7 +473,7 @@ generate_time()
         _, result, extra_data = self._ready_export(example)
         assert "generate_time" in extra_data
 
-    def test_get_invocation_time(self):
+    def test_invocation_time_not_baked(self):
         invocation = self._new_invocation()
         self.app.workflow_manager.get_invocation.side_effect = [invocation]
         example = """# Example
@@ -417,9 +482,7 @@ invocation_time(invocation_id=1)
 ```
 """
         _, result, extra_data = self._ready_export(example)
-        assert "invocations" in extra_data
-        assert "create_time" in extra_data["invocations"]["be8be0fd2ce547f6"]
-        assert extra_data["invocations"]["be8be0fd2ce547f6"]["create_time"] == invocation.create_time.isoformat()
+        assert "invocations" not in extra_data
 
     def test_export_replaces_embedded_history_dataset_type(self):
         hda = self._new_hda()


### PR DESCRIPTION
Two related cleanups to the internal Galaxy-markdown export path.

### 1. Handle `implicit_collection_jobs_id` in job directives

`tool_stdout` / `tool_stderr` / `job_metrics` / `job_parameters` only dispatched on `job_id`, even though the directive-argument regex recognizes `implicit_collection_jobs_id` and `resolve_invocation_markdown` emits it for map-over steps. So those directives no-op'd on parse, and PDF/HTML export (`to_basic_markdown`) rendered a literal `job_metrics(implicit_collection_jobs_id=...)` code block instead of a table for any report covering a mapped step.

This adds a shared resolver (`_job_for_job_directive`) that accepts either id. For a map-over the representative job stands in for the step. There is no ICJ-level access accessor, so access is still enforced by running the representative job through `get_accessible_job` (rather than returning a bare `sa_session.get` to a handler). `ToBasicMarkdownDirectiveHandler` renders the representative job, labeled *"Representative job of N mapped jobs"* so it isn't silently element-0.

### 2. Drop the orphaned `extra_rendering_data` baking

`ReadyForExportMarkdownDirectiveHandler` baked per-object data into `extra_rendering_data` buckets (`history_datasets`, `history_dataset_collections`, `workflows`, `histories`, `jobs`, `invocations`), declared as `InvocationReport` fields and merged into the report / page-export payloads. The client migrated to resolving every markdown object live and stopped reading these buckets:

- **jobs**: `useJobStore.fetchJob` + `GET /api/jobs` (incl. `implicit_collection_jobs_id`) in JobMetrics/JobParameters/ToolStd (cf79d14db1, 5f3d617b1d, late 2023).
- **datasets/collections**: dataset store / `fetchCollectionSummary` / `/api/datasets` in HistoryDatasetDisplay etc. (PR #19719, "revise_markdown_wrapper").
- **Markdown.vue** reads only `update_time` / `title` / `model_class` / `id` off the report.

Confirmed no remaining consumer: `chat.py` already discards the buckets; `pages.py` and the workflow report generator only pass them through to that live-fetching client; bioblend's `get_invocation_report` returns the dict but only reads `report["markdown"]`. `PageDetails` / `ToolReportForDataset` use `extra="allow"`, so they need no schema change.

Removes the bucket-populating handlers (now no-ops), the `ensure_rendering_data_for` / `extend_history_dataset_rendering_data` helpers, the now-unused `HDCASerializer` import, the six `InvocationReport` schema fields, and the matching generated client types. Keeps `errors`, `generate_time`, `generate_version`, and the embed-expansion pass (`export_markdown_embed_expanded`) untouched.

### Thermo Nuclear Review 

<details>
## Verdict: Approve — this is a strong, structurally healthy change

This is the rare diff that **deletes a layer of complexity rather than rearranging it**, and the one new abstraction it adds is exactly the right code-judo move. No blockers.

### What's good (and worth naming, since the bar is structural)

**1. `_job_for_job_directive` is the correct consolidation.** Before, four sibling branches each repeated `if object_id is not None and object_type == "job_id": job = job_manager.get_accessible_job(...)`. The diff collapses all four to a shared resolver + uniform `if job is not None:` dispatch. That's the right altitude — it folds the new `implicit_collection_jobs_id` case in *once* instead of bolting a second `elif` onto each of the four branches (which is the spaghetti path a lesser change would have taken). Access stays enforced through `get_accessible_job` on the representative job rather than a bare `sa_session.get` leaking to a handler — good instinct, and the access-denied test pins it.

**2. The `extra_rendering_data` removal deletes a whole dead layer, cleanly.** Six `Optional[dict[str, Any]]` schema fields, the generated TS types, two helpers (`ensure_rendering_data_for` / `extend_history_dataset_rendering_data`), the `HDCASerializer` import, and ~10 handler bodies — all gone. I verified `rval.update(extra_rendering_data)` in the markdown generator now only ever carries `errors` / `generate_time` / `generate_version`, all of which remain declared, so the schema trim is coherent end-to-end. Replacing loosely-typed `dict[str, Any]` buckets with nothing is a real type-boundary improvement, not just dead-code pruning.

**3. The block of ~20 `pass` methods reads as a smell but is justified.** The pre-existing "don't default on the base class so each new directive must be considered explicitly" rationale is preserved and consolidated into one comment. I'd normally push to collapse these to a base-class default — but the forcing-function still genuinely guards `ToBasicMarkdownDirectiveHandler`, so keeping it is a defensible judgment call, not drift.

### Minor notes (optional, non-blocking)

- **`_mapped_job_note` false-positive on `job_id`.** It keys off `job.implicit_collection_jobs_association`, so a `job_id(...)` directive pointing at a job that *happens* to be an ICJ constituent would render "Representative job of N mapped jobs" even though the user asked for that one specific job. `resolve_invocation_markdown` won't emit that, but a hand-authored report could. Low severity — mention it only if you want the note strictly scoped to the ICJ-resolved path (e.g. have the resolver flag "this came in as an ICJ" rather than re-deriving from the job).

- **`len(...job_list)` materializes all Job rows to get a count**, once per job directive present (up to 4× for the same step). It's an export path, so cold — but `len(icj_assoc.implicit_collection_jobs.jobs)` counts the associations without the `Job` join query if you want to trim it.

- **File is 1450 lines** — already well over 1k before this PR, and this change is net-neutral there (it *reduces* `ReadyForExportMarkdownDirectiveHandler`'s complexity). Not flagging the 1k rule since the diff doesn't cross the threshold, but `markdown_util.py` is a standing decomposition candidate independent of this work (the ~30-branch `_remap` if/elif chain is the obvious future table-drive target — correctly out of scope here).

Tests are appropriately red-to-green: ICJ rendering for all three job directives, access-denied non-leak, and the inverted `*_not_baked` assertions on `TestReadyExport`. Good coverage for the behavior change.

Ship it.
</details>

### Notes

- **Discovered, not fixed here**: `DatasetsService.report()` unpacks a 2-tuple from the 3-tuple `ready_galaxy_markdown_for_export()`, so that dataset tool-report path looks pre-existing-broken on `dev` independent of this change.

### Tests

- Add ICJ rendering + access-denied coverage for `to_basic_markdown`.
- Update `TestReadyExport` to assert the buckets are no longer baked.
