### PR TITLE
Show newer available tool version badge in tool form and empty-parameter state more clearly

### DIFF
--- a/client/src/components/Form/FormCardSticky.test.js
+++ b/client/src/components/Form/FormCardSticky.test.js
@@ -66,6 +66,18 @@ describe("FormCardSticky.vue", () => {
         expect(wrapper.text()).toContain("(Galaxy Version 23.0)");
     });
 
+    it("renders latest version badge when requested", () => {
+        const wrapper = mountComponent({ isLatestVersion: true });
+        const badge = wrapper.find("[data-description='latest tool version']");
+        expect(badge.exists()).toBe(true);
+        expect(badge.text()).toBe("Latest version");
+    });
+
+    it("does not render latest version badge by default", () => {
+        const wrapper = mountComponent();
+        expect(wrapper.find("[data-description='latest tool version']").exists()).toBe(false);
+    });
+
     it("renders slot content: buttons, default, footer", () => {
         const wrapper = mountComponent(
             {},

--- a/client/src/components/Form/FormCardSticky.test.js
+++ b/client/src/components/Form/FormCardSticky.test.js
@@ -66,13 +66,6 @@ describe("FormCardSticky.vue", () => {
         expect(wrapper.text()).toContain("(Galaxy Version 23.0)");
     });
 
-    it("renders latest version badge when requested", () => {
-        const wrapper = mountComponent({ isLatestVersion: true });
-        const badge = wrapper.find("[data-description='latest tool version']");
-        expect(badge.exists()).toBe(true);
-        expect(badge.text()).toBe("Latest version");
-    });
-
     it("renders newer version badge when requested", () => {
         const wrapper = mountComponent({ isNotLatestVersion: true });
         const badge = wrapper.find("[data-description='newer tool version']");
@@ -80,9 +73,9 @@ describe("FormCardSticky.vue", () => {
         expect(badge.text()).toBe("Newer version available");
     });
 
-    it("does not render latest version badge by default", () => {
+    it("does not render newer version badge by default", () => {
         const wrapper = mountComponent();
-        expect(wrapper.find("[data-description='latest tool version']").exists()).toBe(false);
+        expect(wrapper.find("[data-description='newer tool version']").exists()).toBe(false);
     });
 
     it("renders slot content: buttons, default, footer", () => {

--- a/client/src/components/Form/FormCardSticky.test.js
+++ b/client/src/components/Form/FormCardSticky.test.js
@@ -73,6 +73,13 @@ describe("FormCardSticky.vue", () => {
         expect(badge.text()).toBe("Latest version");
     });
 
+    it("renders newer version badge when requested", () => {
+        const wrapper = mountComponent({ isNotLatestVersion: true });
+        const badge = wrapper.find("[data-description='newer tool version']");
+        expect(badge.exists()).toBe(true);
+        expect(badge.text()).toBe("Newer version available");
+    });
+
     it("does not render latest version badge by default", () => {
         const wrapper = mountComponent();
         expect(wrapper.find("[data-description='latest tool version']").exists()).toBe(false);

--- a/client/src/components/Form/FormCardSticky.test.js
+++ b/client/src/components/Form/FormCardSticky.test.js
@@ -66,11 +66,18 @@ describe("FormCardSticky.vue", () => {
         expect(wrapper.text()).toContain("(Galaxy Version 23.0)");
     });
 
-    it("renders newer version badge when requested", () => {
+    it("renders clickable newer version badge with a tooltip when requested", async () => {
         const wrapper = mountComponent({ isNotLatestVersion: true });
         const badge = wrapper.find("[data-description='newer tool version']");
         expect(badge.exists()).toBe(true);
         expect(badge.text()).toBe("Newer version available");
+        expect(badge.attributes("title")).toBe("Switch to the latest available tool version");
+        expect(badge.element.tagName).toBe("BUTTON");
+        expect(badge.attributes("type")).toBe("button");
+
+        await badge.trigger("click");
+
+        expect(wrapper.emitted("newer-version-click")).toHaveLength(1);
     });
 
     it("does not render newer version badge by default", () => {

--- a/client/src/components/Form/FormCardSticky.vue
+++ b/client/src/components/Form/FormCardSticky.vue
@@ -25,6 +25,10 @@ withDefaults(
         isLoading: false,
     },
 );
+
+const emit = defineEmits<{
+    "newer-version-click": [];
+}>();
 </script>
 
 <template>
@@ -50,9 +54,15 @@ withDefaults(
 
                         <BBadge
                             v-if="isNotLatestVersion"
+                            v-g-tooltip.hover.focus
+                            tag="button"
+                            type="button"
+                            class="border-0 cursor-pointer"
                             pill
                             variant="warning"
-                            data-description="newer tool version">
+                            title="Switch to the latest available tool version"
+                            data-description="newer tool version"
+                            @click="emit('newer-version-click')">
                             Newer version available
                         </BBadge>
                     </div>

--- a/client/src/components/Form/FormCardSticky.vue
+++ b/client/src/components/Form/FormCardSticky.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { faWrench, type IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BBadge } from "bootstrap-vue";
 
 import { absPath } from "@/utils/redirect";
 
@@ -17,8 +18,10 @@ withDefaults(
         logo?: string;
         name?: string;
         version?: string;
+        isLatestVersion?: boolean;
     }>(),
     {
+        isLatestVersion: false,
         isLoading: false,
     },
 );
@@ -41,10 +44,21 @@ withDefaults(
                             v-if="version"
                             class="text-muted"
                             data-description="galaxy tool version"
-                            :data-version="version"
-                            >(Galaxy Version {{ version }})</span
-                        >
+                            :data-version="version">
+                            (Galaxy Version {{ version }})
+                        </span>
+
+                        <BBadge
+                            v-if="isLatestVersion"
+                            v-g-tooltip.hover
+                            pill
+                            variant="info"
+                            title="Selected tool version is the latest available version"
+                            data-description="latest tool version">
+                            Latest version
+                        </BBadge>
                     </div>
+
                     <div class="d-flex flex-nowrap align-items-start flex-gapx-1">
                         <slot name="buttons" />
                     </div>

--- a/client/src/components/Form/FormCardSticky.vue
+++ b/client/src/components/Form/FormCardSticky.vue
@@ -19,9 +19,11 @@ withDefaults(
         name?: string;
         version?: string;
         isLatestVersion?: boolean;
+        isNotLatestVersion?: boolean;
     }>(),
     {
         isLatestVersion: false,
+        isNotLatestVersion: false,
         isLoading: false,
     },
 );
@@ -56,6 +58,13 @@ withDefaults(
                             title="Selected tool version is the latest available version"
                             data-description="latest tool version">
                             Latest version
+                        </BBadge>
+                        <BBadge
+                            v-if="isNotLatestVersion"
+                            pill
+                            variant="warning"
+                            data-description="newer tool version">
+                            Newer version available
                         </BBadge>
                     </div>
 

--- a/client/src/components/Form/FormCardSticky.vue
+++ b/client/src/components/Form/FormCardSticky.vue
@@ -18,11 +18,9 @@ withDefaults(
         logo?: string;
         name?: string;
         version?: string;
-        isLatestVersion?: boolean;
         isNotLatestVersion?: boolean;
     }>(),
     {
-        isLatestVersion: false,
         isNotLatestVersion: false,
         isLoading: false,
     },
@@ -50,15 +48,6 @@ withDefaults(
                             (Galaxy Version {{ version }})
                         </span>
 
-                        <BBadge
-                            v-if="isLatestVersion"
-                            v-g-tooltip.hover
-                            pill
-                            variant="info"
-                            title="Selected tool version is the latest available version"
-                            data-description="latest tool version">
-                            Latest version
-                        </BBadge>
                         <BBadge
                             v-if="isNotLatestVersion"
                             pill

--- a/client/src/components/Form/FormCardSticky.vue
+++ b/client/src/components/Form/FormCardSticky.vue
@@ -27,7 +27,7 @@ withDefaults(
 );
 
 const emit = defineEmits<{
-    "newer-version-click": [];
+    (e: "newer-version-click"): void;
 }>();
 </script>
 

--- a/client/src/components/Tool/ToolCard.test.js
+++ b/client/src/components/Tool/ToolCard.test.js
@@ -14,6 +14,13 @@ const { server, http } = useServerMock();
 
 vi.mock("@/api/schema");
 
+vi.mock("@/composables/userLocalStorageFromHashedId", async () => {
+    const { ref } = await import("vue");
+    return {
+        useUserLocalStorageFromHashId: (_key, initialValue) => ref(initialValue),
+    };
+});
+
 const config = { enable_tool_source_display: false };
 setupMockConfig(config);
 
@@ -90,5 +97,31 @@ describe("ToolCard", () => {
         const backdropActive = wrapper.findAll(".portlet-backdrop");
         expect(backdropActive.length).toBe(1);
         await flushPromises();
+    });
+
+    it("shows latest version badge for the latest lineage version", async () => {
+        await wrapper.setProps({
+            version: "2.0",
+            options: {
+                ...wrapper.props("options"),
+                version: "2.0",
+                versions: ["1.0", "2.0"],
+            },
+        });
+
+        expect(wrapper.find("[data-description='latest tool version']").text()).toBe("Latest version");
+    });
+
+    it("does not show latest version badge for older lineage versions", async () => {
+        await wrapper.setProps({
+            version: "1.0",
+            options: {
+                ...wrapper.props("options"),
+                version: "1.0",
+                versions: ["1.0", "2.0"],
+            },
+        });
+
+        expect(wrapper.find("[data-description='latest tool version']").exists()).toBe(false);
     });
 });

--- a/client/src/components/Tool/ToolCard.test.js
+++ b/client/src/components/Tool/ToolCard.test.js
@@ -99,20 +99,7 @@ describe("ToolCard", () => {
         await flushPromises();
     });
 
-    it("shows latest version badge for the latest lineage version", async () => {
-        await wrapper.setProps({
-            version: "2.0",
-            options: {
-                ...wrapper.props("options"),
-                version: "2.0",
-                versions: ["1.0", "2.0"],
-            },
-        });
-
-        expect(wrapper.find("[data-description='latest tool version']").text()).toBe("Latest version");
-    });
-
-    it("does not show latest version badge for older lineage versions", async () => {
+    it("shows newer version badge for older lineage versions", async () => {
         await wrapper.setProps({
             version: "1.0",
             options: {
@@ -122,6 +109,32 @@ describe("ToolCard", () => {
             },
         });
 
-        expect(wrapper.find("[data-description='latest tool version']").exists()).toBe(false);
+        expect(wrapper.find("[data-description='newer tool version']").text()).toBe("Newer version available");
+    });
+
+    it("does not show newer version badge for the latest lineage version", async () => {
+        await wrapper.setProps({
+            version: "2.0",
+            options: {
+                ...wrapper.props("options"),
+                version: "2.0",
+                versions: ["1.0", "2.0"],
+            },
+        });
+
+        expect(wrapper.find("[data-description='newer tool version']").exists()).toBe(false);
+    });
+
+    it("does not show newer version badge for a single version", async () => {
+        await wrapper.setProps({
+            version: "1.0",
+            options: {
+                ...wrapper.props("options"),
+                version: "1.0",
+                versions: ["1.0"],
+            },
+        });
+
+        expect(wrapper.find("[data-description='newer tool version']").exists()).toBe(false);
     });
 });

--- a/client/src/components/Tool/ToolCard.test.js
+++ b/client/src/components/Tool/ToolCard.test.js
@@ -1,4 +1,4 @@
-import { expectConfigurationRequest, getLocalVue } from "@tests/vitest/helpers";
+import { expectConfigurationRequest, getLocalVue, injectTestRouter } from "@tests/vitest/helpers";
 import { setupMockConfig } from "@tests/vitest/mockConfig";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
@@ -25,12 +25,17 @@ const config = { enable_tool_source_display: false };
 setupMockConfig(config);
 
 const localVue = getLocalVue();
+const router = injectTestRouter(localVue);
 
 describe("ToolCard", () => {
     let wrapper;
     let userStore;
 
     beforeEach(async () => {
+        if (router.currentRoute.fullPath !== "/") {
+            await router.push("/");
+        }
+
         // some child component must be bypassing useConfig - so we need to explicitly
         // stup the API endpoint also. If you can drop this without request problems in log,
         // this hack can be removed.
@@ -65,6 +70,7 @@ describe("ToolCard", () => {
                 disabled: false,
             },
             localVue,
+            router,
             pinia,
         });
         userStore = useUserStore();
@@ -99,7 +105,7 @@ describe("ToolCard", () => {
         await flushPromises();
     });
 
-    it("shows newer version badge for older lineage versions", async () => {
+    it("shows newer version badge when latest version is not active and navigates to the latest alias", async () => {
         await wrapper.setProps({
             version: "1.0",
             options: {
@@ -109,7 +115,12 @@ describe("ToolCard", () => {
             },
         });
 
-        expect(wrapper.find("[data-description='newer tool version']").text()).toBe("Newer version available");
+        const badge = wrapper.find("[data-description='newer tool version']");
+        expect(badge.text()).toBe("Newer version available");
+
+        await badge.trigger("click");
+
+        expect(router.currentRoute.fullPath).toBe("/?tool_id=identifier&version=latest");
     });
 
     it("does not show newer version badge for the latest lineage version", async () => {
@@ -125,7 +136,7 @@ describe("ToolCard", () => {
         expect(wrapper.find("[data-description='newer tool version']").exists()).toBe(false);
     });
 
-    it("does not show newer version badge for a single version", async () => {
+    it("does not show newer version badge for single-version tools", async () => {
         await wrapper.setProps({
             version: "1.0",
             options: {

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -5,6 +5,7 @@ import { BAlert, BPopover } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, onBeforeMount, ref, watch } from "vue";
 
+import { useToolRouting } from "@/composables/route";
 import { useStorageLocationConfiguration } from "@/composables/storageLocation";
 import { useConfigStore } from "@/stores/configurationStore";
 import { useToolsServiceCredentialsDefinitionsStore } from "@/stores/toolsServiceCredentialsDefinitionsStore";
@@ -88,6 +89,7 @@ const props = defineProps({
 const emit = defineEmits(["onChangeVersion", "updatePreferredObjectStoreId"]);
 
 const { setToolServiceCredentialsDefinitionFor } = useToolsServiceCredentialsDefinitionsStore();
+const { routeToTool } = useToolRouting();
 
 function onChangeVersion(v) {
     emit("onChangeVersion", v);
@@ -130,6 +132,10 @@ const showVersions = computed(() => visibleVersions.value.length > 1);
 const latestVersion = computed(() => versions.value[versions.value.length - 1]);
 const isNotLatestVersion = computed(() => Boolean(latestVersion.value && props.version !== latestVersion.value));
 
+function onNewerVersionClick() {
+    routeToTool(props.id);
+}
+
 const storageLocationModalTitle = computed(() => {
     if (isOnlyPreference.value) {
         return "Tool Execution Preferred Storage";
@@ -169,7 +175,8 @@ onBeforeMount(() => {
         :description="props.description"
         :name="props.title"
         :version="props.version"
-        :is-not-latest-version="isNotLatestVersion">
+        :is-not-latest-version="isNotLatestVersion"
+        @newer-version-click="onNewerVersionClick">
         <template v-slot:buttons>
             <GButtonGroup class="tool-card-buttons">
                 <ToolFavoriteButton v-if="hasUser" :id="props.id" />

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -127,6 +127,10 @@ const visibleVersions = computed(() => {
     return filtered;
 });
 const showVersions = computed(() => visibleVersions.value.length > 1);
+const latestVersion = computed(() => versions.value[versions.value.length - 1]);
+const isLatestVersion = computed(() =>
+    Boolean(props.version && latestVersion.value && props.version === latestVersion.value),
+);
 
 const storageLocationModalTitle = computed(() => {
     if (isOnlyPreference.value) {
@@ -166,7 +170,8 @@ onBeforeMount(() => {
         :error-message="errorText || ''"
         :description="props.description"
         :name="props.title"
-        :version="props.version">
+        :version="props.version"
+        :is-latest-version="isLatestVersion">
         <template v-slot:buttons>
             <GButtonGroup class="tool-card-buttons">
                 <ToolFavoriteButton v-if="hasUser" :id="props.id" />

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -128,9 +128,7 @@ const visibleVersions = computed(() => {
 });
 const showVersions = computed(() => visibleVersions.value.length > 1);
 const latestVersion = computed(() => versions.value[versions.value.length - 1]);
-const isLatestVersion = computed(() =>
-    Boolean(props.version && latestVersion.value && props.version === latestVersion.value),
-);
+const isNotLatestVersion = computed(() => Boolean(latestVersion.value && props.version !== latestVersion.value));
 
 const storageLocationModalTitle = computed(() => {
     if (isOnlyPreference.value) {
@@ -171,7 +169,7 @@ onBeforeMount(() => {
         :description="props.description"
         :name="props.title"
         :version="props.version"
-        :is-latest-version="isLatestVersion">
+        :is-not-latest-version="isNotLatestVersion">
         <template v-slot:buttons>
             <GButtonGroup class="tool-card-buttons">
                 <ToolFavoriteButton v-if="hasUser" :id="props.id" />

--- a/client/src/components/Tool/ToolForm.test.js
+++ b/client/src/components/Tool/ToolForm.test.js
@@ -5,7 +5,7 @@ import { getLocalVue, injectTestRouter, suppressBootstrapVueWarnings } from "@te
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { createPinia } from "pinia";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 import MockCurrentHistory from "@/components/providers/MockCurrentHistory";
@@ -19,6 +19,13 @@ const { server, http } = useServerMock();
 const localVue = getLocalVue();
 const router = injectTestRouter(localVue);
 const pinia = createPinia();
+
+vi.mock("@/composables/userLocalStorageFromHashedId", async () => {
+    const { ref } = await import("vue");
+    return {
+        useUserLocalStorageFromHashId: (_key, initialValue) => ref(initialValue),
+    };
+});
 
 describe("ToolForm", () => {
     let wrapper;
@@ -95,6 +102,8 @@ describe("ToolForm", () => {
         expect(button.attributes("data-title")).toBe("Run tool: tool_name (version)");
         const dropdown = wrapper.findAll(".dropdown-item");
         expect(dropdown.length).toBe(2);
+        const noToolParametersAlert = wrapper.find("[data-description='no tool parameters']");
+        expect(noToolParametersAlert.text()).toContain("This tool requires no input parameters and can be run as is.");
         const help = wrapper.find(".form-help");
         expect(help.text()).toBe("help_text");
         const creator = wrapper.find(".creative-work-creator");

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -43,6 +43,11 @@
             @onChangeVersion="onChangeVersion">
             <div class="mt-2 mb-4">
                 <Heading v-localize h2 separator bold size="sm"> Tool Parameters </Heading>
+
+                <GAlert v-if="showNoToolParametersAlert" show variant="info" data-description="no tool parameters">
+                    This tool requires no input parameters and can be run as is.
+                </GAlert>
+
                 <FormDisplay
                     :id="toolId"
                     :inputs="formConfig.inputs"
@@ -134,6 +139,7 @@ import GModal from "../BaseComponents/GModal.vue";
 import ToolRecommendation from "../ToolRecommendation.vue";
 import ToolCard from "./ToolCard.vue";
 import ToolFormTags from "./ToolFormTags.vue";
+import GAlert from "@/components/BaseComponents/GAlert.vue";
 import ButtonSpinner from "@/components/Common/ButtonSpinner.vue";
 import Heading from "@/components/Common/Heading.vue";
 import FormSelect from "@/components/Form/Elements/FormSelect.vue";
@@ -154,6 +160,7 @@ export default {
         ToolFormTags,
         ToolRecommendation,
         Heading,
+        GAlert,
         GModal,
     },
     props: {
@@ -277,6 +284,9 @@ export default {
         },
         initialized() {
             return this.formData !== undefined;
+        },
+        showNoToolParametersAlert() {
+            return !this.loading && this.formConfig?.inputs?.length === 0;
         },
         canMutateHistory() {
             return this.currentHistory && canMutateHistory(this.currentHistory);


### PR DESCRIPTION
This PR makes two potentially ambiguous tool-form states explicit:

- When an older tool version is active, shows a `Newer version available` warning badge beside the version. The badge includes a tooltip and navigates to the same tool with `version=latest` when clicked.
- When a tool has no input parameters, shows an informational alert so the empty `Tool Parameters` section is not mistaken for a loading or rendering failure.

The version badge remains hidden when the latest version is active or when the tool has only one version.

### Newer version available

<img width="1119" height="348" alt="image" src="https://github.com/user-attachments/assets/b14f3b5f-cacf-4de8-9756-ecbcfc47f57a" />

### No input parameters

<img width="1119" height="348" alt="image" src="https://github.com/user-attachments/assets/bda495c7-67e4-42ff-b118-ccdedfd3185b" />

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open a tool with multiple versions and select an older version.
  2. Confirm the header shows the `Newer version available` badge.
  3. Hover over or focus the badge and confirm the tooltip explains that it switches to the latest version.
  4. Click the badge and confirm navigation keeps the same `tool_id` and uses `version=latest`.
  5. Confirm the badge is absent when the latest version is active.
  6. Open a tool without input parameters, such as `/?tool_id=interactive_tool_loom&version=latest`.
  7. Confirm the `Tool Parameters` section shows: `This tool requires no input parameters and can be run as is.`

## License

- [x] I agree to license these and all my past contributions to the core Galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).