### PR TITLE
[26.1] Fix storage operation column types (Database migration)

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -12953,7 +12953,7 @@ class DatasetStorageOperationRun(Base):
     succeeded_count: Mapped[int] = mapped_column(default=0)
     failed_count: Mapped[int] = mapped_column(default=0)
     skipped_count: Mapped[int] = mapped_column(default=0)
-    total_bytes_processed: Mapped[int] = mapped_column(default=0)
+    total_bytes_processed: Mapped[int] = mapped_column(BigInteger, default=0)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 
@@ -12969,7 +12969,7 @@ class DatasetStorageOperationRunItem(Base):
     dataset_id: Mapped[int] = mapped_column(ForeignKey("dataset.id", ondelete="CASCADE"), index=True)
     state: Mapped[str] = mapped_column(String(32), index=True)
     reason_code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
-    bytes_processed: Mapped[int] = mapped_column(default=0)
+    bytes_processed: Mapped[int] = mapped_column(BigInteger, default=0)
     create_time: Mapped[datetime] = mapped_column(default=now, nullable=True)
     update_time: Mapped[datetime] = mapped_column(default=now, onupdate=now, nullable=True)
 

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/fac9c76612f9_increase_dataset_storage_operation_run_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/fac9c76612f9_increase_dataset_storage_operation_run_.py
@@ -1,0 +1,57 @@
+"""increase dataset_storage_operation_run total_bytes_processed to bigint
+
+Revision ID: fac9c76612f9
+Revises: 6925fe4c8a17
+Create Date: 2026-06-27 09:42:18.664714
+
+"""
+
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import alter_column
+
+# revision identifiers, used by Alembic.
+revision = "fac9c76612f9"
+down_revision = "6925fe4c8a17"
+branch_labels = None
+depends_on = None
+
+run_table_name = "dataset_storage_operation_run"
+run_total_bytes_column = "total_bytes_processed"
+
+item_table_name = "dataset_storage_operation_run_item"
+item_bytes_column = "bytes_processed"
+
+
+def upgrade():
+    alter_column(
+        run_table_name,
+        run_total_bytes_column,
+        existing_type=sa.INTEGER(),
+        type_=sa.BIGINT(),
+        existing_nullable=False,
+    )
+    alter_column(
+        item_table_name,
+        item_bytes_column,
+        existing_type=sa.INTEGER(),
+        type_=sa.BIGINT(),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    alter_column(
+        run_table_name,
+        run_total_bytes_column,
+        existing_type=sa.BIGINT(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )
+    alter_column(
+        item_table_name,
+        item_bytes_column,
+        existing_type=sa.BIGINT(),
+        type_=sa.INTEGER(),
+        existing_nullable=False,
+    )


### PR DESCRIPTION
Fixes #22993

Increases the byte count size (from int to bigint) in the bulk storage operations model columns to support bigger file transfers.

> [!Warning]
> This PR contains a database migration

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
