### PR TITLE
[25.1] Allow workflows with optional credentials to run without credentials set

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -276,8 +276,10 @@ export default {
         },
         hasCredentialsErrors() {
             if (this.formConfig.credentials?.length) {
-                const { hasUserProvidedAllRequiredServiceCredentials } =
-                    useUserToolCredentials(this.formConfig.id, this.formConfig.version);
+                const { hasUserProvidedAllRequiredServiceCredentials } = useUserToolCredentials(
+                    this.formConfig.id,
+                    this.formConfig.version,
+                );
                 return !hasUserProvidedAllRequiredServiceCredentials.value;
             }
             return false;

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -276,11 +276,8 @@ export default {
         },
         hasCredentialsErrors() {
             if (this.formConfig.credentials?.length) {
-                const { hasUserProvidedAllRequiredServiceCredentials, toolHasRequiredServiceCredentials } =
+                const { hasUserProvidedAllRequiredServiceCredentials } =
                     useUserToolCredentials(this.formConfig.id, this.formConfig.version);
-                if (!toolHasRequiredServiceCredentials.value) {
-                    return false;
-                }
                 return !hasUserProvidedAllRequiredServiceCredentials.value;
             }
             return false;

--- a/client/src/composables/userToolCredentials.test.ts
+++ b/client/src/composables/userToolCredentials.test.ts
@@ -322,6 +322,31 @@ describe("useUserToolCredentials", () => {
             expect(hasUserProvidedAllRequiredServiceCredentials.value).toBe(true);
         });
 
+        it("should return true for hasUserProvidedAllRequiredServiceCredentials when only optional credentials exist and none are set", () => {
+            // Set up a tool with only optional credentials
+            const OPTIONAL_ONLY_TOOL_ID = "optional-only-tool";
+            const OPTIONAL_ONLY_TOOL_VERSION = "1.0.0";
+
+            toolsServiceCredentialsDefinitionsStore.setToolServiceCredentialsDefinitionFor(
+                OPTIONAL_ONLY_TOOL_ID,
+                OPTIONAL_ONLY_TOOL_VERSION,
+                [TEST_OPTIONAL_SERVICE_DEFINITION],
+            );
+
+            // No user credentials set up yet (empty array)
+            userToolsServiceCredentialsStore.userToolsServices[
+                `${TEST_USER_ID}-${OPTIONAL_ONLY_TOOL_ID}-${OPTIONAL_ONLY_TOOL_VERSION}`
+            ] = [];
+
+            const { hasUserProvidedAllRequiredServiceCredentials, toolHasRequiredServiceCredentials } =
+                useUserToolCredentials(OPTIONAL_ONLY_TOOL_ID, OPTIONAL_ONLY_TOOL_VERSION);
+
+            // Tool has no required credentials
+            expect(toolHasRequiredServiceCredentials.value).toBe(false);
+            // Should return true because there are no required credentials to provide
+            expect(hasUserProvidedAllRequiredServiceCredentials.value).toBe(true);
+        });
+
         it("should correctly compute hasUserProvidedSomeOptionalServiceCredentials", () => {
             const { hasUserProvidedSomeOptionalServiceCredentials } = useUserToolCredentials(
                 TEST_TOOL_ID,

--- a/client/src/composables/userToolCredentials.ts
+++ b/client/src/composables/userToolCredentials.ts
@@ -153,7 +153,8 @@ export function useUserToolCredentials(toolId: string, toolVersion: string) {
     /** Whether user has provided all required service credentials. */
     const hasUserProvidedAllRequiredServiceCredentials = computed<boolean>(() => {
         if (!currentUserToolServices.value || currentUserToolServices.value.length === 0) {
-            return false;
+            // If there are no required credentials, this is fine
+            return !toolHasRequiredServiceCredentials.value;
         }
 
         for (const definition of sourceCredentialsDefinition.value.services.values()) {


### PR DESCRIPTION
Fixes #21848

PR #21889 fixed this issue for **individual tool execution** by adding a workaround in `ToolForm.vue`, but the bug still existed for **workflow execution** in `WorkflowRunFormSimple.vue`. This PR fixes the root cause in the composable itself, which fixes it for all components.

**Root cause:** The `hasUserProvidedAllRequiredServiceCredentials` computed property in `client/src/composables/userToolCredentials.ts` returned `false` when `currentUserToolServices` was empty, without checking if there were actually any required credentials. Now it checks `toolHasRequiredServiceCredentials` before returning false — returning `true` when there are no required credentials, even if no credentials are configured.

**Impact:**
- Fixes workflow execution with optional credentials (the remaining bug)
- Fixes the root cause, so the workaround in `ToolForm.vue` (from #21889) can potentially be removed in a follow-up PR
- Prevents this issue from appearing in any other components that use `hasUserProvidedAllRequiredServiceCredentials`

**Before fix:** Workflows with only optional credentials → Run button disabled
**After fix:** Workflows with only optional credentials → Run button enabled ✓

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
