### PR TITLE
Report tool-model / test-parse failures in test-case validation; fix Infinity in_range bound

### DIFF
--- a/lib/galaxy/tool_util/parameters/case.py
+++ b/lib/galaxy/tool_util/parameters/case.py
@@ -669,13 +669,21 @@ def validate_test_cases_for_tool_source(
     tool_source: ToolSource, use_latest_profile: bool = False, name: Optional[str] = None
 ) -> List[TestCaseStateValidationResult]:
     name = name or f"PydanticModelFor[{tool_source.parse_id()}]"
-    tool_parameter_bundle = input_models_for_tool_source(tool_source)
     if use_latest_profile:
         # this might get old but it is fine, just needs to be updated when test case changes are made
         profile = "26.1"
     else:
         profile = tool_source.parse_profile()
-    test_cases: List[ToolSourceTest] = tool_source.parse_tests_to_dict()["tests"]
+    # Building the parameter model or parsing the test cases can itself raise on a tool
+    # whose parameters cannot be modeled (e.g. an unknown parameter type) or whose
+    # <test> block is malformed. This function's contract is to *report* such problems,
+    # so capture the failure as a single validation result rather than raising out to
+    # the caller (the upgrade advisor, planemo / lint, CI).
+    try:
+        tool_parameter_bundle = input_models_for_tool_source(tool_source)
+        test_cases: List[ToolSourceTest] = tool_source.parse_tests_to_dict()["tests"]
+    except Exception as e:
+        return [TestCaseStateValidationResult(TestCaseToolState({}), [], e, [], profile)]
     results_by_test: List[TestCaseStateValidationResult] = []
     for test_case in test_cases:
         validation_result = test_case_validation(test_case, tool_parameter_bundle.parameters, profile, name=name)

--- a/lib/galaxy/tool_util/parser/parameter_validators.py
+++ b/lib/galaxy/tool_util/parser/parameter_validators.py
@@ -243,7 +243,11 @@ def _parse_int(xml_el: Element, attribute: str) -> Optional[int]:
 
 def _parse_number(xml_el: Element, attribute: str) -> Optional[Union[float, int]]:
     raw_value = xml_el.get(attribute)
-    if raw_value and ("." in raw_value or "e" in raw_value or "inf" in raw_value):
+    # Match the float forms case-insensitively: "Infinity"/"Inf"/"INF" and scientific
+    # notation such as "1E5" would otherwise fall through to int() and raise, even
+    # though float() parses them (e.g. an in_range validator with max="Infinity").
+    lowered = raw_value.lower() if raw_value else ""
+    if raw_value and ("." in lowered or "e" in lowered or "inf" in lowered):
         return float(raw_value)
     elif raw_value:
         return int(raw_value)

--- a/test/unit/tool_util/test_parameter_test_cases.py
+++ b/test/unit/tool_util/test_parameter_test_cases.py
@@ -85,6 +85,44 @@ def test_parameter_test_cases_validate():
     assert validation_result[2].validation_error
 
 
+def test_unmodelable_tool_is_reported_not_raised(tmp_path):
+    # A tool whose parameter model cannot be built (here, an unknown parameter type)
+    # must be reported as a validation error, not raise out of the validator.
+    tool = (
+        '<tool id="badtype" name="t" version="1.0" profile="24.2"><command>echo</command>'
+        '<inputs><param name="n" type="not_a_real_type"/></inputs>'
+        '<outputs><data name="o" format="txt"/></outputs>'
+        '<tests><test><param name="n" value="x"/>'
+        '<output name="o"><assert_contents><has_text text="x"/></assert_contents></output>'
+        "</test></tests></tool>"
+    )
+    path = tmp_path / "badtype.xml"
+    path.write_text(tool)
+    results = validate_test_cases_for_tool_source(get_tool_source(str(path)), use_latest_profile=True)
+    assert results
+    assert results[0].validation_error is not None
+
+
+def test_infinity_in_range_validator_bound_does_not_crash(tmp_path):
+    # An in_range validator bound written as "Infinity" must parse as float("inf")
+    # rather than crash int("Infinity") while building the parameter model, so a
+    # tool that uses it validates normally. (A float parameter is used because an
+    # integer field cannot carry an le=inf bound in the underlying pydantic model.)
+    tool = (
+        '<tool id="inf" name="t" version="1.0" profile="24.2"><command>echo</command>'
+        '<inputs><param name="n" type="float" value="1">'
+        '<validator type="in_range" min="0" max="Infinity"/></param></inputs>'
+        '<outputs><data name="o" format="txt"/></outputs>'
+        '<tests><test><param name="n" value="5"/>'
+        '<output name="o"><assert_contents><has_text text="x"/></assert_contents></output>'
+        "</test></tests></tool>"
+    )
+    path = tmp_path / "inf.xml"
+    path.write_text(tool)
+    results = validate_test_cases_for_tool_source(get_tool_source(str(path)), use_latest_profile=True)
+    assert results[0].validation_error is None
+
+
 def test_legacy_features_fail_validation_with_24_2(tmp_path):
     for filename in TOOLS_THAT_USE_UNQUALIFIED_PARAMETER_ACCESS:
         _assert_tool_test_parsing_only_fails_with_newer_profile(tmp_path, filename, index=None)


### PR DESCRIPTION
Fixes #23003.

`validate_test_cases_for_tool_source()` builds the parameter model (`input_models_for_tool_source`) and parses the test cases (`parse_tests_to_dict`) *before* its per-test loop, outside any `try/except`. A tool whose model cannot be built (e.g. an unknown parameter type) or whose `<test>` block is malformed therefore raised an unhandled exception out of the whole call, so a caller validating tools it does not control (the 24.2 upgrade advisor, planemo / lint, CI) aborted instead of reporting the tool.

This change has two parts:

1. **Report, don't raise (holistic).** Wrap the model build + test parsing so a failure becomes a single reported `TestCaseStateValidationResult` with the error, rather than escaping. This addresses the model-construction / test-parsing layer — **31 tools** across the public Galaxy tool corpus.

2. **`_parse_number` `Infinity` fix (targeted).** An `in_range` validator bound written `Infinity` (or `Inf`, or scientific notation like `1E5`) fell through the case-sensitive float check (`"inf" in raw_value`) to `int()`, which raised, even though `float()` parses it. The check is now case-insensitive, so such a tool validates instead of crashing.

This complements #23002, which fixes the same "report, don't raise" gap one layer in (per-test state building). With both, the validator goes from 159 crashing corpus tools to 15; the remaining 15 fail earlier in `get_tool_source` (malformed XML, or a macro file missing from the checkout), before this function is reached.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

`test/unit/tool_util/test_parameter_test_cases.py`:
- `test_unmodelable_tool_is_reported_not_raised` — a tool with an unknown parameter type is reported (`validation_error`), not raised.
- `test_infinity_in_range_validator_bound_does_not_crash` — a tool with an `in_range` `max="Infinity"` validates cleanly.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
