### PR TITLE
[RFC][WIP] Early, early draft of displaying Galaxy notebooks in Loom & auto-syncing.

### DIFF
--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -33,6 +33,9 @@ const props = defineProps<{
     exportLink?: string;
     showIdentifier?: boolean;
     directDownloadLink?: boolean;
+    // Hide the sticky title/toolbar header. Chrome-free hosts (e.g. PageView's
+    // embedded/displayOnly views) render their own title, so this avoids a duplicate.
+    hideHeader?: boolean;
 }>();
 
 // Refs and data
@@ -93,7 +96,7 @@ onMounted(() => {
     <div class="markdown-wrapper px-2">
         <LoadingSpan v-if="loading" />
         <div v-else class="d-flex flex-column">
-            <div class="d-flex flex-column sticky-top bg-white">
+            <div v-if="!hideHeader" class="d-flex flex-column sticky-top bg-white">
                 <div class="d-flex">
                     <Heading v-localize h1 separator inline size="md" class="flex-grow-1">
                         {{ pageTitle }}

--- a/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/HistoryDatasetDisplay.vue
@@ -171,7 +171,7 @@ const dataContent = computed(() => getContentById(props.datasetId));
 const dataError = computed(() => getContentLoadError(props.datasetId));
 const dataLoading = computed(() => isLoadingContent(props.datasetId));
 const downloadUrl = computed(() => `${getAppRoot()}dataset/display?dataset_id=${props.datasetId}`);
-const displayUrl = computed(() => `${getAppRoot()}datasets/${props.datasetId}/display/?preview=True`);
+const displayUrl = computed(() => `${getAppRoot()}api/datasets/${props.datasetId}/display?preview=True`);
 const importUrl = computed(() => `${getAppRoot()}dataset/imp?dataset_id=${props.datasetId}`);
 const metaContent = computed(() => getDataset(props.datasetId) as Dataset);
 const metaError = computed(() => getDatasetError(props.datasetId));

--- a/client/src/components/Page/PageView.vue
+++ b/client/src/components/Page/PageView.vue
@@ -146,6 +146,7 @@ function stsUrl(config: any) {
                         :markdown-config="page"
                         :download-endpoint="stsUrl(config)"
                         :read-only="true"
+                        hide-header
                         class="page-markdown" />
                     <PageHtml v-else :page="page" />
                 </div>

--- a/client/src/components/Page/PageView.vue
+++ b/client/src/components/Page/PageView.vue
@@ -8,6 +8,7 @@ import { computed, onMounted, ref } from "vue";
 import type { PublishedItem as PublishedItemType } from "@/components/Common/models/PublishedItem";
 import { PAGE_LABELS, PUBLISHED_LABELS } from "@/components/Page/constants";
 import { useConfig } from "@/composables/config";
+import { useEmbedBridge } from "@/composables/embedBridge";
 import { useUserStore } from "@/stores/userStore";
 import { urlData } from "@/utils/url";
 
@@ -27,12 +28,14 @@ interface PageData extends PublishedItemType {
 interface Props {
     pageId: string;
     embed?: boolean;
+    embedOrigin?: string;
     showHeading?: boolean;
     displayOnly?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     embed: false,
+    embedOrigin: undefined,
     showHeading: true,
     displayOnly: false,
 });
@@ -92,6 +95,18 @@ function onEdit() {
 /** Whether to render chrome-free (embed or displayOnly). */
 const isChromeFree = computed(() => props.embed || props.displayOnly);
 
+const contentRoot = ref<HTMLElement>();
+const pageTitle = computed(() => page.value?.title || page.value?.name);
+
+// Notify an external embedder (e.g. Loom/Orbit) of lifecycle/size/navigation.
+useEmbedBridge({
+    enabled: isChromeFree.value,
+    pageId: props.pageId,
+    title: pageTitle,
+    root: contentRoot,
+    explicitOrigin: props.embedOrigin,
+});
+
 function stsUrl(config: any) {
     return `${dataUrl.value}/prepare_download`;
 }
@@ -99,7 +114,7 @@ function stsUrl(config: any) {
 
 <template>
     <div v-if="isChromeFree" id="columns" class="page-view embed">
-        <div id="center" class="container-root">
+        <div id="center" ref="contentRoot" class="container-root">
             <div
                 v-if="props.displayOnly && page && !loading"
                 class="page-display-toolbar d-flex align-items-center p-2 border-bottom">

--- a/client/src/components/Page/PageView.vue
+++ b/client/src/components/Page/PageView.vue
@@ -197,3 +197,85 @@ function stsUrl(config: any) {
     }
 }
 </style>
+
+<!--
+  Themed-embed dark content rules. Deliberately NOT ``scoped``: App.vue tags the app
+  root ``embed-themed`` only when an embedded theme is active, and that gate (plus the
+  ``.page-view.embed`` chrome-free container) scopes these tightly enough. A scoped
+  block can't express this -- ``:global(#app.embed-themed) .page-view.embed`` is
+  mis-compiled by the scoped transform (the descendant is dropped), landing the rules
+  on ``#app`` itself. Colors come from the theme's ``--content-*`` variables; the rules
+  simply don't exist without the gate, so un-themed embeds are byte-identical to before.
+-->
+<style lang="scss">
+#app.embed-themed .page-view.embed {
+    background: var(--content-background);
+    color: var(--content-text);
+
+    .container-root {
+        background: var(--content-background);
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        color: var(--content-heading);
+        border-color: var(--content-border);
+    }
+
+    a {
+        color: var(--content-link);
+
+        &:hover,
+        &:focus {
+            color: var(--content-link-hover);
+        }
+    }
+
+    code,
+    pre,
+    kbd,
+    samp {
+        background-color: var(--content-surface);
+        color: var(--content-text);
+        border-color: var(--content-border);
+    }
+
+    blockquote {
+        color: var(--content-text-muted);
+        border-color: var(--content-border);
+    }
+
+    hr {
+        border-color: var(--content-border);
+    }
+
+    table {
+        color: var(--content-text);
+
+        th,
+        td {
+            border-color: var(--content-border);
+        }
+    }
+
+    .text-muted {
+        color: var(--content-text-muted) !important;
+    }
+
+    // Bootstrap background utilities hardcode light surfaces with !important (e.g. the
+    // markdown title's sticky ``bg-white`` header), so they need !important to retint.
+    .bg-white,
+    .bg-light {
+        background-color: var(--content-surface) !important;
+    }
+
+    // Heading separator segments (``.stripe``) are a light Bootstrap border color.
+    .stripe {
+        background-color: var(--content-border) !important;
+    }
+}
+</style>

--- a/client/src/composables/embedBridge.test.ts
+++ b/client/src/composables/embedBridge.test.ts
@@ -1,0 +1,199 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ref } from "vue";
+
+import { resolveEmbedTargetOrigin, shouldInterceptLink, useEmbedBridge } from "./embedBridge";
+
+const ORIGIN = "https://orbit.example";
+
+describe("resolveEmbedTargetOrigin", () => {
+    test("prefers the explicit origin", () => {
+        const win = { location: { ancestorOrigins: ["https://other.example"] } } as unknown as Window;
+        expect(resolveEmbedTargetOrigin(win, ORIGIN)).toBe(ORIGIN);
+    });
+
+    test("falls back to the parent ancestor origin", () => {
+        const win = { location: { ancestorOrigins: [ORIGIN] } } as unknown as Window;
+        expect(resolveEmbedTargetOrigin(win)).toBe(ORIGIN);
+    });
+
+    test("returns null when neither is known (never '*')", () => {
+        const win = { location: { ancestorOrigins: undefined } } as unknown as Window;
+        expect(resolveEmbedTargetOrigin(win)).toBeNull();
+    });
+});
+
+describe("shouldInterceptLink", () => {
+    test.each([
+        ["/datasets/123", true],
+        ["https://example.org/x", true],
+        ["#in-page", false],
+        ["javascript:void(0)", false],
+        ["", false],
+        [null, false],
+        [undefined, false],
+    ])("shouldInterceptLink(%s) === %s", (href, expected) => {
+        expect(shouldInterceptLink(href as string | null | undefined)).toBe(expected);
+    });
+});
+
+interface MockWinOptions {
+    ancestorOrigins?: string[];
+    resizeObserver?: boolean;
+}
+
+function makeMockWin(options: MockWinOptions = {}) {
+    const postMessage = vi.fn();
+    const parent = { postMessage };
+    let resizeCb: (() => void) | undefined;
+    const win = {
+        parent,
+        location: { ancestorOrigins: options.ancestorOrigins },
+        ResizeObserver: options.resizeObserver
+            ? class {
+                  constructor(cb: () => void) {
+                      resizeCb = cb;
+                  }
+                  observe() {
+                      resizeCb?.();
+                  }
+                  disconnect() {}
+              }
+            : undefined,
+    } as unknown as Window;
+    return { win, postMessage };
+}
+
+function mountBridge(opts: {
+    enabled: boolean;
+    win: Window;
+    root: HTMLElement;
+    title?: string;
+    explicitOrigin?: string;
+}) {
+    const title = ref<string | undefined>(opts.title);
+    const rootRef = ref<HTMLElement | undefined>(opts.root);
+    const wrapper = mount({
+        template: "<div />",
+        setup() {
+            useEmbedBridge({
+                enabled: opts.enabled,
+                pageId: "p1",
+                title,
+                root: rootRef,
+                explicitOrigin: opts.explicitOrigin,
+                win: opts.win,
+            });
+        },
+    });
+    return { wrapper, title };
+}
+
+describe("useEmbedBridge", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+        vi.clearAllMocks();
+    });
+
+    test("posts ready and title on mount, origin-restricted", () => {
+        const root = document.createElement("div");
+        document.body.appendChild(root);
+        const { win, postMessage } = makeMockWin({ ancestorOrigins: [ORIGIN] });
+
+        const { wrapper } = mountBridge({ enabled: true, win, root, title: "My Page" });
+
+        expect(postMessage).toHaveBeenCalledWith({ type: "galaxy-embed:ready", pageId: "p1" }, ORIGIN);
+        expect(postMessage).toHaveBeenCalledWith({ type: "galaxy-embed:title", title: "My Page" }, ORIGIN);
+        wrapper.destroy();
+    });
+
+    test("does nothing when disabled", () => {
+        const root = document.createElement("div");
+        document.body.appendChild(root);
+        const { win, postMessage } = makeMockWin({ ancestorOrigins: [ORIGIN] });
+
+        const { wrapper } = mountBridge({ enabled: false, win, root, title: "X" });
+
+        expect(postMessage).not.toHaveBeenCalled();
+        wrapper.destroy();
+    });
+
+    test("sends nothing when no target origin can be resolved", () => {
+        const root = document.createElement("div");
+        document.body.appendChild(root);
+        const { win, postMessage } = makeMockWin({ ancestorOrigins: undefined });
+
+        const { wrapper } = mountBridge({ enabled: true, win, root, title: "X" });
+
+        expect(postMessage).not.toHaveBeenCalled();
+        wrapper.destroy();
+    });
+
+    test("intercepts in-iframe link clicks and routes them to the parent", () => {
+        const root = document.createElement("div");
+        const anchor = document.createElement("a");
+        anchor.setAttribute("href", "/datasets/123");
+        root.appendChild(anchor);
+        document.body.appendChild(root);
+        const { win, postMessage } = makeMockWin({ ancestorOrigins: [ORIGIN] });
+
+        const { wrapper } = mountBridge({ enabled: true, win, root });
+
+        const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+        anchor.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "galaxy-embed:navigate", href: expect.stringContaining("/datasets/123") }),
+            ORIGIN,
+        );
+        wrapper.destroy();
+    });
+
+    test("leaves in-page anchors alone", () => {
+        const root = document.createElement("div");
+        const anchor = document.createElement("a");
+        anchor.setAttribute("href", "#section");
+        root.appendChild(anchor);
+        document.body.appendChild(root);
+        const { win, postMessage } = makeMockWin({ ancestorOrigins: [ORIGIN] });
+
+        const { wrapper } = mountBridge({ enabled: true, win, root });
+
+        const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+        anchor.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(false);
+        const navigateCalls = postMessage.mock.calls.filter((c) => c[0]?.type === "galaxy-embed:navigate");
+        expect(navigateCalls).toHaveLength(0);
+        wrapper.destroy();
+    });
+
+    test("emits height from a ResizeObserver when available", () => {
+        const root = document.createElement("div");
+        document.body.appendChild(root);
+        const { win, postMessage } = makeMockWin({ ancestorOrigins: [ORIGIN], resizeObserver: true });
+
+        const { wrapper } = mountBridge({ enabled: true, win, root });
+
+        const heightCalls = postMessage.mock.calls.filter((c) => c[0]?.type === "galaxy-embed:height");
+        expect(heightCalls.length).toBeGreaterThan(0);
+        expect(heightCalls[0]?.[1]).toBe(ORIGIN);
+        wrapper.destroy();
+    });
+
+    test("re-emits title when it changes", async () => {
+        const root = document.createElement("div");
+        document.body.appendChild(root);
+        const { win, postMessage } = makeMockWin({ ancestorOrigins: [ORIGIN] });
+
+        const { wrapper, title } = mountBridge({ enabled: true, win, root, title: "First" });
+        postMessage.mockClear();
+
+        title.value = "Second";
+        await wrapper.vm.$nextTick();
+
+        expect(postMessage).toHaveBeenCalledWith({ type: "galaxy-embed:title", title: "Second" }, ORIGIN);
+        wrapper.destroy();
+    });
+});

--- a/client/src/composables/embedBridge.ts
+++ b/client/src/composables/embedBridge.ts
@@ -1,0 +1,133 @@
+import { onBeforeUnmount, onMounted, type Ref, watch } from "vue";
+
+/**
+ * postMessage bridge for Galaxy's chrome-free embed surface
+ * (`/published/page?embed=true`). When the page is framed by an external embedder
+ * (e.g. a Loom/Orbit shell), it notifies the parent of lifecycle/size/navigation
+ * events so the embedder can size the iframe and intercept link clicks instead of
+ * navigating the whole Galaxy app inside a small pane.
+ *
+ * All messages are origin-restricted (never `*`): see {@link resolveEmbedTargetOrigin}.
+ */
+
+export const EMBED_MESSAGE_PREFIX = "galaxy-embed:";
+
+export type EmbedMessage =
+    | { type: "galaxy-embed:ready"; pageId: string }
+    | { type: "galaxy-embed:height"; px: number }
+    | { type: "galaxy-embed:title"; title: string }
+    | { type: "galaxy-embed:navigate"; href: string };
+
+/**
+ * Resolve the origin to which embed postMessages may be sent. Prefer an explicit
+ * origin (passed by the embedder via `?embed_origin=`); else the real parent origin
+ * from `ancestorOrigins` (Chromium/Electron). Returns `null` when neither is known
+ * -- callers then send nothing rather than fall back to the insecure `"*"`.
+ */
+export function resolveEmbedTargetOrigin(win: Window, explicitOrigin?: string): string | null {
+    if (explicitOrigin) {
+        return explicitOrigin;
+    }
+    const ancestors = win.location.ancestorOrigins;
+    if (ancestors && ancestors.length > 0) {
+        return ancestors[0] ?? null;
+    }
+    return null;
+}
+
+/**
+ * Whether a clicked anchor should be routed to the parent rather than navigating
+ * the embed iframe itself. In-page (`#...`) and `javascript:` links are left alone.
+ */
+export function shouldInterceptLink(href: string | null | undefined): boolean {
+    if (!href) {
+        return false;
+    }
+    const trimmed = href.trim();
+    if (trimmed === "" || trimmed.startsWith("#") || trimmed.toLowerCase().startsWith("javascript:")) {
+        return false;
+    }
+    return true;
+}
+
+export interface UseEmbedBridgeOptions {
+    /** Only wire the bridge when rendering chrome-free (embedded). */
+    enabled: boolean;
+    pageId: string;
+    /** Page title; emitted as `title` and re-emitted when it changes. */
+    title: Ref<string | undefined>;
+    /** Container whose size is observed and whose link clicks are intercepted. */
+    root: Ref<HTMLElement | undefined | null>;
+    /** Embedder origin from `?embed_origin=`; falls back to `ancestorOrigins`. */
+    explicitOrigin?: string;
+    /** Injectable for tests; defaults to the global `window`. */
+    win?: Window;
+}
+
+/** `ResizeObserver` is a DOM global, not a member of the `Window` interface. */
+type EmbedWindow = Window & { ResizeObserver?: typeof ResizeObserver };
+
+export function useEmbedBridge(options: UseEmbedBridgeOptions): void {
+    const win = (options.win ?? window) as EmbedWindow;
+    // Nothing to do when disabled or when there is no distinct parent frame.
+    if (!options.enabled || win.parent === win) {
+        return;
+    }
+    const targetOrigin = resolveEmbedTargetOrigin(win, options.explicitOrigin);
+
+    function post(message: EmbedMessage): void {
+        if (!targetOrigin) {
+            return;
+        }
+        win.parent.postMessage(message, targetOrigin);
+    }
+
+    let resizeObserver: ResizeObserver | undefined;
+
+    function onClick(event: MouseEvent): void {
+        const target = event.target as HTMLElement | null;
+        const anchor = target?.closest?.("a") as HTMLAnchorElement | null;
+        if (!anchor) {
+            return;
+        }
+        const href = anchor.getAttribute("href");
+        if (!shouldInterceptLink(href)) {
+            return;
+        }
+        event.preventDefault();
+        // Prefer the resolved absolute URL so the parent gets a navigable href.
+        post({ type: "galaxy-embed:navigate", href: anchor.href || href! });
+    }
+
+    onMounted(() => {
+        post({ type: "galaxy-embed:ready", pageId: options.pageId });
+        if (options.title.value) {
+            post({ type: "galaxy-embed:title", title: options.title.value });
+        }
+        const root = options.root.value;
+        if (root) {
+            root.addEventListener("click", onClick);
+            if (typeof win.ResizeObserver !== "undefined") {
+                const observer = new win.ResizeObserver(() => {
+                    post({ type: "galaxy-embed:height", px: root.scrollHeight });
+                });
+                observer.observe(root);
+                resizeObserver = observer;
+            }
+        }
+    });
+
+    watch(
+        () => options.title.value,
+        (title) => {
+            if (title) {
+                post({ type: "galaxy-embed:title", title });
+            }
+        },
+    );
+
+    onBeforeUnmount(() => {
+        options.root.value?.removeEventListener("click", onClick);
+        resizeObserver?.disconnect();
+    });
+}

--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="app" :style="theme">
+    <div id="app" :style="theme" :class="{ 'embed-themed': embedded && !!theme }">
         <div id="everything">
             <div id="background" />
             <template v-if="!embedded">
@@ -68,6 +68,8 @@ import { useNotificationsStore } from "@/stores/notificationsStore";
 import { useTourStore } from "@/stores/tourStore";
 import { useUserStore } from "@/stores/userStore";
 import { useWindowManagerStore } from "@/stores/windowManagerStore";
+
+import { resolveTheme } from "./resolveTheme";
 
 import Alert from "@/components/Alert.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
@@ -195,17 +197,12 @@ export default {
             return true;
         },
         theme() {
-            if (this.embedded) {
-                return null;
-            }
-
-            const themeKeys = Object.keys(this.config.themes);
-            if (themeKeys.length > 0) {
-                const foundTheme = themeKeys.includes(this.currentTheme);
-                const selectedTheme = foundTheme ? this.currentTheme : themeKeys[0];
-                return this.config.themes[selectedTheme];
-            }
-            return null;
+            return resolveTheme({
+                embedded: this.embedded,
+                themes: this.config.themes,
+                queryTheme: this.$route.query.theme,
+                currentTheme: this.currentTheme,
+            });
         },
         windowTab() {
             return this.windowManagerStore.getTab();

--- a/client/src/entry/analysis/resolveTheme.test.ts
+++ b/client/src/entry/analysis/resolveTheme.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTheme, type Themes } from "./resolveTheme";
+
+const THEMES: Themes = {
+    blue: { "--masthead-color": "#2c3143" },
+    orbit: { "--masthead-color": "#2c3143", "--content-background": "#2c3143", "--content-text": "#f0f2f8" },
+};
+
+describe("resolveTheme — embedded", () => {
+    it("applies the theme requested via ?theme= when it exists", () => {
+        const theme = resolveTheme({ embedded: true, themes: THEMES, queryTheme: "orbit" });
+        expect(theme).toBe(THEMES.orbit);
+        expect(theme?.["--content-background"]).toBe("#2c3143");
+    });
+
+    it("returns null for an unknown ?theme= id (no theme applied)", () => {
+        expect(resolveTheme({ embedded: true, themes: THEMES, queryTheme: "nope" })).toBeNull();
+    });
+
+    it("returns null when embedded with no ?theme= (today's behavior)", () => {
+        expect(resolveTheme({ embedded: true, themes: THEMES, queryTheme: undefined })).toBeNull();
+    });
+
+    it("ignores the user's currentTheme while embedded (only ?theme= selects)", () => {
+        expect(
+            resolveTheme({ embedded: true, themes: THEMES, queryTheme: undefined, currentTheme: "blue" }),
+        ).toBeNull();
+    });
+
+    it("takes the first value when vue-router yields a string[] query", () => {
+        const theme = resolveTheme({ embedded: true, themes: THEMES, queryTheme: ["orbit", "blue"] });
+        expect(theme).toBe(THEMES.orbit);
+    });
+});
+
+describe("resolveTheme — normal app", () => {
+    it("applies the user's currentTheme when configured", () => {
+        // A ?theme= query must NOT override the logged-in user's pref outside embed.
+        const theme = resolveTheme({ embedded: false, themes: THEMES, queryTheme: "orbit", currentTheme: "blue" });
+        expect(theme).toBe(THEMES.blue);
+    });
+
+    it("falls back to the first theme when currentTheme is unknown", () => {
+        expect(resolveTheme({ embedded: false, themes: THEMES, currentTheme: "missing" })).toBe(THEMES.blue);
+    });
+
+    it("returns null when no themes are configured", () => {
+        expect(resolveTheme({ embedded: false, themes: {}, currentTheme: "blue" })).toBeNull();
+        expect(resolveTheme({ embedded: false, themes: null })).toBeNull();
+    });
+});

--- a/client/src/entry/analysis/resolveTheme.ts
+++ b/client/src/entry/analysis/resolveTheme.ts
@@ -1,0 +1,43 @@
+export type ThemeVars = Record<string, string>;
+export type Themes = Record<string, ThemeVars>;
+
+export interface ResolveThemeArgs {
+    /** Whether the app is rendered chrome-free (embed iframe / in-frame). */
+    embedded: boolean;
+    /** All configured themes as flat CSS-variable dicts (``config.themes``). */
+    themes: Themes | null | undefined;
+    /** ``?theme=`` query value (vue-router gives string | string[] | undefined). */
+    queryTheme?: string | string[] | null;
+    /** The logged-in user's selected theme id (normal app only). */
+    currentTheme?: string | null;
+}
+
+/**
+ * Resolve which theme's CSS-variable dict to apply at the app root.
+ *
+ * Embedded pages (e.g. the Loom/Orbit notebook iframe) have no user theme pref and
+ * no masthead picker, so the embedder selects a theme via ``?theme=<id>``. That is
+ * honored *only* when embedded, so it never overrides a logged-in user's chosen
+ * theme in the normal app. Unknown/absent ids yield ``null`` (no theme applied).
+ *
+ * In the normal app the user's ``currentTheme`` wins, falling back to the first
+ * configured theme; no themes configured yields ``null``.
+ */
+export function resolveTheme({ embedded, themes, queryTheme, currentTheme }: ResolveThemeArgs): ThemeVars | null {
+    const all = themes || {};
+
+    if (embedded) {
+        const requested = Array.isArray(queryTheme) ? queryTheme[0] : queryTheme;
+        if (typeof requested === "string" && requested in all) {
+            return all[requested];
+        }
+        return null;
+    }
+
+    const keys = Object.keys(all);
+    if (keys.length === 0) {
+        return null;
+    }
+    const selected = currentTheme && keys.includes(currentTheme) ? currentTheme : keys[0];
+    return all[selected];
+}

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -195,6 +195,7 @@ export function getRouter(Galaxy) {
                 props: (route) => ({
                     pageId: route.query.id,
                     embed: route.query.embed ? parseBool(route.query.embed) : undefined,
+                    embedOrigin: route.query.embed_origin || undefined,
                     showHeading: route.query.heading ? parseBool(route.query.heading) : undefined,
                     displayOnly: route.query.displayOnly === "true",
                 }),

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -697,7 +697,7 @@
 :Description:
     Location of files available for a short time as downloads (short
     term storage). This directory is exclusively used for serving
-    dynamically generated downloadable content. Galaxy may use the
+    dynamically generated downloadable content. Galaxy may uses the
     new_file_path parameter as a general temporary directory and that
     directory should be monitored by a tool such as tmpwatch in
     production environments. short_term_storage_dir on the other hand
@@ -1008,7 +1008,7 @@
 
 :Description:
     XML config file that contains data table entries for the
-    ToolDataTableManager.  This file is manually maintained by the
+    ToolDataTableManager.  This file is manually # maintained by the
     Galaxy administrator (.sample used if default does not exist).
     The value of this option will be resolved with respect to
     <config_dir>.
@@ -1288,7 +1288,7 @@
     destination level for heterogeneous clusters. conda job resolution
     requires bash or zsh so if this is switched to /bin/sh for
     instance - conda resolution should be disabled. Containerized jobs
-    always use /bin/sh - for maximum portability tool authors
+    always use /bin/sh - so more maximum portability tool authors
     should assume generated commands run in sh.
 :Default: ``/bin/bash``
 :Type: str
@@ -1302,6 +1302,24 @@
     Directory in which the toolbox search index is stored. The value
     of this option will be resolved with respect to <data_dir>.
 :Default: ``tool_search_index``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+``tool_tag_mappings_file``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Optional YAML file mapping tool ids to curated tag names. Tags
+    drive the `tag:` autocompletion, the favorite-tags grouping in the
+    My Tools panel, and the `tool_tags` Whoosh search field. If unset,
+    Galaxy ships a small example covering the tools used by its own
+    integration tests; admins who want production-grade tag coverage
+    can generate a snapshot for their instance with
+    `scripts/extract_tool_sections_from_api.py`. The file must be a
+    YAML document with a top-level `tool_tags:` mapping from tool id
+    to a list of tag names.
+:Default: ``None``
 :Type: str
 
 
@@ -1323,7 +1341,7 @@
 
 :Description:
     Set this to true to attempt to resolve bio.tools metadata for
-    tools for tool not resolved via biotools_content_directory.
+    tools for tool not resovled via biotools_content_directory.
 :Default: ``false``
 :Type: bool
 
@@ -2750,6 +2768,26 @@
     intact to protect your users.  Uncomment and leave empty to not
     set the `X-Frame-Options` header.
 :Default: ``SAMEORIGIN``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``embed_allowed_origins``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Space-separated list of origins permitted to embed Galaxy's
+    chrome-free embed surfaces (`/published/*?embed=true`) in an
+    iframe. When set, Galaxy emits a `Content-Security-Policy:
+    frame-ancestors <origins>` header on those embed responses,
+    restricting which parent sites may frame them (for example a
+    Loom/Orbit desktop shell). This is the framing (`frame-ancestors`)
+    control and is intentionally distinct from
+    `allowed_origin_hostnames` (the CORS allow-list) -- they govern
+    unrelated browser mechanisms. Leave unset to emit no
+    `frame-ancestors` CSP (embed responses simply omit
+    `X-Frame-Options` as before).
+:Default: ``None``
 :Type: str
 
 
@@ -5663,9 +5701,57 @@
     false }, jupyterlite: { model: gpt-4o } } Set static_responses to
     a YAML file path to replace all LLM calls with deterministic
     responses for testing: inference_services: { static_responses:
-    test/integration/static_agents.yml }
+    test/integration/static_agents.yml } Per-agent or default-block
+    ``structured_output_override: true|false`` beats the model
+    capability table -- see ``agent_model_capabilities_file`` for the
+    table's location and contents.
 :Default: ``None``
 :Type: any
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``agent_model_capabilities_file``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    YAML file with capability hints for agent inference models. Maps
+    fnmatch-style globs against model names to features such as
+    structured-output (tool-calling / JSON-mode) support. Galaxy ships
+    a sample populated with common model families; admins can drop a
+    file named ``agent_model_capabilities.yml`` in ``config_dir`` to
+    override the shipped table for private models.
+    ``inference_services`` ``structured_output_override`` overrides
+    this table for a specific agent or default block.
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``agent_model_capabilities.yml``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~
+``gtn_database_path``
+~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Path to the SQLite FTS5 database used by the GTN training agent.
+    Resolves against ``data_dir`` so admins can place it in a
+    mutable-data directory. The file is downloaded automatically on
+    first use from ``gtn_database_url`` if it does not exist.
+    The value of this option will be resolved with respect to
+    <data_dir>.
+:Default: ``gtn/gtn_search.db``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~
+``gtn_database_url``
+~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    URL used to download the GTN search database when the local file
+    at ``gtn_database_path`` is missing.
+:Default: ``https://depot.galaxyproject.org/chatgxy/gtn_search.db``
+:Type: str
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -6163,6 +6249,3 @@
     for user defined tools.
 :Default: ``false``
 :Type: bool
-
-
-

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -54,7 +54,10 @@ from galaxy.util.resources import (
     as_file,
     resource_path,
 )
-from galaxy.util.themes import flatten_theme
+from galaxy.util.themes import (
+    flatten_theme,
+    flattened_builtin_themes,
+)
 from galaxy.version import (
     VERSION_MAJOR,
     VERSION_MINOR,
@@ -1299,14 +1302,17 @@ class GalaxyAppConfiguration(GalaxyAppConfigurationAttributes, BaseAppConfigurat
                     for key, val in themes.items():
                         theme_dict[key] = flatten_theme(val)
 
-        self.themes = {}
+        # Seed built-in themes (e.g. ``orbit``) so they are always available even when
+        # no themes_config_file exists; admin config below may override them by key.
+        builtin_themes = flattened_builtin_themes()
+        self.themes = dict(builtin_themes)
 
         if "themes_config_file_by_host" in self.config_dict:
             self.themes_by_host = {}
             resolve_to_dir = self.schema.paths_to_resolve["themes_config_file"]
             resolve_dir_path = getattr(self, resolve_to_dir)
             for host, file_name in self.config_dict["themes_config_file_by_host"].items():
-                self.themes_by_host[host] = {}
+                self.themes_by_host[host] = dict(builtin_themes)
                 file_path = self._in_dir(resolve_dir_path, file_name)
                 _load_theme(file_path, self.themes_by_host[host])
         else:

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -216,6 +216,7 @@ class GalaxyAppConfigurationAttributes:
     upstream_gzip: bool
     upstream_mod_zip: bool
     x_frame_options: str
+    embed_allowed_origins: str | None
     nginx_upload_store: str | None
     nginx_upload_path: str | None
     nginx_upload_job_files_store: str | None

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1,21 +1,21 @@
 # Galaxy is configured by default to be usable in a single-user development
 # environment.  To tune the application for a multi-user production
 # environment, see the documentation at:
-# 
+#
 #  https://docs.galaxyproject.org/en/master/admin/production.html
-# 
+#
 # Throughout this sample configuration file, except where stated otherwise,
 # uncommented values override the default if left unset, whereas commented
 # values are set to the default value.  Relative paths are relative to the root
 # Galaxy directory.
-# 
+#
 # Examples of many of these options are explained in more detail in the Galaxy
 # Community Hub.
-# 
+#
 #   https://galaxyproject.org/admin/config
-# 
+#
 # Config hackers are encouraged to check there before asking for help.
-# 
+#
 # Configuration for Gravity process manager.
 # ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
 gravity:
@@ -1007,6 +1007,17 @@ galaxy:
   # this option will be resolved with respect to <data_dir>.
   #tool_search_index_dir: tool_search_index
 
+  # Optional YAML file mapping tool ids to curated tag names. Tags drive
+  # the `tag:` autocompletion, the favorite-tags grouping in the My
+  # Tools panel, and the `tool_tags` Whoosh search field. If unset,
+  # Galaxy ships a small example covering the tools used by its own
+  # integration tests; admins who want production-grade tag coverage can
+  # generate a snapshot for their instance with
+  # `scripts/extract_tool_sections_from_api.py`. The file must be a YAML
+  # document with a top-level `tool_tags:` mapping from tool id to a
+  # list of tag names.
+  #tool_tag_mappings_file: null
+
   # Point Galaxy at a repository consisting of a copy of the bio.tools
   # database (e.g. https://github.com/bio-tools/content/) to resolve
   # bio.tools data for tool metadata.
@@ -1673,6 +1684,18 @@ galaxy:
   # to protect your users.  Uncomment and leave empty to not set the
   # `X-Frame-Options` header.
   #x_frame_options: SAMEORIGIN
+
+  # Space-separated list of origins permitted to embed Galaxy's
+  # chrome-free embed surfaces (`/published/*?embed=true`) in an iframe.
+  # When set, Galaxy emits a `Content-Security-Policy: frame-ancestors
+  # <origins>` header on those embed responses, restricting which parent
+  # sites may frame them (for example a Loom/Orbit desktop shell). This
+  # is the framing (`frame-ancestors`) control and is intentionally
+  # distinct from `allowed_origin_hostnames` (the CORS allow-list) --
+  # they govern unrelated browser mechanisms. Leave unset to emit no
+  # `frame-ancestors` CSP (embed responses simply omit `X-Frame-Options`
+  # as before).
+  #embed_allowed_origins: null
 
   # nginx can also handle file uploads (user-to-Galaxy) via
   # nginx_upload_module. Configuration for this is complex and explained
@@ -3330,4 +3353,3 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
-

--- a/lib/galaxy/config/sample/themes_conf.yml.sample
+++ b/lib/galaxy/config/sample/themes_conf.yml.sample
@@ -1,3 +1,12 @@
+# Each theme is a nested map that is flattened into CSS custom properties applied at
+# the app root (e.g. ``masthead: {text: {color: ...}}`` -> ``--masthead-text-color``).
+#
+# A ``content:`` block flattens to ``--content-*`` variables consumed by the page /
+# markdown render surfaces (background, text, links, code, borders), so a theme can
+# darken page content -- not just the masthead. When a content var is omitted the
+# render stack falls back to its built-in light default, so existing themes are
+# unaffected. See the built-in ``orbit`` theme (galaxy.util.themes) for a full dark
+# content example; it is always available even without this file.
 blue:
   masthead:
     color: "#2c3143"
@@ -12,6 +21,16 @@ blue:
     logo:
       img: "/static/favicon.svg"
       img-secondary: null
+  # Light content surface (matches the default render colors -- shown for reference).
+  content:
+    background: "#ffffff"
+    surface: "#f8f9fa"
+    text: "#2c3143"
+    text-muted: "#5a6072"
+    heading: "#2c3143"
+    border: "#dee2e6"
+    link: "#2077b3"
+    link-hover: "#14507a"
 
 lightblue:
   masthead:

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2061,6 +2061,20 @@ mapping:
           to protect your users.  Uncomment and leave empty to not set the
           `X-Frame-Options` header.
 
+      embed_allowed_origins:
+        type: str
+        required: false
+        desc: |
+          Space-separated list of origins permitted to embed Galaxy's chrome-free
+          embed surfaces (`/published/*?embed=true`) in an iframe. When set, Galaxy
+          emits a `Content-Security-Policy: frame-ancestors <origins>` header on those
+          embed responses, restricting which parent sites may frame them (for example a
+          Loom/Orbit desktop shell). This is the framing (`frame-ancestors`) control and
+          is intentionally distinct from `allowed_origin_hostnames` (the CORS
+          allow-list) -- they govern unrelated browser mechanisms. Leave unset to emit
+          no `frame-ancestors` CSP (embed responses simply omit `X-Frame-Options` as
+          before).
+
       nginx_upload_store:
         type: str
         required: false

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -69,7 +69,10 @@ from galaxy.schema.schema import (
     UpdatePagePayload,
 )
 from galaxy.structured_app import MinimalManagerApp
-from galaxy.util import unicodify
+from galaxy.util import (
+    now,
+    unicodify,
+)
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.util.search import (
     FilteredTerm,
@@ -141,6 +144,15 @@ class PageManager(sharable.SharableModelManager[model.Page], UsesAnnotations):
         """ """
         super().__init__(app)
         self.workflow_manager = app.workflow_manager
+
+    def resolve_embed_token(self, token: str) -> Optional[model.PageEmbedToken]:
+        """Return the embed-token record if it exists and has not expired, else None."""
+        if not token:
+            return None
+        record = self.session().get(model.PageEmbedToken, token)
+        if record is None or record.expiration_time is None or not record.expiration_time > now():
+            return None
+        return record
 
     def index_query(
         self, trans: ProvidesUserContext, payload: PageIndexQueryPayload, include_total_count: bool = False

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1399,6 +1399,37 @@ class PasswordResetToken(Base):
         self.expiration_time = now() + timedelta(hours=24)
 
 
+EMBED_TOKEN_TTL = timedelta(minutes=15)
+
+
+class PageEmbedToken(Base):
+    """Short-lived credential for embedding a Page's rendered view.
+
+    Minted by the page owner; presented by an external embedder (e.g. Loom/Orbit)
+    via the ``x-galaxy-embed-token`` header. It authenticates as the owning user
+    but is only honored on routes explicitly marked ``embed_allowed=True`` (all
+    read-only, single-resource GET/HEAD routes), so it is a read scoped to that
+    allow-list rather than a full-account credential. Short TTL bounds exposure.
+    """
+
+    __tablename__ = "page_embed_token"
+
+    token: Mapped[str] = mapped_column(String(32), primary_key=True, unique=True, index=True)
+    page_id: Mapped[int] = mapped_column(ForeignKey("page.id", ondelete="CASCADE"), index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("galaxy_user.id", ondelete="CASCADE"), index=True)
+    expiration_time: Mapped[datetime]
+
+    page: Mapped["Page"] = relationship()
+    user: Mapped["User"] = relationship()
+
+    def __init__(self, page, user, token=None):
+        # CSPRNG bearer credential (parity with API keys); 16 bytes -> 32 hex chars.
+        self.token = token or token_hex(16)
+        self.page = page
+        self.user = user
+        self.expiration_time = now() + EMBED_TOKEN_TTL
+
+
 class ToolSource(Base, Dictifiable, RepresentById):
     __tablename__ = "tool_source"
     __table_args__ = (UniqueConstraint("hash", "source_class", "identity_hash"),)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/f0e1d2c3b4a5_create_page_embed_token_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/f0e1d2c3b4a5_create_page_embed_token_table.py
@@ -1,0 +1,34 @@
+"""create page_embed_token table
+
+Revision ID: f0e1d2c3b4a5
+Revises: 28885b317f78
+Create Date: 2026-06-20 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import (
+    create_table,
+    drop_table,
+)
+
+# revision identifiers, used by Alembic.
+revision = "f0e1d2c3b4a5"
+down_revision = "28885b317f78"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_table(
+        "page_embed_token",
+        sa.Column("token", sa.String(32), primary_key=True),
+        sa.Column("page_id", sa.Integer, sa.ForeignKey("page.id", ondelete="CASCADE"), index=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("galaxy_user.id", ondelete="CASCADE"), index=True),
+        sa.Column("expiration_time", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade():
+    drop_table("page_embed_token")

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -4348,6 +4348,14 @@ class PageDetails(PageSummary):
     )
     generate_version: Optional[str] = GenerateVersionField
     generate_time: Optional[str] = GenerateTimeField
+    embed_url: Optional[str] = Field(
+        default=None,
+        title="Embed URL",
+        description=(
+            "Chrome-free, frame-embeddable URL for rendering this page's latest revision "
+            "(e.g. in Loom/Orbit). None when no request context is available."
+        ),
+    )
     model_config = ConfigDict(extra="allow")
 
 
@@ -4382,6 +4390,19 @@ class PageRevisionDetails(PageRevisionSummary):
 
 class PageRevisionList(RootModel):
     root: list[PageRevisionSummary] = Field(default=[])
+
+
+class PageEmbedToken(Model):
+    token: str = Field(
+        ...,
+        title="Embed Token",
+        description="Short-lived, page-scoped token authenticating a read-only embedded render of the page.",
+    )
+    expires_at: datetime = Field(
+        ...,
+        title="Expiration Time",
+        description="UTC time after which the embed token is no longer valid.",
+    )
 
 
 class LandingRequestState(str, Enum):

--- a/lib/galaxy/util/themes.py
+++ b/lib/galaxy/util/themes.py
@@ -18,3 +18,50 @@ def flatten_theme(theme: Theme, prefix: str = "-") -> Dict[str, str]:
             flat_attributes.update(flatten_theme(val, f"{prefix}-{key}"))
 
     return flat_attributes
+
+
+# Built-in themes seeded into ``config.themes`` regardless of ``themes_config_file``
+# (which has no sample fallback, so an admin with no themes_conf.yml has none).
+# Admin config may override a built-in by redefining its key.
+#
+# ``orbit`` mirrors the Orbit shell palette (app/src/renderer/styles.css :root) so an
+# embedded Galaxy Page rendered inside Orbit's dark chrome reads as part of the shell.
+# Its ``content`` block flattens to ``--content-*`` css variables consumed by the page
+# / markdown render stack; the ``masthead`` block keeps ``orbit`` a complete, normally
+# selectable theme too.
+BUILTIN_THEMES: Dict[str, Theme] = {
+    "orbit": {
+        "masthead": {
+            "color": "#2c3143",
+            "text": {
+                "color": "#f0f2f8",
+                "hover": "#ffd700",
+                "active": "#ffffff",
+            },
+            "link": {
+                "color": "transparent",
+                "hover": "transparent",
+                "active": "#181a24",
+            },
+            "logo": {
+                "img": "/static/favicon.svg",
+                "img-secondary": None,
+            },
+        },
+        "content": {
+            "background": "#2c3143",
+            "surface": "#343a50",
+            "text": "#f0f2f8",
+            "text-muted": "rgba(240, 242, 248, 0.55)",
+            "heading": "#f8fafc",
+            "border": "rgba(255, 255, 255, 0.12)",
+            "link": "#ffd700",
+            "link-hover": "#ffe450",
+        },
+    },
+}
+
+
+def flattened_builtin_themes() -> Dict[str, Dict[str, str]]:
+    """Built-in themes as flat css-variable dicts, ready to seed ``config.themes``."""
+    return {key: flatten_theme(theme) for key, theme in BUILTIN_THEMES.items()}

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -75,9 +75,11 @@ from galaxy import (
 )
 from galaxy.exceptions import (
     AdminRequiredException,
+    AuthenticationFailed,
     UserCannotRunAsException,
     UserRequiredException,
 )
+from galaxy.managers.pages import PageManager
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
 from galaxy.model import User
@@ -102,6 +104,7 @@ api_key_query = APIKeyQuery(name="key", auto_error=False)
 api_key_header = APIKeyHeader(name="x-api-key", auto_error=False)
 api_key_cookie = APIKeyCookie(name="galaxysession", auto_error=False)
 api_bearer_token = HTTPBearer(auto_error=False)
+embed_token_header = APIKeyHeader(name="x-galaxy-embed-token", auto_error=False)
 
 
 def get_app() -> StructuredApp:
@@ -161,6 +164,7 @@ def get_session(
 
 
 def get_api_user(
+    request: Request,
     user_manager: UserManager = depends(UserManager),
     key: str = Security(api_key_query),
     x_api_key: str = Security(api_key_header),
@@ -174,6 +178,13 @@ def get_api_user(
         ),
     ),
 ) -> Optional[User]:
+    # An embed-token route dependency (added via `embed_allowed=True`) runs before
+    # this and, on success, stashes the recovered user here. The embed token is
+    # *only* honored on routes that opt in -- on every other route this attribute
+    # is unset, so an embed token is silently ignored (default-deny).
+    embed_user = getattr(request.state, "embed_user", None)
+    if embed_user is not None:
+        return embed_user
     if api_key := key or x_api_key:
         user = user_manager.by_api_key(api_key=api_key)
     elif bearer_token:
@@ -186,6 +197,30 @@ def get_api_user(
         else:
             raise UserCannotRunAsException
     return user
+
+
+def embed_token_dependency(
+    request: Request,
+    embed_token: Optional[str] = Security(embed_token_header),
+    page_manager: PageManager = depends(PageManager),
+) -> None:
+    """Authenticate a page embed token on routes that opt in via `embed_allowed=True`.
+
+    A valid `x-galaxy-embed-token` header recovers the token's user and stashes it on
+    `request.state` for `get_api_user`, so the request runs with that user's normal
+    access control. The token is honored *only* on opted-in routes (the decorator is
+    the allow-list); on every other route it is silently ignored -> default-deny. It
+    grants no extra privilege: it is read-only by virtue of which routes are marked,
+    and account/admin/mutation routes are simply never marked (keeps the api-key sink
+    closed). The marked set must never include a listing/enumeration route. Absent
+    token -> no-op (normal auth applies); present-but-invalid -> 401.
+    """
+    if not embed_token:
+        return
+    record = page_manager.resolve_embed_token(embed_token)
+    if record is None:
+        raise AuthenticationFailed("Invalid or expired embed token.")
+    request.state.embed_user = record.user
 
 
 def get_user(
@@ -552,6 +587,16 @@ class FrameworkRouter(APIRouter):
                 kwd["dependencies"].append(self.admin_user_dependency)
             else:
                 kwd["dependencies"] = [self.admin_user_dependency]
+
+        # embed_allowed=True opts a route into page-embed-token auth (read-only
+        # allow-list). Never mark a listing/enumeration route.
+        embed_allowed = kwd.pop("embed_allowed", False)
+        if embed_allowed:
+            embed_dependency = Depends(embed_token_dependency)
+            if "dependencies" in kwd:
+                kwd["dependencies"].append(embed_dependency)
+            else:
+                kwd["dependencies"] = [embed_dependency]
 
         public = kwd.pop("public", False)
         openapi_extra = kwd.pop("openapi_extra", {})

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -189,6 +189,7 @@ class FastAPIDatasetCollections:
     @router.get(
         "/api/dataset_collections/{hdca_id}",
         summary="Returns detailed information about the given collection.",
+        embed_allowed=True,
     )
     def show(
         self,

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -325,10 +325,12 @@ class FastAPIDatasets:
         "/api/datasets/{history_content_id}/display",
         summary="Displays (preview) or downloads dataset content.",
         response_class=StreamingResponse,
+        embed_allowed=True,
     )
     @router.head(
         "/api/datasets/{history_content_id}/display",
         summary="Check if dataset content can be previewed or downloaded.",
+        embed_allowed=True,
     )
     def display(
         self,
@@ -408,10 +410,12 @@ class FastAPIDatasets:
         summary="Returns the metadata file associated with this history item.",
         response_class=GalaxyFileResponse,
         operation_id="datasets__get_metadata_file",
+        embed_allowed=True,
     )
     @router.head(
         "/api/datasets/{history_content_id}/metadata_file",
         summary="Check if metadata file can be downloaded.",
+        embed_allowed=True,
     )
     def get_metadata_file_datasets(
         self,
@@ -436,6 +440,7 @@ class FastAPIDatasets:
     @router.get(
         "/api/datasets/{dataset_id}",
         summary="Displays information about and/or content of a dataset.",
+        embed_allowed=True,
     )
     def show(
         self,

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -20,6 +20,7 @@ from galaxy.schema.schema import (
     AsyncFile,
     CreatePagePayload,
     PageDetails,
+    PageEmbedToken,
     PageIndexQueryPayload,
     PageRevisionDetails,
     PageRevisionList,
@@ -237,6 +238,7 @@ class FastAPIPages:
         "/api/pages/{id}",
         summary="Return a page summary and the content of the last revision.",
         response_description="The page summary information.",
+        embed_allowed=True,
     )
     def show(
         self,
@@ -245,6 +247,18 @@ class FastAPIPages:
     ) -> PageDetails:
         """Return summary information about a specific Page and the content of the last revision."""
         return self.service.show(trans, id)
+
+    @router.post(
+        "/api/pages/{id}/embed_token",
+        summary="Create a short-lived, page-scoped token for embedding this page's rendered view.",
+    )
+    def create_embed_token(
+        self,
+        id: PageIdPathParam,
+        trans: ProvidesUserContext = DependsOnTrans,
+    ) -> PageEmbedToken:
+        """Mint a short-lived token authenticating a read-only embedded render of this page."""
+        return self.service.create_embed_token(trans, id)
 
     @router.get(
         "/api/pages/{id}/sharing",

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 from typing import (
     Any,
+    Optional,
     TYPE_CHECKING,
 )
 from urllib.parse import urljoin
@@ -130,9 +131,19 @@ class GalaxyCORSMiddleware(CORSMiddleware):
 
 
 class XFrameOptionsMiddleware:
-    def __init__(self, app, x_frame_options: str):
+    """Controls iframe-embedding headers.
+
+    On non-embed responses, sets ``X-Frame-Options`` (clickjacking protection). On
+    embed responses (``/published/*?embed=true``) it omits ``X-Frame-Options`` and,
+    when ``embed_allowed_origins`` is configured, emits
+    ``Content-Security-Policy: frame-ancestors <origins>`` so framing is restricted
+    to a supported allow-list (e.g. a Loom/Orbit shell) rather than wide-open.
+    """
+
+    def __init__(self, app, x_frame_options: Optional[str] = None, embed_allowed_origins: Optional[str] = None):
         self.app = app
         self.x_frame_options = x_frame_options
+        self.embed_allowed_origins = embed_allowed_origins
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http":
@@ -143,17 +154,26 @@ class XFrameOptionsMiddleware:
 
         async def send_with_header(message):
             if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
                 if not _is_embed_request(request.url.path, str(request.url.query)):
-                    headers = MutableHeaders(scope=message)
-                    headers.append("X-Frame-Options", self.x_frame_options)
+                    if self.x_frame_options:
+                        headers.append("X-Frame-Options", self.x_frame_options)
+                elif self.embed_allowed_origins:
+                    headers.append("Content-Security-Policy", f"frame-ancestors {self.embed_allowed_origins}")
             await send(message)
 
         await self.app(scope, receive, send_with_header)
 
 
 def add_galaxy_middleware(app: FastAPI, gx_app):
-    if x_frame_options := gx_app.config.x_frame_options:
-        app.add_middleware(XFrameOptionsMiddleware, x_frame_options=x_frame_options)
+    x_frame_options = gx_app.config.x_frame_options
+    embed_allowed_origins = gx_app.config.get("embed_allowed_origins", None)
+    if x_frame_options or embed_allowed_origins:
+        app.add_middleware(
+            XFrameOptionsMiddleware,
+            x_frame_options=x_frame_options,
+            embed_allowed_origins=embed_allowed_origins,
+        )
 
     GalaxyFileResponse.nginx_x_accel_redirect_base = gx_app.config.nginx_x_accel_redirect_base
     GalaxyFileResponse.apache_xsendfile = gx_app.config.apache_xsendfile

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -1,9 +1,13 @@
 import logging
 from typing import (
+    Optional,
     Union,
 )
 
-from galaxy import exceptions
+from galaxy import (
+    exceptions,
+    model,
+)
 from galaxy.celery.helpers import async_task_summary
 from galaxy.celery.tasks import prepare_pdf_download
 from galaxy.managers import base
@@ -25,6 +29,7 @@ from galaxy.schema.schema import (
     CreatePagePayload,
     PageContentFormat,
     PageDetails,
+    PageEmbedToken,
     PageIndexQueryPayload,
     PageRevisionDetails,
     PageRevisionList,
@@ -93,8 +98,21 @@ class PagesService(ServiceBase):
         rval["content"] = page.latest_revision.content
         rval["content_format"] = page.latest_revision.content_format
         rval["edit_source"] = page.latest_revision.edit_source
+        rval["embed_url"] = self._embed_url(trans, trans.security.encode_id(page.id))
         self.manager.rewrite_content_for_export(trans, rval)
         return PageDetails(**rval)
+
+    def _embed_url(self, trans, encoded_id: str) -> Optional[str]:
+        """Chrome-free, frame-embeddable URL for the page's latest revision.
+
+        Lets Loom/Orbit avoid hand-constructing the URL. None outside a request
+        context (e.g. internal serialization without a request).
+        """
+        request = getattr(trans, "request", None)
+        if request is None:
+            return None
+        base = request.url_path.rstrip("/")
+        return f"{base}/published/page?id={encoded_id}&embed=true"
 
     def create(self, trans, payload: CreatePagePayload) -> PageDetails:
         """
@@ -135,6 +153,20 @@ class PagesService(ServiceBase):
         """
         page = base.get_object(trans, id, "Page", check_ownership=False, check_accessible=True)
         return self._page_to_details(trans, page)
+
+    def create_embed_token(self, trans, id: DecodedDatabaseIdField) -> PageEmbedToken:
+        """Mint a short-lived, page-scoped token for embedding this page's rendered view.
+
+        Ownership is required to mint -- a token grants read access to the page and
+        the datasets/visualizations it references, so only the owner should issue one.
+        (A shared-page minting path can be added later once shared-resource scope is
+        settled; ownership-only is the safe v1 subset.)
+        """
+        page = base.get_object(trans, id, "Page", check_ownership=True)
+        token = model.PageEmbedToken(page, trans.user)
+        trans.sa_session.add(token)
+        trans.sa_session.commit()
+        return PageEmbedToken(token=token.token, expires_at=token.expiration_time)
 
     def show_pdf(self, trans, id: DecodedDatabaseIdField):
         """

--- a/lib/galaxy_test/api/test_pages_history_attached.py
+++ b/lib/galaxy_test/api/test_pages_history_attached.py
@@ -1,6 +1,9 @@
 """API tests for history-attached pages (pages created with history_id)."""
 
+import requests
+
 from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
     DatasetPopulator,
     skip_without_agents,
 )
@@ -60,6 +63,17 @@ class TestHistoryPagesApi(BasePagesApiTestCase):
         assert len(pages_h1) == 1
         assert len(pages_h2) == 1
         assert pages_h1[0]["id"] != pages_h2[0]["id"]
+
+    def test_history_page_details_embed_url(self):
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Embeddable")
+        details = self.dataset_populator.get_history_page(page["id"])
+        self._assert_has_keys(details, "embed_url")
+        embed_url = details["embed_url"]
+        assert embed_url, "embed_url should be populated in a request context"
+        assert "/published/page?id=" in embed_url
+        assert "embed=true" in embed_url
+        assert page["id"] in embed_url
 
     def test_get_history_page_details(self):
         history_id = self.dataset_populator.new_history()
@@ -262,6 +276,210 @@ class TestHistoryPagesApi(BasePagesApiTestCase):
             # document actual behavior — may be 200 or 403 depending on
             # whether history sharing propagates to page access
             assert response.status_code in (200, 403)
+
+    # --- A5: Embed token ---
+
+    def test_create_embed_token(self):
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Hello")
+        response = self._post(f"pages/{page['id']}/embed_token", data={}, json=True)
+        self._assert_status_code_is(response, 200)
+        body = response.json()
+        self._assert_has_keys(body, "token", "expires_at")
+        assert body["token"]
+        assert body["expires_at"]
+
+    def test_embed_token_403_on_unowned_page(self):
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Private")
+        with self._different_user():
+            response = self._post(f"pages/{page['id']}/embed_token", data={}, json=True)
+            self._assert_status_code_is(response, 403)
+
+    # --- A6: Embed token scoped read (1b) ---
+
+    def _mint_embed_token(self, page_id: str) -> str:
+        response = self._post(f"pages/{page_id}/embed_token", data={}, json=True)
+        self._assert_status_code_is(response, 200)
+        return response.json()["token"]
+
+    def _embed_get(self, route: str, token: str) -> requests.Response:
+        """GET with ONLY the embed token header -- no API key (truly scoped)."""
+        return requests.get(self._api_url(route), headers={"x-galaxy-embed-token": token})
+
+    def test_embed_token_reads_own_page(self):
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Embed me")
+        token = self._mint_embed_token(page["id"])
+        response = self._embed_get(f"pages/{page['id']}", token)
+        self._assert_status_code_is(response, 200)
+        assert "Embed me" in response.json()["content"]
+
+    def test_embed_token_denies_other_users_page(self):
+        # The recovered user is access-controlled: the token cannot read a page
+        # owned by a different user.
+        history_id = self.dataset_populator.new_history()
+        page_a = self.dataset_populator.new_history_page(history_id, content="# A")
+        token = self._mint_embed_token(page_a["id"])
+        with self._different_user():
+            other_history = self.dataset_populator.new_history()
+            page_b = self.dataset_populator.new_history_page(other_history, content="# B")
+        response = self._embed_get(f"pages/{page_b['id']}", token)
+        self._assert_status_code_is(response, 403)
+
+    def test_embed_token_invalid_rejected(self):
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# A")
+        response = self._embed_get(f"pages/{page['id']}", "not-a-real-token")
+        self._assert_status_code_is(response, 401)
+
+    def test_embed_token_rejected_on_account_endpoint(self):
+        # Q5: the embed token must NOT authenticate the api-key endpoint (or any
+        # route not marked embed_allowed) -- otherwise an exfiltrated token could
+        # read the user's permanent API key.
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# A")
+        token = self._mint_embed_token(page["id"])
+        user_id = self.dataset_populator.user_id()
+        response = self._embed_get(f"users/{user_id}/api_key", token)
+        assert response.status_code in (401, 403), f"expected denial, got {response.status_code}"
+
+    def test_embed_token_cannot_mint_more_tokens(self):
+        # Read-only invariant: the token authenticates only GET/HEAD routes. The
+        # mint endpoint is a POST and is not marked, so the embed token alone
+        # cannot ride it -- it cannot escalate by minting fresh tokens.
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# A")
+        token = self._mint_embed_token(page["id"])
+        response = requests.post(
+            self._api_url(f"pages/{page['id']}/embed_token"),
+            headers={"x-galaxy-embed-token": token},
+            json={},
+        )
+        assert response.status_code in (401, 403), f"expected denial, got {response.status_code}"
+
+    def test_embed_token_head_on_display(self):
+        # The display route marks HEAD as well as GET; the token must authenticate
+        # the HEAD probe plugins use before fetching.
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="col1\tcol2\n1\t2\n", wait=True)
+        page = self.dataset_populator.new_history_page(history_id, content="# Embed")
+        token = self._mint_embed_token(page["id"])
+        response = requests.head(
+            self._api_url(f"datasets/{hda['id']}/display?preview=True"),
+            headers={"x-galaxy-embed-token": token},
+        )
+        self._assert_status_code_is(response, 200)
+
+    def test_embed_token_reads_dataset(self):
+        # The token recovers the full owning user; on the marked display route it
+        # reads the user's own dataset.
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="col1\tcol2\n1\t2\n", wait=True)
+        page = self.dataset_populator.new_history_page(history_id, content="# Embed")
+        token = self._mint_embed_token(page["id"])
+        response = self._embed_get(f"datasets/{hda['id']}/display?preview=True", token)
+        self._assert_status_code_is(response, 200)
+
+    def test_embed_token_denies_other_users_dataset(self):
+        # The recovered user is still access-controlled -- the token is not a
+        # super-user: it cannot read another user's *private* dataset. (Public
+        # datasets are readable by anyone by design, so the dataset must be made
+        # private to exercise the ACL boundary.)
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Mine")
+        token = self._mint_embed_token(page["id"])
+        with self._different_user():
+            other_history = self.dataset_populator.new_history()
+            other_hda = self.dataset_populator.new_dataset(other_history, content="secret\n", wait=True)
+            self.dataset_populator.make_private(other_history, other_hda["id"])
+        response = self._embed_get(f"datasets/{other_hda['id']}/display?preview=True", token)
+        self._assert_status_code_is(response, 403)
+
+    def _new_collection(self, history_id: str) -> str:
+        dccp = DatasetCollectionPopulator(self.galaxy_interactor)
+        return dccp.create_list_in_history(
+            history_id, contents=[("e1", "data1\n"), ("e2", "data2\n")], wait=True
+        ).json()["outputs"][0]["id"]
+
+    def test_embed_token_reads_collection(self):
+        history_id = self.dataset_populator.new_history()
+        hdca_id = self._new_collection(history_id)
+        page = self.dataset_populator.new_history_page(history_id, content="# Collection")
+        token = self._mint_embed_token(page["id"])
+        response = self._embed_get(f"dataset_collections/{hdca_id}", token)
+        self._assert_status_code_is(response, 200)
+
+    def test_embed_token_denies_other_users_collection(self):
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Mine")
+        token = self._mint_embed_token(page["id"])
+        with self._different_user():
+            other_history = self.dataset_populator.new_history()
+            other_hdca = self._new_collection(other_history)
+        response = self._embed_get(f"dataset_collections/{other_hdca}", token)
+        self._assert_status_code_is(response, 403)
+
+    def test_embed_token_reads_plugin_metadata(self):
+        # The embedded VisualizationFrame fetches GET /api/plugins/{name} for plugin
+        # metadata (static config: entry_point, href). That route is NOT marked
+        # embed_allowed -- plugin metadata is public config, served anonymously, so
+        # the embed token falls through to anonymous and still reads it.
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Viz")
+        token = self._mint_embed_token(page["id"])
+        response = self._embed_get("plugins/example", token)
+        self._assert_status_code_is(response, 200)
+        assert "entry_point" in response.json()
+
+    def test_embed_token_cannot_enumerate_plugin_history(self):
+        # Invariant: the embed token must not reach the plugin show route's
+        # ?history_id= enumeration branch (lists all viz-compatible datasets in a
+        # history). The route is unmarked, so the token is ignored -> anonymous ->
+        # get_owned(history_id, None) is refused. The enumeration never runs.
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Viz")
+        token = self._mint_embed_token(page["id"])
+        response = self._embed_get(f"plugins/example?history_id={history_id}", token)
+        assert response.status_code != 200, f"enumeration branch leaked: {response.status_code}"
+        assert "hdas" not in response.text
+
+    def test_embed_token_reads_dataset_metadata(self):
+        # Most embeddable viz plugins fetch GET /api/datasets/{id} for dataset
+        # metadata (column types, etc.) before fetching /display. The route is
+        # marked embed_allowed so the recovered user reads its own dataset.
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content="col1\tcol2\n1\t2\n", wait=True)
+        page = self.dataset_populator.new_history_page(history_id, content="# Viz")
+        token = self._mint_embed_token(page["id"])
+        response = self._embed_get(f"datasets/{hda['id']}", token)
+        self._assert_status_code_is(response, 200)
+        assert response.json()["id"] == hda["id"]
+
+    def test_embed_token_denies_other_users_dataset_metadata(self):
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Mine")
+        token = self._mint_embed_token(page["id"])
+        with self._different_user():
+            other_history = self.dataset_populator.new_history()
+            other_hda = self.dataset_populator.new_dataset(other_history, content="secret\n", wait=True)
+            self.dataset_populator.make_private(other_history, other_hda["id"])
+        response = self._embed_get(f"datasets/{other_hda['id']}", token)
+        self._assert_status_code_is(response, 403)
+
+    def test_embed_token_denies_other_users_metadata_file(self):
+        # The metadata_file route is marked (igv fetches it). Access control fires
+        # before the file lookup, so a cross-user private dataset is refused --
+        # proving the marked route does not leak.
+        history_id = self.dataset_populator.new_history()
+        page = self.dataset_populator.new_history_page(history_id, content="# Mine")
+        token = self._mint_embed_token(page["id"])
+        with self._different_user():
+            other_history = self.dataset_populator.new_history()
+            other_hda = self.dataset_populator.new_dataset(other_history, content="secret\n", wait=True)
+            self.dataset_populator.make_private(other_history, other_hda["id"])
+        response = self._embed_get(f"datasets/{other_hda['id']}/metadata_file?metadata_file=bam_index", token)
+        self._assert_status_code_is(response, 403)
 
     def test_history_page_shared_history_no_write(self):
         history_id = self.dataset_populator.new_history()

--- a/test/unit/app/managers/test_PageManager.py
+++ b/test/unit/app/managers/test_PageManager.py
@@ -1,0 +1,48 @@
+"""Unit tests for PageManager embed-token resolution (expiry boundary)."""
+
+from datetime import timedelta
+
+from galaxy import model
+from galaxy.managers.pages import PageManager
+from galaxy.model import now
+from .base import BaseTestCase
+
+
+class TestPageManager(BaseTestCase):
+    def set_up_managers(self):
+        super().set_up_managers()
+        # PageManager.__init__ reads app.workflow_manager; the mock app does not
+        # populate it and resolve_embed_token never uses it, so stub it.
+        self.app.workflow_manager = None
+        self.page_manager: PageManager = self.app[PageManager]
+
+    def _mint_token(self, expiration_time=None) -> model.PageEmbedToken:
+        user = self.user_manager.create(email="embed@example.com", username="embed", password="123456")
+        page = model.Page()
+        page.title = "Embed page"
+        page.slug = "embed-page"
+        page.user = user
+        token = model.PageEmbedToken(page=page, user=user)
+        if expiration_time is not None:
+            token.expiration_time = expiration_time
+        session = self.page_manager.session()
+        session.add_all([page, token])
+        session.commit()
+        return token
+
+    def test_resolve_valid_token(self):
+        token = self._mint_token()
+        resolved = self.page_manager.resolve_embed_token(token.token)
+        assert resolved is not None
+        assert resolved.token == token.token
+        assert resolved.user is not None
+
+    def test_resolve_expired_token_returns_none(self):
+        token = self._mint_token(expiration_time=now() - timedelta(minutes=1))
+        assert self.page_manager.resolve_embed_token(token.token) is None
+
+    def test_resolve_unknown_token_returns_none(self):
+        assert self.page_manager.resolve_embed_token("does-not-exist") is None
+
+    def test_resolve_empty_token_returns_none(self):
+        assert self.page_manager.resolve_embed_token("") is None

--- a/test/unit/util/test_themes.py
+++ b/test/unit/util/test_themes.py
@@ -1,0 +1,40 @@
+from galaxy.util.themes import (
+    BUILTIN_THEMES,
+    flatten_theme,
+    flattened_builtin_themes,
+)
+
+
+def test_flatten_theme_nests_with_double_dash_prefix():
+    flat = flatten_theme({"masthead": {"color": "#000", "text": {"color": "#fff"}}})
+    assert flat["--masthead-color"] == "#000"
+    assert flat["--masthead-text-color"] == "#fff"
+
+
+def test_flatten_theme_emits_content_css_variables():
+    flat = flatten_theme({"content": {"background": "#2c3143", "text": "#f0f2f8"}})
+    assert flat["--content-background"] == "#2c3143"
+    assert flat["--content-text"] == "#f0f2f8"
+
+
+def test_flatten_theme_skips_non_str_non_dict_values():
+    # ``None`` (e.g. ``img-secondary: null``) is neither str nor dict and is dropped.
+    flat = flatten_theme({"logo": {"img": "/x.svg", "img-secondary": None}})
+    assert flat == {"--logo-img": "/x.svg"}
+
+
+def test_builtin_orbit_theme_exposes_content_vars():
+    flat = flattened_builtin_themes()
+    assert "orbit" in flat
+    orbit = flat["orbit"]
+    # Content surface vars the page/markdown render stack consumes.
+    assert orbit["--content-background"] == "#2c3143"
+    assert orbit["--content-text"] == "#f0f2f8"
+    assert orbit["--content-link"] == "#ffd700"
+    # Still a complete theme (masthead present) so it is normally selectable.
+    assert orbit["--masthead-color"] == "#2c3143"
+
+
+def test_builtin_themes_are_nested_form():
+    # Source-of-truth constant stays nested; flatten happens on demand.
+    assert isinstance(BUILTIN_THEMES["orbit"]["content"], dict)

--- a/test/unit/webapps/api/test_embed_allowed_routes.py
+++ b/test/unit/webapps/api/test_embed_allowed_routes.py
@@ -1,0 +1,45 @@
+"""Snapshot of which API routes opt into page-embed-token auth.
+
+Pins the exact (method, path) set carrying ``embed_allowed=True`` (i.e. the
+``embed_token_dependency``). The embed token recovers the page owner's *full*
+user, so this marked set IS the entire trust boundary -- marking a new route,
+especially a listing/enumeration route, silently widens what an exfiltrated
+embed token can read. This test forces any change to that set to be deliberate.
+"""
+
+from fastapi import FastAPI
+
+from galaxy.webapps.base.api import include_all_package_routers
+from galaxy.webapps.galaxy.api import embed_token_dependency
+
+# Every entry MUST be a single-resource, read-only GET/HEAD route. Do NOT add a
+# listing/enumeration route -- see embed_token_dependency's docstring.
+EXPECTED_EMBED_ALLOWED_ROUTES = {
+    ("GET", "/api/pages/{id}"),
+    ("GET", "/api/datasets/{history_content_id}/display"),
+    ("HEAD", "/api/datasets/{history_content_id}/display"),
+    ("GET", "/api/datasets/{history_content_id}/metadata_file"),
+    ("HEAD", "/api/datasets/{history_content_id}/metadata_file"),
+    ("GET", "/api/datasets/{dataset_id}"),
+    ("GET", "/api/dataset_collections/{hdca_id}"),
+}
+
+
+def _embed_allowed_routes():
+    app = FastAPI()
+    include_all_package_routers(app, "galaxy.webapps.galaxy.api")
+    found = set()
+    for route in app.routes:
+        dependencies = getattr(route, "dependencies", None) or []
+        if not any(getattr(d, "dependency", None) is embed_token_dependency for d in dependencies):
+            continue
+        # Galaxy registers each route with and without a trailing slash; collapse
+        # the pair to the one logical route.
+        path = route.path.rstrip("/") or "/"
+        for method in route.methods or []:
+            found.add((method, path))
+    return found
+
+
+def test_embed_allowed_route_allow_list_is_pinned():
+    assert _embed_allowed_routes() == EXPECTED_EMBED_ALLOWED_ROUTES

--- a/test/unit/webapps/test_xframe_embed_csp.py
+++ b/test/unit/webapps/test_xframe_embed_csp.py
@@ -1,0 +1,46 @@
+"""Unit tests for XFrameOptionsMiddleware embed framing headers (Phase 1.1)."""
+
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from galaxy.webapps.galaxy.fast_app import XFrameOptionsMiddleware
+
+EMBED_ORIGINS = "https://orbit.example https://loom.example"
+
+
+def _client(embed_allowed_origins=None, x_frame_options="SAMEORIGIN"):
+    async def endpoint(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(
+        routes=[
+            Route("/published/page", endpoint),
+            Route("/api/whatever", endpoint),
+        ]
+    )
+    app.add_middleware(
+        XFrameOptionsMiddleware,
+        x_frame_options=x_frame_options,
+        embed_allowed_origins=embed_allowed_origins,
+    )
+    return TestClient(app)
+
+
+def test_non_embed_request_sets_xframe_no_csp():
+    resp = _client(embed_allowed_origins=EMBED_ORIGINS).get("/api/whatever")
+    assert resp.headers.get("x-frame-options") == "SAMEORIGIN"
+    assert "content-security-policy" not in resp.headers
+
+
+def test_embed_request_emits_frame_ancestors_csp_no_xframe():
+    resp = _client(embed_allowed_origins=EMBED_ORIGINS).get("/published/page?id=abc&embed=true")
+    assert "x-frame-options" not in resp.headers
+    assert resp.headers.get("content-security-policy") == f"frame-ancestors {EMBED_ORIGINS}"
+
+
+def test_embed_request_without_configured_origins_omits_csp_and_xframe():
+    resp = _client(embed_allowed_origins=None).get("/published/page?id=abc&embed=true")
+    assert "x-frame-options" not in resp.headers
+    assert "content-security-policy" not in resp.headers


### PR DESCRIPTION
> _Posted by Claude (AI assistant) on behalf of @jmchilton — drafted with their direction, not authored by them personally._

**⚠️ [RFC][WIP] — early, early draft. Not for merge.** Sharing the Galaxy-side half of a cross-repo spike so the shape can be discussed. Expect rough edges, missing tests/docs, and churn.

## What this is

The **Galaxy server changes** that let an external shell (Loom/Orbit) embed a *private, history-attached* notebook Page and have it render with full Galaxy fidelity (live dataset displays, visualizations, charts) — without publishing the page and without handing the shell a full API key.

Paired with the Loom side (the embedder + brain): **galaxyproject/loom#351**.

## Pieces (high level)

- **Scoped embed-token auth.** `POST /api/pages/{id}/embed_token` mints a short-TTL, page-scoped token (`PageEmbedToken` model + migration). A per-route `embed_allowed=True` decorator opts specific GET/HEAD routes into token auth (page show, dataset display/show/metadata_file, collection show); the token resolves to the owning user, with containment from the route allow-list + GET/HEAD-only marking. **Load-bearing invariant: never mark a listing/enumeration route.** Account endpoints (`/api/users/*`) are never marked, so an exfiltrated token can't reach the api-key sink.
- **Embeddable surface.** Reuse `/published/page?id=X&embed=true` (already chrome-free via `PageView`); add a configurable `embed_allowed_origins` → `Content-Security-Policy: frame-ancestors` (Galaxy has no frame CSP today), and an `embed_url` convenience field on `PageDetails`.
- **postMessage embed bridge** in `PageView.vue` (ready/height/title/navigate, origin-restricted) for an iframe-based shell.
- **Embed theming** — a built-in `orbit` theme + content theming, and hiding the duplicate title in the embedded view.

## Status / asks

- This is a **design spike**, not a finished PR — feedback on the auth model (per-route allow-list + full-user recovery vs. a true scoped capability) is the main thing I'm after.
- Security notes, the route allow-list snapshot test, and the model pivot rationale live alongside the Loom-side design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
