### PR TITLE
[26.0] Pin galaxy-tool-util-models to current minor version in dependents

### DIFF
--- a/packages/schema/setup.cfg
+++ b/packages/schema/setup.cfg
@@ -14,7 +14,7 @@ version = 26.0.2.dev0
 [options]
 include_package_data = True
 install_requires =
-    galaxy-tool-util-models
+    galaxy-tool-util-models>=26.0
     galaxy-util
     pydantic[email]>=2.7.4
 packages = find:

--- a/packages/tool_shed_schema/setup.cfg
+++ b/packages/tool_shed_schema/setup.cfg
@@ -14,7 +14,7 @@ version = 26.0.2.dev0
 [options]
 include_package_data = True
 install_requires =
-    galaxy-tool-util-models
+    galaxy-tool-util-models>=26.0
     pydantic>=2.7.4
     typing-extensions
 packages = find:

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -14,7 +14,7 @@ version = 26.0.2.dev0
 [options]
 include_package_data = True
 install_requires =
-    galaxy-tool-util-models
+    galaxy-tool-util-models>=26.0
     galaxy-util[template,image-util]>=22.1
     conda-package-streaming
     lxml!=4.2.2


### PR DESCRIPTION
xref #22861

galaxy-tool-util-models was listed as an unversioned dependency in galaxy-schema, galaxy-tool-util, and galaxy-tool-shed-schema. This caused pip to leave it at a stale version when upgrading an existing virtualenv, because the already-installed version satisfied the loose (unconstrained) requirement.

The symptom was ImportError failures at job execution time — e.g.:

  ImportError: cannot import name 'AnySafeValidatorModel' from
    'galaxy.tool_util_models.parameter_validators'

    — where galaxy-util (at the new version) referenced a symbol that
    didn't exist in the older galaxy-tool-util-models still present in
    the venv.

    Fix: add a >=26.0 lower bound in each dependent package so pip is
    forced to upgrade galaxy-tool-util-models when installing any of
    these packages at 26.0 or later.

    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
