### PR TITLE
[26.1] Log SSE dispatch task and addressed webapp workers

### DIFF
--- a/lib/galaxy/managers/sse_dispatch.py
+++ b/lib/galaxy/managers/sse_dispatch.py
@@ -101,6 +101,12 @@ class SSEEventDispatcher:
         # Only fan out to webapp processes — job handlers and workflow schedulers
         # don't have browser SSE connections to push to.
         declare_queues = self._get_declare_queues()
+        log.debug(
+            "SSE dispatch task=%s addressed to %d webapp worker(s): %s",
+            task,
+            len(declare_queues),
+            ", ".join(q.name for q in declare_queues) or "<none>",
+        )
         control_task = self._control_task_factory(self._queue_worker)
         start_time = time.perf_counter() if self._statsd_client is not None else 0.0
         try:


### PR DESCRIPTION
## What

Adds a single `debug`-level log line in `SSEEventDispatcher._send()` that records, for every SSE event dispatched, the task name and the set of webapp workers it is addressed to.

Example output (logger `galaxy.managers.sse_dispatch`):

```
SSE dispatch task=history_update addressed to 2 webapp worker(s): control.web.1@host-a, control.web.2@host-a
```

## Why

The SSE dispatcher fans out via a topic exchange with routing key `control.*`, so the workers actually targeted aren't visible in the routing key — they're the `declare_queues` list (one `control.{server_name}@{hostname}` queue per active webapp `WorkerProcess`). This log makes it easy to see which workers a given event was sent to, and in particular surfaces the "addressed to zero active webapp workers" case, which is a common thing to be debugging.

## Notes

- Covers every SSE task type (`notify_users`, `notify_broadcast`, `history_update`, `subscribe`/`unsubscribe_history_viewer`, `entry_point_update`) since they all funnel through `_send()`.
- Plain `log.debug(...)` — no-op when DEBUG is disabled, and the `", ".join(...)` only runs when args are formatted, so there's no overhead in the common case.