### PR TITLE
Fix OIDC login repeating scopes after multiple requests

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -240,6 +240,8 @@ class PSAAuthnz(IdentityProvider):
             self.config[setting_name("USERNAME_KEY")] = oidc_backend_config.get("username_key")
         if oidc_backend_config.get("domain") is not None:
             self.config[setting_name("DOMAIN")] = oidc_backend_config.get("domain")
+        if oidc_backend_config.get("extra_scopes") is not None:
+            self.config[setting_name("SCOPE")] = oidc_backend_config.get("extra_scopes")
 
         # OIDC-specific settings (only set for OIDC backends)
         if self._is_oidc_backend():

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -318,9 +318,6 @@ class PSAAuthnz(IdentityProvider):
         ):
             backend.DEFAULT_SCOPE.append("https://www.googleapis.com/auth/cloud-platform")
 
-        if self.config["EXTRA_SCOPES"] is not None:
-            backend.DEFAULT_SCOPE.extend(self.config["EXTRA_SCOPES"])
-
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):

--- a/test/unit/authnz/test_psa_authnz.py
+++ b/test/unit/authnz/test_psa_authnz.py
@@ -546,26 +546,43 @@ def test_authenticate_does_not_mutate_backend_default_scope(psa_authnz):
     remain the same across multiple calls to authenticate().
     """
     shared_default_scope = ["openid", "email", "profile"]
-    psa_authnz.config["EXTRA_SCOPES"] = ["offline_access", "custom_scope"]
+    psa_authnz.config["SCOPE"] = ["offline_access", "custom_scope"]
 
     class FakeBackend:
         name = "oidc"
         DEFAULT_SCOPE = shared_default_scope
 
+        def __init__(self):
+            self.strategy = None
+
+        def setting(self, name, default=None):
+            return self.strategy.setting(name, default=default, backend=self)
+
+        def get_scope(self):
+            scope = self.setting("SCOPE", [])
+            if not self.setting("IGNORE_DEFAULT_SCOPE", False):
+                scope = scope + (self.DEFAULT_SCOPE or [])
+            return scope
+
+    backend_instance = FakeBackend()
     observed_scopes = []
 
+    def fake_load_backend(strategy, redirect_uri):
+        backend_instance.strategy = strategy
+        return backend_instance
+
     def fake_do_auth(backend):
-        observed_scopes.append(list(backend.DEFAULT_SCOPE))
+        observed_scopes.append(backend.get_scope())
         return MagicMock()
 
     with (
         patch("galaxy.authnz.psa_authnz.on_the_fly_config"),
-        patch.object(psa_authnz, "_load_backend", side_effect=[FakeBackend(), FakeBackend()]),
+        patch.object(psa_authnz, "_load_backend", side_effect=fake_load_backend),
         patch("galaxy.authnz.psa_authnz.do_auth", side_effect=fake_do_auth),
     ):
         psa_authnz.authenticate(make_mock_trans())
         psa_authnz.authenticate(make_mock_trans())
 
-    expected = ["openid", "email", "profile", "offline_access", "custom_scope"]
+    expected = ["offline_access", "custom_scope", "openid", "email", "profile"]
     assert observed_scopes == [expected, expected]
     assert shared_default_scope == ["openid", "email", "profile"]

--- a/test/unit/authnz/test_psa_authnz.py
+++ b/test/unit/authnz/test_psa_authnz.py
@@ -28,6 +28,7 @@ from jwt import (
     InvalidIssuerError,
     InvalidSignatureError,
 )
+from social_core.backends.base import BaseAuth
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.utils import (
     module_member,
@@ -635,7 +636,7 @@ def test_authenticate_with_real_backend_does_not_accumulate_extra_scopes(psa_aut
     backend_class = module_member(backend_path)
     original_default_scope = backend_class.DEFAULT_SCOPE
     expected_default_scope = list(original_default_scope or [])
-    backend_instances = []
+    backend_instances: list[BaseAuth] = []
     observed_scopes = []
 
     psa_authnz.config["provider"] = provider

--- a/test/unit/authnz/test_psa_authnz.py
+++ b/test/unit/authnz/test_psa_authnz.py
@@ -562,6 +562,7 @@ def test_authenticate_does_not_mutate_backend_default_scope(psa_authnz):
             self.strategy = None
 
         def setting(self, name, default=None):
+            assert self.strategy is not None
             return self.strategy.setting(name, default=default, backend=self)
 
         def get_scope(self):
@@ -634,19 +635,18 @@ def test_authenticate_with_real_backend_does_not_accumulate_extra_scopes(psa_aut
     backend_class = module_member(backend_path)
     original_default_scope = backend_class.DEFAULT_SCOPE
     expected_default_scope = list(original_default_scope or [])
-    backend_instance = None
+    backend_instances = []
     observed_scopes = []
 
     psa_authnz.config["provider"] = provider
     psa_authnz.config[setting_name("SCOPE")] = extra_scopes
 
     def fake_load_backend(strategy, redirect_uri):
-        nonlocal backend_instance
-        if backend_instance is None:
-            backend_instance = backend_class(strategy, redirect_uri)
+        if not backend_instances:
+            backend_instances.append(backend_class(strategy, redirect_uri))
         else:
-            backend_instance.strategy = strategy
-        return backend_instance
+            backend_instances[0].strategy = strategy
+        return backend_instances[0]
 
     def fake_do_auth(backend):
         observed_scopes.append(backend.get_scope())

--- a/test/unit/authnz/test_psa_authnz.py
+++ b/test/unit/authnz/test_psa_authnz.py
@@ -29,6 +29,10 @@ from jwt import (
     InvalidSignatureError,
 )
 from social_core.backends.open_id_connect import OpenIdConnectAuth
+from social_core.utils import (
+    module_member,
+    setting_name,
+)
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -37,8 +41,10 @@ from galaxy.authnz.managers import AuthnzManager
 from galaxy.authnz.oidc_utils import decode_access_token as decode_access_token_oidc
 from galaxy.authnz.psa_authnz import (
     AUTH_PIPELINE,
+    BACKENDS,
     decode_access_token,
     PSAAuthnz,
+    Strategy,
     sync_user_profile,
 )
 
@@ -586,3 +592,78 @@ def test_authenticate_does_not_mutate_backend_default_scope(psa_authnz):
     expected = ["offline_access", "custom_scope", "openid", "email", "profile"]
     assert observed_scopes == [expected, expected]
     assert shared_default_scope == ["openid", "email", "profile"]
+
+
+@pytest.mark.parametrize("provider, backend_path", BACKENDS.items())
+def test_configured_extra_scopes_are_requested_without_mutating_backend_default_scope(provider, backend_path):
+    """
+    Verify the actual backend classes Galaxy uses request configured scopes via
+    social-core's SCOPE setting without mutating the backend's DEFAULT_SCOPE.
+    """
+    extra_scopes = ["offline_access", "custom_scope"]
+    backend_class = module_member(backend_path)
+    original_default_scope = backend_class.DEFAULT_SCOPE
+    expected_default_scope = list(original_default_scope or [])
+    config = {
+        "provider": provider,
+        "redirect_uri": "https://galaxy.example.com/authnz/callback",
+        setting_name("SCOPE"): extra_scopes,
+    }
+    trans = make_mock_trans()
+    strategy = Strategy(trans.request, trans.session, None, config)
+
+    try:
+        backend = backend_class(strategy, config["redirect_uri"])
+        observed_scopes = backend.get_scope()
+
+        assert observed_scopes == extra_scopes + expected_default_scope
+        assert backend_class.DEFAULT_SCOPE is original_default_scope
+        assert list(backend_class.DEFAULT_SCOPE or []) == expected_default_scope
+    finally:
+        backend_class.DEFAULT_SCOPE = original_default_scope
+
+
+@pytest.mark.parametrize("provider, backend_path", BACKENDS.items())
+def test_authenticate_with_real_backend_does_not_accumulate_extra_scopes(psa_authnz, provider, backend_path):
+    """
+    Verify repeated authenticate() calls request the same scope list when using
+    the actual backend classes Galaxy supports, even if a backend instance is
+    reused across calls.
+    """
+    extra_scopes = ["offline_access", "custom_scope"]
+    backend_class = module_member(backend_path)
+    original_default_scope = backend_class.DEFAULT_SCOPE
+    expected_default_scope = list(original_default_scope or [])
+    backend_instance = None
+    observed_scopes = []
+
+    psa_authnz.config["provider"] = provider
+    psa_authnz.config[setting_name("SCOPE")] = extra_scopes
+
+    def fake_load_backend(strategy, redirect_uri):
+        nonlocal backend_instance
+        if backend_instance is None:
+            backend_instance = backend_class(strategy, redirect_uri)
+        else:
+            backend_instance.strategy = strategy
+        return backend_instance
+
+    def fake_do_auth(backend):
+        observed_scopes.append(backend.get_scope())
+        return MagicMock()
+
+    try:
+        with (
+            patch("galaxy.authnz.psa_authnz.on_the_fly_config"),
+            patch.object(psa_authnz, "_load_backend", side_effect=fake_load_backend),
+            patch("galaxy.authnz.psa_authnz.do_auth", side_effect=fake_do_auth),
+        ):
+            psa_authnz.authenticate(make_mock_trans())
+            psa_authnz.authenticate(make_mock_trans())
+
+        expected_scope = extra_scopes + expected_default_scope
+        assert observed_scopes == [expected_scope, expected_scope]
+        assert backend_class.DEFAULT_SCOPE is original_default_scope
+        assert list(backend_class.DEFAULT_SCOPE or []) == expected_default_scope
+    finally:
+        backend_class.DEFAULT_SCOPE = original_default_scope

--- a/test/unit/authnz/test_psa_authnz.py
+++ b/test/unit/authnz/test_psa_authnz.py
@@ -536,3 +536,36 @@ def test_sync_user_profile_updates_when_account_interface_disabled():
     manager.update_username.assert_called_once_with(trans, user, "newname", commit=False)
     assert session.commit.call_count == 1
     notify.assert_called_once()
+
+
+def test_authenticate_does_not_mutate_backend_default_scope(psa_authnz):
+    """
+    Previously had a bug where the backend default scope was being mutated
+    when extra scopes were added to the config. This test ensures that
+    the backend default scope is not mutated, and the scopes
+    remain the same across multiple calls to authenticate().
+    """
+    shared_default_scope = ["openid", "email", "profile"]
+    psa_authnz.config["EXTRA_SCOPES"] = ["offline_access", "custom_scope"]
+
+    class FakeBackend:
+        name = "oidc"
+        DEFAULT_SCOPE = shared_default_scope
+
+    observed_scopes = []
+
+    def fake_do_auth(backend):
+        observed_scopes.append(list(backend.DEFAULT_SCOPE))
+        return MagicMock()
+
+    with (
+        patch("galaxy.authnz.psa_authnz.on_the_fly_config"),
+        patch.object(psa_authnz, "_load_backend", side_effect=[FakeBackend(), FakeBackend()]),
+        patch("galaxy.authnz.psa_authnz.do_auth", side_effect=fake_do_auth),
+    ):
+        psa_authnz.authenticate(make_mock_trans())
+        psa_authnz.authenticate(make_mock_trans())
+
+    expected = ["openid", "email", "profile", "offline_access", "custom_scope"]
+    assert observed_scopes == [expected, expected]
+    assert shared_default_scope == ["openid", "email", "profile"]


### PR DESCRIPTION
Ran into a bug where OIDC login gradually accrues more and more repetitions of the requested scopes (when using `extra_scopes` in the OIDC backend config).

It looks like this is because the backend's  `DEFAULT_SCOPE` is mutated during authentication to add the extra scopes. On every request, an extra copy of the extra scopes is appended. Example seen in my testing:

`scope=openid profile email roles offline_access https://dev.gvl.org.au/api:* roles offline_access https://dev.gvl.org.au/api:* roles offline_access https://dev.gvl.org.au/api:*`

The `social-core` library we use already has a mechanism for combining default with custom scopes, we just need to set the config correctly.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
