### PR TITLE
[26.1] Create notebooks from invocation reports instead of a new page/report

### DIFF
--- a/client/src/components/PageDisplay/PageForm.vue
+++ b/client/src/components/PageDisplay/PageForm.vue
@@ -114,6 +114,8 @@ async function onSubmit() {
         });
         if (error) {
             errorMessage.value = error.err_msg;
+        } else if (data.history_id) {
+            router.push(`/histories/${data.history_id}/pages/${data.id}`);
         } else {
             router.push(`/pages/editor?id=${data.id}`);
         }

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -272,6 +272,11 @@ class PageManager(sharable.SharableModelManager[model.Page], UsesAnnotations):
         user = trans.get_user()
         history_id = getattr(payload, "history_id", None)
 
+        # When creating from an invocation, automatically attach to its history
+        if payload.invocation_id and not history_id:
+            invocation = self.workflow_manager.get_invocation(trans, payload.invocation_id)
+            history_id = invocation.history_id
+
         # Slug validation: required for non-history pages
         if history_id:
             # Verify user owns the history

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -274,17 +274,19 @@ class PageManager(sharable.SharableModelManager[model.Page], UsesAnnotations):
 
         # When creating from an invocation, automatically attach to its history
         if payload.invocation_id and not history_id:
-            invocation = self.workflow_manager.get_invocation(trans, payload.invocation_id)
+            invocation = self.workflow_manager.get_invocation(
+                trans, payload.invocation_id, check_ownership=False, check_accessible=True
+            )
             history_id = invocation.history_id
 
         # Slug validation: required for non-history pages
         if history_id:
-            # Verify user owns the history
+            # Get the accessible history
             history = trans.sa_session.get(model.History, history_id)
             if not history:
                 raise exceptions.ObjectNotFound("History not found")
-            if history.user != user:
-                raise exceptions.ItemOwnershipException("Cannot create page on history you do not own")
+            base.security_check(trans, history, check_ownership=False, check_accessible=True)
+
             # History-attached pages don't need a slug
             content_format = payload.content_format or "markdown"
             content = payload.content or ""

--- a/lib/galaxy_test/api/test_pages_history_attached.py
+++ b/lib/galaxy_test/api/test_pages_history_attached.py
@@ -313,6 +313,7 @@ steps:
             )
             invocation_id = summary.invocation_id
             self._put(f"histories/{history_id}/publish", json=True)
+            self._put(f"workflows/{summary.workflow_id}/publish", json=True)
             with self._different_user():
                 payload = {"invocation_id": invocation_id, "title": "Shared Invocation Page"}
                 create_response = self._post("pages", payload, json=True)

--- a/lib/galaxy_test/api/test_pages_history_attached.py
+++ b/lib/galaxy_test/api/test_pages_history_attached.py
@@ -3,6 +3,7 @@
 from galaxy_test.base.populators import (
     DatasetPopulator,
     skip_without_agents,
+    skip_without_tool,
 )
 from .test_pages import BasePagesApiTestCase
 
@@ -273,6 +274,50 @@ class TestHistoryPagesApi(BasePagesApiTestCase):
                 f"pages/{page['id']}", {"content": "# Hacked", "content_format": "markdown"}, json=True
             )
             self._assert_status_code_is(update_response, 403)
+
+    def test_history_page_accessible_history_create(self):
+        # Published (accessible but not owned) history — user should be able to create a page on it.
+        history_id = self.dataset_populator.new_history()
+        self._put(f"histories/{history_id}/publish", json=True)
+        with self._different_user():
+            payload = {"history_id": history_id, "content": "# Shared page", "content_format": "markdown"}
+            create_response = self._post("pages", payload, json=True)
+            self._assert_status_code_is(create_response, 200)
+            assert create_response.json()["history_id"] == history_id
+
+    @skip_without_tool("cat")
+    def test_accessible_invocation_create_page(self):
+        # Invocation whose history is published — another user can create a page via invocation_id.
+        test_data = """
+input_1:
+  value: 1.bed
+  type: File
+"""
+        with self.dataset_populator.test_history() as history_id:
+            summary = self.workflow_populator.run_workflow(
+                """
+class: GalaxyWorkflow
+inputs:
+  input_1: data
+outputs:
+  output_1:
+    outputSource: first_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat
+    in:
+      input1: input_1
+""",
+                test_data=test_data,
+                history_id=history_id,
+            )
+            invocation_id = summary.invocation_id
+            self._put(f"histories/{history_id}/publish", json=True)
+            with self._different_user():
+                payload = {"invocation_id": invocation_id, "title": "Shared Invocation Page"}
+                create_response = self._post("pages", payload, json=True)
+                self._assert_status_code_is(create_response, 200)
+                assert create_response.json()["history_id"] == history_id
 
     # --- A5: Cross-Type Validation ---
 


### PR DESCRIPTION
With an invocation report, it makes sense that when the user clicks Edit, a history notebook (with added `history_id` context) is created instead of a simple page.

This also ensures that for an accessible invocation, any user can create a history notebook from the invocation's report. (We were checking for ownership as well).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
