### PR TITLE
[26.1] Update tiffviewer to v0.0.5

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -110,7 +110,7 @@ tabulator:
     version: 0.0.9
 tiffviewer:
     package: "@galaxyproject/tiffviewer"
-    version: 0.0.4
+    version: 0.0.5
 ts_visjs:
     package: "@galaxyproject/ts_visjs"
     version: 0.0.6


### PR DESCRIPTION
Just bumping the TiffViewer visualization version to address https://github.com/galaxyproject/galaxy/issues/22480 and https://github.com/galaxyproject/galaxy/issues/22479

Could be backported to 26.0 if needed.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
