### PR TITLE
[26.1] Release request-scoped DB connection during long-lived streams

### DIFF
--- a/lib/galaxy/managers/sse.py
+++ b/lib/galaxy/managers/sse.py
@@ -280,6 +280,7 @@ class SSEConnectionManager:
         self,
         is_disconnected: IsDisconnected,
         user_id: Optional[int],
+        release_db_session: Callable[[], None],
         catch_up: Optional[SSEEvent] = None,
         keepalive: float = 30.0,
         galaxy_session_id: Optional[int] = None,
@@ -291,10 +292,23 @@ class SSEConnectionManager:
         ``disconnect`` in ``finally``. The ``is_disconnected`` callable is
         what the service passes in (typically ``request.is_disconnected`` from
         starlette) so the manager stays framework-agnostic.
+
+        ``release_db_session`` is required and called once, right before
+        entering the keepalive loop. All database work needed to open the stream
+        (auth, catch-up) has happened by then, and the loop below never touches
+        the database. FastAPI otherwise keeps the request-scoped SQLAlchemy
+        session — and its pooled connection — checked out until this
+        StreamingResponse finishes, i.e. until the client disconnects, which for
+        an SSE stream can be hours. Releasing it here avoids pinning one DB
+        connection per connected browser tab and exhausting the pool / server
+        slots. It is mandatory (rather than optional) precisely so a future
+        caller cannot silently reintroduce that leak; callers with nothing to
+        release pass a no-op.
         """
         queue = self.connect(user_id, galaxy_session_id)
         if catch_up is not None:
             await queue.put(catch_up)
+        release_db_session()
         try:
             while True:
                 if await is_disconnected():

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -134,6 +134,7 @@ class FastAPIPlugins:
         request: Request,
         payload: ChatCompletionRequest = Body(...),
         user: User = DependsOnUser,
+        trans: SessionRequestContext = DependsOnTrans,
         plugin_name: str = Path(
             ...,
             title="Plugin Name",
@@ -150,7 +151,7 @@ class FastAPIPlugins:
             plugin_specs = plugin and plugin.config.get("specs")
             plugin_ai_prompt = plugin_specs and plugin_specs.get("ai_prompt")
             if plugin_ai_prompt:
-                return await self._open_ai_adapter(payload, plugin_ai_prompt, plugin_name)
+                return await self._open_ai_adapter(trans, payload, plugin_ai_prompt, plugin_name)
             else:
                 return self._create_error("Selected plugin has no AI prompt.")
         else:
@@ -183,6 +184,7 @@ class FastAPIPlugins:
 
     async def _open_ai_adapter(
         self,
+        trans: SessionRequestContext,
         payload: ChatCompletionRequest,
         prompt: str,
         plugin_name: str,
@@ -258,6 +260,14 @@ class FastAPIPlugins:
         except Exception as e:
             log.debug("Failed to initialize OpenAI client.", exc_info=e)
             return self._create_error("Failed to initialize OpenAI client.", 500)
+
+        # Release the request-scoped DB session before the (potentially long)
+        # upstream call. All DB work for this request is done; proxying to the AI
+        # provider and streaming its response back never touches the database, so
+        # holding the pooled connection open for the whole exchange would needlessly
+        # pin a connection per in-flight chat request. Capture the concrete Session
+        # now, while the request-id ContextVar keying scoped_session is in scope.
+        trans.sa_session().close()
 
         # Connect to ai provider
         log.info(f"Proxying to {ai_model}, tokens: {max_tokens}.")

--- a/lib/galaxy/webapps/galaxy/services/events.py
+++ b/lib/galaxy/webapps/galaxy/services/events.py
@@ -48,7 +48,18 @@ class EventsService(ServiceBase):
         user_id = user_context.user.id if not user_context.anonymous else None
         session_id = user_context.galaxy_session.id if user_context.galaxy_session else None
         catch_up = self.notifications.build_status_catchup(user_context, last_event_id)
-        return self.sse_manager.stream(is_disconnected, user_id, catch_up=catch_up, galaxy_session_id=session_id)
+        # Capture the concrete request-scoped Session now, while the request-id
+        # ContextVar that keys ``scoped_session`` is still in scope. Its
+        # ``close()`` returns the pooled connection; the long-lived stream loop
+        # never needs the database again. See ``SSEConnectionManager.stream``.
+        sa_session = user_context.sa_session()
+        return self.sse_manager.stream(
+            is_disconnected,
+            user_id,
+            catch_up=catch_up,
+            galaxy_session_id=session_id,
+            release_db_session=sa_session.close,
+        )
 
     def subscribe_history_viewer(self, user_context: ProvidesUserContext, history_ids: list[str]) -> None:
         """Register the requesting user/session as a viewer for each history.

--- a/test/unit/app/managers/test_sse_stream.py
+++ b/test/unit/app/managers/test_sse_stream.py
@@ -1,0 +1,90 @@
+"""Unit tests for :meth:`galaxy.managers.sse.SSEConnectionManager.stream`.
+
+The focus here is the database-connection lifecycle contract: an SSE stream is
+long-lived (it can stay open for hours) but only touches the database while it
+is being opened. The ``release_db_session`` callback must therefore run exactly
+once, before the keepalive loop starts polling, so the request-scoped pooled DB
+connection is returned instead of being pinned for the life of the connection.
+See ``SSEConnectionManager.stream`` for the production rationale.
+"""
+
+from galaxy.managers.sse import (
+    SSEConnectionManager,
+    SSEEvent,
+)
+
+
+class FakeSession:
+    """Stand-in for the request-scoped SQLAlchemy ``Session``.
+
+    ``close`` returns the pooled connection in production; here it records that
+    the connection was released and treats a second close as a contract
+    violation (double-release of a checked-in connection is a latent bug).
+    """
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        if self.closed:
+            raise AssertionError("session closed more than once")
+        self.closed = True
+
+
+async def _drain(gen):
+    return [chunk async for chunk in gen]
+
+
+async def test_release_db_session_called_before_loop():
+    """The release callback fires before the first disconnect poll."""
+    manager = SSEConnectionManager()
+    released_before_first_poll = []
+
+    session = FakeSession()
+
+    async def is_disconnected():
+        # Record the release state the first time the loop polls us, then break.
+        released_before_first_poll.append(session.closed)
+        return True
+
+    await _drain(manager.stream(is_disconnected, user_id=1, release_db_session=session.close))
+
+    assert released_before_first_poll == [True]
+    assert session.closed is True
+
+
+async def test_release_db_session_released_once_with_catch_up():
+    """Catch-up priming does not change the single, pre-loop release.
+
+    Asserts the effect (the session is closed exactly once) via the fake's own
+    double-close guard rather than counting calls.
+    """
+    manager = SSEConnectionManager()
+    session = FakeSession()
+
+    async def is_disconnected():
+        return True
+
+    catch_up = SSEEvent(event="notification_status", data="{}")
+    await _drain(
+        manager.stream(
+            is_disconnected,
+            user_id=1,
+            release_db_session=session.close,
+            catch_up=catch_up,
+        )
+    )
+
+    assert session.closed is True
+
+
+async def test_stream_disconnect_cleans_up_connection():
+    """The finally block unregisters the connection when the client leaves."""
+    manager = SSEConnectionManager()
+
+    async def is_disconnected():
+        return True
+
+    await _drain(manager.stream(is_disconnected, user_id=1, release_db_session=lambda: None))
+
+    assert manager.total_connections == 0


### PR DESCRIPTION
Long-lived StreamingResponses pinned a PostgreSQL connection for the entire stream lifetime. Galaxy's per-request SQLAlchemy session is a FastAPI yield-dependency whose teardown (returning the pooled connection) runs only after the response body finishes -- which for an SSE stream is when the browser closes the EventSource, potentially hours later. The request queries the DB while opening the stream (auth, history, notification catch-up), checking out a connection that then sits idle-in-transaction for the life of the connection. With many connected clients the pool / server slots are exhausted, surfacing as "remaining connection slots are reserved for ... SUPERUSER" on unrelated requests (Fixes GALAXY-MAIN-4KSCZZZ0017E1).

Release the connection once all open-time DB work is done, before the keepalive loop that never touches the DB:

- SSEConnectionManager.stream gains a release_db_session callback, invoked once after catch-up priming and before the loop. EventsService captures the concrete request-scoped Session (while the request-id ContextVar keying scoped_session is still in scope) and passes its close.
- The /api/plugins chat-completions streamer releases its session before the upstream OpenAI call, which is the long-lived part there.

Add unit tests covering the release contract (fires before the first poll, exactly once even with catch-up, and is optional).

Claude said we don't need to do this for other things we stream but I'll have a chat about that ;)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
