### PR TITLE
Add a lower bound for galaxy-tool-util-models in dependents

### DIFF
--- a/packages/schema/pyproject.toml
+++ b/packages/schema/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
     {name = "Galaxy Project and Community", email = "galaxy-committers@lists.galaxyproject.org"},
 ]
 dependencies = [
-    "galaxy-tool-util-models",
+    "galaxy-tool-util-models>=26.1",
     "galaxy-util",
     "pydantic[email]>=2.7.4",
 ]

--- a/packages/tool_shed_schema/pyproject.toml
+++ b/packages/tool_shed_schema/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
     {name = "Galaxy Project and Community", email = "galaxy-committers@lists.galaxyproject.org"},
 ]
 dependencies = [
-    "galaxy-tool-util-models",
+    "galaxy-tool-util-models>=26.1",
     "pydantic>=2.7.4",
     "typing-extensions",
 ]

--- a/packages/tool_util/pyproject.toml
+++ b/packages/tool_util/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     {name = "Galaxy Project and Community", email = "galaxy-committers@lists.galaxyproject.org"},
 ]
 dependencies = [
-    "galaxy-tool-util-models",
+    "galaxy-tool-util-models>=26.1",
     "galaxy-util[template,image-util]>=22.1",
     "conda-package-streaming",
     "jsonschema",


### PR DESCRIPTION
I ran into an issue when upgrading the CFDE instance: the `galaxy-tool-util-models` package was not upgraded in the job execution venv, which caused an error at job execution. I solved this for CFDE by pinning the version in the playbook, but that doesn't address the underlying problem. This is an attempt to address the root issue. 

### Summary
`galaxy-tool-util-models` was listed as an unversioned dependency in `galaxy-schema`, `galaxy-tool-util`, and `galaxy-tool-shed-schema`. This caused pip to leave it at a stale version when upgrading an existing (job execution) venv, because the already-installed version satisfied the loose (unconstrained) requirement. This resulted in an error at job execution time

```
ImportError: cannot import name 'AnySafeValidatorModel' from 'galaxy.tool_util_models.parameter_validators'
```

where `galaxy-util` (at the new version) referenced a symbol that didn't exist in the older `galaxy-tool-util-models` still present in the venv.

**Note:** When cutting the next release (26.2), the lower bound in these three packages should be updated from `>=26.1` to `>=26.2` to maintain the same guarantee going forward. This can be automated via release util scripts.

I'm not sure this is the right solution. Claude thinks it's reasonable: (1) it introduces a lower bound, not an exact pin; and (2) 
"...because galaxy-tool-util-models and its dependents are tightly coupled — they're developed, versioned, and released together in lockstep. A bare unversioned dependency implies "any version works," which is clearly false here. Adding a lower bound just makes the metadata reflect reality."

### Alternatives considered
- **Wipe and recreate the venv on every upgrade**: reliable but causes downtime, which is unacceptable for point releases.
- **Wipe only on "major" (galaxy) version upgrades (i.e., 26.1 --> 26.2)**: reduces risk but requires coordinated downtime and is easy to forget.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
