### PR TITLE
[26.1] Address arch-review issues from #22807: move business logic out of chat controller

### DIFF
--- a/client/src/composables/useActiveContext.test.ts
+++ b/client/src/composables/useActiveContext.test.ts
@@ -195,5 +195,10 @@ describe("useActiveContext", () => {
             );
             expect(contextLabel.value).toBe("History Notebook: test-page-id");
         });
+
+        it("labels standalone page editor context without historyId", () => {
+            const { contextLabel } = withRoute("/pages/editor", { id: "test-page-id" }, {});
+            expect(contextLabel.value).toBe("Page: test-page-id");
+        });
     });
 });

--- a/client/src/composables/usePageProposals.test.ts
+++ b/client/src/composables/usePageProposals.test.ts
@@ -255,6 +255,15 @@ describe("usePageProposals", () => {
             dismissProposal(makeProposalMsg("full_replacement", "x"));
             expect(mockPersistedDismissed.value[PAGE_ID]).toBeUndefined();
         });
+
+        it("persisted dismissal survives a loadForPage reload", () => {
+            const { dismissProposal, loadForPage, dismissedProposals } = setup();
+            const msg = makeProposalMsg("full_replacement", "x");
+            dismissProposal(msg);
+            dismissedProposals.value = new Set();
+            loadForPage(PAGE_ID);
+            expect(dismissedProposals.value.has(msg.id)).toBe(true);
+        });
     });
 
     describe("applyFullReplacement", () => {
@@ -295,8 +304,11 @@ describe("usePageProposals", () => {
 
         it("marks message as dismissed after applying", async () => {
             const { dismissedProposals, applySectionPatched } = setup();
-            const msg = makeMsg();
-            await applySectionPatched("patched", msg);
+            const msg = makeProposalMsg("section_patch", "", {
+                target_section_heading: "Methods",
+                new_section_content: "# Methods\nUpdated",
+            });
+            await applySectionPatched("# Patched doc", msg);
             expect(dismissedProposals.value.has(msg.id)).toBe(true);
         });
     });

--- a/client/src/stores/pageEditorStore.test.ts
+++ b/client/src/stores/pageEditorStore.test.ts
@@ -1066,4 +1066,62 @@ describe("usePageEditorStore", () => {
             expect(store.showRevisions).toBe(false);
         });
     });
+
+    describe("chatError", () => {
+        it("is null by default", () => {
+            const store = usePageEditorStore();
+            expect(store.chatError).toBeNull();
+        });
+
+        it("is reset to null on clearCurrentPage", () => {
+            const store = usePageEditorStore();
+            store.chatError = "some error";
+            store.clearCurrentPage();
+            expect(store.chatError).toBeNull();
+        });
+
+        it("is reset to null on $reset", () => {
+            const store = usePageEditorStore();
+            store.chatError = "some error";
+            store.$reset();
+            expect(store.chatError).toBeNull();
+        });
+    });
+
+    describe("chat exchange IDs", () => {
+        it("returns null for an unknown page", () => {
+            const store = usePageEditorStore();
+            expect(store.getCurrentChatExchangeId("page-1")).toBeNull();
+        });
+
+        it("stores and retrieves an exchange ID per page", () => {
+            const store = usePageEditorStore();
+            store.setCurrentChatExchangeId("page-1", "exchange-abc");
+            expect(store.getCurrentChatExchangeId("page-1")).toBe("exchange-abc");
+        });
+
+        it("isolates IDs across different pages", () => {
+            const store = usePageEditorStore();
+            store.setCurrentChatExchangeId("page-1", "ex-1");
+            store.setCurrentChatExchangeId("page-2", "ex-2");
+            expect(store.getCurrentChatExchangeId("page-1")).toBe("ex-1");
+            expect(store.getCurrentChatExchangeId("page-2")).toBe("ex-2");
+        });
+
+        it("clears a specific page ID without affecting others", () => {
+            const store = usePageEditorStore();
+            store.setCurrentChatExchangeId("page-1", "ex-1");
+            store.setCurrentChatExchangeId("page-2", "ex-2");
+            store.clearCurrentChatExchangeId("page-1");
+            expect(store.getCurrentChatExchangeId("page-1")).toBeNull();
+            expect(store.getCurrentChatExchangeId("page-2")).toBe("ex-2");
+        });
+
+        it("overrides an existing entry when set again", () => {
+            const store = usePageEditorStore();
+            store.setCurrentChatExchangeId("page-1", "ex-1");
+            store.setCurrentChatExchangeId("page-1", "ex-2");
+            expect(store.getCurrentChatExchangeId("page-1")).toBe("ex-2");
+        });
+    });
 });

--- a/lib/galaxy/managers/agents.py
+++ b/lib/galaxy/managers/agents.py
@@ -107,7 +107,10 @@ class AgentService:
         When agent_type is 'auto', the router agent handles the query directly,
         either answering it or using output functions to hand off to specialists.
         """
-        if agent_type == "auto":
+        if agent_type == "auto" and isinstance(context, dict) and context.get("page_id"):
+            log.info("Routing to page_assistant for notebook context")
+            return await self.execute_agent("page_assistant", query, trans, user, context)
+        elif agent_type == "auto":
             # Router handles everything via output functions:
             # - Answers general questions directly
             # - Hands off to error_analysis for debugging

--- a/lib/galaxy/managers/chat.py
+++ b/lib/galaxy/managers/chat.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from typing import (
     Any,
     Optional,
     Union,
 )
+
+log = logging.getLogger(__name__)
 
 from pydantic_ai.messages import (
     ModelMessage,
@@ -63,6 +66,29 @@ class ChatManager:
         trans.sa_session.add(chat_message)
         trans.sa_session.commit()
         return chat_exchange
+
+    def resolve_page_from_interface_context(
+        self, trans: ProvidesUserContext, query_context: Optional[dict[str, Any]]
+    ) -> tuple[Optional[int], Optional["Page"]]:
+        """Extract and validate a page from an interface_context notebook payload.
+
+        Swallows only ID-decode failures; access-control errors propagate.
+        Returns (None, None) when the payload is absent or the encoded ID is invalid.
+        """
+        interface_context = query_context.get("interface_context") if isinstance(query_context, dict) else None
+        if not (
+            isinstance(interface_context, dict)
+            and interface_context.get("contextType") == "notebook"
+            and interface_context.get("pageId")
+        ):
+            return None, None
+        try:
+            page_id = trans.security.decode_id(interface_context["pageId"])
+        except Exception:
+            log.warning("Ignoring invalid notebook pageId in interface_context: %s", interface_context.get("pageId"))
+            return None, None
+        page_obj = self.get_accessible_page(trans, page_id)
+        return page_id, page_obj
 
     def get_accessible_page(self, trans: ProvidesUserContext, page_id: int) -> Page:
         """Return a Page the current user is allowed to read, or raise."""

--- a/lib/galaxy/webapps/galaxy/api/chat.py
+++ b/lib/galaxy/webapps/galaxy/api/chat.py
@@ -197,25 +197,8 @@ class ChatAPI:
             # being masked as 500.
             page_obj = self.chat_manager.get_accessible_page(trans, page_id)
 
-        # New unified format: notebook context via interface_context JSON.
-        # Accepts {"contextType": "notebook", "pageId": "<encoded-id>", "historyId": "<encoded-id>"}
-        # sent by GalaxyAI when the user is on the page editor route.  We decode the
-        # ID here so the rest of the handler can reuse the existing page_id path unchanged.
-        # Backward-compatible: legacy payload.page_id still works.
         if page_id is None:
-            interface_context = query_context.get("interface_context") if isinstance(query_context, dict) else None
-            if (
-                isinstance(interface_context, dict)
-                and interface_context.get("contextType") == "notebook"
-                and interface_context.get("pageId")
-            ):
-                try:
-                    page_id = trans.security.decode_id(interface_context["pageId"])
-                    page_obj = self.chat_manager.get_accessible_page(trans, page_id)
-                except Exception:
-                    log.warning(
-                        "Ignoring invalid notebook pageId in interface_context: %s", interface_context.get("pageId")
-                    )
+            page_id, page_obj = self.chat_manager.resolve_page_from_interface_context(trans, query_context)
 
         try:
             if HAS_AGENTS:
@@ -224,6 +207,7 @@ class ChatAPI:
                 # Export page content (encodes IDs) so the agent sees the same
                 # text the editor has -- hashes and proposals match the client.
                 if page_id:
+                    full_context["page_id"] = page_id
                     if page_obj:
                         full_context["history_id"] = page_obj.history_id
                         if not full_context.get("history_id"):
@@ -258,11 +242,6 @@ class ChatAPI:
 
                 if payload and payload.entity_context:
                     full_context["entities"] = payload.entity_context.model_dump(exclude_none=True)
-
-                # When we already know this is a notebook chat, bypass the router
-                # and go straight to page_assistant — no need for an LLM to decide.
-                if page_id and agent_type == "auto":
-                    agent_type = "page_assistant"
 
                 agent_response = await self._get_agent_response_full(
                     query_text, agent_type, trans, user, job, full_context

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -62,6 +62,7 @@ from galaxy.agents.base import truncate_message_history
 from galaxy.agents.custom_tool import CritiqueReport
 from galaxy.agents.registry import build_default_registry
 from galaxy.agents.tools import SimplifiedToolRecommendationResult
+from galaxy.managers.agents import AgentService
 
 agent_registry = build_default_registry()
 from galaxy.agents import base as agents_base
@@ -90,6 +91,7 @@ from galaxy.util.unittest_utils import pytestmark_live_llm
 class TestAgentUnitMocked:
     def setup_method(self):
         self.mock_config = mock.Mock()
+        self.mock_job_manager = mock.Mock()
         self.mock_config.ai_api_key = "test-key"
         self.mock_config.ai_model = "llama-4-scout"
         self.mock_config.ai_api_base_url = "http://localhost:4000/v1/"
@@ -1262,6 +1264,58 @@ class TestAgentUnitMocked:
         assert "#workflow/github.com/iwc-workflows/atac/main" in rendered
         assert "Steps: 12" in rendered
         assert "bowtie2" in rendered
+
+    @pytest.mark.asyncio
+    async def test_route_and_execute_uses_page_assistant_when_page_id_in_context(self):
+        """AgentService.route_and_execute bypasses the router and calls page_assistant
+        directly when 'page_id' is present in the context dict."""
+        service = AgentService(
+            config=self.mock_config,
+            job_manager=self.mock_job_manager,
+            registry=build_default_registry(),
+        )
+
+        sentinel = object()
+        with mock.patch.object(service, "execute_agent", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = sentinel
+            result = await service.route_and_execute(
+                "help me edit this page",
+                trans=self.mock_trans,
+                user=self.mock_user,
+                context={"page_id": 42, "page_content": "# My Page"},
+                agent_type="auto",
+            )
+
+        mock_exec.assert_awaited_once_with(
+            "page_assistant",
+            "help me edit this page",
+            self.mock_trans,
+            self.mock_user,
+            {"page_id": 42, "page_content": "# My Page"},
+        )
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_route_and_execute_falls_through_to_router_without_page_id(self):
+        """Without page_id in context, auto-routing goes to the router, not page_assistant."""
+        service = AgentService(
+            config=self.mock_config,
+            job_manager=self.mock_job_manager,
+            registry=build_default_registry(),
+        )
+
+        with mock.patch.object(service, "execute_agent", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = mock.Mock()
+            await service.route_and_execute(
+                "how do I run BWA?",
+                trans=self.mock_trans,
+                user=self.mock_user,
+                context={"interface_context": {"contextType": "notebook", "someId": "abc"}},
+                agent_type="auto",
+            )
+
+        mock_exec.assert_awaited_once()
+        assert mock_exec.call_args[0][0] == "router"
 
     @pytest.mark.asyncio
     async def test_tool_rec_search_iwc_workflows_uses_module_helper(self):

--- a/test/unit/app/test_chat_manager.py
+++ b/test/unit/app/test_chat_manager.py
@@ -219,3 +219,54 @@ class TestGetRoutingHistory:
         exchange = self._exchange_with("not valid json{{{")
         _, responding = self._routing_history(mgr, trans, exchange)
         assert responding is False
+
+
+class TestResolvePageFromInterfaceContext:
+    """resolve_page_from_interface_context extracts and validates a page from
+    an interface_context notebook payload, delegating access-check to
+    get_accessible_page."""
+
+    def _trans(self, decoded_id=99):
+        trans = _make_trans()
+        trans.security = mock.Mock()
+        trans.security.decode_id.return_value = decoded_id
+        return trans
+
+    def test_returns_none_none_when_query_context_is_none(self):
+        mgr = ChatManager()
+        assert mgr.resolve_page_from_interface_context(_make_trans(), None) == (None, None)
+
+    def test_returns_none_none_when_interface_context_absent(self):
+        mgr = ChatManager()
+        assert mgr.resolve_page_from_interface_context(_make_trans(), {"other_key": "value"}) == (None, None)
+
+    def test_returns_none_none_when_context_type_is_not_notebook(self):
+        mgr = ChatManager()
+        trans = self._trans()
+        ctx = {"interface_context": {"contextType": "tool", "pageId": "abc"}}
+        assert mgr.resolve_page_from_interface_context(trans, ctx) == (None, None)
+
+    def test_returns_none_none_when_page_id_missing(self):
+        mgr = ChatManager()
+        trans = self._trans()
+        ctx = {"interface_context": {"contextType": "notebook"}}
+        assert mgr.resolve_page_from_interface_context(trans, ctx) == (None, None)
+
+    def test_returns_none_none_when_decode_raises(self):
+        mgr = ChatManager()
+        trans = self._trans()
+        trans.security.decode_id.side_effect = Exception("bad id")
+        ctx = {"interface_context": {"contextType": "notebook", "pageId": "invalid"}}
+        assert mgr.resolve_page_from_interface_context(trans, ctx) == (None, None)
+
+    def test_returns_page_id_and_page_obj_on_success(self):
+        mgr = ChatManager()
+        trans = self._trans(decoded_id=42)
+        fake_page = mock.Mock()
+        with mock.patch.object(mgr, "get_accessible_page", return_value=fake_page) as mock_get:
+            ctx = {"interface_context": {"contextType": "notebook", "pageId": "encodedAbc"}}
+            page_id, page_obj = mgr.resolve_page_from_interface_context(trans, ctx)
+
+        assert page_id == 42
+        assert page_obj is fake_page
+        mock_get.assert_called_once_with(trans, 42)


### PR DESCRIPTION
## Summary

Followup to #22807. Addresses architectural and test-quality issues identified in code review.

**Python (architecture):**
- Extract `interface_context` notebook-ID parsing from the chat controller into `ChatManager.resolve_page_from_interface_context`. The controller now delegates with a single call instead of embedding 20 lines of decode + access-check logic. Access-control errors propagate correctly; only ID-decode failures are swallowed.
- Pass `page_id` through `full_context` and move the notebook → `page_assistant` routing decision into `AgentService.route_and_execute`, keeping routing logic out of the HTTP layer.

**Client (test quality):**
- `useActiveContext.test.ts` — add test for standalone page editor label (`"Page: <id>"`, no `historyId`)
- `pageEditorStore.test.ts` — add `chatError` state and chat exchange ID method tests
- `usePageProposals.test.ts` — add dismiss→reload round-trip test; fix `applySectionPatched` fixture to use a real proposal message for symmetry with `applyFullReplacement`

## Test plan

- [ ] Python syntax verified (`py_compile`)
- [ ] `npx vitest run` on all changed test files: 148 tests pass