### PR TITLE
[26.1] Enforce color format in JSON schema tests via FormatChecker

### DIFF
--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -1234,9 +1234,11 @@ gx_color:
    - parameter: '#aabbcc'
    - parameter: '#000000'
    - parameter: '#abcd'
+   - parameter: 'red'
   request_invalid:
    - parameter: null
    - parameter: {}
+   - parameter: 'foobar'
   workflow_step_valid:
    - parameter: '#aabbcc'
    - parameter: '#000000'
@@ -1253,9 +1255,6 @@ gx_color:
     - parameter: 'foobar'
     - parameter: 5
     - parameter: {__class__: 'ConnectedValue2'}
-  _json_schema_skip:
-    workflow_step_invalid: "color validator uses AfterValidator"
-    workflow_step_linked_invalid: "color validator uses AfterValidator"
 
 gx_data:
   request_valid:

--- a/test/unit/tool_util/test_parameter_specification_json_schema.py
+++ b/test/unit/tool_util/test_parameter_specification_json_schema.py
@@ -22,8 +22,10 @@ from typing import (
 )
 
 import jsonschema
+import jsonschema.exceptions
 import pytest
 import yaml
+from pydantic_extra_types.color import Color as _Color
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 9), reason="jsonschema<4.24 on Python 3.8 mishandles additionalProperties in anyOf"
@@ -72,8 +74,21 @@ def _json_schema_for(bundle: ToolParameterBundleModel, state_representation: Sta
     return to_json_schema(model)
 
 
+_FORMAT_CHECKER = jsonschema.FormatChecker()
+
+
+@_FORMAT_CHECKER.checks("color", raises=jsonschema.exceptions.FormatError)
+def _check_color_format(value: object) -> bool:
+    if isinstance(value, str):
+        try:
+            _Color(value)
+        except Exception as e:
+            raise jsonschema.exceptions.FormatError(f"{value!r} is not a valid color", cause=e)
+    return True
+
+
 def _json_schema_validates(schema: Dict[str, Any], state_dict: RawStateDict) -> bool:
-    validator = jsonschema.Draft202012Validator(schema)
+    validator = jsonschema.Draft202012Validator(schema, format_checker=_FORMAT_CHECKER)
     errors = list(validator.iter_errors(state_dict))
     return len(errors) == 0
 


### PR DESCRIPTION
Followup to #22869.

That PR introduced `format: "color"` in the JSON schema for color parameters and added `_json_schema_skip` because standard JSON Schema validators don't enforce unknown `format` values.

This PR removes the workaround by registering a `"color"` format checker in the test suite backed by `pydantic_extra_types.Color`. Passing the checker to `Draft202012Validator` makes `format: "color"` actually enforced during tests, so:

- `_json_schema_skip` is removed from `gx_color`
- `'foobar'` is added to `request_invalid` (now caught at schema level)
- `'red'` is added to `request_valid` (documents that named colors are accepted)

## How to test the changes?
- [x] I've included appropriate automated tests.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the MIT license.