### PR TITLE
[26.1] Fix upload_file_from_url passing decoded id to FetchDataPayload

### DIFF
--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -424,9 +424,8 @@ class AgentOperationsManager:
         dbkey: str = "?",
         file_name: str | None = None,
     ) -> dict[str, Any]:
-        decoded_history_id = self.trans.security.decode_id(history_id)
         fetch_payload = FetchDataPayload(
-            history_id=decoded_history_id,
+            history_id=history_id,
             targets=[
                 DataElementsTarget(
                     destination=HdaDestination(type="hdas"),


### PR DESCRIPTION
FetchDataPayload.history_id is a DecodedDatabaseIdField, which expects the encoded id string and decodes it itself. upload_file_from_url was pre-decoding history_id to an int, tripping the field's isinstance(str) validator and failing every call. Pass the encoded id straight through, matching invoke_workflow's handling of the same field type.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Use it via an agent. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
