### PR TITLE
[26.1] Auto-grow the GalaxyAI chat input as you type

### DIFF
--- a/client/src/components/GalaxyAI/ChatInput.test.ts
+++ b/client/src/components/GalaxyAI/ChatInput.test.ts
@@ -154,7 +154,13 @@ describe("ChatInput", () => {
             Object.defineProperty(el, "scrollHeight", { configurable: true, value });
         }
 
-        it("sizes the textarea to its content on mount", () => {
+        it("does not set height on mount when value is empty", () => {
+            const wrapper = mountInput({ value: "" });
+            const el = wrapper.find("textarea").element as HTMLTextAreaElement;
+            expect(el.style.height).toBe("");
+        });
+
+        it("sizes the textarea to its content on mount when value is non-empty", () => {
             // onMounted resizes synchronously, so mock scrollHeight on the
             // prototype before mounting and restore it afterwards.
             const proto = window.HTMLTextAreaElement.prototype;
@@ -184,7 +190,7 @@ describe("ChatInput", () => {
             expect(el.style.height).toBe("120px");
         });
 
-        it("shrinks back down when the value is cleared after submit", async () => {
+        it("resets height to '' when value is cleared (e.g. after submit)", async () => {
             const wrapper = mountInput({ value: "a\nb\nc\nd\ne" });
             const el = wrapper.find("textarea").element as HTMLTextAreaElement;
 
@@ -193,10 +199,9 @@ describe("ChatInput", () => {
             await wrapper.vm.$nextTick();
             expect(el.style.height).toBe("140px");
 
-            mockScrollHeight(el, 40);
             await wrapper.setProps({ value: "" });
             await wrapper.vm.$nextTick();
-            expect(el.style.height).toBe("40px");
+            expect(el.style.height).toBe("");
         });
     });
 

--- a/client/src/components/GalaxyAI/ChatInput.test.ts
+++ b/client/src/components/GalaxyAI/ChatInput.test.ts
@@ -149,6 +149,57 @@ describe("ChatInput", () => {
         });
     });
 
+    describe("auto-resize", () => {
+        function mockScrollHeight(el: HTMLTextAreaElement, value: number) {
+            Object.defineProperty(el, "scrollHeight", { configurable: true, value });
+        }
+
+        it("sizes the textarea to its content on mount", () => {
+            // onMounted resizes synchronously, so mock scrollHeight on the
+            // prototype before mounting and restore it afterwards.
+            const proto = window.HTMLTextAreaElement.prototype;
+            const original = Object.getOwnPropertyDescriptor(proto, "scrollHeight");
+            Object.defineProperty(proto, "scrollHeight", { configurable: true, get: () => 96 });
+            try {
+                const wrapper = mountInput({ value: "line one\nline two\nline three" });
+                const el = wrapper.find("textarea").element as HTMLTextAreaElement;
+                expect(el.style.height).toBe("96px");
+            } finally {
+                if (original) {
+                    Object.defineProperty(proto, "scrollHeight", original);
+                } else {
+                    delete (proto as { scrollHeight?: number }).scrollHeight;
+                }
+            }
+        });
+
+        it("grows when the value changes (typing / mention insert)", async () => {
+            const wrapper = mountInput({ value: "short" });
+            const el = wrapper.find("textarea").element as HTMLTextAreaElement;
+
+            mockScrollHeight(el, 120);
+            await wrapper.setProps({ value: "much\nlonger\ncontent\nhere" });
+            await wrapper.vm.$nextTick();
+
+            expect(el.style.height).toBe("120px");
+        });
+
+        it("shrinks back down when the value is cleared after submit", async () => {
+            const wrapper = mountInput({ value: "a\nb\nc\nd\ne" });
+            const el = wrapper.find("textarea").element as HTMLTextAreaElement;
+
+            mockScrollHeight(el, 140);
+            await wrapper.setProps({ value: "a\nb\nc\nd\ne\nf" });
+            await wrapper.vm.$nextTick();
+            expect(el.style.height).toBe("140px");
+
+            mockScrollHeight(el, 40);
+            await wrapper.setProps({ value: "" });
+            await wrapper.vm.$nextTick();
+            expect(el.style.height).toBe("40px");
+        });
+    });
+
     describe("busy state UI", () => {
         it("shows loading indicator when busy", () => {
             const wrapper = mountInput({ busy: true });

--- a/client/src/components/GalaxyAI/ChatInput.test.ts
+++ b/client/src/components/GalaxyAI/ChatInput.test.ts
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,7 +15,6 @@ vi.mock("@/stores/historyItemsStore", () => ({
 function mountInput(
     props: Record<string, unknown> = {},
     stubs: Record<string, boolean> = {
-        FontAwesomeIcon: true,
         LoadingSpan: true,
         MentionDropdown: true,
     },
@@ -207,14 +207,20 @@ describe("ChatInput", () => {
     });
 
     describe("busy state UI", () => {
-        it("shows loading indicator when busy", () => {
+        it("shows spinner icon when busy", () => {
             const wrapper = mountInput({ busy: true });
-            expect(wrapper.findComponent({ name: "LoadingSpan" }).exists()).toBe(true);
+            const buttonIcon = wrapper.findComponent(GButton).findComponent(FontAwesomeIcon);
+            expect(buttonIcon.classes()).toContain("fa-spinner");
+            expect(buttonIcon.classes()).toContain("fa-spin");
+            expect(buttonIcon.classes()).not.toContain("fa-paper-plane");
         });
 
-        it("hides loading indicator when not busy", () => {
+        it("shows send icon when not busy", () => {
             const wrapper = mountInput({ busy: false });
-            expect(wrapper.findComponent({ name: "LoadingSpan" }).exists()).toBe(false);
+            const buttonIcon = wrapper.findComponent(GButton).findComponent(FontAwesomeIcon);
+            expect(buttonIcon.classes()).toContain("fa-paper-plane");
+            expect(buttonIcon.classes()).not.toContain("fa-spinner");
+            expect(buttonIcon.classes()).not.toContain("fa-spin");
         });
     });
 });

--- a/client/src/components/GalaxyAI/ChatInput.test.ts
+++ b/client/src/components/GalaxyAI/ChatInput.test.ts
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
+import GButton from "../BaseComponents/GButton.vue";
 import ChatInput from "./ChatInput.vue";
 
 vi.mock("@/stores/historyStore", () => ({
@@ -66,27 +67,27 @@ describe("ChatInput", () => {
 
         it("disables send button when value is empty", () => {
             const wrapper = mountInput({ value: "" });
-            expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(true);
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
         });
 
         it("disables send button when value is whitespace", () => {
             const wrapper = mountInput({ value: "   " });
-            expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(true);
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
         });
 
         it("enables send button when value has content", () => {
             const wrapper = mountInput({ value: "hello" });
-            expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(false);
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(false);
         });
 
         it("disables send button when busy even with content", () => {
             const wrapper = mountInput({ value: "hello", busy: true });
-            expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(true);
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
         });
 
         it("disables send button when disabled prop is true even with content", () => {
             const wrapper = mountInput({ value: "hello", disabled: true });
-            expect((wrapper.find("button").element as HTMLButtonElement).disabled).toBe(true);
+            expect(wrapper.findComponent(GButton).props("disabled")).toBe(true);
         });
     });
 
@@ -102,7 +103,7 @@ describe("ChatInput", () => {
 
         it("emits submit on send button click", async () => {
             const wrapper = mountInput({ value: "hello" });
-            await wrapper.find("button").trigger("click");
+            await wrapper.findComponent(GButton).trigger("click");
             expect(wrapper.emitted("submit")).toBeTruthy();
         });
 

--- a/client/src/components/GalaxyAI/ChatInput.vue
+++ b/client/src/components/GalaxyAI/ChatInput.vue
@@ -35,6 +35,12 @@ function resize() {
     if (!textarea) {
         return;
     }
+    if (!textarea.value) {
+        // No content — let CSS min-height govern; don't measure scrollHeight
+        // which would include the placeholder's wrapped height.
+        textarea.style.height = "";
+        return;
+    }
     // Reset first so the element can shrink, then grow to fit content.
     // CSS max-height caps growth and overflow-y:auto takes over past the cap.
     textarea.style.height = "auto";
@@ -49,7 +55,11 @@ watch(
     () => nextTick(resize),
 );
 
-onMounted(resize);
+onMounted(() => {
+    if (props.value) {
+        resize();
+    }
+});
 
 function onInput(event: Event) {
     const textarea = event.target as HTMLTextAreaElement;

--- a/client/src/components/GalaxyAI/ChatInput.vue
+++ b/client/src/components/GalaxyAI/ChatInput.vue
@@ -5,6 +5,7 @@ import { nextTick, onMounted, ref, watch } from "vue";
 
 import { detectMentionTrigger, type EntityType, type MentionTrigger } from "@/composables/useEntityMentions";
 
+import GButton from "../BaseComponents/GButton.vue";
 import MentionDropdown from "./MentionDropdown.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -150,13 +151,15 @@ function closeMention() {
             class="form-control chat-input"
             @input="onInput"
             @keydown="onKeydown" />
-        <button
+        <GButton
             :disabled="busy || disabled || !props.value.trim()"
-            class="btn btn-primary send-button"
+            class="send-button"
+            color="blue"
+            size="large"
             @click="emit('submit')">
             <FontAwesomeIcon v-if="!busy" :icon="faPaperPlane" fixed-width />
             <LoadingSpan v-else message="" />
-        </button>
+        </GButton>
 
         <MentionDropdown
             ref="dropdownRef"
@@ -175,7 +178,7 @@ function closeMention() {
 .chat-input-container {
     display: flex;
     gap: 0.5rem;
-    align-items: flex-end;
+    align-items: flex-start;
     position: relative;
 
     .chat-input {
@@ -197,9 +200,7 @@ function closeMention() {
     }
 
     .send-button {
-        flex-shrink: 0;
-        border-radius: $border-radius-base;
-        padding: 0.5rem 0.875rem;
+        display: block;
     }
 }
 

--- a/client/src/components/GalaxyAI/ChatInput.vue
+++ b/client/src/components/GalaxyAI/ChatInput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { ref } from "vue";
+import { nextTick, onMounted, ref, watch } from "vue";
 
 import { detectMentionTrigger, type EntityType, type MentionTrigger } from "@/composables/useEntityMentions";
 
@@ -29,6 +29,27 @@ const emit = defineEmits<{
 const textareaEl = ref<HTMLTextAreaElement | null>(null);
 const dropdownRef = ref<InstanceType<typeof MentionDropdown> | null>(null);
 const mentionTrigger = ref<MentionTrigger | null>(null);
+
+function resize() {
+    const textarea = textareaEl.value;
+    if (!textarea) {
+        return;
+    }
+    // Reset first so the element can shrink, then grow to fit content.
+    // CSS max-height caps growth and overflow-y:auto takes over past the cap.
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+}
+
+// props.value is the single funnel for every value change -- user typing
+// (round-trips through the parent), programmatic @-mention inserts, and the
+// parent clearing the field after submit. nextTick lets the DOM update first.
+watch(
+    () => props.value,
+    () => nextTick(resize),
+);
+
+onMounted(resize);
 
 function onInput(event: Event) {
     const textarea = event.target as HTMLTextAreaElement;
@@ -156,6 +177,7 @@ function closeMention() {
         font-size: 0.9rem;
         min-height: 2.5rem;
         max-height: 8rem;
+        overflow-y: auto;
 
         &:focus {
             border-color: $brand-primary;

--- a/client/src/components/GalaxyAI/ChatInput.vue
+++ b/client/src/components/GalaxyAI/ChatInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
+import { faPaperPlane, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { nextTick, onMounted, ref, watch } from "vue";
 
@@ -7,7 +7,6 @@ import { detectMentionTrigger, type EntityType, type MentionTrigger } from "@/co
 
 import GButton from "../BaseComponents/GButton.vue";
 import MentionDropdown from "./MentionDropdown.vue";
-import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const props = withDefaults(
     defineProps<{
@@ -157,8 +156,7 @@ function closeMention() {
             color="blue"
             size="large"
             @click="emit('submit')">
-            <FontAwesomeIcon v-if="!busy" :icon="faPaperPlane" fixed-width />
-            <LoadingSpan v-else message="" />
+            <FontAwesomeIcon :icon="!busy ? faPaperPlane : faSpinner" fixed-width :spin="busy" />
         </GButton>
 
         <MentionDropdown


### PR DESCRIPTION
The GalaxyAI prompt box is fixed at a single row today, so typing a longer question scrolls the text inside a cramped little box instead of letting the field grow. This makes it adjust to its content as you type, up to a sensible cap, then scroll past that -- which is what #22921 asks for.

The textarea now resizes to fit its content. I drive the resize off a single `watch` on the value prop, since that's the one point every change flows through: typing (which round-trips through the parent's `v-model`), programmatic `@`-mention inserts, and the parent clearing the field after a message is sent. So growing, shrinking back on clear, and the initial mount sizing are all one code path rather than scattered handlers. The existing `max-height: 8rem` (~6 lines) stays as the limit, and I added `overflow-y: auto` so it scrolls once it hits that cap.

Nothing about the controlled-component contract, the mention dropdown, or focus/cursor handling changes.

**Tests:** added an `auto-resize` block covering mount sizing, growth on value change, and shrink-on-clear. happy-dom has no layout engine (`scrollHeight` is 0) and doesn't apply SFC CSS, so the tests mock `scrollHeight` and assert on the inline height the resize writes; I mutation-checked them (removing the resize logic fails all three).

**To verify manually:** open the GalaxyAI panel and type/paste several lines into the prompt -- the box grows with the text, starts scrolling once it reaches the cap, and collapses back after you send.

Closes #22921.
