### PR TITLE
GitHub workflows updates in preparation for ubuntu-26.04

### DIFF
--- a/.github/actions/install_apptainer/action.yaml
+++ b/.github/actions/install_apptainer/action.yaml
@@ -1,0 +1,37 @@
+name: Install Apptainer
+description: Install Apptainer's singularity from the official PPA
+runs:
+  using: "composite"
+  steps:
+    - name: Add Apptainer official PPA
+      run: |
+        sudo add-apt-repository -y ppa:apptainer/ppa
+      shell: bash
+    - name: Force APT to treat this PPA as a standard amd64 repository
+      # Otherwise apt will ignore the amd64 packages from the PPA and install
+      # the amd64v3 version from the Ubuntu repositories.
+      run: |
+        CODENAME=$(lsb_release -sc)
+        FILE="/etc/apt/sources.list.d/apptainer-ubuntu-ppa-${CODENAME}.sources"
+        # Only relevant for distro releases that use the new DEB822 .sources files
+        if [ -f "$FILE" ]; then
+            sudo sed -i "/Suites:/a Architectures: amd64" "$FILE"
+        fi
+      shell: bash
+    - name: Prefer the packages from the PPA
+      run: |
+        sudo tee /etc/apt/preferences.d/pin-apptainer-ppa <<EOF
+        Package: *
+        Pin: release o=LP-PPA-apptainer-ppa
+        Pin-Priority: 1001
+        EOF
+      shell: bash
+    - name: Install apptainer package
+      run: |
+        sudo apt-get update
+        # Diagnostic: Check what APT thinks before installing
+        apt policy apptainer
+        # Need to explicitly install squashfuse due to
+        # https://bugs.launchpad.net/ubuntu/+source/apptainer/+bug/2152206
+        sudo apt-get -y install apptainer squashfuse
+      shell: bash

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -52,20 +52,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-api
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Run tests
         run: ./run_tests.sh --coverage --skip_flakey_fails -api lib/galaxy_test/api -- --num-shards=2 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'

--- a/.github/workflows/bioblend.yaml
+++ b/.github/workflows/bioblend.yaml
@@ -50,18 +50,14 @@ jobs:
       - name: Calculate Python version for BioBlend from tox_env
         id: get_bioblend_python_version
         run: echo "bioblend_python_version=$(echo "${{ matrix.tox_env }}" | sed -e 's/^py\([3-9]\)\([0-9]\+\)/\1.\2/')" >> $GITHUB_OUTPUT
-      - name: Set up Python for BioBlend
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ steps.get_bioblend_python_version.outputs.bioblend_python_version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
       - name: Install tox
-        run: uv tool install tox --with tox-uv
+        run: uv tool install --python ${BIOBLEND_PYTHON_VERSION} tox --with tox-uv
+        env:
+          BIOBLEND_PYTHON_VERSION: ${{ steps.get_bioblend_python_version.outputs.bioblend_python_version }}
       - name: Set up Python for Galaxy
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.galaxy_python_version }}
+        run: uv python install ${{ matrix.galaxy_python_version }}
       - name: Run tests
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -85,7 +85,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v6.2.0
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
       - name: Set outputs
         id: commit

--- a/.github/workflows/check_test_class_names.yaml
+++ b/.github/workflows/check_test_class_names.yaml
@@ -20,11 +20,12 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Install Python dependencies
         run: uv pip install --system -r requirements.txt -r lib/galaxy/dependencies/pinned-test-requirements.txt
       - name: Run tests

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -41,11 +41,10 @@ jobs:
           repository: galaxyproject/galaxy-test-data
           path: galaxy-test-data
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Move test data
         run: rsync -av --remove-source-files --exclude .git galaxy-test-data/ 'galaxy root/test-data/'
       - name: Install planemo

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -44,20 +44,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-api
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Run tests
         run: ./run_tests.sh --coverage --skip_flakey_fails -cwl lib/galaxy_test/api/cwl -- -m "${{ matrix.marker }} and ${{ matrix.conformance-version }}"
         working-directory: 'galaxy root'

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -45,15 +45,10 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: uv tool install tox --with tox-uv
       - name: Set database connection on PostgreSQL

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -13,11 +13,10 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: '3.10'
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: '3.10'
       - name: Update dependencies
         run: make update-dependencies
       - name: Create pull request

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -36,11 +36,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - uses: nanasess/setup-chromedriver@v3
       - name: Run tests
         run: bash ./test/deployment/usegalaxystar.bash

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,13 +33,15 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies
-        run: uv pip install --system -r requirements.txt -r lib/galaxy/dependencies/dev-requirements.txt sphinxcontrib-simpleversioning
+        run: |
+          uv venv .venv
+          . .venv/bin/activate
+          uv pip install -r requirements.txt -r lib/galaxy/dependencies/dev-requirements.txt sphinxcontrib-simpleversioning
       - name: Add Google Analytics to doc/source/conf.py
         run: |
           sed -i -e "/html_theme_options = {/a\

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -35,16 +35,10 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Restore client cache
         uses: actions/cache@v5.0.5
         with:

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -48,20 +48,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-framework
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Run tests
         run: GALAXY_TEST_USE_LEGACY_TOOL_API="${{ matrix.use-legacy-api }}" ./run_tests.sh --coverage --framework-tools
         working-directory: 'galaxy root'

--- a/.github/workflows/framework_workflows.yaml
+++ b/.github/workflows/framework_workflows.yaml
@@ -48,20 +48,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-framework
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Run tests
         run: ./run_tests.sh --coverage --framework-workflows
         working-directory: 'galaxy root'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Install Python
         run: uv python install
       - name: Install Apptainer's singularity
-        uses: eWaterCycle/setup-apptainer@v2
+        uses: './galaxy root/.github/actions/install_apptainer'
       - name: Run tests
         run: |
           . .ci/minikube-test-setup/start_services.sh

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -57,20 +57,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Install Apptainer's singularity
         uses: eWaterCycle/setup-apptainer@v2
       - name: Run tests

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -59,20 +59,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration-selenium
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Restore client cache
         uses: actions/cache@v5.0.5
         with:

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -28,13 +28,11 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
-  setup-selenium:
-    uses: ./.github/workflows/setup_selenium.yaml
   build-client:
     uses: ./.github/workflows/build_client.yaml
   test:
     name: Test
-    needs: [setup-selenium, build-client]
+    needs: [build-client]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,22 +40,11 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: uv tool install tox --with tox-uv
       - name: Run linting
-        run: tox -e lint
-      - name: Run docstring linting
-        run: tox -e lint_docstring_include_list
-      - name: Run mypy checks
-        run: tox -e mypy
-      - name: Run format checks
-        run: tox -e format
+        run: tox -e lint,lint_docstring_include_list,mypy,format

--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -39,20 +39,12 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           package_json_file: 'galaxy root/client/package.json'
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-api
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Install dependencies
         run: ./scripts/common_startup.sh --dev-wheels --skip-client-build
         working-directory: 'galaxy root'

--- a/.github/workflows/main_tools.yaml
+++ b/.github/workflows/main_tools.yaml
@@ -40,20 +40,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-framework
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Run tests
         run: ./run_tests.sh --coverage --main_tools
         working-directory: 'galaxy root'

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Apptainer's singularity
-        uses: eWaterCycle/setup-apptainer@v2
+        uses: './galaxy root/.github/actions/install_apptainer'
       - name: Install tox
         run: uv tool install tox --with tox-uv
       - name: Run tests

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -29,15 +29,10 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Apptainer's singularity
         uses: eWaterCycle/setup-apptainer@v2
       - name: Install tox

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -46,20 +46,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-performance
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Run tests
         run: ./run_tests.sh --ci_test_metrics --structured_data_html --structured_data_report_file "test.json" --skip_flakey_fails -api lib/galaxy_test/performance
         working-directory: 'galaxy root'

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -58,20 +58,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-playwright
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Restore client cache
         uses: actions/cache@v5.0.5
         with:

--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -45,13 +45,11 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || '' }}
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: '3.10'
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: false
+          python-version: '3.10'
       - name: Install script dependencies
         run: uv tool install galaxy-release-util
       - name: Build Python packages

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -59,20 +59,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-selenium
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Restore client cache
         uses: actions/cache@v5.0.5
         with:

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -28,13 +28,11 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
-  setup-selenium:
-    uses: ./.github/workflows/setup_selenium.yaml
   build-client:
     uses: ./.github/workflows/build_client.yaml
   test:
     name: Test
-    needs: [setup-selenium, build-client]
+    needs: [build-client]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/setup_selenium.yaml
+++ b/.github/workflows/setup_selenium.yaml
@@ -1,8 +1,0 @@
-on:
-  workflow_call:
-jobs:
-  setup_chromedriver:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install chromedriver
-        uses: nanasess/setup-chromedriver@v3

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -25,11 +25,10 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get -y install ffmpeg
       - name: Install tox

--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -29,11 +29,10 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install Apptainer's singularity
         uses: eWaterCycle/setup-apptainer@v2
       - name: Install ffmpeg

--- a/.github/workflows/test_galaxy_packages_for_pulsar.yaml
+++ b/.github/workflows/test_galaxy_packages_for_pulsar.yaml
@@ -34,9 +34,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Apptainer's singularity
-        uses: eWaterCycle/setup-apptainer@v2
+        uses: './galaxy root/.github/actions/install_apptainer'
       - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get -y install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ffmpeg
       - name: Install tox
         run: uv tool install tox --with tox-uv
       - name: Run tests

--- a/.github/workflows/tool_form_harness.yaml
+++ b/.github/workflows/tool_form_harness.yaml
@@ -68,20 +68,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-playwright
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Install dependencies
         run: ./scripts/common_startup.sh --dev-wheels --skip-client-build
         working-directory: 'galaxy root'

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -40,20 +40,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-toolshed
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Install dependencies
         run: ./scripts/common_startup.sh --dev-wheels --skip-client-build
         working-directory: 'galaxy root'

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -40,20 +40,12 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
-      - name: Cache galaxy venv
-        uses: actions/cache@v5.0.5
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-unit-postgres
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python
+        run: uv python install
       - name: Run migration tests
         run: ./run_tests.sh -unit test/unit/data/model/migrations/test_migrations.py
         working-directory: 'galaxy root'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -29,15 +29,10 @@ jobs:
         with:
           path: 'galaxy root'
           persist-credentials: false
-      - uses: actions/setup-python@v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get -y install ffmpeg
       - name: Install tox

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -71,7 +71,7 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
 
     # Use a throw-away virtualenv
     TEST_ENV_DIR=$(mktemp -d -t gxpkgtestenvXXXXXX)
-    ${VENV_CMD} "$TEST_ENV_DIR"
+    ${VENV_CMD} "${TEST_ENV_DIR}"
     # shellcheck disable=SC1091
     . "${TEST_ENV_DIR}/bin/activate"
     if [ "${PIP_CMD}" = 'python -m pip' ]; then
@@ -115,4 +115,6 @@ while read -r package_dir || [ -n "$package_dir" ]; do  # https://stackoverflow.
         ${TWINE_CMD} check dist/*
     fi
     cd ..
+    deactivate
+    rm -rf "${TEST_ENV_DIR}"
 done < $PACKAGE_LIST_FILE


### PR DESCRIPTION
Changes in preparation for the switch of the `ubuntu-latest` alias to `ubuntu-26.04`, see https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/

See individual commits for details.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
