### PR TITLE
[26.1] Fix session_duration check using local time instead of UTC

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -41,6 +41,7 @@ from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
 from galaxy.model import History
 from galaxy.model.base import ensure_object_added_to_session
+from galaxy.model.orm.now import now as utc_now
 from galaxy.structured_app import (
     BasicSharedApp,
     MinimalApp,
@@ -383,7 +384,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 #
                 # Make sure we're not past the duration, and either log out or
                 # update timestamp.
-                now = datetime.datetime.now()
+                now = utc_now()
                 if self.galaxy_session.last_action:
                     expiration_time = self.galaxy_session.last_action + datetime.timedelta(
                         minutes=config.session_duration


### PR DESCRIPTION
## What

Replace `datetime.datetime.now()` (local time) with `utc_now()` (imported from `galaxy.model.orm.now`) in the session expiry check within `GalaxyWebTransaction.__init__`.

## Why

The session duration check in `GalaxyWebTransaction.__init__` uses `datetime.datetime.now()` which returns **local system time** without timezone info. However, the `GalaxySession.last_action` field is set via `galaxy.model.orm.now.now()`, which returns **UTC time** stripped of its timezone marker. Both are naive `datetime` objects, but they represent different points in time when the server is not running in the UTC timezone.

On non-UTC systems (e.g. Asia/Shanghai, UTC+8), this mismatch causes every freshly created session to be immediately evaluated as expired:

```
Session created:    last_action = 2026-06-18 03:18:40.123456  (UTC, naive)
Session check:      now        = 2026-06-18 11:18:40.234567  (CST, naive)
expiration = last_action + timedelta(minutes=480)
           = 03:18:40.123456 + 8h
           = 11:18:40.123456
expiration < now   →   11:18:40.123456 < 11:18:40.234567   →   True
```

The check passes when `session_duration: 0` only because `if config.session_duration:` evaluates to `False`, skipping the entire block.

The result is an infinite redirect loop: `/` → 302 → `/login/start?message=You have been logged out due to inactivity...` → 302 → itself.

## How to reproduce

1. Set system timezone to anything other than UTC (e.g. `Asia/Shanghai`)
2. Configure `session_duration: 480` in `galaxy.yml`
3. Start Galaxy, access `http://YOUR_HOST:8080/` without any existing session cookie
4. Observe the infinite redirect loop

Or test directly with curl:
```bash
curl -v http://127.0.0.1:8080/ 2>&1 | grep -E 'location:|set-cookie:'
```

## Changes

- `lib/galaxy/webapps/base/webapp.py`: Added `from galaxy.model.orm.now import now as utc_now`, replaced `now = datetime.datetime.now()` with `now = utc_now()` at line 385.

## How to test the changes?

- [ ] I've included appropriate automated tests.
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Ensure server timezone is not UTC (`date +%Z` should not show `UTC`)
  2. Set `session_duration: 480` in config, restart Galaxy
  3. Run `curl -v http://127.0.0.1:8080/ 2>&1 | grep location:` — should redirect to `/login/start` **without** the "inactivity" query parameter
  4. Follow the redirect with `curl -L --max-redirs 3` — should land on a login page, not loop

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).