### PR TITLE
[26.1] Cut GTN training agent token usage by capping its search loop

### DIFF
--- a/lib/galaxy/agents/gtn/search.py
+++ b/lib/galaxy/agents/gtn/search.py
@@ -80,6 +80,8 @@ def sanitize_fts5_query(query: str, preserve_phrases: bool = True) -> str:
     'find "exact phrase" in data'
     >>> sanitize_fts5_query('find "exact phrase" in data', preserve_phrases=False)
     'find exact phrase in data'
+    >>> sanitize_fts5_query("color deconvolution site:example.org/path")
+    'color deconvolution site example org path'
     """
     if not query or not query.strip():
         return ""
@@ -88,7 +90,11 @@ def sanitize_fts5_query(query: str, preserve_phrases: bool = True) -> str:
     # word individually rather than treating the hyphenated form as one token.
     sanitized = query.replace("-", " ")
 
-    for char in ",():+?!;[]":
+    # Models sometimes paste URL- or operator-flavored tokens (site:, dotted
+    # hostnames, slashes, column-filter colons). Left in, ".", ":" and "/" reach
+    # FTS5 as syntax and the whole search errors out as no-results -- so strip
+    # them along with the other FTS5 operators.
+    for char in ",.:/()+?!;[]^=~@<>{}|&":
         sanitized = sanitized.replace(char, " ")
 
     # Phrase preservation only works with a balanced pair of quotes. An odd

--- a/lib/galaxy/agents/gtn_training.py
+++ b/lib/galaxy/agents/gtn_training.py
@@ -52,8 +52,29 @@ class GTNTrainingAgent(BaseGalaxyAgent):
 
     agent_type = AgentType.GTN_TRAINING
 
+    # The model tends to keep re-searching long after it has enough material,
+    # and every extra round re-sends the whole growing transcript -- a single
+    # query was costing ~18 search rounds / ~90k tokens. Cap the number of
+    # data-gathering tool calls and, once spent, return a terminal instruction
+    # so the model synthesizes from what it already has instead of looping.
+    MAX_TOOL_CALLS = 3
+    # Note: name the search tools explicitly rather than saying "don't call any
+    # tools" -- the structured response is itself delivered via an output tool
+    # call, so a blanket "no tools" instruction makes the model emit prose that
+    # fails structured-output validation.
+    _TOOL_BUDGET_MESSAGE = (
+        "SEARCH BUDGET REACHED. You already have enough material to answer. "
+        "Do NOT call search_gtn_tutorials, search_gtn_faqs, "
+        "search_tutorials_by_tools, or get_tutorial_content again. Produce your "
+        "final structured answer now from the results and tutorial content "
+        "already returned above. If none is a strong match, say so and point to "
+        "the relevant GTN topic page."
+    )
+
     def __init__(self, deps: GalaxyAgentDependencies):
         super().__init__(deps)
+
+        self._tool_calls = 0
 
         db_path = getattr(deps.config, "gtn_database_path", None)
         download_url = getattr(deps.config, "gtn_database_url", None)
@@ -65,6 +86,14 @@ class GTNTrainingAgent(BaseGalaxyAgent):
         except (OSError, RuntimeError) as e:
             log.warning(f"GTN database not available: {e}")
             self.gtn_db = None
+
+    def _charge_tool_budget(self) -> Optional[str]:
+        """Count a data-gathering tool call; once over budget return a stop
+        message instead of more data so the model answers from what it has."""
+        self._tool_calls += 1
+        if self._tool_calls > self.MAX_TOOL_CALLS:
+            return self._TOOL_BUDGET_MESSAGE
+        return None
 
     def _create_agent(self) -> Agent[GalaxyAgentDependencies, Any]:
         if not self._supports_structured_output():
@@ -79,6 +108,10 @@ class GTNTrainingAgent(BaseGalaxyAgent):
             deps_type=GalaxyAgentDependencies,
             output_type=GTNSearchResponse,
             system_prompt=self.get_system_prompt(),
+            # gpt-oss occasionally emits prose instead of a valid GTNSearchResponse;
+            # the pydantic-ai default of 1 output retry turns that into a hard error.
+            # Allow a couple more attempts so an occasional malformed output recovers.
+            retries=3,
         )
 
         @agent.tool
@@ -91,6 +124,9 @@ class GTNTrainingAgent(BaseGalaxyAgent):
             limit: int = 5,
         ) -> str:
             """Search GTN tutorials using full-text search over titles, descriptions, and content."""
+            over_budget = self._charge_tool_budget()
+            if over_budget:
+                return over_budget
             if not self.gtn_db:
                 return json.dumps({"error": "GTN database not available"})
             try:
@@ -119,6 +155,9 @@ class GTNTrainingAgent(BaseGalaxyAgent):
             max_length: int = 1500,
         ) -> str:
             """Get the full content of a specific tutorial by topic and name."""
+            over_budget = self._charge_tool_budget()
+            if over_budget:
+                return over_budget
             if not self.gtn_db:
                 return "GTN database not available"
             try:
@@ -154,6 +193,9 @@ class GTNTrainingAgent(BaseGalaxyAgent):
             over ``search_gtn_tutorials`` for queries shorter than about
             eight words or phrased as ``what is X`` / ``how do I X``.
             """
+            over_budget = self._charge_tool_budget()
+            if over_budget:
+                return over_budget
             if not self.gtn_db:
                 return json.dumps({"error": "GTN database not available"})
             try:
@@ -175,6 +217,9 @@ class GTNTrainingAgent(BaseGalaxyAgent):
             limit: int = 5,
         ) -> str:
             """Find tutorials that use specific Galaxy tools."""
+            over_budget = self._charge_tool_budget()
+            if over_budget:
+                return over_budget
             if not self.gtn_db:
                 return json.dumps({"error": "GTN database not available"})
             try:
@@ -200,6 +245,8 @@ class GTNTrainingAgent(BaseGalaxyAgent):
         validation_error = self._validate_query(query)
         if validation_error:
             return self._validation_error_response(validation_error)
+
+        self._tool_calls = 0
 
         if not self.gtn_db:
             return self._build_response(


### PR DESCRIPTION
The GTN training agent burns a startling amount of tokens on simple tutorial questions. Tracing a representative one -- "I have brightfield RGB histology images, how do I quantify stain components, and are there tutorials?" -- under gpt-oss-120b, a single question cost ~88k-180k tokens. The router hands off to the GTN agent correctly, but the agent then fires ~18-30 `search_gtn_tutorials` calls, and since every tool round re-sends the whole growing transcript, the input tokens compound badly.

The fix is a small budget on the agent's data-gathering tools. After a few search/content calls they return a "you already have enough, answer now" message instead of more results, so the model synthesizes from what it has rather than looping. On the same query that brings usage from ~88k down to ~21k (about 4x) while still surfacing the same correct tutorial, with no drop in answer quality.

Two things fell out of the investigation:

- The stop message has to name the specific search tools rather than say "don't call any tools" -- the structured response is itself delivered via an output-tool call, so a blanket instruction made the model emit prose that failed validation. I also bumped structured-output retries from 1 to 3, since gpt-oss occasionally produces a malformed response and a single retry turned that into a hard, user-facing error. Together these took the error rate to zero across repeated runs.
- The FTS5 sanitizer wasn't stripping `.`, `:`, or `/`, so when the model built a search like `site:training.galaxyproject.org` the query errored out as no-results and the agent wasted rounds. That's a separate commit.

Measured against real gpt-oss-120b via the Jetstream inference endpoint; existing agent/search unit tests pass.
