### PR TITLE
[26.1] Handle existing rows in tool_source during db migration

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/566b691307a5_persist_validated_job_internal_tool_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/566b691307a5_persist_validated_job_internal_tool_.py
@@ -6,6 +6,7 @@ Create Date: 2025-09-30 04:48:19.727414
 
 """
 
+from alembic import op
 from sqlalchemy import (
     Column,
     Integer,
@@ -55,7 +56,18 @@ def upgrade():
         # Add tool_source.source_class as a new NOT NULL string column
         add_column(
             tool_source_table_name,
-            Column(tool_source_source_class_column, String(255), nullable=False),
+            Column(tool_source_source_class_column, String(255)),
+        )
+
+        # Set tool_source.source_class on existing rows
+        op.execute("UPDATE tool_source SET source_class = 'YamlToolSource' WHERE source_class IS NULL")
+
+        # Set nullable on tool_source.source_class
+        alter_column(
+            tool_source_table_name,
+            tool_source_source_class_column,
+            existing_type=String(255),
+            nullable=False,
         )
 
 


### PR DESCRIPTION


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
