### PR TITLE
[26.1] Emit SSE/queue metrics as gauges, sample SSE counts in web workers

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3498,11 +3498,30 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    How often (in seconds) the Celery beat task emits queue-depth,
-    SSE-connection, and WorkerProcess gauges. Only active when
-    statsd_host is set. Set to 0 to disable.
+    How often (in seconds) background observability gauges are
+    sampled: control-queue depth and WorkerProcess counts from the
+    Celery beat task, and (when enable_sse_connection_metrics is set)
+    active SSE-connection counts from each web worker. This is the
+    shared cadence for all of them. Only active when statsd_host is
+    set. Set to 0 to disable all background gauges.
 :Default: ``15``
 :Type: int
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_sse_connection_metrics``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Emit the galaxy.sse.connections.active gauge from each web worker,
+    reporting how many Server-Sent Events connections that worker
+    currently holds (tagged by kind and server_name). Sampled on the
+    queue_metrics_interval cadence. Off by default so that enabling
+    statsd does not by itself start measuring SSE connections;
+    requires statsd_host to be set and queue_metrics_interval greater
+    than 0.
+:Default: ``false``
+:Type: bool
 
 
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/sse_updates.md
+++ b/doc/source/admin/sse_updates.md
@@ -149,16 +149,32 @@ you use for Gunicorn worker health:
 
 | Metric                                     | Type    | Source                | Meaning                                                      |
 | ------------------------------------------ | ------- | --------------------- | ------------------------------------------------------------ |
+| `galaxy.sse.connections.active` (tags: `kind`, `server_name`) | gauge | each web worker | Currently open SSE connections, split into `broadcast` (all, including anonymous) and `per_user` (bound to a specific user). |
 | `galaxy.sse.connections.dropped`           | counter | `SSEConnectionManager` | A per-connection asyncio queue filled up; an event was lost. |
 | `galaxy.sse.dispatch.count` (tag: `task`) | counter | `SSEEventDispatcher`  | Control-task fan-outs by event kind.                         |
 | `galaxy.sse.dispatch.latency_ms` (tag: `task`) | timing | `SSEEventDispatcher`  | Wall time spent enqueueing the control task.                 |
 | `galaxy.sse.dispatch.skipped_no_qw`        | counter | `SSEEventDispatcher`  | Producer tried to dispatch with no queue worker bound — events would have been dropped. |
+| `galaxy.control_queue.depth` (tag: `queue_name`) | gauge | Celery beat | Pending message count per webapp/handler control queue. |
+| `galaxy.worker_process.active` (tag: `app_type`) | gauge | Celery beat | Recently-active worker rows in the database, grouped by app type. |
 
-You can also expose a "currently connected SSE clients" gauge if you wire
-one up: each `SSEConnectionManager` instance publishes
-`total_broadcast_connections` (all connections, including anonymous) and
-`total_per_user_connections` (connections bound to a specific user). These
-are per-worker numbers; sum across workers for a cluster total.
+All three are emitted as statsd **gauges** — point-in-time values, not timings —
+so the datasource stores a single current value per series rather than the
+mean/percentile aggregation statsd applies to timing metrics.
+
+`galaxy.control_queue.depth` and `galaxy.worker_process.active` are sampled by
+the `emit_queue_metrics_task` Celery beat task (cadence:
+`queue_metrics_interval`).
+
+`galaxy.sse.connections.active` is sampled differently: the
+`SSEConnectionManager` is per-process state, so each **web worker** emits its
+own counts (the Celery worker holds no connections and would only ever report
+zero). Every worker tags its sample with its `server_name` so the per-worker
+series don't collide — sum across `server_name` for a cluster total.
+
+This gauge is **opt-in**: set `enable_sse_connection_metrics: true` (it is off
+by default, so turning on statsd does not by itself start measuring SSE
+connections). It then samples on the shared `queue_metrics_interval` cadence,
+so that must be greater than 0.
 
 Alerting recommendations:
 
@@ -271,9 +287,9 @@ stream is healthy end-to-end:
    that connection within a second or two, and the history panel
    refreshes without a polling round-trip.
 3. On the server side, `galaxy.sse.dispatch.count` should be ticking up
-   for each event kind your users exercise. If you wired up the
-   connection gauges, they should reflect roughly one connection per
-   open browser tab.
+   for each event kind your users exercise, and
+   `galaxy.sse.connections.active` should reflect roughly one connection
+   per open browser tab (summed across the reporting processes).
 
 If the connection opens but no events arrive, the most common causes
 are: a proxy buffering responses (revisit the NGINX section), or a

--- a/lib/galaxy/app/__init__.py
+++ b/lib/galaxy/app/__init__.py
@@ -78,7 +78,10 @@ from galaxy.managers.notification import NotificationManager
 from galaxy.managers.object_store_instances import UserObjectStoreResolverImpl
 from galaxy.managers.roles import RoleManager
 from galaxy.managers.session import GalaxySessionManager
-from galaxy.managers.sse import SSEConnectionManager
+from galaxy.managers.sse import (
+    SSEConnectionGaugeEmitter,
+    SSEConnectionManager,
+)
 from galaxy.managers.sse_dispatch import SSEEventDispatcher
 from galaxy.managers.tasks import (
     AsyncTasksManager,
@@ -845,6 +848,7 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication, InstallationT
             ("queue worker", self._shutdown_queue_worker),
             ("file watcher", self._shutdown_watcher),
             ("database heartbeat", self._shutdown_database_heartbeat),
+            ("SSE connection gauge emitter", self._shutdown_sse_connection_gauge_emitter),
             ("history audit monitor", self._shutdown_history_audit_monitor),
             ("workflow scheduler", self._shutdown_scheduling_manager),
             ("object store", self._shutdown_object_store),
@@ -1028,6 +1032,31 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication, InstallationT
             monitor = self._register_singleton(HistoryAuditMonitor)
             self.database_heartbeat.add_audit_monitor_change_callback(monitor.on_role_change)
 
+        # Per-worker SSE connection-count gauge. The SSEConnectionManager is
+        # per-process state, so it must be sampled here in each web worker
+        # rather than from the Celery beat task (which holds no connections and
+        # would always report zero). Opt-in (enable_sse_connection_metrics) and
+        # only when statsd is actually configured (a non-None client) and the
+        # shared queue_metrics_interval cadence is enabled. The server_name is
+        # read post-fork so each worker tags its own series.
+        self.sse_connection_gauge_emitter: Optional[SSEConnectionGaugeEmitter] = None
+        statsd_client = self.execution_timer_factory.galaxy_statsd_client
+        if (
+            statsd_client is not None
+            and self.config.enable_sse_connection_metrics
+            and self.config.queue_metrics_interval > 0
+        ):
+
+            def _start_sse_connection_gauge_emitter():
+                self.sse_connection_gauge_emitter = SSEConnectionGaugeEmitter(
+                    self[SSEConnectionManager],
+                    self.config.server_name,
+                    interval=self.config.queue_metrics_interval,
+                )
+                self.sse_connection_gauge_emitter.start()
+
+            self.application_stack.register_postfork_function(_start_sse_connection_gauge_emitter)
+
         # Start web stack message handling
         self.application_stack.register_postfork_function(self.application_stack.start)
         self.application_stack.register_postfork_function(self.queue_worker.bind_and_start)
@@ -1061,6 +1090,10 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication, InstallationT
 
     def _shutdown_database_heartbeat(self):
         self.database_heartbeat.shutdown()
+
+    def _shutdown_sse_connection_gauge_emitter(self):
+        if self.sse_connection_gauge_emitter is not None:
+            self.sse_connection_gauge_emitter.shutdown()
 
     def _shutdown_history_audit_monitor(self):
         if not self.config.enable_sse_updates:

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -12,7 +12,6 @@ from typing import (
 from urllib.parse import urlparse
 
 from celery import current_task
-from lagom.exceptions import UnresolvableType
 from sqlalchemy import (
     and_,
     create_engine,
@@ -50,7 +49,6 @@ from galaxy.managers.markdown_util import generate_branded_pdf
 from galaxy.managers.model_stores import ModelStoreManager
 from galaxy.managers.notification import NotificationManager
 from galaxy.managers.queue_metrics import emit_queue_metrics
-from galaxy.managers.sse import SSEConnectionManager
 from galaxy.managers.tool_data import ToolDataImportManager
 from galaxy.managers.workflow_completion import WorkflowCompletionManager
 from galaxy.metadata.set_metadata import set_metadata_portable
@@ -770,25 +768,23 @@ def dispatch_pending_notifications(notification_manager: NotificationManager):
         log.info(f"Successfully dispatched {count} notifications.")
 
 
-@galaxy_task(action="emit queue and SSE observability metrics")
+@galaxy_task(action="emit queue and worker-process observability metrics")
 def emit_queue_metrics_task(app: MinimalManagerApp):
-    """Sample control-queue depth, SSE connection count, and worker rows → statsd.
+    """Sample control-queue depth and worker rows → statsd.
 
     Resolves the narrow collaborators ``emit_queue_metrics`` needs from the app
     container and passes them in — keeps the emitter module free of
     ``StructuredApp`` service-locator lookups.
-    """
-    try:
-        sse_manager: Optional[SSEConnectionManager] = app[SSEConnectionManager]
-    except UnresolvableType:
-        sse_manager = None
 
+    SSE connection counts are emitted by the web workers themselves (see
+    ``galaxy.managers.sse.SSEConnectionGaugeEmitter``); the Celery worker has no
+    live connections to sample.
+    """
     emit_queue_metrics(
         statsd_client=app.execution_timer_factory.galaxy_statsd_client,
         connection=app.amqp_internal_connection_obj,
         application_stack=app.application_stack,
         model=app.model,
-        sse_manager=sse_manager,
     )
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2004,10 +2004,21 @@ galaxy:
   # really. Do not set this in production environments.
   #statsd_mock_calls: false
 
-  # How often (in seconds) the Celery beat task emits queue-depth,
-  # SSE-connection, and WorkerProcess gauges. Only active when
-  # statsd_host is set. Set to 0 to disable.
+  # How often (in seconds) background observability gauges are sampled:
+  # control-queue depth and WorkerProcess counts from the Celery beat
+  # task, and (when enable_sse_connection_metrics is set) active
+  # SSE-connection counts from each web worker. This is the shared
+  # cadence for all of them. Only active when statsd_host is set. Set to
+  # 0 to disable all background gauges.
   #queue_metrics_interval: 15
+
+  # Emit the galaxy.sse.connections.active gauge from each web worker,
+  # reporting how many Server-Sent Events connections that worker
+  # currently holds (tagged by kind and server_name). Sampled on the
+  # queue_metrics_interval cadence. Off by default so that enabling
+  # statsd does not by itself start measuring SSE connections; requires
+  # statsd_host to be set and queue_metrics_interval greater than 0.
+  #enable_sse_connection_metrics: false
 
   # Add an option to the library upload form which allows administrators
   # to upload a directory of files.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2577,8 +2577,22 @@ mapping:
         default: 15
         required: false
         desc: |
-          How often (in seconds) the Celery beat task emits queue-depth, SSE-connection,
-          and WorkerProcess gauges. Only active when statsd_host is set. Set to 0 to disable.
+          How often (in seconds) background observability gauges are sampled: control-queue
+          depth and WorkerProcess counts from the Celery beat task, and (when
+          enable_sse_connection_metrics is set) active SSE-connection counts from each web
+          worker. This is the shared cadence for all of them. Only active when statsd_host is
+          set. Set to 0 to disable all background gauges.
+
+      enable_sse_connection_metrics:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Emit the galaxy.sse.connections.active gauge from each web worker, reporting how
+          many Server-Sent Events connections that worker currently holds (tagged by kind and
+          server_name). Sampled on the queue_metrics_interval cadence. Off by default so that
+          enabling statsd does not by itself start measuring SSE connections; requires
+          statsd_host to be set and queue_metrics_interval greater than 0.
 
       library_import_dir:
         type: str

--- a/lib/galaxy/managers/queue_metrics.py
+++ b/lib/galaxy/managers/queue_metrics.py
@@ -1,18 +1,23 @@
-"""Periodic gauge emitter for control-queue depth and SSE-connection counts.
+"""Periodic gauge emitter for control-queue depth and worker-process counts.
 
 Scheduled by Celery beat (see ``galaxy.celery.__init__.setup_periodic_tasks``)
 at a fixed cadence. Opens a short-lived kombu connection, iterates the control
 queues returned by ``all_control_queues_for_declare`` and samples each queue's
-message-count via a passive declare. Also samples in-memory connection counts
-from ``SSEConnectionManager`` and the active-``WorkerProcess`` count from the
-database.
+message-count via a passive declare. Also samples the active-``WorkerProcess``
+count from the database.
+
+SSE connection counts are deliberately *not* sampled here: the
+``SSEConnectionManager`` is per-process state held by the web workers, so the
+Celery worker would only ever see an empty manager. Each web worker emits its
+own ``galaxy.sse.connections.active`` gauge instead (see
+``galaxy.managers.sse.SSEConnectionGaugeEmitter``).
 
 All instrumentation no-ops when ``statsd_client`` is ``None`` — i.e. statsd
 isn't configured.
 
 The sub-emitters take narrow, typed collaborators (a kombu connection, an
-application stack, a model mapping, the statsd client, an SSE manager) rather
-than the whole ``StructuredApp``. The Celery task in
+application stack, a model mapping, the statsd client) rather than the whole
+``StructuredApp``. The Celery task in
 ``galaxy.celery.tasks.emit_queue_metrics_task`` is the composition root that
 resolves those narrow deps from the app and passes them in.
 """
@@ -31,7 +36,6 @@ from sqlalchemy import (
     select,
 )
 
-from galaxy.managers.sse import SSEConnectionManager
 from galaxy.model import WorkerProcess
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.queues import (
@@ -47,23 +51,6 @@ if TYPE_CHECKING:
     from galaxy.web.statsd_client import VanillaGalaxyStatsdClient
 
 log = logging.getLogger(__name__)
-
-
-def emit_sse_connection_gauges(
-    statsd_client: "VanillaGalaxyStatsdClient",
-    sse_manager: SSEConnectionManager,
-) -> None:
-    """Emit ``galaxy.sse.connections.active`` gauges by connection kind."""
-    statsd_client.timing(
-        "galaxy.sse.connections.active",
-        sse_manager.total_broadcast_connections,
-        tags={"kind": "broadcast"},
-    )
-    statsd_client.timing(
-        "galaxy.sse.connections.active",
-        sse_manager.total_per_user_connections,
-        tags={"kind": "per_user"},
-    )
 
 
 def emit_control_queue_depth(
@@ -97,7 +84,7 @@ def emit_control_queue_depth(
                         exc_info=True,
                     )
                     continue
-                statsd_client.timing(
+                statsd_client.gauge(
                     "galaxy.control_queue.depth",
                     declared.message_count,
                     tags={"queue_name": queue.name},
@@ -122,7 +109,7 @@ def emit_worker_process_gauge(
         for app_type, count in session.execute(stmt):
             counts[app_type or "unknown"] = int(count)
     for app_type, count in counts.items():
-        statsd_client.timing(
+        statsd_client.gauge(
             "galaxy.worker_process.active",
             count,
             tags={"app_type": app_type},
@@ -149,13 +136,10 @@ def emit_queue_metrics(
     connection: "Optional[Connection]",
     application_stack: ApplicationStack,
     model: GalaxyModelMapping,
-    sse_manager: Optional[SSEConnectionManager],
 ) -> None:
     """Periodic entry-point — no-ops when statsd isn't configured."""
     if statsd_client is None:
         return
-    if sse_manager is not None:
-        _run("sse_connections", statsd_client, lambda: emit_sse_connection_gauges(statsd_client, sse_manager))
     _run(
         "control_queue_depth",
         statsd_client,

--- a/lib/galaxy/managers/sse.py
+++ b/lib/galaxy/managers/sse.py
@@ -7,6 +7,7 @@ to async SSE endpoint handlers running in the uvicorn event loop.
 
 import asyncio
 import logging
+import threading
 from collections import defaultdict
 from collections.abc import (
     AsyncIterator,
@@ -274,6 +275,29 @@ class SSEConnectionManager:
         """Number of active SSE connections bound to a specific user_id."""
         return sum(len(queues) for queues in self._connections.values())
 
+    def emit_connection_gauges(self, server_name: str) -> None:
+        """Publish this worker's SSE connection counts as statsd gauges.
+
+        No-ops when statsd isn't configured. The counts are per-process — only
+        the worker holding a connection knows about it — so this must be called
+        from the web worker that owns the manager, and each worker tags its
+        sample with ``server_name`` so the per-worker series don't collide
+        (statsd gauges are last-write-wins per metric+tag set). Sum across
+        workers for a cluster total.
+        """
+        if self._statsd_client is None:
+            return
+        self._statsd_client.gauge(
+            "galaxy.sse.connections.active",
+            self.total_broadcast_connections,
+            tags={"kind": "broadcast", "server_name": server_name},
+        )
+        self._statsd_client.gauge(
+            "galaxy.sse.connections.active",
+            self.total_per_user_connections,
+            tags={"kind": "per_user", "server_name": server_name},
+        )
+
     # -- High-level streaming helper --
 
     async def stream(
@@ -311,3 +335,33 @@ class SSEConnectionManager:
                     yield ": keepalive\n\n"
         finally:
             self.disconnect(user_id, queue, galaxy_session_id)
+
+
+class SSEConnectionGaugeEmitter(threading.Thread):
+    """Periodically publish a web worker's SSE connection-count gauges.
+
+    Runs as a daemon thread inside each web worker — the only process that
+    knows how many SSE connections it holds. Sampling these counts from the
+    Celery beat task instead would always report zero, since that process has
+    no live connections. Reads are plain ``len()`` over the manager's
+    in-memory sets; a transient race with connect/disconnect is acceptable for
+    a monitoring gauge.
+    """
+
+    def __init__(self, manager: SSEConnectionManager, server_name: str, interval: int = 15) -> None:
+        super().__init__(name=f"sse_connection_gauge.{server_name}", daemon=True)
+        self._manager = manager
+        self._server_name = server_name
+        self._interval = interval
+        self._exit = threading.Event()
+
+    def run(self) -> None:
+        while not self._exit.is_set():
+            try:
+                self._manager.emit_connection_gauges(self._server_name)
+            except Exception:
+                log.warning("Failed to emit SSE connection gauges", exc_info=True)
+            self._exit.wait(self._interval)
+
+    def shutdown(self) -> None:
+        self._exit.set()

--- a/lib/galaxy/web/statsd_client.py
+++ b/lib/galaxy/web/statsd_client.py
@@ -33,6 +33,10 @@ class VanillaGalaxyStatsdClient:
         infix = self._effective_infix(path, tags)
         self.statsd_client.timing(infix + path, time)
 
+    def gauge(self, path, value, tags=None):
+        infix = self._effective_infix(path, tags)
+        self.statsd_client.gauge(infix + path, value)
+
     def incr(self, path, n=1, tags=None):
         infix = self._effective_infix(path, tags)
         self.statsd_client.incr(infix + path, n)
@@ -60,6 +64,14 @@ class PyTestGalaxyStatsdClient(VanillaGalaxyStatsdClient):
             timing[path].append({"time": time, "tags": tags})
         super().timing(path, time, tags=tags)
 
+    def gauge(self, path, value, tags=None):
+        if (metrics := CURRENT_TEST_METRICS) is not None:
+            gauge = metrics.setdefault("gauge", {})
+            if path not in gauge:
+                gauge[path] = []
+            gauge[path].append({"value": value, "tags": tags})
+        super().gauge(path, value, tags=tags)
+
     def incr(self, path, n=1, tags=None):
         if (metrics := CURRENT_TEST_METRICS) is not None:
             counter = metrics["counter"]
@@ -77,6 +89,9 @@ class PyTestGalaxyStatsdClient(VanillaGalaxyStatsdClient):
 
 class MockStatsClient:
     def timing(self, path, time, tags=None):
+        pass
+
+    def gauge(self, path, value, tags=None):
         pass
 
     def incr(self, path, n=1, tags=None):

--- a/lib/galaxy_test/conftest.py
+++ b/lib/galaxy_test/conftest.py
@@ -67,7 +67,7 @@ class JsonReportHooks:
     def pytest_json_runtest_metadata(self, item, call):
         if call.when == "setup":
             statsd.CURRENT_TEST = str(uuid.uuid4())
-            statsd.CURRENT_TEST_METRICS = {"timing": {}, "counter": {}}
+            statsd.CURRENT_TEST_METRICS = {"timing": {}, "counter": {}, "gauge": {}}
             return {}
         if call.when == "teardown":
             statsd.CURRENT_TEST = None

--- a/test/unit/app/managers/test_queue_metrics.py
+++ b/test/unit/app/managers/test_queue_metrics.py
@@ -1,10 +1,9 @@
 """Unit tests for :mod:`galaxy.managers.queue_metrics`.
 
-The ``SSEConnectionManager`` and the kombu connection are small hand-built
-fakes — no broker or database is required. Assertions are on the recorded
-state of the statsd client (counters, timings) rather than on mock call-lists
-so a regression that stops emitting a gauge fails the test for the right
-reason.
+The kombu connection is a small hand-built fake — no broker or database is
+required. Assertions are on the recorded state of the statsd client (counters,
+gauges) rather than on mock call-lists so a regression that stops emitting a
+gauge fails the test for the right reason.
 
 The failure-isolation test drives real sub-emitters into their error paths by
 handing them genuinely broken collaborators (a connection whose ``clone()``
@@ -26,7 +25,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from galaxy.managers import queue_metrics
-from galaxy.managers.sse import SSEConnectionManager
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.web.statsd_client import VanillaGalaxyStatsdClient
 from galaxy.web_stack import ApplicationStack
@@ -41,27 +39,20 @@ class FakeStatsdClient:
     """In-memory statsd recorder — see docstring in ``test_sse_dispatch.py``."""
 
     counters: dict[tuple[str, tuple[tuple[str, str], ...]], int] = field(default_factory=dict)
-    timings: list[tuple[str, float, tuple[tuple[str, str], ...]]] = field(default_factory=list)
+    gauges: list[tuple[str, float, tuple[tuple[str, str], ...]]] = field(default_factory=list)
 
     def incr(self, metric: str, tags: Optional[dict[str, str]] = None) -> None:
         key = (metric, tuple(sorted((tags or {}).items())))
         self.counters[key] = self.counters.get(key, 0) + 1
 
-    def timing(self, metric: str, value: float, tags: Optional[dict[str, str]] = None) -> None:
-        self.timings.append((metric, value, tuple(sorted((tags or {}).items()))))
+    def gauge(self, metric: str, value: float, tags: Optional[dict[str, str]] = None) -> None:
+        self.gauges.append((metric, value, tuple(sorted((tags or {}).items()))))
 
     def counter(self, metric: str, tags: Optional[dict[str, str]] = None) -> int:
         return self.counters.get((metric, tuple(sorted((tags or {}).items()))), 0)
 
-    def timings_for(self, metric: str) -> list[tuple[float, dict[str, str]]]:
-        return [(v, dict(t)) for m, v, t in self.timings if m == metric]
-
-
-def _fake_sse_manager(broadcast: int = 3, per_user: int = 5):
-    m = MagicMock(spec=SSEConnectionManager)
-    m.total_broadcast_connections = broadcast
-    m.total_per_user_connections = per_user
-    return m
+    def gauges_for(self, metric: str) -> list[tuple[float, dict[str, str]]]:
+        return [(v, dict(t)) for m, v, t in self.gauges if m == metric]
 
 
 def _make_fake_queue(name: str, count: int):
@@ -89,18 +80,6 @@ def _make_fake_connection(channel=None):
 # ---------------------------------------------------------------------------
 
 
-def test_emit_sse_connection_gauges_emits_both_kinds():
-    statsd = FakeStatsdClient()
-    queue_metrics.emit_sse_connection_gauges(
-        cast(VanillaGalaxyStatsdClient, statsd), _fake_sse_manager(broadcast=4, per_user=7)
-    )
-
-    assert statsd.timings_for("galaxy.sse.connections.active") == [
-        (4, {"kind": "broadcast"}),
-        (7, {"kind": "per_user"}),
-    ]
-
-
 def test_emit_control_queue_depth_emits_per_queue(monkeypatch):
     statsd = FakeStatsdClient()
     fake_queues = [
@@ -119,7 +98,7 @@ def test_emit_control_queue_depth_emits_per_queue(monkeypatch):
         cast(ApplicationStack, MagicMock()),
     )
 
-    assert statsd.timings_for("galaxy.control_queue.depth") == [
+    assert statsd.gauges_for("galaxy.control_queue.depth") == [
         (3, {"queue_name": "control.main@h"}),
         (0, {"queue_name": "control.main.1@h"}),
     ]
@@ -145,7 +124,7 @@ def test_emit_control_queue_depth_skips_failed_passive_declare(monkeypatch):
         cast(ApplicationStack, MagicMock()),
     )
 
-    assert statsd.timings_for("galaxy.control_queue.depth") == [
+    assert statsd.gauges_for("galaxy.control_queue.depth") == [
         (9, {"queue_name": "control.good@h"}),
     ]
 
@@ -155,7 +134,7 @@ def test_emit_control_queue_depth_no_broker_connection_is_noop():
     queue_metrics.emit_control_queue_depth(
         cast(VanillaGalaxyStatsdClient, statsd), None, cast(ApplicationStack, MagicMock())
     )
-    assert statsd.timings == []
+    assert statsd.gauges == []
 
 
 # ---------------------------------------------------------------------------
@@ -172,7 +151,6 @@ def test_emit_queue_metrics_is_silent_when_statsd_is_none():
         connection=None,
         application_stack=cast(ApplicationStack, MagicMock()),
         model=cast(GalaxyModelMapping, MagicMock()),
-        sse_manager=None,
     )
 
 
@@ -182,11 +160,10 @@ def test_emit_queue_metrics_isolates_real_subemitter_failures(monkeypatch):
     We drive the failures through the actual sub-emitter bodies — not monkey-
     patched side_effects — by handing in a connection whose ``.clone()`` raises
     (for ``emit_control_queue_depth``) and a model whose ``.new_session()``
-    raises (for ``emit_worker_process_gauge``). The SSE gauge is given healthy
-    collaborators and should still land.
+    raises (for ``emit_worker_process_gauge``). One failing sub-emitter must not
+    take the other down.
     """
     statsd = FakeStatsdClient()
-    sse_manager = _fake_sse_manager(broadcast=2, per_user=1)
 
     broken_connection = MagicMock()
     broken_connection.clone.side_effect = RuntimeError("broker is gone")
@@ -202,25 +179,17 @@ def test_emit_queue_metrics_isolates_real_subemitter_failures(monkeypatch):
         lambda stack: [_make_fake_queue("control.main@h", 0)],
     )
 
-    # Must not raise — the SSE gauge still lands.
+    # Must not raise — each failure is isolated.
     queue_metrics.emit_queue_metrics(
         statsd_client=cast(VanillaGalaxyStatsdClient, statsd),
         connection=broken_connection,
         application_stack=cast(ApplicationStack, MagicMock()),
         model=cast(GalaxyModelMapping, broken_model),
-        sse_manager=sse_manager,
     )
-
-    # SSE gauge landed despite the other two failing.
-    sse_timings = statsd.timings_for("galaxy.sse.connections.active")
-    assert (2, {"kind": "broadcast"}) in sse_timings
-    assert (1, {"kind": "per_user"}) in sse_timings
 
     # Each failing sub-emitter bumped its error counter tagged by name.
     assert statsd.counter("galaxy.queue_metrics.error", {"emitter": "control_queue_depth"}) == 1
     assert statsd.counter("galaxy.queue_metrics.error", {"emitter": "worker_process"}) == 1
-    # The healthy SSE sub-emitter did not.
-    assert statsd.counter("galaxy.queue_metrics.error", {"emitter": "sse_connections"}) == 0
 
 
 if __name__ == "__main__":

--- a/test/unit/app/managers/test_sse_connection_gauges.py
+++ b/test/unit/app/managers/test_sse_connection_gauges.py
@@ -1,0 +1,89 @@
+"""Unit tests for the per-worker SSE connection-count gauge.
+
+``SSEConnectionManager.emit_connection_gauges`` is sampled inside each web
+worker (the only process that holds its connections), so these tests assert it
+reports the manager's *own* counts, tags each series with ``server_name`` so
+per-worker series don't collide, and no-ops without a statsd client.
+``SSEConnectionGaugeEmitter`` is the daemon-thread driver; we check it emits at
+least once and stops cleanly.
+"""
+
+import threading
+from dataclasses import (
+    dataclass,
+    field,
+)
+from typing import (
+    cast,
+    Optional,
+)
+
+from galaxy.managers.sse import (
+    SSEConnectionGaugeEmitter,
+    SSEConnectionManager,
+)
+from galaxy.web.statsd_client import VanillaGalaxyStatsdClient
+
+
+@dataclass
+class FakeStatsdClient:
+    """In-memory recorder — captures ``gauge`` calls as plain data.
+
+    ``recorded`` fires on every ``gauge`` call so a test can wait on the real
+    effect (a gauge landed) without instrumenting the production code.
+    """
+
+    gauges: list[tuple[str, float, tuple[tuple[str, str], ...]]] = field(default_factory=list)
+    recorded: threading.Event = field(default_factory=threading.Event)
+
+    def gauge(self, metric: str, value: float, tags: Optional[dict[str, str]] = None) -> None:
+        self.gauges.append((metric, value, tuple(sorted((tags or {}).items()))))
+        self.recorded.set()
+
+    def gauges_for(self, metric: str) -> list[tuple[float, dict[str, str]]]:
+        return [(v, dict(t)) for m, v, t in self.gauges if m == metric]
+
+
+def _manager(statsd: Optional[FakeStatsdClient]) -> SSEConnectionManager:
+    return SSEConnectionManager(statsd_client=cast(Optional[VanillaGalaxyStatsdClient], statsd))
+
+
+async def test_emit_connection_gauges_reports_own_counts_tagged_by_server_name():
+    statsd = FakeStatsdClient()
+    manager = _manager(statsd)
+    # Two connections for a logged-in user, one anonymous (session-only).
+    manager.connect(user_id=7)
+    manager.connect(user_id=7)
+    manager.connect(user_id=None, galaxy_session_id=99)
+
+    manager.emit_connection_gauges("main.1")
+
+    assert statsd.gauges_for("galaxy.sse.connections.active") == [
+        (3, {"kind": "broadcast", "server_name": "main.1"}),
+        (2, {"kind": "per_user", "server_name": "main.1"}),
+    ]
+
+
+async def test_emit_connection_gauges_is_noop_without_statsd():
+    manager = _manager(None)
+    manager.connect(user_id=1)
+    # Must not raise even though no statsd client is configured.
+    manager.emit_connection_gauges("main.1")
+
+
+async def test_emitter_emits_then_stops():
+    statsd = FakeStatsdClient()
+    manager = _manager(statsd)
+    manager.connect(user_id=1)
+
+    # interval=600 so the thread emits once then blocks until shutdown; we wait
+    # on the recorder's event (the real effect) rather than patching the manager.
+    emitter = SSEConnectionGaugeEmitter(manager, "main.1", interval=600)
+    emitter.start()
+    try:
+        assert statsd.recorded.wait(timeout=5), "emitter never emitted a gauge"
+    finally:
+        emitter.shutdown()
+        emitter.join(timeout=5)
+    assert not emitter.is_alive()
+    assert statsd.gauges_for("galaxy.sse.connections.active")


### PR DESCRIPTION
Point-in-time counts (SSE connections, control-queue depth, worker processes) were emitted via statsd timing(), so telegraf/influxdb stored them as timing aggregations (mean/median/percentiles) instead of a single value. Add a gauge() method to the statsd client and emit these as gauges.

The SSEConnectionManager is per-process state registered only on the webapp, so sampling it from the Celery beat task saw an empty manager and always reported ~0. Move SSE connection sampling into each web worker via a per-worker daemon thread (SSEConnectionGaugeEmitter), tagging samples with server_name so per-worker series don't collide. It is opt-in via the new enable_sse_connection_metrics config (default off) and only runs when statsd is actually configured.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
