### PR TITLE
Add RMSX JSON datatype and Flipbook visualization registration

### DIFF
--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -108,6 +108,9 @@ plyr:
 rerunio:
     package: "@galaxyproject/rerunio"
     version: 0.0.0
+rmsx-flipbook:
+    package: "@finn2400/rmsx-flipbook"
+    version: 0.0.1
 tabulator:
     package: "@galaxyproject/tabulator"
     version: 0.0.11

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -110,7 +110,7 @@ rerunio:
     version: 0.0.0
 rmsxflipbook:
     package: "@galaxyproject/rmsxflipbook"
-    version: 0.0.1
+    version: 0.0.2
 tabulator:
     package: "@galaxyproject/tabulator"
     version: 0.0.11

--- a/client/visualizations.yml
+++ b/client/visualizations.yml
@@ -108,8 +108,8 @@ plyr:
 rerunio:
     package: "@galaxyproject/rerunio"
     version: 0.0.0
-rmsx-flipbook:
-    package: "@finn2400/rmsx-flipbook"
+rmsxflipbook:
+    package: "@galaxyproject/rmsxflipbook"
     version: 0.0.1
 tabulator:
     package: "@galaxyproject/tabulator"

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -159,6 +159,7 @@
     <datatype extension="d3_hierarchy" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true"/>
     <datatype extension="cytoscapejson" type="galaxy.datatypes.text:CytoscapeJson" mimetype="application/json" display_in_upload="true" description="Cytoscape JSON format for network visualization, typically containing 'nodes' and 'edges' in a JSON object." description_url="https://js.cytoscape.org/#notation/elements-json" />
     <datatype extension="freq.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="True" description="A JSON-formatted array of objects containing longitude, latitude, and frequency attributes."/>
+    <datatype extension="rmsx.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true" description="RMSX Molstar viewer manifest containing per-slice structures and residue-level RMSX values."/>
     <datatype extension="imgt.json" type="galaxy.datatypes.text:ImgtJson" mimetype="application/json" display_in_upload="True"/>
     <datatype extension="geojson" type="galaxy.datatypes.text:GeoJson" mimetype="application/json" display_in_upload="True">
       <visualization plugin="openlayers" />

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -159,7 +159,9 @@
     <datatype extension="d3_hierarchy" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true"/>
     <datatype extension="cytoscapejson" type="galaxy.datatypes.text:CytoscapeJson" mimetype="application/json" display_in_upload="true" description="Cytoscape JSON format for network visualization, typically containing 'nodes' and 'edges' in a JSON object." description_url="https://js.cytoscape.org/#notation/elements-json" />
     <datatype extension="freq.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="True" description="A JSON-formatted array of objects containing longitude, latitude, and frequency attributes."/>
-    <datatype extension="rmsx.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true" description="RMSX Molstar viewer manifest containing per-slice structures and residue-level RMSX values."/>
+    <datatype extension="rmsx.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="true" description="RMSX Molstar viewer manifest containing per-slice structures and residue-level RMSX values.">
+      <visualization plugin="rmsxflipbook" />
+    </datatype>
     <datatype extension="imgt.json" type="galaxy.datatypes.text:ImgtJson" mimetype="application/json" display_in_upload="True"/>
     <datatype extension="geojson" type="galaxy.datatypes.text:GeoJson" mimetype="application/json" display_in_upload="True">
       <visualization plugin="openlayers" />

--- a/test/unit/data/datatypes/test_datatypes_registry.py
+++ b/test/unit/data/datatypes/test_datatypes_registry.py
@@ -2,6 +2,16 @@ from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import example_datatype_registry_for_sample
 
 
+def test_rmsx_json_datatype_registered():
+    datatypes_registry = example_datatype_registry_for_sample()
+    rmsx_json_datatype = datatypes_registry.get_datatype_by_extension("rmsx.json")
+
+    assert datatypes_registry.datatypes_by_extension["rmsx.json"] is rmsx_json_datatype
+    assert rmsx_json_datatype.__class__.__name__ == "Json"
+    assert rmsx_json_datatype.get_mime() == "application/json"
+    assert "rmsx.json" in datatypes_registry.upload_file_formats
+
+
 def test_matches_any():
     datatypes_registry = example_datatype_registry_for_sample()
     data_datatype = datatypes_registry.get_datatype_by_extension("data")

--- a/test/unit/data/datatypes/test_datatypes_registry.py
+++ b/test/unit/data/datatypes/test_datatypes_registry.py
@@ -2,16 +2,6 @@ from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import example_datatype_registry_for_sample
 
 
-def test_rmsx_json_datatype_registered():
-    datatypes_registry = example_datatype_registry_for_sample()
-    rmsx_json_datatype = datatypes_registry.get_datatype_by_extension("rmsx.json")
-
-    assert datatypes_registry.datatypes_by_extension["rmsx.json"] is rmsx_json_datatype
-    assert rmsx_json_datatype.__class__.__name__ == "Json"
-    assert rmsx_json_datatype.get_mime() == "application/json"
-    assert "rmsx.json" in datatypes_registry.upload_file_formats
-
-
 def test_matches_any():
     datatypes_registry = example_datatype_registry_for_sample()
     data_datatype = datatypes_registry.get_datatype_by_extension("data")


### PR DESCRIPTION
## Summary

- add lightweight `rmsx.json` datatype registration as a JSON subclass with `application/json` mimetype
- add a registry test covering extension lookup, mimetype, class, and upload visibility
- register the published Flipbook visualization as `@galaxyproject/rmsxflipbook@0.0.2`

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest test/unit/data/datatypes/test_datatypes_registry.py -q` (4 passed)
- `make update-client-api-schema` (both generated clients reproduced with no tracked changes)
- YAML parse/assertion check for `client/visualizations.yml`
- npm registry verification for `@galaxyproject/rmsxflipbook@0.0.2`
- [full runtime workflow](https://github.com/AntunesLab/rmsx-galaxy/actions/runs/29756467847) (example smoke test, Planemo/Galaxy wrapper tests, GHCR publish, and anonymous image pull all passed)

## Related work

- galaxyproject/galaxy-visualizations#172, #173, and #174 provide the viewer, npm package, and real 1UBQ/mon_sys example
- galaxyproject/galaxy-test-data#83 provides the matching public Galaxy sample
- the ToolShed wrapper will be proposed to `galaxycomputationalchemistry/galaxy-tools-compchem` after this datatype registration lands
