### PR TITLE
[26.1] Fix misaligned activity bar icons

### DIFF
--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -82,7 +82,7 @@ const meta = computed(() => store.metaForId(props.id));
     <Popper :placement="tooltipPlacement">
         <template v-slot:reference>
             <b-nav-item
-                class="activity-item my-1 p-2"
+                class="activity-item"
                 :class="{ 'nav-item-active': isActive }"
                 :link-attrs="{ id: `activity-${id}` }"
                 :link-classes="`variant-${props.variant}`"
@@ -141,6 +141,9 @@ const meta = computed(() => store.metaForId(props.id));
     position: relative;
     display: flex;
     flex-direction: column;
+    width: 5rem;
+    padding: 0.5rem;
+    margin: 0.125rem 0;
 
     &:deep(.variant-danger) {
         color: $brand-danger;
@@ -200,7 +203,6 @@ const meta = computed(() => store.metaForId(props.id));
     position: relative;
     display: flex;
     justify-content: center;
-    width: 4rem;
     margin-top: 0.5rem;
     font-size: 0.7rem;
 }

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -79,7 +79,7 @@ const meta = computed(() => store.metaForId(props.id));
 </script>
 
 <template>
-    <Popper :placement="tooltipPlacement">
+    <Popper :placement="tooltipPlacement" class="activity-item-popper">
         <template v-slot:reference>
             <b-nav-item
                 class="activity-item"
@@ -136,6 +136,15 @@ const meta = computed(() => store.metaForId(props.id));
 
 <style scoped lang="scss">
 @import "@/style/scss/theme/blue.scss";
+
+.activity-item-popper {
+    // Vertically centers the popper in the activity bar
+    :deep(.popper-reference-container) {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+}
 
 .activity-item {
     position: relative;

--- a/client/src/components/Common/TextShort.vue
+++ b/client/src/components/Common/TextShort.vue
@@ -21,7 +21,14 @@ const trimmedText = computed(() => {
 </script>
 
 <template>
-    <span class="text-break text-center">
+    <span class="text-short-component">
         {{ trimmedText }}
     </span>
 </template>
+
+<style scoped>
+.text-short-component {
+    text-align: center;
+    word-wrap: break-word;
+}
+</style>

--- a/client/src/components/Popper/Popper.vue
+++ b/client/src/components/Popper/Popper.vue
@@ -75,12 +75,6 @@ defineExpose({
     @return 1px solid $border-color;
 }
 
-.popper-reference-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
 .popper-element {
     z-index: 9999;
     border-radius: $border-radius-large;

--- a/client/src/components/Popper/Popper.vue
+++ b/client/src/components/Popper/Popper.vue
@@ -1,6 +1,6 @@
 <template>
     <span>
-        <span v-if="!referenceEl" ref="reference">
+        <span v-if="!referenceEl" ref="reference" class="popper-reference-container">
             <slot name="reference" />
         </span>
         <div v-show="!disabled && visible" ref="popper" class="popper-element" :class="`popper-element-${mode}`">
@@ -73,6 +73,12 @@ defineExpose({
 
 @function popper-border($border-color) {
     @return 1px solid $border-color;
+}
+
+.popper-reference-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .popper-element {


### PR DESCRIPTION
This was interestingly, on Windows, only happening on Chrome for me (not on Firefox). Just some minor CSS changes were needed to fix the misalignment.

| Before 👎 😞 | After  😃 👍 |
| ---- | ---- |
| <img width="289" height="875" alt="chrome_6KyXy9dOjJ" src="https://github.com/user-attachments/assets/1f85ce78-0ab0-4cca-a3da-cb54f9e178ef" /> | <img width="289" height="875" alt="XuIh0kydrx" src="https://github.com/user-attachments/assets/11df17b1-112c-48b9-9782-8cd76f3d6fcc" /> |


Fixes https://github.com/galaxyproject/galaxy/issues/22600

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. (Try on Chrome) Note that activity bar icons are not misaligned like reported in the linked issue
  2. Try zooming in and out for various screen sizes too (that could render a scroll bar in the main activities)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
