### PR TITLE
[26.1] Fix tool panel discover counts and recent tool version duplicates

### DIFF
--- a/client/src/components/Panels/MyToolsLanding.vue
+++ b/client/src/components/Panels/MyToolsLanding.vue
@@ -27,7 +27,7 @@ import {
     FAVORITE_TAG_SECTION_PREFIX,
     PANEL_LABEL_IDS,
 } from "./panelViews";
-import { buildToolLabel, buildToolSection } from "./utilities";
+import { buildToolLabel, buildToolSection, getUniqueToolIdsInPanel } from "./utilities";
 
 import GButton from "../BaseComponents/GButton.vue";
 import ToolItem from "./Common/Tool.vue";
@@ -72,7 +72,10 @@ const {
     favoriteOrder,
     favoriteToolIdsInPanel,
     recentToolIdsToShow,
-} = useToolPanelFavorites(computed(() => props.localToolsById));
+} = useToolPanelFavorites(
+    computed(() => props.localToolsById),
+    computed(() => getUniqueToolIdsInPanel(props.defaultSectionsById || props.localSectionsById)),
+);
 
 const recentToolsLabel = computed(() => buildToolLabel(PANEL_LABEL_IDS.RECENT_TOOLS_LABEL, localize("Recent tools")));
 const favoritesLabel = computed(() => buildToolLabel(PANEL_LABEL_IDS.FAVORITES_LABEL, localize("Favorites")));
@@ -84,9 +87,7 @@ const collapsedLabels = computed(() => ({
 }));
 
 const recentToolsInPanel = computed(() =>
-    recentToolIdsToShow.value
-        .map((toolId) => props.localToolsById[toolId])
-        .filter((tool): tool is Tool => Boolean(tool)),
+    recentToolIdsToShow.value.map((toolId) => props.localToolsById[toolId]).filter((tool) => !!tool),
 );
 
 /**
@@ -432,11 +433,12 @@ function onLabelToggle(labelId: string) {
 <template>
     <div class="toolMenu" data-description="my-tools-landing">
         <ToolPanelLabel
-            v-if="recentToolIdsToShow.length > 0"
+            v-if="recentToolsInPanel.length > 0"
             :definition="recentToolsLabel"
             :collapsed="collapsedLabels[PANEL_LABEL_IDS.RECENT_TOOLS_LABEL]"
             @toggle="onLabelToggle" />
-        <template v-if="recentToolIdsToShow.length > 0 && !recentToolsCollapsed">
+
+        <template v-if="recentToolsInPanel.length > 0 && !recentToolsCollapsed">
             <ToolItem
                 v-for="tool in recentToolsInPanel"
                 :key="`recent-tool-${tool.id}`"

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -17,11 +17,13 @@ import {
     buildToolEntries,
     buildToolLabel,
     buildToolSection,
+    countUniqueToolsInPanel,
     FAVORITES_KEYS,
     filterPanelByToolIds,
     filterTools,
     getValidPanelItems,
     getValidToolsInEachSection,
+    getUniqueToolIdsInPanel,
     getVisibleTools,
     UNSECTIONED_SECTION,
 } from "./utilities";
@@ -187,7 +189,9 @@ const { favoritesCollapsed, favoriteToolIdSet, recentToolIdsToShowSet } = useToo
 // Use composable for search results filtering
 const { favoriteResults, nonFavoriteResults, hasMixedResults } = useFavoriteSearchResults(results, favoriteToolIdSet);
 
-const toolsCount = computed(() => toolsList.value.length);
+const toolsCount = computed(() =>
+    countUniqueToolsInPanel(defaultSectionsById.value || localSectionsById.value, toolsList.value.length),
+);
 
 const resultsSet = computed(() => new Set(results.value));
 const nonFavoriteResultsSet = computed(() => new Set(nonFavoriteResults.value));

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -23,7 +23,6 @@ import {
     filterTools,
     getValidPanelItems,
     getValidToolsInEachSection,
-    getUniqueToolIdsInPanel,
     getVisibleTools,
     UNSECTIONED_SECTION,
 } from "./utilities";

--- a/client/src/components/Panels/ToolBoxSearch.test.ts
+++ b/client/src/components/Panels/ToolBoxSearch.test.ts
@@ -244,6 +244,36 @@ describe("ToolBox search", () => {
         expect(wrapper.find('[data-tool-id="__ZIP_COLLECTION__"]').exists()).toBe(false);
     });
 
+    it("shows each recent tool once when stored recent tools contain duplicate or non-panel version IDs", async () => {
+        const latestZipVersion = {
+            ...toolsList.find((tool) => tool.id === "__ZIP_COLLECTION__")!,
+            id: "toolshed.example.org/repos/dev/zip_collection/zip/1.0",
+            version: "1.0",
+        };
+        const olderZipVersion = {
+            ...latestZipVersion,
+            id: "toolshed.example.org/repos/dev/zip_collection/zip/0.9",
+            version: "0.9",
+        };
+        const { wrapper } = mountToolBox({
+            tools: [...toolsList, latestZipVersion, olderZipVersion],
+            toolSections: {
+                default: {
+                    ...toolsListInPanel,
+                    collection_operations: {
+                        ...(toolsListInPanel.collection_operations as ToolSection),
+                        tools: [latestZipVersion.id, "__FILTER_EMPTY_DATASETS__"],
+                    },
+                },
+            },
+            recentTools: [olderZipVersion.id, latestZipVersion.id, "__FILTER_EMPTY_DATASETS__"],
+        });
+        await flushPromises();
+
+        const toolIds = wrapper.findAll("a[data-tool-id]").wrappers.map((item) => item.attributes("data-tool-id"));
+        expect(toolIds).toEqual([latestZipVersion.id, "__FILTER_EMPTY_DATASETS__"]);
+    });
+
     it("shows one section per favorite tag in stored order and hides empty tag sections", async () => {
         const { wrapper, userStore } = mountToolBox({
             currentUser: SIGNED_IN_USER,

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -3,7 +3,7 @@ import { getLocalVue, injectTestRouter } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { createPinia } from "pinia";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
 import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
@@ -13,6 +13,7 @@ import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { useToolStore } from "@/stores/toolStore";
 
 import viewsListJson from "./testData/viewsList.json";
+import { getUniqueToolIdsInPanel } from "./utilities";
 
 import ToolPanel from "./ToolPanel.vue";
 
@@ -32,6 +33,7 @@ const { server, http } = useServerMock();
 const TEST_PANELS_URI = "/api/tool_panels";
 const DEFAULT_VIEW_ID = "default";
 const PANEL_VIEW_ERR_MSG = "Error loading panel view";
+const toolsListWithExtraVersion = [...toolsList, { ...toolsList[0], id: `${toolsList[0].id}/older-version` }];
 
 vi.mock("@/composables/config");
 
@@ -43,6 +45,10 @@ vi.mock("@/composables/userLocalStorage", () => ({
 
 describe("ToolPanel", () => {
     const viewsList = viewsListJson as Record<string, ToolPanelView>;
+
+    beforeEach(() => {
+        storePanelView(DEFAULT_VIEW_ID);
+    });
 
     /** Mocks and stores a non-default panel view as the current panel view */
     function storeNonDefaultView() {
@@ -62,6 +68,12 @@ describe("ToolPanel", () => {
         return { viewKey, view };
     }
 
+    function storePanelView(viewKey: string) {
+        vi.mocked(useUserLocalStorage).mockImplementation((_key: string, initialValue: unknown) =>
+            ref(_key === "tool-store-view" ? viewKey : initialValue),
+        );
+    }
+
     /**
      * Sets up wrapper for ToolPanel component
      * @param {String} errorView If provided, we mock an error for this view
@@ -73,13 +85,14 @@ describe("ToolPanel", () => {
         errorView: string = "",
         failDefault: boolean = false,
         captureToolsRequest?: (url: URL) => void,
+        panelResponses: Record<string, unknown> = {},
     ) {
         server.use(
             http.untyped.get("/api/tools", ({ request }) => {
                 const url = new URL(request.url);
                 captureToolsRequest?.(url);
                 if (url.searchParams.get("in_panel")?.toLowerCase() === "false") {
-                    return HttpResponse.json(toolsList);
+                    return HttpResponse.json(toolsListWithExtraVersion);
                 }
                 return HttpResponse.json([]);
             }),
@@ -113,8 +126,9 @@ describe("ToolPanel", () => {
         } else {
             // mock response for all panel views
             server.use(
-                http.untyped.get(/\/api\/tool_panels\/.*/, () => {
-                    return HttpResponse.json(toolsListInPanel);
+                http.untyped.get(/\/api\/tool_panels\/.*/, ({ request }) => {
+                    const panelView = new URL(request.url).pathname.split("/").pop() || "";
+                    return HttpResponse.json(panelResponses[panelView] ?? toolsListInPanel);
                 }),
             );
         }
@@ -232,7 +246,24 @@ describe("ToolPanel", () => {
 
     it("shows the tools count on the discover tools button", async () => {
         const wrapper = await createWrapper();
-        const count = toolsList.length;
+        const count = getUniqueToolIdsInPanel(toolsListInPanel).size;
+        const formatted = count < 1000 ? `${count}` : `${Math.floor(count / 1000)}k+`;
+        const discoverButton = wrapper.find('[data-description="toolbox discover tools"]');
+        expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);
+    });
+
+    it("shows the default panel tools count on the My Tools discover tools button", async () => {
+        storePanelView("my_panel");
+        const wrapper = await createWrapper("", false, undefined, {
+            my_panel: {
+                recent_tools_label: {
+                    model_class: "ToolSectionLabel",
+                    id: "recent_tools_label",
+                    text: "Recent tools",
+                },
+            },
+        });
+        const count = getUniqueToolIdsInPanel(toolsListInPanel).size;
         const formatted = count < 1000 ? `${count}` : `${Math.floor(count / 1000)}k+`;
         const discoverButton = wrapper.find('[data-description="toolbox discover tools"]');
         expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -7,10 +7,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
 import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
-import toolsList from "@/components/ToolsView/testData/toolsList.json";
-import toolsListInPanel from "@/components/ToolsView/testData/toolsListInPanel.json";
+import toolsListUntyped from "@/components/ToolsView/testData/toolsList.json";
+import toolsListInPanelUntyped from "@/components/ToolsView/testData/toolsListInPanel.json";
 import { useUserLocalStorage } from "@/composables/userLocalStorage";
-import { useToolStore } from "@/stores/toolStore";
+import { type ToolPanelItem, useToolStore } from "@/stores/toolStore";
 
 import viewsListJson from "./testData/viewsList.json";
 import { getUniqueToolIdsInPanel } from "./utilities";
@@ -30,10 +30,15 @@ const localVue = getLocalVue();
 const router = injectTestRouter(localVue);
 const { server, http } = useServerMock();
 
+const toolsList = toolsListUntyped;
+const toolsListInPanel = toolsListInPanelUntyped as unknown as Record<string, ToolPanelItem>;
+
 const TEST_PANELS_URI = "/api/tool_panels";
 const DEFAULT_VIEW_ID = "default";
 const PANEL_VIEW_ERR_MSG = "Error loading panel view";
-const toolsListWithExtraVersion = [...toolsList, { ...toolsList[0], id: `${toolsList[0].id}/older-version` }];
+
+const firstTool = toolsList[0];
+const toolsListWithExtraVersion = [...toolsList, { ...firstTool, id: `${firstTool?.id}/older-version` }];
 
 vi.mock("@/composables/config");
 

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -9,6 +9,7 @@ import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { MY_PANEL_VIEW_ID } from "./panelViews";
+import { countUniqueToolsInPanel } from "./utilities";
 
 import LoadingSpan from "../LoadingSpan.vue";
 import ActivityPanel from "./ActivityPanel.vue";
@@ -28,13 +29,22 @@ const emit = defineEmits<{
     (e: "onInsertTool", toolId: string, toolName: string): void;
 }>();
 
-const { currentPanelView, currentToolSections, isPanelPopulated, toolSections, toolsById } = storeToRefs(toolStore);
+const { currentPanelView, currentToolSections, defaultPanelView, isPanelPopulated, toolSections, toolsById } =
+    storeToRefs(toolStore);
 const isMyPanel = computed(() => currentPanelView.value === MY_PANEL_VIEW_ID);
 
 const errorMessage = ref("");
 const panelsFetched = ref(false);
 const showFavorites = ref(false);
-const toolsCount = computed(() => Object.keys(toolsById.value || {}).length);
+const headerToolSections = computed(() => {
+    if (isMyPanel.value) {
+        return toolSections.value[defaultPanelView.value] || toolSections.value.default || currentToolSections.value;
+    }
+    return currentToolSections.value;
+});
+const toolsCount = computed(() =>
+    countUniqueToolsInPanel(headerToolSections.value, Object.keys(toolsById.value).length),
+);
 
 function formatToolsCount(count: number) {
     if (count < 1000) {

--- a/client/src/components/Panels/utilities.ts
+++ b/client/src/components/Panels/utilities.ts
@@ -50,6 +50,27 @@ export function buildToolEntries(toolIds: string[], toolsById: Record<string, To
     return toolIds.map((id) => [id, toolsById[id]] as [string, Tool]).filter(([, tool]) => tool !== undefined);
 }
 
+/** Extract unique tool IDs from a panel tree, ignoring section labels and unknown object types. */
+export function getUniqueToolIdsInPanel(panel: Record<string, ToolPanelItem> | null | undefined): Set<string> {
+    const toolIds = new Set<string>();
+    for (const item of Object.values(panel || {})) {
+        if (isToolSection(item) && item.tools) {
+            item.tools.forEach((toolOrLabel) => {
+                if (typeof toolOrLabel === "string") {
+                    toolIds.add(toolOrLabel);
+                }
+            });
+        } else if (isTool(item)) {
+            toolIds.add(item.id);
+        }
+    }
+    return toolIds;
+}
+
+export function countUniqueToolsInPanel(panel: Record<string, ToolPanelItem> | null | undefined, fallbackCount = 0) {
+    return getUniqueToolIdsInPanel(panel).size || fallbackCount;
+}
+
 /** Filter panel to only include tools matching the provided tool IDs */
 export function filterPanelByToolIds(
     panel: Record<string, ToolPanelItem>,

--- a/client/src/composables/toolPanelFavorites.ts
+++ b/client/src/composables/toolPanelFavorites.ts
@@ -6,11 +6,21 @@ import { useUserStore } from "@/stores/userStore";
 
 import { usePersistentToggle } from "./persistentToggle";
 
+function extractBaseToolId(toolId: string, tool: Tool | undefined) {
+    if (tool?.version && toolId.endsWith(`/${tool.version}`)) {
+        return toolId.slice(0, -tool.version.length - 1);
+    }
+    return undefined;
+}
+
 /**
  * Composable for managing favorites and recent tools in the tool panel.
  * Provides computed properties for favorites/recent tool filtering and persistent collapse state.
  */
-export function useToolPanelFavorites(localToolsById: Ref<Record<string, Tool>>) {
+export function useToolPanelFavorites(
+    localToolsById: Ref<Record<string, Tool>>,
+    panelToolIds?: ComputedRef<Set<string>>,
+) {
     const { currentFavorites, recentTools } = storeToRefs(useUserStore());
 
     // Collapse state with localStorage persistence (user-specific)
@@ -31,8 +41,37 @@ export function useToolPanelFavorites(localToolsById: Ref<Record<string, Tool>>)
     );
 
     // Derived recent tools data
-    const recentToolIds = computed(() => recentTools.value || []);
-    const recentToolIdsInPanel = computed(() => recentToolIds.value.filter((toolId) => !!localToolsById.value[toolId]));
+    const recentToolIds = computed(() => [...new Set(recentTools.value || [])]);
+    const panelUniqueToolIds = computed(() => {
+        const baseToolIdMap = new Map<string, string>();
+        for (const toolId of panelToolIds?.value || []) {
+            const baseToolId = extractBaseToolId(toolId, localToolsById.value[toolId]);
+            if (baseToolId) {
+                baseToolIdMap.set(baseToolId, toolId);
+            }
+        }
+        return baseToolIdMap;
+    });
+    const recentToolIdsInPanel = computed(() => {
+        const seenToolIds = new Set<string>();
+        return recentToolIds.value
+            .map((toolId) => {
+                if (!panelToolIds || panelToolIds.value.has(toolId)) {
+                    return toolId;
+                }
+
+                const baseToolId = extractBaseToolId(toolId, localToolsById.value[toolId]);
+                return baseToolId ? panelUniqueToolIds.value.get(baseToolId) : undefined;
+            })
+            .filter((toolId): toolId is string => !!toolId && !!localToolsById.value[toolId])
+            .filter((toolId) => {
+                if (seenToolIds.has(toolId)) {
+                    return false;
+                }
+                seenToolIds.add(toolId);
+                return true;
+            });
+    });
     const recentToolIdsToShow = computed(() =>
         recentToolIdsInPanel.value.filter((toolId) => !favoriteToolIdSet.value.has(toolId)),
     );


### PR DESCRIPTION
Fixes incorrect tool counts in the tool panel, discovers CTA, and duplicate-looking entries in My Tools recent tools.

The discover CTA was counting all installed tool entries from `/api/tools?in_panel=false`, which includes older tool versions. On UseGalaxy.eu, which produced `Discover 16k+ Tools`, while the displayed default panel contains about 4.2k unique tools.

This changes the count to use unique displayed tool IDs from panel data instead. It also fixes the My Tools view, where the header needs to count the default discoverable panel instead of the active `my_panel` data.

Recent tools now canonicalize stored Tool Shed version IDs to the version currently displayed in the panel, so a tool with multiple installed versions appears once, using the displayed/latest panel entry.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start the client dev server against a Galaxy instance with multiple installed versions of the same Tool Shed tool.
  2. Open the tool panel default view and confirm the discover CTA shows the unique displayed panel count, e.g. `Discover 4k+ Tools`, not the full installed-version count.
  3. Switch to My Tools and confirm the discover CTA uses the same default panel count.
  4. Run a tool where multiple versions are installed and confirm Recent tools shows one entry for the displayed panel version.

Manual/API sanity check performed locally against usegalaxy.eu:
- `/api/tools?in_panel=false`: `16613` entries
- `/api/tool_panels/default`: `4290` unique displayed tool IDs
- expected CTA: `Discover 4k+ Tools`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).