### PR TITLE
[26.0] Fix tag creation self-deadlock under SQLite

### DIFF
--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -6,6 +6,8 @@ from typing import (
     Union,
 )
 
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import (
     scoped_session,
@@ -330,17 +332,30 @@ class TagHandler:
 
     def _create_tag_instance(self, tag_name):
         # For good performance caller should first check if there's already an appropriate tag
-        tag = Tag(type=0, name=tag_name)
         if not isinstance(self.sa_session, scoped_session):
-            return tag
-        Session = sessionmaker(self.sa_session.bind)
-        with Session() as separate_session:
-            separate_session.add(tag)
-            try:
-                separate_session.commit()
-            except IntegrityError:
-                # tag already exists, get from database
-                separate_session.rollback()
+            return Tag(type=0, name=tag_name)
+        # Upsert the tag on the session's own connection, ignoring a concurrently
+        # created duplicate (the ``tag.name`` unique constraint) so it does not abort
+        # the caller's transaction. The insert must share the caller's connection: a
+        # second connection would deadlock against an enclosing write transaction
+        # under SQLite's single-writer model.
+        bind = self.sa_session.get_bind()
+        dialect = bind.dialect.name
+        if dialect in ("sqlite", "postgresql"):
+            insert_ = sqlite_insert if dialect == "sqlite" else postgresql_insert
+            self.sa_session.execute(
+                insert_(Tag).values(type=0, name=tag_name).on_conflict_do_nothing(index_elements=["name"])
+            )
+        else:
+            # Backends without a native upsert isolate the insert in a separate
+            # session so a unique-name violation does not abort the caller's transaction.
+            Session = sessionmaker(bind)
+            with Session() as separate_session:
+                separate_session.add(Tag(type=0, name=tag_name))
+                try:
+                    separate_session.commit()
+                except IntegrityError:
+                    separate_session.rollback()
         return self._get_tag(tag_name)
 
     def _get_or_create_tag(self, tag_str):


### PR DESCRIPTION
### What did you do?

`TagHandler._create_tag_instance` created the `Tag` in a **separate** session and committed it, to keep a unique-name `IntegrityError` from aborting the caller's transaction (introduced in #13186 / "Handle unique tag name constraints").

When that runs **inside an open write transaction** — e.g. applying a tag to an output during workflow job creation — the second connection's commit deadlocks against the first on SQLite's single-writer lock. It surfaces intermittently as:

```
(sqlite3.OperationalError) database is locked
[SQL: INSERT INTO tag (type, parent_id, name) VALUES (?, ?, ?)]
```

failing the job and the workflow invocation. It's timing-sensitive: any small added latency in the surrounding code makes it reproducible (it can be triggered on an otherwise-unmodified tree).

### How did you fix it?

Insert the tag on the session's **own** connection using `INSERT ... ON CONFLICT (name) DO NOTHING` (SQLite and PostgreSQL both support this natively). This preserves the duplicate-name isolation that motivated the separate session, without opening a second connection — so there is nothing for the enclosing transaction to deadlock against. Backends without a native upsert keep the separate-session fallback; the single-writer deadlock is SQLite-specific.

Mechanism, from a connection-level trace of a failing run: the scheduler thread held a write lock on connection A (`UPDATE history ... hid_counter`) and then tried `INSERT INTO tag` on connection B (the separate session) — same thread, two connections, blocked until the busy-timeout. With the fix both statements run on the same connection.

### How to test the changes?

<!-- (Select all options that apply) -->
- [ ] I've included relevant automated tests.
- [x] This PR is a refactoring of existing functionality.

Existing coverage exercises this path:
- `test/unit/app/managers/test_TagHandler.py` (8 passed)
- API: `test_tags.py`, `test_item_tags.py`, `test_tool_output_tagging.py` (10 passed)
- The workflow tag tests (`test_run_add_tag_on_collection_output`, `test_tag_auto_propagation`, `test_run_add_tag_on_mapped_over_collection`) pass with the fix; without it they deadlock once enough latency is present on the invoke path.

### License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).