### PR TITLE
[26.1] Fix sharing pages impossible due to incorrect `api/reports` fetches on the client

### DIFF
--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -466,6 +466,7 @@ export function getRouter(Galaxy) {
                             historyId: route.params.historyId,
                             pageId: route.params.pageId,
                             displayOnly: route.query.displayOnly === "true",
+                            invocationId: route.query.invocation_id,
                         }),
                     },
                     {
@@ -588,8 +589,8 @@ export function getRouter(Galaxy) {
                         component: Sharing,
                         props: (route) => ({
                             id: route.query.id,
-                            pluralName: "Reports",
-                            modelClass: "Report",
+                            pluralName: "Pages",
+                            modelClass: "Page",
                         }),
                     },
                     {


### PR DESCRIPTION
We had incorrectly set the route for sharing pages as `reports/sharing`, which, one would think makes sense but since `client/src/components/Sharing/SharingPage.vue` fetches and posts to the API based on the `modelClass` and `pluralName` to it via the route, AND it displays the same variables as well, we were trying to fetch `api/reports` for e.g. which doesn't exist in the backend.

This just changes Reports back to Pages on that sharing view:

<img width="360" alt="firefox_U5qH6w56F0" src="https://github.com/user-attachments/assets/079b42c7-7113-4bde-8453-f0914464ffc3" /> ➡️ <img width="360" alt="ULWxpwMWJ4" src="https://github.com/user-attachments/assets/1a22e187-28ec-4f04-8e97-038ca8c49c4f" />

You will notice that we have Reports on the grid which then changes the language to Pages. I can leave it as is, but if we do want to change it to Reports on the sharing view, we have 2 options:
- We add extra props to `client/src/components/Sharing/SharingPage.vue` which allow us to have reports on the client and still use the pages language on the backend
- We add new API routes for `reports` in addition to `pages` which we can mark as legacy on the backend

Fixes part of https://github.com/galaxyproject/galaxy/issues/22481

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
