### PR TITLE
[26.1] Make GalaxyAI route IWC workflow imports more reliably

### DIFF
--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -99,6 +99,7 @@ English. If the request really wants analysis (e.g. "summarize my history",
 - Wants to find/discover tools ("Is there a tool that converts BAM to FASTQ?")
 - Needs help choosing between tools for an analysis type
 - Asks "what tools are available for X?"
+- Asks to import or find a workflow from IWC for an analysis ("import an IWC workflow for X", "is there an IWC workflow for X I can import?") -- it searches the IWC catalog and surfaces an import action; there is no separate import handoff
 
 **Use `hand_off_to_error_analysis`** when user PROVIDES specific error details:
 
@@ -158,6 +159,7 @@ Key pattern: If user needs to FIND something (job, dataset, history) before anal
 
 - "What tool should I use for X?" → Use hand_off_to_tool_recommendation
 - "Is there a tool that does X?" → Use hand_off_to_tool_recommendation
+- "Import an IWC workflow for X" → Use hand_off_to_tool_recommendation (surfaces the workflow + import action)
 - "How do I use tool X?" → Answer directly (usage help)
 - "What parameters does X need?" → Answer directly (usage help)
 - "Create a tool that does X" → Use hand_off_to_custom_tool

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -5,7 +5,7 @@ Uses pydantic-ai output functions to either:
 - Answer general Galaxy questions directly (returns str)
 - Hand off to error_analysis for job debugging
 - Hand off to custom_tool for explicit tool creation requests
-- Hand off to tool_recommendation for tool discovery
+- Hand off to tool_recommendation for tool and IWC workflow discovery
 - Hand off to gtn_training for tutorial and learning requests
 
 Also exposes a small set of @agent.tool fast-path tools for read-only browsing
@@ -330,13 +330,14 @@ class QueryRouterAgent(BaseGalaxyAgent):
             ctx: RunContext[GalaxyAgentDependencies],
             query: str,
         ) -> str:
-            """Route to tool recommendation agent for finding Galaxy tools.
+            """Route to tool recommendation agent for finding Galaxy tools and IWC workflows.
 
             Use this when the user:
             - Asks what tool to use for a task ("what tool aligns reads?")
             - Wants to find tools for a specific analysis type
             - Needs help discovering available tools
             - Asks "is there a tool that does X?"
+            - Asks to import or find a workflow from IWC for an analysis (it searches IWC and surfaces an import action)
 
             Do NOT use for:
             - How to USE a specific tool (answer directly)
@@ -344,7 +345,7 @@ class QueryRouterAgent(BaseGalaxyAgent):
             - Job errors (use hand_off_to_error_analysis)
 
             Args:
-                query: The tool discovery question
+                query: The tool or workflow discovery question
             """
             return await self._execute_handoff(ctx, AgentType.TOOL_RECOMMENDATION, query)
 

--- a/test/evals/datasets/routing.py
+++ b/test/evals/datasets/routing.py
@@ -194,8 +194,8 @@ ROUTING_CASES: list[Case[str, str, dict[str, Any]]] = [
     _case(
         "import_iwc_workflow",
         "Import a histological staining workflow from IWC.",
-        "router",
-        "Router-direct action. On agent-ops-iwc-reintroduce this triggers search_iwc_workflows + import_workflow_from_iwc tool calls.",
+        "tool_recommendation",
+        "tool_recommendation owns IWC search (search_iwc_workflows) and emits a WORKFLOW_IMPORT action for the surfaced workflow; no in-app agent calls import_workflow_from_iwc directly.",
     ),
     _case(
         "omero_upload_guidance",
@@ -222,6 +222,12 @@ ROUTING_CASES: list[Case[str, str, dict[str, Any]]] = [
         "Generate a Galaxy tool that counts brown pixels in a TIFF image.",
         "custom_tool",
         "Explicit custom_tool request -- writing a tool wrapper, not running an existing one.",
+    ),
+    _case(
+        "recommend_iwc_workflow",
+        "Recommend an IWC workflow for histological staining quantification.",
+        "tool_recommendation",
+        "Recommendation-style IWC ask -- discovery phrasing routes to tool_recommendation, which searches IWC and surfaces an importable workflow.",
     ),
 ]
 


### PR DESCRIPTION
When a user asks GalaxyAI to import or find a workflow from IWC ("import an IWC workflow for X", "is there an IWC workflow for X?"), the router was answering directly instead of handing off to the tool recommendation agent. That's the wrong place for it -- the recommendation agent is what actually searches the IWC catalog (`search_iwc_workflows`) and emits a `WORKFLOW_IMPORT` action so the client can surface an importable workflow. Routing these to the router meant the user got a text answer with nothing importable.

On gpt-oss-120b (the model the assistant runs on in practice), the imperative "import a histological staining workflow from IWC" landed on the plain router 4 times out of 5. This change teaches the router that IWC workflow asks -- whether phrased as an imperative "import..." or a "recommend an IWC workflow for X" discovery question -- belong with the tool recommendation agent. It also widens the handoff's summary and argument description, which still called the agent tools-only even though it already recommends IWC workflows. The change is routing guidance only (the handoff docstring in `router.py` and the matching section in `router.md`); no code path changes.

I pinned the behavior in the routing eval set -- flipped the existing `import_iwc_workflow` case to expect `tool_recommendation` and added a `recommend_iwc_workflow` case for the discovery phrasing -- so a future model or prompt change that regresses this gets caught. With the change, both route to `tool_recommendation` 5/5 on gpt-oss-120b (up from 0/5 for the imperative import).
