### PR TITLE
[26.1] Fix error handling in object store cache

### DIFF
--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -303,6 +303,20 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             else:
                 if self._pull_into_cache(rel_path, **kwargs):
                     return cache_path
+                # Download failed - this typically indicates permission or connectivity issues
+                log.error(
+                    "Failed to pull object into cache. rel_path=%s, cache_path=%s, obj=%s",
+                    rel_path,
+                    cache_path,
+                    obj,
+                )
+        else:
+            # Object doesn't exist in cache or remote storage
+            log.debug(
+                "Object not found in cache or remote storage. rel_path=%s, obj=%s",
+                rel_path,
+                obj,
+            )
         raise ObjectNotFound(f"objectstore.get_filename, no cache_path: {obj}, kwargs: {kwargs}")
 
     def _download_directory_into_cache(self, rel_path, cache_path):

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -309,9 +309,20 @@ class S3ObjectStore(CachingConcreteObjectStore):
                 self._client.head_object(Bucket=self.bucket, Key=rel_path)
                 return True
         except ClientError as e:
-            if e.response["Error"]["Code"] == "404":
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            if error_code == "404":
                 return False
-            raise
+            # Log other errors (403 Forbidden, 401 Unauthorized, 5xx, etc.) as warnings
+            # but treat as "not found" to allow graceful degradation. The actual
+            # download/upload operation will fail with proper diagnostics if there's
+            # a real permission issue. This prevents crashes from transient errors.
+            log.warning(
+                "Error checking existence of object '%s' in S3 (error code: %s). "
+                "Treating as non-existent and will attempt operation.",
+                rel_path,
+                error_code,
+            )
+            return False
 
     def _download(self, rel_path: str) -> bool:
         local_destination = self._get_cache_path(rel_path)


### PR DESCRIPTION
Attempt to fix #23016

Some users are experiencing issues when attempting to upload files to histories when a GCS or S3 bucket object store is the selected storage location.

The `_exists_remotely` method in `s3_boto3.py` re-raises all `ClientError` exceptions except 404, causing the entire operation to crash when encountering:

- 403 Forbidden (permission denied)
- 401 Unauthorized
- 5xx server errors
- Other transient S3/GCS API errors

This is inconsistent with other methods like `_download()`, `_push_file_to_path()`, etc., which properly catch and handle ALL `ClientError` exceptions.

We suspect this might be the reason for the failure when attempting to upload some files to S3-compatible object stores, so hopefully this will help diagnose those errors.

Likely related Sentry issues:
- https://sentry.galaxyproject.org/organizations/galaxy/issues/292806/?project=7
- https://sentry.galaxyproject.org/organizations/galaxy/issues/295620/?project=7


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
