### PR TITLE
[26.1] Disable non anonymous upload methods

### DIFF
--- a/client/src/components/Common/GCard.vue
+++ b/client/src/components/Common/GCard.vue
@@ -186,6 +186,16 @@ interface Props {
      * @default false
      */
     highlighted?: boolean;
+
+    /** Whether the card is disabled (non-interactive, dimmed appearance)
+     * @default false
+     */
+    disabled?: boolean;
+
+    /** Tooltip text to show when the card is disabled
+     * @default undefined
+     */
+    disabledTitle?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -218,6 +228,8 @@ const props = withDefaults(defineProps<Props>(), {
     updateTimeIcon: () => faEdit,
     updateTimeTitle: "Last updated",
     highlighted: false,
+    disabled: false,
+    disabledTitle: undefined,
 });
 
 /**
@@ -304,6 +316,9 @@ const getActionId = (cardId: string, actionId: string) => `g-card-action-${actio
 const allowedTitleLines = computed(() => props.titleNLines);
 
 function onKeyDown(event: KeyboardEvent) {
+    if (props.disabled) {
+        return;
+    }
     if ((props.clickable && event.key === "Enter") || event.key === " ") {
         event.stopPropagation();
         emit("click", event);
@@ -318,20 +333,22 @@ function onKeyDown(event: KeyboardEvent) {
     <component
         :is="'div'"
         :id="`g-card-${props.id}`"
-        :role="props.clickable ? 'button' : undefined"
+        :role="props.clickable && !props.disabled ? 'button' : undefined"
         class="g-card pt-0 px-1 mb-2"
         :class="[
             { 'g-card-grid-view': gridView },
             { 'g-card-selected': selected },
             { 'g-card-current': current },
             { 'g-card-published': published },
-            { 'g-card-clickable': props.clickable },
+            { 'g-card-clickable': props.clickable && !props.disabled },
+            { 'g-card-disabled': props.disabled },
             { 'g-card-dim': props.dimWhenUnselected && !props.selected },
             { 'g-card-dropdown-open': extraActionsOpen },
             containerClass,
         ]"
-        :tabindex="props.clickable ? 0 : undefined"
-        @click="props.clickable ? emit('click', $event) : undefined"
+        :tabindex="props.clickable && !props.disabled ? 0 : undefined"
+        :title="props.disabled ? props.disabledTitle : undefined"
+        @click="props.clickable && !props.disabled ? emit('click', $event) : undefined"
         @keydown="onKeyDown">
         <div
             :id="`g-card-content-${props.id}`"
@@ -762,6 +779,15 @@ function onKeyDown(event: KeyboardEvent) {
 
     &.g-card-highlighted .g-card-content {
         box-shadow: 0 0 0 0.2rem transparentize($brand-primary, 0.75);
+    }
+
+    &.g-card-disabled {
+        cursor: default;
+
+        .g-card-content {
+            filter: saturate(0.3);
+            opacity: 0.5;
+        }
     }
 
     &.g-card-clickable {

--- a/client/src/components/Panels/Upload/UploadMethodList.vue
+++ b/client/src/components/Panels/Upload/UploadMethodList.vue
@@ -3,11 +3,10 @@ import { computed, ref } from "vue";
 import { useRouter } from "vue-router/composables";
 
 import type { CardBadge } from "@/components/Common/GCard.types";
-import { useConfig } from "@/composables/config";
 import { useUploadStagingCounts } from "@/composables/upload/useUploadStaging";
 
 import type { UploadMethodConfig } from "./types";
-import { useAllUploadMethods } from "./uploadMethodRegistry";
+import { useFilteredUploadMethods } from "./uploadMethodRegistry";
 
 import DelayedInput from "@/components/Common/DelayedInput.vue";
 import GCard from "@/components/Common/GCard.vue";
@@ -25,28 +24,13 @@ const props = withDefaults(defineProps<Props>(), {
     searchTeleportTarget: undefined,
 });
 
-const { config, isConfigLoaded } = useConfig();
 const router = useRouter();
 const query = ref("");
 
 const searchInputClass = computed(() => (props.searchTeleportTarget ? "my-2" : props.inPanel ? "my-2" : "mb-3"));
 
-const allUploadMethods = useAllUploadMethods();
+const availableMethods = useFilteredUploadMethods();
 const stagedCountsByMode = useUploadStagingCounts();
-
-const availableMethods = computed(() => {
-    if (!isConfigLoaded.value) {
-        return allUploadMethods.value;
-    }
-
-    return allUploadMethods.value.filter((method: UploadMethodConfig) => {
-        // Filter based on config requirements
-        if (method.requiresConfig) {
-            return method.requiresConfig.every((configKey) => config.value[configKey]);
-        }
-        return true;
-    });
-});
 
 const filteredMethods = computed(() => {
     const rawTokens = query.value.trim().split(/\s+/).filter(Boolean);

--- a/client/src/components/Panels/Upload/UploadMethodList.vue
+++ b/client/src/components/Panels/Upload/UploadMethodList.vue
@@ -101,6 +101,8 @@ function getStagingBadges(method: UploadMethodConfig): CardBadge[] {
                         :title-icon="{ icon: method.icon, class: 'text-primary', size: 'lg' }"
                         :badges="getStagingBadges(method)"
                         :data-method-id="method.id"
+                        :disabled="method.disabled"
+                        :disabled-title="method.disabledTitle"
                         @click="selectUploadMethod(method)" />
                 </template>
             </ScrollList>

--- a/client/src/components/Panels/Upload/UploadMethodModal.vue
+++ b/client/src/components/Panels/Upload/UploadMethodModal.vue
@@ -40,7 +40,8 @@ const { currentHistoryId } = storeToRefs(historyStore);
 const { submitPreparedUpload } = useUploadSubmission();
 
 const modalConfig = computed<UploadModalConfig>(() => props.config ?? {});
-const availableMethods = useFilteredUploadMethods(modalConfig);
+const allowedMethods = computed(() => modalConfig.value.allowedMethods);
+const availableMethods = useFilteredUploadMethods(allowedMethods);
 const selectedMethod = ref<UploadMethodConfig | null>(null);
 const uploadMethodRef = ref<UploadMethodComponent | null>(null);
 const canUpload = ref(false);

--- a/client/src/components/Panels/Upload/UploadMethodModal.vue
+++ b/client/src/components/Panels/Upload/UploadMethodModal.vue
@@ -211,6 +211,8 @@ async function handleStartClick() {
                             :description="method.description"
                             :title-icon="{ icon: method.icon, class: 'text-primary', size: 'lg' }"
                             :selected="selectedMethod?.id === method.id"
+                            :disabled="method.disabled"
+                            :disabled-title="method.disabledTitle"
                             @click="selectMethod(method)" />
                     </div>
                 </aside>

--- a/client/src/components/Panels/Upload/types.ts
+++ b/client/src/components/Panels/Upload/types.ts
@@ -86,9 +86,20 @@ export interface UploadMethodConfig {
     /**
      * When true, this upload method requires the user to be logged in.
      *
-     * Methods with this flag will be hidden from anonymous users.
+     * Methods with this flag will be disabled for anonymous users.
      */
     requiresLogin?: boolean;
+
+    /**
+     * When true, this upload method is disabled and not interactive.
+     * Set reactively by `useFilteredUploadMethods` based on login state.
+     */
+    disabled?: boolean;
+
+    /**
+     * Tooltip text displayed when the method is disabled.
+     */
+    disabledTitle?: string;
 
     /**
      * When true, the Start button in the footer will be shown.

--- a/client/src/components/Panels/Upload/types.ts
+++ b/client/src/components/Panels/Upload/types.ts
@@ -84,6 +84,13 @@ export interface UploadMethodConfig {
     requiresAdvancedMode?: boolean;
 
     /**
+     * When true, this upload method requires the user to be logged in.
+     *
+     * Methods with this flag will be hidden from anonymous users.
+     */
+    requiresLogin?: boolean;
+
+    /**
      * When true, the Start button in the footer will be shown.
      *
      * Set this to false for upload methods that handle their own submission

--- a/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
+++ b/client/src/components/Panels/Upload/uploadMethodRegistry.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ref } from "vue";
+import { reactive, ref } from "vue";
 
-import { getUploadMethod, uploadMethodRegistry, useAllUploadMethods } from "./uploadMethodRegistry";
+import {
+    getUploadMethod,
+    uploadMethodRegistry,
+    useAllUploadMethods,
+    useFilteredUploadMethods,
+} from "./uploadMethodRegistry";
 
 // The advancedMode ref is declared before the vi.mock call so both the mock factory
 // and the test bodies share the same reactive reference.
@@ -11,11 +16,27 @@ vi.mock("@/composables/upload/uploadAdvancedMode", () => ({
     useUploadAdvancedMode: () => ({ advancedMode }),
 }));
 
+// Reactive state object for useUserStore mock — storeToRefs expects a reactive object.
+const userStoreState = reactive({ isAnonymous: true });
+
+vi.mock("@/stores/userStore", () => ({
+    useUserStore: () => userStoreState,
+}));
+
+// Reactive refs for useConfig mock.
+const galaxyConfig = ref({});
+const isConfigLoaded = ref(true);
+
+vi.mock("@/composables/config", () => ({
+    useConfig: () => ({ config: galaxyConfig, isConfigLoaded }),
+}));
+
 // Derive method ID lists from the registry so they stay in sync automatically
 // whenever a method is added, removed, or promoted/demoted to advanced mode.
 const ALL_METHOD_IDS = Object.keys(uploadMethodRegistry) as Array<keyof typeof uploadMethodRegistry>;
 const ADVANCED_METHOD_IDS = ALL_METHOD_IDS.filter((id) => uploadMethodRegistry[id].requiresAdvancedMode);
 const STANDARD_METHOD_IDS = ALL_METHOD_IDS.filter((id) => !uploadMethodRegistry[id].requiresAdvancedMode);
+const LOGIN_METHOD_IDS = ALL_METHOD_IDS.filter((id) => uploadMethodRegistry[id].requiresLogin);
 
 describe("uploadMethodRegistry", () => {
     describe("getUploadMethod", () => {
@@ -55,6 +76,47 @@ describe("uploadMethodRegistry", () => {
 
             advancedMode.value = false;
             expect(methods.value).toHaveLength(STANDARD_METHOD_IDS.length);
+        });
+    });
+
+    describe("useFilteredUploadMethods", () => {
+        beforeEach(() => {
+            advancedMode.value = false;
+            userStoreState.isAnonymous = true;
+            isConfigLoaded.value = true;
+        });
+
+        it("disables login-required methods when user is anonymous", () => {
+            const methods = useFilteredUploadMethods();
+
+            for (const loginId of LOGIN_METHOD_IDS) {
+                const method = methods.value.find((m) => m.id === loginId);
+                expect(method).toBeDefined();
+                expect(method?.disabled).toBe(true);
+                expect(method?.disabledTitle).toBeDefined();
+            }
+        });
+
+        it("includes login-required methods without disabled when user is logged in", () => {
+            userStoreState.isAnonymous = false;
+            const methods = useFilteredUploadMethods();
+
+            for (const loginId of LOGIN_METHOD_IDS) {
+                const method = methods.value.find((m) => m.id === loginId);
+                expect(method).toBeDefined();
+                expect(method?.disabled).toBeFalsy();
+                expect(method?.disabledTitle).toBeUndefined();
+            }
+        });
+
+        it("filters by allowedMethods when provided", () => {
+            const allowedMethods = ref(["local-file", "paste-content"] as ["local-file", "paste-content"]);
+            const methods = useFilteredUploadMethods(allowedMethods);
+            const ids = methods.value.map((m) => m.id);
+
+            expect(ids).toContain("local-file");
+            expect(ids).toContain("paste-content");
+            expect(ids).not.toContain("paste-links");
         });
     });
 });

--- a/client/src/components/Panels/Upload/uploadMethodRegistry.ts
+++ b/client/src/components/Panels/Upload/uploadMethodRegistry.ts
@@ -148,6 +148,7 @@ export const uploadMethodRegistry: Record<UploadMethod, UploadMethodConfig> = {
         icon: faHdd,
         headerAction: "Import History",
         requiresTargetHistory: false,
+        requiresLogin: true,
         showStartButton: false,
         tips: [
             "Import a complete Galaxy history from a previously exported file or URL",
@@ -163,6 +164,7 @@ export const uploadMethodRegistry: Record<UploadMethod, UploadMethodConfig> = {
         icon: faSitemap,
         headerAction: "Import Workflow",
         requiresTargetHistory: false,
+        requiresLogin: true,
         showStartButton: false,
         tips: [
             "Import workflows from Galaxy Workflow files or public URLs",

--- a/client/src/components/Panels/Upload/uploadMethodRegistry.ts
+++ b/client/src/components/Panels/Upload/uploadMethodRegistry.ts
@@ -11,13 +11,14 @@ import {
     faSitemap,
     faTable,
 } from "@fortawesome/free-solid-svg-icons";
+import { storeToRefs } from "pinia";
 import { computed, type ComputedRef, defineAsyncComponent, type Ref } from "vue";
 
 import { useConfig } from "@/composables/config";
 import { useUploadAdvancedMode } from "@/composables/upload/uploadAdvancedMode";
+import { useUserStore } from "@/stores/userStore";
 
 import type { UploadMethod, UploadMethodConfig } from "./types";
-import type { UploadModalConfig } from "./uploadModalTypes";
 
 export const uploadMethodRegistry: Record<UploadMethod, UploadMethodConfig> = {
     "local-file": {
@@ -209,17 +210,25 @@ export function useAllUploadMethods(): ComputedRef<UploadMethodConfig[]> {
 }
 
 /**
- * Reactive list of upload methods filtered by modal config and Galaxy config requirements.
+ * Reactive list of upload methods filtered by allowed methods, Galaxy config, and login requirements.
+ *
+ * @param allowedMethods - Optional list of allowed upload method IDs. When `undefined`,
+ * only `requiresLogin`, `requiresConfig`, and `requiresAdvancedMode` filters are applied.
  */
-export function useFilteredUploadMethods(config: Ref<UploadModalConfig>): ComputedRef<UploadMethodConfig[]> {
+export function useFilteredUploadMethods(
+    allowedMethods?: Ref<UploadMethod[] | undefined>,
+): ComputedRef<UploadMethodConfig[]> {
     const allMethods = useAllUploadMethods();
     const { config: galaxyConfig, isConfigLoaded } = useConfig();
+    const { isAnonymous } = storeToRefs(useUserStore());
 
     return computed(() => {
-        const allowedMethods = config.value.allowedMethods;
-
         return allMethods.value.filter((method) => {
-            if (allowedMethods && !allowedMethods.some((allowedMethod) => allowedMethod === method.id)) {
+            if (method.requiresLogin && isAnonymous.value) {
+                return false;
+            }
+
+            if (allowedMethods?.value && !allowedMethods.value.some((allowedMethod) => allowedMethod === method.id)) {
                 return false;
             }
 

--- a/client/src/components/Panels/Upload/uploadMethodRegistry.ts
+++ b/client/src/components/Panels/Upload/uploadMethodRegistry.ts
@@ -223,20 +223,35 @@ export function useFilteredUploadMethods(
     const { isAnonymous } = storeToRefs(useUserStore());
 
     return computed(() => {
-        return allMethods.value.filter((method) => {
-            if (method.requiresLogin && isAnonymous.value) {
-                return false;
-            }
+        return allMethods.value
+            .map((method) => {
+                let disabled = false;
+                let disabledTitle: string | undefined;
 
-            if (allowedMethods?.value && !allowedMethods.value.some((allowedMethod) => allowedMethod === method.id)) {
-                return false;
-            }
+                if (method.requiresLogin && isAnonymous.value) {
+                    disabled = true;
+                    disabledTitle = "You must be logged in to use this feature";
+                }
 
-            if (!isConfigLoaded.value || !method.requiresConfig) {
-                return true;
-            }
+                if (disabled) {
+                    return { ...method, disabled, disabledTitle };
+                }
 
-            return method.requiresConfig.every((configKey) => Boolean(galaxyConfig.value[configKey]));
-        });
+                return method;
+            })
+            .filter((method) => {
+                if (
+                    allowedMethods?.value &&
+                    !allowedMethods.value.some((allowedMethod) => allowedMethod === method.id)
+                ) {
+                    return false;
+                }
+
+                if (!isConfigLoaded.value || !method.requiresConfig) {
+                    return true;
+                }
+
+                return method.requiresConfig.every((configKey) => Boolean(galaxyConfig.value[configKey]));
+            });
     });
 }

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -10,7 +10,7 @@ import AdminRoutes from "@/entry/analysis/routes/admin-routes";
 import LibraryRoutes from "@/entry/analysis/routes/library-routes";
 import StorageRoutes from "@/entry/analysis/routes/storage-routes";
 import { getAppRoot } from "@/onload/loadConfig";
-import { requireAuth } from "@/router/guards";
+import { requireAuth, requireAuthForUploadMethod } from "@/router/guards";
 import { parseBool } from "@/utils/utils";
 
 import { patchRouterPush } from "./router-push";
@@ -257,6 +257,7 @@ export function getRouter(Galaxy) {
                         path: "upload/:methodId",
                         component: UploadMethodView,
                         props: true,
+                        beforeEnter: requireAuthForUploadMethod,
                     },
                     {
                         path: "help/terms/:term",

--- a/client/src/router/guards.ts
+++ b/client/src/router/guards.ts
@@ -1,18 +1,35 @@
 import type { NavigationGuardNext, Route } from "vue-router";
 
+import type { UploadMethod } from "@/components/Panels/Upload/types";
+import { getUploadMethod } from "@/components/Panels/Upload/uploadMethodRegistry";
 import { useUserStore } from "@/stores/userStore";
 
-export async function requireAuth(to: Route, from: Route, next: NavigationGuardNext) {
+async function redirectIfAnonymous(to: Route, next: NavigationGuardNext) {
     const userStore = useUserStore();
     await userStore.loadUser(false);
 
     if (userStore.isAnonymous) {
         next({
             path: "/login/start",
-            query: {
-                redirect: to.fullPath,
-            },
+            query: { redirect: to.fullPath },
         });
+        return true;
+    }
+    return false;
+}
+
+export async function requireAuth(to: Route, _from: Route, next: NavigationGuardNext) {
+    if (await redirectIfAnonymous(to, next)) {
+        return;
+    }
+    next();
+}
+
+export async function requireAuthForUploadMethod(to: Route, _from: Route, next: NavigationGuardNext) {
+    const methodId = to.params.methodId as UploadMethod;
+    const method = getUploadMethod(methodId);
+
+    if (method?.requiresLogin && (await redirectIfAnonymous(to, next))) {
         return;
     }
     next();


### PR DESCRIPTION
Some upload methods don't really make sense for anonymous users, so they are now disabled and require the user to log in.

In order to make this consistent with other components that we disable for anonymous users, I had to update GCard to support the **disabled** state. Even if it is technically an enhancement, I hope it is fine to target 26.1 since it should not affect other usages of GCard.

Also adds a route guard to prevent direct navigation to the upload routes that require login.

<img width="1171" height="625" alt="image" src="https://github.com/user-attachments/assets/49a98a3b-bcd8-4fe5-a3fe-13392a867e23" />


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
