### PR TITLE
Raise ParameterValueError for unhashable dict select values

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1116,6 +1116,17 @@ class SelectToolParameter(ToolParameter):
                         )
             if is_runtime_value(value):
                 return None
+            if isinstance(value, dict):
+                # A dict is unhashable and can never be a legal value, but
+                # testing membership against the set of legal values would
+                # raise an opaque "unhashable type" TypeError. Treat it as an
+                # invalid option instead.
+                raise ParameterValueError(
+                    f"an invalid option ({value!r}) was selected (valid options: {','.join(iter_to_string(legal_values))})",
+                    self.name,
+                    value,
+                    is_dynamic=self.is_dynamic,
+                )
             if value in legal_values:
                 return value
             elif value in fallback_values:

--- a/test/unit/app/tools/test_select_parameters.py
+++ b/test/unit/app/tools/test_select_parameters.py
@@ -27,6 +27,16 @@ class TestSelectToolParameter(BaseParameterTestCase):
             self.param.from_json("42", self.trans)
         assert str(exc_info.value) == "Parameter 'my_name': requires a value, but no legal values defined"
 
+    def test_dict_value_is_invalid_option(self):
+        # A dict value is unhashable; checking it against the set of legal
+        # values used to raise an opaque "unhashable type: 'dict'" TypeError.
+        param = self._parameter_for(
+            xml="""<param name="my_name" type="select"><option value="a">A</option></param>"""
+        )
+        with pytest.raises(ValueError) as exc_info:
+            param.from_json({"not": "valid"}, self.trans)
+        assert "an invalid option" in str(exc_info.value)
+
     def test_unvalidated_values(self):
         self.options_xml = """<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>"""
         self.trans.workflow_building_mode = True

--- a/test/unit/app/tools/test_select_parameters.py
+++ b/test/unit/app/tools/test_select_parameters.py
@@ -30,9 +30,7 @@ class TestSelectToolParameter(BaseParameterTestCase):
     def test_dict_value_is_invalid_option(self):
         # A dict value is unhashable; checking it against the set of legal
         # values used to raise an opaque "unhashable type: 'dict'" TypeError.
-        param = self._parameter_for(
-            xml="""<param name="my_name" type="select"><option value="a">A</option></param>"""
-        )
+        param = self._parameter_for(xml="""<param name="my_name" type="select"><option value="a">A</option></param>""")
         with pytest.raises(ValueError) as exc_info:
             param.from_json({"not": "valid"}, self.trans)
         assert "an invalid option" in str(exc_info.value)


### PR DESCRIPTION
Submitting a `dict` value for a `select` parameter raised an opaque `TypeError: unhashable type: 'dict'` instead of a normal validation error. In `SelectToolParameter._select_from_json` the value falls through to the scalar branch and is tested with `value in legal_values`, where `legal_values` is a set, so an unhashable `dict` blows up the membership check. This surfaced as an uncaught exception during scheduled workflow execution (#22712).

A dict can never be a legal select option, so this guards that case and raises the same `ParameterValueError` already used for other invalid options.

Fixes #22712

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
