### PR TITLE
[26.1] Enable CORS on ToolShed read-only metadata endpoints

### DIFF
--- a/lib/tool_shed/test/functional/test_shed_cors.py
+++ b/lib/tool_shed/test/functional/test_shed_cors.py
@@ -1,0 +1,37 @@
+import requests
+
+from ..base.api import ShedApiTestCase
+
+ORIGIN = "https://vscode.dev"
+
+
+class TestShedCorsApi(ShedApiTestCase):
+    def test_preflight_allows_cross_origin_get(self):
+        response = requests.options(
+            f"{self.url}/api/repositories",
+            headers={
+                "Origin": ORIGIN,
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == ORIGIN
+
+    def test_get_response_reflects_origin(self):
+        response = requests.get(f"{self.url}/api/repositories", headers={"Origin": ORIGIN})
+        response.raise_for_status()
+        assert response.headers.get("access-control-allow-origin") == ORIGIN
+
+    def test_credentials_not_exposed_cross_origin(self):
+        # No Access-Control-Allow-Credentials keeps the cookie-authenticated surface
+        # unreadable cross-origin: a browser will not expose a credentialed response
+        # without that header.
+        response = requests.get(f"{self.url}/api/repositories", headers={"Origin": ORIGIN})
+        response.raise_for_status()
+        assert "access-control-allow-credentials" not in response.headers
+
+    def test_uncovered_endpoint_has_no_cors(self):
+        # CORS is opt-in per route; an endpoint not marked allow_cors emits no header.
+        response = requests.get(f"{self.url}/api/ga4gh/trs/v2/service-info", headers={"Origin": ORIGIN})
+        response.raise_for_status()
+        assert "access-control-allow-origin" not in response.headers

--- a/lib/tool_shed/webapp/api2/repositories.py
+++ b/lib/tool_shed/webapp/api2/repositories.py
@@ -131,6 +131,7 @@ class FastAPIRepositories:
         "/api/repositories",
         description="Get a list of repositories or perform a search.",
         operation_id="repositories__index",
+        allow_cors=True,
     )
     def index(
         self,
@@ -271,6 +272,7 @@ class FastAPIRepositories:
         "/api/repositories/get_ordered_installable_revisions",
         description="Get an ordered list of the repository changeset revisions that are installable",
         operation_id="repositories__get_ordered_installable_revisions",
+        allow_cors=True,
     )
     def get_ordered_installable_revisions(
         self,

--- a/lib/tool_shed/webapp/api2/tools.py
+++ b/lib/tool_shed/webapp/api2/tools.py
@@ -68,6 +68,7 @@ class FastAPITools:
     @router.get(
         "/api/tools",
         operation_id="tools__index",
+        allow_cors=True,
     )
     def index(
         self,
@@ -146,6 +147,7 @@ class FastAPITools:
         "/api/tools/{tool_id}/versions/{tool_version}",
         operation_id="tools__parameter_model",
         summary="Return Galaxy's meta model description of the tool's inputs",
+        allow_cors=True,
     )
     def show_tool(
         self,


### PR DESCRIPTION
The ToolShed FastAPI app emitted no CORS headers, so browser clients (e.g. the Galaxy Workflows VS Code extension on vscode.dev) couldn't read its public metadata endpoints cross-origin. Web-deployed fails; desktop mode works fine 😅.

This opts the individual public, read-only metadata endpoints into the existing per-route `allow_cors` mechanism (the same one Galaxy uses) rather than blanketing the whole app:
- `GET /api/tools`
- `GET /api/tools/{tool_id}/versions/{tool_version}`
- `GET /api/repositories`
- `GET /api/repositories/get_ordered_installable_revisions`

`allow_cors` reflects the request Origin, sends no `Access-Control-Allow-Credentials`, and auto-adds an OPTIONS preflight route. Because it's opt-in per route, the cookie-authenticated surface (writes, admin, anything requiring auth) stays unreadable cross-origin — a browser won't expose a credentialed response without that header. Endpoints not marked stay header-less (asserted by a test).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
