### PR TITLE
[26.1] Fix My Tools favorite tag sections showing old tool versions

### DIFF
--- a/client/src/components/Panels/MyToolsLanding.vue
+++ b/client/src/components/Panels/MyToolsLanding.vue
@@ -92,7 +92,8 @@ const recentToolsInPanel = computed(() =>
 /**
  * Flatten the parent's panel sections into a single ordered list of tool ids.
  * Used to keep tools inside favorite-tag / favorite-EDAM sections in the same
- * order they appear in the default panel view.
+ * order they appear in the default panel view, while excluding older installed
+ * versions that are present in the all-tools cache but not the panel.
  */
 const orderedToolIds = computed(() => {
     const ordered: string[] = [];
@@ -123,7 +124,6 @@ const orderedToolIds = computed(() => {
         }
     }
 
-    Object.keys(props.localToolsById).forEach(appendToolId);
     return ordered;
 });
 

--- a/client/src/components/Panels/ToolBoxSearch.test.ts
+++ b/client/src/components/Panels/ToolBoxSearch.test.ts
@@ -305,6 +305,32 @@ describe("ToolBox search", () => {
         ).toBe(false);
     });
 
+    it("does not include tagged tool versions that are outside the default panel", async () => {
+        const oldVersion = {
+            ...toolsList.find((tool) => tool.id === "__FILTER_EMPTY_DATASETS__")!,
+            id: "__FILTER_EMPTY_DATASETS_OLD__",
+            name: "Old Filter empty",
+            version: "0.9.0",
+        };
+        const { wrapper } = mountToolBox({
+            currentUser: SIGNED_IN_USER,
+            tools: [...toolsList, oldVersion],
+            favorites: { tags: ["data_cleanup"] },
+        });
+        await flushPromises();
+
+        const dataCleanupSection = wrapper
+            .findAll(".toolSectionTitle")
+            .wrappers.find((item) => item.text().includes("data_cleanup"));
+        expect(dataCleanupSection).toBeTruthy();
+        await dataCleanupSection?.find(".title-link").trigger("click");
+        await flushPromises();
+
+        expect(wrapper.find('[data-tool-id="__FILTER_EMPTY_DATASETS__"]').exists()).toBe(true);
+        expect(wrapper.find('[data-tool-id="__FILTER_EMPTY_DATASETS_OLD__"]').exists()).toBe(false);
+        expect(wrapper.text()).not.toContain("Old Filter empty");
+    });
+
     it("renders top-level favorites in the stored mixed-type order", async () => {
         const { wrapper } = mountToolBox({
             currentUser: SIGNED_IN_USER,


### PR DESCRIPTION
Fixes #23039

## Description

My Tools favorite tag and EDAM sections were using the full client-side tools cache as a fallback when building grouped tool lists. That cache comes from `/api/tools?in_panel=false` and includes every installed tool version, so favoriting a tag such as `Humanities` could show older versions that are not shown in the normal Tools panel.

This changes the My Tools grouped sections to use only tool IDs present in the default/current panel sections. Explicit favorite tools and recent tools still use the full local tool map, but tag/EDAM grouping now mirrors panel-visible tools and excludes old installed versions.

|Before|After|
|--|--|
|<img width="289" height="984" alt="image" src="https://github.com/user-attachments/assets/df78a5a5-06ca-42e4-9916-f8f7a2f26e53" />|<img width="289" height="984" alt="image" src="https://github.com/user-attachments/assets/bcc399aa-8e61-44e4-817c-4964f78cb247" />|

A regression test covers a tagged old-version tool that exists in the tools cache but not in the default panel.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open the My Tools panel.
  2. Favorite a tag such as `Humanities`.
  3. Expand the favorite tag section.
  4. Confirm tools with multiple installed versions appear only as the latest/default panel version.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).