### PR TITLE
[26.1] Fix SSE dispatch cache unit tests: give queue mocks a string .name

### DIFF
--- a/test/unit/app/managers/test_sse_dispatch_cache.py
+++ b/test/unit/app/managers/test_sse_dispatch_cache.py
@@ -17,6 +17,18 @@ import pytest
 from galaxy.managers.sse_dispatch import SSEEventDispatcher
 
 
+def _fake_queue(name: str = "queue") -> MagicMock:
+    """A queue double whose ``.name`` is a real string.
+
+    ``MagicMock(name=...)`` sets the mock's repr label, not a ``.name``
+    attribute, so it must be assigned explicitly — the dispatcher's debug log
+    does ``", ".join(q.name for q in queues)``.
+    """
+    q = MagicMock()
+    q.name = name
+    return q
+
+
 @pytest.fixture
 def fake_declare():
     """Call-counting provider passed to ``SSEEventDispatcher`` via DI.
@@ -24,7 +36,7 @@ def fake_declare():
     Returns a non-empty list by default so the cache stores a value — empty
     results are intentionally not cached (see ``test_empty_result_not_cached``).
     """
-    calls: dict[str, Any] = {"count": 0, "returns": [MagicMock(name="queue")]}
+    calls: dict[str, Any] = {"count": 0, "returns": [_fake_queue()]}
 
     def _provider():
         calls["count"] += 1
@@ -117,7 +129,7 @@ def test_empty_result_not_cached(dispatcher, fake_declare):
     assert fake_declare["count"] == 2
 
     # Once the upstream starts returning a non-empty result, caching resumes.
-    fake_declare["returns"] = [MagicMock(name="queue")]
+    fake_declare["returns"] = [_fake_queue()]
     dispatcher.notify_broadcast("payload")
     dispatcher.notify_broadcast("payload")
     assert fake_declare["count"] == 3


### PR DESCRIPTION
### What did you do?

Fixed four failing unit tests in `test/unit/app/managers/test_sse_dispatch_cache.py`:

```
TypeError: sequence item 0: expected str instance, MagicMock found
```

### Why?

The debug log in `SSEEventDispatcher._send` does:

```python
", ".join(q.name for q in declare_queues) or "<none>"
```

This argument is evaluated eagerly (it is a positional arg to `log.debug`). The test fixtures built queue doubles as `MagicMock(name="queue")`, but `name` is a **reserved `Mock` constructor kwarg** — it sets the mock's repr label, not a `.name` attribute. So `q.name` returned a child `MagicMock` rather than the string `"queue"`, and `str.join` raised `TypeError`.

This is a test-only defect. In production, `all_control_queues_for_declare` returns real `kombu.Queue` objects whose `.name` is a string, so the dispatcher is correct.

### How?

Added a `_fake_queue()` helper that assigns `.name` explicitly as a string, and used it at the two fixture sites. No production code changes.

### How to test the changes?

```
pytest test/unit/app/managers/test_sse_dispatch_cache.py
```

All four tests pass.