### PR TITLE
[26.1] Fix tool shed state serving for stock tools

### DIFF
--- a/lib/galaxy/tool_util/version_updates.py
+++ b/lib/galaxy/tool_util/version_updates.py
@@ -1,0 +1,54 @@
+"""Workflow-safe tool version updates.
+
+Maps tool IDs to version ranges where parameter schemas are unchanged,
+so an older workflow referencing min_version can safely use current_version's
+tool definition for validation and state inspection.
+"""
+
+from typing import (
+    NamedTuple,
+    Optional,
+)
+
+from .version import parse_version
+from .version_util import AnyVersionT
+
+
+class safe_update(NamedTuple):
+    min_version: AnyVersionT
+    current_version: AnyVersionT
+
+
+WORKFLOW_SAFE_TOOL_VERSION_UPDATES: dict[str, safe_update] = {
+    "Filter1": safe_update(parse_version("1.1.0"), parse_version("1.1.1")),
+    "__BUILD_LIST__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),
+    "__APPLY_RULES__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),
+    "__EXTRACT_DATASET__": safe_update(parse_version("1.0.0"), parse_version("1.0.2")),
+    "__RELABEL_FROM_FILE__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),
+    "Grep1": safe_update(parse_version("1.0.1"), parse_version("1.0.4")),
+    "Show beginning1": safe_update(parse_version("1.0.0"), parse_version("1.0.2")),
+    "Show tail1": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
+    "sort1": safe_update(parse_version("1.1.0"), parse_version("1.2.0")),
+    "Convert characters1": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
+    "CONVERTER_interval_to_bgzip_0": safe_update(parse_version("1.0.1"), parse_version("1.0.2")),
+    "CONVERTER_Bam_Bai_0": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
+    "CONVERTER_cram_to_bam_0": safe_update(parse_version("1.0.1"), parse_version("1.0.2")),
+    "CONVERTER_fasta_to_fai": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
+    "CONVERTER_sam_to_bigwig_0": safe_update(parse_version("1.0.2"), parse_version("1.0.3")),
+    "CONVERTER_bam_to_coodinate_sorted_bam": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
+    "CONVERTER_bam_to_qname_sorted_bam": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
+}
+
+
+def is_workflow_safe_version(tool_id: str, requested_version: str) -> Optional[str]:
+    """Check if requested_version falls within a safe update range for tool_id.
+
+    Returns the current_version string if safe, None otherwise.
+    """
+    update = WORKFLOW_SAFE_TOOL_VERSION_UPDATES.get(tool_id)
+    if update is None:
+        return None
+    requested = parse_version(requested_version)
+    if update.min_version <= requested <= update.current_version:
+        return str(update.current_version)
+    return None

--- a/lib/galaxy/tool_util/version_updates.py
+++ b/lib/galaxy/tool_util/version_updates.py
@@ -6,6 +6,7 @@ tool definition for validation and state inspection.
 """
 
 from typing import (
+    Dict,
     NamedTuple,
     Optional,
 )
@@ -19,7 +20,7 @@ class safe_update(NamedTuple):
     current_version: AnyVersionT
 
 
-WORKFLOW_SAFE_TOOL_VERSION_UPDATES: dict[str, safe_update] = {
+WORKFLOW_SAFE_TOOL_VERSION_UPDATES: Dict[str, safe_update] = {
     "Filter1": safe_update(parse_version("1.1.0"), parse_version("1.1.1")),
     "__BUILD_LIST__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),
     "__APPLY_RULES__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),

--- a/lib/galaxy/tool_util/version_util.py
+++ b/lib/galaxy/tool_util/version_util.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+from packaging.version import Version
+
+from .version import LegacyVersion
+
+AnyVersionT = Union[LegacyVersion, Version]
+
+
+__all__ = ["AnyVersionT"]

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -126,9 +126,9 @@ from galaxy.tool_util.verify.interactor import ToolTestDescription
 from galaxy.tool_util.verify.parse import parse_tool_test_descriptions
 from galaxy.tool_util.verify.test_data import TestDataNotFoundError
 from galaxy.tool_util.version import (
-    LegacyVersion,
     parse_version,
 )
+from galaxy.tool_util.version_updates import WORKFLOW_SAFE_TOOL_VERSION_UPDATES
 from galaxy.tool_util_models.parameters import (
     MaybeToolParameterBundle,
     ToolParameterBundleModel,
@@ -386,11 +386,6 @@ IMPLICITLY_REQUIRED_TOOL_FILES: dict[str, dict] = {
 }
 
 
-class safe_update(NamedTuple):
-    min_version: Union[LegacyVersion, Version]
-    current_version: Union[LegacyVersion, Version]
-
-
 class RawToolSource(NamedTuple):
     """Compact representation of a tool's raw source for transport/serialization.
 
@@ -401,28 +396,6 @@ class RawToolSource(NamedTuple):
 
     raw_tool_source: str
     tool_source_class: str
-
-
-# Tool updates that did not change parameters in a way that requires rebuilding workflows
-WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
-    "Filter1": safe_update(parse_version("1.1.0"), parse_version("1.1.1")),
-    "__BUILD_LIST__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),
-    "__APPLY_RULES__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),
-    "__EXTRACT_DATASET__": safe_update(parse_version("1.0.0"), parse_version("1.0.2")),
-    "__RELABEL_FROM_FILE__": safe_update(parse_version("1.0.0"), parse_version("1.1.0")),
-    "Grep1": safe_update(parse_version("1.0.1"), parse_version("1.0.4")),
-    "Show beginning1": safe_update(parse_version("1.0.0"), parse_version("1.0.2")),
-    "Show tail1": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
-    "sort1": safe_update(parse_version("1.1.0"), parse_version("1.2.0")),
-    "Convert characters1": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
-    "CONVERTER_interval_to_bgzip_0": safe_update(parse_version("1.0.1"), parse_version("1.0.2")),
-    "CONVERTER_Bam_Bai_0": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
-    "CONVERTER_cram_to_bam_0": safe_update(parse_version("1.0.1"), parse_version("1.0.2")),
-    "CONVERTER_fasta_to_fai": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
-    "CONVERTER_sam_to_bigwig_0": safe_update(parse_version("1.0.2"), parse_version("1.0.3")),
-    "CONVERTER_bam_to_coodinate_sorted_bam": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
-    "CONVERTER_bam_to_qname_sorted_bam": safe_update(parse_version("1.0.0"), parse_version("1.0.1")),
-}
 
 
 def get_safe_version(tool: "Tool", requested_tool_version: str) -> Optional[str]:

--- a/lib/galaxy/tools/stock.py
+++ b/lib/galaxy/tools/stock.py
@@ -6,6 +6,7 @@ from lxml.etree import XMLSyntaxError
 
 # Set GALAXY_INCLUDES_ROOT from tool shed to point this at a Galaxy root
 # (once we are running the tool shed from packages not rooted with Galaxy).
+import galaxy.datatypes.converters
 import galaxy.tools
 from galaxy.tool_util.loader_directory import looks_like_a_tool_xml
 from galaxy.tool_util.parser import get_tool_source
@@ -15,6 +16,7 @@ from galaxy.util.resources import files
 
 def stock_tool_paths():
     yield from _walk_directory_for_tools(files(galaxy.tools))
+    yield from _walk_directory_for_tools(files(galaxy.datatypes.converters))
     yield from _walk_directory_for_tools(Path(galaxy_directory()) / "test" / "functional" / "tools")
     yield from _walk_directory_for_tools(Path(galaxy_directory()) / "tools")
 

--- a/lib/tool_shed/managers/tools.py
+++ b/lib/tool_shed/managers/tools.py
@@ -23,6 +23,7 @@ from galaxy.tool_util.parser import (
     get_tool_source,
     ToolSource,
 )
+from galaxy.tool_util.version_updates import is_workflow_safe_version
 from galaxy.tools.stock import stock_tool_sources
 from galaxy.util import relpath
 from tool_shed.context import (
@@ -176,7 +177,13 @@ def _stock_tool_source_for(tool_id: str, tool_version: str) -> Optional[ToolSour
     tool_version_sources = STOCK_TOOL_SOURCES.get(tool_id)
     if tool_version_sources is None:
         return None
-    return tool_version_sources.get(tool_version)
+    tool_source = tool_version_sources.get(tool_version)
+    if tool_source is not None:
+        return tool_source
+    safe_version = is_workflow_safe_version(tool_id, tool_version)
+    if safe_version is not None:
+        return tool_version_sources.get(safe_version)
+    return None
 
 
 def _init_stock_tool_sources() -> None:

--- a/test/unit/app/tools/test_stock.py
+++ b/test/unit/app/tools/test_stock.py
@@ -12,6 +12,11 @@ def test_stock_tool_paths():
     assert "parse_values_from_file.xml" in file_names
 
 
+def test_stock_tool_paths_includes_datatype_converters():
+    file_names = [f.name for f in stock_tool_paths()]
+    assert "bam_to_bai.xml" in file_names
+
+
 def test_stock_tool_sources():
     tool_source = next(stock_tool_sources())
     assert tool_source.parse_id()

--- a/test/unit/tool_shed/test_stock_tool_source.py
+++ b/test/unit/tool_shed/test_stock_tool_source.py
@@ -1,0 +1,12 @@
+from tool_shed.managers.tools import _stock_tool_source_for
+
+
+def test_serves_workflow_safe_version_on_exact_miss():
+    # sort1 only ships 1.2.0; 1.1.0 is within its safe-update range and resolves to it.
+    tool_source = _stock_tool_source_for("sort1", "1.1.0")
+    assert tool_source is not None
+    assert tool_source.parse_version() == "1.2.0"
+
+
+def test_returns_none_for_out_of_range_version():
+    assert _stock_tool_source_for("sort1", "0.0.1") is None


### PR DESCRIPTION
Serve tool definitions for datatype converters (practically must have been used in some IWC workflow - but it makes sense in the abstract also) and teach the tool shed to respect our workflow safe versions abstraction and serve compatible tool versions for these workflow safe changes.

## How to test the changes?
- [x] Included some unit tests - they seem fine.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
