### PR TITLE
[26.1] Fix page published view sharing routes

### DIFF
--- a/client/src/components/Common/PublishedItem.vue
+++ b/client/src/components/Common/PublishedItem.vue
@@ -10,6 +10,7 @@ import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 
 interface Props {
     item?: PublishedItem;
+    overridePath?: string;
 }
 
 const props = defineProps<Props>();
@@ -37,7 +38,7 @@ const owner = computed(() => {
 });
 
 const gravatarSource = computed(() => `https://secure.gravatar.com/avatar/${props.item?.email_hash}?d=identicon`);
-const pluralPath = computed(() => plural.value.toLowerCase());
+const pluralPath = computed(() => props.overridePath ?? plural.value.toLowerCase());
 const publishedByUser = computed(() => `/${pluralPath.value}/list_published?f-username=${owner.value}`);
 const urlAll = computed(() => `/${pluralPath.value}/list_published`);
 </script>

--- a/client/src/components/Page/PageView.vue
+++ b/client/src/components/Page/PageView.vue
@@ -141,7 +141,7 @@ function stsUrl(config: any) {
             <LoadingSpan v-else-if="page && !isConfigLoaded" message="Loading Galaxy configuration" />
         </div>
     </div>
-    <PublishedItem v-else :item="page">
+    <PublishedItem v-else :item="page" override-path="pages">
         <template v-slot>
             <div v-if="isConfigLoaded && page">
                 <Markdown


### PR DESCRIPTION
We were routing to `/reports/list_published` (non existent route) instead of `/pages/list_published` on the `PageView` published item view.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a report (standonly, invocation report or Galaxy notebook)
  2. Go to the reports grid
  3. Click on dropdown next to your report's name
  4. Click "View"
  5. On the right, try clicking on the "All published Reports" link
  6. Note that you will be correctly taken to `/pages/list_published` instead of `/reports/list_published`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
