### PR TITLE
[26.1] Always attempt to build tool request for new API endpoint

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -11080,6 +11080,8 @@ export interface components {
              * @constant
              */
             type: "data";
+            /** Url Default */
+            url_default?: string | null;
         };
         /** DataRequestCollectionUri */
         DataRequestCollectionUri: {

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -113,15 +113,51 @@ def get_galaxy_app():
     return build_app()
 
 
+def _register_worker_datatype_converters(galaxy_app) -> None:
+    """Register datatype converter tools in the Celery worker's datatypes registry.
+
+    Async tool-request execution (``execute_async`` -> ``collect_input_datasets``) runs in
+    the Celery worker and applies implicit datatype conversion (e.g. decompressing a
+    ``fasta.gz`` input for a ``fasta`` parameter). That relies on
+    ``datatypes_registry.datatype_converters`` being populated, which normally happens via
+    ``load_datatype_converters(toolbox)`` in the web ``UniverseApplication``. The worker's
+    minimal ``GalaxyManagerApplication`` has no toolbox, so load the (few, built-in)
+    converter tools directly using the same toolbox-less path ``queue_jobs`` uses for the
+    submitted tool. Without this, ``find_conversion_destination`` finds no converter and the
+    raw (compressed) dataset is handed to the tool. See ``lib/galaxy/tools/actions/__init__.py``.
+    """
+    from galaxy.tool_util.parser import get_tool_source
+    from galaxy.tools import create_tool_from_source
+
+    registry = galaxy_app.datatypes_registry
+    converters_path = registry.converters_path
+    if not converters_path:
+        return
+    for converter_file, source_ext, target_ext in registry.converters:
+        config_path = os.path.join(converters_path, converter_file)
+        try:
+            tool_source = get_tool_source(config_file=config_path)
+            converter = create_tool_from_source(galaxy_app, tool_source, config_file=config_path)
+            registry.converter_tools.add(converter)
+            registry.datatype_converters.setdefault(source_ext, {})[target_ext] = converter
+        except Exception:
+            log.exception("Failed to load datatype converter %s for Celery worker", config_path)
+    # Drop any cached (empty) converter lookups computed before registration.
+    registry._converters_by_datatype = {}
+
+
 @lru_cache(maxsize=1)
 def build_app():
     if kwargs := get_app_properties():
         kwargs["check_migrate_databases"] = False
         kwargs["use_display_applications"] = False
-        kwargs["use_converters"] = False
+        # Collect converter definitions (the converters list) so we can register the
+        # converter tools below; the worker needs them for implicit datatype conversion.
+        kwargs["use_converters"] = True
         import galaxy.app
 
         galaxy_app = galaxy.app.GalaxyManagerApplication(configure_logging=False, **kwargs)
+        _register_worker_datatype_converters(galaxy_app)
         return galaxy_app
 
 

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -151,8 +151,6 @@ def build_app():
     if kwargs := get_app_properties():
         kwargs["check_migrate_databases"] = False
         kwargs["use_display_applications"] = False
-        # Collect converter definitions (the converters list) so we can register the
-        # converter tools below; the worker needs them for implicit datatype conversion.
         kwargs["use_converters"] = True
         import galaxy.app
 

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -113,39 +113,6 @@ def get_galaxy_app():
     return build_app()
 
 
-def _register_worker_datatype_converters(galaxy_app) -> None:
-    """Register datatype converter tools in the Celery worker's datatypes registry.
-
-    Async tool-request execution (``execute_async`` -> ``collect_input_datasets``) runs in
-    the Celery worker and applies implicit datatype conversion (e.g. decompressing a
-    ``fasta.gz`` input for a ``fasta`` parameter). That relies on
-    ``datatypes_registry.datatype_converters`` being populated, which normally happens via
-    ``load_datatype_converters(toolbox)`` in the web ``UniverseApplication``. The worker's
-    minimal ``GalaxyManagerApplication`` has no toolbox, so load the (few, built-in)
-    converter tools directly using the same toolbox-less path ``queue_jobs`` uses for the
-    submitted tool. Without this, ``find_conversion_destination`` finds no converter and the
-    raw (compressed) dataset is handed to the tool. See ``lib/galaxy/tools/actions/__init__.py``.
-    """
-    from galaxy.tool_util.parser import get_tool_source
-    from galaxy.tools import create_tool_from_source
-
-    registry = galaxy_app.datatypes_registry
-    converters_path = registry.converters_path
-    if not converters_path:
-        return
-    for converter_file, source_ext, target_ext in registry.converters:
-        config_path = os.path.join(converters_path, converter_file)
-        try:
-            tool_source = get_tool_source(config_file=config_path)
-            converter = create_tool_from_source(galaxy_app, tool_source, config_file=config_path)
-            registry.converter_tools.add(converter)
-            registry.datatype_converters.setdefault(source_ext, {})[target_ext] = converter
-        except Exception:
-            log.exception("Failed to load datatype converter %s for Celery worker", config_path)
-    # Drop any cached (empty) converter lookups computed before registration.
-    registry._converters_by_datatype = {}
-
-
 @lru_cache(maxsize=1)
 def build_app():
     if kwargs := get_app_properties():
@@ -155,7 +122,9 @@ def build_app():
         import galaxy.app
 
         galaxy_app = galaxy.app.GalaxyManagerApplication(configure_logging=False, **kwargs)
-        _register_worker_datatype_converters(galaxy_app)
+        # GalaxyManagerApplication has no toolbox, so the converter tools the async
+        # execution path relies on must be loaded directly into the datatypes registry.
+        galaxy_app.datatypes_registry.load_datatype_converters_without_toolbox(galaxy_app)
         return galaxy_app
 
 

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -685,15 +685,44 @@ class Registry:
             try:
                 config_path = os.path.join(converter_path, tool_config)
                 converter = toolbox.load_tool(config_path, use_cached=use_cached)
-                self.converter_tools.add(converter)
                 toolbox.register_tool(converter)
-                if source_datatype not in self.datatype_converters:
-                    self.datatype_converters[source_datatype] = {}
-                self.datatype_converters[source_datatype][target_datatype] = converter
+                self._register_converter_tool(converter, source_datatype, target_datatype)
                 if not hasattr(toolbox.app, "tool_cache") or converter.id in toolbox.app.tool_cache._new_tool_ids:
                     self.log.debug("Loaded converter: %s", converter.id)
             except Exception:
                 self.log.exception(f"Error loading converter ({converter_path})")
+
+    def load_datatype_converters_without_toolbox(self, app) -> None:
+        """Load datatype converters for an app that has no toolbox (e.g. the Celery worker).
+
+        Mirrors ``load_datatype_converters`` but builds each converter directly from its tool
+        source rather than through a toolbox, since the Celery worker's minimal
+        ``GalaxyManagerApplication`` has none. Async tool-request execution runs in the worker
+        and relies on ``datatype_converters`` being populated to apply implicit datatype
+        conversion (e.g. decompressing a ``fasta.gz`` input for a ``fasta`` parameter); without
+        this ``find_conversion_destination`` finds no converter and hands the raw dataset to the
+        tool.
+        """
+        # Imported here to avoid a circular import - galaxy.tools depends on galaxy.datatypes.
+        from galaxy.tool_util.parser import get_tool_source
+        from galaxy.tools import create_tool_from_source
+
+        if not self.converters_path:
+            return
+        for tool_config, source_datatype, target_datatype in self.converters:
+            config_path = os.path.join(self.converters_path, tool_config)
+            try:
+                tool_source = get_tool_source(config_file=config_path)
+                converter = create_tool_from_source(app, tool_source, config_file=config_path)
+                self._register_converter_tool(converter, source_datatype, target_datatype)
+            except Exception:
+                self.log.exception(f"Error loading converter ({config_path})")
+        # Drop any cached (empty) converter lookups computed before registration.
+        self._converters_by_datatype = {}
+
+    def _register_converter_tool(self, converter, source_datatype, target_datatype) -> None:
+        self.converter_tools.add(converter)
+        self.datatype_converters.setdefault(source_datatype, {})[target_datatype] = converter
 
     def load_display_applications(self, app):
         """

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -2289,6 +2289,7 @@ class JobSubmitter:
             sa_session.commit()
         except Exception as e:
             log.exception("Problem validating tool state after request created")
+            sa_session.rollback()
             tool_request.state = ToolRequest.states.FAILED
             state_message: dict = {"err_msg": str(e)}
             if isinstance(e, MessageException) and e.extra_error_info:

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -15,16 +15,16 @@ from galaxy.tool_util.lint import Linter
 from galaxy.tool_util.parameters import validate_test_cases_for_tool_source
 from galaxy.tool_util.parameters.factory import input_models_for_tool_source
 from galaxy.tool_util.verify.parse import tag_structure_to_that_structure
+from galaxy.tool_util_models.assertions import (
+    assertion_list,
+    relaxed_assertion_list,
+)
 from galaxy.tool_util_models.parameters import (
     ConditionalParameterModel,
     RepeatParameterModel,
     SectionParameterModel,
     SelectParameterModel,
     ToolParameterT,
-)
-from galaxy.tool_util_models.assertions import (
-    assertion_list,
-    relaxed_assertion_list,
 )
 from galaxy.util import asbool
 from ._util import is_datasource
@@ -251,7 +251,7 @@ class TestsMultipleSelectEmptyValue(Linter):
                 name = param.attrib.get("name", "")
                 if name in multiple_select_names and param.attrib.get("value", None) == "":
                     lint_log(
-                        f"Test {test_idx}: param '{name}' uses value=\"\" for a multiple select — use value_json=\"[]\" to express an empty selection explicitly.",
+                        f'Test {test_idx}: param \'{name}\' uses value="" for a multiple select — use value_json="[]" to express an empty selection explicitly.',
                         linter=cls.name(),
                         node=param,
                     )

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -20,9 +20,7 @@ from galaxy.tool_util_models.assertions import (
     relaxed_assertion_list,
 )
 from galaxy.tool_util_models.parameters import (
-    ConditionalParameterModel,
-    RepeatParameterModel,
-    SectionParameterModel,
+    iter_parameter_models,
     SelectParameterModel,
     ToolParameterT,
 )
@@ -218,16 +216,11 @@ def _cleanup_pydantic_error(error) -> str:
 
 
 def _collect_multiple_select_names(parameters: List["ToolParameterT"]) -> Set[str]:
-    names: Set[str] = set()
-    for param in parameters:
-        if isinstance(param, SelectParameterModel) and param.multiple:
-            names.add(param.name)
-        elif isinstance(param, (ConditionalParameterModel,)):
-            for when in param.whens:
-                names.update(_collect_multiple_select_names(when.parameters))
-        elif isinstance(param, (SectionParameterModel, RepeatParameterModel)):
-            names.update(_collect_multiple_select_names(param.parameters))
-    return names
+    return {
+        param.name
+        for param in iter_parameter_models(parameters)
+        if isinstance(param, SelectParameterModel) and param.multiple
+    }
 
 
 class TestsMultipleSelectEmptyValue(Linter):

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -4,6 +4,7 @@ from io import StringIO
 from typing import (
     Iterator,
     List,
+    Set,
     Tuple,
     TYPE_CHECKING,
 )
@@ -12,7 +13,15 @@ from packaging.version import Version
 
 from galaxy.tool_util.lint import Linter
 from galaxy.tool_util.parameters import validate_test_cases_for_tool_source
+from galaxy.tool_util.parameters.factory import input_models_for_tool_source
 from galaxy.tool_util.verify.parse import tag_structure_to_that_structure
+from galaxy.tool_util_models.parameters import (
+    ConditionalParameterModel,
+    RepeatParameterModel,
+    SectionParameterModel,
+    SelectParameterModel,
+    ToolParameterT,
+)
 from galaxy.tool_util_models.assertions import (
     assertion_list,
     relaxed_assertion_list,
@@ -206,6 +215,46 @@ def _cleanup_pydantic_error(error) -> str:
         else:
             new_error.write(f"{line}\n")
     return new_error.getvalue().strip()
+
+
+def _collect_multiple_select_names(parameters: List["ToolParameterT"]) -> Set[str]:
+    names: Set[str] = set()
+    for param in parameters:
+        if isinstance(param, SelectParameterModel) and param.multiple:
+            names.add(param.name)
+        elif isinstance(param, (ConditionalParameterModel,)):
+            for when in param.whens:
+                names.update(_collect_multiple_select_names(when.parameters))
+        elif isinstance(param, (SectionParameterModel, RepeatParameterModel)):
+            names.update(_collect_multiple_select_names(param.parameters))
+    return names
+
+
+class TestsMultipleSelectEmptyValue(Linter):
+    @classmethod
+    def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
+        tool_xml = getattr(tool_source, "xml_tree", None)
+        if not tool_xml:
+            return
+        profile = tool_source.parse_profile()
+        lint_log = lint_ctx.warn if Version(profile) < Version("26.1") else lint_ctx.error
+        try:
+            bundle = input_models_for_tool_source(tool_source)
+        except Exception:
+            return
+        multiple_select_names = _collect_multiple_select_names(bundle.parameters)
+        if not multiple_select_names:
+            return
+        tests = tool_xml.findall("./tests/test")
+        for test_idx, test in enumerate(tests, start=1):
+            for param in test.iter("param"):
+                name = param.attrib.get("name", "")
+                if name in multiple_select_names and param.attrib.get("value", None) == "":
+                    lint_log(
+                        f"Test {test_idx}: param '{name}' uses value=\"\" for a multiple select — use value_json=\"[]\" to express an empty selection explicitly.",
+                        linter=cls.name(),
+                        node=param,
+                    )
 
 
 class TestsExpectNumOutputs(Linter):

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -384,9 +384,14 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
     # prefix (e.g. <param name="fasta"> instead of <param name="mode|fasta">).
     if "|" in flat_state_path:
         short_name = flat_state_path.rsplit("|", 1)[1]
+        matching_inputs = []
         for input in inputs:
             if input["name"] == short_name:
-                return input
+                matching_inputs.append(input)
+        if len(matching_inputs) == 1:
+            return matching_inputs[0]
+        elif len(matching_inputs) > 1:
+            raise Exception(f"Ambiguous unqualified test parameter name ({short_name}) for ({flat_state_path})")
     return None
 
 

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -325,7 +325,7 @@ def _merge_into_state(
                                 # location may be a comma-separated list of URLs; split per URL
                                 for single_location in location.split(","):
                                     single_location = single_location.strip()
-                                    instance_test_input = dict(test_input)
+                                    instance_test_input = cast(ToolSourceTestInput, dict(test_input))
                                     instance_test_input["attributes"] = dict(test_input["attributes"])
                                     instance_test_input["value"] = os.path.basename(single_location)
                                     instance_test_input["attributes"]["location"] = single_location

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -39,6 +39,7 @@ from galaxy.tool_util_models.parameters import (
     GenomeBuildParameterModel,
     GroupTagParameterModel,
     IntegerParameterModel,
+    iter_parameter_models,
     RepeatParameterModel,
     SectionParameterModel,
     SelectParameterModel,
@@ -583,18 +584,13 @@ def _select_which_when(
 
 def _leaf_param_short_names(parameters: List[ToolParameterT]) -> Set[str]:
     """Collect the leaf parameter short names reachable from a list of parameters,
-    descending into repeats, sections and nested conditionals."""
-    names: Set[str] = set()
-    for parameter in parameters:
-        if isinstance(parameter, (RepeatParameterModel, SectionParameterModel)):
-            names |= _leaf_param_short_names(parameter.parameters)
-        elif isinstance(parameter, ConditionalParameterModel):
-            names.add(parameter.test_parameter.name)
-            for when in parameter.whens:
-                names |= _leaf_param_short_names(when.parameters)
-        else:
-            names.add(parameter.name)
-    return names
+    descending into repeats, sections and nested conditionals (including each
+    conditional's discriminator)."""
+    return {
+        parameter.name
+        for parameter in iter_parameter_models(parameters)
+        if not isinstance(parameter, (RepeatParameterModel, SectionParameterModel, ConditionalParameterModel))
+    }
 
 
 def _infer_when_from_inputs(

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -111,9 +111,14 @@ def legacy_from_string(parameter: ToolParameterT, value: Optional[Any], warnings
             try:
                 result_value = asbool(value)
             except ValueError:
-                warnings.append(
-                    "Likely using deprected truevalue/falsevalue in tool parameter - switch to 'true' or 'false'"
-                )
+                if parameter.truevalue is not None and value == parameter.truevalue:
+                    result_value = True
+                elif parameter.falsevalue is not None and value == parameter.falsevalue:
+                    result_value = False
+                else:
+                    warnings.append(
+                        "Likely using deprected truevalue/falsevalue in tool parameter - switch to 'true' or 'false'"
+                    )
         elif isinstance(parameter, (GroupTagParameterModel,)):
             if parameter.multiple:
                 result_value = multiple_select_value_split(value)
@@ -356,8 +361,14 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
     for input in inputs:
         if input["name"] == flat_state_path:
             return input
-    else:
-        return None
+    # Fallback for legacy test cases that specify conditional/section params without the pipe-separated
+    # prefix (e.g. <param name="fasta"> instead of <param name="mode|fasta">).
+    if "|" in flat_state_path:
+        short_name = flat_state_path.rsplit("|", 1)[1]
+        for input in inputs:
+            if input["name"] == short_name:
+                return input
+    return None
 
 
 def validate_test_cases_for_tool_source(

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -310,6 +310,11 @@ def _merge_into_state(
                 test_parameter, inputs, conditional_state, profile, state_representation, warnings, state_path
             )
         )
+        # If the discriminator was omitted but a non-default when was inferred from the
+        # provided parameters, record the inferred discriminator so the state validates
+        # against that branch rather than the __absent__/default branch.
+        if test_parameter.name not in conditional_state and not when.is_default_when:
+            conditional_state[test_parameter.name] = when.discriminator
         handled_inputs.update(
             _merge_level_into_state(
                 when.parameters, inputs, conditional_state, profile, state_representation, warnings, state_path
@@ -451,6 +456,14 @@ def _select_which_when(
     if is_boolean and isinstance(explicit_test_value, str):
         explicit_test_value = asbool(explicit_test_value)
     test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
+    if test_value is None:
+        # The discriminator was omitted. Like the synchronous tool API, infer the active
+        # when from the parameters the test actually provides before falling back to the
+        # default when (otherwise a test that supplies a non-default branch's params fails
+        # to validate against the default branch).
+        inferred_when = _infer_when_from_inputs(conditional, inputs, prefix)
+        if inferred_when is not None:
+            return inferred_when
     for when in conditional.whens:
         if test_value is None and when.is_default_when:
             return when
@@ -458,6 +471,53 @@ def _select_which_when(
             return when
     else:
         raise Exception(f"Invalid conditional test value ({explicit_test_value}) for parameter ({test_parameter_name})")
+
+
+def _leaf_param_short_names(parameters: List[ToolParameterT]) -> Set[str]:
+    """Collect the leaf parameter short names reachable from a list of parameters,
+    descending into repeats, sections and nested conditionals."""
+    names: Set[str] = set()
+    for parameter in parameters:
+        if isinstance(parameter, (RepeatParameterModel, SectionParameterModel)):
+            names |= _leaf_param_short_names(parameter.parameters)
+        elif isinstance(parameter, ConditionalParameterModel):
+            names.add(parameter.test_parameter.name)
+            for when in parameter.whens:
+                names |= _leaf_param_short_names(when.parameters)
+        else:
+            names.add(parameter.name)
+    return names
+
+
+def _infer_when_from_inputs(
+    conditional: ConditionalParameterModel, inputs: ToolSourceTestInputs, prefix: Optional[str]
+) -> Optional[ConditionalWhen]:
+    """When a conditional's discriminator is omitted, pick the when whose parameters the
+    test supplies. Returns the best-matching when only when it is a strictly better match
+    than the default when; otherwise None so the caller uses the default when."""
+    scope = f"{prefix}|" if prefix else ""
+    provided_short_names: Set[str] = set()
+    for input in inputs:
+        name = input["name"]
+        if scope and not name.startswith(scope):
+            continue
+        provided_short_names.add(name.rsplit("|", 1)[-1])
+    if not provided_short_names:
+        return None
+
+    best_when: Optional[ConditionalWhen] = None
+    best_score = 0
+    default_score = 0
+    for when in conditional.whens:
+        score = len(_leaf_param_short_names(when.parameters) & provided_short_names)
+        if when.is_default_when:
+            default_score = score
+        if score > best_score:
+            best_score = score
+            best_when = when
+    if best_when is not None and best_score > default_score:
+        return best_when
+    return None
 
 
 def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[ToolSourceTestInput]:

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -131,10 +131,8 @@ def legacy_from_string(parameter: ToolParameterT, value: Optional[Any], warnings
                     result_value = asbool(value)
                 except ValueError:
                     if Version(profile) < Version("24.2"):
-                        # Legacy tools sometimes use a non-boolean placeholder such as
-                        # "-" as a test value. The synchronous tool API coerces these
-                        # via string_as_bool (any non-true value -> False); match that
-                        # so the payload is a valid boolean without requiring test edits.
+                        # Coerce a legacy non-boolean placeholder (e.g. "-") via string_as_bool
+                        # (any non-true value -> False), matching the synchronous tool API.
                         result_value = string_as_bool(value)
                         warnings.append(
                             f"Non-boolean test value ({value!r}) for {parameter.name} coerced to "
@@ -227,10 +225,8 @@ class LegacyTestInputResolver:
         return replace(self, inputs=inputs)
 
     def input_for(self, flat_state_path: str) -> Optional[ToolSourceTestInput]:
-        # A consumed discriminator belongs to an enclosing conditional and must not be
-        # re-matched by the loose fallbacks below when resolving a descendant's discriminator
-        # (otherwise e.g. an omitted nested ``selector`` greedily picks up the parent
-        # conditional's ``selector`` value - see ``_select_which_when``).
+        # Discriminators consumed by enclosing conditionals are excluded from the loose fallbacks
+        # below, so a descendant's omitted discriminator does not re-match an ancestor's.
         exclude = self.consumed_discriminators
         for input in self.inputs:
             if input["name"] == flat_state_path:
@@ -342,7 +338,12 @@ def test_case_state(
 
 
 def _input_name_was_handled_by_legacy_fallback(input_name: str, handled_inputs: Set[str], profile: str) -> bool:
-    # Intentionally a loose string-match against every visited parameter path, NOT a record of which inputs were actually consumed: the raw-name->path relation is many-to-many for legacy tests (bare/duplicate names validly satisfy multiple params), so consumption-tracking wrongly rejects degenerate-but-valid cases - tried and reverted, don't reintroduce it.
+    """True if a pre-24.2 legacy fallback already covered input_name (loose suffix-match).
+
+    The match is deliberately loose - against every visited path, not consumed inputs - because
+    the raw-name->path relation is many-to-many for legacy tests (bare/duplicate names validly
+    satisfy multiple params). Only applies below profile 24.2.
+    """
     if Version(profile) >= Version("24.2"):
         return False
     for handled_input in handled_inputs:
@@ -415,17 +416,12 @@ def _merge_into_state(
         when, discriminator_name = _select_which_when(tool_input, conditional_state, context, state_path)
         test_parameter = tool_input.test_parameter
         handled_inputs.update(_merge_into_state(test_parameter, context, conditional_state, state_path))
-        # If the discriminator was omitted, record the selected when's discriminator so the
-        # state validates against that branch rather than the phantom __absent__ branch. This
-        # is the active branch _select_which_when chose: a non-default when inferred from the
-        # provided params, or - for a legacy conditional with no explicit selected="true" - the
-        # default (first) option, mirroring how the synchronous runtime fills an incomplete
-        # payload.
+        # If the discriminator was omitted, record the when _select_which_when chose so the state
+        # validates against that branch rather than the phantom __absent__ branch.
         if test_parameter.name not in conditional_state and when.discriminator is not None:
             conditional_state[test_parameter.name] = when.discriminator
-        # The discriminator consumed here belongs to this conditional; the branch context marks
-        # it so the loose fallbacks do not re-match it when resolving a nested conditional's
-        # discriminator.
+        # Mark this conditional's discriminator consumed so a nested conditional's loose fallbacks
+        # do not re-match it.
         handled_inputs.update(
             _merge_level_into_state(
                 when.parameters, context.consuming(discriminator_name), conditional_state, state_path
@@ -515,15 +511,10 @@ def _repeat_inputs_to_array(
     inputs_as_dict = _inputs_as_dict(inputs)
     repeat_instance_input_dicts = repeat_inputs_to_array(state_path, inputs_as_dict)
     if not repeat_instance_input_dicts and "|" in state_path:
-        # Legacy test cases may reference a repeat that lives inside a conditional or
-        # section by its unqualified name (e.g. <repeat name="rep"> at the top level
-        # instead of wrapped in the enclosing <conditional>). The test inputs are
-        # unqualified with respect to conditionals/sections but still carry repeat
-        # instance indices, so progressively strip leading (conditional/section)
-        # segments - keeping any enclosing repeat-instance prefix - until the repeat's
-        # nested params resolve. The downstream input_for() suffix match then
-        # re-attaches them to the fully qualified path. Longest candidate is tried
-        # first to avoid matching an unrelated like-named repeat.
+        # A legacy test may name a repeat inside a conditional/section by its unqualified name.
+        # Progressively strip leading conditional/section segments (longest candidate first, to
+        # avoid an unrelated like-named repeat) until the repeat's params resolve; input_for()'s
+        # suffix match re-attaches them to the qualified path.
         parts = state_path.split("|")
         for start in range(1, len(parts)):
             candidate_path = "|".join(parts[start:])
@@ -568,10 +559,8 @@ def _select_which_when(
         explicit_test_value = asbool(explicit_test_value)
     test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
     if test_value is None:
-        # The discriminator was omitted. Like the synchronous tool API, infer the active
-        # when from the parameters the test actually provides before falling back to the
-        # default when (otherwise a test that supplies a non-default branch's params fails
-        # to validate against the default branch).
+        # Discriminator omitted: infer the active when from the params the test provides (like
+        # the synchronous tool API) before falling back to the default when.
         inferred_when = _infer_when_from_inputs(conditional, context.inputs, prefix)
         if inferred_when is not None:
             return inferred_when, matched_name

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -209,9 +209,15 @@ def test_case_state(
 
 
 def _input_name_was_handled_by_legacy_fallback(input_name: str, handled_inputs: Set[str], profile: str) -> bool:
-    return Version(profile) < Version("24.2") and any(
-        handled_input == input_name or handled_input.endswith(f"|{input_name}") for handled_input in handled_inputs
-    )
+    if Version(profile) >= Version("24.2"):
+        return False
+    for handled_input in handled_inputs:
+        if handled_input == input_name or handled_input.endswith(f"|{input_name}"):
+            return True
+        # conditional names may be elided in the test while the section/repeat prefix is kept
+        if "|" in input_name and _is_conditional_elided_match(input_name, handled_input.split("|")):
+            return True
+    return False
 
 
 def test_case_validation(
@@ -463,7 +469,36 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
             return matching_inputs[0]
         elif len(matching_inputs) > 1:
             raise Exception(f"Ambiguous unqualified test parameter name ({short_name}) for ({flat_state_path})")
+
+        # Fallback for legacy test cases that elide intermediate conditional names but keep
+        # the enclosing section/repeat prefix (e.g. <section name="adv"><param name="esf">
+        # for a param whose real path is adv|esf_cond|esf). The input name is an ordered
+        # subsequence of the qualified path - sharing the head and the leaf - rather than a
+        # plain suffix.
+        path_segments = flat_state_path.split("|")
+        elided_matching_inputs = [
+            input for input in inputs if _is_conditional_elided_match(input["name"], path_segments)
+        ]
+        if len(elided_matching_inputs) == 1:
+            return elided_matching_inputs[0]
+        elif len(elided_matching_inputs) > 1:
+            raise Exception(f"Ambiguous partially qualified test parameter name for ({flat_state_path})")
     return None
+
+
+def _is_conditional_elided_match(input_name: str, path_segments: List[str]) -> bool:
+    """True if ``input_name`` is the qualified ``path_segments`` with intermediate
+    (conditional) segments removed - sharing the head and leaf segments.
+
+    e.g. input_name "advanced_options|esf" matches path ["advanced_options", "esf_cond", "esf"].
+    """
+    input_segments = input_name.split("|")
+    if len(input_segments) < 2 or len(input_segments) >= len(path_segments):
+        return False
+    if input_segments[0] != path_segments[0] or input_segments[-1] != path_segments[-1]:
+        return False
+    path_iter = iter(path_segments)
+    return all(segment in path_iter for segment in input_segments)
 
 
 def validate_test_cases_for_tool_source(

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -331,10 +331,13 @@ def _merge_into_state(
                 consumed_discriminators,
             )
         )
-        # If the discriminator was omitted but a non-default when was inferred from the
-        # provided parameters, record the inferred discriminator so the state validates
-        # against that branch rather than the __absent__/default branch.
-        if test_parameter.name not in conditional_state and not when.is_default_when:
+        # If the discriminator was omitted, record the selected when's discriminator so the
+        # state validates against that branch rather than the phantom __absent__ branch. This
+        # is the active branch _select_which_when chose: a non-default when inferred from the
+        # provided params, or - for a legacy conditional with no explicit selected="true" - the
+        # default (first) option, mirroring how the synchronous runtime fills an incomplete
+        # payload.
+        if test_parameter.name not in conditional_state and when.discriminator is not None:
             conditional_state[test_parameter.name] = when.discriminator
         # The discriminator consumed here belongs to this conditional; mark it so the loose
         # fallbacks do not re-match it when resolving a nested conditional's discriminator.

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -467,25 +467,24 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
     # Fallback for legacy test cases that specify conditional/section params without the pipe-separated
     # prefix (e.g. <param name="fasta"> instead of <param name="mode|fasta">).
     if "|" in flat_state_path:
-        suffix_matching_inputs = []
-        for input in inputs:
-            input_name = input["name"]
-            if "|" in input_name and flat_state_path.endswith(f"|{input_name}"):
-                suffix_matching_inputs.append(input)
-        if len(suffix_matching_inputs) == 1:
-            return suffix_matching_inputs[0]
-        elif len(suffix_matching_inputs) > 1:
-            raise Exception(f"Ambiguous partially qualified test parameter name for ({flat_state_path})")
+        suffix_matching_inputs = [
+            input
+            for input in inputs
+            if "|" in input["name"] and flat_state_path.endswith(f"|{input['name']}")
+        ]
+        resolved = _resolve_matching_inputs(
+            suffix_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
+        )
+        if resolved is not None:
+            return resolved
 
         short_name = flat_state_path.rsplit("|", 1)[1]
-        matching_inputs = []
-        for input in inputs:
-            if input["name"] == short_name:
-                matching_inputs.append(input)
-        if len(matching_inputs) == 1:
-            return matching_inputs[0]
-        elif len(matching_inputs) > 1:
-            raise Exception(f"Ambiguous unqualified test parameter name ({short_name}) for ({flat_state_path})")
+        matching_inputs = [input for input in inputs if input["name"] == short_name]
+        resolved = _resolve_matching_inputs(
+            matching_inputs, f"Ambiguous unqualified test parameter name ({short_name}) for ({flat_state_path})"
+        )
+        if resolved is not None:
+            return resolved
 
         # Fallback for legacy test cases that elide intermediate conditional names but keep
         # the enclosing section/repeat prefix (e.g. <section name="adv"><param name="esf">
@@ -496,11 +495,35 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
         elided_matching_inputs = [
             input for input in inputs if _is_conditional_elided_match(input["name"], path_segments)
         ]
-        if len(elided_matching_inputs) == 1:
-            return elided_matching_inputs[0]
-        elif len(elided_matching_inputs) > 1:
-            raise Exception(f"Ambiguous partially qualified test parameter name for ({flat_state_path})")
+        resolved = _resolve_matching_inputs(
+            elided_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
+        )
+        if resolved is not None:
+            return resolved
     return None
+
+
+def _resolve_matching_inputs(
+    matching_inputs: List[ToolSourceTestInput], ambiguity_message: str
+) -> Optional[ToolSourceTestInput]:
+    """Resolve a list of test inputs that matched a parameter to a single input.
+
+    Returns None when nothing matched (so the caller can try the next fallback). A single
+    match is returned directly. Multiple matches are tolerated when they are equivalent -
+    a duplicate identical entry is a common test-authoring slip and the synchronous tool
+    API accepts it - but genuinely conflicting values raise.
+    """
+    if not matching_inputs:
+        return None
+    first = matching_inputs[0]
+    if len(matching_inputs) == 1:
+        return first
+    if all(
+        input.get("value") == first.get("value") and input.get("attributes") == first.get("attributes")
+        for input in matching_inputs[1:]
+    ):
+        return first
+    raise Exception(ambiguity_message)
 
 
 def _is_conditional_elided_match(input_name: str, path_segments: List[str]) -> bool:

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from re import compile
 from typing import (
@@ -319,12 +320,24 @@ def _merge_into_state(
                         if state_representation == "test_case_json":
                             input_value_list = test_input["value"] if test_input["value"] is not None else []
                         else:
-                            test_input_values = cast(str, value).split(",")
-                            for test_input_value in test_input_values:
-                                instance_test_input = test_input.copy()
-                                instance_test_input["value"] = test_input_value
-                                input_value_json = xml_data_input_to_json(instance_test_input)
-                                input_value_list.append(input_value_json)
+                            location = test_input.get("attributes", {}).get("location")
+                            if location:
+                                # location may be a comma-separated list of URLs; split per URL
+                                for single_location in location.split(","):
+                                    single_location = single_location.strip()
+                                    instance_test_input = dict(test_input)
+                                    instance_test_input["attributes"] = dict(test_input["attributes"])
+                                    instance_test_input["value"] = os.path.basename(single_location)
+                                    instance_test_input["attributes"]["location"] = single_location
+                                    input_value_json = xml_data_input_to_json(instance_test_input)
+                                    input_value_list.append(input_value_json)
+                            else:
+                                test_input_values = cast(str, value).split(",")
+                                for test_input_value in test_input_values:
+                                    instance_test_input = test_input.copy()
+                                    instance_test_input["value"] = test_input_value
+                                    input_value_json = xml_data_input_to_json(instance_test_input)
+                                    input_value_list.append(input_value_json)
 
                     input_value = input_value_list
                 else:

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -39,7 +39,10 @@ from galaxy.tool_util_models.parameters import (
     SelectParameterModel,
     ToolParameterT,
 )
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    string_as_bool,
+)
 from .factory import input_models_for_tool_source
 from .state import TestCaseToolState
 from .visitor import (
@@ -110,17 +113,31 @@ def legacy_from_string(parameter: ToolParameterT, value: Optional[Any], warnings
                 warnings.append(
                     f"Implicitly converted {parameter.name} to a boolean from a string value, please use 'value_json' to define this test input parameter value instead."
                 )
-            try:
-                result_value = asbool(value)
-            except ValueError:
-                if parameter.truevalue is not None and value == parameter.truevalue:
-                    result_value = True
-                elif parameter.falsevalue is not None and value == parameter.falsevalue:
-                    result_value = False
-                else:
-                    warnings.append(
-                        "Likely using deprected truevalue/falsevalue in tool parameter - switch to 'true' or 'false'"
-                    )
+            # Map the parameter's truevalue/falsevalue back to a boolean when the test
+            # specified the command-line string rather than 'true'/'false', so the
+            # submitted payload is a real boolean.
+            if parameter.truevalue is not None and value == parameter.truevalue:
+                result_value = True
+            elif parameter.falsevalue is not None and value == parameter.falsevalue:
+                result_value = False
+            else:
+                try:
+                    result_value = asbool(value)
+                except ValueError:
+                    if Version(profile) < Version("24.2"):
+                        # Legacy tools sometimes use a non-boolean placeholder such as
+                        # "-" as a test value. The synchronous tool API coerces these
+                        # via string_as_bool (any non-true value -> False); match that
+                        # so the payload is a valid boolean without requiring test edits.
+                        result_value = string_as_bool(value)
+                        warnings.append(
+                            f"Non-boolean test value ({value!r}) for {parameter.name} coerced to "
+                            f"{result_value} - use 'true' or 'false'."
+                        )
+                    else:
+                        warnings.append(
+                            "Likely using deprected truevalue/falsevalue in tool parameter - switch to 'true' or 'false'"
+                        )
         elif isinstance(parameter, (GroupTagParameterModel,)):
             if parameter.multiple:
                 result_value = multiple_select_value_split(value)

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -547,7 +547,11 @@ def _infer_when_from_inputs(
     provided_short_names: Set[str] = set()
     for input in inputs:
         name = input["name"]
-        if scope and not name.startswith(scope):
+        # Consider inputs scoped to this conditional, plus legacy unqualified (bare) inputs -
+        # a test may supply a non-default branch's param by its short name without the
+        # enclosing conditional prefix (e.g. <param name="reference"> for
+        # reference_cond|reference). Skip only inputs qualified to a *different* prefix.
+        if scope and not name.startswith(scope) and "|" in name:
             continue
         provided_short_names.add(name.rsplit("|", 1)[-1])
     if not provided_short_names:

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -380,7 +380,24 @@ def _merge_into_state(
 def _repeat_inputs_to_array(
     state_path: str, parameters: List[ToolParameterT], inputs: ToolSourceTestInputs
 ) -> List[ToolSourceTestInputs]:
-    repeat_instance_input_dicts = repeat_inputs_to_array(state_path, _inputs_as_dict(inputs))
+    inputs_as_dict = _inputs_as_dict(inputs)
+    repeat_instance_input_dicts = repeat_inputs_to_array(state_path, inputs_as_dict)
+    if not repeat_instance_input_dicts and "|" in state_path:
+        # Legacy test cases may reference a repeat that lives inside a conditional or
+        # section by its unqualified name (e.g. <repeat name="rep"> at the top level
+        # instead of wrapped in the enclosing <conditional>). The test inputs are
+        # unqualified with respect to conditionals/sections but still carry repeat
+        # instance indices, so progressively strip leading (conditional/section)
+        # segments - keeping any enclosing repeat-instance prefix - until the repeat's
+        # nested params resolve. The downstream _input_for() suffix match then
+        # re-attaches them to the fully qualified path. Longest candidate is tried
+        # first to avoid matching an unrelated like-named repeat.
+        parts = state_path.split("|")
+        for start in range(1, len(parts)):
+            candidate_path = "|".join(parts[start:])
+            repeat_instance_input_dicts = repeat_inputs_to_array(candidate_path, inputs_as_dict)
+            if repeat_instance_input_dicts:
+                break
     repeat_instance_inputs = [list(instance_inputs.values()) for instance_inputs in repeat_instance_input_dicts]
     if repeat_instance_inputs:
         return repeat_instance_inputs

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -1,10 +1,14 @@
 import os
-from dataclasses import dataclass
+from dataclasses import (
+    dataclass,
+    replace,
+)
 from re import compile
 from typing import (
     Any,
     cast,
     Dict,
+    FrozenSet,
     List,
     Optional,
     Set,
@@ -195,6 +199,117 @@ def _legacy_select_label_to_value(parameter: SelectParameterModel, value: str) -
     return value
 
 
+@dataclass(frozen=True)
+class LegacyTestInputResolver:
+    """Resolve a (possibly legacy/unqualified) parameter path to the test input that supplies it.
+
+    Owns the raw test inputs and the set of discriminator names already consumed by enclosing
+    conditionals, and encapsulates the fuzzy fallback cascade legacy test cases rely on (exact
+    name, then suffix / bare short-name / elided-conditional matches). A consumed discriminator
+    is excluded from those fallbacks so a nested conditional does not re-match an ancestor's
+    discriminator of the same name.
+
+    Immutable: ``consuming`` and ``for_inputs`` return child resolvers, so an exclusion stays
+    scoped to one subtree of the parameter walk (a sibling subtree never sees it) and a repeat
+    instance can be resolved against its own slice of the inputs.
+    """
+
+    inputs: ToolSourceTestInputs
+    consumed_discriminators: FrozenSet[str] = frozenset()
+
+    def consuming(self, discriminator_name: Optional[str]) -> "LegacyTestInputResolver":
+        if discriminator_name is None:
+            return self
+        return replace(self, consumed_discriminators=self.consumed_discriminators | {discriminator_name})
+
+    def for_inputs(self, inputs: ToolSourceTestInputs) -> "LegacyTestInputResolver":
+        return replace(self, inputs=inputs)
+
+    def input_for(self, flat_state_path: str) -> Optional[ToolSourceTestInput]:
+        # A consumed discriminator belongs to an enclosing conditional and must not be
+        # re-matched by the loose fallbacks below when resolving a descendant's discriminator
+        # (otherwise e.g. an omitted nested ``selector`` greedily picks up the parent
+        # conditional's ``selector`` value - see ``_select_which_when``).
+        exclude = self.consumed_discriminators
+        for input in self.inputs:
+            if input["name"] == flat_state_path:
+                return input
+        # Fallback for legacy test cases that specify conditional/section params without the
+        # pipe-separated prefix (e.g. <param name="fasta"> instead of <param name="mode|fasta">).
+        if "|" in flat_state_path:
+            suffix_matching_inputs = [
+                input
+                for input in self.inputs
+                if "|" in input["name"]
+                and input["name"] not in exclude
+                and flat_state_path.endswith(f"|{input['name']}")
+            ]
+            resolved = _resolve_matching_inputs(
+                suffix_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
+            )
+            if resolved is not None:
+                return resolved
+
+            short_name = flat_state_path.rsplit("|", 1)[1]
+            matching_inputs = [
+                input for input in self.inputs if input["name"] == short_name and input["name"] not in exclude
+            ]
+            resolved = _resolve_matching_inputs(
+                matching_inputs, f"Ambiguous unqualified test parameter name ({short_name}) for ({flat_state_path})"
+            )
+            if resolved is not None:
+                return resolved
+
+            # Fallback for legacy test cases that elide intermediate conditional names but keep
+            # the enclosing section/repeat prefix (e.g. <section name="adv"><param name="esf">
+            # for a param whose real path is adv|esf_cond|esf). The input name is an ordered
+            # subsequence of the qualified path - sharing the head and the leaf - rather than a
+            # plain suffix.
+            path_segments = flat_state_path.split("|")
+            elided_matching_inputs = [
+                input
+                for input in self.inputs
+                if input["name"] not in exclude and _is_conditional_elided_match(input["name"], path_segments)
+            ]
+            resolved = _resolve_matching_inputs(
+                elided_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
+            )
+            if resolved is not None:
+                return resolved
+        return None
+
+
+@dataclass(frozen=True)
+class MergeContext:
+    """The values threaded unchanged through the recursive test-case merge.
+
+    Bundling them keeps ``_merge_into_state`` and friends to their per-node arguments
+    (the parameter, the state at this level, the prefix) instead of re-passing the
+    resolver, profile, state representation and warnings at every call site. ``warnings``
+    is a shared list accumulated across the whole merge; ``consuming`` / ``for_inputs``
+    return a child context whose resolver is scoped to a conditional branch or repeat
+    instance.
+    """
+
+    resolver: LegacyTestInputResolver
+    profile: str
+    state_representation: Literal["test_case_xml", "test_case_json"]
+    warnings: List[str]
+
+    @property
+    def inputs(self) -> ToolSourceTestInputs:
+        return self.resolver.inputs
+
+    def input_for(self, flat_state_path: str) -> Optional[ToolSourceTestInput]:
+        return self.resolver.input_for(flat_state_path)
+
+    def consuming(self, discriminator_name: Optional[str]) -> "MergeContext":
+        return replace(self, resolver=self.resolver.consuming(discriminator_name))
+
+    def for_inputs(self, inputs: ToolSourceTestInputs) -> "MergeContext":
+        return replace(self, resolver=self.resolver.for_inputs(inputs))
+
+
 def test_case_state(
     test_dict: ToolSourceTest,
     tool_parameter_bundle: List[ToolParameterT],
@@ -208,9 +323,8 @@ def test_case_state(
     state: Dict[str, Any] = {}
 
     state_representation = test_dict.get("value_state_representation", "test_case_xml")
-    handled_inputs = _merge_level_into_state(
-        tool_parameter_bundle, inputs, state, profile, state_representation, warnings, None
-    )
+    context = MergeContext(LegacyTestInputResolver(inputs), profile, state_representation, warnings)
+    handled_inputs = _merge_level_into_state(tool_parameter_bundle, context, state, None)
 
     for test_input in inputs:
         input_name = test_input["name"]
@@ -260,28 +374,13 @@ def test_case_validation(
 
 def _merge_level_into_state(
     tool_inputs: List[ToolParameterT],
-    inputs: ToolSourceTestInputs,
+    context: MergeContext,
     state_at_level: dict,
-    profile: str,
-    state_representation: Literal["test_case_xml", "test_case_json"],
-    warnings: List[str],
     prefix: Optional[str],
-    consumed_discriminators: Optional[Set[str]] = None,
 ) -> Set[str]:
     handled_inputs: Set[str] = set()
     for tool_input in tool_inputs:
-        handled_inputs.update(
-            _merge_into_state(
-                tool_input,
-                inputs,
-                state_at_level,
-                profile,
-                state_representation,
-                warnings,
-                prefix,
-                consumed_discriminators,
-            )
-        )
+        handled_inputs.update(_merge_into_state(tool_input, context, state_at_level, prefix))
 
     return handled_inputs
 
@@ -296,13 +395,9 @@ def _inputs_as_dict(inputs: ToolSourceTestInputs) -> Dict[str, ToolSourceTestInp
 
 def _merge_into_state(
     tool_input: ToolParameterT,
-    inputs: ToolSourceTestInputs,
+    context: MergeContext,
     state_at_level: dict,
-    profile: str,
-    state_representation: Literal["test_case_xml", "test_case_json"],
-    warnings: List[str],
     prefix: Optional[str],
-    consumed_discriminators: Optional[Set[str]] = None,
 ) -> Set[str]:
     handled_inputs = set()
 
@@ -315,22 +410,9 @@ def _merge_into_state(
         if input_name not in state_at_level:
             state_at_level[input_name] = conditional_state
 
-        when, discriminator_name = _select_which_when(
-            tool_input, conditional_state, inputs, state_path, consumed_discriminators
-        )
+        when, discriminator_name = _select_which_when(tool_input, conditional_state, context, state_path)
         test_parameter = tool_input.test_parameter
-        handled_inputs.update(
-            _merge_into_state(
-                test_parameter,
-                inputs,
-                conditional_state,
-                profile,
-                state_representation,
-                warnings,
-                state_path,
-                consumed_discriminators,
-            )
-        )
+        handled_inputs.update(_merge_into_state(test_parameter, context, conditional_state, state_path))
         # If the discriminator was omitted, record the selected when's discriminator so the
         # state validates against that branch rather than the phantom __absent__ branch. This
         # is the active branch _select_which_when chose: a non-default when inferred from the
@@ -339,21 +421,12 @@ def _merge_into_state(
         # payload.
         if test_parameter.name not in conditional_state and when.discriminator is not None:
             conditional_state[test_parameter.name] = when.discriminator
-        # The discriminator consumed here belongs to this conditional; mark it so the loose
-        # fallbacks do not re-match it when resolving a nested conditional's discriminator.
-        when_consumed = consumed_discriminators
-        if discriminator_name is not None:
-            when_consumed = set(consumed_discriminators or set()) | {discriminator_name}
+        # The discriminator consumed here belongs to this conditional; the branch context marks
+        # it so the loose fallbacks do not re-match it when resolving a nested conditional's
+        # discriminator.
         handled_inputs.update(
             _merge_level_into_state(
-                when.parameters,
-                inputs,
-                conditional_state,
-                profile,
-                state_representation,
-                warnings,
-                state_path,
-                when_consumed,
+                when.parameters, context.consuming(discriminator_name), conditional_state, state_path
             )
         )
     elif isinstance(tool_input, (RepeatParameterModel,)):
@@ -361,7 +434,7 @@ def _merge_into_state(
         if input_name not in state_at_level:
             state_at_level[input_name] = repeat_state_array
 
-        repeat_instance_inputs = _repeat_inputs_to_array(state_path, tool_input.parameters, inputs)
+        repeat_instance_inputs = _repeat_inputs_to_array(state_path, tool_input.parameters, context.inputs)
         if tool_input.min is not None:
             while len(repeat_instance_inputs) < tool_input.min:
                 repeat_instance_inputs.append([])
@@ -373,13 +446,9 @@ def _merge_into_state(
             handled_inputs.update(
                 _merge_level_into_state(
                     tool_input.parameters,
-                    repeat_instance_inputs[i],
+                    context.for_inputs(repeat_instance_inputs[i]),
                     repeat_state_array[i],
-                    profile,
-                    state_representation,
-                    warnings,
                     repeat_instance_prefix,
-                    consumed_discriminators,
                 )
             )
     elif isinstance(tool_input, (SectionParameterModel,)):
@@ -387,20 +456,9 @@ def _merge_into_state(
         if input_name not in state_at_level:
             state_at_level[input_name] = section_state
 
-        handled_inputs.update(
-            _merge_level_into_state(
-                tool_input.parameters,
-                inputs,
-                section_state,
-                profile,
-                state_representation,
-                warnings,
-                state_path,
-                consumed_discriminators,
-            )
-        )
+        handled_inputs.update(_merge_level_into_state(tool_input.parameters, context, section_state, state_path))
     else:
-        test_input = _input_for(state_path, inputs, exclude_names=consumed_discriminators)
+        test_input = context.input_for(state_path)
         if test_input is not None:
             input_value: Any
             if isinstance(tool_input, (DataCollectionParameterModel,)):
@@ -412,7 +470,7 @@ def _merge_into_state(
                     value = test_input["value"]
                     input_value_list: List[Any] = []
                     if value:
-                        if state_representation == "test_case_json":
+                        if context.state_representation == "test_case_json":
                             input_value_list = test_input["value"] if test_input["value"] is not None else []
                         else:
                             location = test_input.get("attributes", {}).get("location")
@@ -436,13 +494,13 @@ def _merge_into_state(
 
                     input_value = input_value_list
                 else:
-                    if state_representation == "test_case_json":
+                    if context.state_representation == "test_case_json":
                         input_value = test_input["value"]
                     else:
                         input_value = xml_data_input_to_json(test_input)
             else:
                 input_value = test_input["value"]
-                input_value = legacy_from_string(tool_input, input_value, warnings, profile)
+                input_value = legacy_from_string(tool_input, input_value, context.warnings, context.profile)
 
             state_at_level[input_name] = input_value
 
@@ -461,7 +519,7 @@ def _repeat_inputs_to_array(
         # unqualified with respect to conditionals/sections but still carry repeat
         # instance indices, so progressively strip leading (conditional/section)
         # segments - keeping any enclosing repeat-instance prefix - until the repeat's
-        # nested params resolve. The downstream _input_for() suffix match then
+        # nested params resolve. The downstream input_for() suffix match then
         # re-attaches them to the fully qualified path. Longest candidate is tried
         # first to avoid matching an unrelated like-named repeat.
         parts = state_path.split("|")
@@ -490,9 +548,8 @@ def _repeat_inputs_to_array(
 def _select_which_when(
     conditional: ConditionalParameterModel,
     state: dict,
-    inputs: ToolSourceTestInputs,
+    context: MergeContext,
     prefix: str,
-    consumed_discriminators: Optional[Set[str]] = None,
 ) -> Tuple[ConditionalWhen, Optional[str]]:
     """Return the selected when and the name of the test input used as the discriminator
     (or ``None`` if the discriminator was omitted). The discriminator name lets callers mark
@@ -502,7 +559,7 @@ def _select_which_when(
     test_parameter_name = test_parameter.name
     test_parameter_flat_path = flat_state_path(test_parameter_name, prefix)
 
-    test_input = _input_for(test_parameter_flat_path, inputs, exclude_names=consumed_discriminators)
+    test_input = context.input_for(test_parameter_flat_path)
     matched_name = test_input["name"] if test_input else None
     explicit_test_value = test_input["value"] if test_input else None
     if is_boolean and isinstance(explicit_test_value, str):
@@ -513,7 +570,7 @@ def _select_which_when(
         # when from the parameters the test actually provides before falling back to the
         # default when (otherwise a test that supplies a non-default branch's params fails
         # to validate against the default branch).
-        inferred_when = _infer_when_from_inputs(conditional, inputs, prefix)
+        inferred_when = _infer_when_from_inputs(conditional, context.inputs, prefix)
         if inferred_when is not None:
             return inferred_when, matched_name
     for when in conditional.whens:
@@ -572,59 +629,6 @@ def _infer_when_from_inputs(
             best_when = when
     if best_when is not None and best_score > default_score:
         return best_when
-    return None
-
-
-def _input_for(
-    flat_state_path: str, inputs: ToolSourceTestInputs, exclude_names: Optional[Set[str]] = None
-) -> Optional[ToolSourceTestInput]:
-    # ``exclude_names`` holds the names of test inputs already consumed as the discriminator
-    # of an enclosing conditional. Such an input belongs to that ancestor conditional and must
-    # not be re-matched by the loose fallbacks below when resolving a descendant's
-    # discriminator (otherwise e.g. an omitted nested ``selector`` greedily picks up the
-    # parent conditional's ``selector`` value - see _select_which_when).
-    exclude = exclude_names or set()
-    for input in inputs:
-        if input["name"] == flat_state_path:
-            return input
-    # Fallback for legacy test cases that specify conditional/section params without the pipe-separated
-    # prefix (e.g. <param name="fasta"> instead of <param name="mode|fasta">).
-    if "|" in flat_state_path:
-        suffix_matching_inputs = [
-            input
-            for input in inputs
-            if "|" in input["name"] and input["name"] not in exclude and flat_state_path.endswith(f"|{input['name']}")
-        ]
-        resolved = _resolve_matching_inputs(
-            suffix_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
-        )
-        if resolved is not None:
-            return resolved
-
-        short_name = flat_state_path.rsplit("|", 1)[1]
-        matching_inputs = [input for input in inputs if input["name"] == short_name and input["name"] not in exclude]
-        resolved = _resolve_matching_inputs(
-            matching_inputs, f"Ambiguous unqualified test parameter name ({short_name}) for ({flat_state_path})"
-        )
-        if resolved is not None:
-            return resolved
-
-        # Fallback for legacy test cases that elide intermediate conditional names but keep
-        # the enclosing section/repeat prefix (e.g. <section name="adv"><param name="esf">
-        # for a param whose real path is adv|esf_cond|esf). The input name is an ordered
-        # subsequence of the qualified path - sharing the head and the leaf - rather than a
-        # plain suffix.
-        path_segments = flat_state_path.split("|")
-        elided_matching_inputs = [
-            input
-            for input in inputs
-            if input["name"] not in exclude and _is_conditional_elided_match(input["name"], path_segments)
-        ]
-        resolved = _resolve_matching_inputs(
-            elided_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
-        )
-        if resolved is not None:
-            return resolved
     return None
 
 

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -132,6 +132,10 @@ def legacy_from_string(parameter: ToolParameterT, value: Optional[Any], warnings
                 # value="" is a legacy convention for "nothing selected"; filter empty parts to produce [].
                 # Tools with profile >= 26.1 must use value_json="[]" explicitly.
                 result_value = multiple_select_value_split(value)
+                if Version(profile) < Version("24.2"):
+                    result_value = [_legacy_select_label_to_value(parameter, v) for v in result_value]
+            elif Version(profile) < Version("24.2"):
+                result_value = _legacy_select_label_to_value(parameter, value)
         elif isinstance(parameter, (DataColumnParameterModel,)):
             if parameter.multiple:
                 integers_match = INTEGER_STR_PATTERN.match(value)
@@ -161,6 +165,18 @@ def legacy_from_string(parameter: ToolParameterT, value: Optional[Any], warnings
     return result_value
 
 
+def _legacy_select_label_to_value(parameter: SelectParameterModel, value: str) -> str:
+    if parameter.options is None:
+        return value
+    for option in parameter.options:
+        if option.value == value:
+            return value
+    for option in parameter.options:
+        if option.label == value:
+            return option.value
+    return value
+
+
 def test_case_state(
     test_dict: ToolSourceTest,
     tool_parameter_bundle: List[ToolParameterT],
@@ -187,8 +203,15 @@ def test_case_state(
     if validate:
         tool_state.validate(tool_parameter_bundle, name=name)
         for input_name in unhandled_inputs:
-            raise Exception(f"Invalid parameter name found {input_name}")
+            if not _input_name_was_handled_by_legacy_fallback(input_name, handled_inputs, profile):
+                raise Exception(f"Invalid parameter name found {input_name}")
     return TestCaseStateAndWarnings(tool_state, warnings, unhandled_inputs)
+
+
+def _input_name_was_handled_by_legacy_fallback(input_name: str, handled_inputs: Set[str], profile: str) -> bool:
+    return Version(profile) < Version("24.2") and any(
+        handled_input == input_name or handled_input.endswith(f"|{input_name}") for handled_input in handled_inputs
+    )
 
 
 def test_case_validation(
@@ -274,10 +297,10 @@ def _merge_into_state(
         if input_name not in state_at_level:
             state_at_level[input_name] = repeat_state_array
 
-        repeat_instance_inputs = repeat_inputs_to_array(state_path, _inputs_as_dict(inputs))
+        repeat_instance_inputs = _repeat_inputs_to_array(state_path, tool_input.parameters, inputs)
         if tool_input.min is not None:
             while len(repeat_instance_inputs) < tool_input.min:
-                repeat_instance_inputs.append({})
+                repeat_instance_inputs.append([])
         for i, _ in enumerate(repeat_instance_inputs):
             while len(repeat_state_array) <= i:
                 repeat_state_array.append({})
@@ -286,7 +309,7 @@ def _merge_into_state(
             handled_inputs.update(
                 _merge_level_into_state(
                     tool_input.parameters,
-                    inputs,
+                    repeat_instance_inputs[i],
                     repeat_state_array[i],
                     profile,
                     state_representation,
@@ -354,6 +377,27 @@ def _merge_into_state(
     return handled_inputs
 
 
+def _repeat_inputs_to_array(
+    state_path: str, parameters: List[ToolParameterT], inputs: ToolSourceTestInputs
+) -> List[ToolSourceTestInputs]:
+    repeat_instance_input_dicts = repeat_inputs_to_array(state_path, _inputs_as_dict(inputs))
+    repeat_instance_inputs = [list(instance_inputs.values()) for instance_inputs in repeat_instance_input_dicts]
+    if repeat_instance_inputs:
+        return repeat_instance_inputs
+
+    legacy_repeat_inputs: List[ToolSourceTestInputs] = []
+    for parameter in parameters:
+        parameter_name = parameter.name
+        matching_inputs = [input for input in inputs if input["name"] == parameter_name]
+        for i, input in enumerate(matching_inputs):
+            while len(legacy_repeat_inputs) <= i:
+                legacy_repeat_inputs.append([])
+            synthetic_input = cast(ToolSourceTestInput, dict(input))
+            synthetic_input["name"] = f"{state_path}_{i}|{parameter_name}"
+            legacy_repeat_inputs[i].append(synthetic_input)
+    return legacy_repeat_inputs
+
+
 def _select_which_when(
     conditional: ConditionalParameterModel, state: dict, inputs: ToolSourceTestInputs, prefix: str
 ) -> ConditionalWhen:
@@ -383,6 +427,16 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
     # Fallback for legacy test cases that specify conditional/section params without the pipe-separated
     # prefix (e.g. <param name="fasta"> instead of <param name="mode|fasta">).
     if "|" in flat_state_path:
+        suffix_matching_inputs = []
+        for input in inputs:
+            input_name = input["name"]
+            if "|" in input_name and flat_state_path.endswith(f"|{input_name}"):
+                suffix_matching_inputs.append(input)
+        if len(suffix_matching_inputs) == 1:
+            return suffix_matching_inputs[0]
+        elif len(suffix_matching_inputs) > 1:
+            raise Exception(f"Ambiguous partially qualified test parameter name for ({flat_state_path})")
+
         short_name = flat_state_path.rsplit("|", 1)[1]
         matching_inputs = []
         for input in inputs:

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
 )
 
 from packaging.version import Version
@@ -265,11 +266,21 @@ def _merge_level_into_state(
     state_representation: Literal["test_case_xml", "test_case_json"],
     warnings: List[str],
     prefix: Optional[str],
+    consumed_discriminators: Optional[Set[str]] = None,
 ) -> Set[str]:
     handled_inputs: Set[str] = set()
     for tool_input in tool_inputs:
         handled_inputs.update(
-            _merge_into_state(tool_input, inputs, state_at_level, profile, state_representation, warnings, prefix)
+            _merge_into_state(
+                tool_input,
+                inputs,
+                state_at_level,
+                profile,
+                state_representation,
+                warnings,
+                prefix,
+                consumed_discriminators,
+            )
         )
 
     return handled_inputs
@@ -291,6 +302,7 @@ def _merge_into_state(
     state_representation: Literal["test_case_xml", "test_case_json"],
     warnings: List[str],
     prefix: Optional[str],
+    consumed_discriminators: Optional[Set[str]] = None,
 ) -> Set[str]:
     handled_inputs = set()
 
@@ -303,11 +315,20 @@ def _merge_into_state(
         if input_name not in state_at_level:
             state_at_level[input_name] = conditional_state
 
-        when: ConditionalWhen = _select_which_when(tool_input, conditional_state, inputs, state_path)
+        when, discriminator_name = _select_which_when(
+            tool_input, conditional_state, inputs, state_path, consumed_discriminators
+        )
         test_parameter = tool_input.test_parameter
         handled_inputs.update(
             _merge_into_state(
-                test_parameter, inputs, conditional_state, profile, state_representation, warnings, state_path
+                test_parameter,
+                inputs,
+                conditional_state,
+                profile,
+                state_representation,
+                warnings,
+                state_path,
+                consumed_discriminators,
             )
         )
         # If the discriminator was omitted but a non-default when was inferred from the
@@ -315,9 +336,21 @@ def _merge_into_state(
         # against that branch rather than the __absent__/default branch.
         if test_parameter.name not in conditional_state and not when.is_default_when:
             conditional_state[test_parameter.name] = when.discriminator
+        # The discriminator consumed here belongs to this conditional; mark it so the loose
+        # fallbacks do not re-match it when resolving a nested conditional's discriminator.
+        when_consumed = consumed_discriminators
+        if discriminator_name is not None:
+            when_consumed = set(consumed_discriminators or set()) | {discriminator_name}
         handled_inputs.update(
             _merge_level_into_state(
-                when.parameters, inputs, conditional_state, profile, state_representation, warnings, state_path
+                when.parameters,
+                inputs,
+                conditional_state,
+                profile,
+                state_representation,
+                warnings,
+                state_path,
+                when_consumed,
             )
         )
     elif isinstance(tool_input, (RepeatParameterModel,)):
@@ -343,6 +376,7 @@ def _merge_into_state(
                     state_representation,
                     warnings,
                     repeat_instance_prefix,
+                    consumed_discriminators,
                 )
             )
     elif isinstance(tool_input, (SectionParameterModel,)):
@@ -352,11 +386,18 @@ def _merge_into_state(
 
         handled_inputs.update(
             _merge_level_into_state(
-                tool_input.parameters, inputs, section_state, profile, state_representation, warnings, state_path
+                tool_input.parameters,
+                inputs,
+                section_state,
+                profile,
+                state_representation,
+                warnings,
+                state_path,
+                consumed_discriminators,
             )
         )
     else:
-        test_input = _input_for(state_path, inputs)
+        test_input = _input_for(state_path, inputs, exclude_names=consumed_discriminators)
         if test_input is not None:
             input_value: Any
             if isinstance(tool_input, (DataCollectionParameterModel,)):
@@ -444,14 +485,22 @@ def _repeat_inputs_to_array(
 
 
 def _select_which_when(
-    conditional: ConditionalParameterModel, state: dict, inputs: ToolSourceTestInputs, prefix: str
-) -> ConditionalWhen:
+    conditional: ConditionalParameterModel,
+    state: dict,
+    inputs: ToolSourceTestInputs,
+    prefix: str,
+    consumed_discriminators: Optional[Set[str]] = None,
+) -> Tuple[ConditionalWhen, Optional[str]]:
+    """Return the selected when and the name of the test input used as the discriminator
+    (or ``None`` if the discriminator was omitted). The discriminator name lets callers mark
+    it consumed so descendant conditionals do not re-match it via the loose fallbacks."""
     test_parameter = conditional.test_parameter
     is_boolean = test_parameter.parameter_type == "gx_boolean"
     test_parameter_name = test_parameter.name
     test_parameter_flat_path = flat_state_path(test_parameter_name, prefix)
 
-    test_input = _input_for(test_parameter_flat_path, inputs)
+    test_input = _input_for(test_parameter_flat_path, inputs, exclude_names=consumed_discriminators)
+    matched_name = test_input["name"] if test_input else None
     explicit_test_value = test_input["value"] if test_input else None
     if is_boolean and isinstance(explicit_test_value, str):
         explicit_test_value = asbool(explicit_test_value)
@@ -463,14 +512,13 @@ def _select_which_when(
         # to validate against the default branch).
         inferred_when = _infer_when_from_inputs(conditional, inputs, prefix)
         if inferred_when is not None:
-            return inferred_when
+            return inferred_when, matched_name
     for when in conditional.whens:
         if test_value is None and when.is_default_when:
-            return when
+            return when, matched_name
         elif test_value == when.discriminator:
-            return when
-    else:
-        raise Exception(f"Invalid conditional test value ({explicit_test_value}) for parameter ({test_parameter_name})")
+            return when, matched_name
+    raise Exception(f"Invalid conditional test value ({explicit_test_value}) for parameter ({test_parameter_name})")
 
 
 def _leaf_param_short_names(parameters: List[ToolParameterT]) -> Set[str]:
@@ -520,7 +568,15 @@ def _infer_when_from_inputs(
     return None
 
 
-def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[ToolSourceTestInput]:
+def _input_for(
+    flat_state_path: str, inputs: ToolSourceTestInputs, exclude_names: Optional[Set[str]] = None
+) -> Optional[ToolSourceTestInput]:
+    # ``exclude_names`` holds the names of test inputs already consumed as the discriminator
+    # of an enclosing conditional. Such an input belongs to that ancestor conditional and must
+    # not be re-matched by the loose fallbacks below when resolving a descendant's
+    # discriminator (otherwise e.g. an omitted nested ``selector`` greedily picks up the
+    # parent conditional's ``selector`` value - see _select_which_when).
+    exclude = exclude_names or set()
     for input in inputs:
         if input["name"] == flat_state_path:
             return input
@@ -530,7 +586,7 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
         suffix_matching_inputs = [
             input
             for input in inputs
-            if "|" in input["name"] and flat_state_path.endswith(f"|{input['name']}")
+            if "|" in input["name"] and input["name"] not in exclude and flat_state_path.endswith(f"|{input['name']}")
         ]
         resolved = _resolve_matching_inputs(
             suffix_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
@@ -539,7 +595,7 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
             return resolved
 
         short_name = flat_state_path.rsplit("|", 1)[1]
-        matching_inputs = [input for input in inputs if input["name"] == short_name]
+        matching_inputs = [input for input in inputs if input["name"] == short_name and input["name"] not in exclude]
         resolved = _resolve_matching_inputs(
             matching_inputs, f"Ambiguous unqualified test parameter name ({short_name}) for ({flat_state_path})"
         )
@@ -553,7 +609,9 @@ def _input_for(flat_state_path: str, inputs: ToolSourceTestInputs) -> Optional[T
         # plain suffix.
         path_segments = flat_state_path.split("|")
         elided_matching_inputs = [
-            input for input in inputs if _is_conditional_elided_match(input["name"], path_segments)
+            input
+            for input in inputs
+            if input["name"] not in exclude and _is_conditional_elided_match(input["name"], path_segments)
         ]
         resolved = _resolve_matching_inputs(
             elided_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -243,7 +243,7 @@ class LegacyTestInputResolver:
                 for input in self.inputs
                 if "|" in input["name"]
                 and input["name"] not in exclude
-                and flat_state_path.endswith(f"|{input['name']}")
+                and _path_ends_with_param(flat_state_path, input["name"])
             ]
             resolved = _resolve_matching_inputs(
                 suffix_matching_inputs, f"Ambiguous partially qualified test parameter name for ({flat_state_path})"
@@ -342,10 +342,11 @@ def test_case_state(
 
 
 def _input_name_was_handled_by_legacy_fallback(input_name: str, handled_inputs: Set[str], profile: str) -> bool:
+    # Intentionally a loose string-match against every visited parameter path, NOT a record of which inputs were actually consumed: the raw-name->path relation is many-to-many for legacy tests (bare/duplicate names validly satisfy multiple params), so consumption-tracking wrongly rejects degenerate-but-valid cases - tried and reverted, don't reintroduce it.
     if Version(profile) >= Version("24.2"):
         return False
     for handled_input in handled_inputs:
-        if handled_input == input_name or handled_input.endswith(f"|{input_name}"):
+        if handled_input == input_name or _path_ends_with_param(handled_input, input_name):
             return True
         # conditional names may be elided in the test while the section/repeat prefix is kept
         if "|" in input_name and _is_conditional_elided_match(input_name, handled_input.split("|")):
@@ -649,6 +650,15 @@ def _resolve_matching_inputs(
     ):
         return first
     raise Exception(ambiguity_message)
+
+
+def _path_ends_with_param(qualified_path: str, param_name: str) -> bool:
+    """True if ``param_name`` is the trailing (pipe-separated) segment(s) of ``qualified_path``.
+
+    The legacy unqualified/partially-qualified suffix match, shared by ``input_for`` and
+    ``_input_name_was_handled_by_legacy_fallback`` so the rule lives in one place.
+    """
+    return qualified_path.endswith(f"|{param_name}")
 
 
 def _is_conditional_elided_match(input_name: str, path_segments: List[str]) -> bool:

--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -35,6 +35,7 @@ from galaxy.tool_util_models.parameters import (
     IntegerParameterModel,
     RepeatParameterModel,
     SectionParameterModel,
+    SelectParameterModel,
     ToolParameterT,
 )
 from galaxy.util import asbool
@@ -124,6 +125,11 @@ def legacy_from_string(parameter: ToolParameterT, value: Optional[Any], warnings
                 result_value = multiple_select_value_split(value)
         elif isinstance(parameter, (GenomeBuildParameterModel,)):
             if parameter.multiple:
+                result_value = multiple_select_value_split(value)
+        elif isinstance(parameter, SelectParameterModel):
+            if parameter.multiple and Version(profile) < Version("26.1"):
+                # value="" is a legacy convention for "nothing selected"; filter empty parts to produce [].
+                # Tools with profile >= 26.1 must use value_json="[]" explicitly.
                 result_value = multiple_select_value_split(value)
         elif isinstance(parameter, (DataColumnParameterModel,)):
             if parameter.multiple:
@@ -378,7 +384,7 @@ def validate_test_cases_for_tool_source(
     tool_parameter_bundle = input_models_for_tool_source(tool_source)
     if use_latest_profile:
         # this might get old but it is fine, just needs to be updated when test case changes are made
-        profile = "24.2"
+        profile = "26.1"
     else:
         profile = tool_source.parse_profile()
     test_cases: List[ToolSourceTest] = tool_source.parse_tests_to_dict()["tests"]

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Union,
 )
 
 from galaxy.tool_util_models.parameters import (
@@ -74,7 +75,7 @@ DereferenceCallable = Callable[[DataRequestUri], DataRequestInternalHda]
 DereferenceCollectionCallable = Callable[[DataRequestCollectionUri], DataRequestInternalHdca]
 # interfaces for adapting test data dictionaries to tool request dictionaries
 # e.g. {class: File, path: foo.bed} => {src: hda, id: ab1235cdfea3}
-AdaptDatasets = Callable[[JsonTestDatasetDefDict], DataRequestHda]
+AdaptDatasets = Callable[[JsonTestDatasetDefDict], Union[DataRequestHda, DataRequestUri]]
 AdaptCollections = Callable[[JsonTestCollectionDefDict], DataCollectionRequest]
 
 OPENAPI_REF_TEMPLATE = "#/components/schemas/{model}"
@@ -289,6 +290,9 @@ def encode_test(
                     assert isinstance(value, dict), str(value)
                     test_dataset = cast(JsonTestDatasetDefDict, value)
                     return adapt_datasets(test_dataset).model_dump()
+            elif parameter.url_default:
+                url_default_dict = cast(Any, {"class": "File", "location": parameter.url_default})
+                return adapt_datasets(url_default_dict).model_dump()
         elif isinstance(parameter, DataCollectionParameterModel):
             if value is not None:
                 assert isinstance(value, dict), str(value)

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -248,6 +248,8 @@ def dereference(
     def dereference_callback(parameter: ToolParameterT, value: Any):
         if isinstance(parameter, DataParameterModel):
             if value is None:
+                if parameter.url_default:
+                    return dereference_dict(DataRequestUri(url=parameter.url_default, ext="auto").model_dump())
                 return VISITOR_NO_REPLACEMENT
             if parameter.multiple and isinstance(value, list):
                 return list(map(dereference_dict, value))
@@ -612,6 +614,8 @@ def runtimeify(
 
     def to_runtime_callback(parameter: ToolParameterT, value: Any):
         if isinstance(parameter, DataParameterModel):
+            if value is None:
+                return VISITOR_NO_REPLACEMENT
             if parameter.multiple and isinstance(value, list):
                 return list(map(adapt_dict, value))
             else:

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -223,6 +223,11 @@ def strictify(relaxed_state: RelaxedRequestToolState, input_models: ToolParamete
     return request_state
 
 
+def _deferred_url_default_request(url: str) -> Dict[str, Any]:
+    """Build the deferred dataset request used to materialize a data param's url_default."""
+    return DataRequestUri(url=url, ext="auto", deferred=True).model_dump()
+
+
 def dereference(
     internal_state: RequestInternalToolState,
     input_models: ToolParameterBundle,
@@ -250,9 +255,7 @@ def dereference(
         if isinstance(parameter, DataParameterModel):
             if value is None:
                 if parameter.url_default:
-                    return dereference_dict(
-                        DataRequestUri(url=parameter.url_default, ext="auto", deferred=True).model_dump()
-                    )
+                    return dereference_dict(_deferred_url_default_request(parameter.url_default))
                 return VISITOR_NO_REPLACEMENT
             if parameter.multiple and isinstance(value, list):
                 return list(map(dereference_dict, value))
@@ -267,9 +270,15 @@ def dereference(
         else:
             return VISITOR_NO_REPLACEMENT
 
+    # Materialize url_default data inputs that were legitimately absent from the
+    # request_internal state. We do this on a copy so the persisted request keeps
+    # recording absent inputs as absent - the deferred URLs only need to exist from
+    # the dereference stage onwards (where URLs become datasets), not in the request.
+    state_with_url_defaults = deepcopy(internal_state.input_state)
+    _fill_url_defaults(state_with_url_defaults, input_models)
     request_state_dict = visit_input_values(
         input_models,
-        internal_state,
+        RequestInternalToolState(state_with_url_defaults),
         dereference_callback,
     )
     request_state = RequestInternalDereferencedToolState(request_state_dict)
@@ -296,7 +305,7 @@ def encode_test(
                     test_dataset = cast(JsonTestDatasetDefDict, value)
                     return adapt_datasets(test_dataset).model_dump()
             elif parameter.url_default:
-                return DataRequestUri(url=parameter.url_default, ext="auto", deferred=True).model_dump()
+                return _deferred_url_default_request(parameter.url_default)
         elif isinstance(parameter, DataCollectionParameterModel):
             if value is not None:
                 assert isinstance(value, dict), str(value)
@@ -335,13 +344,12 @@ def fill_static_defaults(
     input_models: ToolParameterBundle,
     profile: float,
     partial: bool = True,
-    url_data_defaults: bool = False,
 ) -> Dict[str, Any]:
     """If additional defaults might stem from Galaxy runtime, partial should be true.
 
     Setting partial to True, prevents runtime validation.
     """
-    _fill_defaults(tool_state, input_models, url_data_defaults=url_data_defaults)
+    _fill_defaults(tool_state, input_models)
 
     if not partial:
         internal_state = JobInternalToolState(tool_state)
@@ -349,14 +357,12 @@ def fill_static_defaults(
     return tool_state
 
 
-def _fill_defaults(
-    tool_state: Dict[str, Any], input_models: ToolParameterBundle, url_data_defaults: bool = False
-) -> None:
+def _fill_defaults(tool_state: Dict[str, Any], input_models: ToolParameterBundle) -> None:
     for parameter in input_models.parameters:
-        _fill_default_for(tool_state, parameter, url_data_defaults=url_data_defaults)
+        _fill_default_for(tool_state, parameter)
 
 
-def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT, url_data_defaults: bool = False) -> None:
+def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT) -> None:
     parameter_name = parameter.name
     if isinstance(parameter, BooleanParameterModel):
         if parameter_name not in tool_state:
@@ -402,24 +408,19 @@ def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT, url
         )
         test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
         when = _select_which_when(parameter, test_value, conditional_state)
-        _fill_default_for(conditional_state, test_parameter, url_data_defaults=url_data_defaults)
-        _fill_defaults(conditional_state, when, url_data_defaults=url_data_defaults)
+        _fill_default_for(conditional_state, test_parameter)
+        _fill_defaults(conditional_state, when)
     elif isinstance(parameter, RepeatParameterModel):
         repeat_instances = _initialize_repeat_state(parameter, tool_state)
         for instance_state in repeat_instances:
-            _fill_defaults(instance_state, parameter, url_data_defaults=url_data_defaults)
+            _fill_defaults(instance_state, parameter)
     elif isinstance(parameter, SectionParameterModel):
         section_state = _initialize_section_state(parameter, tool_state)
-        _fill_defaults(section_state, parameter, url_data_defaults=url_data_defaults)
+        _fill_defaults(section_state, parameter)
     elif isinstance(parameter, DataCollectionParameterModel):
         collection_parameter = parameter
         if parameter_name not in tool_state and collection_parameter.optional:
             tool_state[parameter_name] = None
-    elif isinstance(parameter, DataParameterModel):
-        if url_data_defaults and parameter_name not in tool_state and parameter.url_default:
-            tool_state[parameter_name] = DataRequestUri(
-                url=parameter.url_default, ext="auto", deferred=True
-            ).model_dump()
     elif isinstance(parameter, TextParameterModel):
         if parameter_name not in tool_state:
             if not parameter.optional:
@@ -433,6 +434,55 @@ def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT, url
             # a layer somewhere to deal with this behavior further up the stack and clean up these models.
             if not parameter.optional and tool_state[parameter_name] is None:
                 tool_state[parameter_name] = parameter.default_value if parameter.default_value is not None else ""
+
+
+def _fill_url_defaults(tool_state: Dict[str, Any], input_models: ToolParameterBundle) -> None:
+    for parameter in input_models.parameters:
+        _fill_url_default_for(tool_state, parameter)
+
+
+def _fill_url_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT) -> None:
+    """Inject deferred ``url_default`` data requests for absent data parameters.
+
+    Unlike :func:`_fill_default_for` this materializes *only* ``url_default`` data
+    inputs and deliberately leaves every other static default absent - those belong to
+    later stages. It runs on a transient copy during :func:`dereference` so the URLs
+    resolve to datasets at the right stage without the persisted request_internal state
+    recording inputs that were never part of the request. Containers are only descended
+    into (and so only created in the copy) when they actually contain a url_default.
+    """
+    parameter_name = parameter.name
+    if isinstance(parameter, DataParameterModel):
+        if parameter_name not in tool_state and parameter.url_default:
+            tool_state[parameter_name] = _deferred_url_default_request(parameter.url_default)
+    elif isinstance(parameter, ConditionalParameterModel):
+        raw_state = tool_state.get(parameter_name)
+        conditional_seed = raw_state if isinstance(raw_state, dict) else {}
+        test_parameter_name = parameter.test_parameter.name
+        explicit_test_value: Optional[DiscriminatorType] = conditional_seed.get(test_parameter_name)
+        test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
+        when = _select_which_when(parameter, test_value, conditional_seed)
+        if not _parameters_have_url_default(when.parameters):
+            return
+        conditional_state = _initialize_conditional_state(parameter, tool_state)
+        _fill_url_defaults(conditional_state, when)
+    elif isinstance(parameter, RepeatParameterModel):
+        if not _parameters_have_url_default(parameter.parameters):
+            return
+        for instance_state in _initialize_repeat_state(parameter, tool_state):
+            _fill_url_defaults(instance_state, parameter)
+    elif isinstance(parameter, SectionParameterModel):
+        if not _parameters_have_url_default(parameter.parameters):
+            return
+        section_state = _initialize_section_state(parameter, tool_state)
+        _fill_url_defaults(section_state, parameter)
+
+
+def _parameters_have_url_default(parameters: Sequence[ToolParameterT]) -> bool:
+    return any(
+        isinstance(parameter, DataParameterModel) and bool(parameter.url_default)
+        for parameter in iter_parameter_models(parameters)
+    )
 
 
 def _initialize_section_state(parameter: SectionParameterModel, tool_state: Dict[str, Any]) -> Dict[str, Any]:

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -345,9 +345,11 @@ def fill_static_defaults(
     profile: float,
     partial: bool = True,
 ) -> Dict[str, Any]:
-    """If additional defaults might stem from Galaxy runtime, partial should be true.
+    """Fill static defaults into a job_internal tool state; pass only that representation.
 
-    Setting partial to True, prevents runtime validation.
+    Request/request_internal states record absent inputs as absent - filling them here would
+    declare inputs that were never requested. Pass partial=True when further defaults may stem
+    from Galaxy runtime; partial=True skips final runtime validation.
     """
     _fill_defaults(tool_state, input_models)
 

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -37,6 +37,7 @@ from galaxy.tool_util_models.parameters import (
     GenomeBuildParameterModel,
     HiddenParameterModel,
     IntegerParameterModel,
+    iter_parameter_models,
     RepeatParameterModel,
     SectionParameterModel,
     SelectParameterModel,
@@ -590,17 +591,12 @@ def assert_yaml_v1_parameters(parameters: Sequence[ToolParameterT]) -> None:
     an unsupported type silently pass through ``runtimeify``'s default-case
     ``VISITOR_NO_REPLACEMENT``.
     """
-    for parameter in parameters:
+    for parameter in iter_parameter_models(parameters):
         if type(parameter) not in YAML_V1_SUPPORTED_PARAMETER_MODELS:
             raise AssertionError(
                 f"YAML-origin tool produced unsupported parameter type "
                 f"{type(parameter).__name__} for parameter {getattr(parameter, 'name', '?')!r}"
             )
-        if isinstance(parameter, ConditionalParameterModel):
-            for when in parameter.whens:
-                assert_yaml_v1_parameters(when.parameters)
-        elif isinstance(parameter, (RepeatParameterModel, SectionParameterModel)):
-            assert_yaml_v1_parameters(parameter.parameters)
 
 
 def runtimeify(

--- a/lib/galaxy/tool_util/parameters/convert.py
+++ b/lib/galaxy/tool_util/parameters/convert.py
@@ -249,7 +249,9 @@ def dereference(
         if isinstance(parameter, DataParameterModel):
             if value is None:
                 if parameter.url_default:
-                    return dereference_dict(DataRequestUri(url=parameter.url_default, ext="auto").model_dump())
+                    return dereference_dict(
+                        DataRequestUri(url=parameter.url_default, ext="auto", deferred=True).model_dump()
+                    )
                 return VISITOR_NO_REPLACEMENT
             if parameter.multiple and isinstance(value, list):
                 return list(map(dereference_dict, value))
@@ -279,7 +281,7 @@ def encode_test(
     input_models: ToolParameterBundle,
     adapt_datasets: AdaptDatasets,
     adapt_collections: AdaptCollections,
-):
+) -> RequestToolState:
 
     def encode_callback(parameter: ToolParameterT, value: Any):
         if isinstance(parameter, DataParameterModel):
@@ -293,8 +295,7 @@ def encode_test(
                     test_dataset = cast(JsonTestDatasetDefDict, value)
                     return adapt_datasets(test_dataset).model_dump()
             elif parameter.url_default:
-                url_default_dict = cast(Any, {"class": "File", "location": parameter.url_default})
-                return adapt_datasets(url_default_dict).model_dump()
+                return DataRequestUri(url=parameter.url_default, ext="auto", deferred=True).model_dump()
         elif isinstance(parameter, DataCollectionParameterModel):
             if value is not None:
                 assert isinstance(value, dict), str(value)
@@ -329,13 +330,17 @@ def encode_test(
 
 
 def fill_static_defaults(
-    tool_state: Dict[str, Any], input_models: ToolParameterBundle, profile: float, partial: bool = True
+    tool_state: Dict[str, Any],
+    input_models: ToolParameterBundle,
+    profile: float,
+    partial: bool = True,
+    url_data_defaults: bool = False,
 ) -> Dict[str, Any]:
     """If additional defaults might stem from Galaxy runtime, partial should be true.
 
     Setting partial to True, prevents runtime validation.
     """
-    _fill_defaults(tool_state, input_models)
+    _fill_defaults(tool_state, input_models, url_data_defaults=url_data_defaults)
 
     if not partial:
         internal_state = JobInternalToolState(tool_state)
@@ -343,12 +348,14 @@ def fill_static_defaults(
     return tool_state
 
 
-def _fill_defaults(tool_state: Dict[str, Any], input_models: ToolParameterBundle) -> None:
+def _fill_defaults(
+    tool_state: Dict[str, Any], input_models: ToolParameterBundle, url_data_defaults: bool = False
+) -> None:
     for parameter in input_models.parameters:
-        _fill_default_for(tool_state, parameter)
+        _fill_default_for(tool_state, parameter, url_data_defaults=url_data_defaults)
 
 
-def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT) -> None:
+def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT, url_data_defaults: bool = False) -> None:
     parameter_name = parameter.name
     if isinstance(parameter, BooleanParameterModel):
         if parameter_name not in tool_state:
@@ -394,19 +401,24 @@ def _fill_default_for(tool_state: Dict[str, Any], parameter: ToolParameterT) -> 
         )
         test_value = validate_explicit_conditional_test_value(test_parameter_name, explicit_test_value)
         when = _select_which_when(parameter, test_value, conditional_state)
-        _fill_default_for(conditional_state, test_parameter)
-        _fill_defaults(conditional_state, when)
+        _fill_default_for(conditional_state, test_parameter, url_data_defaults=url_data_defaults)
+        _fill_defaults(conditional_state, when, url_data_defaults=url_data_defaults)
     elif isinstance(parameter, RepeatParameterModel):
         repeat_instances = _initialize_repeat_state(parameter, tool_state)
         for instance_state in repeat_instances:
-            _fill_defaults(instance_state, parameter)
+            _fill_defaults(instance_state, parameter, url_data_defaults=url_data_defaults)
     elif isinstance(parameter, SectionParameterModel):
         section_state = _initialize_section_state(parameter, tool_state)
-        _fill_defaults(section_state, parameter)
+        _fill_defaults(section_state, parameter, url_data_defaults=url_data_defaults)
     elif isinstance(parameter, DataCollectionParameterModel):
         collection_parameter = parameter
         if parameter_name not in tool_state and collection_parameter.optional:
             tool_state[parameter_name] = None
+    elif isinstance(parameter, DataParameterModel):
+        if url_data_defaults and parameter_name not in tool_state and parameter.url_default:
+            tool_state[parameter_name] = DataRequestUri(
+                url=parameter.url_default, ext="auto", deferred=True
+            ).model_dump()
     elif isinstance(parameter, TextParameterModel):
         if parameter_name not in tool_state:
             if not parameter.optional:

--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -134,11 +134,15 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
         elif param_type == "boolean":
             nullable = input_source.parse_optional()
             value = input_source.get_bool_or_none("checked", None if nullable else False)
+            truevalue = input_source.get("truevalue", None)
+            falsevalue = input_source.get("falsevalue", None)
             return BooleanParameterModel(
                 type="boolean",
                 name=input_source.parse_name(),
                 optional=nullable,
                 value=value,
+                truevalue=truevalue,
+                falsevalue=falsevalue,
                 **_common_param_kwargs(input_source),
             )
         elif param_type == "text":

--- a/lib/galaxy/tool_util/parameters/factory.py
+++ b/lib/galaxy/tool_util/parameters/factory.py
@@ -218,11 +218,16 @@ def _from_input_source_galaxy(input_source: InputSource, profile: float) -> Tool
             # missing datasets); only known user is cufflinks which sets it.
             optional = input_source.parse_optional() if param_type == "data" else True
             multiple = input_source.get_bool("multiple", False)
+            url_default = None
+            default_value = input_source.parse_default()
+            if isinstance(default_value, dict) and default_value.get("location"):
+                url_default = default_value["location"]
             return DataParameterModel(
                 type="data",
                 name=input_source.parse_name(),
                 optional=optional,
                 multiple=multiple,
+                url_default=url_default,
                 **_common_param_kwargs(input_source),
             )
         elif param_type == "data_collection":

--- a/lib/galaxy/tool_util/parameters/visitor.py
+++ b/lib/galaxy/tool_util/parameters/visitor.py
@@ -74,10 +74,6 @@ def _visit_input_values(
         name = model.name
         input_value = input_values.get(name, VISITOR_UNDEFINED)
         if input_value is VISITOR_UNDEFINED:
-            if model.parameter_type not in ("gx_repeat", "gx_section", "gx_conditional"):
-                replacement = callback(model, None)
-                if replacement != no_replacement_value:
-                    new_input_values[name] = replacement
             continue
 
         if model.parameter_type == "gx_repeat":

--- a/lib/galaxy/tool_util/parameters/visitor.py
+++ b/lib/galaxy/tool_util/parameters/visitor.py
@@ -74,6 +74,10 @@ def _visit_input_values(
         name = model.name
         input_value = input_values.get(name, VISITOR_UNDEFINED)
         if input_value is VISITOR_UNDEFINED:
+            if model.parameter_type not in ("gx_repeat", "gx_section", "gx_conditional"):
+                replacement = callback(model, None)
+                if replacement != no_replacement_value:
+                    new_input_values[name] = replacement
             continue
 
         if model.parameter_type == "gx_repeat":

--- a/lib/galaxy/tool_util/parser/factory.py
+++ b/lib/galaxy/tool_util/parser/factory.py
@@ -39,7 +39,12 @@ log = logging.getLogger(__name__)
 
 
 def build_xml_tool_source(xml_string: str) -> XmlToolSource:
-    return XmlToolSource(parse_xml_string_to_etree(xml_string))
+    # Preserve significant whitespace (e.g. a leading space in a <validator> regex such as
+    # " *(\\d+, *)*\\d+ *$") to match how tools are parsed from a file (xml_macros.load uses
+    # strip_whitespace=False). Stripping it here corrupts such regexes when a tool is
+    # re-parsed from its stored raw source (async tool requests), which then raised a 500
+    # while statically validating the request.
+    return XmlToolSource(parse_xml_string_to_etree(xml_string, strip_whitespace=False))
 
 
 def build_cwl_tool_source(yaml_string: str) -> CwlToolSource:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -849,9 +849,7 @@ class GalaxyInteractorApi:
             def adapt_datasets(test_input: JsonTestDatasetDefDict) -> Union[DataRequestHda, DataRequestUri]:
                 location = test_input.get("location")
                 if location:
-                    import posixpath
-
-                    ext = posixpath.splitext(posixpath.basename(location))[1].lstrip(".") or "data"
+                    ext = test_input.get("filetype") or "auto"
                     return DataRequestUri(url=location, ext=ext)
                 # if path is not set it might be a composite file with a path,
                 # e.g. composite_shapefile

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -36,10 +36,12 @@ from typing_extensions import (
 )
 
 from galaxy import util
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.tool_util.client.staging import StagingInterface
 from galaxy.tool_util.parameters import (
     DataCollectionRequest,
     DataRequestHda,
+    DataRequestUri,
     encode_test,
     input_models_from_json,
     TestCaseToolState,
@@ -844,7 +846,13 @@ class GalaxyInteractorApi:
             assert request_schema is not None, "Request schema not set"
             parameters = request_schema["parameters"]
 
-            def adapt_datasets(test_input: JsonTestDatasetDefDict) -> DataRequestHda:
+            def adapt_datasets(test_input: JsonTestDatasetDefDict) -> Union[DataRequestHda, DataRequestUri]:
+                location = test_input.get("location")
+                if location:
+                    import posixpath
+
+                    ext = posixpath.splitext(posixpath.basename(location))[1].lstrip(".") or "data"
+                    return DataRequestUri(url=location, ext=ext)
                 # if path is not set it might be a composite file with a path,
                 # e.g. composite_shapefile
                 test_input_path = test_input.get("path", "")
@@ -1790,8 +1798,8 @@ def verify_tool(
             tool_response = galaxy_interactor.resolve_tool_submission(submission)
             data_list, jobs = tool_response.outputs, tool_response.jobs
             data_collection_list = tool_response.output_collections
-        except RunToolException as e:
-            tool_inputs = e.inputs
+        except (RunToolException, RequestParameterInvalidException) as e:
+            tool_inputs = getattr(e, "inputs", None)
             tool_execution_exception = e
             if not testdef.expect_failure:
                 raise e

--- a/lib/galaxy/tool_util/verify/parse.py
+++ b/lib/galaxy/tool_util/verify/parse.py
@@ -79,18 +79,20 @@ def parse_tool_test_descriptions(
         validation_exception: Optional[Exception] = None
         request_and_schema: Optional[TestRequestAndSchema] = None
         tool_parameter_bundle: Optional[ToolParameterBundleModel] = None
-        if validate_on_load:
-            try:
-                if parameters is None:
-                    tool_parameter_bundle = input_models_for_tool_source(tool_source)
-                    parameters = tool_parameter_bundle.parameters
-                validated_test_case = case_state(raw_test_dict, parameters, profile, validate=True)
-                request_and_schema = TestRequestAndSchema(
-                    validated_test_case.tool_state,
-                    tool_parameter_bundle or ToolParameterBundleModel(parameters=parameters),
-                )
-            except Exception as e:
+        try:
+            if parameters is None:
+                tool_parameter_bundle = input_models_for_tool_source(tool_source)
+                parameters = tool_parameter_bundle.parameters
+            validated_test_case = case_state(raw_test_dict, parameters, profile, validate=validate_on_load)
+            request_and_schema = TestRequestAndSchema(
+                validated_test_case.tool_state,
+                tool_parameter_bundle or ToolParameterBundleModel(parameters=parameters),
+            )
+        except Exception as e:
+            if validate_on_load:
                 validation_exception = e
+            else:
+                validation_skipped_reason = f"could not build request: {e}"
 
         if validation_exception:
             tool_id, tool_version = _tool_id_and_version(tool_source, tool_guid)

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -1273,14 +1273,20 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         if state_representation in ["request", "relaxed_request"]:
-            return allow_batching(dynamic_model_information_from_py_type(self, self.py_type), BatchDataInstance)
+            requires_value = None if not self.url_default else False
+            return allow_batching(
+                dynamic_model_information_from_py_type(self, self.py_type, requires_value=requires_value),
+                BatchDataInstance,
+            )
         elif state_representation == "landing_request":
             return allow_batching(
                 dynamic_model_information_from_py_type(self, self.py_type, requires_value=False), BatchDataInstance
             )
         elif state_representation == "request_internal":
+            requires_value = None if not self.url_default else False
             return allow_batching(
-                dynamic_model_information_from_py_type(self, self.py_type_internal), BatchDataInstanceInternal
+                dynamic_model_information_from_py_type(self, self.py_type_internal, requires_value=requires_value),
+                BatchDataInstanceInternal,
             )
         elif state_representation == "landing_request_internal":
             return allow_batching(

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -175,17 +175,25 @@ def _label_value_dicts(options: List[Any]) -> List[Dict[str, Any]]:
     return [{"label": o.label, "value": o.value, "selected": o.selected} for o in options]
 
 
+_UNSET: Any = object()
+
+
 def dynamic_model_information_from_py_type(
     param_model: ParamModel,
     py_type: Type,
     requires_value: Optional[bool] = None,
     validators=None,
     extra_json_schema: Optional[Dict[str, Any]] = None,
+    default: Any = _UNSET,
 ):
     name = safe_field_name(param_model.name)
-    if requires_value is None:
-        requires_value = param_model.request_requires_value
-    initialize = ... if requires_value else None
+    if default is not _UNSET:
+        initialize = default
+        requires_value = False
+    else:
+        if requires_value is None:
+            requires_value = param_model.request_requires_value
+        initialize = ... if requires_value else None
     py_type_is_optional = is_optional(py_type)
     validators = validators or {}
     if not py_type_is_optional and not requires_value:
@@ -1150,6 +1158,7 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
     multiple: Annotated[bool, Field(description="Allow multiple values to be selected.")] = False
     min: Optional[int] = None
     max: Optional[int] = None
+    url_default: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -1248,9 +1257,13 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
             return dynamic_model_information_from_py_type(self, self.py_type_job_internal, requires_value=True)
         elif state_representation == "job_runtime":
             return dynamic_model_information_from_py_type(self, self.py_type_internal_json, requires_value=True)
-        elif state_representation == "test_case_xml":
-            return dynamic_model_information_from_py_type(self, self.py_type_test_case)
-        elif state_representation == "test_case_json":
+        elif state_representation in ("test_case_xml", "test_case_json"):
+            if self.url_default:
+                return dynamic_model_information_from_py_type(
+                    self,
+                    self.py_type_test_case,
+                    default={"class": "File", "location": self.url_default},
+                )
             return dynamic_model_information_from_py_type(self, self.py_type_test_case)
         elif state_representation == "workflow_step":
             return dynamic_model_information_from_py_type(self, type(None), requires_value=False)

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -515,10 +515,6 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
     def py_type(self) -> Type:
         return optional_if_needed(union_type([StrictInt, StrictFloat]), self.optional)
 
-    @staticmethod
-    def _convert_infinity_sentinel_static(v: Any) -> Any:
-        return _convert_infinity_sentinel(v)
-
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         py_type = self.py_type
         if state_representation == "workflow_step_linked":
@@ -536,9 +532,7 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
         # before Pydantic validates the field. These sentinels appear when float('inf') values are
         # round-tripped through Galaxy's safe_dumps/json.loads path (e.g. GET /api/tools/{id}/test_data).
         dynamic_validators: Dict[str, Any] = {
-            "infinity_sentinel": field_validator(safe_field_name(self.name), mode="before")(
-                FloatParameterModel._convert_infinity_sentinel_static
-            )
+            "infinity_sentinel": field_validator(safe_field_name(self.name), mode="before")(_convert_infinity_sentinel)
         }
         return dynamic_model_information_from_py_type(
             self, py_type, requires_value=requires_value, validators=dynamic_validators

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -451,7 +451,9 @@ class IntegerParameterModel(BaseGalaxyToolParameterModelDefinition):
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         py_type = self.py_type
         validators = self.validators[:]
-        if self.min is not None or self.max is not None:
+        # min/max on integer params are UI hints (slider range) that were not enforced by the
+        # old /api/tools endpoint. Only enforce them during strict internal job states.
+        if (self.min is not None or self.max is not None) and state_representation in ("job_internal", "job_runtime"):
             validators.append(InRangeParameterValidatorModel(min=self.min, max=self.max, implicit=True))
         py_type = decorate_type_with_validators_if_needed(py_type, validators)
         if state_representation == "workflow_step_linked":
@@ -499,7 +501,9 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
         elif _is_landing_request(state_representation):
             requires_value = False
         validators = self.validators[:]
-        if self.min is not None or self.max is not None:
+        # min/max on float params are UI hints that were not enforced by the old /api/tools endpoint.
+        # Only enforce them during strict internal job states.
+        if (self.min is not None or self.max is not None) and state_representation in ("job_internal", "job_runtime"):
             validators.append(InRangeParameterValidatorModel(min=self.min, max=self.max, implicit=True))
         py_type = decorate_type_with_validators_if_needed(py_type, validators)
         return dynamic_model_information_from_py_type(self, py_type, requires_value=requires_value)
@@ -1554,10 +1558,8 @@ def ensure_color_valid(value: Optional[Any]):
         return
     if not isinstance(value, str):
         raise ValueError(f"Invalid color value type {value.__class__} encountered.")
-    try:
-        Color(value)
-    except Exception as e:
-        raise ValueError(f"Invalid color value {value!r}: {e}")
+    # Accept any string — matplotlib colormap names and other non-CSS color strings are valid
+    # in Galaxy tools even though they don't pass pydantic_extra_types color validation.
 
 
 class ColorParameterModel(BaseGalaxyToolParameterModelDefinition):

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -470,6 +470,26 @@ class IntegerParameterModel(BaseGalaxyToolParameterModelDefinition):
         return not self.optional and self.value is None
 
 
+_INFINITY_SENTINEL = "__Infinity__"
+_NEG_INFINITY_SENTINEL = "__-Infinity__"
+
+
+def _convert_infinity_sentinel(v: Any) -> Any:
+    """Convert Galaxy JSON sentinel strings for infinity back to Python floats.
+
+    Galaxy's custom JSON encoder (galaxy.util.json.safe_dumps) serializes
+    float('inf') as '__Infinity__' and float('-inf') as '__-Infinity__' to
+    produce valid JSON.  When these sentinel values appear in deserialized
+    parameter dicts (e.g. from GET /api/tools/{id}/test_data) Pydantic must
+    accept them as valid float input.
+    """
+    if v == _INFINITY_SENTINEL:
+        return float("inf")
+    elif v == _NEG_INFINITY_SENTINEL:
+        return float("-inf")
+    return v
+
+
 class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
     parameter_type: Literal["gx_float"] = "gx_float"
     type: Literal["float"]
@@ -477,6 +497,11 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
     min: Optional[float] = None
     max: Optional[float] = None
     validators: List[NumberCompatiableValidators] = []
+
+    @field_validator("value", "min", "max", mode="before")
+    @classmethod
+    def convert_infinity_sentinels(cls, v: Any) -> Any:
+        return _convert_infinity_sentinel(v)
 
     def field_kwargs(self) -> Dict[str, Any]:
         kwargs = super().field_kwargs()
@@ -490,6 +515,10 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
     @property
     def py_type(self) -> Type:
         return optional_if_needed(union_type([StrictInt, StrictFloat]), self.optional)
+
+    @staticmethod
+    def _convert_infinity_sentinel_static(v: Any) -> Any:
+        return _convert_infinity_sentinel(v)
 
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         py_type = self.py_type
@@ -506,7 +535,17 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
         if (self.min is not None or self.max is not None) and state_representation in ("job_internal", "job_runtime"):
             validators.append(InRangeParameterValidatorModel(min=self.min, max=self.max, implicit=True))
         py_type = decorate_type_with_validators_if_needed(py_type, validators)
-        return dynamic_model_information_from_py_type(self, py_type, requires_value=requires_value)
+        # Convert Galaxy JSON sentinel strings ("__Infinity__", "__-Infinity__") to Python floats
+        # before Pydantic validates the field. These sentinels appear when float('inf') values are
+        # round-tripped through Galaxy's safe_dumps/json.loads path (e.g. GET /api/tools/{id}/test_data).
+        dynamic_validators: Dict[str, Any] = {
+            "infinity_sentinel": field_validator(safe_field_name(self.name), mode="before")(
+                FloatParameterModel._convert_infinity_sentinel_static
+            )
+        }
+        return dynamic_model_information_from_py_type(
+            self, py_type, requires_value=requires_value, validators=dynamic_validators
+        )
 
     @property
     def request_requires_value(self) -> bool:

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -182,10 +182,10 @@ def dynamic_model_information_from_py_type(
     param_model: ParamModel,
     py_type: Type,
     requires_value: Optional[bool] = None,
-    validators=None,
+    validators: Optional[Dict[str, Any]] = None,
     extra_json_schema: Optional[Dict[str, Any]] = None,
     default: Any = _UNSET,
-):
+) -> DynamicModelInformation:
     name = safe_field_name(param_model.name)
     if default is not _UNSET:
         initialize = default
@@ -1321,7 +1321,7 @@ class DataParameterModel(BaseGalaxyToolParameterModelDefinition):
 
     @property
     def request_requires_value(self) -> bool:
-        return not self.optional
+        return not self.optional and self.url_default is None
 
 
 class DataCollectionRequest(StrictModel):

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -451,9 +451,7 @@ class IntegerParameterModel(BaseGalaxyToolParameterModelDefinition):
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         py_type = self.py_type
         validators = self.validators[:]
-        # min/max on integer params are UI hints (slider range) that were not enforced by the
-        # old /api/tools endpoint. Only enforce them during strict internal job states.
-        if (self.min is not None or self.max is not None) and state_representation in ("job_internal", "job_runtime"):
+        if self.min is not None or self.max is not None:
             validators.append(InRangeParameterValidatorModel(min=self.min, max=self.max, implicit=True))
         py_type = decorate_type_with_validators_if_needed(py_type, validators)
         if state_representation == "workflow_step_linked":
@@ -530,9 +528,7 @@ class FloatParameterModel(BaseGalaxyToolParameterModelDefinition):
         elif _is_landing_request(state_representation):
             requires_value = False
         validators = self.validators[:]
-        # min/max on float params are UI hints that were not enforced by the old /api/tools endpoint.
-        # Only enforce them during strict internal job states.
-        if (self.min is not None or self.max is not None) and state_representation in ("job_internal", "job_runtime"):
+        if self.min is not None or self.max is not None:
             validators.append(InRangeParameterValidatorModel(min=self.min, max=self.max, implicit=True))
         py_type = decorate_type_with_validators_if_needed(py_type, validators)
         # Convert Galaxy JSON sentinel strings ("__Infinity__", "__-Infinity__") to Python floats
@@ -1597,8 +1593,10 @@ def ensure_color_valid(value: Optional[Any]):
         return
     if not isinstance(value, str):
         raise ValueError(f"Invalid color value type {value.__class__} encountered.")
-    # Accept any string — matplotlib colormap names and other non-CSS color strings are valid
-    # in Galaxy tools even though they don't pass pydantic_extra_types color validation.
+    try:
+        Color(value)
+    except Exception as e:
+        raise ValueError(f"Invalid color value {value!r}: {e}")
 
 
 class ColorParameterModel(BaseGalaxyToolParameterModelDefinition):

--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -9,6 +9,7 @@ from typing import (
     Dict,
     get_args,
     Iterable,
+    Iterator,
     List,
     Mapping,
     NamedTuple,
@@ -2585,6 +2586,28 @@ def simple_input_models(
     parameters: Union[List[ToolParameterModel], List[ToolParameterT]],
 ) -> Iterable[ToolParameterT]:
     return [to_simple_model(m) for m in parameters]
+
+
+def iter_parameter_models(parameters: Iterable[ToolParameterT]) -> Iterator[ToolParameterT]:
+    """Yield every parameter in a parameter tree, depth-first.
+
+    Descends into repeats, sections and *all* branches of every conditional - the purely
+    structural view of the tree, independent of any state. A conditional yields the
+    conditional itself, then its discriminator ``test_parameter``, then every parameter
+    across all of its whens; a repeat/section yields the group node then its children.
+
+    Use this for structure-only queries (collecting names, validating types). When the walk
+    needs to follow values - and so only the active when of each conditional - use
+    ``visit_input_values`` instead.
+    """
+    for parameter in parameters:
+        yield parameter
+        if isinstance(parameter, ConditionalParameterModel):
+            yield parameter.test_parameter
+            for when in parameter.whens:
+                yield from iter_parameter_models(when.parameters)
+        elif isinstance(parameter, (RepeatParameterModel, SectionParameterModel)):
+            yield from iter_parameter_models(parameter.parameters)
 
 
 def create_model_strict(*args, **kwd) -> Type[BaseModel]:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3772,7 +3772,10 @@ class DataManagerTool(OutputParameterJSONTool):
             return
         super().exec_after_process(app, inp_data, out_data, param_dict, job=job, final_job_state=final_job_state)
         # process results of tool
-        data_manager_id = job.data_manager_association.data_manager_id
+        # Use self.data_manager_id (from data_manager_conf.xml, set at toolbox load time) because
+        # the async API reconstructs the tool from raw XML without data_manager_id, causing the
+        # DataManagerJobAssociation to store the tool XML id instead of the conf id when those differ.
+        data_manager_id = self.data_manager_id or job.data_manager_association.data_manager_id
         data_manager = self.app.data_managers.get_manager(data_manager_id)
         assert (
             data_manager is not None

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -4742,6 +4742,8 @@ class RelabelFromFileTool(DatabaseOperationTool):
 
         def add_copied_value_to_new_elements(new_label, dce_object, columns):
             new_label = new_label.strip()
+            if not re.match(r"^[\w\- \.,]+$", new_label):
+                raise exceptions.MessageException(f"Invalid new collection identifier [{new_label}]")
             if new_label in new_elements:
                 raise exceptions.MessageException(
                     f"New identifier [{new_label}] appears twice in resulting collection, these values must be unique."
@@ -4799,9 +4801,6 @@ class RelabelFromFileTool(DatabaseOperationTool):
             for i, dce in enumerate(hdca.collection.elements):
                 dce_object = dce.element_object
                 add_copied_value_to_new_elements(new_labels[i], dce_object, dce.columns)
-        for key in new_elements.keys():
-            if not re.match(r"^[\w\- \.,]+$", key):
-                raise exceptions.MessageException(f"Invalid new collection identifier [{key}]")
         self._add_datasets_to_history(history, new_elements.values())
         output_collections.create_collection(
             next(iter(self.outputs.values())),

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -50,6 +50,7 @@ from galaxy.tools.execution_helpers import (
     ToolExecutionCache,
 )
 from galaxy.tools.parameters.workflow_utils import is_runtime_value
+from galaxy.util.json import swap_inf_nan
 from galaxy.work.context import WorkRequestContext
 from ._types import (
     ToolRequestT,
@@ -325,7 +326,7 @@ def _execute(
             if tool_request:
                 job.tool_request = tool_request
             if execution_slice.validated_param_combination:
-                tool_state = execution_slice.validated_param_combination.input_state
+                tool_state = swap_inf_nan(execution_slice.validated_param_combination.input_state)
                 job.tool_state = tool_state
             log.debug(job_timer.to_str(tool_id=tool.id, job_id=job.id))
             execution_tracker.record_success(execution_slice, job, result)

--- a/lib/galaxy/tools/filter_from_file.xml
+++ b/lib/galaxy/tools/filter_from_file.xml
@@ -38,8 +38,10 @@
                     <element name="i2" value="simple_line_alternative.txt" />
                 </collection>
             </param>
-            <param name="how_filter" value="remove_if_present" />
-            <param name="filter_source" value="filter_labels_1.txt" ftype="txt" />
+            <conditional name="how">
+                <param name="how_filter" value="remove_if_present" />
+                <param name="filter_source" value="filter_labels_1.txt" ftype="txt" />
+            </conditional>
             <output_collection name="output_filtered" type="list">
                 <element name="i1">
                   <assert_contents>
@@ -62,8 +64,10 @@
                     <element name="i2" value="simple_line_alternative.txt" />
                 </collection>
             </param>
-            <param name="how_filter" value="remove_if_absent" />
-            <param name="filter_source" value="filter_labels_1.txt" ftype="txt" />
+            <conditional name="how">
+                <param name="how_filter" value="remove_if_absent" />
+                <param name="filter_source" value="filter_labels_1.txt" ftype="txt" />
+            </conditional>
             <output_collection name="output_filtered" type="list">
                 <element name="i2">
                   <assert_contents>

--- a/lib/galaxy/tools/relabel_from_file.xml
+++ b/lib/galaxy/tools/relabel_from_file.xml
@@ -52,8 +52,10 @@
                     </element>
                 </collection>
             </param>
-            <param name="how_select" value="txt" />
-            <param name="labels" value="new_labels_1.txt" ftype="txt" />
+            <conditional name="how">
+                <param name="how_select" value="txt" />
+                <param name="labels" value="new_labels_1.txt" ftype="txt" />
+            </conditional>
             <output_collection name="output" type="list:paired">
               <element name="new_i1">
                 <element name="forward">
@@ -80,8 +82,10 @@
                     </element>
                 </collection>
             </param>
-            <param name="how_select" value="tabular" />
-            <param name="labels" value="new_labels_2.txt" ftype="tabular" />
+            <conditional name="how">
+                <param name="how_select" value="tabular" />
+                <param name="labels" value="new_labels_2.txt" ftype="tabular" />
+            </conditional>
             <output_collection name="output" type="list:paired">
               <element name="new_i1">
                 <element name="forward">
@@ -109,10 +113,12 @@
                     </element>
                 </collection>
             </param>
-            <param name="how_select" value="tabular_extended" />
-            <param name="labels" value="new_labels_3.txt" ftype="tabular" />
-            <param name="from" value="3" />
-            <param name="to" value="1" />
+            <conditional name="how">
+                <param name="how_select" value="tabular_extended" />
+                <param name="labels" value="new_labels_3.txt" ftype="tabular" />
+                <param name="from" value="3" />
+                <param name="to" value="1" />
+            </conditional>
             <output_collection name="output" type="list:paired">
               <element name="new_i1">
                 <element name="forward">
@@ -140,9 +146,11 @@
                     </element>
                 </collection>
             </param>
-            <param name="strict" value="true" />
-            <param name="how_select" value="tabular" />
-            <param name="labels" value="new_labels_2.txt" ftype="tabular" />
+            <conditional name="how">
+                <param name="how_select" value="tabular" />
+                <param name="labels" value="new_labels_2.txt" ftype="tabular" />
+                <param name="strict" value="true" />
+            </conditional>
         </test>
         <test expect_failure="true">
             <param name="input">
@@ -151,8 +159,10 @@
                     <element name="i3" value="simple_line_alternative.txt" />
                 </collection>
             </param>
-            <param name="how_select" value="txt" />
-            <param name="labels" value="new_labels_1.txt" ftype="txt" />
+            <conditional name="how">
+                <param name="how_select" value="txt" />
+                <param name="labels" value="new_labels_1.txt" ftype="txt" />
+            </conditional>
         </test>
         <!-- test label bad characters -->
         <test expect_failure="true">
@@ -161,8 +171,10 @@
                     <element name="i1" value="simple_line.txt" />
                 </collection>
             </param>
-            <param name="how_select" value="txt" />
-            <param name="labels" value="new_labels_bad_1.txt" ftype="txt" />
+            <conditional name="how">
+                <param name="how_select" value="txt" />
+                <param name="labels" value="new_labels_bad_1.txt" ftype="txt" />
+            </conditional>
         </test>
         <!-- test label bad because of duplicates -->
         <test expect_failure="true">
@@ -172,8 +184,10 @@
                     <element name="i2" value="simple_line.txt" />
                 </collection>
             </param>
-            <param name="how_select" value="txt" />
-            <param name="labels" value="new_labels_bad_2.txt" ftype="txt" />
+            <conditional name="how">
+                <param name="how_select" value="txt" />
+                <param name="labels" value="new_labels_bad_2.txt" ftype="txt" />
+            </conditional>
         </test>
     </tests>
     <help><![CDATA[

--- a/lib/galaxy/util/permutations.py
+++ b/lib/galaxy/util/permutations.py
@@ -8,7 +8,11 @@ with itertools product and permutations. These are open questions.
 """
 
 import copy
-from typing import Tuple
+from typing import (
+    Any,
+    Optional,
+    Tuple,
+)
 
 from galaxy.exceptions import MessageException
 from galaxy.util.bunch import Bunch
@@ -103,7 +107,7 @@ def state_copy(inputs, nested):
     return state_dict_copy
 
 
-def state_set_value(state_dict, key, value, nested):
+def state_set_value(state_dict: dict, key: str, value: Any, nested: bool) -> None:
     if "|" not in key or not nested:
         state_dict[key] = value
     else:
@@ -117,6 +121,8 @@ def state_set_value(state_dict, key, value, nested):
                 repeat_state.append({})
             state_set_value(repeat_state[index], rest, value, nested)
         else:
+            if first not in state_dict:
+                state_dict[first] = {}
             state_set_value(state_dict[first], rest, value, nested)
 
 
@@ -147,7 +153,7 @@ def state_get_value(state_dict, key, nested):
             return state_get_value(state_dict[first], rest, nested)
 
 
-def is_in_state(state_dict, key, nested):
+def is_in_state(state_dict: Optional[dict], key: str, nested: bool) -> bool:
     if not state_dict:
         return False
     if "|" not in key or not nested:

--- a/lib/galaxy/util/permutations.py
+++ b/lib/galaxy/util/permutations.py
@@ -114,16 +114,21 @@ def state_set_value(state_dict: dict, key: str, value: Any, nested: bool) -> Non
         first, rest = key.split("|", 1)
         if first not in state_dict and looks_like_flattened_repeat_key(first):
             repeat_name, index = split_flattened_repeat_key(first)
-            if repeat_name not in state_dict:
-                state_dict[repeat_name] = []
-            repeat_state = state_dict[repeat_name]
-            while len(repeat_state) <= index:
-                repeat_state.append({})
-            state_set_value(repeat_state[index], rest, value, nested)
-        else:
-            if first not in state_dict:
-                state_dict[first] = {}
-            state_set_value(state_dict[first], rest, value, nested)
+            # Only treat as a flattened repeat key if the repeat list already exists
+            # or this is the first element (index 0). This avoids misidentifying
+            # conditional names ending in _N (e.g. "inner_options_1") as repeat indices
+            # when no repeat list has been started yet.
+            if index == 0 or isinstance(state_dict.get(repeat_name), list):
+                if repeat_name not in state_dict:
+                    state_dict[repeat_name] = []
+                repeat_state = state_dict[repeat_name]
+                while len(repeat_state) <= index:
+                    repeat_state.append({})
+                state_set_value(repeat_state[index], rest, value, nested)
+                return
+        if first not in state_dict:
+            state_dict[first] = {}
+        state_set_value(state_dict[first], rest, value, nested)
 
 
 def state_remove_value(state_dict, key, nested):

--- a/lib/galaxy/util/permutations.py
+++ b/lib/galaxy/util/permutations.py
@@ -155,7 +155,7 @@ def is_in_state(state_dict, key, nested):
     else:
         first, rest = key.split("|", 1)
         # repeats?
-        is_in_state(state_dict.get(first), rest, nested)
+        return is_in_state(state_dict.get(first), rest, nested)
 
 
 def looks_like_flattened_repeat_key(key: str) -> bool:

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -55,7 +55,6 @@ from galaxy.schema.tasks import (
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.tool_util.parameters import (
     decode,
-    fill_static_defaults,
     RelaxedRequestToolState,
     RequestToolState,
     strictify,
@@ -263,16 +262,9 @@ class JobsService(ServiceBase):
             request_state = RequestToolState(inputs or {})
         request_state.validate(parameter_bundle, f"{tool.id} (request model)")
         request_internal_state = decode(request_state, parameter_bundle, trans.security.decode_id)
-        # Fill url_default values and re-validate before persisting the ToolRequest.
-        # The execution path handles general defaults, but the internal state must be
-        # fully resolved here so the persisted request is self-contained.
-        fill_static_defaults(
-            request_internal_state.input_state,
-            parameter_bundle,
-            tool.profile,
-            partial=True,
-            url_data_defaults=True,
-        )
+        # request_internal is the representation where absent inputs stay absent - defaults
+        # (including url_default data inputs) are resolved later, at dereference/job_internal
+        # time. Do not fill them here or we would record inputs that were never requested.
         request_internal_state.validate(parameter_bundle, f"{tool.id} (request internal model)")
         tool_request = ToolRequest()
         # TODO: hash and such...

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -55,6 +55,7 @@ from galaxy.schema.tasks import (
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.tool_util.parameters import (
     decode,
+    fill_static_defaults,
     RelaxedRequestToolState,
     RequestToolState,
     strictify,
@@ -262,6 +263,17 @@ class JobsService(ServiceBase):
             request_state = RequestToolState(inputs or {})
         request_state.validate(parameter_bundle, f"{tool.id} (request model)")
         request_internal_state = decode(request_state, parameter_bundle, trans.security.decode_id)
+        # Fill url_default values and re-validate before persisting the ToolRequest.
+        # The execution path handles general defaults, but the internal state must be
+        # fully resolved here so the persisted request is self-contained.
+        fill_static_defaults(
+            request_internal_state.input_state,
+            parameter_bundle,
+            tool.profile,
+            partial=True,
+            url_data_defaults=True,
+        )
+        request_internal_state.validate(parameter_bundle, f"{tool.id} (request internal model)")
         tool_request = ToolRequest()
         # TODO: hash and such...
         tool_source_model = ToolSourceModel(

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -262,9 +262,8 @@ class JobsService(ServiceBase):
             request_state = RequestToolState(inputs or {})
         request_state.validate(parameter_bundle, f"{tool.id} (request model)")
         request_internal_state = decode(request_state, parameter_bundle, trans.security.decode_id)
-        # request_internal is the representation where absent inputs stay absent - defaults
-        # (including url_default data inputs) are resolved later, at dereference/job_internal
-        # time. Do not fill them here or we would record inputs that were never requested.
+        # request_internal records absent inputs as absent; static defaults (incl. url_default
+        # data inputs) are filled later, at dereference/job_internal time (see fill_static_defaults).
         request_internal_state.validate(parameter_bundle, f"{tool.id} (request internal model)")
         tool_request = ToolRequest()
         # TODO: hash and such...

--- a/lib/galaxy/webapps/openapi/utils.py
+++ b/lib/galaxy/webapps/openapi/utils.py
@@ -81,7 +81,7 @@ def get_openapi(
     for route in routes or []:
         if isinstance(route, routing.APIRoute):
             result = get_openapi_path(
-                route=route,
+                route=route,  # type: ignore[arg-type,unused-ignore]
                 operation_ids=operation_ids,
                 model_name_map=model_name_map,
                 field_mapping=field_mapping,
@@ -99,7 +99,7 @@ def get_openapi(
     for webhook in webhooks or []:
         if isinstance(webhook, routing.APIRoute):
             result = get_openapi_path(
-                route=webhook,
+                route=webhook,  # type: ignore[arg-type,unused-ignore]
                 operation_ids=operation_ids,
                 model_name_map=model_name_map,
                 field_mapping=field_mapping,

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1329,3 +1329,39 @@ steps:
         jobs = jobs_response.json()
         assert isinstance(jobs, list)
         return jobs
+
+
+class TestDataManagerJobsApi(ApiTestCase):
+    """API tests for data manager jobs submitted via the async POST /api/jobs endpoint."""
+
+    require_admin_user = True
+    dataset_populator: DatasetPopulator
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    @skip_without_tool("data_manager")
+    def test_data_manager_async_submission_with_mismatched_conf_id(self):
+        # Regression for data manager jobs submitted via POST /api/jobs failing with
+        # "Invalid data manager requested" when the data_manager_conf.xml <data_manager id>
+        # differs from the tool XML <tool id>. The test tool "data_manager" (tool XML id)
+        # is registered in sample_data_manager_conf.xml as id="test_data_manager", which
+        # is exactly that mismatch. Before the fix, exec_after_process looked up the data
+        # manager using DataManagerJobAssociation.data_manager_id, which was set from the
+        # reconstructed tool's XML id ("data_manager") rather than the conf id
+        # ("test_data_manager"), causing the lookup to return None and the job to fail with
+        # exit code 0 but error state.
+        with self.dataset_populator.test_history() as history_id:
+            response = self.dataset_populator.tool_request_raw(
+                tool_id="data_manager",
+                inputs={"ignored_value": "test", "exit_code": 0},
+                history_id=history_id,
+                strict=False,
+            )
+            response.raise_for_status()
+            tool_request_id = response.json()["tool_request_id"]
+            submitted = self.dataset_populator.wait_on_tool_request(tool_request_id)
+            assert submitted, self.dataset_populator.get_tool_request(tool_request_id)
+            jobs = self.galaxy_interactor.jobs_for_tool_request(tool_request_id)
+            self.dataset_populator.wait_for_jobs(jobs, assert_ok=True)

--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -947,6 +947,48 @@ def test_deferred_multi_input(required_tool: RequiredTool, target_history: Targe
     output.assert_contains("chr1    4225    19670")
 
 
+def _assert_input_is_compressed_fasta_gz(target_history: TargetHistory, has_src_dict) -> None:
+    details = target_history._dataset_populator.get_history_dataset_details(
+        target_history.id, dataset_id=has_src_dict.id, assert_ok=False
+    )
+    assert (
+        details["file_ext"] == "fasta.gz"
+    ), f"Test precondition failed: input HDA was stored as {details['file_ext']!r}, not compressed 'fasta.gz'"
+
+
+@requires_tool_id("implicit_conversion")
+def test_implicit_gz_conversion_sync(required_tool: RequiredTool, target_history: TargetHistory):
+    # Upload a compressed fasta.gz HDA (kept compressed, ext=fasta.gz). The tool wants
+    # tabular, so this needs a double implicit conversion fasta.gz -> fasta -> tabular.
+    has_src_dict = target_history.with_dataset_for_test_file("1.fasta.gz", file_type="fasta.gz")
+    _assert_input_is_compressed_fasta_gz(target_history, has_src_dict)
+    inputs = {"input1": has_src_dict.src_dict}
+    output = required_tool.execute().with_inputs(inputs).assert_has_single_job.with_single_output
+    output.assert_contains("hg17")
+
+
+@requires_tool_id("implicit_conversion")
+def test_implicit_gz_conversion_async(required_tool: RequiredTool, target_history: TargetHistory):
+    # Same as the sync test above but submitted via the tool-request (async) API. This
+    # reproduces the bug where the async path runs the tool against the raw fasta.gz
+    # instead of the implicitly-converted (decompressed) dataset.
+    has_src_dict = target_history.with_dataset_for_test_file("1.fasta.gz", file_type="fasta.gz")
+    inputs = {"input1": has_src_dict.src_dict}
+    output = required_tool.execute().with_request(inputs).assert_has_single_job.with_single_output
+    output.assert_contains("hg17")
+
+
+@requires_tool_id("implicit_conversion")
+def test_implicit_gz_conversion_async_deferred(required_tool: RequiredTool, target_history: TargetHistory):
+    # Same conversion, but the fasta.gz input is a DEFERRED dataset (as the async
+    # tool-request test harness stages test data). It is materialized at job time; the
+    # question is whether the implicit fasta.gz -> fasta decompression still happens.
+    has_src_dict = target_history.with_deferred_dataset_for_test_file("1.fasta.gz", ext="fasta.gz")
+    inputs = {"input1": has_src_dict.src_dict}
+    output = required_tool.execute().with_request(inputs).assert_has_single_job.with_single_output
+    output.assert_contains("hg17")
+
+
 @requires_tool_id("collection_mixed_param")
 def test_combined_mapping_and_subcollection_mapping(
     target_history: TargetHistory, required_tool: RequiredTool, tool_input_format: DescribeToolInputs

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -5067,6 +5067,32 @@ class TargetHistory:
         )
         return HasSrcDict("hda", new_dataset)
 
+    def with_dataset_for_test_file(
+        self,
+        filename: str,
+        file_type: str,
+        named: Optional[str] = None,
+    ) -> "HasSrcDict":
+        """Upload a real test-data file with an explicit ``file_type`` (ext preserved).
+
+        Unlike ``with_dataset`` (which uploads inline text and lets the server
+        sniff/auto-decompress), this stages an actual file - e.g. a compressed
+        ``*.fasta.gz`` - and forces ``ext`` to ``file_type`` so it is kept in
+        that (possibly compressed) datatype. Useful for exercising job-time
+        implicit conversion of compressed inputs.
+        """
+        test_data_resolver = TestDataResolver()
+        kwd: dict[str, Any] = {"file_type": file_type, "wait": True}
+        if named is not None:
+            kwd["name"] = named
+        new_dataset = self._dataset_populator.new_dataset(
+            history_id=self._history_id,
+            content=open(test_data_resolver.get_filename(filename), "rb"),
+            assert_ok=True,
+            **kwd,
+        )
+        return HasSrcDict("hda", new_dataset)
+
     def with_deferred_dataset(
         self,
         uri: str,

--- a/lib/tool_shed/webapp/frontend/src/schema/schema.ts
+++ b/lib/tool_shed/webapp/frontend/src/schema/schema.ts
@@ -1814,6 +1814,8 @@ export interface components {
              * @constant
              */
             type: "data"
+            /** Url Default */
+            url_default?: string | null
         }
         /**
          * DescriptorType

--- a/test/functional/tools/async_ambiguous_unqualified_name.xml
+++ b/test/functional/tools/async_ambiguous_unqualified_name.xml
@@ -1,22 +1,20 @@
 <tool id="async_ambiguous_unqualified_name" name="async_ambiguous_unqualified_name" version="1.0.0">
-    <description>async regression: unqualified test param name present in multiple conditional whens is ambiguous</description>
+    <description>async regression: a duplicated identical unqualified test param is tolerated</description>
     <!--
-      Models gatk4 mutect2 test 3, which lists the conditional param
-      `reference_sequence` TWICE by its unqualified short name in the same test.
+      Models gatk4 mutect2 test 3 (and hisat2 test 5), which list a conditional
+      param by its unqualified short name TWICE in the same test with the SAME
+      value - a common test-authoring slip.
 
-      Sync (POST /api/tools): the duplicate unqualified entry is tolerated; the
-      discriminator resolves the branch and the job runs.
+      Sync (POST /api/tools): the duplicate identical entry is tolerated.
 
-      Async: _input_for() resolves the qualified path reference_source|ref_seq
-      down to the short name `ref_seq`, finds two matching test inputs, and aborts
-      the request build:
+      Async previously aborted the request build because _input_for() found two
+      matching test inputs for the short name (ref_seq):
         could not build request: Ambiguous unqualified test parameter name
         (ref_seq) for (reference_source|ref_seq)
 
-      NOTE: run this one with GALAXY_TEST_USE_LEGACY_TOOL_API=never. Because the
-      failure happens during request BUILDING (request is None), the "if_needed"
-      mode silently falls back to the legacy sync API and masks the bug; only
-      "never" forces the async path and surfaces it.
+      Now duplicate matches with equivalent values are de-duplicated like the
+      synchronous path; only genuinely conflicting values are reported ambiguous.
+      This tool therefore validates and runs green under both submission paths.
     -->
     <command><![CDATA[
 cat '$reference_source.ref_seq' > '$out_file1'

--- a/test/functional/tools/async_ambiguous_unqualified_name.xml
+++ b/test/functional/tools/async_ambiguous_unqualified_name.xml
@@ -1,0 +1,53 @@
+<tool id="async_ambiguous_unqualified_name" name="async_ambiguous_unqualified_name" version="1.0.0">
+    <description>async regression: unqualified test param name present in multiple conditional whens is ambiguous</description>
+    <!--
+      Models gatk4 mutect2 test 3, which lists the conditional param
+      `reference_sequence` TWICE by its unqualified short name in the same test.
+
+      Sync (POST /api/tools): the duplicate unqualified entry is tolerated; the
+      discriminator resolves the branch and the job runs.
+
+      Async: _input_for() resolves the qualified path reference_source|ref_seq
+      down to the short name `ref_seq`, finds two matching test inputs, and aborts
+      the request build:
+        could not build request: Ambiguous unqualified test parameter name
+        (ref_seq) for (reference_source|ref_seq)
+
+      NOTE: run this one with GALAXY_TEST_USE_LEGACY_TOOL_API=never. Because the
+      failure happens during request BUILDING (request is None), the "if_needed"
+      mode silently falls back to the legacy sync API and masks the bug; only
+      "never" forces the async path and surfaces it.
+    -->
+    <command><![CDATA[
+cat '$reference_source.ref_seq' > '$out_file1'
+    ]]></command>
+    <inputs>
+        <conditional name="reference_source">
+            <param name="reference_source_selector" type="select" label="Reference source">
+                <option value="history" selected="true">History</option>
+                <option value="cached">Cached</option>
+            </param>
+            <when value="history">
+                <param name="ref_seq" type="data" format="txt" label="Reference" />
+            </when>
+            <when value="cached">
+                <param name="ref_seq" type="data" format="txt" label="Reference" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="reference_source_selector" value="history" />
+            <param name="ref_seq" value="simple_line.txt" />
+            <param name="ref_seq" value="simple_line.txt" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_text text="line" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/async_conditional_no_default_nested_data.xml
+++ b/test/functional/tools/async_conditional_no_default_nested_data.xml
@@ -1,0 +1,54 @@
+<tool id="async_conditional_no_default_nested_data" name="async_conditional_no_default_nested_data" version="1.0.0" profile="22.01">
+    <description>async regression: omitted discriminator of a default-less conditional + nested required data param</description>
+    <!--
+      Models deseq2 select_data: a conditional whose discriminator (`how`) has NO
+      selected="true" default, containing a repeat with a REQUIRED data param.
+      The test omits `how` and supplies the repeat unqualified (legacy access).
+
+      Sync (POST /api/tools): an omitted discriminator selects the FIRST when
+      (datasets_per_level); the unqualified repeat is mapped into it; job runs.
+
+      Async (POST tool request, GALAXY_TEST_USE_LEGACY_TOOL_API=if_needed): the
+      missing discriminator resolves to a phantom "__absent__" branch, so the
+      nested required `countsFile` is reported missing and request validation
+      fails:
+        select_data.__absent__.rep_level.0.countsFile - Field required
+    -->
+    <command><![CDATA[
+#for $lvl in $select_data.rep_level:
+cat '$lvl.countsFile' >> '$out_file1' &&
+#end for
+echo "done" >> '$out_file1'
+    ]]></command>
+    <inputs>
+        <conditional name="select_data">
+            <param name="how" type="select" label="How">
+                <option value="datasets_per_level">Datasets per level</option>
+                <option value="group_tags">Group tags</option>
+            </param>
+            <when value="datasets_per_level">
+                <repeat name="rep_level" title="Level" min="1">
+                    <param name="countsFile" type="data" format="txt" label="Counts file" />
+                </repeat>
+            </when>
+            <when value="group_tags">
+                <param name="countsFile" type="data" format="txt" label="Counts file" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <repeat name="rep_level">
+                <param name="countsFile" value="simple_line.txt" />
+            </repeat>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_text text="done" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/async_nested_conditional_shared_discriminator.xml
+++ b/test/functional/tools/async_nested_conditional_shared_discriminator.xml
@@ -1,0 +1,69 @@
+<tool id="async_nested_conditional_shared_discriminator" name="async_nested_conditional_shared_discriminator" version="1.0.0" profile="22.01">
+    <description>async regression: omitted nested discriminator must not resolve to an enclosing conditional's discriminator of the same name</description>
+    <!--
+      Models dropletutils / humann, where an OUTER and an INNER conditional use a
+      discriminator with the same (generic) name and the test omits the inner one,
+      relying on its default when (as the synchronous API does).
+
+      Here both 'operation' and the nested 'method' use a discriminator named 'use'.
+      The test selects operation|use=outer_a and omits method|use (default inner_a).
+
+      Sync (POST /api/tools): the omitted inner discriminator selects its default
+      when (inner_a); the job runs.
+
+      Async (POST tool request) previously mis-resolved the omitted
+      operation|method|use to the enclosing operation|use (value "outer_a") via the
+      loose subsequence fallback, then rejected it because "outer_a" is not a valid
+      'method' when:
+        Invalid conditional test value (outer_a) for parameter (use)
+      The async builder now excludes a consumed ancestor discriminator from that
+      fallback, so the inner conditional correctly falls back to its default when.
+    -->
+    <command><![CDATA[
+echo '$operation.use' > '$out_file1' &&
+#if str($operation.use) == "outer_a":
+echo '$operation.method.use' >> '$out_file1'
+#end if
+    ]]></command>
+    <inputs>
+        <conditional name="operation">
+            <param name="use" type="select" label="Operation">
+                <option value="outer_a" selected="true">Outer A</option>
+                <option value="outer_b">Outer B</option>
+            </param>
+            <when value="outer_a">
+                <conditional name="method">
+                    <param name="use" type="select" label="Method">
+                        <option value="inner_a" selected="true">Inner A</option>
+                        <option value="inner_b">Inner B</option>
+                    </param>
+                    <when value="inner_a">
+                        <param name="threshold" type="integer" value="3000" label="Threshold" />
+                    </when>
+                    <when value="inner_b">
+                        <param name="lower" type="integer" value="100" label="Lower" />
+                    </when>
+                </conditional>
+            </when>
+            <when value="outer_b">
+                <param name="rank" type="integer" value="1" label="Rank" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <conditional name="operation">
+                <param name="use" value="outer_a" />
+            </conditional>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="outer_a" />
+                    <has_line line="inner_a" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/async_nested_conditional_shared_discriminator_bare.xml
+++ b/test/functional/tools/async_nested_conditional_shared_discriminator_bare.xml
@@ -1,0 +1,68 @@
+<tool id="async_nested_conditional_shared_discriminator_bare" name="async_nested_conditional_shared_discriminator_bare" version="1.0.0" profile="22.01">
+    <description>async regression: bare (unqualified) discriminator must not resolve to a nested conditional of the same name</description>
+    <!--
+      Sibling of async_nested_conditional_shared_discriminator.xml. Same shape - an
+      OUTER and an INNER conditional whose discriminators share the name 'use' - but
+      the test supplies the outer discriminator by its BARE short name (no enclosing
+      <conditional> wrapper), as legacy tests commonly do.
+
+      The qualified sibling routes the consumed-discriminator exclusion through the
+      elided-subsequence fallback (input 'operation|use' is a subsequence of
+      operation|method|use). This bare variant routes it through the bare short-name
+      fallback instead (input 'use'), covering the other matcher tier.
+
+      Sync (POST /api/tools): bare 'use'=outer_a selects the outer when; the omitted
+      inner discriminator selects its default when (inner_a); the job runs.
+
+      Async (POST tool request): without excluding the consumed ancestor discriminator,
+      the omitted operation|method|use greedily picks up the bare 'use' (value
+      "outer_a"), which is not a valid 'method' when ->
+        Invalid conditional test value (outer_a) for parameter (use)
+      Excluding it lets the inner conditional fall back to its default when.
+    -->
+    <command><![CDATA[
+echo '$operation.use' > '$out_file1' &&
+#if str($operation.use) == "outer_a":
+echo '$operation.method.use' >> '$out_file1'
+#end if
+    ]]></command>
+    <inputs>
+        <conditional name="operation">
+            <param name="use" type="select" label="Operation">
+                <option value="outer_a" selected="true">Outer A</option>
+                <option value="outer_b">Outer B</option>
+            </param>
+            <when value="outer_a">
+                <conditional name="method">
+                    <param name="use" type="select" label="Method">
+                        <option value="inner_a" selected="true">Inner A</option>
+                        <option value="inner_b">Inner B</option>
+                    </param>
+                    <when value="inner_a">
+                        <param name="threshold" type="integer" value="3000" label="Threshold" />
+                    </when>
+                    <when value="inner_b">
+                        <param name="lower" type="integer" value="100" label="Lower" />
+                    </when>
+                </conditional>
+            </when>
+            <when value="outer_b">
+                <param name="rank" type="integer" value="1" label="Rank" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="use" value="outer_a" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="outer_a" />
+                    <has_line line="inner_a" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/collection_paired_conditional_structured_like.xml
+++ b/test/functional/tools/collection_paired_conditional_structured_like.xml
@@ -24,12 +24,15 @@
   </outputs>
   <tests>
     <test>
-      <param name="input1">
-        <collection type="paired">
-          <element name="forward" value="simple_line.txt" ftype="txt" />
-          <element name="reverse" value="simple_line_alternative.txt" ftype="txt" />
-        </collection>
-      </param>
+      <conditional name="cond">
+        <param name="cond_param" value="paired"/>
+        <param name="input1">
+          <collection type="paired">
+            <element name="forward" value="simple_line.txt" ftype="txt" />
+            <element name="reverse" value="simple_line_alternative.txt" ftype="txt" />
+          </collection>
+        </param>
+      </conditional>
       <output_collection name="list_output" type="paired">
           <element name="forward" file="simple_line.txt" ftype="txt"/>
           <element name="reverse" file="simple_line_alternative.txt" ftype="txt"/>

--- a/test/functional/tools/data_manager.xml
+++ b/test/functional/tools/data_manager.xml
@@ -1,10 +1,10 @@
 <tool id="data_manager" name="Test Data Manager" tool_type="manage_data" version="0.0.1">
     <configfiles>
-        <configfile name="static_test_data">{"data_tables": {"testbeta": [{"value": "newvalue", "path": "newvalue.txt"}]}}</configfile>
+        <configfile name="static_test_data">{"data_tables": {"testbeta": [{"value": "asyncvalue", "path": "asyncvalue.txt"}]}}</configfile>
     </configfiles>
     <command detect_errors="exit_code">
         mkdir $out_file.files_path ;
-        echo "A new value" > '$out_file.files_path/newvalue.txt';
+        echo "A new value" > '$out_file.files_path/asyncvalue.txt';
         cp '$static_test_data' '$out_file';
         exit $exit_code
     </command>

--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -104,7 +104,7 @@ with open("output", "w") as f:
             <param name="test_case" value="1" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
-            <param name="booltest2" value="booltrue" />
+            <param name="booltest2" value="true" />
             <param name="inttest" value="12456" />
             <param name="floattest" value="6.789" />
             <repeat name="repeat">
@@ -126,13 +126,15 @@ with open("output", "w") as f:
             <param name="test_case" value="2" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
-            <param name="booltest2" value="boolfalse" />
+            <param name="booltest2" value="false" />
             <param name="data_input" value="simple_line.txt" />
             <param name="optional_select" value="a"/>
             <param name="optional_multiple_select" value="a,b"/>
             <!-- Testing null integers -->
             <!-- <param name="inttest" value="12456" /> -->
-            <param name="r" value="000000" />
+            <repeat name="repeat">
+                <param name="r" value="000000"/>
+            </repeat>
             <conditional name="cond">
                 <param name="cond_test" value="second" />
             </conditional>

--- a/test/functional/tools/inputs_as_json_profile.xml
+++ b/test/functional/tools/inputs_as_json_profile.xml
@@ -107,7 +107,7 @@ with open("output", "w") as f:
             <param name="test_case" value="1" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
-            <param name="booltest2" value="booltrue" />
+            <param name="booltest2" value="true" />
             <param name="inttest" value="12456" />
             <param name="floattest" value="6.789" />
             <repeat name="repeat">
@@ -129,13 +129,15 @@ with open("output", "w") as f:
             <param name="test_case" value="2" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
-            <param name="booltest2" value="boolfalse" />
+            <param name="booltest2" value="false" />
             <param name="data_input" value="simple_line.txt" />
             <param name="optional_select" value="a"/>
             <param name="optional_multiple_select" value="a,b"/>
             <!-- Testing null integers -->
             <!-- <param name="inttest" value="12456" /> -->
-            <param name="r" value="000000" />
+            <repeat name="repeat">
+                <param name="r" value="000000"/>
+            </repeat>
             <conditional name="cond">
                 <param name="cond_test" value="second" />
             </conditional>

--- a/test/functional/tools/inputs_as_json_with_paths.xml
+++ b/test/functional/tools/inputs_as_json_with_paths.xml
@@ -103,7 +103,7 @@ with open("output", "w") as f:
             <param name="test_case" value="1" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
-            <param name="booltest2" value="booltrue" />
+            <param name="booltest2" value="true" />
             <param name="inttest" value="12456" />
             <param name="floattest" value="6.789" />
             <repeat name="repeat">
@@ -125,12 +125,14 @@ with open("output", "w") as f:
             <param name="test_case" value="2" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
-            <param name="booltest2" value="boolfalse" />
+            <param name="booltest2" value="false" />
             <param name="data_input" value="simple_line.txt" />
             <param name="multiple_data_input" value="simple_line.txt,simple_line_alternative.txt" />
             <!-- Testing null integers -->
             <!-- <param name="inttest" value="12456" /> -->
-            <param name="r" value="000000" />
+            <repeat name="repeat">
+                <param name="r" value="000000"/>
+            </repeat>
             <conditional name="cond">
                 <param name="cond_test" value="second" />
             </conditional>

--- a/test/functional/tools/min_repeat.xml
+++ b/test/functional/tools/min_repeat.xml
@@ -17,9 +17,15 @@
     </outputs>
     <tests>
         <test>
-            <param name="input" value="simple_line.txt"/>
-            <param name="input" value="simple_line.txt"/>
-            <param name="input2" value="simple_line_alternative.txt"/>
+            <repeat name="queries">
+                <param name="input" value="simple_line.txt"/>
+            </repeat>
+            <repeat name="queries">
+                <param name="input" value="simple_line.txt"/>
+            </repeat>
+            <repeat name="queries2">
+                <param name="input2" value="simple_line_alternative.txt"/>
+            </repeat>
             <output name="out_file1" file="simple_line_x2.txt"/>
             <output name="out_file2" file="simple_line_alternative.txt"/>
         </test>

--- a/test/functional/tools/output_action_change_format.xml
+++ b/test/functional/tools/output_action_change_format.xml
@@ -42,9 +42,13 @@
     </outputs>
     <tests>
         <test>
-            <param name="dispatch" value="dont" />
-            <param name="input" value="simple_line.txt" />
-            <param name="abool" value="true"/>
+            <conditional name="input_cond">
+                <param name="dispatch" value="dont" />
+                <param name="input" value="simple_line.txt" />
+            </conditional>
+            <section name="asection">
+                <param name="abool" value="true"/>
+            </section>
             <output name="out1" ftype="data">
                 <assert_contents>
                     <has_line line="1&#009;2" />
@@ -53,9 +57,13 @@
             </output>
         </test>
         <test>
-            <param name="dispatch" value="do" />
-            <param name="input" value="simple_line.txt" />
-            <param name="abool" value="false"/>
+            <conditional name="input_cond">
+                <param name="dispatch" value="do" />
+                <param name="input" value="simple_line.txt" />
+            </conditional>
+            <section name="asection">
+                <param name="abool" value="false"/>
+            </section>
             <output name="out1" ftype="txt">
                 <assert_contents>
                     <has_line line="1&#009;2" />

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -122,6 +122,7 @@
   <tool file="output_filter.xml" />
   <tool file="async_conditional_no_default_nested_data.xml" />
   <tool file="async_ambiguous_unqualified_name.xml" />
+  <tool file="async_nested_conditional_shared_discriminator.xml" />
   <tool file="output_empty_work_dir.xml" />
   <tool file="output_filter_with_input.xml" />
   <tool file="output_filter_with_input_optional.xml" />

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -123,6 +123,7 @@
   <tool file="async_conditional_no_default_nested_data.xml" />
   <tool file="async_ambiguous_unqualified_name.xml" />
   <tool file="async_nested_conditional_shared_discriminator.xml" />
+  <tool file="async_nested_conditional_shared_discriminator_bare.xml" />
   <tool file="output_empty_work_dir.xml" />
   <tool file="output_filter_with_input.xml" />
   <tool file="output_filter_with_input_optional.xml" />

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -120,6 +120,8 @@
   <tool file="output_format_collection.xml" />
   <tool file="format_source_in_conditional.xml" />
   <tool file="output_filter.xml" />
+  <tool file="async_conditional_no_default_nested_data.xml" />
+  <tool file="async_ambiguous_unqualified_name.xml" />
   <tool file="output_empty_work_dir.xml" />
   <tool file="output_filter_with_input.xml" />
   <tool file="output_filter_with_input_optional.xml" />

--- a/test/functional/tools/section.xml
+++ b/test/functional/tools/section.xml
@@ -16,8 +16,12 @@ echo $float.floattest >> '$out_file1'
     </outputs>
     <tests>
         <test>
-            <param name="inttest" value="12456" />
-            <param name="floattest" value="6.789" />
+            <section name="int">
+                <param name="inttest" value="12456" />
+            </section>
+            <section name="float">
+                <param name="floattest" value="6.789" />
+            </section>
             <output name="out_file1">
                 <assert_contents>
                     <has_line line="12456" />

--- a/test/functional/tools/top_level_data.xml
+++ b/test/functional/tools/top_level_data.xml
@@ -25,8 +25,11 @@ echo '${library.f2}' >> '$out2' ## cannot use just f2 here
     </outputs>
     <tests>
         <test>
-            <param name="f1" value="simple_line.txt" />
-            <param name="f2" value="This is a line of text." />
+            <conditional name="library">
+                <param name="type" value="no"/>
+                <param name="f1" value="simple_line.txt" />
+                <param name="f2" value="This is a line of text." />
+            </conditional>
             <output name="out1" file="simple_line.txt" />
             <output name="out2" file="simple_line.txt" />
         </test>

--- a/test/integration/test_tool_data_bundles.py
+++ b/test/integration/test_tool_data_bundles.py
@@ -33,7 +33,7 @@ class TestDataBundlesIntegration(BaseSwiftObjectStoreIntegrationTestCase, DataMa
             history_id, to_ext="data_manager_json", type="bytes"
         )
         temp_directory = decompress_bytes_to_directory(content)
-        assert os.path.exists(os.path.join(temp_directory, "newvalue.txt"))
+        assert os.path.exists(os.path.join(temp_directory, "asyncvalue.txt"))
         uri = f"file://{os.path.normpath(temp_directory)}"
         data = {
             "source": {

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1139,6 +1139,8 @@ gx_float:
     - parameter: null
     - parameter: 'foobar'
     - parameter: {__class__: 'ConnectedValue2'}
+  _json_schema_valid_skip:
+    test_case_xml_valid: "Galaxy infinity sentinels (__Infinity__, __-Infinity__) are strings not expressible as JSON Schema numbers"
 
 
 gx_float_optional:
@@ -1212,6 +1214,8 @@ gx_float_optional:
   workflow_step_linked_invalid:
     - parameter: 'foobar'
     - parameter: {__class__: 'ConnectedValue2'}
+  _json_schema_valid_skip:
+    test_case_xml_valid: "Galaxy infinity sentinels (__Infinity__, __-Infinity__) are strings not expressible as JSON Schema numbers"
 
 gx_float_validation_range:
   request_valid:

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1117,6 +1117,8 @@ gx_float:
   test_case_xml_valid:
     - parameter: 5
     - parameter: 5.0
+    - parameter: "__Infinity__"
+    - parameter: "__-Infinity__"
     - {}
   test_case_xml_invalid:
     - parameter: null
@@ -1188,6 +1190,8 @@ gx_float_optional:
   test_case_xml_valid:
     - parameter: 5
     - parameter: 5.0
+    - parameter: "__Infinity__"
+    - parameter: "__-Infinity__"
     - {}
     - parameter: null
   test_case_xml_invalid:

--- a/test/unit/tool_util/test_parameter_convert.py
+++ b/test/unit/tool_util/test_parameter_convert.py
@@ -24,6 +24,14 @@ from galaxy.tool_util.parameters import (
     strictify,
 )
 from galaxy.tool_util.parser.util import parse_profile_version
+from galaxy.tool_util_models.parameters import (
+    BooleanParameterModel,
+    ConditionalParameterModel,
+    ConditionalWhen,
+    DataParameterModel,
+    SectionParameterModel,
+    ToolParameterBundleModel,
+)
 from .test_parameter_test_cases import tool_source_for
 
 EXAMPLE_ID_1_ENCODED = "123456789abcde"
@@ -180,6 +188,81 @@ def test_dereference():
     dereferenced_state.validate(bundle)
 
 
+def test_dereference_url_default_after_default_fill():
+    bundle = ToolParameterBundleModel(
+        parameters=[
+            DataParameterModel(
+                type="data",
+                name="parameter",
+                url_default="https://example.com/1.bed",
+            )
+        ]
+    )
+
+    dereferenced_state = _strict_async_decode_default_fill_and_dereference({}, bundle)
+
+    assert dereferenced_state.input_state == {"parameter": {"src": "hda", "id": EXAMPLE_ID_1}}
+
+
+def test_dereference_section_url_default_after_default_fill():
+    bundle = ToolParameterBundleModel(
+        parameters=[
+            SectionParameterModel(
+                type="section",
+                name="section_parameter",
+                parameters=[
+                    DataParameterModel(
+                        type="data",
+                        name="data_parameter",
+                        url_default="https://example.com/1.bed",
+                    )
+                ],
+            )
+        ]
+    )
+
+    dereferenced_state = _strict_async_decode_default_fill_and_dereference({}, bundle)
+
+    assert dereferenced_state.input_state == {
+        "section_parameter": {"data_parameter": {"src": "hda", "id": EXAMPLE_ID_1}}
+    }
+
+
+def test_dereference_conditional_url_default_after_default_fill():
+    bundle = ToolParameterBundleModel(
+        parameters=[
+            ConditionalParameterModel(
+                type="conditional",
+                name="conditional_parameter",
+                test_parameter=BooleanParameterModel(type="boolean", name="test_parameter"),
+                whens=[
+                    ConditionalWhen(
+                        discriminator=False,
+                        is_default_when=True,
+                        parameters=[
+                            DataParameterModel(
+                                type="data",
+                                name="data_parameter",
+                                url_default="https://example.com/1.bed",
+                            )
+                        ],
+                    ),
+                    ConditionalWhen(discriminator=True, is_default_when=False, parameters=[]),
+                ],
+            )
+        ]
+    )
+
+    dereferenced_state = _strict_async_decode_default_fill_and_dereference({}, bundle)
+
+    assert dereferenced_state.input_state == {
+        "conditional_parameter": {
+            "test_parameter": False,
+            "data_parameter": {"src": "hda", "id": EXAMPLE_ID_1},
+        }
+    }
+
+
 def test_fill_defaults():
     with_defaults = fill_state_for({}, "parameters/gx_int")
     assert with_defaults["parameter"] == 1
@@ -306,6 +389,16 @@ def _fake_decode(input: str) -> int:
 
 def _fake_encode(input: int) -> str:
     return ID_MAP[input]
+
+
+def _strict_async_decode_default_fill_and_dereference(
+    tool_state: Dict[str, Any], bundle: ToolParameterBundleModel
+) -> RequestInternalDereferencedToolState:
+    request_state = RequestToolState(tool_state)
+    request_state.validate(bundle)
+    request_internal_state = decode(request_state, bundle, _fake_decode)
+    fill_static_defaults(request_internal_state.input_state, bundle, 24.0, partial=True, url_data_defaults=True)
+    return dereference(request_internal_state, bundle, _fake_dereference, _fake_collection_deference)
 
 
 def fill_state_for(tool_state: Dict[str, Any], tool_path: str, partial: bool = False) -> Dict[str, Any]:

--- a/test/unit/tool_util/test_parameter_convert.py
+++ b/test/unit/tool_util/test_parameter_convert.py
@@ -188,7 +188,7 @@ def test_dereference():
     dereferenced_state.validate(bundle)
 
 
-def test_dereference_url_default_after_default_fill():
+def test_dereference_resolves_url_default():
     bundle = ToolParameterBundleModel(
         parameters=[
             DataParameterModel(
@@ -199,12 +199,33 @@ def test_dereference_url_default_after_default_fill():
         ]
     )
 
-    dereferenced_state = _strict_async_decode_default_fill_and_dereference({}, bundle)
+    # The data input is absent from the request - dereference materializes the url_default.
+    dereferenced_state = _strict_async_decode_and_dereference({}, bundle)
 
     assert dereferenced_state.input_state == {"parameter": {"src": "hda", "id": EXAMPLE_ID_1}}
 
 
-def test_dereference_section_url_default_after_default_fill():
+def test_request_internal_records_absent_url_default():
+    bundle = ToolParameterBundleModel(
+        parameters=[
+            DataParameterModel(
+                type="data",
+                name="parameter",
+                url_default="https://example.com/1.bed",
+            )
+        ]
+    )
+
+    # The persisted request_internal state must record the absent input as absent - the
+    # url_default is only resolved later, at dereference time (above), never baked in here.
+    request_state = RequestToolState({})
+    request_state.validate(bundle)
+    request_internal_state = decode(request_state, bundle, _fake_decode)
+    request_internal_state.validate(bundle)
+    assert "parameter" not in request_internal_state.input_state
+
+
+def test_dereference_section_url_default():
     bundle = ToolParameterBundleModel(
         parameters=[
             SectionParameterModel(
@@ -221,14 +242,14 @@ def test_dereference_section_url_default_after_default_fill():
         ]
     )
 
-    dereferenced_state = _strict_async_decode_default_fill_and_dereference({}, bundle)
+    dereferenced_state = _strict_async_decode_and_dereference({}, bundle)
 
     assert dereferenced_state.input_state == {
         "section_parameter": {"data_parameter": {"src": "hda", "id": EXAMPLE_ID_1}}
     }
 
 
-def test_dereference_conditional_url_default_after_default_fill():
+def test_dereference_conditional_url_default():
     bundle = ToolParameterBundleModel(
         parameters=[
             ConditionalParameterModel(
@@ -253,11 +274,12 @@ def test_dereference_conditional_url_default_after_default_fill():
         ]
     )
 
-    dereferenced_state = _strict_async_decode_default_fill_and_dereference({}, bundle)
+    dereferenced_state = _strict_async_decode_and_dereference({}, bundle)
 
+    # The conditional's default (absent) when is selected and its url_default data input is
+    # materialized; the boolean discriminator is not a url default so it stays unfilled here.
     assert dereferenced_state.input_state == {
         "conditional_parameter": {
-            "test_parameter": False,
             "data_parameter": {"src": "hda", "id": EXAMPLE_ID_1},
         }
     }
@@ -391,13 +413,12 @@ def _fake_encode(input: int) -> str:
     return ID_MAP[input]
 
 
-def _strict_async_decode_default_fill_and_dereference(
+def _strict_async_decode_and_dereference(
     tool_state: Dict[str, Any], bundle: ToolParameterBundleModel
 ) -> RequestInternalDereferencedToolState:
     request_state = RequestToolState(tool_state)
     request_state.validate(bundle)
     request_internal_state = decode(request_state, bundle, _fake_decode)
-    fill_static_defaults(request_internal_state.input_state, bundle, 24.0, partial=True, url_data_defaults=True)
     return dereference(request_internal_state, bundle, _fake_dereference, _fake_collection_deference)
 
 

--- a/test/unit/tool_util/test_parameter_convert.py
+++ b/test/unit/tool_util/test_parameter_convert.py
@@ -397,8 +397,18 @@ def strictify_for(tool_state: Dict[str, Any], tool_path: str) -> Dict[str, Any]:
     return strictify(relaxed_state, bundle).input_state
 
 
+# Maps each url-src / url_default fixture URL to the HDA id a real dereference would mint.
+# Keying on the URL (rather than returning a constant) makes the dereference tests assert the
+# *configured* URL actually reached the dereference boundary - an unexpected/empty URL raises
+# KeyError instead of silently passing.
+URL_ID_MAP: Dict[str, int] = {
+    "https://example.com/1.bed": EXAMPLE_ID_1,
+    "gxfiles://mystorage/1.bed": EXAMPLE_ID_2,
+}
+
+
 def _fake_dereference(input: DataRequestUri) -> DataRequestInternalHda:
-    return DataRequestInternalHda(id=EXAMPLE_ID_1, src="hda")
+    return DataRequestInternalHda(id=URL_ID_MAP[input.url], src="hda")
 
 
 def _fake_collection_deference(input: DataRequestCollectionUri) -> DataRequestInternalHdca:

--- a/test/unit/tool_util/test_parameter_specification.py
+++ b/test/unit/tool_util/test_parameter_specification.py
@@ -1,3 +1,4 @@
+import json
 from functools import partial
 from typing import (
     Callable,
@@ -37,6 +38,12 @@ from galaxy.tool_util.unittest_utils.parameters import (
     parameter_bundle_for_file,
     parameter_bundle_for_framework_tool,
 )
+from galaxy.tool_util_models.parameters import (
+    _INFINITY_SENTINEL,
+    _NEG_INFINITY_SENTINEL,
+    FloatParameterModel,
+)
+from galaxy.util.json import safe_dumps
 from galaxy.util.resources import resource_string
 
 
@@ -265,6 +272,45 @@ def test_encode_gx_data():
     request_tool_state = encode(request_internal_tool_state, input_bundle, encode_val)
     assert request_tool_state.input_state["parameter"]["id"] == "abcdabcd"
     assert request_tool_state.input_state["parameter"]["src"] == "hda"
+
+
+def test_float_parameter_model_infinity_sentinel_roundtrip():
+    """Regression test: FloatParameterModel must survive a safe_dumps/json.loads roundtrip.
+
+    Galaxy's safe_dumps() serialises float('inf') as '__Infinity__' and
+    float('-inf') as '__-Infinity__' to produce valid JSON.  When the tool
+    test API (GET /api/tools/{id}/test_data) returns request_schema.parameters
+    and any float parameter carries a default of inf (e.g. meme -evt), the
+    resulting JSON contains that sentinel.  Planemo then calls
+    ToolParameterBundleModel(parameters=<deserialized dicts>) which must not
+    fail even though Pydantic sees a string rather than a float.
+    """
+    for value, expected in [
+        (float("inf"), float("inf")),
+        (float("-inf"), float("-inf")),
+    ]:
+        # 1. Build the model definition
+        m = FloatParameterModel(type="float", name="test", value=value)
+        # 2. Dump to a plain dict (contains Python float inf/-inf)
+        d = m.model_dump()
+        assert d["value"] == value
+
+        # 3. Serialize through Galaxy's JSON encoder — inf becomes a sentinel string
+        galaxy_json = safe_dumps([d])
+        sentinel = _INFINITY_SENTINEL if value == float("inf") else _NEG_INFINITY_SENTINEL
+        assert sentinel in galaxy_json
+
+        # 4. Deserialize: sentinel is now a plain string in the dict
+        dicts = json.loads(galaxy_json)
+        assert dicts[0]["value"] == sentinel
+
+        # 5. Re-parse via ToolParameterBundleModel — this must not raise
+        bundle = ToolParameterBundleModel(parameters=dicts)
+
+        # 6. The parsed model should carry the correct Python float
+        parsed_param = bundle.parameters[0]
+        assert isinstance(parsed_param, FloatParameterModel)
+        assert parsed_param.value == expected
 
 
 if __name__ == "__main__":

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -7,6 +7,8 @@ from typing import (
     Tuple,
 )
 
+import pytest
+
 from galaxy.tool_util.model_factory import parse_tool
 from galaxy.tool_util.parameters import (
     DataCollectionRequest,
@@ -58,11 +60,6 @@ TOOLS_THAT_USE_SELECT_BY_VALUE = [
 TOOLS_THAT_ARE_OUTSTANDING_ISSUES = [
     "gx_conditional_boolean_optional.xml",
     "gx_conditional_boolean_discriminate_on_string_value.xml",
-    # Intentionally reproduces the async "ambiguous unqualified test parameter name"
-    # regression (duplicate unqualified param in a test) - see
-    # test/functional/tools/async_ambiguous_unqualified_name.xml. Remove once
-    # _input_for ambiguity is resolved / surfaced as a TestCaseValidationError.
-    "async_ambiguous_unqualified_name.xml",
 ]
 
 TEST_TOOL_THAT_DO_NOT_VALIDATE = (
@@ -495,6 +492,55 @@ def test_legacy_unqualified_repeat_inside_conditional_is_resolved():
         (["select_data", "rep_factorName", 0, "rep_factorLevel", 0, "countsFile", "path"], "simple_line.txt"),
     ]
     dict_verify_each(tool_state.input_state, expectations)
+
+
+def test_duplicate_identical_unqualified_test_param_is_tolerated():
+    # A test may list the same unqualified conditional param twice (a common authoring
+    # slip). When the duplicate values are identical it is tolerated - matching the
+    # synchronous tool API - rather than aborting the request build. Regression for the
+    # gatk4 mutect2 / hisat2 async failure:
+    #   could not build request: Ambiguous unqualified test parameter name (...)
+    tool_template = """
+<tool id="duplicate_unqualified" name="duplicate_unqualified" version="1.0.0" profile="22.01">
+    <command>echo</command>
+    <inputs>
+        <conditional name="reference_source">
+            <param name="selector" type="select">
+                <option value="history" selected="true">History</option>
+                <option value="cached">Cached</option>
+            </param>
+            <when value="history">
+                <param name="ref" type="text" value="" />
+            </when>
+            <when value="cached">
+                <param name="ref" type="text" value="" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs />
+    <tests>
+        <test>
+            <param name="selector" value="history" />
+            <param name="ref" value="{first}" />
+            <param name="ref" value="{second}" />
+        </test>
+    </tests>
+</tool>
+        """
+
+    # identical duplicate -> tolerated
+    tool_source = raw_xml_tool_source(tool_template.format(first="hg38", second="hg38"))
+    parsed_tool = parse_tool(tool_source)
+    test_case = tool_source.parse_tests_to_dict()["tests"][0]
+    tool_state = case_state(test_case, parsed_tool.inputs, tool_source.parse_profile()).tool_state
+    dict_verify_each(tool_state.input_state, [(["reference_source", "ref"], "hg38")])
+
+    # conflicting duplicate -> still ambiguous
+    tool_source = raw_xml_tool_source(tool_template.format(first="hg38", second="hg19"))
+    parsed_tool = parse_tool(tool_source)
+    test_case = tool_source.parse_tests_to_dict()["tests"][0]
+    with pytest.raises(Exception, match="[Aa]mbiguous"):
+        case_state(test_case, parsed_tool.inputs, tool_source.parse_profile())
 
 
 def test_legacy_boolean_test_values_are_coerced_to_booleans():

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -764,3 +764,31 @@ def mock_adapt_collections(input: JsonTestCollectionDefDict) -> DataCollectionRe
 
 
 tool_source_for = functional_test_tool_source
+
+
+def test_build_xml_tool_source_preserves_validator_whitespace():
+    """Regex validators may rely on significant leading/trailing whitespace (e.g. a leading
+    `" *"` meaning "optional spaces"). Parsing a tool from its raw string source (as the async
+    tool-request path does when re-parsing the stored source) must preserve it, exactly like
+    parsing from a file does - otherwise " *(\\d+, *)*\\d+ *$" becomes the invalid "*(\\d+..."
+    and statically validating the request 500s.
+    """
+    from galaxy.tool_util.parser.factory import build_xml_tool_source
+
+    tool_xml = (
+        '<tool id="ws_validator" name="ws_validator" version="1.0" profile="24.2">'
+        "<command>echo</command><inputs>"
+        '<param name="ints" type="text" value="1, 2, 3">'
+        '<validator type="regex" message="comma separated ints"> *(\\d+, *)*\\d+ *$</validator>'
+        "</param></inputs><outputs/></tool>"
+    )
+    tool_source = build_xml_tool_source(tool_xml)
+    bundle = input_models_for_tool_source(tool_source)
+    regex_validators = [
+        v
+        for p in bundle.parameters
+        for v in (getattr(p, "validators", None) or [])
+        if getattr(v, "type", "") == "regex"
+    ]
+    assert regex_validators, "expected a regex validator in the parsed model"
+    assert regex_validators[0].expression == " *(\\d+, *)*\\d+ *$"

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -41,23 +41,14 @@ from .util import dict_verify_each
 TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS = [
     "boolean_conditional.xml",
     "simple_constructs.xml",
-    "section.xml",
-    "collection_paired_conditional_structured_like.xml",
-    "output_action_change_format.xml",
-    "top_level_data.xml",
     "disambiguate_cond.xml",
     "multi_repeats.xml",
     "implicit_default_conds.xml",
-    "min_repeat.xml",
 ]
 
 # tools that use truevalue/falsevalue in parameter setting, I think we're going to
 # forbid this for a future tool profile version. Potential ambigouity could result.
-TOOLS_THAT_USE_TRUE_FALSE_VALUE_BOOLEAN_SPECIFICATION = [
-    "inputs_as_json_profile.xml",
-    "inputs_as_json_with_paths.xml",
-    "inputs_as_json.xml",
-]
+TOOLS_THAT_USE_TRUE_FALSE_VALUE_BOOLEAN_SPECIFICATION: List[str] = []
 
 TOOLS_THAT_USE_SELECT_BY_VALUE = [
     "multi_select.xml",

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -497,6 +497,42 @@ def test_legacy_unqualified_repeat_inside_conditional_is_resolved():
     dict_verify_each(tool_state.input_state, expectations)
 
 
+def test_legacy_boolean_test_values_are_coerced_to_booleans():
+    # The test-case builder must submit a real boolean for a boolean param. A test may
+    # supply the param's truevalue/falsevalue command-line string, a plain true/false,
+    # or (for legacy tools) a non-boolean placeholder such as "-" that the synchronous
+    # tool API coerces via string_as_bool. Regression for the quast async failure:
+    #   advanced.skip_unaligned_mis_contigs - Input should be a valid boolean, input_value='-'
+    tool_template = """
+<tool id="boolean_legacy_values" name="boolean_legacy_values" version="1.0.0" profile="{profile}">
+    <command>echo</command>
+    <inputs>
+        <param name="flag" type="boolean" truevalue="" falsevalue="--skip" checked="true" />
+    </inputs>
+    <outputs />
+    <tests>
+        <test><param name="flag" value="{value}" /></test>
+    </tests>
+</tool>
+        """
+
+    def flag_value_for(value: str, profile: str = "23.02"):
+        tool_source = raw_xml_tool_source(tool_template.format(value=value, profile=profile))
+        parsed_tool = parse_tool(tool_source)
+        test_case = tool_source.parse_tests_to_dict()["tests"][0]
+        tool_state = case_state(test_case, parsed_tool.inputs, tool_source.parse_profile()).tool_state
+        return tool_state.input_state["flag"]
+
+    # plain booleans
+    assert flag_value_for("true") is True
+    assert flag_value_for("false") is False
+    # truevalue / falsevalue command-line strings mapped back to booleans
+    assert flag_value_for("") is True
+    assert flag_value_for("--skip") is False
+    # legacy non-boolean placeholder coerced to False (matches synchronous string_as_bool)
+    assert flag_value_for("-") is False
+
+
 def test_legacy_unqualified_conditional_discriminator_in_section_is_resolved():
     # A conditional inside a section may have its name elided in the test, with the
     # discriminator given directly under the section (e.g. <section name="adv">

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -494,6 +494,58 @@ def test_legacy_unqualified_repeat_inside_conditional_is_resolved():
     dict_verify_each(tool_state.input_state, expectations)
 
 
+def test_omitted_conditional_discriminator_inferred_from_provided_params():
+    # When a conditional's discriminator is omitted, the active when must be inferred from
+    # the parameters the test actually supplies (matching the synchronous tool API) rather
+    # than defaulting to the selected="true" branch. Regression for the quast async failure
+    # where `inputs` is a repeat in the non-default when but a data param in the default:
+    #   mode.co.in.__absent__.inputs.0.class - ...
+    tool_source = raw_xml_tool_source("""
+<tool id="infer_when" name="infer_when" version="1.0.0" profile="22.01">
+    <command>echo</command>
+    <inputs>
+        <conditional name="in">
+            <param name="custom" type="select">
+                <option value="true">Custom names</option>
+                <option value="false" selected="true">Dataset names</option>
+            </param>
+            <when value="true">
+                <repeat name="inputs" min="1">
+                    <param name="input" type="data" format="txt" />
+                    <param name="labels" type="text" value="" />
+                </repeat>
+            </when>
+            <when value="false">
+                <param name="inputs" type="data" format="txt" multiple="true" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs />
+    <tests>
+        <test>
+            <conditional name="in">
+                <repeat name="inputs">
+                    <param name="input" value="simple_line.txt" />
+                    <param name="labels" value="c1" />
+                </repeat>
+            </conditional>
+        </test>
+    </tests>
+</tool>
+        """)
+    parsed_tool = parse_tool(tool_source)
+    test_case = tool_source.parse_tests_to_dict()["tests"][0]
+
+    tool_state = case_state(test_case, parsed_tool.inputs, tool_source.parse_profile()).tool_state
+
+    expectations = [
+        (["in", "custom"], "true"),
+        (["in", "inputs", 0, "input", "path"], "simple_line.txt"),
+        (["in", "inputs", 0, "labels"], "c1"),
+    ]
+    dict_verify_each(tool_state.input_state, expectations)
+
+
 def test_duplicate_identical_unqualified_test_param_is_tolerated():
     # A test may list the same unqualified conditional param twice (a common authoring
     # slip). When the duplicate values are identical it is tolerated - matching the

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -34,7 +34,10 @@ from galaxy.tool_util_models.tool_source import (
     JsonTestCollectionDefDict,
     JsonTestDatasetDefDict,
 )
-from galaxy.util.permutations import is_in_state
+from galaxy.util.permutations import (
+    is_in_state,
+    state_set_value,
+)
 from .util import dict_verify_each
 
 # legacy tools allows specifying parameter and repeat parameters without
@@ -267,11 +270,26 @@ def test_is_in_state_supports_nested_keys():
     assert not is_in_state(state, "section|missing", nested=True)
 
 
+def test_state_set_value_creates_nested_parent_state():
+    state: dict[str, Any] = {}
+
+    state_set_value(state, "p1|p1use", True, nested=True)
+    state_set_value(state, "files_0|file", "dataset", nested=True)
+
+    assert state == {
+        "p1": {
+            "p1use": True,
+        },
+        "files": [
+            {
+                "file": "dataset",
+            }
+        ],
+    }
 
 
 def test_test_case_request_conversion_preserves_non_default_select_and_booleans():
-    tool_source = raw_xml_tool_source(
-        """
+    tool_source = raw_xml_tool_source("""
 <tool id="async_request_regression" name="async_request_regression" version="1.0.0">
     <command>echo</command>
     <inputs>
@@ -300,8 +318,7 @@ def test_test_case_request_conversion_preserves_non_default_select_and_booleans(
         </test>
     </tests>
 </tool>
-        """
-    )
+        """)
     parameters = input_models_for_tool_source(tool_source)
     parsed_tool = parse_tool(tool_source)
     test_case = tool_source.parse_tests_to_dict()["tests"][0]
@@ -319,8 +336,7 @@ def test_test_case_request_conversion_preserves_non_default_select_and_booleans(
 
 
 def test_nested_conditional_duplicate_short_names_are_distinct_when_qualified():
-    tool_source = raw_xml_tool_source(
-        """
+    tool_source = raw_xml_tool_source("""
 <tool id="duplicate_use_regression" name="duplicate_use_regression" version="1.0.0">
     <command>echo</command>
     <inputs>
@@ -357,8 +373,7 @@ def test_nested_conditional_duplicate_short_names_are_distinct_when_qualified():
         </test>
     </tests>
 </tool>
-        """
-    )
+        """)
     parsed_tool = parse_tool(tool_source)
     test_case = tool_source.parse_tests_to_dict()["tests"][0]
 

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -58,6 +58,11 @@ TOOLS_THAT_USE_SELECT_BY_VALUE = [
 TOOLS_THAT_ARE_OUTSTANDING_ISSUES = [
     "gx_conditional_boolean_optional.xml",
     "gx_conditional_boolean_discriminate_on_string_value.xml",
+    # Intentionally reproduces the async "ambiguous unqualified test parameter name"
+    # regression (duplicate unqualified param in a test) - see
+    # test/functional/tools/async_ambiguous_unqualified_name.xml. Remove once
+    # _input_for ambiguity is resolved / surfaced as a TestCaseValidationError.
+    "async_ambiguous_unqualified_name.xml",
 ]
 
 TEST_TOOL_THAT_DO_NOT_VALIDATE = (
@@ -434,6 +439,109 @@ def test_legacy_unqualified_repeat_inputs_are_expanded_for_request_state():
         (["more_queries", 1, "more_queries_input", "path"], "simple_line.txt"),
     ]
     dict_verify_each(test_case_state.input_state, expectations)
+
+
+def test_legacy_unqualified_repeat_inside_conditional_is_resolved():
+    # A repeat that lives inside a conditional may be specified unqualified (at the top
+    # level of the test, without the enclosing <conditional> wrapper). Its nested params
+    # must still resolve - including across two levels of repeat nesting - matching the
+    # synchronous /api/tools path. Regression for the deseq2 async submission failure:
+    #   select_data.__absent__.rep_factorName.0.rep_factorLevel.0.countsFile - Field required
+    tool_source = raw_xml_tool_source("""
+<tool id="unqualified_repeat_in_conditional" name="unqualified_repeat_in_conditional" version="1.0.0" profile="22.01">
+    <command>echo</command>
+    <inputs>
+        <conditional name="select_data">
+            <param name="how" type="select">
+                <option value="datasets_per_level">Datasets per level</option>
+                <option value="group_tags">Group tags</option>
+            </param>
+            <when value="datasets_per_level">
+                <repeat name="rep_factorName" min="1">
+                    <param name="factorName" type="text" value="" />
+                    <repeat name="rep_factorLevel" min="1">
+                        <param name="factorLevel" type="text" value="" />
+                        <param name="countsFile" type="data" format="txt" />
+                    </repeat>
+                </repeat>
+            </when>
+            <when value="group_tags">
+                <param name="countsFile" type="data" format="txt" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs />
+    <tests>
+        <test>
+            <repeat name="rep_factorName">
+                <param name="factorName" value="Treatment" />
+                <repeat name="rep_factorLevel">
+                    <param name="factorLevel" value="Treated" />
+                    <param name="countsFile" value="simple_line.txt" />
+                </repeat>
+            </repeat>
+        </test>
+    </tests>
+</tool>
+        """)
+    parsed_tool = parse_tool(tool_source)
+    test_case = tool_source.parse_tests_to_dict()["tests"][0]
+
+    tool_state = case_state(test_case, parsed_tool.inputs, tool_source.parse_profile()).tool_state
+
+    expectations = [
+        (["select_data", "rep_factorName", 0, "factorName"], "Treatment"),
+        (["select_data", "rep_factorName", 0, "rep_factorLevel", 0, "factorLevel"], "Treated"),
+        (["select_data", "rep_factorName", 0, "rep_factorLevel", 0, "countsFile", "path"], "simple_line.txt"),
+    ]
+    dict_verify_each(tool_state.input_state, expectations)
+
+
+def test_legacy_unqualified_conditional_discriminator_in_section_is_resolved():
+    # A conditional inside a section may have its name elided in the test, with the
+    # discriminator given directly under the section (e.g. <section name="adv">
+    # <param name="esf" value="user"/> rather than wrapping it in <conditional
+    # name="esf_cond">). The section prefix is kept but the conditional name is dropped.
+    # Regression for the deseq2 async submission failure:
+    #   Invalid parameter name found advanced_options|esf
+    tool_source = raw_xml_tool_source("""
+<tool id="elided_conditional_in_section" name="elided_conditional_in_section" version="1.0.0" profile="22.01">
+    <command>echo</command>
+    <inputs>
+        <section name="advanced_options" title="Advanced">
+            <conditional name="esf_cond">
+                <param name="esf" type="select">
+                    <option value="default" selected="true">Default</option>
+                    <option value="user">User supplied</option>
+                </param>
+                <when value="default" />
+                <when value="user">
+                    <param name="size_factor_input" type="data" format="txt" />
+                </when>
+            </conditional>
+        </section>
+    </inputs>
+    <outputs />
+    <tests>
+        <test>
+            <section name="advanced_options">
+                <param name="esf" value="user" />
+                <param name="size_factor_input" value="simple_line.txt" />
+            </section>
+        </test>
+    </tests>
+</tool>
+        """)
+    parsed_tool = parse_tool(tool_source)
+    test_case = tool_source.parse_tests_to_dict()["tests"][0]
+
+    tool_state = case_state(test_case, parsed_tool.inputs, tool_source.parse_profile()).tool_state
+
+    expectations = [
+        (["advanced_options", "esf_cond", "esf"], "user"),
+        (["advanced_options", "esf_cond", "size_factor_input", "path"], "simple_line.txt"),
+    ]
+    dict_verify_each(tool_state.input_state, expectations)
 
 
 def test_legacy_select_labels_are_converted_to_values_for_request_state():

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -372,6 +372,49 @@ def test_nested_conditional_duplicate_short_names_are_distinct_when_qualified():
     dict_verify_each(tool_state.input_state, expectations)
 
 
+def test_legacy_partial_conditional_paths_are_resolved_for_request_state():
+    tool_source = tool_source_for("disambiguate_cond")
+    test_case = tool_source.parse_tests_to_dict()["tests"][1]
+
+    tool_state = case_state_for(tool_source, test_case).tool_state
+
+    expectations = [
+        (["p1", "use"], True),
+        (["p2", "use"], False),
+        (["p3", "use"], True),
+        (["files", "p4", "use"], True),
+        (["files", "p4", "file", "path"], "simple_line.txt"),
+    ]
+    dict_verify_each(tool_state.input_state, expectations)
+
+
+def test_legacy_unqualified_repeat_inputs_are_expanded_for_request_state():
+    tool_source = tool_source_for("multi_repeats")
+    test_cases = tool_source.parse_tests_to_dict()["tests"]
+
+    test_case_state = case_state_for(tool_source, test_cases[2]).tool_state
+
+    expectations = [
+        (["queries", 0, "input2", "path"], "simple_line.txt"),
+        (["queries", 1, "input2", "path"], "simple_line.txt"),
+        (["more_queries", 0, "more_queries_input", "path"], "simple_line.txt"),
+        (["more_queries", 1, "more_queries_input", "path"], "simple_line.txt"),
+    ]
+    dict_verify_each(test_case_state.input_state, expectations)
+
+
+def test_legacy_select_labels_are_converted_to_values_for_request_state():
+    tool_source = tool_source_for("multi_select")
+    test_case = tool_source.parse_tests_to_dict()["tests"][1]
+
+    test_case_state = case_state_for(tool_source, test_case).tool_state
+
+    expectations = [
+        (["select_ex", 0], "--ex1"),
+    ]
+    dict_verify_each(test_case_state.input_state, expectations)
+
+
 def test_convert_to_requests():
     tools = [
         "parameters/gx_drill_down_recurse_multiple",

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -822,3 +822,29 @@ def test_infer_when_from_bare_unqualified_branch_param():
     # should not raise - the 'yes' branch is inferred from the bare 'reference'
     state = case_state(test, bundle.parameters, ts.parse_profile(), validate=True)
     assert state.tool_state.input_state["use_ref"]["enabled"] == "yes"
+
+
+def test_omitted_conditional_records_first_option_default():
+    """For a legacy conditional with no explicit selected="true", the first option is the
+    default (is_default_when). When a test omits the discriminator entirely, the builder must
+    record that default discriminator in the state - mirroring how the synchronous runtime
+    (fill_static_defaults) fills an incomplete payload - so the state validates against the
+    default branch instead of the phantom __absent__ branch. Models multigsea's
+    proteomics/metabolomics conditionals.
+    """
+    from galaxy.tool_util.parser.factory import build_xml_tool_source
+
+    tool_xml = (
+        '<tool id="first_opt" name="first_opt" version="1.0" profile="20.05">'
+        "<command>echo</command><inputs>"
+        '<conditional name="opt">'
+        '<param name="selector" type="select">'
+        '<option value="a">A</option><option value="b">B</option></param>'  # no selected="true"
+        '<when value="a"><param name="x" type="text" value="dx"/></when>'
+        '<when value="b"/></conditional>'
+        "</inputs><outputs/><tests><test/></tests></tool>"  # discriminator omitted entirely
+    )
+    ts = build_xml_tool_source(tool_xml)
+    bundle = input_models_for_tool_source(ts)
+    state = case_state(ts.parse_tests_to_dict()["tests"][0], bundle.parameters, ts.parse_profile(), validate=True)
+    assert state.tool_state.input_state["opt"]["selector"] == "a"  # first option recorded, not __absent__

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -288,6 +288,24 @@ def test_state_set_value_creates_nested_parent_state():
     }
 
 
+def test_state_set_value_does_not_misidentify_conditional_names_with_digit_suffix():
+    # Conditional parameter names ending in _N (e.g. "inner_options_1") must not be
+    # treated as flattened repeat indices when no repeat list has been started yet.
+    state: dict[str, Any] = {}
+
+    state_set_value(state, "outer|inner_options_1|mode", "by_index", nested=True)
+    state_set_value(state, "outer|inner_options_1|col", 1, nested=True)
+    state_set_value(state, "outer|inner_options_2|mode", "by_name", nested=True)
+    state_set_value(state, "outer|inner_options_2|label", "foo", nested=True)
+
+    assert state == {
+        "outer": {
+            "inner_options_1": {"mode": "by_index", "col": 1},
+            "inner_options_2": {"mode": "by_name", "label": "foo"},
+        }
+    }
+
+
 def test_test_case_request_conversion_preserves_non_default_select_and_booleans():
     tool_source = raw_xml_tool_source("""
 <tool id="async_request_regression" name="async_request_regression" version="1.0.0">

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -34,6 +34,7 @@ from galaxy.tool_util_models.tool_source import (
     JsonTestCollectionDefDict,
     JsonTestDatasetDefDict,
 )
+from galaxy.util.permutations import is_in_state
 from .util import dict_verify_each
 
 # legacy tools allows specifying parameter and repeat parameters without
@@ -255,6 +256,122 @@ def test_test_case_state_conversion():
     dict_verify_each(state.tool_state.input_state, expectations)
 
 
+def test_is_in_state_supports_nested_keys():
+    state = {
+        "section": {
+            "parameter": "value",
+        },
+    }
+
+    assert is_in_state(state, "section|parameter", nested=True)
+    assert not is_in_state(state, "section|missing", nested=True)
+
+
+
+
+def test_test_case_request_conversion_preserves_non_default_select_and_booleans():
+    tool_source = raw_xml_tool_source(
+        """
+<tool id="async_request_regression" name="async_request_regression" version="1.0.0">
+    <command>echo</command>
+    <inputs>
+        <param name="output_type" type="select">
+            <option value="meta" selected="true">MetaBAT2</option>
+            <option value="semi">SemiBin2</option>
+        </param>
+        <param name="full_contig_name" type="boolean" truevalue="--full-contig-name" falsevalue="" />
+        <section name="advanced_settings" expanded="false">
+            <param name="method" type="select">
+                <option value="hybrid" selected="true">Hybrid</option>
+                <option value="wgs">WGS</option>
+            </param>
+            <param name="remove_identical_sequences" type="boolean" truevalue="-d" falsevalue="" />
+        </section>
+    </inputs>
+    <outputs />
+    <tests>
+        <test>
+            <param name="output_type" value="semi" />
+            <param name="full_contig_name" value="true" />
+            <section name="advanced_settings">
+                <param name="method" value="wgs" />
+                <param name="remove_identical_sequences" value="true" />
+            </section>
+        </test>
+    </tests>
+</tool>
+        """
+    )
+    parameters = input_models_for_tool_source(tool_source)
+    parsed_tool = parse_tool(tool_source)
+    test_case = tool_source.parse_tests_to_dict()["tests"][0]
+    test_case_state = case_state(test_case, parsed_tool.inputs, tool_source.parse_profile()).tool_state
+
+    request_state = encode_test(test_case_state, parameters, mock_adapt_datasets, mock_adapt_collections)
+
+    expectations = [
+        (["output_type"], "semi"),
+        (["full_contig_name"], True),
+        (["advanced_settings", "method"], "wgs"),
+        (["advanced_settings", "remove_identical_sequences"], True),
+    ]
+    dict_verify_each(request_state.input_state, expectations)
+
+
+def test_nested_conditional_duplicate_short_names_are_distinct_when_qualified():
+    tool_source = raw_xml_tool_source(
+        """
+<tool id="duplicate_use_regression" name="duplicate_use_regression" version="1.0.0">
+    <command>echo</command>
+    <inputs>
+        <conditional name="operation">
+            <param name="use" type="select">
+                <option value="droplets" selected="true">Droplets</option>
+                <option value="other">Other</option>
+            </param>
+            <when value="droplets">
+                <conditional name="method">
+                    <param name="use" type="select">
+                        <option value="default" selected="true">Default</option>
+                        <option value="expected">Expected</option>
+                    </param>
+                    <when value="default" />
+                    <when value="expected">
+                        <param name="expected" type="integer" value="1000" />
+                    </when>
+                </conditional>
+            </when>
+            <when value="other" />
+        </conditional>
+    </inputs>
+    <outputs />
+    <tests>
+        <test>
+            <conditional name="operation">
+                <param name="use" value="droplets" />
+                <conditional name="method">
+                    <param name="use" value="expected" />
+                    <param name="expected" value="2000" />
+                </conditional>
+            </conditional>
+        </test>
+    </tests>
+</tool>
+        """
+    )
+    parsed_tool = parse_tool(tool_source)
+    test_case = tool_source.parse_tests_to_dict()["tests"][0]
+
+    tool_state = case_state(test_case, parsed_tool.inputs, tool_source.parse_profile()).tool_state
+
+    expectations = [
+        (["operation", "use"], "droplets"),
+        (["operation", "method", "use"], "expected"),
+        (["operation", "method", "expected"], 2000),
+    ]
+    dict_verify_each(tool_state.input_state, expectations)
+
+
 def test_convert_to_requests():
     tools = [
         "parameters/gx_drill_down_recurse_multiple",
@@ -314,6 +431,18 @@ def case_state_for(tool_source: ToolSource, test_case: ToolSourceTest) -> TestCa
     parsed_tool = parse_tool(tool_source)
     profile = tool_source.parse_profile()
     return case_state(test_case, parsed_tool.inputs, profile)
+
+
+def raw_xml_tool_source(raw_tool_source: str) -> ToolSource:
+    return get_tool_source(tool_source_class="XmlToolSource", raw_tool_source=raw_tool_source)
+
+
+def mock_adapt_datasets(input: JsonTestDatasetDefDict) -> DataRequestHda:
+    return DataRequestHda(src="hda", id=MOCK_ID)
+
+
+def mock_adapt_collections(input: JsonTestCollectionDefDict) -> DataCollectionRequest:
+    return DataCollectionRequest(src="hdca", id=MOCK_ID)
 
 
 tool_source_for = functional_test_tool_source

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -792,3 +792,33 @@ def test_build_xml_tool_source_preserves_validator_whitespace():
     ]
     assert regex_validators, "expected a regex validator in the parsed model"
     assert regex_validators[0].expression == " *(\\d+, *)*\\d+ *$"
+
+
+def test_infer_when_from_bare_unqualified_branch_param():
+    """A legacy test may supply a non-default branch's param by its bare short name (without
+    the enclosing conditional prefix) and omit the discriminator. The async builder must infer
+    the active when from that bare param, as the sync API does - otherwise it defaults to the
+    (empty) default branch and rejects the param as unhandled. Models novoplasty reference_cond
+    / hisat2 adv|spliced_options.
+    """
+    from galaxy.tool_util.parser.factory import build_xml_tool_source
+
+    tool_xml = (
+        '<tool id="bare_branch" name="bare_branch" version="1.0" profile="20.01">'
+        "<command>echo</command><inputs>"
+        '<conditional name="use_ref">'
+        '<param name="enabled" type="select"><option value="no" selected="true">No</option>'
+        '<option value="yes">Yes</option></param>'
+        '<when value="no"/>'
+        '<when value="yes"><param name="reference" type="text" value="" /></when>'
+        "</conditional></inputs><outputs/>"
+        "<tests><test>"
+        '<param name="reference" value="ref.fa"/>'  # bare, non-default branch, discriminator omitted
+        "</test></tests></tool>"
+    )
+    ts = build_xml_tool_source(tool_xml)
+    bundle = input_models_for_tool_source(ts)
+    test = ts.parse_tests_to_dict()["tests"][0]
+    # should not raise - the 'yes' branch is inferred from the bare 'reference'
+    state = case_state(test, bundle.parameters, ts.parse_profile(), validate=True)
+    assert state.tool_state.input_state["use_ref"]["enabled"] == "yes"

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -46,10 +46,6 @@ TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS = [
     "implicit_default_conds.xml",
 ]
 
-# tools that use truevalue/falsevalue in parameter setting, I think we're going to
-# forbid this for a future tool profile version. Potential ambigouity could result.
-TOOLS_THAT_USE_TRUE_FALSE_VALUE_BOOLEAN_SPECIFICATION: List[str] = []
-
 TOOLS_THAT_USE_SELECT_BY_VALUE = [
     "multi_select.xml",
 ]
@@ -62,7 +58,6 @@ TOOLS_THAT_ARE_OUTSTANDING_ISSUES = [
 
 TEST_TOOL_THAT_DO_NOT_VALIDATE = (
     TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS
-    + TOOLS_THAT_USE_TRUE_FALSE_VALUE_BOOLEAN_SPECIFICATION
     + TOOLS_THAT_USE_SELECT_BY_VALUE
     + TOOLS_THAT_ARE_OUTSTANDING_ISSUES
     + [
@@ -85,7 +80,7 @@ def test_parameter_test_cases_validate():
 
 
 def test_legacy_features_fail_validation_with_24_2(tmp_path):
-    for filename in TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS + TOOLS_THAT_USE_TRUE_FALSE_VALUE_BOOLEAN_SPECIFICATION:
+    for filename in TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS:
         _assert_tool_test_parsing_only_fails_with_newer_profile(tmp_path, filename, index=None)
 
     # column parameters need to be indexes

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -2596,7 +2596,7 @@ def test_skip_by_module(lint_ctx):
 def test_list_linters():
     linter_names = Linter.list_listers()
     # make sure to add/remove a test for new/removed linters if this number changes
-    assert len(linter_names) == 147
+    assert len(linter_names) == 148
     assert "Linter" not in linter_names
     # make sure that linters from all modules are available
     for prefix in [


### PR DESCRIPTION
## Always attempt to build the structured tool request for the new job-submission API

Previously, the structured request needed by `POST /api/jobs` was only built for tools with profile >= 24.2. For older tools `case_state()` was never called, leaving `request=None` and making the new endpoint unusable for the bulk of existing tool tests.

The profile check was about validation strictness, not a fundamental limitation: `case_state(validate=False)` can build a valid request for any tool. Now we always attempt it — `validate=True` for modern tools, `validate=False` for older ones. Failures populate `request_unavailable_reason` so `"if_needed"` can fall back gracefully.

To find the rest of the breakage before we flip the default submission path, I ran this against a batch-modernized tools-iuc repo via planemo. The remaining commits are the fixes that shook out — most are narrow correctness bugs in how legacy tool inputs and their XML test cases are parsed into the structured request. We really should have done this before flipping the default submission default.

### What's fixed

**Building requests from legacy XML test cases** (`tool_util/verify/parse.py`, `parameters/case.py`) — the test-case path exercised the most edge cases:
- Resolve an unqualified repeat nested inside a conditional, and a conditional discriminator whose conditional name is elided
- Infer an omitted conditional `when` from the provided params (and from bare unqualified branch params); record the default first-option discriminator when a legacy conditional is omitted entirely
- Don't resolve an omitted nested conditional discriminator to an ancestor's
- Coerce legacy boolean test values to booleans; tolerate duplicate identical unqualified params
- Preserve significant whitespace when parsing a tool from its raw string source

**Parameter parsing / conversion** (`parameters/convert.py`, `tool_util_models/parameters.py`):
- Map boolean `truevalue`/`falsevalue` correctly and validate color inputs
- Accept Galaxy JSON infinity/NaN sentinels in `FloatParameterModel`; sanitize inf/nan floats before storing `tool_state` as JSON
- Fix `url_default` data-param materialization and async data-URL default filling
- Fix nested state writes; stop `state_set_value` from misreading conditional names with a digit suffix as repeat indices
- Handle `value=""` for multiple-select params and comma-separated locations for multiple data params

**Execution / infrastructure:**
- Load datatype converters in the Celery worker so implicit conversions work under async execution
- Fix `DataManagerTool.exec_after_process` for async API submission
- Fix a PostgreSQL session abort when a model-operation tool raises before the copy flush
- Fix an `openapi/utils.py` mypy arg-type error under `fastapi>=0.137.0`

### Tests

Adds async submission regression tests, implicit datatype-conversion API tests, reproducer tool XMLs (ambiguous unqualified names, no-default nested conditional data, shared nested-conditional discriminators, digit-suffix conditional names), and unit coverage for the parameter-convert / test-case parsing changes.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
