### PR TITLE
chore: drop MacOS x86

### DIFF
--- a/lib/galaxy/tool_util/deps/brew_exts.py
+++ b/lib/galaxy/tool_util/deps/brew_exts.py
@@ -39,7 +39,7 @@ WHITESPACE_PATTERN = re.compile(r"[\s]+")
 DESCRIPTION = "Script built on top of linuxbrew to operate on isolated, versioned brew installed environments."
 
 if sys.platform == "darwin":
-    DEFAULT_HOMEBREW_ROOT = "/usr/local"
+    DEFAULT_HOMEBREW_ROOT = "/opt/homebrew"
 else:
     DEFAULT_HOMEBREW_ROOT = os.path.join(os.path.expanduser("~"), ".linuxbrew")
 
@@ -58,8 +58,7 @@ class BrewContext:
         raw_config = brew_execute(["config"])
         config_lines = [line.strip().split(":", 1) for line in raw_config.split("\n") if line]
         config = {p[0].strip(): p[1].strip() for p in config_lines}
-        # unset if "/usr/local" -> https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/cmd/config.rb
-        homebrew_prefix = config.get("HOMEBREW_PREFIX", "/usr/local")
+        homebrew_prefix = config.get("HOMEBREW_PREFIX", "/opt/homebrew")
         homebrew_cellar = config.get("HOMEBREW_CELLAR", os.path.join(homebrew_prefix, "Cellar"))
         self.homebrew_prefix = homebrew_prefix
         self.homebrew_cellar = homebrew_cellar

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -56,10 +56,7 @@ USE_LOCAL_DEFAULT = False
 def conda_link() -> str:
     arch = platform.machine()
     if IS_OS_X:
-        if "arm64" in arch:
-            url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh"
-        else:
-            url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh"
+        url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh"
     else:
         if "arm64" in arch or "aarch64" in arch:
             url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh"

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -207,10 +207,9 @@ def conda_platform() -> str:
     machine = _platform_module.machine().lower()
     if IS_OS_X:
         conda_arch_map = {
-            "x86_64": "osx-64",
             "arm64": "osx-arm64",
         }
-        default_platform = "osx-64"
+        default_platform = "osx-arm64"
     else:
         conda_arch_map = {
             "x86_64": "linux-64",


### PR DESCRIPTION
# What

Remove macOS x86. Adjust homebrew for the path it uses on ARM

# Why

MacOS x86 is EOL, even Rosetta is gone from the next release. Accounting for it is needless maintenance work

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
