### PR TITLE
[26.1] Rewrite proxy redirect headers to dev origin

### DIFF
--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -50,17 +50,19 @@ export default defineConfig(({ command }) => ({
     // Use relative base so CSS asset references work with any proxy prefix.
     // The HTML script tags use url_for() which handles the prefix correctly.
     base: "./",
-    resolve:
-        command === "serve"
+    resolve: {
+        tsconfigPaths: true,
+        // In dev, resolve @galaxyproject/* workspace packages directly to
+        // source so edits trigger HMR without a rebuild. Production builds
+        // use the packages' published dist/ via their package.json exports.
+        ...(command === "serve"
             ? {
-                  // In dev, resolve @galaxyproject/* workspace packages directly to
-                  // source so edits trigger HMR without a rebuild. Production builds
-                  // use the packages' published dist/ via their package.json exports.
                   alias: {
                       "@galaxyproject/galaxy-api-client": resolve(__dirname, "packages/api-client/src/index.ts"),
                   },
               }
-            : {},
+            : {}),
+    },
     define: {
         // Make jQuery available globally for plugins and legacy code
         global: "globalThis",
@@ -96,10 +98,7 @@ export default defineConfig(({ command }) => ({
         }),
         galaxyDevServerPlugin(), // Transform proxied Galaxy HTML for HMR support
     ],
-    // Note: resolve.alias and resolve.extensions are set by galaxyLegacyPlugin
-    resolve: {
-        tsconfigPaths: true,
-    },
+    // Note: resolve.extensions are set by galaxyLegacyPlugin
     css: {
         lightningcss: {
             errorRecovery: true,
@@ -164,14 +163,32 @@ export default defineConfig(({ command }) => ({
                 secure: false,
                 cookieDomainRewrite: "",
                 configure: (proxy) => {
-                    // Strip Secure flag and fix SameSite from upstream HTTPS cookies so
-                    // they are accepted by the browser on http://localhost.
-                    proxy.on("proxyRes", (proxyRes) => {
+                    proxy.on("proxyRes", (proxyRes, req) => {
+                        // Strip Secure flag and fix SameSite from upstream HTTPS cookies so
+                        // they are accepted by the browser on http://localhost.
                         const cookies = proxyRes.headers["set-cookie"];
                         if (cookies) {
                             proxyRes.headers["set-cookie"] = cookies.map((cookie) =>
                                 cookie.replace(/;\s*Secure/gi, "").replace(/;\s*SameSite=None/gi, "; SameSite=Lax"),
                             );
+                        }
+                        // Rewrite Location header to use the dev server origin instead of
+                        // the Galaxy backend. With changeOrigin=true, Galaxy sees the backend
+                        // Host and generates absolute URLs (e.g. in TUS upload responses).
+                        // Without this rewrite, the browser tries to access the backend directly
+                        // which causes CORS failures.
+                        const location = proxyRes.headers["location"];
+                        if (location) {
+                            const targetUrl = new URL(process.env.GALAXY_URL || "http://127.0.0.1:8080");
+                            const locationUrl = new URL(location, targetUrl);
+                            const fallbackDevHost = req.headers.host || `localhost:${process.env.VITE_PORT || 5173}`;
+                            const devOrigin = req.headers.origin || `http://${fallbackDevHost}`;
+
+                            // Only rewrite locations generated for the Galaxy backend.
+                            if (locationUrl.origin === targetUrl.origin) {
+                                proxyRes.headers["location"] =
+                                    `${devOrigin}${locationUrl.pathname}${locationUrl.search}${locationUrl.hash}`;
+                            }
                         }
                     });
                 },


### PR DESCRIPTION
After https://github.com/galaxyproject/galaxy/pull/22943/changes/62df3eb78367f20bd477fdae62f6d6c18aeea5b9, it seems that using the dev proxy `make client-dev-server` with local file uploads in the new Activity fails with:


Access to XMLHttpRequest at 'http://127.0.0.1:8080/api/upload/resumable_upload/5021e87784e84e02b4221a199b811f39' from origin 'http://localhost:5173' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.


I'm not sure if this is the correct fix (Qwen 3.6 came up with the fix), but it works for me.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Run the client through `make client-dev-server`
  - Try to upload a local file using the new upload activity
  - It should work now

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
