### PR TITLE
Add Galaxy Notebook functionality to the MCP

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -19995,6 +19995,12 @@ export interface components {
         PageRevisionDetails: {
             /** Content */
             content?: string | null;
+            /**
+             * Content for Editor
+             * @description Raw text contents of the last page revision (type dependent on content_format).
+             * @default
+             */
+            content_editor: string | null;
             content_format?: components["schemas"]["PageContentFormat"] | null;
             /**
              * Create Time

--- a/client/src/components/PageEditor/PageRevisionView.test.ts
+++ b/client/src/components/PageEditor/PageRevisionView.test.ts
@@ -16,6 +16,7 @@ const REVISION: PageRevisionDetails = {
     update_time: "2025-01-01T00:00:00Z",
     title: "Test Revision",
     content: "# Title\nOld line 1\nOld line 2",
+    content_editor: "# Title\nOld line 1\nOld line 2",
     content_format: "markdown",
 };
 

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -1104,6 +1104,17 @@ class AgentOperationsManager:
 
     # ==================== Pages (notebooks and reports) ====================
 
+    def _dump_page(self, model, include_rendered: bool = False) -> dict[str, Any]:
+        """Serialize a page/revision schema, dropping the large rendered form by default.
+
+        content_editor (editable encoded-id markdown) is always kept; content (the
+        embed-expanded render form) is included only when include_rendered is True.
+        """
+        result = model.model_dump(mode="json")
+        if not include_rendered:
+            result.pop("content", None)
+        return result
+
     def list_pages(
         self,
         history_id: Optional[str] = None,
@@ -1146,10 +1157,7 @@ class AgentOperationsManager:
         """
         decoded_page_id = self.trans.security.decode_id(page_id)
         details = self.pages_service.show(self.trans, decoded_page_id)
-        result = details.model_dump(mode="json")
-        if not include_rendered:
-            result.pop("content", None)
-        return result
+        return self._dump_page(details, include_rendered)
 
     def create_page(
         self,
@@ -1172,24 +1180,23 @@ class AgentOperationsManager:
             slug=slug,
         )
         details = self.pages_service.create(self.trans, payload)
-        return details.model_dump(mode="json")
+        return self._dump_page(details)
 
     def update_page(
         self,
         page_id: str,
         content: Optional[str] = None,
         title: Optional[str] = None,
-        edit_source: str = "agent",
     ) -> dict[str, Any]:
-        """Update a page. Supplying content creates a new revision tagged with edit_source."""
+        """Update a page. Supplying content creates a new revision tagged edit_source=agent."""
         decoded_page_id = self.trans.security.decode_id(page_id)
         payload = UpdatePagePayload(
             content=content,
             title=title,
-            edit_source=edit_source,
+            edit_source="agent",
         )
         details = self.pages_service.update(self.trans, decoded_page_id, payload)
-        return details.model_dump(mode="json")
+        return self._dump_page(details)
 
     def list_page_revisions(self, page_id: str, sort_desc: bool = False) -> dict[str, Any]:
         """List the revision history of a page (provenance via edit_source)."""
@@ -1210,14 +1217,11 @@ class AgentOperationsManager:
         decoded_page_id = self.trans.security.decode_id(page_id)
         decoded_revision_id = self.trans.security.decode_id(revision_id)
         revision = self.pages_service.show_revision(self.trans, decoded_page_id, decoded_revision_id)
-        result = revision.model_dump(mode="json")
-        if not include_rendered:
-            result.pop("content", None)
-        return result
+        return self._dump_page(revision, include_rendered)
 
     def revert_page_revision(self, page_id: str, revision_id: str) -> dict[str, Any]:
         """Roll a page back to an earlier revision (creates a new 'restore' revision)."""
         decoded_page_id = self.trans.security.decode_id(page_id)
         decoded_revision_id = self.trans.security.decode_id(revision_id)
         revision = self.pages_service.revert_revision(self.trans, decoded_page_id, decoded_revision_id)
-        return revision.model_dump(mode="json")
+        return self._dump_page(revision)

--- a/lib/galaxy/agents/operations.py
+++ b/lib/galaxy/agents/operations.py
@@ -31,8 +31,11 @@ from galaxy.schema.fetch_data import (
 from galaxy.schema.invocation import InvocationSerializationParams
 from galaxy.schema.schema import (
     CreateHistoryPayload,
+    CreatePagePayload,
     DatasetSourceType,
     InvocationIndexPayload,
+    PageIndexQueryPayload,
+    UpdatePagePayload,
     WorkflowIndexPayload,
 )
 from galaxy.schema.workflows import InvokeWorkflowPayload
@@ -72,6 +75,7 @@ class AgentOperationsManager:
         self._dataset_collections_service: Optional[Any] = None
         self._dynamic_tools_manager: Optional[Any] = None
         self._file_source_instances_manager: Optional[Any] = None
+        self._pages_service: Optional[Any] = None
 
     def _encode_id(self, value: int) -> str:
         return self.trans.security.encode_id(value)
@@ -172,6 +176,14 @@ class AgentOperationsManager:
 
             self._file_source_instances_manager = self.app[FileSourceInstancesManager]
         return self._file_source_instances_manager
+
+    @property
+    def pages_service(self):
+        if self._pages_service is None:
+            from galaxy.webapps.galaxy.services.pages import PagesService
+
+            self._pages_service = self.app[PagesService]
+        return self._pages_service
 
     def connect(self) -> dict[str, Any]:
         config = self.app.config
@@ -1089,3 +1101,123 @@ class AgentOperationsManager:
             "file_sources": file_sources,
             "count": len(file_sources),
         }
+
+    # ==================== Pages (notebooks and reports) ====================
+
+    def list_pages(
+        self,
+        history_id: Optional[str] = None,
+        search: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+        show_published: bool = False,
+        show_shared: bool = False,
+        deleted: bool = False,
+    ) -> dict[str, Any]:
+        """List pages viewable by the current user.
+
+        When history_id is set, only pages attached to that history (Galaxy
+        Notebooks) are returned. Defaults to the user's own pages; published or
+        shared pages are included only when explicitly requested.
+        """
+        payload = PageIndexQueryPayload(
+            history_id=history_id,
+            search=search,
+            limit=limit,
+            offset=offset,
+            show_own=True,
+            show_published=show_published,
+            show_shared=show_shared,
+            deleted=deleted,
+        )
+        pages, total_matches = self.pages_service.index(self.trans, payload, include_total_count=True)
+        return {
+            "pages": pages.model_dump(mode="json"),
+            "count": len(pages.root),
+            "total_matches": total_matches,
+        }
+
+    def get_page(self, page_id: str, include_rendered: bool = False) -> dict[str, Any]:
+        """Return a page with its latest-revision content.
+
+        content_editor (editable markdown with encoded-id directives) is always
+        returned. The embed-expanded render form (content) can be large and is
+        included only when include_rendered is True.
+        """
+        decoded_page_id = self.trans.security.decode_id(page_id)
+        details = self.pages_service.show(self.trans, decoded_page_id)
+        result = details.model_dump(mode="json")
+        if not include_rendered:
+            result.pop("content", None)
+        return result
+
+    def create_page(
+        self,
+        history_id: Optional[str] = None,
+        title: Optional[str] = None,
+        content: Optional[str] = None,
+        annotation: Optional[str] = None,
+        slug: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Create a markdown page. Attach it to a history (notebook) by passing history_id.
+
+        Standalone reports (no history_id) require a unique slug and a title.
+        """
+        payload = CreatePagePayload(
+            history_id=history_id,
+            title=title,
+            content=content,
+            content_format="markdown",
+            annotation=annotation,
+            slug=slug,
+        )
+        details = self.pages_service.create(self.trans, payload)
+        return details.model_dump(mode="json")
+
+    def update_page(
+        self,
+        page_id: str,
+        content: Optional[str] = None,
+        title: Optional[str] = None,
+        edit_source: str = "agent",
+    ) -> dict[str, Any]:
+        """Update a page. Supplying content creates a new revision tagged with edit_source."""
+        decoded_page_id = self.trans.security.decode_id(page_id)
+        payload = UpdatePagePayload(
+            content=content,
+            title=title,
+            edit_source=edit_source,
+        )
+        details = self.pages_service.update(self.trans, decoded_page_id, payload)
+        return details.model_dump(mode="json")
+
+    def list_page_revisions(self, page_id: str, sort_desc: bool = False) -> dict[str, Any]:
+        """List the revision history of a page (provenance via edit_source)."""
+        decoded_page_id = self.trans.security.decode_id(page_id)
+        revisions = self.pages_service.list_revisions(self.trans, decoded_page_id, sort_desc=sort_desc)
+        return {
+            "revisions": revisions.model_dump(mode="json"),
+            "count": len(revisions.root),
+        }
+
+    def get_page_revision(self, page_id: str, revision_id: str, include_rendered: bool = False) -> dict[str, Any]:
+        """Return a single page revision with its content.
+
+        Mirrors get_page: content_editor (editable encoded-id markdown) is always
+        returned; the embed-expanded render form (content) is included only when
+        include_rendered is True.
+        """
+        decoded_page_id = self.trans.security.decode_id(page_id)
+        decoded_revision_id = self.trans.security.decode_id(revision_id)
+        revision = self.pages_service.show_revision(self.trans, decoded_page_id, decoded_revision_id)
+        result = revision.model_dump(mode="json")
+        if not include_rendered:
+            result.pop("content", None)
+        return result
+
+    def revert_page_revision(self, page_id: str, revision_id: str) -> dict[str, Any]:
+        """Roll a page back to an earlier revision (creates a new 'restore' revision)."""
+        decoded_page_id = self.trans.security.decode_id(page_id)
+        decoded_revision_id = self.trans.security.decode_id(revision_id)
+        revision = self.pages_service.revert_revision(self.trans, decoded_page_id, decoded_revision_id)
+        return revision.model_dump(mode="json")

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -4376,6 +4376,7 @@ class PageRevisionSummary(Model):
 class PageRevisionDetails(PageRevisionSummary):
     title: Optional[str] = None
     content: Optional[str] = None
+    content_editor: Optional[str] = ContentEditorField
     content_format: Optional[PageContentFormat] = None
 
 

--- a/lib/galaxy/webapps/galaxy/api/mcp.py
+++ b/lib/galaxy/webapps/galaxy/api/mcp.py
@@ -1180,6 +1180,238 @@ def get_mcp_app(gx_app):
             ops_manager = get_operations_manager(api_key, ctx)
             return ops_manager.import_workflow_from_iwc(trs_id)
 
+    # ==================== Pages (notebooks and reports) ====================
+
+    @mcp.tool()
+    def list_pages(
+        api_key: str,
+        ctx: MCPContext,
+        history_id: str | None = None,
+        search: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        show_published: bool = False,
+        show_shared: bool = False,
+    ) -> dict[str, Any]:
+        """List Galaxy pages (markdown documents) viewable by the user.
+
+        A page attached to a history is a "Galaxy Notebook"; a standalone page is
+        a "Report". Pass history_id to list only that history's notebooks.
+
+        Args:
+            history_id: Encoded history id. When set, returns only notebooks
+                attached to that history.
+            search: Freetext filter over title/content.
+            limit: Max pages to return (default 100).
+            offset: Pagination offset.
+            show_published: Also include pages published by other users (default False).
+            show_shared: Also include pages shared with the user (default False).
+
+        Returns:
+            Dict with `pages` (summaries incl. encoded id, title, history_id,
+            latest_revision_id), `count`, and `total_matches`.
+
+        NEXT STEPS:
+        - Read one: get_page(page_id)
+        - Create a notebook: create_page(history_id=...)
+        """
+        with _mcp_error_handler("list_pages"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.list_pages(
+                history_id=history_id,
+                search=search,
+                limit=limit,
+                offset=offset,
+                show_published=show_published,
+                show_shared=show_shared,
+            )
+
+    @mcp.tool()
+    def get_page(
+        page_id: str,
+        api_key: str,
+        ctx: MCPContext,
+        include_rendered: bool = False,
+    ) -> dict[str, Any]:
+        """Get a page and the content of its latest revision.
+
+        Returns `content_editor`: the editable Galaxy-flavored markdown, with
+        ENCODED ids in directives (e.g. `history_dataset_id=f2db41e1fa331b3e`).
+        This is the form to edit and pass back to update_page.
+
+        Args:
+            page_id: Encoded id of the page (from list_pages / create_page).
+            include_rendered: When True, also return `content` -- the
+                embed-expanded render form (inlined dataset previews). Can be
+                large; omit unless you need the rendered output.
+
+        Returns:
+            Page details including `content_editor`, metadata, and `edit_source`
+            of the latest revision.
+
+        NEXT STEPS:
+        - Edit it: update_page(page_id, content=...)
+        - See history: list_page_revisions(page_id)
+        """
+        with _mcp_error_handler("get_page"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.get_page(page_id, include_rendered=include_rendered)
+
+    @mcp.tool()
+    def create_page(
+        api_key: str,
+        ctx: MCPContext,
+        history_id: str | None = None,
+        title: str | None = None,
+        content: str | None = None,
+        annotation: str | None = None,
+        slug: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a markdown page (Galaxy Notebook or Report).
+
+        Pass history_id to create a history-attached notebook (title auto-fills
+        from the history if omitted). Omit history_id to create a standalone
+        report -- reports REQUIRE both a title and a unique slug
+        (lowercase/digits/hyphens).
+
+        Content is Galaxy-flavored markdown. To embed a dataset, use a directive
+        with the ENCODED dataset id, e.g.
+        `history_dataset_display(history_dataset_id=f2db41e1fa331b3e)` or
+        `history_dataset_collection_display(history_dataset_collection_id=...)`.
+        Get encoded ids from get_history_contents / get_dataset_details.
+
+        Args:
+            history_id: Encoded history id to attach the page to (notebook).
+            title: Page title.
+            content: Initial markdown content.
+            annotation: Optional annotation attached to the page.
+            slug: URL slug (required for standalone reports).
+
+        Returns:
+            Created page details including encoded id and content_editor.
+
+        NEXT STEPS:
+        - Edit it: update_page(page_id, content=...)
+        """
+        with _mcp_error_handler("create_page"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.create_page(
+                history_id=history_id,
+                title=title,
+                content=content,
+                annotation=annotation,
+                slug=slug,
+            )
+
+    @mcp.tool()
+    def update_page(
+        page_id: str,
+        api_key: str,
+        ctx: MCPContext,
+        content: str | None = None,
+        title: str | None = None,
+    ) -> dict[str, Any]:
+        """Update a page, creating a new revision when content changes.
+
+        Content is Galaxy-flavored markdown using ENCODED ids in directives
+        (e.g. `history_dataset_id=f2db41e1fa331b3e`) -- never raw integer ids or
+        HIDs. Get encoded ids from get_history_contents / get_dataset_details.
+        Edits made through this tool are recorded with edit_source="agent".
+
+        Args:
+            page_id: Encoded id of the page.
+            content: New markdown content. Omit to leave content unchanged.
+            title: New title. Omit to leave unchanged.
+
+        Returns:
+            Updated page details including content_editor.
+
+        NEXT STEPS:
+        - Inspect revisions: list_page_revisions(page_id)
+        - Roll back: revert_page_revision(page_id, revision_id)
+        """
+        with _mcp_error_handler("update_page"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.update_page(page_id, content=content, title=title)
+
+    @mcp.tool()
+    def list_page_revisions(
+        page_id: str,
+        api_key: str,
+        ctx: MCPContext,
+        sort_desc: bool = False,
+    ) -> dict[str, Any]:
+        """List the revision history of a page.
+
+        Each revision carries an `edit_source` ("user", "agent", or "restore")
+        recording who made the edit.
+
+        Args:
+            page_id: Encoded id of the page.
+            sort_desc: Newest-first when True (default oldest-first).
+
+        Returns:
+            Dict with `revisions` (encoded id, page_id, edit_source, timestamps)
+            and `count`.
+
+        NEXT STEPS:
+        - Read a revision: get_page_revision(page_id, revision_id)
+        - Roll back: revert_page_revision(page_id, revision_id)
+        """
+        with _mcp_error_handler("list_page_revisions"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.list_page_revisions(page_id, sort_desc=sort_desc)
+
+    @mcp.tool()
+    def get_page_revision(
+        page_id: str,
+        revision_id: str,
+        api_key: str,
+        ctx: MCPContext,
+        include_rendered: bool = False,
+    ) -> dict[str, Any]:
+        """Get the content of a single page revision.
+
+        Mirrors get_page: returns `content_editor` (the editable Galaxy-flavored
+        markdown with ENCODED ids in directives) -- the form to compare against
+        get_page or pass back to update_page.
+
+        Args:
+            page_id: Encoded id of the page.
+            revision_id: Encoded id of the revision (from list_page_revisions).
+            include_rendered: When True, also return `content` -- the
+                embed-expanded render form. Can be large; omit unless needed.
+
+        Returns:
+            Revision details including `content_editor`, `edit_source`, and timestamps.
+        """
+        with _mcp_error_handler("get_page_revision"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.get_page_revision(page_id, revision_id, include_rendered=include_rendered)
+
+    @mcp.tool()
+    def revert_page_revision(
+        page_id: str,
+        revision_id: str,
+        api_key: str,
+        ctx: MCPContext,
+    ) -> dict[str, Any]:
+        """Roll a page back to an earlier revision.
+
+        Creates a NEW revision from the target revision's content, recorded with
+        edit_source="restore" (the history is append-only -- nothing is deleted).
+
+        Args:
+            page_id: Encoded id of the page.
+            revision_id: Encoded id of the revision to restore.
+
+        Returns:
+            The new restored revision's details.
+        """
+        with _mcp_error_handler("revert_page_revision"):
+            ops_manager = get_operations_manager(api_key, ctx)
+            return ops_manager.revert_page_revision(page_id, revision_id)
+
     mcp_app = mcp.http_app(path="/")
     mcp_app.state.mcp_server = mcp
 

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -349,6 +349,13 @@ class TestMCPServerSmoke(IntegrationTestCase):
             "search_iwc_workflows",
             "get_iwc_workflow_details",
             "import_workflow_from_iwc",
+            "list_pages",
+            "get_page",
+            "create_page",
+            "update_page",
+            "list_page_revisions",
+            "get_page_revision",
+            "revert_page_revision",
         }
         assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
 
@@ -563,3 +570,86 @@ class TestMCPServerSmoke(IntegrationTestCase):
         data = result.data
         assert "id" in data
         assert data["trsID"] == trs_id
+
+    def test_mcp_page_lifecycle(self):
+        """create_page -> get_page -> update_page -> list_page_revisions round-trip."""
+        mcp_server = self._get_mcp_server()
+        api_key = self._get_api_key()
+        populator = DatasetPopulator(self._get_interactor(api_key=api_key))
+        history_id = populator.new_history()
+
+        async def _flow():
+            async with Client(mcp_server) as client:
+                created = await client.call_tool(
+                    "create_page",
+                    {"api_key": api_key, "history_id": history_id, "title": "MCP Notebook", "content": "# Intro\n"},
+                )
+                page_id = created.data["id"]
+                got = await client.call_tool("get_page", {"api_key": api_key, "page_id": page_id})
+                await client.call_tool(
+                    "update_page",
+                    {"api_key": api_key, "page_id": page_id, "content": "# Intro\n\n## Methods\n"},
+                )
+                revisions = await client.call_tool("list_page_revisions", {"api_key": api_key, "page_id": page_id})
+                listed = await client.call_tool("list_pages", {"api_key": api_key, "history_id": history_id})
+                return created, got, revisions, listed
+
+        created, got, revisions, listed = self._run_async(_flow())
+        assert not created.is_error, created
+        assert created.data["history_id"] == history_id
+        # get_page returns the editable content and omits the rendered form by default
+        assert "content_editor" in got.data
+        assert "content" not in got.data
+        # update_page created a second revision tagged with edit_source="agent"
+        assert revisions.data["count"] == 2
+        assert revisions.data["revisions"][-1]["edit_source"] == "agent"
+        # the notebook shows up when listing pages for its history
+        assert created.data["id"] in {p["id"] for p in listed.data["pages"]}
+
+    def test_mcp_page_directive_and_revert(self):
+        """Dataset directives survive in encoded-id space; revert restores prior content."""
+        mcp_server = self._get_mcp_server()
+        api_key = self._get_api_key()
+        populator = DatasetPopulator(self._get_interactor(api_key=api_key))
+        history_id = populator.new_history()
+        hda_id = populator.new_dataset(history_id)["id"]
+        directive = f"# Analysis\n\n```galaxy\nhistory_dataset_display(history_dataset_id={hda_id})\n```\n"
+
+        async def _flow():
+            async with Client(mcp_server) as client:
+                created = await client.call_tool(
+                    "create_page",
+                    {"api_key": api_key, "history_id": history_id, "title": "Directive NB", "content": directive},
+                )
+                page_id = created.data["id"]
+                editor = await client.call_tool("get_page", {"api_key": api_key, "page_id": page_id})
+                rendered = await client.call_tool(
+                    "get_page", {"api_key": api_key, "page_id": page_id, "include_rendered": True}
+                )
+                await client.call_tool(
+                    "update_page", {"api_key": api_key, "page_id": page_id, "content": "# Replaced\n"}
+                )
+                revisions = await client.call_tool("list_page_revisions", {"api_key": api_key, "page_id": page_id})
+                first_rev_id = revisions.data["revisions"][0]["id"]
+                old_rev = await client.call_tool(
+                    "get_page_revision",
+                    {"api_key": api_key, "page_id": page_id, "revision_id": first_rev_id},
+                )
+                reverted = await client.call_tool(
+                    "revert_page_revision",
+                    {"api_key": api_key, "page_id": page_id, "revision_id": first_rev_id},
+                )
+                return editor, rendered, old_rev, reverted
+
+        editor, rendered, old_rev, reverted = self._run_async(_flow())
+        # content_editor keeps the directive with the ENCODED dataset id (encoded-id space)
+        assert hda_id in editor.data["content_editor"]
+        assert "content" not in editor.data
+        # include_rendered exposes the expanded render form
+        assert "content" in rendered.data
+        # get_page_revision mirrors get_page: editable content_editor by default, rendered omitted
+        assert hda_id in old_rev.data["content_editor"]
+        assert "content" not in old_rev.data
+        # revert appends a new "restore" revision carrying the original directive content
+        assert reverted.data["edit_source"] == "restore"
+        assert hda_id in reverted.data["content"]

--- a/test/integration/test_agents.py
+++ b/test/integration/test_agents.py
@@ -652,4 +652,5 @@ class TestMCPServerSmoke(IntegrationTestCase):
         assert "content" not in old_rev.data
         # revert appends a new "restore" revision carrying the original directive content
         assert reverted.data["edit_source"] == "restore"
-        assert hda_id in reverted.data["content"]
+        assert hda_id in reverted.data["content_editor"]
+        assert "content" not in reverted.data

--- a/test/unit/app/managers/test_AgentOperationsManager.py
+++ b/test/unit/app/managers/test_AgentOperationsManager.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from galaxy.agents.operations import AgentOperationsManager
+from galaxy.schema.fields import Security
 from .base import BaseTestCase
 
 
@@ -419,3 +420,190 @@ class TestAgentOperationsManagerWithMockedServices(BaseTestCase):
 
         with pytest.raises(ValueError, match="User must be authenticated"):
             agent_ops.list_user_file_sources()
+
+
+class TestAgentOperationsManagerPages(BaseTestCase):
+    """Page (notebook/report) operations against a mocked PagesService."""
+
+    def set_up_managers(self):
+        super().set_up_managers()
+        # DecodedDatabaseIdField on page payloads decodes via the module-global
+        # Security.security; point it at the same helper trans uses to encode.
+        Security.security = self.trans.security
+        self.agent_ops = AgentOperationsManager(app=self.app, trans=self.trans)
+
+    def _mock_pages_service(self, mock_service):
+        return mock.patch.object(
+            type(self.agent_ops), "pages_service", new_callable=lambda: property(lambda self: mock_service)
+        )
+
+    def test_list_pages_defaults_to_own_only(self):
+        pages = mock.MagicMock()
+        pages.model_dump.return_value = []
+        pages.root = []
+        mock_service = mock.MagicMock()
+        mock_service.index.return_value = (pages, 0)
+
+        with self._mock_pages_service(mock_service):
+            result = self.agent_ops.list_pages()
+
+        payload = mock_service.index.call_args.args[1]
+        assert payload.show_own is True
+        assert payload.show_published is False
+        assert payload.show_shared is False
+        assert payload.history_id is None
+        assert result["count"] == 0
+        assert result["total_matches"] == 0
+
+    def test_list_pages_history_filter(self):
+        encoded_history_id = self.trans.security.encode_id(42)
+        pages = mock.MagicMock()
+        pages.model_dump.return_value = []
+        pages.root = []
+        mock_service = mock.MagicMock()
+        mock_service.index.return_value = (pages, 5)
+
+        with self._mock_pages_service(mock_service):
+            result = self.agent_ops.list_pages(history_id=encoded_history_id)
+
+        payload = mock_service.index.call_args.args[1]
+        assert payload.history_id == 42
+        assert result["total_matches"] == 5
+
+    def test_get_page_drops_rendered_by_default(self):
+        details = mock.MagicMock()
+        details.model_dump.return_value = {"id": "p1", "content_editor": "# Notes", "content": "<rendered>"}
+        mock_service = mock.MagicMock()
+        mock_service.show.return_value = details
+
+        with (
+            self._mock_pages_service(mock_service),
+            mock.patch.object(self.trans.security, "decode_id", return_value=7),
+        ):
+            result = self.agent_ops.get_page("encoded_page")
+
+        assert result["content_editor"] == "# Notes"
+        assert "content" not in result
+        mock_service.show.assert_called_once_with(self.trans, 7)
+
+    def test_get_page_includes_rendered_when_requested(self):
+        details = mock.MagicMock()
+        details.model_dump.return_value = {"id": "p1", "content_editor": "# Notes", "content": "<rendered>"}
+        mock_service = mock.MagicMock()
+        mock_service.show.return_value = details
+
+        with (
+            self._mock_pages_service(mock_service),
+            mock.patch.object(self.trans.security, "decode_id", return_value=7),
+        ):
+            result = self.agent_ops.get_page("encoded_page", include_rendered=True)
+
+        assert result["content"] == "<rendered>"
+
+    def test_create_page_sets_markdown_format(self):
+        details = mock.MagicMock()
+        details.model_dump.return_value = {"id": "p1"}
+        mock_service = mock.MagicMock()
+        mock_service.create.return_value = details
+
+        with self._mock_pages_service(mock_service):
+            self.agent_ops.create_page(title="Report", content="# Hi", slug="my-report")
+
+        payload = mock_service.create.call_args.args[1]
+        assert payload.content_format == "markdown"
+        assert payload.title == "Report"
+        assert payload.slug == "my-report"
+        assert payload.history_id is None
+
+    def test_create_page_with_history_decodes_id(self):
+        encoded_history_id = self.trans.security.encode_id(99)
+        details = mock.MagicMock()
+        details.model_dump.return_value = {"id": "p1"}
+        mock_service = mock.MagicMock()
+        mock_service.create.return_value = details
+
+        with self._mock_pages_service(mock_service):
+            self.agent_ops.create_page(history_id=encoded_history_id, content="# Hi")
+
+        payload = mock_service.create.call_args.args[1]
+        assert payload.history_id == 99
+        assert payload.content_format == "markdown"
+
+    def test_update_page_sets_edit_source_agent(self):
+        details = mock.MagicMock()
+        details.model_dump.return_value = {"id": "p1"}
+        mock_service = mock.MagicMock()
+        mock_service.update.return_value = details
+
+        with (
+            self._mock_pages_service(mock_service),
+            mock.patch.object(self.trans.security, "decode_id", return_value=7),
+        ):
+            self.agent_ops.update_page("encoded_page", content="# New")
+
+        call = mock_service.update.call_args
+        assert call.args[1] == 7
+        payload = call.args[2]
+        assert payload.edit_source == "agent"
+        assert payload.content == "# New"
+
+    def test_list_page_revisions(self):
+        revisions = mock.MagicMock()
+        revisions.model_dump.return_value = [{"id": "r1"}]
+        revisions.root = [{"id": "r1"}]
+        mock_service = mock.MagicMock()
+        mock_service.list_revisions.return_value = revisions
+
+        with (
+            self._mock_pages_service(mock_service),
+            mock.patch.object(self.trans.security, "decode_id", return_value=7),
+        ):
+            result = self.agent_ops.list_page_revisions("encoded_page")
+
+        mock_service.list_revisions.assert_called_once_with(self.trans, 7, sort_desc=False)
+        assert result["count"] == 1
+
+    def test_get_page_revision_drops_rendered_by_default(self):
+        revision = mock.MagicMock()
+        revision.model_dump.return_value = {"id": "r1", "content_editor": "# Notes", "content": "<rendered>"}
+        mock_service = mock.MagicMock()
+        mock_service.show_revision.return_value = revision
+
+        with (
+            self._mock_pages_service(mock_service),
+            mock.patch.object(self.trans.security, "decode_id", side_effect=[7, 3]),
+        ):
+            result = self.agent_ops.get_page_revision("encoded_page", "encoded_rev")
+
+        mock_service.show_revision.assert_called_once_with(self.trans, 7, 3)
+        assert result["content_editor"] == "# Notes"
+        assert "content" not in result
+
+    def test_get_page_revision_includes_rendered_when_requested(self):
+        revision = mock.MagicMock()
+        revision.model_dump.return_value = {"id": "r1", "content_editor": "# Notes", "content": "<rendered>"}
+        mock_service = mock.MagicMock()
+        mock_service.show_revision.return_value = revision
+
+        with (
+            self._mock_pages_service(mock_service),
+            mock.patch.object(self.trans.security, "decode_id", side_effect=[7, 3]),
+        ):
+            result = self.agent_ops.get_page_revision("encoded_page", "encoded_rev", include_rendered=True)
+
+        assert result["content"] == "<rendered>"
+
+    def test_revert_page_revision_returns_restore(self):
+        revision = mock.MagicMock()
+        revision.model_dump.return_value = {"id": "r2", "edit_source": "restore"}
+        mock_service = mock.MagicMock()
+        mock_service.revert_revision.return_value = revision
+
+        with (
+            self._mock_pages_service(mock_service),
+            mock.patch.object(self.trans.security, "decode_id", side_effect=[7, 3]),
+        ):
+            result = self.agent_ops.revert_page_revision("encoded_page", "encoded_rev")
+
+        mock_service.revert_revision.assert_called_once_with(self.trans, 7, 3)
+        assert result["edit_source"] == "restore"


### PR DESCRIPTION
I drove three novel detailed analyses across different applications last night to demo notebooks leveraging this functionality. I asked that agent that used this functionality if this required changes and it believed this was totally sufficient. Otherwise the MCP worked brilliantly - truly in awe how seamless this all was.

On the implementation level - I am not a huge fan of the mocked unit tests or the "===" section comments "===" but they are well established patterns in these files (https://gist.github.com/jmchilton/8147e21a98d541d87a0f7bd336abf9b7) so it is better to keep them than remove them I think.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
