### PR TITLE
Workflow extraction: keep input and output labels unique

### DIFF
--- a/client/src/components/History/WorkflowExtractionForm.test.ts
+++ b/client/src/components/History/WorkflowExtractionForm.test.ts
@@ -111,7 +111,27 @@ function summary(jobs: WorkflowExtractionJob[], warnings: string[] = []): Workfl
     return { history_id: "history-1", jobs, warnings };
 }
 
+/** Second input sharing INPUT_JOB's output name ("myfile.txt") → colliding newName. */
+const INPUT_JOB_DUP: WorkflowExtractionJob = {
+    ...INPUT_JOB,
+    outputs: [{ ...INPUT_JOB.outputs![0], id: "ds-3" } as NonNullable<WorkflowExtractionJob["outputs"]>[number]],
+};
+
+/** Two tool jobs whose exposed outputs default to the same label ("shared"). */
+const TOOL_JOB_OUT_A: WorkflowExtractionJob = {
+    ...TOOL_JOB,
+    id: "job-out-a",
+    outputs: [{ ...TOOL_OUTPUT, id: "out-a", name: "shared" }],
+};
+const TOOL_JOB_OUT_B: WorkflowExtractionJob = {
+    ...TOOL_JOB,
+    id: "job-out-b",
+    outputs: [{ ...TOOL_OUTPUT, id: "out-b", name: "shared" }],
+};
+
 const SUMMARY_WITH_JOBS = summary([TOOL_JOB, INPUT_JOB]);
+const SUMMARY_WITH_DUPLICATE_INPUT_NAMES = summary([INPUT_JOB, INPUT_JOB_DUP]);
+const SUMMARY_WITH_DUPLICATE_OUTPUT_NAMES = summary([TOOL_JOB_OUT_A, TOOL_JOB_OUT_B]);
 const SUMMARY_WITH_MAPPED_JOB = summary([MAPPED_TOOL_JOB]);
 const SUMMARY_WITH_DUPLICATE_MAPPED_JOBS = summary([MAPPED_TOOL_JOB, MAPPED_TOOL_JOB_2]);
 const SUMMARY_WITH_PLAIN_AND_MAPPED_JOBS = summary([TOOL_JOB, MAPPED_TOOL_JOB]);
@@ -422,6 +442,99 @@ describe("WorkflowExtractionForm", () => {
             // no name set — button stays disabled
             await clickCreateButton(wrapper);
             expect(extractWorkflowByIds).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("uniqueness validation", () => {
+        function disabledReason(wrapper: ReturnType<typeof shallowMount>): string {
+            return wrapper.findComponent(GButton).props("disabledTitle") as string;
+        }
+
+        function card(wrapper: ReturnType<typeof shallowMount>, index: number) {
+            return wrapper.findAllComponents(WorkflowExtractionCard).at(index);
+        }
+
+        it("de-duplicates colliding input names so the UI reflects what will be created", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_DUPLICATE_INPUT_NAMES);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+
+            const names = [card(wrapper, 0).props("job").newName, card(wrapper, 1).props("job").newName];
+            expect(new Set(names)).toEqual(new Set(["myfile.txt", "myfile.txt (2)"]));
+            // Names are unique, so the backend won't reject — submit is enabled.
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(false);
+        });
+
+        it("re-uniquifies when an input is renamed into a collision", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_DUPLICATE_INPUT_NAMES);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+
+            // Cards start as ["myfile.txt", "myfile.txt (2)"]; rename the 2nd back onto the 1st.
+            card(wrapper, 1).vm.$emit("rename");
+            await flushPromises();
+            (wrapper.findComponent(RenameModal).props("renameAction") as (name: string) => void)("myfile.txt");
+            await wrapper.vm.$nextTick();
+
+            expect(card(wrapper, 1).props("job").newName).toBe("myfile.txt (2)");
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(false);
+        });
+
+        async function renameOutputVia(wrapper: ReturnType<typeof shallowMount>, index: number, label: string) {
+            card(wrapper, index).vm.$emit("rename-output", 0);
+            await flushPromises();
+            (wrapper.findComponent(RenameModal).props("renameAction") as (name: string) => void)(label);
+            await wrapper.vm.$nextTick();
+        }
+
+        it("disables submit when two exposed outputs share a label, re-enables after relabel", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_DUPLICATE_OUTPUT_NAMES);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            card(wrapper, 0).vm.$emit("toggle-output", 0);
+            card(wrapper, 1).vm.$emit("toggle-output", 0);
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
+            expect(disabledReason(wrapper)).toBe("Exposed output labels must be unique");
+
+            await renameOutputVia(wrapper, 1, "distinct");
+
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(false);
+        });
+
+        it("treats internal-whitespace variants as duplicate output labels (backend parity)", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_DUPLICATE_OUTPUT_NAMES);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            card(wrapper, 0).vm.$emit("toggle-output", 0);
+            card(wrapper, 1).vm.$emit("toggle-output", 0);
+            await wrapper.vm.$nextTick();
+
+            // Relabel both so they differ only by internal whitespace; the backend
+            // collapses "a  b" and "a b" to the same string and 400s the second.
+            await renameOutputVia(wrapper, 0, "a  b");
+            await renameOutputVia(wrapper, 1, "a b");
+
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
+            expect(disabledReason(wrapper)).toBe("Exposed output labels must be unique");
+        });
+
+        it("treats labels colliding only after 255-char truncation as duplicates (backend parity)", async () => {
+            vi.mocked(extractWorkflowFromHistory).mockResolvedValue(SUMMARY_WITH_DUPLICATE_OUTPUT_NAMES);
+            const wrapper = await mountForm();
+            await setWorkflowName(wrapper, "Extracted WF");
+            card(wrapper, 0).vm.$emit("toggle-output", 0);
+            card(wrapper, 1).vm.$emit("toggle-output", 0);
+            await wrapper.vm.$nextTick();
+
+            // Identical for 255 chars, differ only after — the backend truncates both
+            // to the same string and 400s the second; the frontend must predict that.
+            await renameOutputVia(wrapper, 0, "x".repeat(255) + "A");
+            await renameOutputVia(wrapper, 1, "x".repeat(255) + "B");
+
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
+            expect(disabledReason(wrapper)).toBe("Exposed output labels must be unique");
         });
     });
 });

--- a/client/src/components/History/WorkflowExtractionForm.vue
+++ b/client/src/components/History/WorkflowExtractionForm.vue
@@ -94,6 +94,7 @@ const submissionDisabled = computed(
         submitting.value ||
         hasUnnamedSelectedInputs.value ||
         hasUnnamedSelectedOutputs.value ||
+        hasDuplicateOutputLabels.value ||
         !workflowName.value.trim() ||
         hasNoSelectedSteps.value,
 );
@@ -107,6 +108,9 @@ const submissionDisabledMsg = computed(() => {
     }
     if (hasUnnamedSelectedOutputs.value) {
         return "All exposed outputs must have a label";
+    }
+    if (hasDuplicateOutputLabels.value) {
+        return "Exposed output labels must be unique";
     }
     if (hasNoSelectedSteps.value) {
         return "At least one workflow step must be selected";
@@ -207,6 +211,18 @@ const hasUnnamedSelectedOutputs = computed(() => {
     });
 });
 
+function hasDuplicates(values: string[]): boolean {
+    return new Set(values).size !== values.length;
+}
+
+/** Duplicate exposed-output labels. Normalized the same way the backend's
+ *  `_sanitize_output_label` does (trim + collapse internal whitespace) so the
+ *  disabled-button prediction matches the backend's 400 exactly. */
+const hasDuplicateOutputLabels = computed(() => {
+    const labels = selectedOutputLabels.value.map((output) => output.label.trim().replace(/\s+/g, " ").slice(0, 255));
+    return hasDuplicates(labels);
+});
+
 extractWorkflow();
 
 function getSelectedInputs(type: "dataset" | "dataset_collection"): { ids: string[]; names: string[] } {
@@ -219,11 +235,32 @@ function getSelectedInputs(type: "dataset" | "dataset_collection"): { ids: strin
     };
 }
 
+/** Append a numeric suffix until `desired` is unique within `taken`, then record it.
+ *  Input step labels share one namespace, so the workflow's input names stay unique
+ *  in the UI exactly as they will be created — the backend rejects duplicates. */
+function uniqueInputLabel(desired: string, taken: Set<string>): string {
+    let label = desired;
+    let suffix = 2;
+    while (taken.has(label)) {
+        label = `${desired} (${suffix})`;
+        suffix++;
+    }
+    taken.add(label);
+    return label;
+}
+
 async function extractWorkflow() {
     try {
         const result = await extractWorkflowFromHistory(props.historyId);
         if (result.jobs) {
-            jobsList.value = result.jobs.map(toExtractionRow);
+            const rows = result.jobs.map(toExtractionRow);
+            const taken = new Set<string>();
+            for (const row of rows) {
+                if (isInputStep(row)) {
+                    row.newName = uniqueInputLabel(row.newName, taken);
+                }
+            }
+            jobsList.value = rows;
         }
 
         warnings.value = result.warnings || [];
@@ -294,8 +331,15 @@ async function renameInput(newName: string) {
     }
 
     // Instead of using the computed `toRenameInput`, we directly update the `newName` in the `jobsList`
-    // to ensure reactivity and that the change is reflected in the UI immediately.
-    (jobsList.value[renameIndex.value] as InputStep).newName = newName;
+    // to ensure reactivity and that the change is reflected in the UI immediately. Re-uniquify so
+    // renaming into a collision suffixes the input just renamed rather than silently colliding.
+    const taken = new Set<string>();
+    jobsList.value.forEach((job, index) => {
+        if (isInputStep(job) && index !== renameIndex.value) {
+            taken.add(job.newName);
+        }
+    });
+    (jobsList.value[renameIndex.value] as InputStep).newName = uniqueInputLabel(newName, taken);
 }
 
 async function renameOutput(newName: string) {

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -71,6 +71,30 @@ def _sanitize_output_label(label: str) -> str:
     return label[:255]
 
 
+def _validate_input_names(
+    dataset_names: Optional[list[str]],
+    dataset_collection_names: Optional[list[str]],
+) -> None:
+    """Validate user-supplied workflow input names (step labels).
+
+    Dataset and collection input names share one namespace (the single
+    ``step_labels`` set in ``extract_steps``), so uniqueness is checked across
+    the combined list. Only inspects names that were actually supplied — the
+    no-names default path (the ``"Input Dataset"`` constants) is untouched.
+    Names are kept raw: limits are enforced by rejection, never truncation.
+    """
+    provided = (dataset_names or []) + (dataset_collection_names or [])
+    seen: set[str] = set()
+    for name in provided:
+        if not name.strip():
+            raise exceptions.RequestParameterInvalidException("workflow input names must not be empty")
+        if len(name) > 255:
+            raise exceptions.RequestParameterInvalidException(f"workflow input name exceeds 255 characters: {name!r}")
+        if name in seen:
+            raise exceptions.RequestParameterInvalidException(f"workflow input names must be unique: {name!r}")
+        seen.add(name)
+
+
 class WorkflowsService(ServiceBase):
     def __init__(
         self,
@@ -227,6 +251,7 @@ class WorkflowsService(ServiceBase):
     ) -> WorkflowExtractionResult:
         if trans.user is None:
             raise exceptions.AuthenticationRequired("Workflow extraction requires an authenticated user.")
+        _validate_input_names(payload.dataset_names, payload.dataset_collection_names)
         stored_workflow = extract_workflow(
             trans,
             user=trans.user,
@@ -306,6 +331,8 @@ class WorkflowsService(ServiceBase):
                 )
             for hdca in output_hdcas:
                 dataset_collection_manager.get_dataset_collection_instance(trans, "history", hdca.id)
+
+        _validate_input_names(payload.dataset_names, payload.dataset_collection_names)
 
         output_targets = collect_output_label_targets(
             trans,

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -136,6 +136,23 @@ class TestWorkflowExtractionApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCas
 
     @skip_without_tool("cat1")
     @summarize_instance_history_on_error
+    def test_extract_from_history_duplicate_input_names_rejected(self, history_id):
+        """POST /api/histories/{id}/extract_workflow rejects duplicate input names."""
+        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n", wait=True)
+        d2 = self.dataset_populator.new_dataset(history_id, content="beta\n", wait=True)
+        response = self._post(
+            f"histories/{history_id}/extract_workflow",
+            data={
+                "workflow_name": "dup names from history",
+                "dataset_hids": [d1["hid"], d2["hid"]],
+                "dataset_names": ["dup", "dup"],
+            },
+            json=True,
+        )
+        assert response.status_code == 400, response.text
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
     def test_extract_udt_step_with_downstream_tool(self, history_id):
         # A UDT job used to be silently dropped from the extraction because
         # get_tool(job.tool_id) returned None for UUID-based tool IDs. The fix
@@ -1338,6 +1355,110 @@ test_data:
             },
             (400,),
         )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_distinct_output_labels_colliding_after_truncation_rejected(self, history_id):
+        """Two labels identical for 255 chars but differing after collide once
+        `_sanitize_output_label` truncates to 255 — the second must be rejected."""
+        d1, _, cat1_job_id_a = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        out_a = self._history_contents(history_id)[-1]
+        run_b = self.dataset_populator.run_tool(
+            tool_id="cat1",
+            inputs={"input1": {"src": "hda", "id": d1["id"]}},
+            history_id=history_id,
+        )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+        out_b = run_b["outputs"][0]
+        cat1_job_id_b = run_b["jobs"][0]["id"]
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "truncation collision",
+                "hda_ids": [d1["id"]],
+                "job_ids": [cat1_job_id_a, cat1_job_id_b],
+                "output_labels": [
+                    {"kind": "hda", "id": out_a["id"], "label": "x" * 255 + "A"},
+                    {"kind": "hda", "id": out_b["id"], "label": "x" * 255 + "B"},
+                ],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_duplicate_dataset_names_rejected(self, history_id):
+        """Two data inputs given the same name collide in the single step-label
+        namespace. Without the guard the second input silently loses its label."""
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "duplicate input names",
+                "hda_ids": [d1["id"], d2["id"]],
+                "job_ids": [cat1_job_id],
+                "dataset_names": ["dup", "dup"],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_duplicate_name_across_dataset_and_collection_rejected(self, history_id):
+        """Dataset and collection input names share one namespace — a name reused
+        across the two lists must still be rejected."""
+        d1, _, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        hdca = self.dataset_collection_populator.create_list_in_history(history_id, wait=True).json()["outputs"][0]
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "dup across input namespaces",
+                "hda_ids": [d1["id"]],
+                "hdca_ids": [hdca["id"]],
+                "job_ids": [cat1_job_id],
+                "dataset_names": ["shared"],
+                "dataset_collection_names": ["shared"],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_empty_input_name_rejected(self, history_id):
+        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n", wait=True)
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "empty input name",
+                "hda_ids": [d1["id"]],
+                "dataset_names": ["   "],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_overlong_input_name_rejected(self, history_id):
+        """WorkflowStep.label is Unicode(255); an over-long input name is a
+        commit-time error, so reject it up front."""
+        d1 = self.dataset_populator.new_dataset(history_id, content="alpha\n", wait=True)
+        self._assert_extract_rejected(
+            {
+                "workflow_name": "overlong input name",
+                "hda_ids": [d1["id"]],
+                "dataset_names": ["x" * 256],
+            },
+            (400,),
+        )
+
+    @skip_without_tool("cat1")
+    @summarize_instance_history_on_error
+    def test_extract_unique_dataset_names_ok(self, history_id):
+        """Distinct names must not be over-rejected; both labels are kept verbatim."""
+        d1, d2, cat1_job_id = self._seed_two_inputs_and_run_cat1(history_id, c1="alpha\n", c2="beta\n")
+        downloaded = self._extract_and_download_workflow_by_ids(
+            hda_ids=[d1["id"], d2["id"]],
+            job_ids=[cat1_job_id],
+            dataset_names=["first input", "second input"],
+        )
+        input_steps = self.assert_steps_of_type(downloaded, "data_input", expected_len=2)
+        assert {step["label"] for step in input_steps} == {"first input", "second input"}, input_steps
 
 
 class TestWorkflowExtractionSummaryApi(_ExtractionHelpersMixin, BaseWorkflowsApiTestCase):


### PR DESCRIPTION
Inputs: backend rejects duplicate/empty/overlong provided input names (400). The form now de-duplicates input names client-side (numeric suffix, on load + on rename) so the UI shows exactly the labels that will be created — two same-named datasets become "X" / "X (2)" — and never trips the backend rejection. Fixes a regression where colliding default input names disabled the Create button (selenium test_extract_default_off_creates_no_workflow_outputs).

Outputs: backend already 400s on duplicate exposed-output labels; the form predicts that inline (disabled submit), normalizing the same way as _sanitize_output_label (trim + collapse whitespace + 255 truncate).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
