### PR TITLE
[26.1] Bump up gravity to 1.2.3

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -98,7 +98,7 @@ google-auth==2.53.0
 google-cloud-batch==0.21.0
 google-genai==2.3.0
 googleapis-common-protos==1.75.0
-gravity==1.2.2
+gravity==1.2.3
 greenlet==3.5.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
 griffelib==2.0.2
 groq==1.2.0

--- a/packages/config/setup.cfg
+++ b/packages/config/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.10
 [options.extras_require]
 test = 
     pytest
-    gravity>=1.2.0
+    gravity>=1.2.3
 
 [options.packages.find]
 where = src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "fissix",
     "fs",
     "future>=1.0.0",  # Python 3.12 support
-    "gravity>=1.2.0",  # Python 3.14 support
+    "gravity>=1.2.3",  # Graceful restart on galaxy >= 26.1
     "gunicorn!=25.1.0",  # https://github.com/benoitc/gunicorn/discussions/3509
     "gxformat2>=0.27.0",
     "h5grove>=1.2.1",


### PR DESCRIPTION
Fixes graceful restarts on 26.1

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
