### PR TITLE
[26.1] Fix legacy DatabaseVault secrets canonical key migration

### DIFF
--- a/lib/galaxy/security/vault.py
+++ b/lib/galaxy/security/vault.py
@@ -221,20 +221,6 @@ class DatabaseVault(Vault):
         if key_obj and key_obj.value:
             f = self._get_multi_fernet()
             return f.decrypt(key_obj.value.encode("utf-8")).decode("utf-8")
-        # Galaxy <= 26.0 emitted a leading slash in vault keys, which was stored
-        # in the database. PR #22530 normalized keys to not have leading slashes.
-        # Fall back to reading the legacy form and rewrite under the canonical
-        # key so the secret survives the Galaxy upgrade. This fallback can be
-        # removed after a deprecation window once operators have migrated.
-        legacy_key_obj = self._get_vault_value(f"/{key}")
-        if legacy_key_obj and legacy_key_obj.value:
-            log.warning("Migrating legacy non-canonical DatabaseVault secret to canonical path: %s", key)
-            f = self._get_multi_fernet()
-            value = f.decrypt(legacy_key_obj.value.encode("utf-8")).decode("utf-8")
-            self.write_secret(key, value)
-            self.sa_session.delete(legacy_key_obj)
-            self.sa_session.flush()
-            return value
         return None
 
     def write_secret(self, key: str, value: str) -> None:
@@ -314,7 +300,7 @@ class VaultKeyPrefixWrapper(Vault):
     Adds a prefix to all vault keys, such as the galaxy instance id
     """
 
-    def __init__(self, vault: Vault, prefix: str):
+    def __init__(self, vault: Vault, prefix: str, leading_slash: bool = False):
         self.vault = vault
         # Strip conventional outer slashes so admins can write `/galaxy`,
         # `galaxy`, or `/galaxy/` interchangeably in config. Reject anything
@@ -326,12 +312,21 @@ class VaultKeyPrefixWrapper(Vault):
                 "double slashes or whitespace adjacent to a slash."
             )
         self.prefix = stripped
+        # HashicorpVault must use canonical (no leading slash) paths, since hvac
+        # turns a leading slash into a `//` KV path that Vault 2.0 rejects (#22530).
+        # DatabaseVault stores the key verbatim in a DB column where the leading
+        # slash is harmless, so it keeps the legacy `/{prefix}/{key}` location to
+        # avoid orphaning secrets written before #22530.
+        self.leading_slash = leading_slash
+
+    def _prefixed(self, key: str) -> str:
+        return f"/{self.prefix}/{key}" if self.leading_slash else f"{self.prefix}/{key}"
 
     def read_secret(self, key: str) -> Optional[str]:
-        return self.vault.read_secret(f"{self.prefix}/{key}")
+        return self.vault.read_secret(self._prefixed(key))
 
     def write_secret(self, key: str, value: str) -> None:
-        return self.vault.write_secret(f"{self.prefix}/{key}", value)
+        return self.vault.write_secret(self._prefixed(key), value)
 
     def list_secrets(self, key: str) -> list[str]:
         raise NotImplementedError()
@@ -348,15 +343,21 @@ class VaultFactory:
     @staticmethod
     def from_vault_type(app, vault_type: Optional[str], cfg: dict) -> Vault:
         vault: Vault
+        # DatabaseVault keeps the legacy leading-slash key location (see
+        # VaultKeyPrefixWrapper); HashicorpVault must use canonical paths.
+        legacy_leading_slash = False
         if vault_type == "hashicorp":
             token_renewal_enabled = app.config.vault_token_renewal_interval > 0
             vault = HashicorpVault(cfg, token_renewal_enabled=token_renewal_enabled)
         elif vault_type == "database":
             vault = DatabaseVault(app.model.context, cfg)
+            legacy_leading_slash = True
         else:
             raise InvalidVaultConfigException(f"Unknown vault type: {vault_type}")
         vault_prefix = cfg.get("path_prefix") or "/galaxy"
-        return VaultKeyValidationWrapper(VaultKeyPrefixWrapper(vault, prefix=vault_prefix))
+        return VaultKeyValidationWrapper(
+            VaultKeyPrefixWrapper(vault, prefix=vault_prefix, leading_slash=legacy_leading_slash)
+        )
 
     @staticmethod
     def from_app(app) -> Vault:

--- a/lib/galaxy/security/vault.py
+++ b/lib/galaxy/security/vault.py
@@ -221,6 +221,20 @@ class DatabaseVault(Vault):
         if key_obj and key_obj.value:
             f = self._get_multi_fernet()
             return f.decrypt(key_obj.value.encode("utf-8")).decode("utf-8")
+        # Galaxy <= 26.0 emitted a leading slash in vault keys, which was stored
+        # in the database. PR #22530 normalized keys to not have leading slashes.
+        # Fall back to reading the legacy form and rewrite under the canonical
+        # key so the secret survives the Galaxy upgrade. This fallback can be
+        # removed after a deprecation window once operators have migrated.
+        legacy_key_obj = self._get_vault_value(f"/{key}")
+        if legacy_key_obj and legacy_key_obj.value:
+            log.warning("Migrating legacy non-canonical DatabaseVault secret to canonical path: %s", key)
+            f = self._get_multi_fernet()
+            value = f.decrypt(legacy_key_obj.value.encode("utf-8")).decode("utf-8")
+            self.write_secret(key, value)
+            self.sa_session.delete(legacy_key_obj)
+            self.sa_session.flush()
+            return value
         return None
 
     def write_secret(self, key: str, value: str) -> None:

--- a/lib/galaxy/security/vault.py
+++ b/lib/galaxy/security/vault.py
@@ -38,6 +38,12 @@ class Vault(abc.ABC):
     A simple abstraction for reading/writing from external vaults.
     """
 
+    # Whether this backend uses canonical (no-leading-slash) keys.
+    # Hashicorp Vault 2.0 rejects leading/double slashes, so it must use
+    # canonical keys. DatabaseVault keeps using the legacy /{prefix}/{key}
+    # form used by Galaxy <= 26.0, so existing rows are found in place.
+    use_canonical_keys = True
+
     @abc.abstractmethod
     def read_secret(self, key: str) -> Optional[str]:
         """
@@ -191,6 +197,8 @@ class HashicorpVault(Vault):
 
 
 class DatabaseVault(Vault):
+    use_canonical_keys = False
+
     def __init__(self, sa_session, config):
         self.sa_session = sa_session
         self.encryption_keys = config.get("encryption_keys")
@@ -300,11 +308,12 @@ class VaultKeyPrefixWrapper(Vault):
     Adds a prefix to all vault keys, such as the galaxy instance id
     """
 
-    def __init__(self, vault: Vault, prefix: str, leading_slash: bool = False):
+    def __init__(self, vault: Vault, prefix: str):
         self.vault = vault
         # Strip conventional outer slashes so admins can write `/galaxy`,
-        # `galaxy`, or `/galaxy/` interchangeably in config. Reject anything
-        # that would still produce a non-canonical Vault path after stripping.
+        # `galaxy`, or `/galaxy/` interchangeably in config. Reject empty
+        # prefixes or prefixes that would be invalid in either canonical or
+        # legacy form (double slashes or whitespace adjacent to a slash).
         stripped = prefix.strip("/")
         if not stripped or VAULT_KEY_INVALID_REGEX.search(stripped):
             raise InvalidVaultConfigException(
@@ -312,15 +321,11 @@ class VaultKeyPrefixWrapper(Vault):
                 "double slashes or whitespace adjacent to a slash."
             )
         self.prefix = stripped
-        # HashicorpVault must use canonical (no leading slash) paths, since hvac
-        # turns a leading slash into a `//` KV path that Vault 2.0 rejects (#22530).
-        # DatabaseVault stores the key verbatim in a DB column where the leading
-        # slash is harmless, so it keeps the legacy `/{prefix}/{key}` location to
-        # avoid orphaning secrets written before #22530.
-        self.leading_slash = leading_slash
 
     def _prefixed(self, key: str) -> str:
-        return f"/{self.prefix}/{key}" if self.leading_slash else f"{self.prefix}/{key}"
+        if self.vault.use_canonical_keys:
+            return f"{self.prefix}/{key}"
+        return f"/{self.prefix}/{key}"
 
     def read_secret(self, key: str) -> Optional[str]:
         return self.vault.read_secret(self._prefixed(key))
@@ -343,21 +348,15 @@ class VaultFactory:
     @staticmethod
     def from_vault_type(app, vault_type: Optional[str], cfg: dict) -> Vault:
         vault: Vault
-        # DatabaseVault keeps the legacy leading-slash key location (see
-        # VaultKeyPrefixWrapper); HashicorpVault must use canonical paths.
-        legacy_leading_slash = False
         if vault_type == "hashicorp":
             token_renewal_enabled = app.config.vault_token_renewal_interval > 0
             vault = HashicorpVault(cfg, token_renewal_enabled=token_renewal_enabled)
         elif vault_type == "database":
             vault = DatabaseVault(app.model.context, cfg)
-            legacy_leading_slash = True
         else:
             raise InvalidVaultConfigException(f"Unknown vault type: {vault_type}")
         vault_prefix = cfg.get("path_prefix") or "/galaxy"
-        return VaultKeyValidationWrapper(
-            VaultKeyPrefixWrapper(vault, prefix=vault_prefix, leading_slash=legacy_leading_slash)
-        )
+        return VaultKeyValidationWrapper(VaultKeyPrefixWrapper(vault, prefix=vault_prefix))
 
     @staticmethod
     def from_app(app) -> Vault:

--- a/test/unit/data/security/test_vault.py
+++ b/test/unit/data/security/test_vault.py
@@ -174,12 +174,13 @@ def test_vault_key_prefix_wrapper_emits_canonical_path(prefix):
 
 
 @pytest.mark.parametrize("prefix", ["/galaxy", "galaxy", "/galaxy/"])
-def test_vault_key_prefix_wrapper_emits_legacy_leading_slash_path(prefix):
-    # DatabaseVault keeps the legacy leading-slash location. The wrapper must
-    # prepend a single leading slash regardless of how the prefix is spelled.
+def test_vault_key_prefix_wrapper_emits_legacy_leading_slash_path_for_database_vault(prefix):
+    # DatabaseVault keeps the legacy leading-slash location because use_canonical_keys=False.
+    # The wrapper must prepend a single leading slash regardless of how the prefix is spelled.
     inner = _make_mocked_hashicorp_vault()
     inner.client.secrets.kv.read_secret_version.return_value = {"data": {"data": {"value": "v"}}}
-    vault = VaultKeyValidationWrapper(VaultKeyPrefixWrapper(inner, prefix=prefix, leading_slash=True))
+    inner.use_canonical_keys = False
+    vault = VaultKeyValidationWrapper(VaultKeyPrefixWrapper(inner, prefix=prefix))
 
     assert vault.read_secret("user/1/preferences/editor") == "v"
     inner.client.secrets.kv.read_secret_version.assert_called_once_with(path="/galaxy/user/1/preferences/editor")

--- a/test/unit/data/security/test_vault.py
+++ b/test/unit/data/security/test_vault.py
@@ -130,32 +130,23 @@ class TestDatabaseVault(AbstractTestCases.VaultTestBase):
         with self.assertRaises(InvalidToken):
             vault.read_secret("my/incorrect/secret")
 
-    def test_legacy_key_migration(self):
-        # Simulate a secret stored with a leading slash (pre-26.1 format)
+    def test_database_vault_keeps_legacy_leading_slash_location(self):
+        # DatabaseVault never had the hvac double-slash problem, so it keeps the
+        # pre-26.1 leading-slash key location to avoid orphaning existing secrets.
         config = GalaxyDataTestConfig(vault_config_file=VAULT_CONF_DATABASE)
         app = GalaxyDataTestApp(config=config)
         vault = VaultFactory.from_app(app)
 
-        # The vault chain is VaultKeyValidationWrapper(VaultKeyPrefixWrapper(DatabaseVault))
-        # The prefix is 'my_galaxy_instance' (from vault_conf_database.yml with leading slash stripped)
-        # Pre-26.1, VaultKeyPrefixWrapper emitted /{prefix}/{key}, so the DB stored keys like
-        # /my_galaxy_instance/my/legacy/secret. Write that directly to simulate the legacy state.
+        vault.write_secret("my/legacy/secret", "legacy value")
+
         inner = _unwrap_vault(vault)
         assert isinstance(inner, DatabaseVault)
-        inner.write_secret("/my_galaxy_instance/my/legacy/secret", "legacy value")
-
-        # Read with the new canonical format through the full wrapper chain
-        # VaultKeyValidationWrapper normalizes → VaultKeyPrefixWrapper adds prefix →
-        # DatabaseVault.read_secret("my_galaxy_instance/my/legacy/secret") should migrate
+        # The prefix is 'my_galaxy_instance' (from vault_conf_database.yml). The
+        # secret must be stored under the legacy leading-slash key, matching what
+        # pre-26.1 Galaxy wrote so upgraded instances can still read it.
+        assert inner._get_vault_value("/my_galaxy_instance/my/legacy/secret") is not None
+        assert inner._get_vault_value("my_galaxy_instance/my/legacy/secret") is None
         assert vault.read_secret("my/legacy/secret") == "legacy value"
-
-        # Verify the secret is now accessible with the canonical key
-        assert vault.read_secret("my/legacy/secret") == "legacy value"
-
-        # Verify the legacy key no longer exists (was migrated to canonical form)
-        assert inner._get_vault_value("/my_galaxy_instance/my/legacy/secret") is None
-        # Verify the canonical key now exists
-        assert inner._get_vault_value("my_galaxy_instance/my/legacy/secret") is not None
 
 
 def _make_mocked_hashicorp_vault() -> HashicorpVault:
@@ -179,6 +170,23 @@ def test_vault_key_prefix_wrapper_emits_canonical_path(prefix):
     vault.write_secret("user/1/preferences/editor", "vscode")
     inner.client.secrets.kv.v2.create_or_update_secret.assert_called_once_with(
         path="galaxy/user/1/preferences/editor", secret={"value": "vscode"}
+    )
+
+
+@pytest.mark.parametrize("prefix", ["/galaxy", "galaxy", "/galaxy/"])
+def test_vault_key_prefix_wrapper_emits_legacy_leading_slash_path(prefix):
+    # DatabaseVault keeps the legacy leading-slash location. The wrapper must
+    # prepend a single leading slash regardless of how the prefix is spelled.
+    inner = _make_mocked_hashicorp_vault()
+    inner.client.secrets.kv.read_secret_version.return_value = {"data": {"data": {"value": "v"}}}
+    vault = VaultKeyValidationWrapper(VaultKeyPrefixWrapper(inner, prefix=prefix, leading_slash=True))
+
+    assert vault.read_secret("user/1/preferences/editor") == "v"
+    inner.client.secrets.kv.read_secret_version.assert_called_once_with(path="/galaxy/user/1/preferences/editor")
+
+    vault.write_secret("user/1/preferences/editor", "vscode")
+    inner.client.secrets.kv.v2.create_or_update_secret.assert_called_once_with(
+        path="/galaxy/user/1/preferences/editor", secret={"value": "vscode"}
     )
 
 

--- a/test/unit/data/security/test_vault.py
+++ b/test/unit/data/security/test_vault.py
@@ -13,6 +13,7 @@ from galaxy.model.unittest_utils.data_app import (
 )
 from galaxy.security.vault import (
     _unwrap_vault,
+    DatabaseVault,
     HashicorpVault,
     InvalidVaultConfigException,
     InvalidVaultKeyException,
@@ -128,6 +129,33 @@ class TestDatabaseVault(AbstractTestCases.VaultTestBase):
         vault = VaultFactory.from_app(app)
         with self.assertRaises(InvalidToken):
             vault.read_secret("my/incorrect/secret")
+
+    def test_legacy_key_migration(self):
+        # Simulate a secret stored with a leading slash (pre-26.1 format)
+        config = GalaxyDataTestConfig(vault_config_file=VAULT_CONF_DATABASE)
+        app = GalaxyDataTestApp(config=config)
+        vault = VaultFactory.from_app(app)
+
+        # The vault chain is VaultKeyValidationWrapper(VaultKeyPrefixWrapper(DatabaseVault))
+        # The prefix is 'my_galaxy_instance' (from vault_conf_database.yml with leading slash stripped)
+        # Pre-26.1, VaultKeyPrefixWrapper emitted /{prefix}/{key}, so the DB stored keys like
+        # /my_galaxy_instance/my/legacy/secret. Write that directly to simulate the legacy state.
+        inner = _unwrap_vault(vault)
+        assert isinstance(inner, DatabaseVault)
+        inner.write_secret("/my_galaxy_instance/my/legacy/secret", "legacy value")
+
+        # Read with the new canonical format through the full wrapper chain
+        # VaultKeyValidationWrapper normalizes → VaultKeyPrefixWrapper adds prefix →
+        # DatabaseVault.read_secret("my_galaxy_instance/my/legacy/secret") should migrate
+        assert vault.read_secret("my/legacy/secret") == "legacy value"
+
+        # Verify the secret is now accessible with the canonical key
+        assert vault.read_secret("my/legacy/secret") == "legacy value"
+
+        # Verify the legacy key no longer exists (was migrated to canonical form)
+        assert inner._get_vault_value("/my_galaxy_instance/my/legacy/secret") is None
+        # Verify the canonical key now exists
+        assert inner._get_vault_value("my_galaxy_instance/my/legacy/secret") is not None
 
 
 def _make_mocked_hashicorp_vault() -> HashicorpVault:


### PR DESCRIPTION
Fixes #22938

The difference is in **how each backend signals "key not found"**:

**HashicorpVault** gets an `hvac.exceptions.InvalidPath` exception when the canonical path doesn't exist in Vault. That exception is the trigger — it tells the code "canonical path failed, try the legacy form with leading `/`".

**DatabaseVault** just returns `None` from `_get_vault_value()` when the canonical key doesn't exist. There's no exception, no signal — `None` could mean either:
- "This key was never written" (legitimate missing secret)
- "This key exists but with a leading `/`" (legacy format)

The code had no way to distinguish these cases, so it just returned `None` and the secret appeared lost.

The fix adds the same fallback logic: after the canonical lookup returns `None`, try `/{key}` as a second attempt. If that finds something, migrate it. If both return `None`, the secret genuinely doesn't exist.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
