### PR TITLE
[26.1] Fix GModal content truncation and dev proxy cookie handling

### DIFF
--- a/client/src/components/BaseComponents/GModal.vue
+++ b/client/src/components/BaseComponents/GModal.vue
@@ -239,8 +239,9 @@ defineExpose({ showModal, hideModal });
 
     padding: var(--spacing-3);
 
+    max-height: calc(100vh - 4rem);
+
     section {
-        height: 100%;
         width: 100%;
         display: flex;
         flex-direction: column;
@@ -253,9 +254,14 @@ defineExpose({ showModal, hideModal });
             padding: var(--spacing-2);
             margin: calc(var(--spacing-2) * -1);
 
-            max-height: 100%;
             display: flex;
             flex-direction: column;
+        }
+    }
+
+    &.g-fixed-height {
+        section {
+            height: 100%;
         }
     }
 
@@ -306,6 +312,10 @@ defineExpose({ showModal, hideModal });
         height: calc(100vh - 6rem);
         max-width: calc(100vw - 6rem);
         max-height: calc(100vh - 6rem);
+
+        section {
+            height: 100%;
+        }
     }
 
     header {

--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -170,9 +170,7 @@ export default defineConfig(({ command }) => ({
                         const cookies = proxyRes.headers["set-cookie"];
                         if (cookies) {
                             proxyRes.headers["set-cookie"] = cookies.map((cookie) =>
-                                cookie
-                                    .replace(/;\s*Secure/gi, "")
-                                    .replace(/;\s*SameSite=None/gi, "; SameSite=Lax")
+                                cookie.replace(/;\s*Secure/gi, "").replace(/;\s*SameSite=None/gi, "; SameSite=Lax"),
                             );
                         }
                     });

--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -160,8 +160,23 @@ export default defineConfig(({ command }) => ({
             // Proxy everything except Vite's own routes to Galaxy backend
             "^/(?!(@|src/|node_modules/|__vite))": {
                 target: process.env.GALAXY_URL || "http://127.0.0.1:8080",
-                changeOrigin: !!process.env.CHANGE_ORIGIN,
-                secure: process.env.CHANGE_ORIGIN ? false : true,
+                changeOrigin: true,
+                secure: false,
+                cookieDomainRewrite: "",
+                configure: (proxy) => {
+                    // Strip Secure flag and fix SameSite from upstream HTTPS cookies so
+                    // they are accepted by the browser on http://localhost.
+                    proxy.on("proxyRes", (proxyRes) => {
+                        const cookies = proxyRes.headers["set-cookie"];
+                        if (cookies) {
+                            proxyRes.headers["set-cookie"] = cookies.map((cookie) =>
+                                cookie
+                                    .replace(/;\s*Secure/gi, "")
+                                    .replace(/;\s*SameSite=None/gi, "; SameSite=Lax")
+                            );
+                        }
+                    });
+                },
             },
         },
         cors: true,


### PR DESCRIPTION
## Summary

- **GModal truncation fix**: Without an explicit height on the dialog, `section { height: 100% }` resolved to `auto`, so `.g-modal-content`'s `overflow: auto` never activated and the dialog clipped instead of scrolling. Added `max-height: calc(100vh - 4rem)` to cap the dialog, and scoped `section { height: 100% }` to only `.g-fixed-height` and `.g-fullscreen` where the dialog has an actual pixel height that makes the percentage meaningful.
- **Vite dev proxy fix**: When proxying a remote HTTPS Galaxy server, upstream cookies carry `Secure` and `SameSite=None`. Browsers silently drop `Secure` cookies on `http://localhost`, so `galaxysession` was never stored, `/context` returned `session_csrf_token: null`, and login failed with "No session token set". Added a `proxyRes` handler to strip `Secure` and rewrite `SameSite=None → Lax`, enabled `changeOrigin: true` unconditionally, and added `cookieDomainRewrite: ""` to remove upstream domain attributes.

Fixes #22899

## Test plan

- [ ] Open User → Preferences → Manage Your Preferred Galaxy Storage — modal appears without truncation, content area scrolls when content exceeds viewport height
- [ ] Run `GALAXY_URL=https://test.galaxyproject.org/ pnpm develop` and confirm login works in Safari (no CSRF error)