### PR TITLE
[26.1] Make unowned but accessible pages uneditable

### DIFF
--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -345,7 +345,7 @@ class PageManager(sharable.SharableModelManager[model.Page], UsesAnnotations):
         page = trans.sa_session.get(model.Page, id)
         if not page:
             raise exceptions.ObjectNotFound("Page not found")
-        page = base.security_check(trans, page, check_ownership=False, check_accessible=True)
+        page = base.security_check(trans, page, check_ownership=True, check_accessible=True)
 
         # Validate slug changes (only for non-history pages)
         if payload.slug is not None and payload.slug != page.slug:

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -498,6 +498,13 @@ steps:
         show_json = show_response.json()
         assert show_json["annotation"] == "newannotation"
 
+    def test_update_as_other_user(self):
+        response_json = self._create_valid_page_with_slug("pagetoupdateasother")
+        page_id = response_json["id"]
+        with self._different_user():
+            update_response = self._update_page(page_id, "newannotation", "newslug", "newtitle", error_code=403)
+            assert update_response["err_msg"] == "Page is not owned by the current user"
+
     def test_403_on_unowner_show(self):
         response_json = self._create_valid_page_as("others_page_show@bx.psu.edu", "otherspageshow")
         show_response = self._get(f"pages/{response_json['id']}")


### PR DESCRIPTION
As mentioned in #22873 :

> If you make a page accessible (regardless of standalone/notebook/report), it can be edited by any other user and saved. that doesn't seem right? it does work nicely in that we can have collaborative notebooks, but we need to implement that properly. For now, accessible pages should just be viewable?

I'll add a bit of polish to allow "copying" another user's report by clicking edit, in that other #22873 PR which already updates the Edit button (do not want a conflict here).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
