### PR TITLE
[26.1] Remove GHCR container build job

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -10,67 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  ghcrbuild:
-    name: Build container image for GHCR
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
-      - name: Set outputs
-        id: commit
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Set branch name
-        id: branch
-        run: |
-          if [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
-            echo "name=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-          elif [[ "$GITHUB_REF" == "refs/heads/dev" ]]; then
-            echo "name=dev" >> $GITHUB_OUTPUT
-          elif [[ "$GITHUB_REF" == "refs/heads/release_"* ]]; then
-            echo "name=${GITHUB_REF#refs/heads/release_}-auto" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-      - name: Extract metadata for container image
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{steps.branch.outputs.name}}
-      - name: Build args
-        id: buildargs
-        run: |
-            echo "gitcommit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT 
-            echo "builddate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"  >> $GITHUB_OUTPUT
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          platforms: linux/amd64
-
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push container image to ghcr
-        uses: docker/build-push-action@v7
-        with:
-          build-args: |
-              GIT_COMMIT=${{ steps.buildargs.outputs.gitcommit }}
-              BUILD_DATE=${{ steps.buildargs.outputs.builddate }}
-              IMAGE_TAG=${{ steps.branch.outputs.name }}
-          file: .k8s_ci.Dockerfile
-          push: true
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-
   build:
     name: Build container image for Galaxy repos
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR https://github.com/galaxyproject/galaxy/pull/22827 broke the GHCR Docker build as the `GITHUB_TOKEN` no longer has write permission to push the image.  The `ghcrbuild` task was added in https://github.com/galaxyproject/galaxy/pull/18514 so that forks (AnVIL, Bioconductor) could build and deploy images without credentials as the `build` task requires access to secrets and is gated so it only runs when `org == galaxyproject`

I think anyone forking Galaxy that needs their own Docker images should not rely on our workflows and the `ghcrbuild` task is a frequent source of noise and transient failures.

An alternative fix would be to add job level permissions:
```
ghcrbuild:
    name: Build container image for GHCR
    runs-on: ubuntu-latest
    permissions:
      contents: read
      packages: write
```
It would be great if this was backported to `dev` ASAP as the job fails there as well.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
