### PR TITLE
Scottcain add run centerpanel

### DIFF
--- a/config/plugins/webhooks/iframe/__init__.py
+++ b/config/plugins/webhooks/iframe/__init__.py
@@ -1,0 +1,9 @@
+def main(trans, webhook, params):
+    url = getattr(trans.app.config, "center_panel_url", None)
+    if not url:
+        return {}
+    return {
+        "src": url,
+        "title": getattr(trans.app.config, "center_panel_title", ""),
+        "height": getattr(trans.app.config, "center_panel_height", 1000),
+    }

--- a/config/plugins/webhooks/iframe/config.yml
+++ b/config/plugins/webhooks/iframe/config.yml
@@ -1,0 +1,5 @@
+id: iframe
+type:
+  - tool
+  - workflow
+activate: true

--- a/config/plugins/webhooks/iframe/script.js
+++ b/config/plugins/webhooks/iframe/script.js
@@ -25,4 +25,4 @@
         .catch(function (e) {
             console.error("Galaxy iframe webhook error:", e);
         });
-})();
+})(); 

--- a/config/plugins/webhooks/iframe/script.js
+++ b/config/plugins/webhooks/iframe/script.js
@@ -25,4 +25,4 @@
         .catch(function (e) {
             console.error("Galaxy iframe webhook error:", e);
         });
-})(); 
+)();

--- a/config/plugins/webhooks/iframe/script.js
+++ b/config/plugins/webhooks/iframe/script.js
@@ -1,0 +1,28 @@
+(function () {
+    var galaxyRoot = typeof Galaxy !== "undefined" ? Galaxy.root : "/";
+    var container = document.getElementById("iframe");
+    if (!container) return;
+
+    fetch(galaxyRoot + "api/webhooks/iframe/data")
+        .then(function (response) {
+            return response.json();
+        })
+        .then(function (data) {
+            if (!data || !data.src) return;
+            var title = data.title || "";
+            var height = data.height || 1000;
+            var header = title
+                ? '<div id="iframe-header"><div id="iframe-name">' + title + "</div></div>"
+                : "";
+            container.innerHTML =
+                header +
+                '<iframe id="webhook-iframe" src="' +
+                data.src +
+                '" style="width:100%; height:' +
+                height +
+                'px; border:none;"></iframe>';
+        })
+        .catch(function (e) {
+            console.error("Galaxy iframe webhook error:", e);
+        });
+})();

--- a/config/plugins/webhooks/iframe/styles.css
+++ b/config/plugins/webhooks/iframe/styles.css
@@ -1,0 +1,16 @@
+#iframe {
+    border: 1px solid #adb5bd;
+    border-radius: 3px;
+    overflow: hidden;
+    margin-top: 10px;
+}
+
+#iframe-header {
+    background: #343a40;
+    padding: 10px 15px;
+}
+
+#iframe-name {
+    color: #fff;
+    font-size: 14px;
+}

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1141,6 +1141,44 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~
+``center_panel_url``
+~~~~~~~~~~~~~~~~~~
+
+:Description:
+    URL to display in an iframe panel shown to the user after a tool or
+    workflow job is submitted. When set, the iframe webhook plugin
+    included with Galaxy will embed this URL below the standard
+    job-submission confirmation message. Leave unset to disable the
+    panel. Requires the iframe webhook to be active (enabled by default
+    when webhooks_dir includes config/plugins/webhooks).
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~
+``center_panel_title``
+~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Title displayed in the header bar of the center panel iframe. Only
+    used when center_panel_url is set. Leave unset to omit the header
+    bar entirely.
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~
+``center_panel_height``
+~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Height in pixels of the center panel iframe. Only used when
+    center_panel_url is set.
+:Default: ``1000``
+:Type: int
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 ``job_working_directory``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/special_topics/webhooks.rst
+++ b/doc/source/admin/special_topics/webhooks.rst
@@ -19,6 +19,38 @@ webhook folders as you like as a comma separated list.
 Webhooks supports one additional layer of activating/deactivating by changing the ``activate: true`` in each config of each webhook.
 
 
+Built-in center panel iframe
+----------------------------
+
+Galaxy ships with an ``iframe`` webhook (``config/plugins/webhooks/iframe/``) that displays a configurable web page
+in a panel below the standard job-submission confirmation message after a user runs a tool or workflow.
+
+The webhook is active by default whenever ``webhooks_dir`` includes ``config/plugins/webhooks`` (the default value).
+It renders nothing unless ``center_panel_url`` is set in ``galaxy.yml``, so there is no visible effect for
+installations that do not configure it.
+
+To enable the center panel, add the following to your ``galaxy.yml``:
+
+.. code-block:: yaml
+
+    galaxy:
+        center_panel_url: https://example.org/your-help-or-news-page
+        center_panel_title: Resources & Help   # optional — omit to hide the header bar
+        center_panel_height: 800               # optional — defaults to 1000 px
+
+Configuration options
+^^^^^^^^^^^^^^^^^^^^^
+
+``center_panel_url``
+    URL to embed in the iframe. Leave unset (the default) to disable the panel entirely.
+
+``center_panel_title``
+    Text shown in a dark header bar above the iframe. If omitted, no header bar is rendered.
+
+``center_panel_height``
+    Height of the iframe in pixels. Defaults to ``1000``.
+
+
 Entry points
 ------------
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -901,6 +901,22 @@ galaxy:
   # webhooks used to test the webhook framework.
   #webhooks_dir: config/plugins/webhooks
 
+  # URL to display in an iframe panel shown to the user after a tool or
+  # workflow job is submitted. When set, the iframe webhook plugin included
+  # with Galaxy will embed this URL below the standard job-submission
+  # confirmation message. Leave unset to disable the panel. Requires the
+  # iframe webhook to be active (enabled by default when webhooks_dir
+  # includes config/plugins/webhooks).
+  #center_panel_url: null
+
+  # Title displayed in the header bar of the center panel iframe. Only
+  # used when center_panel_url is set. Leave unset to omit the header bar.
+  #center_panel_title: null
+
+  # Height in pixels of the center panel iframe. Only used when
+  # center_panel_url is set.
+  #center_panel_height: 1000
+
   # Each job is given a unique empty directory as its current working
   # directory. This option defines in what parent directory those
   # directories will be created.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -828,6 +828,33 @@ mapping:
           comma-separated list. Add test/functional/webhooks to this list to include the demo
           webhooks used to test the webhook framework.
 
+      center_panel_url:
+        type: str
+        default: null
+        required: false
+        desc: |
+          URL to display in an iframe panel shown to the user after a tool or workflow
+          job is submitted. When set, the iframe webhook plugin included with Galaxy will
+          embed this URL below the standard job-submission confirmation message. Leave
+          unset to disable the panel. Requires the iframe webhook to be active (enabled
+          by default when webhooks_dir includes config/plugins/webhooks).
+
+      center_panel_title:
+        type: str
+        default: null
+        required: false
+        desc: |
+          Title displayed in the header bar of the center panel iframe. Only used when
+          center_panel_url is set. Leave unset to omit the header bar entirely.
+
+      center_panel_height:
+        type: int
+        default: 1000
+        required: false
+        desc: |
+          Height in pixels of the center panel iframe. Only used when center_panel_url
+          is set.
+
       job_working_directory:
         type: str
         default: jobs_directory

--- a/lib/galaxy_test/api/test_webhooks.py
+++ b/lib/galaxy_test/api/test_webhooks.py
@@ -19,6 +19,7 @@ class TestWebhooksApi(ApiTestCase):
             "trans_object",
             "xkcd",
             "gtn",
+            "iframe",
         ]:
             assert expected_id in ids
 
@@ -26,6 +27,13 @@ class TestWebhooksApi(ApiTestCase):
         response = self._get("webhooks/trans_object/data")
         self._assert_status_code_is(response, 200)
         self._assert_has_keys(response.json(), "username")
+
+    def test_iframe_data_unconfigured(self):
+        # When center_panel_url is not set the endpoint must return an empty
+        # dict so the client-side script can silently skip rendering.
+        response = self._get("webhooks/iframe/data")
+        self._assert_status_code_is(response, 200)
+        assert response.json() == {}
 
     def _assert_are_webhooks(self, response):
         response_list = response.json()

--- a/test/functional/webhooks/iframe
+++ b/test/functional/webhooks/iframe
@@ -1,0 +1,1 @@
+../../../config/plugins/webhooks/iframe


### PR DESCRIPTION
This is a first effort add generalizing the use of the post-run job webhook that eu uses for their site so that any instance can make use of it, as mentioned in https://github.com/galaxyproject/galaxy/issues/23036

Did I vibe code it? Yes. Do the changes seem pretty minimal and straightforward? Also yes.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

I also ran Galaxy locally to test that what I expected to happen did after pressing the "run job" button.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
