### PR TITLE
[26.1] Hide generated headers for tabular previews

### DIFF
--- a/client/src/components/Dataset/Tabular/TabularChunkedView.test.ts
+++ b/client/src/components/Dataset/Tabular/TabularChunkedView.test.ts
@@ -1,0 +1,42 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { shallowMount } from "@vue/test-utils";
+import axios from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import TabularChunkedView from "./TabularChunkedView.vue";
+import GTable from "@/components/Common/GTable.vue";
+
+vi.mock("axios");
+vi.mock("@/onload/loadConfig", () => ({
+    getAppRoot: () => "/",
+}));
+
+const localVue = getLocalVue();
+
+function mountChunkedView(fileExt: string) {
+    vi.mocked(axios.get).mockResolvedValue({ data: { ck_data: "", offset: 0, data_line_offset: 0 } });
+    return shallowMount(TabularChunkedView as object, {
+        localVue,
+        propsData: {
+            options: {
+                id: "dataset-id",
+                file_ext: fileExt,
+                metadata_columns: 2,
+            },
+        },
+    });
+}
+
+describe("TabularChunkedView", () => {
+    it("hides the table header for generic tabular datasets", () => {
+        const wrapper = mountChunkedView("tabular");
+
+        expect(wrapper.findComponent(GTable).props("hideHeader")).toBe(true);
+    });
+
+    it("keeps the table header for CSV datasets", () => {
+        const wrapper = mountChunkedView("csv");
+
+        expect(wrapper.findComponent(GTable).props("hideHeader")).toBe(false);
+    });
+});

--- a/client/src/components/Dataset/Tabular/TabularChunkedView.vue
+++ b/client/src/components/Dataset/Tabular/TabularChunkedView.vue
@@ -200,6 +200,7 @@ onMounted(() => {
             striped
             head-variant="dark"
             :fields="fields"
+            :hide-header="props.options.file_ext === 'tabular'"
             :items="tableRows"
             :load-more-loading="loading" />
     </div>

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -390,6 +390,12 @@ class Tabular(TabularData):
     def get_column_names(self, first_line: str) -> Optional[list[str]]:
         return None
 
+    def make_html_peek_header(self, dataset: DatasetProtocol, *args, **kwargs) -> str:
+        # Only generic tabular loses generated headers; subclasses may define real column labels.
+        if type(self) is Tabular:
+            return ""
+        return super().make_html_peek_header(dataset, *args, **kwargs)
+
     def set_meta(
         self,
         dataset: DatasetProtocol,

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -112,3 +112,16 @@ def test_tabular_column_types_override():
         assert dataset.metadata.columns == 6
         assert dataset.metadata.delimiter == "\t"
         assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_display_peek_does_not_render_table_header():
+    dataset = MockDataset(id=1)
+    dataset.peek = "question_id\tcurator_name\nensembl-grab-q1\tLG\n"
+    dataset.metadata.columns = 2
+    dataset.metadata.delimiter = "\t"
+
+    html = Tabular().display_peek(dataset)  # type: ignore [arg-type]
+
+    assert "<th>" not in html
+    assert "<td>question_id</td>" in html
+    assert "<td>curator_name</td>" in html

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -1,4 +1,8 @@
 import tempfile
+from typing import (
+    Any,
+    cast,
+)
 
 from galaxy.datatypes.tabular import (
     MAX_DATA_LINES,
@@ -116,9 +120,11 @@ def test_tabular_column_types_override():
 
 def test_tabular_display_peek_does_not_render_table_header():
     dataset = MockDataset(id=1)
-    setattr(dataset, "peek", "question_id\tcurator_name\nensembl-grab-q1\tLG\n")
-    setattr(dataset.metadata, "columns", 2)
-    setattr(dataset.metadata, "delimiter", "\t")
+    dataset_for_peek = cast(Any, dataset)
+    metadata = cast(Any, dataset.metadata)
+    dataset_for_peek.peek = "question_id\tcurator_name\nensembl-grab-q1\tLG\n"
+    metadata.columns = 2
+    metadata.delimiter = "\t"
 
     html = Tabular().display_peek(dataset)  # type: ignore [arg-type]
 

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -116,9 +116,9 @@ def test_tabular_column_types_override():
 
 def test_tabular_display_peek_does_not_render_table_header():
     dataset = MockDataset(id=1)
-    dataset.peek = "question_id\tcurator_name\nensembl-grab-q1\tLG\n"
-    dataset.metadata.columns = 2
-    dataset.metadata.delimiter = "\t"
+    setattr(dataset, "peek", "question_id\tcurator_name\nensembl-grab-q1\tLG\n")
+    setattr(dataset.metadata, "columns", 2)
+    setattr(dataset.metadata, "delimiter", "\t")
 
     html = Tabular().display_peek(dataset)  # type: ignore [arg-type]
 


### PR DESCRIPTION
Generic Galaxy `tabular` datasets may contain a first row that looks like column labels, but the generic datatype does not treat that row as a semantic table header. The current preview UI still renders generated headers above that first row:

- history peek shows generated `1 2 3 ...` headers
- full dataset preview shows generated `Column 1`, `Column 2`, etc.

This makes the first data row appear under an extra generated header row. This PR hides those generated headers only for the exact generic `tabular` display paths. It does not infer file headers, change metadata, or alter CSV/TSV/subclass behavior.

## Screenshots

| View | Before | After |
| --- | --- | --- |
| History peek | Generated `1 2 3 ...` header is shown above the first row.<br><img width="420" alt="Before history peek showing generated numeric headers" src="https://github.com/user-attachments/assets/ed296976-0693-4df6-a11d-32c3be6b135f" /> | Peek starts with the first dataset row; no generated header is shown.<br><img width="420" alt="After history peek without generated headers" src="https://github.com/user-attachments/assets/ae6ad736-2c6d-4fcb-ae4e-27e8903dd563" /> |
| Full preview | Generated `Column 1`, `Column 2`, etc. header is shown above the first row.<br><img width="420" alt="Before full preview showing generated Column headers" src="https://github.com/user-attachments/assets/6e7b9e8e-f80c-48ea-8687-7f2bb36f19d9" /> | Preview starts with the first dataset row; no generated header is shown.<br><img width="420" alt="After full preview without generated Column headers" src="https://github.com/user-attachments/assets/9d287de3-9990-4675-8e23-cc273b44ab07" /> |

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy from this branch.
  2. Upload a generic `tabular` dataset with content like:
     ```
     question_id	curator_name	domain
     ensembl-grab-q1	LG	Genomics
     bam-infer-read-length-q1	SN	Genomics
     differential-composition-q1	SN	Single-cell
     ```
  3. Expand the dataset in the history panel and confirm the peek starts with `question_id curator_name domain`, with no generated `1 2 3` header row.
  4. Open the dataset preview and confirm it starts with `question_id curator_name domain`, with no generated `Column 1`, `Column 2`, etc. header row.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
