### PR TITLE
[26.1] Keep the standalone SSE monitor out of the control-queue routing table

### DIFF
--- a/lib/galaxy/app/__init__.py
+++ b/lib/galaxy/app/__init__.py
@@ -99,7 +99,10 @@ from galaxy.model.base import (
     ModelMapping,
     SharedModelMapping,
 )
-from galaxy.model.database_heartbeat import DatabaseHeartbeat
+from galaxy.model.database_heartbeat import (
+    DatabaseHeartbeat,
+    WEBAPP,
+)
 from galaxy.model.database_utils import (
     database_exists,
     is_one_database,
@@ -1014,7 +1017,10 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication, InstallationT
             handlers[signal.SIGUSR1] = self.heartbeat.dump_signal_handler
         self._configure_signal_handlers(handlers)
 
-        self.database_heartbeat = DatabaseHeartbeat(application_stack=self.application_stack)
+        self.database_heartbeat = DatabaseHeartbeat(
+            application_stack=self.application_stack,
+            app_type=WEBAPP if self.is_webapp else None,
+        )
         self.database_heartbeat.add_change_callback(self.watchers.change_state)
         self.application_stack.register_postfork_function(self.database_heartbeat.start)
 

--- a/lib/galaxy/model/database_heartbeat.py
+++ b/lib/galaxy/model/database_heartbeat.py
@@ -18,12 +18,16 @@ log = logging.getLogger(__name__)
 
 WEBAPP = "webapp"  # WorkerProcess.app_type for web apps.
 SSE_MONITOR = "sse_monitor"  # WorkerProcess.app_type for the standalone SSE monitor process.
-SSE_MONITOR_SERVER_PREFIX = "sse_monitor."  # server_name prefix used by the standalone SSE monitor process.
 
 
 class DatabaseHeartbeat:
-    def __init__(self, application_stack, heartbeat_interval=60):
+    def __init__(self, application_stack, app_type=None, heartbeat_interval=60):
         self.application_stack = application_stack
+        # Concrete role for this process's WorkerProcess row, set by the
+        # caller (WEBAPP / SSE_MONITOR / None for job handlers). Drives the
+        # config-watcher / audit-monitor election and lets control-task
+        # routing skip processes that run no consumer (the SSE monitor).
+        self.app_type = app_type
         self.new_session = self.application_stack.app.model.new_session
         self.heartbeat_interval = heartbeat_interval
         self.hostname = socket.gethostname()
@@ -105,13 +109,6 @@ class DatabaseHeartbeat:
         for callback in self._audit_monitor_observers:
             callback(self._is_history_audit_monitor)
 
-    def _app_type(self):
-        if self.application_stack.app.is_webapp:
-            return WEBAPP
-        if self.server_name.startswith(SSE_MONITOR_SERVER_PREFIX):
-            return SSE_MONITOR
-        return None
-
     def update_watcher_designation(self):
         expression = self._worker_process_identifying_clause()
         stmt = select(WorkerProcess).with_for_update(of=WorkerProcess).where(expression)
@@ -119,9 +116,8 @@ class DatabaseHeartbeat:
             worker_process = session.scalars(stmt).first()
             if not worker_process:
                 worker_process = WorkerProcess(server_name=self.server_name, hostname=self.hostname)
-            app_type = self._app_type()
-            if app_type is not None:
-                worker_process.app_type = app_type
+            if self.app_type is not None:
+                worker_process.app_type = self.app_type
             worker_process.update_time = now()
             worker_process.pid = self.pid
             session.add(worker_process)

--- a/lib/galaxy/queues/__init__.py
+++ b/lib/galaxy/queues/__init__.py
@@ -17,7 +17,10 @@ from kombu import (
     Exchange,
     Queue,
 )
-from sqlalchemy import select
+from sqlalchemy import (
+    or_,
+    select,
+)
 
 from galaxy.model import WorkerProcess
 from galaxy.util import now
@@ -33,6 +36,10 @@ galaxy_exchange = Exchange("galaxy_core_exchange", type="topic")
 DEFAULT_ACTIVE_PROCESS_WINDOW_SECONDS = 120
 # Matches WorkerProcess.app_type set by DatabaseHeartbeat for webapp processes.
 WEBAPP_APP_TYPE = "webapp"
+# Matches WorkerProcess.app_type for the standalone SSE monitor. It registers a
+# liveness heartbeat for the audit-monitor election but runs no control
+# consumer, so it must be kept out of the control-queue routing table.
+SSE_MONITOR_APP_TYPE = "sse_monitor"
 
 
 def all_control_queues_for_declare(application_stack: "ApplicationStack", webapp_only: bool = False) -> list[Queue]:
@@ -51,6 +58,11 @@ def all_control_queues_for_declare(application_stack: "ApplicationStack", webapp
     registered themselves with ``app_type='webapp'``. This is what the SSE
     dispatcher wants: job handlers and workflow schedulers have no browser
     connections, so routing SSE events to them is wasted work.
+
+    Otherwise (the general control-task path) every consumer is included
+    except the standalone SSE monitor: it registers a liveness heartbeat for
+    the audit-monitor election but runs no control consumer, so declaring and
+    feeding a queue it never drains would just leak messages.
     """
     app = application_stack.app
     try:
@@ -59,6 +71,9 @@ def all_control_queues_for_declare(application_stack: "ApplicationStack", webapp
         )
         if webapp_only:
             stmt = stmt.where(WorkerProcess.app_type == WEBAPP_APP_TYPE)
+        else:
+            # ``!=`` alone would drop NULL app_type rows (job handlers); keep them.
+            stmt = stmt.where(or_(WorkerProcess.app_type != SSE_MONITOR_APP_TYPE, WorkerProcess.app_type.is_(None)))
         with app.model.new_session() as session:
             processes = session.scalars(stmt).all()
     except Exception:

--- a/lib/galaxy/sse_monitor/__main__.py
+++ b/lib/galaxy/sse_monitor/__main__.py
@@ -14,7 +14,10 @@ import sys
 import threading
 
 from galaxy.celery import get_app_properties
-from galaxy.model.database_heartbeat import DatabaseHeartbeat
+from galaxy.model.database_heartbeat import (
+    DatabaseHeartbeat,
+    SSE_MONITOR,
+)
 
 log = logging.getLogger("galaxy.sse_monitor")
 
@@ -52,8 +55,12 @@ def main() -> int:
     # GalaxyManagerApplication doesn't wire a DatabaseHeartbeat (that lives on
     # UniverseApplication, which pulls in the webapp stack we don't need). We
     # spin up our own and register the audit-monitor callback so election
-    # transitions start/stop the producer cleanly.
-    heartbeat = DatabaseHeartbeat(application_stack=app.application_stack)
+    # transitions start/stop the producer cleanly. We register with the
+    # concrete SSE_MONITOR app_type: that marks the WorkerProcess row purely as
+    # a liveness/election marker so webapps defer the audit-monitor role to us
+    # (and re-elect within one interval if we die), while control-task routing
+    # skips it — this daemon runs no control consumer.
+    heartbeat = DatabaseHeartbeat(application_stack=app.application_stack, app_type=SSE_MONITOR)
 
     monitor = None
     if app.config.enable_sse_updates:

--- a/test/unit/app/queue_worker/test_control_queue_routing.py
+++ b/test/unit/app/queue_worker/test_control_queue_routing.py
@@ -1,0 +1,61 @@
+"""Tests for ``all_control_queues_for_declare`` process filtering.
+
+The standalone SSE monitor registers a liveness ``WorkerProcess`` row (for the
+audit-monitor election) but runs no control consumer, so it must be excluded
+from the general control-queue routing table — otherwise producers declare and
+feed a queue nothing drains. Webapps and job handlers (``app_type`` NULL) must
+still be routed to. The ``webapp_only`` path stays webapp-only for SSE events.
+
+Uses the real sqlite ``database_app`` fixture and inserts real ``WorkerProcess``
+rows so the SQL filter is exercised, not mocked.
+"""
+
+import galaxy.web_stack as stack
+from galaxy.model import WorkerProcess
+from galaxy.model.database_heartbeat import (
+    SSE_MONITOR,
+    WEBAPP,
+)
+from galaxy.queues import all_control_queues_for_declare
+from galaxy.util import now
+
+
+def _make_app(database_app):
+    app = database_app()
+    app.config.attach_to_pools = False
+    app.application_stack = stack.application_stack_instance(app=app)
+    return app
+
+
+def _insert_processes(app):
+    with app.model.new_session() as session, session.begin():
+        session.add_all(
+            [
+                WorkerProcess(server_name="web.1", hostname="h", app_type=WEBAPP, update_time=now()),
+                WorkerProcess(server_name="handler.1", hostname="h", app_type=None, update_time=now()),
+                WorkerProcess(server_name="sse_monitor.h.7", hostname="h", app_type=SSE_MONITOR, update_time=now()),
+            ]
+        )
+
+
+def _queue_names(queues):
+    return {q.name for q in queues}
+
+
+def test_general_declare_excludes_sse_monitor(database_app):
+    app = _make_app(database_app)
+    _insert_processes(app)
+
+    names = _queue_names(all_control_queues_for_declare(app.application_stack))
+
+    # Webapp and the NULL-app_type job handler are routed to; the SSE monitor is not.
+    assert names == {"control.web.1@h", "control.handler.1@h"}
+
+
+def test_webapp_only_declare_returns_only_webapps(database_app):
+    app = _make_app(database_app)
+    _insert_processes(app)
+
+    names = _queue_names(all_control_queues_for_declare(app.application_stack, webapp_only=True))
+
+    assert names == {"control.web.1@h"}

--- a/test/unit/app/queue_worker/test_control_queue_routing.py
+++ b/test/unit/app/queue_worker/test_control_queue_routing.py
@@ -10,6 +10,9 @@ Uses the real sqlite ``database_app`` fixture and inserts real ``WorkerProcess``
 rows so the SQL filter is exercised, not mocked.
 """
 
+import pytest
+from sqlalchemy import delete
+
 import galaxy.web_stack as stack
 from galaxy.model import WorkerProcess
 from galaxy.model.database_heartbeat import (
@@ -20,11 +23,27 @@ from galaxy.queues import all_control_queues_for_declare
 from galaxy.util import now
 
 
-def _make_app(database_app):
+@pytest.fixture
+def app(database_app):
+    """Build an app and guarantee the shared ``worker_process`` table is clean.
+
+    The ``postgres_app`` fixture reuses one session-scoped database, so rows left
+    behind by a prior test would otherwise collide on insert and leak into other
+    tests. Clear the table before and after each test to keep it isolated.
+    """
     app = database_app()
     app.config.attach_to_pools = False
     app.application_stack = stack.application_stack_instance(app=app)
-    return app
+    _clear_processes(app)
+    try:
+        yield app
+    finally:
+        _clear_processes(app)
+
+
+def _clear_processes(app):
+    with app.model.new_session() as session, session.begin():
+        session.execute(delete(WorkerProcess))
 
 
 def _insert_processes(app):
@@ -42,8 +61,7 @@ def _queue_names(queues):
     return {q.name for q in queues}
 
 
-def test_general_declare_excludes_sse_monitor(database_app):
-    app = _make_app(database_app)
+def test_general_declare_excludes_sse_monitor(app):
     _insert_processes(app)
 
     names = _queue_names(all_control_queues_for_declare(app.application_stack))
@@ -52,8 +70,7 @@ def test_general_declare_excludes_sse_monitor(database_app):
     assert names == {"control.web.1@h", "control.handler.1@h"}
 
 
-def test_webapp_only_declare_returns_only_webapps(database_app):
-    app = _make_app(database_app)
+def test_webapp_only_declare_returns_only_webapps(app):
     _insert_processes(app)
 
     names = _queue_names(all_control_queues_for_declare(app.application_stack, webapp_only=True))


### PR DESCRIPTION
## What

The standalone `galaxy-sse-monitor` daemon registers a `DatabaseHeartbeat` `WorkerProcess` row so webapps defer the history-audit-monitor role to it (and re-elect a webapp within one heartbeat interval if it dies). But the daemon runs **no control-queue consumer** — it only binds a publisher. Because `all_control_queues_for_declare()` turns every active `WorkerProcess` row into a routing target, producers were declaring and feeding a `control.sse_monitor.*` queue that nothing ever drains, leaking messages on the broker.

## How

- `DatabaseHeartbeat` now takes a concrete `app_type` from the caller (`WEBAPP` for webapps, `SSE_MONITOR` for the monitor) instead of inferring it from `is_webapp` plus a `server_name` prefix match. The role is now set explicitly where each process is built.
- `all_control_queues_for_declare()` excludes `SSE_MONITOR` rows from the general control-task declare path. The `webapp_only` path (SSE event fan-out) is unchanged, and job handlers (NULL `app_type`) are still routed to.

Net effect: the monitor keeps its liveness/election role (the `WorkerProcess` row) but is no longer a phantom target in the control-queue routing table.

## Notes

- history_update / SSE events already used the `webapp_only` path, so the monitor never received those; this only affected the general control fan-out (`reconfigure_watcher`, toolbox reindex, etc.).
- Split out of the SSE statsd-metrics work as an independent change.

## Testing

New `test/unit/app/queue_worker/test_control_queue_routing.py` inserts real `WorkerProcess` rows (webapp / NULL handler / sse_monitor) and asserts the monitor is excluded from the general declare while only webapps appear under `webapp_only`. Existing heartbeat/queue-worker unit tests still pass.