### PR TITLE
[26.1] Release request-scoped DB connection during streams via GalaxyStreamingResponse (alternative to #22939)

### DIFF
--- a/lib/galaxy/managers/sse.py
+++ b/lib/galaxy/managers/sse.py
@@ -291,6 +291,11 @@ class SSEConnectionManager:
         ``disconnect`` in ``finally``. The ``is_disconnected`` callable is
         what the service passes in (typically ``request.is_disconnected`` from
         starlette) so the manager stays framework-agnostic.
+
+        The request-scoped DB connection is released before this loop runs by
+        :class:`galaxy.webapps.base.api.GalaxyStreamingResponse`, which wraps
+        this generator — see that class for why long-lived streams must not
+        pin a pooled connection.
         """
         queue = self.connect(user_id, galaxy_session_id)
         if catch_up is not None:

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -22,6 +22,7 @@ from fastapi.responses import JSONResponse
 from starlette.responses import (
     FileResponse,
     Response,
+    StreamingResponse,
 )
 from starlette_context import context
 from starlette_context.middleware import RawContextMiddleware
@@ -72,9 +73,53 @@ def _get_range_header(range_header: str, file_size: int) -> tuple[int, int]:
     return start, end
 
 
+def _live_request_sessions() -> list:
+    """Concrete request-scoped SQLAlchemy Sessions that already exist for this request.
+
+    Reads ``galaxy.app.app``'s ``model`` + ``install_model`` scoped registries
+    directly, keyed by the current request-id (``request_scopefunc``). It never
+    calls the ``scoped_session`` proxy, which would lazily *create* a session.
+    Returns ``[]`` when no Galaxy app is bound (the tool shed / reports webapps
+    reuse this module) or when no session was opened during the request.
+    """
+    try:
+        from galaxy import app as galaxy_app  # lazy: keep base/api.py importable by non-Galaxy webapps
+    except Exception:
+        return []
+    app = getattr(galaxy_app, "app", None)
+    if app is None:
+        return []
+    sessions = []
+    for mapping in (getattr(app, "model", None), getattr(app, "install_model", None)):
+        if mapping is None:
+            continue
+        existing = mapping.scoped_registry.registry.get(mapping.request_scopefunc())
+        if existing is not None:
+            sessions.append(existing)
+    return sessions
+
+
+def _release_request_sessions(sessions: list) -> None:
+    """Close the captured request-scoped sessions, returning their pooled connections.
+
+    ``Session.close()`` is idempotent, so the later guarded close in
+    ``get_app_with_request_session``'s teardown is harmless.
+    """
+    for session in sessions:
+        try:
+            session.close()
+        except Exception:
+            log.warning("Failed to release request-scoped DB session before streaming", exc_info=True)
+
+
 class GalaxyFileResponse(FileResponse):
     """
     Augments starlette FileResponse with x-accel-redirect/x-sendfile and byte-range handling.
+
+    Like :class:`GalaxyStreamingResponse`, it releases the request-scoped DB
+    connection(s) before sending the file body — see that class's docstring for
+    the rationale and the contract/footgun. File downloads never touch the
+    database after the response is constructed.
     """
 
     nginx_x_accel_redirect_base: Optional[str] = None
@@ -107,6 +152,10 @@ class GalaxyFileResponse(FileResponse):
             self.headers["x-accel-redirect"] = self.nginx_x_accel_redirect_base + os.path.abspath(path)
         elif self.apache_xsendfile:
             self.headers["x-sendfile"] = os.path.abspath(path)
+        # Capture the live request-scoped session(s) now, while we are in the
+        # request's asyncio task (so the request-id ContextVar resolves), to
+        # release before streaming the body. See GalaxyStreamingResponse.
+        self._sessions_to_release = _live_request_sessions()
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
         if self.stat_result is None:
@@ -140,6 +189,11 @@ class GalaxyFileResponse(FileResponse):
                     self.status_code = status.HTTP_206_PARTIAL_CONTENT
                     break
 
+        # All DB work for this request is done; the body below is pure file I/O
+        # (or a header-only x-accel/x-sendfile/HEAD response). Release the pooled
+        # connection(s) before we start sending so a slow/large download doesn't
+        # pin them for the whole transfer.
+        _release_request_sessions(self._sessions_to_release)
         await send(
             {
                 "type": "http.response.start",
@@ -175,6 +229,53 @@ class GalaxyFileResponse(FileResponse):
                     )
         if self.background is not None:
             await self.background()
+
+
+class GalaxyStreamingResponse(StreamingResponse):
+    """A ``StreamingResponse`` that releases the request-scoped DB connection(s)
+    before the body starts streaming.
+
+    WHY: FastAPI's request-scoped SQLAlchemy session (and its pooled DB
+    connection) is held checked-out by the ``get_app_with_request_session``
+    yield-dependency until the *entire* response body has been sent. For a
+    long-lived stream (SSE, a large file/archive download, an upstream proxy)
+    that can be minutes to hours, pinning one pooled connection per in-flight
+    stream and exhausting the pool / server connection slots. This class closes
+    the session(s) the moment streaming begins, returning the connection to the
+    pool while bytes are still flowing.
+
+    CONTRACT — read before using this class:
+      This is ONLY safe when the response body performs NO database access after
+      the response object is constructed. Every byte the body yields must come
+      from data already materialized (a zipstream over files on disk, a
+      ``BytesIO``, an upstream HTTP proxy, the SSE in-memory queue). If the body
+      lazily loads an ORM relationship, issues a query, or commits, it trips the
+      FOOTGUN below.
+
+    FOOTGUN: the request-id ``ContextVar`` that keys the ``scoped_session`` is
+      still set while the body streams (same asyncio task). If body code touches
+      ``app.model.session`` after we close it, ``scoped_session`` will SILENTLY
+      create a brand-new session under the same request-id — re-pinning a
+      connection for the rest of the stream, and any writes on it are a latent
+      correctness bug. Do not stream DB-backed lazy data through this class.
+
+    Idempotency: ``Session.close()`` is a no-op on an already-closed session, and
+    the dependency teardown's ``unset_request_id`` is guarded, so the
+    double-close at request end is harmless. This class never deletes the
+    registry entry — the teardown owns that.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Capture concrete, already-open request-scoped sessions NOW, while we
+        # are guaranteed to be in the request's asyncio task (so the request-id
+        # ContextVar resolves). We never call the scoped proxy, which would
+        # lazily create a session if none exists.
+        self._sessions_to_release = _live_request_sessions()
+
+    async def stream_response(self, send: "Send") -> None:
+        _release_request_sessions(self._sessions_to_release)
+        await super().stream_response(send)
 
 
 def add_sentry_middleware(app: FastAPI) -> None:

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -29,6 +29,7 @@ from galaxy.schema.schema import (
     UpdateDatasetPermissionsPayloadAliases,
 )
 from galaxy.util import listify
+from galaxy.webapps.base.api import GalaxyStreamingResponse
 
 FolderIdPathParam = Annotated[
     LibraryFolderDatabaseIdField,
@@ -298,7 +299,7 @@ def query_parameter_as_list(query):
 
 def serve_workbook(content: BytesIO, filename: Optional[str]) -> StreamingResponse:
     filename = filename or "galaxy_sample_sheet_workbook.xlsx"
-    return StreamingResponse(
+    return GalaxyStreamingResponse(
         content,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         headers={"Content-Disposition": f"attachment; filename={filename}"},

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -41,7 +41,10 @@ from galaxy.schema.schema import (
     ToolReportForDataset,
 )
 from galaxy.util.zipstream import ZipstreamWrapper
-from galaxy.webapps.base.api import GalaxyFileResponse
+from galaxy.webapps.base.api import (
+    GalaxyFileResponse,
+    GalaxyStreamingResponse,
+)
 from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
@@ -376,12 +379,12 @@ class FastAPIDatasets:
             if file_name:
                 return GalaxyFileResponse(file_name, headers=headers)
         elif isinstance(display_data, ZipstreamWrapper):
-            return StreamingResponse(display_data.response(), headers=headers)
+            return GalaxyStreamingResponse(display_data.response(), headers=headers)
         elif isinstance(display_data, bytes):
-            return StreamingResponse(BytesIO(display_data), headers=headers)
+            return GalaxyStreamingResponse(BytesIO(display_data), headers=headers)
         elif isinstance(display_data, str):
-            return StreamingResponse(content=StringIO(display_data), headers=headers)
-        return StreamingResponse(display_data, headers=headers)
+            return GalaxyStreamingResponse(content=StringIO(display_data), headers=headers)
+        return GalaxyStreamingResponse(display_data, headers=headers)
 
     @router.get(
         "/api/histories/{history_id}/contents/{history_content_id}/metadata_file",

--- a/lib/galaxy/webapps/galaxy/api/events.py
+++ b/lib/galaxy/webapps/galaxy/api/events.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.webapps.base.api import GalaxyStreamingResponse
 from galaxy.webapps.galaxy.services.events import EventsService
 from . import (
     depends,
@@ -61,7 +62,7 @@ class FastAPIEvents:
 
         Anonymous users receive only broadcast events.
         """
-        return StreamingResponse(
+        return GalaxyStreamingResponse(
             self.service.open_stream(trans, last_event_id, request.is_disconnected),
             media_type="text/event-stream",
             headers={

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -69,6 +69,7 @@ from galaxy.schema.tasks import (
     CopyDatasetsPayload,
     CopyDatasetsResponse,
 )
+from galaxy.webapps.base.api import GalaxyStreamingResponse
 from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
@@ -1146,7 +1147,7 @@ class FastAPIHistoryContents:
         archive = self.service.archive(trans, history_id, filter_query_params, filename, dry_run)
         if isinstance(archive, HistoryContentsArchiveDryRunResult):
             return archive
-        return StreamingResponse(archive.response(), headers=archive.get_headers())
+        return GalaxyStreamingResponse(archive.response(), headers=archive.get_headers())
 
     @router.get(
         "/api/histories/{history_id}/contents/archive",
@@ -1166,7 +1167,7 @@ class FastAPIHistoryContents:
         archive = self.service.archive(trans, history_id, filter_query_params, filename, dry_run)
         if isinstance(archive, HistoryContentsArchiveDryRunResult):
             return archive
-        return StreamingResponse(archive.response(), headers=archive.get_headers())
+        return GalaxyStreamingResponse(archive.response(), headers=archive.get_headers())
 
     @router.post(
         "/api/histories/{history_id}/contents_from_store",
@@ -1225,4 +1226,4 @@ class FastAPIHistoryContents:
 
     def _download_collection(self, trans, id):
         archive = self.service.get_dataset_collection_archive_for_download(trans, id)
-        return StreamingResponse(archive.response(), headers=archive.get_headers())
+        return GalaxyStreamingResponse(archive.response(), headers=archive.get_headers())

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -31,6 +31,7 @@ from galaxy.schema.schema import (
     SharingStatus,
     UpdatePagePayload,
 )
+from galaxy.webapps.base.api import GalaxyStreamingResponse
 from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
@@ -210,7 +211,7 @@ class FastAPIPages:
         This feature may not be available in this Galaxy.
         """
         pdf_bytes = self.service.show_pdf(trans, id)
-        return StreamingResponse(io.BytesIO(pdf_bytes), media_type="application/pdf")
+        return GalaxyStreamingResponse(io.BytesIO(pdf_bytes), media_type="application/pdf")
 
     @router.post(
         "/api/pages/{id}/prepare_download",

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -18,10 +18,7 @@ from fastapi import (
     Query,
     Request,
 )
-from fastapi.responses import (
-    JSONResponse,
-    StreamingResponse,
-)
+from fastapi.responses import JSONResponse
 from openai import (
     APIError,
     AsyncOpenAI,
@@ -51,6 +48,7 @@ from galaxy.model import (
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.visualization import VisualizationPluginResponse
 from galaxy.structured_app import StructuredApp
+from galaxy.webapps.base.api import GalaxyStreamingResponse
 from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnApp,
@@ -134,6 +132,7 @@ class FastAPIPlugins:
         request: Request,
         payload: ChatCompletionRequest = Body(...),
         user: User = DependsOnUser,
+        trans: SessionRequestContext = DependsOnTrans,
         plugin_name: str = Path(
             ...,
             title="Plugin Name",
@@ -150,7 +149,7 @@ class FastAPIPlugins:
             plugin_specs = plugin and plugin.config.get("specs")
             plugin_ai_prompt = plugin_specs and plugin_specs.get("ai_prompt")
             if plugin_ai_prompt:
-                return await self._open_ai_adapter(payload, plugin_ai_prompt, plugin_name)
+                return await self._open_ai_adapter(trans, payload, plugin_ai_prompt, plugin_name)
             else:
                 return self._create_error("Selected plugin has no AI prompt.")
         else:
@@ -183,6 +182,7 @@ class FastAPIPlugins:
 
     async def _open_ai_adapter(
         self,
+        trans: SessionRequestContext,
         payload: ChatCompletionRequest,
         prompt: str,
         plugin_name: str,
@@ -259,6 +259,15 @@ class FastAPIPlugins:
             log.debug("Failed to initialize OpenAI client.", exc_info=e)
             return self._create_error("Failed to initialize OpenAI client.", 500)
 
+        # Release the request-scoped DB session before the (potentially long)
+        # upstream call. All DB work for this request is done; proxying to the AI
+        # provider and streaming its response back never touches the database, so
+        # holding the pooled connection open for the whole exchange would needlessly
+        # pin a connection per in-flight chat request. This covers the upstream
+        # call itself, which happens here in the handler before GalaxyStreamingResponse
+        # gets a chance to release at stream start.
+        trans.sa_session().close()
+
         # Connect to ai provider
         log.info(f"Proxying to {ai_model}, tokens: {max_tokens}.")
         try:
@@ -290,7 +299,7 @@ class FastAPIPlugins:
                 finally:
                     await client.close()
 
-            return StreamingResponse(
+            return GalaxyStreamingResponse(
                 generate(),
                 media_type="text/event-stream",
                 headers={

--- a/lib/galaxy/webapps/galaxy/api/proxy.py
+++ b/lib/galaxy/webapps/galaxy/api/proxy.py
@@ -16,10 +16,7 @@ from fastapi import (
     Query,
     Request,
 )
-from starlette.responses import (
-    Response,
-    StreamingResponse,
-)
+from starlette.responses import Response
 
 from galaxy.exceptions import (
     GatewayTimeoutException,
@@ -29,6 +26,7 @@ from galaxy.exceptions import (
 )
 from galaxy.files.uris import validate_uri_access
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.webapps.base.api import GalaxyStreamingResponse
 from . import (
     DependsOnTrans,
     Router,
@@ -127,7 +125,7 @@ class FastAPIProxy:
 
                 streaming = True
                 # StreamingResponse will handle chunked transfer encoding automatically
-                return StreamingResponse(
+                return GalaxyStreamingResponse(
                     stream_with_cleanup(),
                     status_code=response.status_code,
                     headers=filtered_headers,

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -102,6 +102,7 @@ from galaxy.web import (
     expose_api_raw_anonymous_and_sessionless,
     format_return_as_json,
 )
+from galaxy.webapps.base.api import GalaxyStreamingResponse
 from galaxy.webapps.base.controller import (
     SharableMixin,
     url_for,
@@ -1617,7 +1618,7 @@ class FastAPIInvocations:
         trans: ProvidesUserContext = DependsOnTrans,
     ):
         wfi_report = self.invocations_service.show_invocation_report(trans, invocation_id, format="pdf")
-        return StreamingResponse(
+        return GalaxyStreamingResponse(
             content=BytesIO(wfi_report),
             media_type="application/pdf",
             headers={

--- a/test/unit/app/managers/test_sse_stream.py
+++ b/test/unit/app/managers/test_sse_stream.py
@@ -1,0 +1,26 @@
+"""Unit tests for :meth:`galaxy.managers.sse.SSEConnectionManager.stream`.
+
+The DB-connection release for SSE now lives in
+:class:`galaxy.webapps.base.api.GalaxyStreamingResponse` (covered by
+``test/unit/webapps/base/test_streaming_response.py``). These tests just cover
+the manager's own lifecycle contract: a connection is registered on entry and
+cleaned up in the ``finally`` block when the client disconnects.
+"""
+
+from galaxy.managers.sse import SSEConnectionManager
+
+
+async def _drain(gen):
+    return [chunk async for chunk in gen]
+
+
+async def test_stream_disconnect_cleans_up_connection():
+    """The finally block unregisters the connection when the client leaves."""
+    manager = SSEConnectionManager()
+
+    async def is_disconnected():
+        return True
+
+    await _drain(manager.stream(is_disconnected, user_id=1))
+
+    assert manager.total_connections == 0

--- a/test/unit/webapps/test_streaming_response.py
+++ b/test/unit/webapps/test_streaming_response.py
@@ -1,0 +1,167 @@
+"""Unit tests for the DB-connection release in :mod:`galaxy.webapps.base.api`.
+
+``GalaxyStreamingResponse`` / ``GalaxyFileResponse`` must return the
+request-scoped pooled DB connection(s) the moment streaming begins, so a
+long-lived stream (SSE, a slow/large download) does not pin a connection for
+its whole lifetime. These tests drive the responses with fake ASGI ``send``
+callables and a fake Galaxy app whose scoped registries hold ``FakeSession``
+objects, and assert the sessions are closed *before* the first body byte.
+"""
+
+from types import SimpleNamespace
+
+from galaxy.webapps.base.api import (
+    GalaxyFileResponse,
+    GalaxyStreamingResponse,
+)
+
+KEY = "test-request-id"
+
+
+class FakeSession:
+    """Request-scoped Session stand-in. ``close`` records the release and
+    treats a second close as a contract violation (double-release is a bug)."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        if self.closed:
+            raise AssertionError("session closed more than once")
+        self.closed = True
+
+
+def _mapping(registry: dict):
+    """A model-mapping stand-in exposing the registry access the helper uses."""
+    return SimpleNamespace(
+        scoped_registry=SimpleNamespace(registry=registry),
+        request_scopefunc=lambda: KEY,
+    )
+
+
+def _install_fake_app(monkeypatch, *, model_registry=None, install_registry=None, app_present=True):
+    if not app_present:
+        monkeypatch.setattr("galaxy.app.app", None)
+        return None
+    app = SimpleNamespace(
+        model=_mapping(model_registry if model_registry is not None else {}),
+        install_model=_mapping(install_registry if install_registry is not None else {}),
+    )
+    monkeypatch.setattr("galaxy.app.app", app)
+    return app
+
+
+async def _collect(send_messages):
+    async def send(message):
+        send_messages.append(message)
+
+    return send
+
+
+async def test_streaming_releases_session_before_first_chunk(monkeypatch):
+    session = FakeSession()
+    _install_fake_app(monkeypatch, model_registry={KEY: session})
+    observed = []
+
+    async def body():
+        observed.append(session.closed)  # state captured when the first chunk is produced
+        yield b"data"
+
+    response = GalaxyStreamingResponse(body())
+    messages: list = []
+    await response.stream_response(await _collect(messages))
+
+    assert observed == [True]
+    assert session.closed is True
+
+
+async def test_streaming_releases_both_model_and_install_sessions(monkeypatch):
+    model_session = FakeSession()
+    install_session = FakeSession()
+    _install_fake_app(monkeypatch, model_registry={KEY: model_session}, install_registry={KEY: install_session})
+
+    async def body():
+        yield b"x"
+
+    response = GalaxyStreamingResponse(body())
+    await response.stream_response(await _collect([]))
+
+    assert model_session.closed is True
+    assert install_session.closed is True
+
+
+async def test_streaming_no_session_does_not_lazy_create(monkeypatch):
+    model_registry: dict = {}
+    _install_fake_app(monkeypatch, model_registry=model_registry)
+
+    async def body():
+        yield b"x"
+
+    response = GalaxyStreamingResponse(body())
+    assert response._sessions_to_release == []
+
+    await response.stream_response(await _collect([]))
+
+    # We must never have touched the scoped proxy, which would have created one.
+    assert model_registry == {}
+
+
+async def test_streaming_no_app_bound_is_noop(monkeypatch):
+    _install_fake_app(monkeypatch, app_present=False)
+
+    async def body():
+        yield b"x"
+
+    response = GalaxyStreamingResponse(body())
+    assert response._sessions_to_release == []
+
+    messages: list = []
+    await response.stream_response(await _collect(messages))
+    assert any(m["type"] == "http.response.body" for m in messages)
+
+
+async def test_file_response_releases_before_response_start(monkeypatch, tmp_path):
+    f = tmp_path / "download.txt"
+    f.write_bytes(b"hello")
+    session = FakeSession()
+    _install_fake_app(monkeypatch, model_registry={KEY: session})
+
+    response = GalaxyFileResponse(str(f))
+    closed_at_start = []
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            closed_at_start.append(session.closed)
+
+    async def receive():
+        return {"type": "http.request"}
+
+    await response({"type": "http", "method": "GET", "headers": []}, receive, send)
+
+    assert closed_at_start == [True]
+    assert session.closed is True
+
+
+async def test_file_response_releases_on_xaccel_header_only_path(monkeypatch, tmp_path):
+    f = tmp_path / "download.txt"
+    f.write_bytes(b"hello")
+    session = FakeSession()
+    _install_fake_app(monkeypatch, model_registry={KEY: session})
+
+    class XAccelFileResponse(GalaxyFileResponse):
+        nginx_x_accel_redirect_base = "/internal"
+
+    response = XAccelFileResponse(str(f))
+    closed_at_start = []
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            closed_at_start.append(session.closed)
+
+    async def receive():
+        return {"type": "http.request"}
+
+    await response({"type": "http", "method": "GET", "headers": []}, receive, send)
+
+    assert closed_at_start == [True]
+    assert session.closed is True


### PR DESCRIPTION
**Alternative to #22939** — same fix for the same incident, different approach. Only one of the two should be merged.

## Problem (both PRs)

Sentry `GALAXY-MAIN-4KSCZZZ0017E1`: PostgreSQL connection-slot exhaustion (`remaining connection slots are reserved for ... SUPERUSER`) right after SSE was enabled. Galaxy's per-request SQLAlchemy session is a FastAPI yield-dependency whose teardown (returning the pooled connection) runs only **after the response body finishes**. For a `StreamingResponse` that means the connection is held until the client disconnects — for an SSE stream, potentially hours. The connection is checked out while the stream is opened (auth, history, notification catch-up) and then sits idle-in-transaction for the life of the stream, so with many connected clients the pool / server slots are exhausted and unrelated requests fail.

## How this differs from #22939

| | #22939 (targeted) | this PR (GalaxyStreamingResponse) |
|---|---|---|
| Mechanism | A `release_db_session` callback threaded into `SSEConnectionManager.stream`, plus an explicit `close()` in the chat endpoint | Generic `GalaxyStreamingResponse` + a release hook on `GalaxyFileResponse` (both in `webapps/base/api.py`) that close the request-scoped session(s) at stream start |
| Surface | SSE + chat only | Every streaming endpoint: SSE, chat, proxy, dataset display/archive, history/collection archive, PDF, workbooks — plus all file downloads via `GalaxyFileResponse` |
| Latent download bug | Not addressed | Also fixed — large/slow archive and file downloads no longer pin a connection for the whole transfer |
| Files touched | 4 | 12 |
| Manager coupling | `SSEConnectionManager` gains a release parameter | `SSEConnectionManager` stays framework-agnostic; release lives in the response layer |

The chat endpoint additionally keeps an explicit pre-call `close()` in both PRs, because its expensive wait (the upstream OpenAI call) happens in the handler *before* the body streams, which a stream-start release cannot cover.

## Why releasing at stream start is safe everywhere

A thorough pass over every streaming response confirmed **no body touches the database after the response is constructed**:
- dataset/archive downloads resolve all file paths up front; the zipstream only `open()`s files from a pre-built list,
- PDF and workbook endpoints build a `BytesIO` in memory,
- the proxy streams an upstream HTTP response and never touches the Galaxy DB.

`_live_request_sessions()` reads the scoped registry directly (never the `scoped_session` proxy) so it cannot lazily create a session, and degrades to a no-op when no Galaxy app is bound (tool shed / reports reuse `base/api.py`).

**Documented footgun:** the request-id `ContextVar` keying the scoped session is still set while the body streams, so any *post-release* DB access in a body would silently re-create a session under the same request-id (re-pinning a connection, risking stale reads). This is only safe because all current bodies are DB-free; the class docstring spells out the contract for future streaming endpoints.

## Trade-offs

- **For this approach:** one centralized, hard-to-forget mechanism; also fixes connection-pinning on long file/archive/proxy downloads.
- **Against:** larger surface (touches more endpoints); a generic response subclass is (lazily) coupled to `galaxy.app`; the footgun above must be respected by future streaming bodies.

Tests: unit coverage for the release contract (sessions closed before the first body chunk, both `model` + `install_model` released, no lazy-create when no session exists, no-op when no app, and the `GalaxyFileResponse` header-only path).

Fixes GALAXY-MAIN-4KSCZZZ0017E1.
