### PR TITLE
[26.1] Fix New Chat button while a GalaxyAI conversation is in flight

### DIFF
--- a/client/src/components/GalaxyAI.newchat.test.ts
+++ b/client/src/components/GalaxyAI.newchat.test.ts
@@ -1,0 +1,208 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount, type Wrapper } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import { useChatStore } from "@/stores/chatStore";
+
+import GalaxyAI from "./GalaxyAI.vue";
+
+const { mockGet, mockPost, mockPut, ChatMessageCellStub, ChatInputStub } = vi.hoisted(() => ({
+    mockGet: vi.fn(),
+    mockPost: vi.fn(),
+    mockPut: vi.fn(),
+    // render functions because the test environment uses the runtime-only Vue build
+    ChatMessageCellStub: {
+        name: "ChatMessageCellStub",
+        props: ["message"],
+        render(this: { message: { content: string } }, h: (...args: unknown[]) => unknown) {
+            return h("div", { class: "chat-message-stub" }, [this.message.content]);
+        },
+    },
+    ChatInputStub: {
+        name: "ChatInputStub",
+        props: ["value", "busy"],
+        render(h: (...args: unknown[]) => unknown) {
+            return h("input", { class: "chat-input-stub" });
+        },
+    },
+}));
+
+vi.mock("@/api", () => ({
+    GalaxyApi: () => ({ GET: mockGet, POST: mockPost, PUT: mockPut, DELETE: vi.fn() }),
+}));
+
+vi.mock("@/api/client", () => ({
+    GalaxyApi: () => ({ GET: mockGet, POST: mockPost, PUT: mockPut, DELETE: vi.fn() }),
+}));
+
+vi.mock("vue-router/composables", () => ({
+    useRoute: () => ({ path: "/", params: {}, query: {} }),
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/app", () => ({
+    getGalaxyInstance: () => ({ frame: { add: vi.fn() } }),
+}));
+
+// Child components are referenced directly from setup scope, so the test-utils
+// `stubs` option cannot replace them — mock the modules instead.
+vi.mock("@/components/GalaxyAI/ChatMessageCell.vue", () => ({ default: ChatMessageCellStub }));
+vi.mock("@/components/GalaxyAI/ChatInput.vue", () => ({ default: ChatInputStub }));
+
+vi.mock("@/composables/useActiveContext", () => ({
+    useActiveContext: () => ({ activeContext: ref(null), contextLabel: ref("") }),
+}));
+
+vi.mock("@/composables/agentActions", () => ({
+    useAgentActions: () => ({ processingAction: ref(false), handleAction: vi.fn() }),
+}));
+
+vi.mock("@/composables/confirmDialog", () => ({
+    useConfirmDialog: () => ({ confirm: vi.fn() }),
+}));
+
+vi.mock("@/composables/markdown", () => ({
+    useMarkdown: () => ({ renderMarkdown: (content: string) => content }),
+}));
+
+vi.mock("@/composables/toast", () => ({
+    useToast: () => ({ error: vi.fn(), success: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}));
+
+vi.mock("@/composables/useEntityMentions", () => ({
+    MENTION_PATTERN_SOURCE: "@(dataset|history):(\\S+)",
+    parseMentions: () => [],
+    resolveMentions: () => [],
+    buildEntityContext: () => null,
+}));
+
+vi.mock("@/composables/userLocalStorage", () => ({
+    useUserLocalStorage: vi.fn((_key: string, initialValue: unknown) => ref(initialValue)),
+}));
+
+const localVue = getLocalVue();
+
+// jsdom does not implement Element.scrollTo
+window.HTMLElement.prototype.scrollTo = vi.fn();
+
+function mountChat() {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const wrapper = mount(GalaxyAI as object, {
+        localVue,
+        pinia,
+        propsData: { panel: true },
+        stubs: { FontAwesomeIcon: true, BSkeleton: true },
+    });
+    const chatStore = useChatStore();
+    return { wrapper, chatStore };
+}
+
+function messageTexts(wrapper: Wrapper<Vue>) {
+    return wrapper.findAll(".chat-message-stub").wrappers.map((w) => w.text());
+}
+
+async function sendMessage(wrapper: Wrapper<Vue>, text: string) {
+    const input = wrapper.findComponent(ChatInputStub);
+    input.vm.$emit("input", text);
+    await wrapper.vm.$nextTick();
+    input.vm.$emit("submit");
+    await flushPromises();
+}
+
+function deferredResponse() {
+    let resolve!: (value: unknown) => void;
+    const promise = new Promise((r) => {
+        resolve = r;
+    });
+    return { promise, resolve };
+}
+
+describe("GalaxyAI", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGet.mockResolvedValue({ data: [], error: undefined });
+    });
+
+    it("appends the response and records the exchange id on a normal exchange", async () => {
+        mockPost.mockResolvedValue({
+            data: { response: "Here you go", exchange_id: "exchange-123" },
+            error: undefined,
+        });
+        const { wrapper, chatStore } = mountChat();
+        await flushPromises();
+
+        await sendMessage(wrapper, "find me a mapper");
+
+        const texts = messageTexts(wrapper);
+        expect(texts).toHaveLength(3);
+        expect(texts[1]).toBe("find me a mapper");
+        expect(texts[2]).toBe("Here you go");
+        expect(chatStore.activeChatId).toBe("exchange-123");
+    });
+
+    it("resets an unsaved conversation when a new chat is requested mid-flight", async () => {
+        const deferred = deferredResponse();
+        mockPost.mockReturnValue(deferred.promise);
+        const { wrapper, chatStore } = mountChat();
+        await flushPromises();
+
+        await sendMessage(wrapper, "what mappers are available?");
+        expect(messageTexts(wrapper)).toHaveLength(2);
+        expect(wrapper.find(".loading-entry").exists()).toBe(true);
+        // the conversation is unsaved — no exchange id yet, so the identity
+        // (activeChatId) would not change and a plain showChat(null) is a no-op
+        expect(chatStore.activeChatId).toBeNull();
+
+        chatStore.requestNewChat();
+        await flushPromises();
+
+        const texts = messageTexts(wrapper);
+        expect(texts).toHaveLength(1);
+        expect(texts[0]).toContain("New conversation started");
+        expect(wrapper.find(".loading-entry").exists()).toBe(false);
+
+        // the stale response must not be appended or re-attach the old exchange
+        deferred.resolve({ data: { response: "Late answer", exchange_id: "exchange-123" }, error: undefined });
+        await flushPromises();
+
+        expect(messageTexts(wrapper)).toHaveLength(1);
+        expect(chatStore.activeChatId).toBeNull();
+    });
+
+    it("does not let a stale response clobber a newly started conversation", async () => {
+        const first = deferredResponse();
+        const second = deferredResponse();
+        mockPost.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+        const { wrapper, chatStore } = mountChat();
+        await flushPromises();
+
+        await sendMessage(wrapper, "first question");
+        chatStore.requestNewChat();
+        await flushPromises();
+        await sendMessage(wrapper, "second question");
+        expect(wrapper.find(".loading-entry").exists()).toBe(true);
+
+        first.resolve({ data: { response: "First answer", exchange_id: "exchange-1" }, error: undefined });
+        await flushPromises();
+
+        // still only welcome + second user message, still waiting on the second response
+        let texts = messageTexts(wrapper);
+        expect(texts).toHaveLength(2);
+        expect(texts[1]).toBe("second question");
+        expect(wrapper.find(".loading-entry").exists()).toBe(true);
+        expect(chatStore.activeChatId).toBeNull();
+
+        second.resolve({ data: { response: "Second answer", exchange_id: "exchange-2" }, error: undefined });
+        await flushPromises();
+
+        texts = messageTexts(wrapper);
+        expect(texts).toHaveLength(3);
+        expect(texts[2]).toBe("Second answer");
+        expect(wrapper.find(".loading-entry").exists()).toBe(false);
+        expect(chatStore.activeChatId).toBe("exchange-2");
+    });
+});

--- a/client/src/components/GalaxyAI.vue
+++ b/client/src/components/GalaxyAI.vue
@@ -138,6 +138,10 @@ const selectedAgentType = ref("auto");
 const currentChatId = ref<string | null>(null);
 const hasLoadedInitialChat = ref(false);
 
+// Bumped whenever the displayed conversation changes so that responses still in
+// flight for a previous conversation can be recognized as stale and dropped.
+let conversationGeneration = 0;
+
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true, removeNewlinesAfterList: true });
 const { processingAction, handleAction } = useAgentActions();
 
@@ -220,6 +224,14 @@ watch(
     },
 );
 
+// A "new chat" request must work even when the conversation identity wouldn't
+// change (an unsaved conversation has no exchange id), so it arrives as a counter
+// bump rather than through the exchangeId prop.
+watch(
+    () => chatStore.newChatRequestCount,
+    () => startNewChat(),
+);
+
 function showWelcome() {
     messages.value.push({
         id: generateId(),
@@ -256,6 +268,10 @@ async function submitQuery() {
     scrollToBottom(chatContainer.value);
 
     busy.value = true;
+    const generation = conversationGeneration;
+    // False once the conversation changes while we're waiting (e.g. the user
+    // started a new chat) — stale responses must not touch the current one.
+    const stillCurrent = () => generation === conversationGeneration;
 
     try {
         const parsed = parseMentions(currentQuery);
@@ -275,6 +291,10 @@ async function submitQuery() {
                 entity_context: entityContext,
             },
         });
+
+        if (!stillCurrent()) {
+            return;
+        }
 
         if (error) {
             const errorText = errorMessageAsString(error, "Failed to get response from GalaxyAI.");
@@ -319,23 +339,29 @@ async function submitQuery() {
         }
     } catch (e) {
         console.error("Unexpected chat error:", e);
-        const errorMsg: ChatMessage = {
-            id: generateId(),
-            role: "assistant",
-            content: "Unexpected error occurred. Please try again.",
-            timestamp: new Date(),
-            agentType: selectedAgentType.value,
-            confidence: "low",
-            feedback: null,
-        };
-        messages.value.push(errorMsg);
+        if (stillCurrent()) {
+            const errorMsg: ChatMessage = {
+                id: generateId(),
+                role: "assistant",
+                content: "Unexpected error occurred. Please try again.",
+                timestamp: new Date(),
+                agentType: selectedAgentType.value,
+                confidence: "low",
+                feedback: null,
+            };
+            messages.value.push(errorMsg);
 
-        await nextTick();
-        scrollToBottom(chatContainer.value);
+            await nextTick();
+            scrollToBottom(chatContainer.value);
+        }
     } finally {
-        busy.value = false;
-        await nextTick();
-        scrollToBottom(chatContainer.value);
+        // Only clear the busy indicator if it still belongs to this request — the
+        // current conversation may have its own request in flight by now.
+        if (stillCurrent()) {
+            busy.value = false;
+            await nextTick();
+            scrollToBottom(chatContainer.value);
+        }
     }
 }
 
@@ -380,11 +406,19 @@ async function fetchConversation(exchangeId: string) {
         return;
     }
 
+    const generation = ++conversationGeneration;
+
     const { data: fullConversation, error } = await GalaxyApi().GET(`/api/chat/exchange/{exchange_id}/messages`, {
         params: {
             path: { exchange_id: exchangeId },
         },
     });
+
+    if (generation !== conversationGeneration) {
+        // A newer conversation was loaded (or a new chat started) while this one
+        // was being fetched — don't overwrite it.
+        return;
+    }
 
     if (error) {
         Toast.error(errorMessageAsString(error, "Failed to load conversation."), "Error loading conversation");
@@ -444,7 +478,9 @@ async function loadLatestChat() {
 }
 
 function startNewChat() {
+    conversationGeneration++;
     hasLoadedInitialChat.value = true;
+    busy.value = false;
     messages.value = [
         {
             id: generateId(),

--- a/client/src/components/GalaxyAI/ChatActions.test.ts
+++ b/client/src/components/GalaxyAI/ChatActions.test.ts
@@ -70,17 +70,31 @@ describe("ChatActions", () => {
             expect(mockPush).toHaveBeenCalledWith("/galaxyai/new");
         });
 
-        it("calls chatStore.showChat(null) in docked mode", async () => {
-            const { wrapper, store } = mountComponent("docked");
+        it("requests a new chat in all modes", async () => {
+            for (const source of ["center", "docked", "panel"] as const) {
+                const { wrapper, store } = mountComponent(source);
+                await findButton(wrapper, "Start New Chat").trigger("click");
+                expect(store.requestNewChat).toHaveBeenCalled();
+            }
+        });
+
+        it("still requests a new chat when already at /galaxyai/new, without re-routing", async () => {
+            mockRoute = { path: "/galaxyai/new", params: { exchangeId: "new" } };
+            const { wrapper, store } = mountComponent("center");
             await findButton(wrapper, "Start New Chat").trigger("click");
-            expect(store.showChat).toHaveBeenCalledWith(null);
+            expect(mockPush).not.toHaveBeenCalled();
+            expect(store.requestNewChat).toHaveBeenCalled();
+        });
+
+        it("does not route in docked mode", async () => {
+            const { wrapper } = mountComponent("docked");
+            await findButton(wrapper, "Start New Chat").trigger("click");
             expect(mockPush).not.toHaveBeenCalled();
         });
 
-        it("calls chatStore.showChat(null) in panel mode", async () => {
-            const { wrapper, store } = mountComponent("panel");
+        it("does not route in panel mode", async () => {
+            const { wrapper } = mountComponent("panel");
             await findButton(wrapper, "Start New Chat").trigger("click");
-            expect(store.showChat).toHaveBeenCalledWith(null);
             expect(mockPush).not.toHaveBeenCalled();
         });
 

--- a/client/src/components/GalaxyAI/ChatActions.vue
+++ b/client/src/components/GalaxyAI/ChatActions.vue
@@ -19,6 +19,8 @@ import { getGalaxyInstance } from "@/app";
 import { useActivityStore } from "@/stores/activityStore.js";
 import { useChatStore } from "@/stores/chatStore";
 
+import { useStartNewChat } from "./useStartNewChat";
+
 import GButton from "../BaseComponents/GButton.vue";
 
 const props = defineProps<{
@@ -37,15 +39,12 @@ const route = useRoute();
 const router = useRouter();
 const chatStore = useChatStore();
 const activityStore = useActivityStore("default");
+const startNewChat = useStartNewChat();
 
 const showingActivityPanel = computed(() => activityStore.toggledSideBar === "galaxyai");
 
 function startNew() {
-    if (props.source === "center") {
-        router.push("/galaxyai/new");
-    } else {
-        chatStore.showChat(null);
-    }
+    startNewChat(props.source === "center");
     emit("update:collapsed", false);
 }
 

--- a/client/src/components/GalaxyAI/ChatHistoryPanel.vue
+++ b/client/src/components/GalaxyAI/ChatHistoryPanel.vue
@@ -15,6 +15,7 @@ import { errorMessageAsString } from "@/utils/simple-error";
 
 import { getAgentIcon } from "./agentTypes";
 import type { ChatHistoryItem } from "./chatTypes";
+import { useStartNewChat } from "./useStartNewChat";
 
 import GButton from "../BaseComponents/GButton.vue";
 import ChatModeSelector from "./ChatModeSelector.vue";
@@ -33,6 +34,8 @@ const notebookPageId = computed(() => {
     const ctx = activeContext.value;
     return ctx?.contextType === "notebook" ? ctx.pageId : undefined;
 });
+
+const newChat = useStartNewChat();
 
 const { chatHistory, loading } = storeToRefs(chatStore);
 
@@ -78,11 +81,7 @@ function handleItemClick(item: ChatHistoryItem, index: number, event: MouseEvent
 }
 
 function startNewChat() {
-    if (chatStore.isCenterMode) {
-        router.push("/galaxyai/new");
-    } else {
-        chatStore.showChat(null);
-    }
+    newChat(chatStore.isCenterMode);
 }
 
 async function deleteSelected() {

--- a/client/src/components/GalaxyAI/useStartNewChat.ts
+++ b/client/src/components/GalaxyAI/useStartNewChat.ts
@@ -1,0 +1,26 @@
+import { useRoute, useRouter } from "vue-router/composables";
+
+import { useChatStore } from "@/stores/chatStore";
+
+/** Shared behavior for the various "New Chat" buttons. */
+export function useStartNewChat() {
+    const route = useRoute();
+    const router = useRouter();
+    const chatStore = useChatStore();
+
+    /** @param center whether the fresh conversation should open in the center view */
+    return function startNewChat(center: boolean) {
+        if (center) {
+            if (route.path !== "/galaxyai/new") {
+                router.push("/galaxyai/new");
+            }
+        } else {
+            // make sure the docked/bottom panel is visible
+            chatStore.showChat();
+        }
+        // Reset via the store, not just the route/id above: for an unsaved
+        // conversation the identity wouldn't change, so a plain navigation or
+        // showChat(null) is a no-op.
+        chatStore.requestNewChat();
+    };
+}

--- a/client/src/stores/chatStore.test.ts
+++ b/client/src/stores/chatStore.test.ts
@@ -105,6 +105,24 @@ describe("chatStore", () => {
         });
     });
 
+    describe("requestNewChat", () => {
+        it("bumps the request counter so chat surfaces reset even when the id would not change", () => {
+            const store = useChatStore();
+            expect(store.newChatRequestCount).toBe(0);
+            store.requestNewChat();
+            expect(store.newChatRequestCount).toBe(1);
+            store.requestNewChat();
+            expect(store.newChatRequestCount).toBe(2);
+        });
+
+        it("clears the active chat id", () => {
+            const store = useChatStore();
+            store.setActiveChatId("abc");
+            store.requestNewChat();
+            expect(store.activeChatId).toBeNull();
+        });
+    });
+
     describe("deleteChats", () => {
         it("removes the given ids from history", () => {
             const store = useChatStore();

--- a/client/src/stores/chatStore.ts
+++ b/client/src/stores/chatStore.ts
@@ -14,6 +14,7 @@ export const useChatStore = defineStore("chatStore", () => {
     const cachedActiveChatId = useUserLocalStorage<string>("active-chat-id", "");
     const chatHistory = ref<ChatHistoryItem[]>([]);
     const loading = ref(false);
+    const newChatRequestCount = ref(0);
 
     const isRightPanelOpen = computed(() => chatLocation.value === "right" && chatVisible.value);
     const isBottomPanelOpen = computed(() => chatLocation.value === "bottom" && chatVisible.value);
@@ -118,6 +119,14 @@ export const useChatStore = defineStore("chatStore", () => {
         }
     }
 
+    /** Ask chat surfaces to reset to a fresh conversation. A counter bump rather than
+     * an id change, so the reset also fires for an unsaved conversation whose identity
+     * (activeChatId / route param) wouldn't change. */
+    function requestNewChat() {
+        setActiveChatId(null);
+        newChatRequestCount.value++;
+    }
+
     /** Returns the active chat id, falling back to the most recent history item, or null. */
     function resolveDockChatId(): string | null {
         return activeChatId.value ?? chatHistory.value[0]?.id ?? null;
@@ -144,6 +153,8 @@ export const useChatStore = defineStore("chatStore", () => {
         hideChat,
         loadHistory,
         loading,
+        newChatRequestCount,
+        requestNewChat,
         toggleChat,
         setLocation,
         setActiveChatId,


### PR DESCRIPTION
Clicking "New Chat" in GalaxyAI looked broken whenever a conversation was ongoing -- the button isn't disabled, the click just silently did nothing. The reset only ever happened when the conversation *identity* changed (the route param in center mode, `activeChatId` in panel/docked mode), and for an unsaved conversation that identity doesn't change: `activeChatId` is still null because no exchange id has come back yet, and in center mode pushing `/galaxyai/new` again is a duplicate navigation. So the click was a no-op exactly when you'd most want a fresh start.

This routes the reset through the store instead: `chatStore.requestNewChat()` bumps a counter that the chat component watches, so the reset fires regardless of whether the identity changed. All three New Chat entry points (the header actions in center/docked/panel mode and the sidebar history panel) now share one small `useStartNewChat` composable.

There was a second bug hiding behind the first: even when the reset did fire, a response still in flight for the abandoned conversation would land in the fresh chat and re-attach the old exchange id, yanking you right back into the old conversation. Each conversation is now tagged with a generation counter and responses from a previous generation are dropped (busy state is guarded the same way, so the loading skeleton tracks the right request).

The first commit adds tests demonstrating all three failures before the fix: the dead reset on an unsaved conversation, the stale response being appended, and a stale response racing a newly started conversation that already has its own request in flight.

Possible follow-up: dropped responses are still persisted server-side as part of the abandoned exchange -- cancelling the request outright (AbortController plus backend support) would avoid that, but it's out of scope here.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open GalaxyAI (any mode -- center `/galaxyai`, docked, or bottom panel), send a message, and click "New Chat" while the response is still loading: the conversation should reset immediately, and the late response should not appear or pull you back into the old chat.
  2. Same scenario from the sidebar chat history panel's "New Chat" button.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
