### PR TITLE
[26.1] Fix view state logic for paste links upload

### DIFF
--- a/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
+++ b/client/src/components/Panels/Upload/methods/PasteLinksUpload.vue
@@ -84,7 +84,13 @@ function createPasteUrlItem(id: number, url: string, name: string): PasteUrlItem
 
 const urlItems = ref<PasteUrlItem[]>([]);
 const urlText = ref("");
-const showInputArea = ref(true);
+const showInputOverride = ref(false);
+const showInputArea = computed(() => {
+    if (urlItems.value.length > 0) {
+        return showInputOverride.value;
+    }
+    return true;
+});
 const { clear: clearStaging } = useUploadStaging<PasteUrlItem>(props.method.id, urlItems, {
     disableStore: props.transient,
 });
@@ -143,16 +149,16 @@ function addUrlsFromText() {
     }
 
     urlText.value = "";
-    showInputArea.value = false;
+    showInputOverride.value = false;
     scrollToBottom();
 }
 
 function showUrlInput() {
-    showInputArea.value = true;
+    showInputOverride.value = true;
 }
 
 function showUrlList() {
-    showInputArea.value = false;
+    showInputOverride.value = false;
 }
 
 function scrollToBottom() {
@@ -168,7 +174,7 @@ function removeItem(id: number) {
     urlItems.value = urlItems.value.filter((item) => item.id !== id);
 
     if (urlItems.value.length === 0) {
-        showInputArea.value = true;
+        showInputOverride.value = false;
         resetCollection();
     }
 }
@@ -221,7 +227,7 @@ function reset() {
     urlItems.value = [];
     urlText.value = "";
     clearStaging();
-    showInputArea.value = true;
+    showInputOverride.value = false;
     resetCollection();
 }
 


### PR DESCRIPTION
Ensure the URL input area is automatically displayed when the link list is empty, and the staged view is displayed when there are existing elements.

Before the fix, if you had some links already pasted (before uploading), then navigate to a different page and then back again, the "paste area" was shown instead of the already pasted entries, which could be a bit confusing and required an extra click to show the proper view.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
