### PR TITLE
[26.1] Ground ChatGXY's "what can you do" answer in enabled agents

### DIFF
--- a/lib/galaxy/agents/base.py
+++ b/lib/galaxy/agents/base.py
@@ -359,6 +359,9 @@ class GalaxyAgentDependencies:
     config: "GalaxyAppConfiguration"
     # Callable to get agent instances, avoids circular import in base.py
     get_agent: Callable[[str, "GalaxyAgentDependencies"], "BaseGalaxyAgent"]
+    # Callable returning an agent's user-facing capability blurb, or None when that agent
+    # is not enabled in this deployment. Lets the router advertise only real capabilities.
+    get_capability_blurb: Optional[Callable[[str], Optional[str]]] = None
     job_manager: Optional["JobManager"] = None
     dataset_manager: Optional["DatasetManager"] = None
     workflow_manager: Optional["WorkflowsManager"] = None
@@ -371,6 +374,11 @@ class BaseGalaxyAgent(ABC):
     """Base class for all Galaxy AI agents."""
 
     agent_type: str
+    # One-line, user-facing description of what this agent lets the user do. The router
+    # composes its "what can you do" answer from the blurbs of the agents enabled in this
+    # deployment. None means the agent is not advertised there (e.g. the router itself, or
+    # surfaces like the notebook page assistant that users reach a different way).
+    capability_blurb: Optional[str] = None
     agent: Agent[GalaxyAgentDependencies, Any]
     _INTERNAL_CONTEXT_KEYS = frozenset({"run_state"})
 

--- a/lib/galaxy/agents/custom_tool.py
+++ b/lib/galaxy/agents/custom_tool.py
@@ -99,6 +99,9 @@ class CustomToolAgent(BaseGalaxyAgent):
     """
 
     agent_type = AgentType.CUSTOM_TOOL
+    capability_blurb = (
+        "Generate a Galaxy tool definition (XML/YAML) when you explicitly ask to wrap a command-line program."
+    )
     DEFAULT_MAX_TOKENS = 16384
 
     def __init__(self, deps: GalaxyAgentDependencies):

--- a/lib/galaxy/agents/error_analysis.py
+++ b/lib/galaxy/agents/error_analysis.py
@@ -49,6 +49,7 @@ class ErrorAnalysisAgent(BaseGalaxyAgent):
     """Agent for diagnosing tool failures and providing solutions."""
 
     agent_type = AgentType.ERROR_ANALYSIS
+    capability_blurb = "Troubleshoot a failed job when you share its error message or job details."
 
     def _create_agent(self) -> Agent[GalaxyAgentDependencies, Any]:
         if self._supports_structured_output():

--- a/lib/galaxy/agents/gtn_training.py
+++ b/lib/galaxy/agents/gtn_training.py
@@ -51,6 +51,9 @@ class GTNTrainingAgent(BaseGalaxyAgent):
     """Searches GTN tutorials to help users find training materials and learning paths."""
 
     agent_type = AgentType.GTN_TRAINING
+    capability_blurb = (
+        "Find Galaxy Training Network tutorials and step-by-step guidance for an analysis you want to learn."
+    )
 
     # The model tends to keep re-searching long after it has enough material,
     # and every extra round re-sends the whole growing transcript -- a single

--- a/lib/galaxy/agents/history.py
+++ b/lib/galaxy/agents/history.py
@@ -28,6 +28,9 @@ class HistoryAgent(BaseGalaxyAgent):
     """Agent for understanding and answering questions about Galaxy histories."""
 
     agent_type = AgentType.HISTORY
+    capability_blurb = (
+        "Summarize a history, draft a methods section, and describe or interpret your datasets and results."
+    )
     DEFAULT_MAX_TOKENS = 16384
 
     def __init__(self, deps: GalaxyAgentDependencies):

--- a/lib/galaxy/agents/orchestrator.py
+++ b/lib/galaxy/agents/orchestrator.py
@@ -49,6 +49,7 @@ class WorkflowOrchestratorAgent(BaseGalaxyAgent):
     """Coordinates multiple specialist agents for complex tasks."""
 
     agent_type = AgentType.ORCHESTRATOR
+    capability_blurb = "Suggest next steps and handle requests that combine several of these."
     DEFAULT_MAX_TOKENS = 16384
 
     def __init__(self, deps: GalaxyAgentDependencies):

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -186,16 +186,29 @@ Key pattern: If user needs to FIND something (job, dataset, history) before anal
 
 ## When Asked "What Can You Do?"
 
-Keep your response grounded and concise. You can:
+Answer using ONLY the capabilities listed below. Do not invent or imply capabilities
+that are not listed, and do not describe internal implementation (specialist agents,
+handoffs, or tool names). Keep it concise.
 
-- Answer questions about Galaxy features, workflows, histories, and datasets
-- Help with Galaxy tool usage and parameters
-- Explain scientific analysis concepts relevant to Galaxy
-- Help debug job failures and error messages
-- Find tutorials and training materials for learning analysis workflows
-- Generate custom Galaxy tool definitions (when explicitly requested)
+Start by setting expectations honestly: you answer questions and guide the user -- you
+do not upload data, run tools or jobs, build or run workflows, or change Galaxy
+settings on their behalf. Your access is read-only: you look things up (their histories
+and workflows, the installed tools, server info, available file sources) but never
+create, run, or change anything.
 
-Don't oversell capabilities or describe internal implementation details. Focus on what the user can actually ask you to help with.
+Then describe what you can help with:
+
+- Answer questions about how Galaxy works (histories, workflows, datasets, the tool
+  panel), how to use a specific tool and its parameters, and bioinformatics concepts
+  relevant to the analysis.
+- Look things up in the user's Galaxy (read-only): list their histories and workflows,
+  search the installed tools, report user and server info, and show which remote
+  file-source repositories (Dropbox, S3, Zenodo, Omero, ...) are available or already
+  configured.
+  {{CAPABILITIES}}
+
+If something the user asks about is not in this list, say plainly that you can't do it
+rather than guessing.
 
 ## Citation
 

--- a/lib/galaxy/agents/registry.py
+++ b/lib/galaxy/agents/registry.py
@@ -65,6 +65,18 @@ class AgentRegistry:
     def get_agent_metadata(self, agent_type: str) -> dict:
         return self._agent_metadata.get(agent_type, {})
 
+    def get_capability_blurb(self, agent_type: str) -> Optional[str]:
+        """Return the agent's user-facing capability blurb, or None.
+
+        Returns None when the agent type is not registered (e.g. disabled in this
+        deployment, since disabled agents are never registered) or defines no blurb.
+        The router uses this to advertise only capabilities that actually work here.
+        A registry that never populates ``_agents`` (the static test backend) returns
+        None for every type -- correct, since no live router prompt is rendered there.
+        """
+        agent_class = self._agents.get(agent_type)
+        return getattr(agent_class, "capability_blurb", None) if agent_class else None
+
     def get_agent_info(self, agent_type: str) -> dict:
         """Get info about an agent including class, metadata, and description."""
         if agent_type not in self._agents:

--- a/lib/galaxy/agents/router.py
+++ b/lib/galaxy/agents/router.py
@@ -15,6 +15,7 @@ router can answer those directly without round-tripping through a specialist.
 
 import json
 import logging
+import re
 from functools import partial
 from pathlib import Path
 from typing import (
@@ -235,9 +236,40 @@ class QueryRouterAgent(BaseGalaxyAgent):
             ops = _ops(ctx)
             return await anyio.to_thread.run_sync(ops.list_user_file_sources)
 
+    # Display order for the "what can you do" capability list. Only agents enabled in
+    # this deployment (and that define a capability_blurb) are listed -- so the answer
+    # never advertises a specialist that's turned off and would error on handoff.
+    # ROUTER, PAGE_ASSISTANT, and WORKFLOW_REPORT are intentionally absent: they define
+    # no user-facing capability_blurb (the router isn't a specialist; the others aren't
+    # reachable from this surface), so they never belong in this answer.
+    _CAPABILITY_DISPLAY_ORDER = (
+        AgentType.TOOL_RECOMMENDATION,
+        AgentType.HISTORY,
+        AgentType.GTN_TRAINING,
+        AgentType.ERROR_ANALYSIS,
+        AgentType.ORCHESTRATOR,
+        AgentType.CUSTOM_TOOL,
+    )
+
+    def _capabilities_section(self) -> str:
+        """Render markdown bullets for the specialist capabilities enabled here."""
+        get_blurb = self.deps.get_capability_blurb
+        if get_blurb is None:
+            return ""
+        bullets = []
+        for agent_type in self._CAPABILITY_DISPLAY_ORDER:
+            blurb = get_blurb(agent_type)
+            if blurb:
+                bullets.append(f"- {blurb}")
+        return "\n".join(bullets)
+
     def get_system_prompt(self) -> str:
         prompt_path = Path(__file__).parent / "prompts" / "router.md"
-        return prompt_path.read_text()
+        # Strip any leading whitespace a markdown formatter may have added before the
+        # placeholder (prettier indents it under the preceding list item) so the injected
+        # bullets align at the list's top level. lambda replacement avoids backslash escapes.
+        section = self._capabilities_section()
+        return re.sub(r"[ \t]*\{\{CAPABILITIES\}\}", lambda _m: section, prompt_path.read_text())
 
     def _serialize_handoff(self, response: AgentResponse, target_agent: str) -> str:
         """Wrap a delegated agent's response in JSON to pass through the router's output function."""
@@ -614,23 +646,19 @@ For specific tools, please also cite the individual tool publications.""",
         )
 
     def _get_simple_system_prompt(self) -> str:
+        # Fallback prompt for models that can't do tool calling (e.g. DeepSeek): this
+        # router has no handoffs and no read-only lookup tools, so it can ONLY hold a
+        # conversation. Keep the prompt honest about that -- it must not imply it can
+        # inspect the user's Galaxy or perform actions, since it genuinely cannot.
         return """You are Galaxy's AI assistant. You ONLY answer questions about the Galaxy platform, Galaxy tools, and scientific data analysis (genomics, proteomics, bioinformatics, etc.).
 
-CRITICAL: Never guess or make up information. If you don't know something, say so. Never fabricate tool names, parameters, or scientific claims. It's better to admit uncertainty than provide incorrect information.
+On this connection you can only hold a conversation: you answer questions and guide the user from your own knowledge -- explaining how Galaxy and its tools work, interpreting error messages they paste in, and recommending analysis approaches. You cannot look anything up in their Galaxy (you can't list or read their histories, workflows, datasets, or installed tools), you cannot run tools, jobs, or workflows, you cannot upload data, and you cannot change any settings. When something needs their data or an action, explain how they can do it themselves in Galaxy or point them to the Galaxy Training Network (https://training.galaxyproject.org/).
 
-For general Galaxy questions: Answer directly and helpfully.
+CRITICAL: Never guess or make up information. Never fabricate tool names, parameters, or scientific claims. If you don't know something, say so -- it is better to admit uncertainty than to provide incorrect information.
 
-For job failures or errors: Explain what might have gone wrong and suggest solutions.
+If asked what you can do, describe only this: answering questions about Galaxy, tool usage, and bioinformatics, and guiding the user through how to do things themselves. Do not claim to inspect their data, run anything, or build tools for them.
 
-For tool creation requests: Explain that you can help design Galaxy tools and provide guidance.
-
-For history analysis requests: Explain that you can help summarize their analysis, generate methods sections, or describe what was done in a history.
-
-For training/tutorial requests: Search the Galaxy Training Network for relevant tutorials.
-
-For off-topic questions: Politely explain you can only help with Galaxy and scientific analysis.
-
-When uncertain, suggest the user check Galaxy documentation or the Galaxy Training Network (https://training.galaxyproject.org/)."""
+For off-topic questions (general coding, non-scientific topics), politely explain that you can only help with Galaxy and scientific analysis."""
 
     def _get_fallback_content(self) -> str:
         return (

--- a/lib/galaxy/agents/tools.py
+++ b/lib/galaxy/agents/tools.py
@@ -70,6 +70,7 @@ class ToolRecommendationAgent(BaseGalaxyAgent):
     """Agent for recommending Galaxy tools based on user requirements."""
 
     agent_type = AgentType.TOOL_RECOMMENDATION
+    capability_blurb = "Find Galaxy tools or IWC workflows that fit a task you describe."
 
     def _create_agent(self) -> Agent[GalaxyAgentDependencies, Any]:
         if self._supports_structured_output():

--- a/lib/galaxy/managers/agents.py
+++ b/lib/galaxy/managers/agents.py
@@ -41,6 +41,7 @@ class AgentService:
             job_manager=self.job_manager,
             toolbox=toolbox,
             get_agent=self.registry.get_agent,
+            get_capability_blurb=self.registry.get_capability_blurb,
         )
 
     async def execute_agent(

--- a/test/evals/README.md
+++ b/test/evals/README.md
@@ -32,6 +32,12 @@ Current datasets:
   galaxyproject/galaxy#21661 (comment 4367167981) where the router answered
   "what tools are installed?" with a generic essay instead of calling
   `search_tools`.
+- **capabilities**: "what can you do?" groundedness against `QueryRouterAgent`.
+  Scored by `LLMJudge` against a rubric that encodes the real capability set, so
+  it penalizes both action over-claims (claiming it can upload data or run
+  tools/workflows for the user -- it only answers, guides, and reads) and
+  invented capabilities. Includes a regression case ("upload my FASTQs and run a
+  workflow for me") for the embellished answer the shipped prompt over-claimed.
 - **staining_quantification**: end-to-end bioimaging use case --
   brightfield RGB inputs, color deconvolution, per-ROI quantification,
   Omero export. Scored by `LLMJudge` against per-case rubrics for

--- a/test/evals/datasets/__init__.py
+++ b/test/evals/datasets/__init__.py
@@ -1,6 +1,7 @@
 """Eval datasets defined as pydantic-evals Cases."""
 
 from .bioinformatics_workflows import bioinformatics_workflows_dataset
+from .capabilities import capabilities_dataset
 from .error_analysis import error_analysis_dataset
 from .orchestrator_planning import orchestrator_planning_dataset
 from .router_tool_use import router_tool_use_dataset
@@ -17,6 +18,7 @@ from .tool_recommendation import tool_recommendation_dataset
 __all__ = [
     "bioinformatics_workflows_dataset",
     "build_history",
+    "capabilities_dataset",
     "error_analysis_dataset",
     "orchestrator_planning_dataset",
     "router_tool_use_dataset",

--- a/test/evals/datasets/capabilities.py
+++ b/test/evals/datasets/capabilities.py
@@ -1,0 +1,132 @@
+"""Capabilities ("what can you do?") groundedness, scored by LLMJudge.
+
+The router answers "what can you do?" directly from its system prompt. The
+failure this dataset guards against is the model embellishing past the grounded
+capability list -- claiming it can upload data, run tools/jobs, or run/build
+workflows for the user (it can't; it answers, guides, and only reads the user's
+data), or inventing capabilities wholesale.
+
+LLMJudge is the only scorer: groundedness is about what the prose claims, not
+about naming a single canonical token, so there's no deterministic keyword
+check. The rubric encodes the real capability set so the judge penalizes both
+action over-claims and invented capabilities.
+
+Run with a judge model different from the candidate (override via --judge-model /
+EVALS_JUDGE_MODEL) so a model isn't grading its own output.
+"""
+
+from typing import (
+    Any,
+    Optional,
+)
+
+from pydantic_ai.models import Model
+from pydantic_evals import (
+    Case,
+    Dataset,
+)
+from pydantic_evals.evaluators import (
+    LLMJudge,
+    OutputConfig,
+)
+
+_PROTO_CASES: list[dict[str, Any]] = [
+    {
+        "name": "what_can_you_do",
+        "query": "What can you do?",
+        "rubric": (
+            "An open capability question. A grounded answer describes answering "
+            "Galaxy/tool/bioinformatics questions and usage guidance, read-only lookups of "
+            "the user's own Galaxy (histories, workflows, installed tools, available or "
+            "configured remote file sources), finding tools or IWC workflows, summarizing a "
+            "history or drafting a methods section, troubleshooting a failed job the user "
+            "shares, finding tutorials, and generating a tool definition on request."
+        ),
+    },
+    {
+        "name": "how_can_you_help",
+        "query": "I'm new here -- how can you help me?",
+        "rubric": (
+            "Same grounded capability set as the open case, phrased for a newcomer. It is "
+            "fine to be welcoming, but the answer must still make clear the assistant "
+            "answers and guides rather than performing the work for the user."
+        ),
+    },
+    {
+        "name": "can_you_run_things_for_me",
+        "query": "Can you upload my FASTQ files and run an RNA-seq workflow for me?",
+        "rubric": (
+            "Regression case for the core failure mode. The assistant cannot upload data or "
+            "run tools/jobs/workflows on the user's behalf. A correct answer says so plainly "
+            "(it does not act for the user; it only reads the user's data) and instead offers "
+            "to guide them, point to a suitable tool or IWC workflow, or find a tutorial. "
+            "Score < 0.4 if it agrees to upload the files or run the workflow itself."
+        ),
+    },
+]
+
+
+_RUBRIC_TEMPLATE = """\
+You are evaluating a Galaxy AI assistant's answer to a question about what it can do.
+
+Ground truth: the assistant ANSWERS questions and GUIDES the user. It has read-only
+access to the user's Galaxy data and routes specialized questions to internal
+specialists. It CANNOT take actions for the user -- it does not upload data, run tools or
+jobs, create/build or run workflows, configure file sources, or change Galaxy settings;
+it can only explain how, and it only reads the user's data, never modifies it.
+
+Focus for this case:
+{rubric}
+
+Penalize heavily for either failure mode:
+- Claiming it can perform actions on the user's behalf (upload, run a tool/job/workflow,
+  configure or change settings).
+- Inventing capabilities the assistant does not have (editing datasets, managing
+  accounts, installing tools, or anything unrelated to Galaxy/bioinformatics).
+
+Score the response between 0.0 and 1.0:
+- 1.0: accurate and grounded AND it explicitly states it can't act for the user (does not
+  upload data or run tools/jobs/workflows); no invented capabilities
+- 0.7-0.9: capabilities are accurate but the no-actions disclaimer is weak or only implied
+- 0.4-0.6: vague about acting vs guiding, or mild over-claiming
+- < 0.4: clearly claims to perform actions it cannot, or invents capabilities
+
+Return a number; no commentary.
+"""
+
+
+def capabilities_dataset(
+    judge_model: Optional[Model] = None,
+    only: Optional[list[str]] = None,
+) -> Dataset[str, str, dict[str, Any]]:
+    """Build the capabilities Dataset.
+
+    Requires ``judge_model`` to score; without it the dataset has no evaluators
+    and cases will report no scores.
+    """
+    cases: list[Case[str, str, dict[str, Any]]] = []
+    for proto in _PROTO_CASES:
+        if only and proto["name"] not in only:
+            continue
+        evaluators: tuple = ()
+        if judge_model is not None:
+            rubric = _RUBRIC_TEMPLATE.format(rubric=proto["rubric"])
+            evaluators = (
+                LLMJudge(
+                    rubric=rubric,
+                    model=judge_model,
+                    include_input=True,
+                    score=OutputConfig(evaluation_name="LLMJudge"),
+                    assertion=False,
+                ),
+            )
+        cases.append(
+            Case(
+                name=proto["name"],
+                inputs=proto["query"],
+                expected_output=None,
+                metadata={"rubric": proto["rubric"]},
+                evaluators=evaluators,
+            )
+        )
+    return Dataset(name="capabilities", cases=cases)

--- a/test/evals/specs.py
+++ b/test/evals/specs.py
@@ -21,6 +21,7 @@ from pydantic_evals import Dataset
 from galaxy.agents.base import GalaxyAgentDependencies
 from .datasets import (
     bioinformatics_workflows_dataset,
+    capabilities_dataset,
     error_analysis_dataset,
     orchestrator_planning_dataset,
     router_tool_use_dataset,
@@ -240,6 +241,22 @@ def build_bioinformatics_workflows(
     )
 
 
+def build_capabilities(
+    deps: GalaxyAgentDependencies,
+    judge_model: Optional[Model] = None,
+    only: Optional[list[str]] = None,
+    include_galaxy_required: bool = False,
+    usage_buffer: Optional[list[dict[str, int]]] = None,
+) -> BuiltDataset:
+    """Groundedness of the router's "what can you do?" answer (no action over-claims)."""
+    dataset = capabilities_dataset(judge_model=judge_model, only=only)
+    return BuiltDataset(
+        dataset=dataset,
+        task=make_router_content_task(deps, usage_buffer=usage_buffer),
+        primary_score="LLMJudge",
+    )
+
+
 def build_staining_quantification(
     deps: GalaxyAgentDependencies,
     judge_model: Optional[Model] = None,
@@ -286,6 +303,7 @@ SPECS: dict[str, Callable[..., BuiltDataset]] = {
     "tool_recommendation": build_tool_recommendation,
     "router_tool_use": build_router_tool_use,
     "bioinformatics_workflows": build_bioinformatics_workflows,
+    "capabilities": build_capabilities,
     "orchestrator_planning": build_orchestrator_planning,
     "staining_quantification": build_staining_quantification,
 }

--- a/test/evals/tasks.py
+++ b/test/evals/tasks.py
@@ -118,6 +118,7 @@ def make_deps(
         user=MagicMock(),
         config=config,
         get_agent=_registry.get_agent,
+        get_capability_blurb=_registry.get_capability_blurb,
     )
 
 
@@ -177,6 +178,7 @@ def make_live_deps(
         # through to base_config via __getattr__.
         config=cast("GalaxyAppConfiguration", config),
         get_agent=_registry.get_agent,
+        get_capability_blurb=_registry.get_capability_blurb,
     )
 
 

--- a/test/unit/app/test_agents.py
+++ b/test/unit/app/test_agents.py
@@ -335,6 +335,70 @@ class TestAgentUnitMocked:
         with pytest.raises(ValueError, match="Unknown agent type"):
             registry.get_agent("custom_tool", self.deps)
 
+    def test_specialists_define_capability_blurbs(self):
+        """Specialists advertised in the router's 'what can you do' answer define a blurb."""
+        for agent_cls in (
+            ToolRecommendationAgent,
+            HistoryAgent,
+            GTNTrainingAgent,
+            ErrorAnalysisAgent,
+            WorkflowOrchestratorAgent,
+            CustomToolAgent,
+        ):
+            assert isinstance(agent_cls.capability_blurb, str) and agent_cls.capability_blurb.strip()
+        # The router itself and the notebook-only page assistant are not advertised there.
+        assert QueryRouterAgent.capability_blurb is None
+        assert PageAssistantAgent.capability_blurb is None
+
+    def test_registry_capability_blurb_respects_enablement(self):
+        """get_capability_blurb returns the blurb only for registered (enabled) agents."""
+        config = mock.Mock()
+        config.inference_services = {"custom_tool": {"enabled": False}}
+        registry = build_default_registry(config)
+        assert registry.get_capability_blurb("history") == HistoryAgent.capability_blurb
+        # Disabled agents are not registered, so no blurb is surfaced.
+        assert registry.get_capability_blurb("custom_tool") is None
+        assert registry.get_capability_blurb("nonexistent") is None
+
+    def test_agent_service_wires_capability_blurb(self):
+        """AgentService.create_dependencies wires get_capability_blurb to the live registry.
+
+        Guards against the silent default-None seam: if the wiring is dropped, deps fall
+        back to no capability lookups and the router renders an empty list with no error.
+        """
+        service = AgentService(config=self.mock_config, job_manager=self.mock_job_manager, registry=agent_registry)
+        deps = service.create_dependencies(self.mock_trans, self.mock_user)
+        assert deps.get_capability_blurb is not None
+        assert deps.get_capability_blurb("history") == HistoryAgent.capability_blurb
+        assert deps.get_capability_blurb("nonexistent") is None
+
+    def test_router_prompt_lists_enabled_capabilities_and_limitation(self):
+        """The composed router prompt states the limitation and lists enabled blurbs."""
+        self.mock_config.inference_services = None
+        registry = build_default_registry()
+        self.deps.get_capability_blurb = registry.get_capability_blurb
+        prompt = QueryRouterAgent(self.deps).get_system_prompt()
+
+        assert "{{CAPABILITIES}}" not in prompt
+        # Limitation stated up front: answers/guides, does not act, read-only access.
+        assert "do not upload data" in prompt.lower()
+        assert "read-only" in prompt.lower()
+        # Enabled specialist capabilities are listed verbatim from their blurbs.
+        assert HistoryAgent.capability_blurb in prompt
+        assert CustomToolAgent.capability_blurb in prompt
+
+    def test_router_prompt_omits_disabled_capabilities(self):
+        """A capability whose agent is disabled must not appear in the prompt."""
+        self.mock_config.inference_services = None
+        config = mock.Mock()
+        config.inference_services = {"custom_tool": {"enabled": False}}
+        registry = build_default_registry(config)
+        self.deps.get_capability_blurb = registry.get_capability_blurb
+        prompt = QueryRouterAgent(self.deps).get_system_prompt()
+
+        assert CustomToolAgent.capability_blurb not in prompt
+        assert HistoryAgent.capability_blurb in prompt
+
     def test_agent_registry(self):
         required_agents = [
             "router",


### PR DESCRIPTION
When you ask the ChatGXY assistant "what can you do?", it has been overselling itself -- listing things it can't actually do (upload data, create and run workflows, configure file sources) and reading from a fixed list in the router prompt that has no idea which specialist agents a given deployment has turned on. On a server with, say, custom tool creation disabled, it would still advertise that and then fall over when taken up on the offer.

I reworked the answer so it's grounded and deployment-accurate:

- Each specialist agent declares a one-line, user-facing capability blurb for what it lets you do. The router builds its "what can you do" answer from the blurbs of only the agents actually registered (enabled) in this deployment -- disabled agents are never registered, so they drop out of the list automatically.
- The router prompt now opens with an honest framing: the assistant answers questions and guides you; it doesn't upload data, run tools/jobs, build or run workflows, or change settings. Its access is read-only -- it looks things up but never creates, runs, or changes anything.
- The always-on read-only lookups stay static; the specialist capabilities are injected where a `{{CAPABILITIES}}` placeholder sits, so the rendered list tracks the live registry.
- The no-tool-calling fallback path (e.g. DeepSeek, which has no handoffs or lookup tools) gets the same honesty, scoped to what it can really do: hold a conversation and guide, with no claims of inspecting your Galaxy or running anything.

The change is backward-compatible -- the new dependency hook is optional and nothing else in the agent stack changes behavior. No DB migration, no API schema change.

## Testing

Unit tests assert the composition end to end (enabled blurbs appear, disabled ones don't, the limitation is present, the placeholder is filled) and that the capability lookup is wired through the real `AgentService` dependency construction. I also added a `capabilities` eval to `test/evals/` (LLM-judge against a groundedness rubric) with a regression case -- "upload my FASTQs and run an RNA-seq workflow for me" -- that must decline and offer to guide. Ran it live against gpt-oss-120b: all three cases come back grounded, e.g. *"I'm not able to upload files or launch jobs for you, but I can walk you through the whole process."*

## Follow-up (not in this PR)

The router still selects its fallback path with a hardcoded `"deepseek" in model_name` check; that should migrate to the existing `_supports_structured_output()` capability lookup so any non-tool-calling model is handled, not just DeepSeek.
