### PR TITLE
Report test-case state-building errors instead of raising

### DIFF
--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -358,17 +358,26 @@ def _input_name_was_handled_by_legacy_fallback(input_name: str, handled_inputs: 
 def test_case_validation(
     test_dict: ToolSourceTest, tool_parameter_bundle: List[ToolParameterT], profile: str, name: Optional[str] = None
 ) -> TestCaseStateValidationResult:
-    test_case_state_and_warnings = test_case_state(test_dict, tool_parameter_bundle, profile, validate=False)
     exception: Optional[Exception] = None
+    # Build the test-case state inside the try as well: turning the test inputs into
+    # state (resolving conditional ``when`` branches, coercing typed values, expanding
+    # repeats) can itself raise on a malformed test case. This function's contract is
+    # to *report* such problems as a validation error, so any failure here is captured
+    # like a model-validation failure rather than escaping to the caller.
+    tool_state: TestCaseToolState = TestCaseToolState({})
+    warnings: List[str] = []
     try:
-        test_case_state_and_warnings.tool_state.validate(tool_parameter_bundle, name=name)
+        test_case_state_and_warnings = test_case_state(test_dict, tool_parameter_bundle, profile, validate=False)
+        tool_state = test_case_state_and_warnings.tool_state
+        warnings = test_case_state_and_warnings.warnings
+        tool_state.validate(tool_parameter_bundle, name=name)
         for input_name in test_case_state_and_warnings.unhandled_inputs:
             raise Exception(f"Invalid parameter name found {input_name}")
     except Exception as e:
         exception = e
     return TestCaseStateValidationResult(
-        test_case_state_and_warnings.tool_state,
-        test_case_state_and_warnings.warnings,
+        tool_state,
+        warnings,
         exception,
         tool_parameter_bundle,
         profile,

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -85,6 +85,54 @@ def test_parameter_test_cases_validate():
     assert validation_result[2].validation_error
 
 
+def _validate_inline_tool(tmp_path, name: str, inputs: str, test_body: str):
+    tool = (
+        f'<tool id="{name}" name="t" version="1.0" profile="24.2">'
+        "<command>echo</command>"
+        f"<inputs>{inputs}</inputs>"
+        '<outputs><data name="o" format="txt"/></outputs>'
+        f"<tests><test>{test_body}"
+        '<output name="o"><assert_contents><has_text text="x"/></assert_contents></output>'
+        "</test></tests>"
+        "</tool>"
+    )
+    path = tmp_path / f"{name}.xml"
+    path.write_text(tool)
+    return validate_test_cases_for_tool_source(get_tool_source(str(path)), use_latest_profile=True)
+
+
+def test_malformed_test_case_is_reported_not_raised(tmp_path):
+    # Building the test-case state can fail on a malformed test (coercing a typed
+    # value, resolving a conditional ``when`` branch). validate_test_cases_for_tool_source
+    # must report these as a validation error rather than raising out of the call.
+
+    # A non-numeric value for an integer/float parameter (int()/float() coercion).
+    for param_type in ("integer", "float"):
+        results = _validate_inline_tool(
+            tmp_path,
+            f"numeric_{param_type}",
+            f'<param name="n" type="{param_type}" value="1"/>',
+            '<param name="n" value="not_a_number"/>',
+        )
+        assert results[0].validation_error is not None
+
+    # A conditional test value that selects no ``when`` branch.
+    cond_inputs = (
+        '<conditional name="c"><param name="mode" type="select">'
+        '<option value="a">A</option><option value="b">B</option></param>'
+        '<when value="a"><param name="x" type="integer" value="1"/></when>'
+        '<when value="b"><param name="y" type="integer" value="1"/></when>'
+        "</conditional>"
+    )
+    results = _validate_inline_tool(
+        tmp_path,
+        "cond_unknown",
+        cond_inputs,
+        '<conditional name="c"><param name="mode" value="nosuch"/></conditional>',
+    )
+    assert results[0].validation_error is not None
+
+
 def test_legacy_features_fail_validation_with_24_2(tmp_path):
     for filename in TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS:
         _assert_tool_test_parsing_only_fails_with_newer_profile(tmp_path, filename, index=None)


### PR DESCRIPTION
Fixes #23001.

`validate_test_cases_for_tool_source()` is meant to return a per-test validation result, but in `test_case_validation()` only the model validation and the unhandled-parameter-name check ran inside the `try/except` that records `validation_error`. Building the test-case state (`test_case_state()`) ran *before* it, so any failure there escaped the whole call:

- a conditional test value that selects no `when` branch (`Invalid conditional test value ...`),
- a non-numeric value for an `integer` / `float` parameter (`legacy_from_string` `int()` / `float()`),
- other malformed test inputs handled while building state.

A caller validating tools it does not control — the 24.2 upgrade advisor, planemo / lint, CI — then aborts instead of reporting the test case as invalid.

This moves `test_case_state()` inside the `try`, so a state-building failure is captured as that test's `validation_error`, exactly like the existing `tool_state.validate(...)` failure and the "Invalid parameter name found" check. When state building fails the result falls back to an empty tool state.

Across the public Galaxy tool corpus this converts **113 of 159** tools that previously crashed the validator into reported validation errors. The remaining 46 fail earlier (during parameter-model construction or XML parsing) and are out of scope for this change.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

`test/unit/tool_util/test_parameter_test_cases.py::test_malformed_test_case_is_reported_not_raised` builds tools with (a) a non-numeric value for an integer/float parameter and (b) a conditional test value that selects no `when`, and asserts the validator returns a `validation_error` for each instead of raising.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
