### PR TITLE
[26.1] Fix input mangling when conditional parameter name ends in `_N`

### DIFF
--- a/lib/galaxy/tool_util/parameters/visitor.py
+++ b/lib/galaxy/tool_util/parameters/visitor.py
@@ -117,8 +117,6 @@ def _select_which_when(conditional: ConditionalParameterModel, state: dict) -> C
     explicit_test_value = state.get(test_parameter_name)
     test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
     for when in conditional.whens:
-        print(when.discriminator)
-        print(type(when.discriminator))
         if test_value is None and when.is_default_when:
             return when
         elif test_value == when.discriminator:

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -189,6 +189,23 @@ def expand_flat_parameters_to_nested(incoming_copy: ToolRequestT) -> dict[str, A
     return nested_dict
 
 
+def _remove_internal_state_keys(state: Any) -> None:
+    """Remove ``__``-prefixed keys from every dict in the nested state.
+
+    ``visit_input_values`` injects internal book-keeping entries such as
+    ``__current_case__`` and ``__index__`` as side-effects.  These must not
+    reach the job-internal Pydantic validation layer, which uses ``extra='forbid'``.
+    """
+    if isinstance(state, dict):
+        for key in [k for k in state if k.startswith("__")]:
+            del state[key]
+        for v in state.values():
+            _remove_internal_state_keys(v)
+    elif isinstance(state, list):
+        for item in state:
+            _remove_internal_state_keys(item)
+
+
 def expand_meta_parameters(
     trans: WorkRequestContext, tool, incoming: ToolRequestT, input_format: InputFormatT
 ) -> ExpandedT:
@@ -315,7 +332,6 @@ def split_inputs_flat(inputs: dict[str, Any], classifier):
 
 
 def split_inputs_nested(inputs, nested_dict, classifier):
-    single_inputs: dict[str, Any] = {}
     matched_multi_inputs: dict[str, Any] = {}
     multiplied_multi_inputs: dict[str, Any] = {}
     unset_value = object()
@@ -326,9 +342,7 @@ def split_inputs_nested(inputs, nested_dict, classifier):
             return
 
         input_type, expanded_val = classifier(value, prefixed_name)
-        if input_type == input_classification.SINGLE:
-            single_inputs[prefixed_name] = expanded_val
-        elif input_type == input_classification.MATCHED:
+        if input_type == input_classification.MATCHED:
             matched_multi_inputs[prefixed_name] = expanded_val
         elif input_type == input_classification.MULTIPLIED:
             multiplied_multi_inputs[prefixed_name] = expanded_val
@@ -336,8 +350,8 @@ def split_inputs_nested(inputs, nested_dict, classifier):
     visit_input_values(
         inputs=inputs, input_values=nested_dict, callback=visitor, allow_case_inference=True, unset_value=unset_value
     )
-    single_inputs_nested = expand_flat_parameters_to_nested(single_inputs)
-    return (single_inputs_nested, matched_multi_inputs, multiplied_multi_inputs)
+    _remove_internal_state_keys(nested_dict)
+    return (nested_dict, matched_multi_inputs, multiplied_multi_inputs)
 
 
 ExpandedAsyncT = tuple[

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -717,6 +717,30 @@ steps:
             assert os.path.exists(output_dataset_paths[1])
             assert not os.path.exists(output_dataset_paths[0])
 
+    @skip_without_tool("conditional_name_digit_suffix")
+    def test_create_job_with_conditional_name_digit_suffix(self):
+        # Regression: expand_meta_parameters_async used to mangle conditional names ending
+        # in _N (e.g. "inner_options_1") by misidentifying them as repeat indices, causing
+        # Pydantic job-internal validation to fail with extra_forbidden / list_type errors.
+        with self.dataset_populator.test_history() as history_id:
+            response = self.dataset_populator.tool_request_raw(
+                tool_id="conditional_name_digit_suffix",
+                inputs={
+                    "outer": {
+                        "select": "a",
+                        "inner_options_1": {"mode": "by_index", "col": 1},
+                        "inner_options_2": {"mode": "by_name", "label": "foo"},
+                    }
+                },
+                history_id=history_id,
+            )
+            response.raise_for_status()
+            tool_request_id = response.json()["tool_request_id"]
+            submitted = self.dataset_populator.wait_on_tool_request(tool_request_id)
+            assert submitted, self.dataset_populator.get_tool_request(tool_request_id)
+            jobs = self.galaxy_interactor.jobs_for_tool_request(tool_request_id)
+            self.dataset_populator.wait_for_jobs(jobs, assert_ok=True)
+
     def _hack_to_skip_test_if_state_ok(self, job_state):
         if job_state().json()["state"] == "ok":
             message = "Job state switch from running to ok too quickly - the rest of the test requires the job to be in a running state. Skipping test."

--- a/test/functional/tools/conditional_name_digit_suffix.xml
+++ b/test/functional/tools/conditional_name_digit_suffix.xml
@@ -1,0 +1,42 @@
+<tool id="conditional_name_digit_suffix" name="conditional_name_digit_suffix" version="0.1.0">
+    <description>Regression tool: conditional names ending in _N must not be treated as repeat indices</description>
+    <command>echo done</command>
+    <inputs>
+        <conditional name="outer">
+            <param name="select" type="select">
+                <option value="a">A</option>
+            </param>
+            <when value="a">
+                <!-- Names ending in _1 / _2 are the pattern that looks_like_flattened_repeat_key
+                     would misidentify as "repeat item 1/2 of a repeat named inner_options". -->
+                <conditional name="inner_options_1">
+                    <param name="mode" type="select">
+                        <option value="by_index">By Index</option>
+                        <option value="by_name">By Name</option>
+                    </param>
+                    <when value="by_index">
+                        <param name="col" type="integer" value="1" />
+                    </when>
+                    <when value="by_name">
+                        <param name="label" type="text" value="" />
+                    </when>
+                </conditional>
+                <conditional name="inner_options_2">
+                    <param name="mode" type="select">
+                        <option value="by_index">By Index</option>
+                        <option value="by_name">By Name</option>
+                    </param>
+                    <when value="by_index">
+                        <param name="col" type="integer" value="1" />
+                    </when>
+                    <when value="by_name">
+                        <param name="label" type="text" value="" />
+                    </when>
+                </conditional>
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -61,6 +61,7 @@
   <tool file="filter_static_regexp.xml" />
   <tool file="select_from_dataset.xml" />
   <tool file="select_from_dataset_in_conditional.xml" />
+  <tool file="conditional_name_digit_suffix.xml" />
   <tool file="select_from_csvdataset.xml" />
   <tool file="select_from_dataset_optional.xml" />
   <tool file="drill_down.xml" />

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -5,6 +5,7 @@ from typing import (
 import pytest
 
 from galaxy.exceptions import RequestParameterInvalidException
+from galaxy.tools.parameters.meta import _remove_internal_state_keys
 from galaxy.tools.parameters.wrapped import (
     nested_key_to_path,
     process_key,
@@ -25,6 +26,45 @@ def test_nested_key_to_path():
         1,
         "data_table_column_value",
     ]
+
+
+def test_remove_internal_state_keys():
+    state = {
+        "__class__": "RuntimeValue",
+        "selected_tasks": {
+            "selected_task": "train",
+            "__current_case__": 0,
+            "_private": "kept",
+            "input_options": {
+                "selected_input": "tabular",
+                "__current_case__": 1,
+                "repeat_0": {"__index__": 0, "__identifier__": "foo", "col": 1},
+            },
+        },
+    }
+    _remove_internal_state_keys(state)
+    assert state == {
+        "selected_tasks": {
+            "selected_task": "train",
+            "_private": "kept",
+            "input_options": {
+                "selected_input": "tabular",
+                "repeat_0": {"col": 1},
+            },
+        },
+    }
+
+
+def test_remove_internal_state_keys_list():
+    # visit_input_values represents repeat groups as lists of dicts, each with __index__
+    state = {
+        "repeat": [
+            {"__index__": 0, "col": 1},
+            {"__index__": 1, "col": 2},
+        ]
+    }
+    _remove_internal_state_keys(state)
+    assert state == {"repeat": [{"col": 1}, {"col": 2}]}
 
 
 class TestProcessKey:


### PR DESCRIPTION
split_inputs_nested flattened the already-nested input state to |‑separated flat keys via visit_input_values, then called expand_flat_parameters_to_nested to rebuild the dict.  That rebuild uses process_key / looks_like_flattened_repeat_key, which treats any path component ending in _<digit> (e.g. "column_selector_options_1") as a repeat-item index rather than a literal conditional name.  The result was a spurious "column_selector_options" list instead of the expected "column_selector_options_1" / "column_selector_options_2" dicts, which then caused Pydantic to report extra_forbidden on the fake list and list_type (None) on col1 once fill_static_defaults initialised the now-missing conditional to an empty dict.

The flat→nested round-trip was never needed for the nested-input path: the dict coming in is already correctly structured.  Fix by returning nested_dict directly from split_inputs_nested as single_inputs, only extracting batch (matched / multiplied) inputs as flat-key entries as before.  Strip internal state keys starting with __ that visit_input_values stamps so they don't appear as extra fields when the state reaches Pydantic validation.

Also remove stray print() debug calls left in visitor.py.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
