### PR TITLE
[26.1] Fix galaxy-api-client npm publishing on release

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -135,5 +135,7 @@ jobs:
         working-directory: 'client'
       - name: publish client-api
         if: (github.event_name == 'workflow_dispatch' && inputs.release_type == 'release') || (github.event_name == 'release' && !github.event.release.prerelease)
-        run: npm publish --provenance --access public
+        # Publish like the client: pnpm + --no-git-checks (CI publishes from a detached
+        # tag checkout with a dirty tree, which pnpm's default git checks would block).
+        run: pnpm publish --provenance --access public --no-git-checks
         working-directory: 'client/packages/api-client'

--- a/client/packages/api-client/package.json
+++ b/client/packages/api-client/package.json
@@ -2,6 +2,11 @@
   "name": "@galaxyproject/galaxy-api-client",
   "version": "25.0.0-dev.0",
   "description": "A client library for the Galaxy API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/galaxyproject/galaxy.git",
+    "directory": "client/packages/api-client"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
`@galaxyproject/galaxy-api-client`'s last npm publish was `25.1.0`, hand-pushed in January
2026 as a one-off backfill -- it has **never** published from a release-triggered run,
while `@galaxyproject/galaxy-client` publishes on every release. Two changes so api-client
publishes the same way the client does.

**Root cause.** The publish step runs with `--provenance`, and sigstore provenance
validation requires `package.json`'s `repository.url` to match the build's source repo.
api-client has no `repository` field, so it fails with E422. Confirmed from the one run
where the step actually executed (the v26.0.0 release run):

```
npm error code E422
npm error 422 Unprocessable Entity - PUT .../@galaxyproject%2fgalaxy-api-client -
  Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match "https://github.com/galaxyproject/galaxy" from provenance
```

galaxy-client publishes fine because it *has* a `repository` field. It's gone unnoticed
because most release runs never reach this point -- the publishes skip on the
prerelease-flagged event, or the job aborts at the client publish before reaching
api-client.

**Changes:**
1. Add a `repository` field (with `directory` for the monorepo subdir) to
   `client/packages/api-client/package.json`, mirroring galaxy-client's -- this is what
   unblocks the provenance publish.
2. Switch the api-client publish to `pnpm publish --provenance --access public
   --no-git-checks`, matching galaxy-client. `--no-git-checks` is required because CI
   publishes from a detached release-tag checkout with a dirty tree.

Targeting `release_26.1` so 26.1.0 publishes api-client cleanly; merges forward to `dev`.

**Follow-up (not in this PR):** the job publishes the client before api-client in the same
job, so once `galaxy-client@X` exists a re-run dies at the client step ("cannot publish
over") before reaching api-client. Worth making them independent, but not needed for the
next clean release.
