### PR TITLE
[26.1] Align remote file browser labels

### DIFF
--- a/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
+++ b/client/src/components/Panels/Upload/methods/RemoteFilesUpload.vue
@@ -713,6 +713,7 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
                                 class="mr-2 text-warning"
                                 fixed-width />
                             <span
+                                class="remote-files-browser-label"
                                 data-test-id="remote-files-browser-label"
                                 :data-label="item.label"
                                 :data-entry-kind="item.isLeaf ? 'file' : 'directory'">
@@ -941,6 +942,10 @@ defineExpose<UploadMethodComponent>({ prepareUpload, reset });
         &:hover {
             background-color: rgba($brand-primary, 0.05);
         }
+    }
+
+    .remote-files-browser-label {
+        text-align: start;
     }
 }
 


### PR DESCRIPTION
Fixes text alignment of file and folder names in the remote files browser table within the Upload panel. Labels were centered by default (inherited from table styling), which made long file names harder to read. Now they align to the start.

|Before|After|
|---|---|
|<img width="1104" height="495" alt="before" src="https://github.com/user-attachments/assets/bf19a104-4d82-43a9-bb29-f4eb9b25e7a7" />|<img width="1104" height="495" alt="after" src="https://github.com/user-attachments/assets/fd5e2e41-2faa-4ea2-8974-6706849213a6" />|

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open the Beta Upload panel (click the upload icon in the toolbar).
  2. Select the "Remote files" tab.
  3. Browse a file source and verify that long file/folder names are left-aligned (start-aligned) rather than centered in the name column.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).