### PR TITLE
[26.1] Speed up workflow Run form: memoize and skip redundant history scans (#22927)

### DIFF
--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -5,6 +5,7 @@ Mock infrastructure for testing ModelManagers.
 import os
 import shutil
 import tempfile
+from collections.abc import Hashable
 from typing import (
     Any,
     cast,
@@ -335,6 +336,7 @@ class MockTrans:
         self.__user = user
         self.security = self.app.security
         self.history = history
+        self._short_term_cache: dict[tuple[Hashable, ...], Any] = {}
 
         self.request: Any = Bunch(
             headers={},
@@ -348,6 +350,12 @@ class MockTrans:
     @property
     def tag_handler(self):
         return self.app.tag_handler
+
+    def set_cache_value(self, args: tuple[Hashable, ...], value: Any):
+        self._short_term_cache[args] = value
+
+    def get_cache_value(self, args: tuple[Hashable, ...], default: Any = None) -> Any:
+        return self._short_term_cache.get(args, default)
 
     def check_csrf_token(self, payload):
         pass

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -5,7 +5,10 @@ Mock infrastructure for testing ModelManagers.
 import os
 import shutil
 import tempfile
-from collections.abc import Hashable
+from collections.abc import (
+    Callable,
+    Hashable,
+)
 from typing import (
     Any,
     cast,
@@ -356,6 +359,14 @@ class MockTrans:
 
     def get_cache_value(self, args: tuple[Hashable, ...], default: Any = None) -> Any:
         return self._short_term_cache.get(args, default)
+
+    def get_or_set_cache_value(self, args: tuple[Hashable, ...], factory: Callable[[], Any]) -> Any:
+        miss = object()
+        value = self.get_cache_value(args, miss)
+        if value is miss:
+            value = factory()
+            self.set_cache_value(args, value)
+        return value
 
     def check_csrf_token(self, payload):
         pass

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -193,6 +193,11 @@ class ProvidesAppContext:
         return self.app.install_model
 
 
+# Sentinel distinguishing a cached value (which may legitimately be ``None``)
+# from a cache miss in ``get_or_set_cache_value``.
+_CACHE_MISS: Any = object()
+
+
 class ProvidesUserContext(ProvidesAppContext):
     """For transaction-like objects to provide Galaxy convenience layer for
     reasoning about users.
@@ -211,6 +216,17 @@ class ProvidesUserContext(ProvidesAppContext):
 
     def get_cache_value(self, args: tuple[Hashable, ...], default: Any = None) -> Any:
         return self._short_term_cache.get(args, default)
+
+    def get_or_set_cache_value(self, args: tuple[Hashable, ...], factory: Callable[[], Any]) -> Any:
+        """Return the cached value for ``args``, computing and storing it via
+        ``factory`` on a miss. Request-scoped memoization for work repeated
+        within a single transaction (e.g. identical history-option queries
+        otherwise issued once per parameter while building a workflow Run form)."""
+        value = self.get_cache_value(args, _CACHE_MISS)
+        if value is _CACHE_MISS:
+            value = factory()
+            self.set_cache_value(args, value)
+        return value
 
     @property
     def tag_handler(self):

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -37,7 +37,10 @@ A method that requires a user but not a history should declare its
 # more checks against this issue.
 import abc
 import string
-from collections.abc import Callable
+from collections.abc import (
+    Callable,
+    Hashable,
+)
 from json import dumps
 from typing import (
     Any,
@@ -201,12 +204,12 @@ class ProvidesUserContext(ProvidesAppContext):
     workflow_building_mode: Literal[1, True, False] = False
     galaxy_session: Optional[GalaxySession] = None
     _tag_handler: Optional[GalaxyTagHandlerSession] = None
-    _short_term_cache: dict[tuple[str, ...], Any]
+    _short_term_cache: dict[tuple[Hashable, ...], Any]
 
-    def set_cache_value(self, args: tuple[str, ...], value: Any):
+    def set_cache_value(self, args: tuple[Hashable, ...], value: Any):
         self._short_term_cache[args] = value
 
-    def get_cache_value(self, args: tuple[str, ...], default: Any = None) -> Any:
+    def get_cache_value(self, args: tuple[Hashable, ...], default: Any = None) -> Any:
         return self._short_term_cache.get(args, default)
 
     @property

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -93,6 +93,7 @@ from . import (
 from .dataset_matcher import get_dataset_matcher_factory
 from .sanitize import ToolParameterSanitizer
 from .workflow_utils import (
+    ConnectedValue,
     is_runtime_value,
     runtime_to_json,
     runtime_to_object,
@@ -1878,12 +1879,65 @@ def _carried_state_label(value) -> str:
 def _is_connected_value(value) -> bool:
     """True iff ``value`` is a workflow ``ConnectedValue`` (an input fed by an
     upstream step's output rather than chosen at runtime)."""
-    return is_runtime_value(value) and runtime_to_json(value)["__class__"] == "ConnectedValue"
+    return is_runtime_value(value) and isinstance(runtime_to_object(value), ConnectedValue)
 
 
-# Sentinel distinguishing a populated cache entry (always a ``(rows, total)``
-# tuple) from a cache miss.
-_PAGE_CACHE_MISS: Any = object()
+def _paginated_visible_datasets(
+    trans: "ProvidesHistoryContext",
+    history: "History",
+    *,
+    extensions: Optional[set[str]],
+    valid_states: Optional[tuple[str, ...]],
+    search: Optional[str] = None,
+    offset: int = 0,
+    limit: int = 50,
+) -> tuple[list[HistoryDatasetAssociation], int]:
+    """``history.paginated_active_visible_datasets`` memoized on the request.
+
+    Building one form with many ``data`` parameters (most notably the workflow
+    Run form, which renders every step in a single request) otherwise re-issues
+    the same paginated SQL against the same, unchanging history once per
+    parameter -- O(parameters) round-trips, slow even on an empty history
+    (issue #22927). Results are memoized by signature on the request context's
+    short-term cache (see ``ProvidesUserContext.get_or_set_cache_value``); the
+    cache is shared across every step's proxy work context for the request and
+    never outlives it, so the history cannot change underneath it.
+    """
+    key = (
+        "data_param_hda_page",
+        history.id,
+        frozenset(extensions) if extensions is not None else None,
+        tuple(valid_states) if valid_states is not None else None,
+        search or None,
+        offset,
+        limit,
+    )
+    return trans.get_or_set_cache_value(
+        key,
+        lambda: history.paginated_active_visible_datasets(
+            extensions=extensions, valid_states=valid_states, search=search, offset=offset, limit=limit
+        ),
+    )
+
+
+def _paginated_dataset_collections(
+    trans: "ProvidesHistoryContext",
+    history: "History",
+    *,
+    visible_only: bool,
+    search: Optional[str] = None,
+    offset: int = 0,
+    limit: int = 50,
+) -> tuple[list[HistoryDatasetCollectionAssociation], int]:
+    """``history.paginated_active_dataset_collections`` memoized on the request
+    context's short-term cache (see :func:`_paginated_visible_datasets`)."""
+    key = ("data_param_hdca_page", history.id, bool(visible_only), search or None, offset, limit)
+    return trans.get_or_set_cache_value(
+        key,
+        lambda: history.paginated_active_dataset_collections(
+            visible_only=visible_only, search=search, offset=offset, limit=limit
+        ),
+    )
 
 
 class BaseDataToolParameter(ToolParameter):
@@ -1981,68 +2035,6 @@ class BaseDataToolParameter(ToolParameter):
         self._acceptable_extensions_cache = accepted
         return accepted
 
-    def _paginated_visible_datasets(
-        self,
-        trans: "ProvidesHistoryContext",
-        history: "History",
-        *,
-        extensions: Optional[set[str]],
-        valid_states: Optional[tuple[str, ...]],
-        search: Optional[str] = None,
-        offset: int = 0,
-        limit: int = 50,
-    ) -> tuple[list[HistoryDatasetAssociation], int]:
-        """``history.paginated_active_visible_datasets`` memoized on the request.
-
-        Building one form with many ``data`` parameters (most notably the workflow
-        Run form, which renders every step in a single request) otherwise re-issues
-        the same paginated SQL against the same, unchanging history once per
-        parameter -- O(parameters) round-trips, slow even on an empty history
-        (issue #22927). The results are cached by signature on the request context's
-        short-term cache (see ``ProvidesHistoryContext.set_cache_value``); the cache
-        is shared across every step's proxy work context for the request and never
-        outlives it, so the history cannot change underneath it.
-        """
-        key = (
-            "data_param_hda_page",
-            history.id,
-            frozenset(extensions) if extensions is not None else None,
-            tuple(valid_states) if valid_states is not None else None,
-            search or None,
-            offset,
-            limit,
-        )
-        cached = trans.get_cache_value(key, _PAGE_CACHE_MISS)
-        if cached is not _PAGE_CACHE_MISS:
-            return cached
-        result = history.paginated_active_visible_datasets(
-            extensions=extensions, valid_states=valid_states, search=search, offset=offset, limit=limit
-        )
-        trans.set_cache_value(key, result)
-        return result
-
-    def _paginated_dataset_collections(
-        self,
-        trans: "ProvidesHistoryContext",
-        history: "History",
-        *,
-        visible_only: bool,
-        search: Optional[str] = None,
-        offset: int = 0,
-        limit: int = 50,
-    ) -> tuple[list[HistoryDatasetCollectionAssociation], int]:
-        """``history.paginated_active_dataset_collections`` memoized on the request
-        context's short-term cache (see :meth:`_paginated_visible_datasets`)."""
-        key = ("data_param_hdca_page", history.id, bool(visible_only), search or None, offset, limit)
-        cached = trans.get_cache_value(key, _PAGE_CACHE_MISS)
-        if cached is not _PAGE_CACHE_MISS:
-            return cached
-        result = history.paginated_active_dataset_collections(
-            visible_only=visible_only, search=search, offset=offset, limit=limit
-        )
-        trans.set_cache_value(key, result)
-        return result
-
     def _uses_python_options_filter(self) -> bool:
         """True iff matching depends on per-row Python state that cannot be
         pushed to SQL (dynamic options with ``options_filter_attribute``, or a
@@ -2071,7 +2063,7 @@ class BaseDataToolParameter(ToolParameter):
                 chunk_size = MAX_OPTIONS_PAGE_SIZE
                 db_offset = 0
                 while True:
-                    rows, total = self._paginated_visible_datasets(
+                    rows, total = _paginated_visible_datasets(
                         trans,
                         history,
                         extensions=self._acceptable_extensions(),
@@ -2093,7 +2085,7 @@ class BaseDataToolParameter(ToolParameter):
                 chunk_size = MAX_OPTIONS_PAGE_SIZE
                 db_offset = 0
                 while True:
-                    collection_rows, total = self._paginated_dataset_collections(
+                    collection_rows, total = _paginated_dataset_collections(
                         trans,
                         history,
                         visible_only=True,
@@ -2658,7 +2650,7 @@ class DataToolParameter(BaseDataToolParameter):
         valid_states = dataset_matcher_factory.valid_input_states
 
         def hda_query(*, offset, limit):
-            return self._paginated_visible_datasets(
+            return _paginated_visible_datasets(
                 trans,
                 history,
                 extensions=acceptable_extensions,
@@ -2768,7 +2760,7 @@ class DataToolParameter(BaseDataToolParameter):
         _offset, _limit, hdca_search = builder.page("hdca")
 
         def hdca_query(*, offset, limit):
-            return self._paginated_dataset_collections(
+            return _paginated_dataset_collections(
                 trans, history, visible_only=True, search=hdca_search, offset=offset, limit=limit
             )
 
@@ -2998,7 +2990,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         history_query = self._history_query(trans)
 
         def hdca_query(*, offset, limit):
-            return self._paginated_dataset_collections(
+            return _paginated_dataset_collections(
                 trans, history, visible_only=False, search=hdca_search, offset=offset, limit=limit
             )
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1875,6 +1875,12 @@ def _carried_state_label(value) -> str:
     return "not in current history"
 
 
+def _is_connected_value(value) -> bool:
+    """True iff ``value`` is a workflow ``ConnectedValue`` (an input fed by an
+    upstream step's output rather than chosen at runtime)."""
+    return is_runtime_value(value) and runtime_to_json(value)["__class__"] == "ConnectedValue"
+
+
 # Sentinel distinguishing a populated cache entry (always a ``(rows, total)``
 # tuple) from a cache miss.
 _PAGE_CACHE_MISS: Any = object()
@@ -2051,6 +2057,10 @@ class BaseDataToolParameter(ToolParameter):
         if trans.workflow_building_mode is workflow_building_modes.ENABLED or trans.app.name == "tool_shed":
             return RuntimeValue()
         if self.optional:
+            return None
+        if _is_connected_value((other_values or {}).get(self.name)):
+            # Connected inputs are supplied by an upstream step; there is no
+            # default to pick from the history, so skip the scan (issue #22927).
             return None
         if (history := trans.history) is not None:
             dataset_matcher_factory = get_dataset_matcher_factory(trans)
@@ -2577,6 +2587,12 @@ class DataToolParameter(BaseDataToolParameter):
         if history is None or trans.workflow_building_mode is workflow_building_modes.ENABLED:
             return d
 
+        if _is_connected_value(other_values.get(self.name)):
+            # Input is wired to an upstream step: the run form renders it as
+            # "connected" (no dropdown) and never uses these options, so skip the
+            # per-parameter history scan entirely (issue #22927).
+            return d
+
         dataset_matcher_factory = get_dataset_matcher_factory(trans)
         dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
 
@@ -2933,6 +2949,11 @@ class DataCollectionToolParameter(BaseDataToolParameter):
 
         history = trans.history
         if history is None or trans.workflow_building_mode is workflow_building_modes.ENABLED:
+            return d
+
+        if _is_connected_value(other_values.get(self.name)):
+            # Connected collection input: fed by an upstream step, rendered as
+            # "connected" with no dropdown, so skip the history scan (issue #22927).
             return d
 
         dataset_matcher_factory = get_dataset_matcher_factory(trans)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -102,6 +102,7 @@ from .workflow_utils import (
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from galaxy.managers.context import ProvidesHistoryContext
     from galaxy.model import (
         History,
         HistoryItem,
@@ -1874,6 +1875,11 @@ def _carried_state_label(value) -> str:
     return "not in current history"
 
 
+# Sentinel distinguishing a populated cache entry (always a ``(rows, total)``
+# tuple) from a cache miss.
+_PAGE_CACHE_MISS: Any = object()
+
+
 class BaseDataToolParameter(ToolParameter):
     multiple: bool
 
@@ -1969,6 +1975,68 @@ class BaseDataToolParameter(ToolParameter):
         self._acceptable_extensions_cache = accepted
         return accepted
 
+    def _paginated_visible_datasets(
+        self,
+        trans: "ProvidesHistoryContext",
+        history: "History",
+        *,
+        extensions: Optional[set[str]],
+        valid_states: Optional[tuple[str, ...]],
+        search: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[HistoryDatasetAssociation], int]:
+        """``history.paginated_active_visible_datasets`` memoized on the request.
+
+        Building one form with many ``data`` parameters (most notably the workflow
+        Run form, which renders every step in a single request) otherwise re-issues
+        the same paginated SQL against the same, unchanging history once per
+        parameter -- O(parameters) round-trips, slow even on an empty history
+        (issue #22927). The results are cached by signature on the request context's
+        short-term cache (see ``ProvidesHistoryContext.set_cache_value``); the cache
+        is shared across every step's proxy work context for the request and never
+        outlives it, so the history cannot change underneath it.
+        """
+        key = (
+            "data_param_hda_page",
+            history.id,
+            frozenset(extensions) if extensions is not None else None,
+            tuple(valid_states) if valid_states is not None else None,
+            search or None,
+            offset,
+            limit,
+        )
+        cached = trans.get_cache_value(key, _PAGE_CACHE_MISS)
+        if cached is not _PAGE_CACHE_MISS:
+            return cached
+        result = history.paginated_active_visible_datasets(
+            extensions=extensions, valid_states=valid_states, search=search, offset=offset, limit=limit
+        )
+        trans.set_cache_value(key, result)
+        return result
+
+    def _paginated_dataset_collections(
+        self,
+        trans: "ProvidesHistoryContext",
+        history: "History",
+        *,
+        visible_only: bool,
+        search: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[HistoryDatasetCollectionAssociation], int]:
+        """``history.paginated_active_dataset_collections`` memoized on the request
+        context's short-term cache (see :meth:`_paginated_visible_datasets`)."""
+        key = ("data_param_hdca_page", history.id, bool(visible_only), search or None, offset, limit)
+        cached = trans.get_cache_value(key, _PAGE_CACHE_MISS)
+        if cached is not _PAGE_CACHE_MISS:
+            return cached
+        result = history.paginated_active_dataset_collections(
+            visible_only=visible_only, search=search, offset=offset, limit=limit
+        )
+        trans.set_cache_value(key, result)
+        return result
+
     def _uses_python_options_filter(self) -> bool:
         """True iff matching depends on per-row Python state that cannot be
         pushed to SQL (dynamic options with ``options_filter_attribute``, or a
@@ -1993,7 +2061,9 @@ class BaseDataToolParameter(ToolParameter):
                 chunk_size = MAX_OPTIONS_PAGE_SIZE
                 db_offset = 0
                 while True:
-                    rows, total = history.paginated_active_visible_datasets(
+                    rows, total = self._paginated_visible_datasets(
+                        trans,
+                        history,
                         extensions=self._acceptable_extensions(),
                         valid_states=dataset_matcher_factory.valid_input_states,
                         offset=db_offset,
@@ -2013,17 +2083,19 @@ class BaseDataToolParameter(ToolParameter):
                 chunk_size = MAX_OPTIONS_PAGE_SIZE
                 db_offset = 0
                 while True:
-                    rows, total = history.paginated_active_dataset_collections(
+                    collection_rows, total = self._paginated_dataset_collections(
+                        trans,
+                        history,
                         visible_only=True,
                         offset=db_offset,
                         limit=chunk_size,
                     )
-                    if not rows:
+                    if not collection_rows:
                         return None
-                    for hdca in rows:
+                    for hdca in collection_rows:
                         if dataset_collection_matcher.hdca_match(hdca):
                             return hdca
-                    db_offset += len(rows)
+                    db_offset += len(collection_rows)
                     if db_offset >= total:
                         return None
 
@@ -2517,7 +2589,7 @@ class DataToolParameter(BaseDataToolParameter):
         job_input_values = util.listify(other_values.get(self.name))
 
         job_input_values = self._page_hda_matches(
-            builder, history, dataset_matcher, dataset_matcher_factory, job_input_values
+            trans, builder, history, dataset_matcher, dataset_matcher_factory, job_input_values
         )
         unresolved = self._pin_live_hda_inputs(builder, history, dataset_matcher, job_input_values)
         self._carry_unresolved_inputs(builder, history, unresolved)
@@ -2553,6 +2625,7 @@ class DataToolParameter(BaseDataToolParameter):
 
     def _page_hda_matches(
         self,
+        trans,
         builder: DataOptionsBuilder,
         history,
         dataset_matcher,
@@ -2569,7 +2642,9 @@ class DataToolParameter(BaseDataToolParameter):
         valid_states = dataset_matcher_factory.valid_input_states
 
         def hda_query(*, offset, limit):
-            return history.paginated_active_visible_datasets(
+            return self._paginated_visible_datasets(
+                trans,
+                history,
                 extensions=acceptable_extensions,
                 valid_states=valid_states,
                 search=hda_search,
@@ -2677,8 +2752,8 @@ class DataToolParameter(BaseDataToolParameter):
         _offset, _limit, hdca_search = builder.page("hdca")
 
         def hdca_query(*, offset, limit):
-            return history.paginated_active_dataset_collections(
-                visible_only=True, search=hdca_search, offset=offset, limit=limit
+            return self._paginated_dataset_collections(
+                trans, history, visible_only=True, search=hdca_search, offset=offset, limit=limit
             )
 
         def hdca_filter(hdca):
@@ -2902,8 +2977,8 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         history_query = self._history_query(trans)
 
         def hdca_query(*, offset, limit):
-            return history.paginated_active_dataset_collections(
-                visible_only=False, search=hdca_search, offset=offset, limit=limit
+            return self._paginated_dataset_collections(
+                trans, history, visible_only=False, search=hdca_search, offset=offset, limit=limit
             )
 
         def hdca_filter(hdca):

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -954,22 +954,18 @@ class DynamicOptions:
             url = fill_template(from_url_options.from_url, context)
             request_body = template_or_none(from_url_options.request_body, context)
             request_headers = template_or_none(from_url_options.request_headers, context)
+            cache_key = (url, from_url_options.request_method, request_body, request_headers)
             try:
-                unset_value = object()
-                cached_value = trans.get_cache_value(
-                    (url, from_url_options.request_method, request_body, request_headers), unset_value
-                )
-                if cached_value is unset_value:
-                    data = request(
+                data = trans.get_or_set_cache_value(
+                    cache_key,
+                    lambda: request(
                         url=url,
                         method=from_url_options.request_method,
                         data=json.loads(request_body) if request_body else None,
                         headers=json.loads(request_headers) if request_headers else None,
                         timeout=10,
-                    )
-                    trans.set_cache_value((url, from_url_options.request_method, request_body, request_headers), data)
-                else:
-                    data = cached_value
+                    ),
+                )
             except Exception as e:
                 log.warning("Fetching from url '%s' failed: %s", url, str(e))
                 data = None

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -7,6 +7,7 @@ import os
 import re
 import socket
 import time
+from collections.abc import Hashable
 from contextlib import ExitStack
 from http.cookies import CookieError
 from typing import (
@@ -337,7 +338,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         self.galaxy_session = None
         self.error_message = None
         self.host = self.request.host
-        self._short_term_cache: dict[tuple[str, ...], Any] = {}
+        self._short_term_cache: dict[tuple[Hashable, ...], Any] = {}
 
         # set any cross origin resource sharing headers if configured to do so
         self.set_cors_headers()

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -1,4 +1,5 @@
 import abc
+from collections.abc import Hashable
 from typing import (
     Any,
     Literal,
@@ -39,13 +40,19 @@ class WorkRequestContext(ProvidesHistoryContext):
         workflow_building_mode=False,
         url_builder=None,
         galaxy_session: Optional["GalaxySession"] = None,
+        short_term_cache: Optional[dict[tuple[Hashable, ...], Any]] = None,
     ):
         self._app = app
         self.__user = user
         self.__user_current_roles: Optional[list[Role]] = None
         self.__history = history
         self._url_builder = url_builder
-        self._short_term_cache: dict[tuple[str, ...], Any] = {}
+        # When proxying an existing transaction (see ``proxy_work_context_for_history``)
+        # share its request-scoped cache so work done across proxies of the same
+        # request -- e.g. every step of a workflow Run form build -- is reused.
+        self._short_term_cache: dict[tuple[Hashable, ...], Any] = (
+            short_term_cache if short_term_cache is not None else {}
+        )
         self.workflow_building_mode = workflow_building_mode
         self.galaxy_session = galaxy_session
 
@@ -195,4 +202,5 @@ def proxy_work_context_for_history(
         url_builder=trans.url_builder,
         workflow_building_mode=workflow_building_mode,
         galaxy_session=trans.galaxy_session,
+        short_term_cache=trans._short_term_cache,
     )

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+from collections.abc import Hashable
 from typing import (
     Any,
 )
@@ -1052,6 +1053,7 @@ class MockTrans(ProvidesAppContext):
         self.history = None
         self.workflow_building_mode = workflow_building_modes.ENABLED
         self.tag_handler = app.tag_handler
+        self._short_term_cache: dict[tuple[Hashable, ...], Any] = {}
 
     @property
     def galaxy_session(self):

--- a/test/unit/app/tools/test_execution.py
+++ b/test/unit/app/tools/test_execution.py
@@ -1,7 +1,11 @@
 """Test Tool execution and state handling logic."""
 
 from collections import OrderedDict
-from typing import cast
+from collections.abc import Hashable
+from typing import (
+    Any,
+    cast,
+)
 
 import webob.exc
 from sqlalchemy import select
@@ -206,6 +210,7 @@ class MockTrans:
         self.sa_session = self.app.model.context
         self.url_builder = None
         self.galaxy_session = None
+        self._short_term_cache: dict[tuple[Hashable, ...], Any] = {}
 
     def get_history(self, **kwargs):
         return self.history


### PR DESCRIPTION
## What this does

Building a workflow **Run** form (`GET /api/workflows/{id}/download?style=run`) renders every step in a single request, and each `data` / `data_collection` parameter independently re-issued the *same* paginated history SQL (`History.paginated_active_visible_datasets` / `paginated_active_dataset_collections`) in both `get_initial_value` and `to_dict`. A single history scan became **O(number of parameters)** DB round-trips — slow even on an *empty* history, and scaling with workflow size. This is what produces the multi-minute "Loading workflow run data" hang reported in #22927.

Two complementary fixes:

1. **Memoize history option queries on the request context.** `Tool.to_json` builds a fresh `proxy_work_context_for_history` per step, so results are cached by `(filter, page)` signature on the request's short-term cache (`ProvidesHistoryContext.set_cache_value`), and `proxy_work_context_for_history` now shares the parent transaction's `_short_term_cache` with each per-step proxy. The cache stays request-scoped and shared across every step of a build, without attaching state to the SQLAlchemy `History` instance. Cache keys include the history id because a proxy may target a different history than the parent. (Cache key type widened from `tuple[str, ...]` to `tuple[Hashable, ...]` to allow richer signatures.)

2. **Skip the scan entirely for connected inputs.** A Run form renders inputs wired to an upstream step's output as *connected* (keyed off the `ConnectedValue`), never as a history dropdown — and the dropdowns lazy-load from `/api/histories/{id}/contents` anyway. So `DataToolParameter` / `DataCollectionToolParameter.to_dict` and `get_initial_value` now short-circuit when the parameter's current value is a `ConnectedValue`. In a typical chained workflow most tool-step inputs are connected, removing the bulk of the remaining per-step queries on top of the memoization.

## Impact

Benchmark (50-step workflow, empty history, 3 builds), vs. unpatched 26.1:

| metric | before | after |
|---|---|---|
| `_workflow_to_dict_run` | ~9100 ms | ~750 ms (**~13× faster**) |
| SQL executions | 2478 | 180 (**−93%**) |
| paginated history scans | 1164 | 15 |

## Files

- `lib/galaxy/tools/parameters/basic.py` — `_paginated_visible_datasets` / `_paginated_dataset_collections` memoization helpers; `_is_connected_value` short-circuits.
- `lib/galaxy/work/context.py` — `WorkRequestContext` accepts and shares a `short_term_cache`; `proxy_work_context_for_history` passes the parent's through.
- `lib/galaxy/managers/context.py`, `lib/galaxy/webapps/base/webapp.py`, `lib/galaxy/app_unittest_utils/galaxy_mock.py` — widen short-term cache key type to `Hashable`; mock trans gains the cache API.

## Related (not included)

The benchmarks used to find and quantify this regression live in [c28e00f](https://github.com/mvdbeek/galaxy/commit/c28e00f41636d89fbff82a386e52ec36c4e522c2) (profileable Run-form benchmarks + `_acceptable_extensions` micro-benchmark). **It is intentionally left out of this PR** — as a standalone addition it's probably not worth carrying, since it's primarily scaffolding for diagnosing this specific issue rather than a generally useful feature.
