### PR TITLE
[26.1] Match tpv in conditional dependency requirement to pinned version

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -14,7 +14,7 @@ ldap3==2.9.1
 python-pam
 galaxycloudrunner
 pkce
-total-perspective-vortex>=3.1.2,<4
+total-perspective-vortex>=3.2.1,<4
 openai
 fastmcp>=2.13.0
 # upper version constraint because of https://github.com/galaxyproject/galaxy/issues/20600


### PR DESCRIPTION
We bumped tpv in https://github.com/galaxyproject/galaxy/pull/22206 and changed the syntax in the integration test. auto-rejection of user defined tools in TPV seems safer and is what the test now documents, so we should match that in the conditional dependencies. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
