### PR TITLE
[26.1] Fallback to default chunk size for file uploads

### DIFF
--- a/client/src/composables/upload/useUploadSubmission.test.ts
+++ b/client/src/composables/upload/useUploadSubmission.test.ts
@@ -3,7 +3,7 @@ import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { http, HttpResponse } from "msw";
 import { createPinia, setActivePinia } from "pinia";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, ref } from "vue";
 
 import { useServerMock } from "@/api/client/__mocks__";
@@ -11,6 +11,7 @@ import type { PreparedUpload } from "@/components/Panels/Upload/types";
 import { useUploadState } from "@/components/Panels/Upload/uploadState";
 import { makeCollectionConfig, makeLibraryItem, makeUrlItem } from "@/composables/upload/testHelpers/uploadFixtures";
 import { buildPreparedUpload } from "@/utils/upload";
+import * as uploadUtils from "@/utils/upload";
 
 import { useUploadSubmission } from "./useUploadSubmission";
 
@@ -312,5 +313,23 @@ describe("useUploadSubmission", () => {
         const batch = useUploadState().activeBatches.value[0];
         expect(batch?.status).toBe("error");
         expect(batch?.collectionId).toBeUndefined();
+    });
+
+    it("falls back to the default chunk size when the server config reports 0", async () => {
+        server.use(http.get("/api/configuration", () => HttpResponse.json({ chunk_upload_size: 0 })));
+
+        const uploadDatasetsSpy = vi.spyOn(uploadUtils, "uploadDatasets").mockResolvedValue(undefined);
+        const apiItem = makeUrlItem({ name: "remote.txt", url: "https://example.org/remote.txt" });
+        const wrapper = mountHarness({ apiItems: buildPreparedUpload([apiItem]).apiItems, uploadItems: [apiItem] });
+        await flushPromises();
+
+        await wrapper.find(SELECTORS.RUN).trigger("click");
+        await flushPromises();
+
+        expect(uploadDatasetsSpy).toHaveBeenCalled();
+        expect(uploadDatasetsSpy.mock.calls[0]?.[1]).toMatchObject({
+            chunkSize: 10485760,
+        });
+        uploadDatasetsSpy.mockRestore();
     });
 });

--- a/client/src/composables/upload/useUploadSubmission.ts
+++ b/client/src/composables/upload/useUploadSubmission.ts
@@ -13,7 +13,7 @@ import {
 } from "@/composables/upload/uploadTracking";
 import { useUploadBatchOperations } from "@/composables/upload/useUploadBatchOperations";
 import { errorMessageAsString } from "@/utils/simple-error";
-import type { UploadDatasetsConfig } from "@/utils/upload";
+import { DEFAULT_CHUNK_SIZE, type UploadDatasetsConfig } from "@/utils/upload";
 import { isFetchApiCompatible, uploadCollectionDatasets, uploadDatasets } from "@/utils/upload";
 
 /**
@@ -66,9 +66,12 @@ export function useUploadSubmission() {
             return;
         }
 
+        const configuredChunkSize = Number(galaxyConfig.value.chunk_upload_size);
+        const chunkSize = configuredChunkSize > 0 ? configuredChunkSize : DEFAULT_CHUNK_SIZE;
+
         return new Promise<void>((resolve, reject) => {
             const config: UploadDatasetsConfig = {
-                chunkSize: galaxyConfig.value.chunk_upload_size as number,
+                chunkSize,
                 success: (response) => {
                     const uploadedDatasets = datasetsFromFetchResponse(response);
 


### PR DESCRIPTION
Ensures that the upload process uses a sensible default chunk size if the server configuration reports an invalid or zero value. This prevents potential issues or failures during the upload submission when the backend configuration is missing or misconfigured.

For some reason, usegalaxy.eu was returning `chunk_upload_size: 0` in the configuration, and that resulted in local (and paste content) file upload stuck in a loop without really uploading anything. This should prevent that in the future and make the upload more robust for wrong config values of `chunk_upload_size`.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
