### PR TITLE
Also lint ITs

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -402,7 +402,7 @@ def lint_tool_source_with_modules(lint_context: LintContext, tool_source, linter
 
     for module in linter_modules:
         module_name = module.__name__.split(".")[-1]
-        lint_tool_types = getattr(module, "lint_tool_types", ["default", "manage_data"])
+        lint_tool_types = getattr(module, "lint_tool_types", ["default", "manage_data", "interactive"])
         if not ("*" in lint_tool_types or tool_type in lint_tool_types):
             continue
 


### PR DESCRIPTION
Messages for EUs tools are: 

```
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_anylabeling_0.4.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_anylabeling.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_askomics.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_audiolabeler.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_bam_iobio.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_bellavista.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_blobtoolkit.xml
.. WARNING (OutputsNameInvalidCheetah): Tool output name [Interactive BlobToolKit on data ${on_string}] is not a valid Cheetah placeholder.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_celljourney.xml
.. WARNING (OutputsNameInvalidCheetah): Tool output name [Interactive CellJourney on data ${on_string}] is not a valid Cheetah placeholder.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellpose.xml
.. WARNING (HelpEmpty): Help section appears to be empty.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellprofiler.xml
.. WARNING (HelpEmpty): Help section appears to be empty.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellxgene_0.16.2.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellxgene_1.1.1.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellxgene_1.3.0.xml
.. WARNING (XMLOrder): Best practice violation [stdio] elements should come before [environment_variables]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellxgene_mouse_sciatic_nerve.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellxgene_VIP_3.1.xml
.. WARNING (HelpInvalidRST): Invalid reStructuredText found in help - [<string>:3: (WARNING/2) Title underline too short.

CELLxGENE VIP - "Cell by gene" plugin to visualize scRNA-seq, spatial transcriptomics, and multiome data.
=============================================================================
].
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_cellxgene.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_climate_notebook.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
.. WARNING (HelpInvalidRST): Invalid reStructuredText found in help - [<string>:22: (WARNING/2) Block quote ends without a blank line; unexpected unindent.
].
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_copasi.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_copernicus.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_divand.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
.. WARNING (CitationsInvalid): Citation 'doi:10.5194/gmd-7-225-2014' uses the legacy 'doi:' prefix; use the bare DOI '10.5194/gmd-7-225-2014' instead.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_dot.xml
.. WARNING (OutputsNameInvalidCheetah): Tool output name [Interactive Dot Viewer on data ${on_string}] is not a valid Cheetah placeholder.
.. WARNING (HelpInvalidRST): Invalid reStructuredText found in help - [<string>:18: (WARNING/2) Inline emphasis start-string without end-string.
].
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_ethercalc.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_genenotebook.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_geoexplorer.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (HelpInvalidRST): Invalid reStructuredText found in help - [<string>:13: (WARNING/2) Inline strong start-string without end-string.
].
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_guacamole_desktop.xml
.. WARNING (InputsMissing): Found no input parameters.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_hdfview.xml
.. WARNING (ToolVersionPEP404): Tool version [@TOOL_VERSION@] is not compliant with PEP 440.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_hicbrowser.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_higlass.xml
.. ERROR (XSD): Invalid XML: Element 'xml': This element is not expected.
.. WARNING (XMLOrder): Best practice violation [macros] elements should come before [environment_variables]
.. WARNING (ConditionalParamTypeBool): Conditional [labeled] first param of type="boolean" is discouraged, use a select
.. WARNING (HelpInvalidRST): Invalid reStructuredText found in help - [<string>:34: (WARNING/2) Document may not end with a transition.
].
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_holoviz.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_ideal.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_ilastik.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_isee.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_jupytergis_notebook.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_jupyter_notebook_1.0.0.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_jupyter_notebook_1.0.1.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_jupyter_notebook_1.0.2.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_jupyter_notebook_1.0.3.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_jupyter_notebook.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_libertem.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_loom.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsMissing): Found no input parameters.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_metashark.xml
.. WARNING (InputsMissing): Found no input parameters.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_metashrimps.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_mgnify_notebook_1.2.2.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_mgnify_notebook.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_ml_jupyter_notebook_0.2.xml
.. ERROR (XSD): Invalid XML: Element 'param', attribute 'required': The attribute 'required' is not allowed.
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_ml_jupyter_notebook.xml
.. ERROR (XSD): Invalid XML: Element 'param', attribute 'required': The attribute 'required' is not allowed.
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_napari_0.7.0.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_napari_0.7.1.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_napari.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_neo4j.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_odv_5_8.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_odv.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_openrefine.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_pampa.xml
.. WARNING (InputsMissing): Found no input parameters.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_pangeo_ml_notebook.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_pangeo_notebook.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_panoply.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_paraview.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_pavian.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_pcstudio.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_phinch.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_phyloseq.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_pretextview.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_pyiron.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_qgis3_34.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_qgis.xml
.. WARNING (HelpEmpty): Help section appears to be empty.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_qiskit_jupyter_notebook.xml
.. ERROR (XSD): Invalid XML: Element 'variable': This element is not expected. Expected is ( secret ).
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [configfiles]
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_qupath_0.6.0.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_qupath.xml
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_radiant.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_rstudio_0_3.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsMissing): Found no input parameters.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_rstudio_24.1.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsMissing): Found no input parameters.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_rstudio_askor.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsMissing): Found no input parameters.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_rstudio_bioc_3.20.xml
.. ERROR (XSD): Invalid XML: Element 'icon': This element is not expected.
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [inputs]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_rstudio.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsMissing): Found no input parameters.
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_scoop3.xml
.. WARNING (HelpInvalidRST): Invalid reStructuredText found in help - [<string>:3: (WARNING/2) Block quote ends without a blank line; unexpected unindent.
].
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_scop3p_toolkit.xml
.. ERROR (XSD): Invalid XML: Element 'data', attribute 'help': The attribute 'help' is not allowed.
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (XMLOrder): Best practice violation [stdio] elements should come before [command]
.. WARNING (InputsMissing): Found no input parameters.
.. WARNING (HelpInvalidRST): Invalid reStructuredText found in help - [<string>:30: (WARNING/2) Title underline too short.

Using this Toolkit
=================
].
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_simtext_app.xml
.. WARNING (InputsNameRedundantArgument): Param input [input] 'name' attribute is redundant if argument implies the same name.
.. WARNING (InputsNameRedundantArgument): Param input [matrix] 'name' attribute is redundant if argument implies the same name.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_source.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsDataFormat): Param input [input] with no format specified - 'data' format will be assumed.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_stac.xml
.. WARNING (InputsMissing): Found no input parameters.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_tadviewer.xml
.. WARNING (OutputsOutput): Avoid the use of 'output' and replace by 'data' or 'collection'
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_vcf_iobio.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_vrm_editor.xml
.. WARNING (CitationsMissing): No citations found, consider adding citations to your tool.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_wallace.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
.. WARNING (InputsMissing): Found no input parameters.
Failed linting
Linting tool /home/berntm/projects/galaxyproject/galaxy/tools/interactive/interactivetool_wilson.xml
.. WARNING (XMLOrder): Best practice violation [command] elements should come before [environment_variables]
Failed linting
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
