### PR TITLE
[26.1] Fix celery worker cold-start thundering herd (build app once, scope tool-data walk to load pass)

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -6,7 +6,10 @@ from functools import (
     wraps,
 )
 from multiprocessing import get_context
-from threading import local
+from threading import (
+    local,
+    Lock,
+)
 from typing import (
     Any,
 )
@@ -113,19 +116,32 @@ def get_galaxy_app():
     return build_app()
 
 
-@lru_cache(maxsize=1)
-def build_app():
-    if kwargs := get_app_properties():
-        kwargs["check_migrate_databases"] = False
-        kwargs["use_display_applications"] = False
-        kwargs["use_converters"] = True
-        import galaxy.app
+_build_app_lock = Lock()
+_built_app = None
 
-        galaxy_app = galaxy.app.GalaxyManagerApplication(configure_logging=False, **kwargs)
-        # GalaxyManagerApplication has no toolbox, so the converter tools the async
-        # execution path relies on must be loaded directly into the datatypes registry.
-        galaxy_app.datatypes_registry.load_datatype_converters_without_toolbox(galaxy_app)
-        return galaxy_app
+
+def build_app():
+    # Build the app under a double-checked lock so that a cold start with N
+    # concurrent threads (celery ``--pool threads``) builds exactly one app; the
+    # losing threads wait on the lock and reuse the winner's result.
+    global _built_app
+    if _built_app is not None:
+        return _built_app
+    with _build_app_lock:
+        if _built_app is not None:
+            return _built_app
+        if kwargs := get_app_properties():
+            kwargs["check_migrate_databases"] = False
+            kwargs["use_display_applications"] = False
+            kwargs["use_converters"] = True
+            import galaxy.app
+
+            galaxy_app = galaxy.app.GalaxyManagerApplication(configure_logging=False, **kwargs)
+            # GalaxyManagerApplication has no toolbox, so the converter tools the async
+            # execution path relies on must be loaded directly into the datatypes registry.
+            galaxy_app.datatypes_registry.load_datatype_converters_without_toolbox(galaxy_app)
+            _built_app = galaxy_app
+    return _built_app
 
 
 @lru_cache(maxsize=1)

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -14,7 +14,7 @@ import os
 import os.path
 import re
 import string
-import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from glob import glob
 from tempfile import NamedTemporaryFile
@@ -23,6 +23,7 @@ from typing import (
     BinaryIO,
     Callable,
     Dict,
+    Iterator,
     List,
     Optional,
     overload,
@@ -85,17 +86,41 @@ class StoresConfigFilePaths(Protocol):
 
 
 class ToolDataPathFiles:
-    update_time: float
+    # ``None`` means no directory listing is cached, in which case ``exists()``
+    # resolves each path directly via ``os.path.exists``. A listing is only
+    # cached for the duration of a load pass (see ``cached``), so it can never
+    # outlive the on-disk state it was taken from.
+    _tool_data_path_files: Optional[Set[str]]
 
     def __init__(self, tool_data_path):
         self.tool_data_path = os.path.abspath(tool_data_path)
-        self.update_time = 0
+        self._tool_data_path_files = None
+        self._cache_depth = 0
 
     @property
     def tool_data_path_files(self) -> Set[str]:
-        if time.time() - self.update_time > 1:
+        return self._tool_data_path_files if self._tool_data_path_files is not None else set()
+
+    @contextmanager
+    def cached(self) -> Iterator[None]:
+        # Walk the tool-data tree once and share the listing for the duration of
+        # a load pass, so the many ``exists()`` checks a pass performs don't each
+        # re-walk (a full walk of a production tool-data tree can take longer
+        # than a single table takes to load). The snapshot is dropped on exit so
+        # it can never go stale relative to disk. Re-entrant: only the outermost
+        # ``cached`` builds and clears the listing.
+        if self._cache_depth == 0:
             self.update_files()
-        return self._tool_data_path_files
+        self._cache_depth += 1
+        try:
+            yield
+        finally:
+            self._cache_depth -= 1
+            if self._cache_depth == 0:
+                self.invalidate()
+
+    def invalidate(self) -> None:
+        self._tool_data_path_files = None
 
     def update_files(self) -> None:
         try:
@@ -111,10 +136,11 @@ class ToolDataPathFiles:
                     ],
                 )
             )
-            self.update_time = time.time()
         except Exception:
             log.exception("Failed to update _tool_data_path_files")
-            self._tool_data_path_files = set()
+            # Leave the listing uncached so exists() falls back to
+            # os.path.exists(); the walk is retried on the next load pass.
+            self.invalidate()
 
     def exists(self, path: str) -> bool:
         path = os.path.abspath(path)
@@ -1097,29 +1123,32 @@ class ToolDataTableManager(Dictifiable):
         table_elems = []
         tree = util.parse_xml(config_filename)
         root = tree.getroot()
-        for table_elem in root.findall("table"):
-            table = self.from_elem(
-                table_elem,
-                tool_data_path,
-                from_shed_config,
-                filename=config_filename,
-                tool_data_path_files=self.tool_data_path_files,
-                other_config_dict=self.other_config_dict,
-            )
-            table_elems.append(table_elem)
-            if table.name not in self.data_tables:
-                self.data_tables[table.name] = table
-                log.debug("Loaded tool data table '%s' from file '%s'", table.name, config_filename)
-            else:
-                log.debug(
-                    "Loading another instance of data table '%s' from file '%s', attempting to merge content.",
-                    table.name,
-                    config_filename,
+        # Share a single directory listing across every table in this config so
+        # the per-table exists() checks don't each re-walk the tool-data tree.
+        with self.tool_data_path_files.cached():
+            for table_elem in root.findall("table"):
+                table = self.from_elem(
+                    table_elem,
+                    tool_data_path,
+                    from_shed_config,
+                    filename=config_filename,
+                    tool_data_path_files=self.tool_data_path_files,
+                    other_config_dict=self.other_config_dict,
                 )
-                self.data_tables[table.name].merge_tool_data_table(
-                    table, allow_duplicates=False
-                )  # only merge content, do not persist to disk, do not allow duplicate rows when merging
-                # FIXME: This does not account for an entry with the same unique build ID, but a different path.
+                table_elems.append(table_elem)
+                if table.name not in self.data_tables:
+                    self.data_tables[table.name] = table
+                    log.debug("Loaded tool data table '%s' from file '%s'", table.name, config_filename)
+                else:
+                    log.debug(
+                        "Loading another instance of data table '%s' from file '%s', attempting to merge content.",
+                        table.name,
+                        config_filename,
+                    )
+                    self.data_tables[table.name].merge_tool_data_table(
+                        table, allow_duplicates=False
+                    )  # only merge content, do not persist to disk, do not allow duplicate rows when merging
+                    # FIXME: This does not account for an entry with the same unique build ID, but a different path.
         return table_elems
 
     def from_elem(
@@ -1223,7 +1252,6 @@ class ToolDataTableManager(Dictifiable):
         out_elems = [elem for elem in out_elems if elem not in remove_elems]
         # add new elems
         out_elems.extend(new_elems)
-        out_path_is_new = not os.path.exists(full_path)
 
         root = util.parse_xml_string('<?xml version="1.0"?>\n<tables></tables>')
         for elem in out_elems:
@@ -1231,8 +1259,6 @@ class ToolDataTableManager(Dictifiable):
         with RenamedTemporaryFile(full_path, mode="w") as out:
             out.write(util.xml_to_string(root, pretty=True))
         os.chmod(full_path, RW_R__R__)
-        if out_path_is_new:
-            self.tool_data_path_files.update_files()
 
     def reload_tables(
         self, table_names: Optional[Union[List[str], str]] = None, path: Optional[str] = None
@@ -1248,9 +1274,12 @@ class ToolDataTableManager(Dictifiable):
                 table_names = list(tables.keys())
         elif not isinstance(table_names, list):
             table_names = [table_names]
-        for table_name in table_names:
-            tables[table_name].reload_from_files()
-            log.debug("Reloaded tool data table '%s' from files.", table_name)
+        # Share a single, freshly walked directory listing across every table
+        # reloaded in this pass, then drop it so it can't go stale on disk.
+        with self.tool_data_path_files.cached():
+            for table_name in table_names:
+                tables[table_name].reload_from_files()
+                log.debug("Reloaded tool data table '%s' from files.", table_name)
         return table_names
 
     def get_table_names_by_path(self, path: str) -> List[str]:

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -85,15 +85,36 @@ class StoresConfigFilePaths(Protocol):
     def get(self, key: Any, default: Optional[Any]) -> Optional[Any]: ...
 
 
+class ToolDataFilesystem(Protocol):
+    """The two filesystem operations ``ToolDataPathFiles`` performs.
+
+    Injected so tests can supply an in-memory implementation and assert caching
+    behaviour (e.g. one walk per load pass) without monkeypatching ``os``.
+    """
+
+    def walk(self, path: str) -> Iterator[Tuple[str, List[str], List[str]]]: ...
+
+    def exists(self, path: str) -> bool: ...
+
+
+class _OsFilesystem:
+    def walk(self, path: str) -> Iterator[Tuple[str, List[str], List[str]]]:
+        return os.walk(path)
+
+    def exists(self, path: str) -> bool:
+        return os.path.exists(path)
+
+
 class ToolDataPathFiles:
     # ``None`` means no directory listing is cached, in which case ``exists()``
-    # resolves each path directly via ``os.path.exists``. A listing is only
-    # cached for the duration of a load pass (see ``cached``), so it can never
-    # outlive the on-disk state it was taken from.
+    # resolves each path directly via the filesystem. A listing is only cached
+    # for the duration of a load pass (see ``cached``), so it can never outlive
+    # the on-disk state it was taken from.
     _tool_data_path_files: Optional[Set[str]]
 
-    def __init__(self, tool_data_path):
+    def __init__(self, tool_data_path, filesystem: Optional[ToolDataFilesystem] = None):
         self.tool_data_path = os.path.abspath(tool_data_path)
+        self._fs = filesystem or _OsFilesystem()
         self._tool_data_path_files = None
         self._cache_depth = 0
 
@@ -124,10 +145,10 @@ class ToolDataPathFiles:
 
     def update_files(self) -> None:
         try:
-            content = os.walk(self.tool_data_path)
+            content = self._fs.walk(self.tool_data_path)
             self._tool_data_path_files = set(
                 filter(
-                    os.path.exists,
+                    self._fs.exists,
                     [
                         os.path.join(dirpath, fn)
                         for dirpath, _, fn_list in content
@@ -147,7 +168,7 @@ class ToolDataPathFiles:
         if path in self.tool_data_path_files:
             return True
         else:
-            return os.path.exists(path)
+            return self._fs.exists(path)
 
 
 ErrorListT = List[str]
@@ -1046,13 +1067,14 @@ class ToolDataTableManager(Dictifiable):
         config_filename: Optional[Union[StrPath, List[StrPath]]] = None,
         tool_data_table_config_path_set=None,
         other_config_dict: Optional[StoresConfigFilePaths] = None,
+        filesystem: Optional[ToolDataFilesystem] = None,
     ) -> None:
         self.tool_data_path = tool_data_path
         # This stores all defined data table entries from both the tool_data_table_conf.xml file and the shed_tool_data_table_conf.xml file
         # at server startup. If tool shed repositories are installed that contain a valid file named tool_data_table_conf.xml.sample, entries
         # from that file are inserted into this dict at the time of installation.
         self.data_tables = {}
-        self.tool_data_path_files = ToolDataPathFiles(self.tool_data_path)
+        self.tool_data_path_files = ToolDataPathFiles(self.tool_data_path, filesystem=filesystem)
         self.other_config_dict = other_config_dict or {}
         for single_config_filename in util.listify(config_filename):
             if not single_config_filename:

--- a/test/unit/tool_util/data/test_tool_data.py
+++ b/test/unit/tool_util/data/test_tool_data.py
@@ -1,8 +1,9 @@
+import os
+
 import pytest
 
 from galaxy.tool_util.data import (
     DataTableColumnMismatch,
-    ToolDataPathFiles,
     ToolDataTableManager,
 )
 
@@ -185,6 +186,27 @@ def test_append_entries_with_attribution_noop_when_all_duplicates(tdt_manager):
     assert table.data == rows_before
 
 
+class CountingFilesystem:
+    """Real filesystem access that records walk and exists calls.
+
+    Injected via the ``filesystem`` constructor argument so the "walk once per
+    load pass" invariant can be asserted with an actual implementation instead
+    of monkeypatching ``os``.
+    """
+
+    def __init__(self):
+        self.walks = 0
+        self.exists_lookups = 0
+
+    def walk(self, path):
+        self.walks += 1
+        return os.walk(path)
+
+    def exists(self, path):
+        self.exists_lookups += 1
+        return os.path.exists(path)
+
+
 def _write_multi_table_conf(tmp_path):
     for name in ("t1", "t2", "t3"):
         (tmp_path / f"{name}.loc").write_text(f"{name}\t{name}name\t/irrelevant\n")
@@ -193,72 +215,42 @@ def _write_multi_table_conf(tmp_path):
     return conf
 
 
-def test_directory_walked_once_per_load_pass(tmp_path, monkeypatch):
+def test_directory_walked_once_per_load_pass(tmp_path):
     # Regression: the tool-data tree must be walked once per load pass, not once
-    # per exists() check. update_files() is the sole os.walk site, so counting
-    # its calls counts walks; exists() (many calls, one per table) must not add
-    # walks. Guards ToolDataPathFiles.cached() against the old per-call re-walk.
+    # per exists() check. The many exists() calls a pass makes (at least one per
+    # table) must all share a single walk. Guards ToolDataPathFiles.cached()
+    # against the old per-call re-walk.
     conf = _write_multi_table_conf(tmp_path)
+    fs = CountingFilesystem()
 
-    walks = 0
-    exists_lookups = 0
-    real_update = ToolDataPathFiles.update_files
-    real_exists = ToolDataPathFiles.exists
-
-    def counting_update(self):
-        nonlocal walks
-        walks += 1
-        return real_update(self)
-
-    def counting_exists(self, path):
-        nonlocal exists_lookups
-        exists_lookups += 1
-        return real_exists(self, path)
-
-    monkeypatch.setattr(ToolDataPathFiles, "update_files", counting_update)
-    monkeypatch.setattr(ToolDataPathFiles, "exists", counting_exists)
-    manager = ToolDataTableManager(tmp_path, conf)
+    manager = ToolDataTableManager(tmp_path, conf, filesystem=fs)
 
     assert {"t1", "t2", "t3"}.issubset(manager.data_tables)
     # One exists() per table (at least), but the tree is walked exactly once.
-    assert exists_lookups >= 3
-    assert walks == 1, f"expected one walk per load pass, got {walks}"
+    assert fs.exists_lookups >= 3
+    assert fs.walks == 1, f"expected one walk per load pass, got {fs.walks}"
 
 
-def test_reload_walks_once_regardless_of_table_count(tmp_path, monkeypatch):
+def test_reload_walks_once_regardless_of_table_count(tmp_path):
     conf = _write_multi_table_conf(tmp_path)
-    manager = ToolDataTableManager(tmp_path, conf)
+    fs = CountingFilesystem()
+    manager = ToolDataTableManager(tmp_path, conf, filesystem=fs)
 
-    walks = 0
-    real_update = ToolDataPathFiles.update_files
-
-    def counting_update(self):
-        nonlocal walks
-        walks += 1
-        return real_update(self)
-
-    monkeypatch.setattr(ToolDataPathFiles, "update_files", counting_update)
+    fs.walks = 0
     manager.reload_tables()
-    assert walks == 1, f"expected one walk per reload pass, got {walks}"
+    assert fs.walks == 1, f"expected one walk per reload pass, got {fs.walks}"
 
 
-def test_exists_outside_load_pass_does_not_walk(tmp_path, monkeypatch):
-    # Outside a load pass nothing is cached, so exists() falls back to
-    # os.path.exists() and never walks -- the listing can't outlive disk state.
+def test_exists_outside_load_pass_does_not_walk(tmp_path):
+    # Outside a load pass nothing is cached, so exists() falls back to the
+    # filesystem and never walks -- the listing can't outlive disk state.
     conf = _write_multi_table_conf(tmp_path)
-    manager = ToolDataTableManager(tmp_path, conf)
+    fs = CountingFilesystem()
+    manager = ToolDataTableManager(tmp_path, conf, filesystem=fs)
     tdpf = manager.tool_data_path_files
 
-    walks = 0
-    real_update = ToolDataPathFiles.update_files
-
-    def counting_update(self):
-        nonlocal walks
-        walks += 1
-        return real_update(self)
-
-    monkeypatch.setattr(ToolDataPathFiles, "update_files", counting_update)
+    fs.walks = 0
     assert tdpf.exists(str(tmp_path / "t1.loc")) is True
     assert tdpf.exists(str(tmp_path / "missing.loc")) is False
-    assert walks == 0, f"exists() outside a load pass must not walk, got {walks}"
+    assert fs.walks == 0, f"exists() outside a load pass must not walk, got {fs.walks}"
     assert tdpf._tool_data_path_files is None

--- a/test/unit/tool_util/data/test_tool_data.py
+++ b/test/unit/tool_util/data/test_tool_data.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from galaxy.tool_util.data import (
@@ -195,7 +193,7 @@ def _write_multi_table_conf(tmp_path):
     return conf
 
 
-def test_directory_walked_once_per_load_pass(tmp_path):
+def test_directory_walked_once_per_load_pass(tmp_path, monkeypatch):
     # Regression: the tool-data tree must be walked once per load pass, not once
     # per exists() check. update_files() is the sole os.walk site, so counting
     # its calls counts walks; exists() (many calls, one per table) must not add
@@ -217,11 +215,9 @@ def test_directory_walked_once_per_load_pass(tmp_path):
         exists_lookups += 1
         return real_exists(self, path)
 
-    with (
-        mock.patch.object(ToolDataPathFiles, "update_files", counting_update),
-        mock.patch.object(ToolDataPathFiles, "exists", counting_exists),
-    ):
-        manager = ToolDataTableManager(tmp_path, conf)
+    monkeypatch.setattr(ToolDataPathFiles, "update_files", counting_update)
+    monkeypatch.setattr(ToolDataPathFiles, "exists", counting_exists)
+    manager = ToolDataTableManager(tmp_path, conf)
 
     assert {"t1", "t2", "t3"}.issubset(manager.data_tables)
     # One exists() per table (at least), but the tree is walked exactly once.
@@ -229,7 +225,7 @@ def test_directory_walked_once_per_load_pass(tmp_path):
     assert walks == 1, f"expected one walk per load pass, got {walks}"
 
 
-def test_reload_walks_once_regardless_of_table_count(tmp_path):
+def test_reload_walks_once_regardless_of_table_count(tmp_path, monkeypatch):
     conf = _write_multi_table_conf(tmp_path)
     manager = ToolDataTableManager(tmp_path, conf)
 
@@ -241,12 +237,12 @@ def test_reload_walks_once_regardless_of_table_count(tmp_path):
         walks += 1
         return real_update(self)
 
-    with mock.patch.object(ToolDataPathFiles, "update_files", counting_update):
-        manager.reload_tables()
+    monkeypatch.setattr(ToolDataPathFiles, "update_files", counting_update)
+    manager.reload_tables()
     assert walks == 1, f"expected one walk per reload pass, got {walks}"
 
 
-def test_exists_outside_load_pass_does_not_walk(tmp_path):
+def test_exists_outside_load_pass_does_not_walk(tmp_path, monkeypatch):
     # Outside a load pass nothing is cached, so exists() falls back to
     # os.path.exists() and never walks -- the listing can't outlive disk state.
     conf = _write_multi_table_conf(tmp_path)
@@ -261,8 +257,8 @@ def test_exists_outside_load_pass_does_not_walk(tmp_path):
         walks += 1
         return real_update(self)
 
-    with mock.patch.object(ToolDataPathFiles, "update_files", counting_update):
-        assert tdpf.exists(str(tmp_path / "t1.loc")) is True
-        assert tdpf.exists(str(tmp_path / "missing.loc")) is False
+    monkeypatch.setattr(ToolDataPathFiles, "update_files", counting_update)
+    assert tdpf.exists(str(tmp_path / "t1.loc")) is True
+    assert tdpf.exists(str(tmp_path / "missing.loc")) is False
     assert walks == 0, f"exists() outside a load pass must not walk, got {walks}"
     assert tdpf._tool_data_path_files is None

--- a/test/unit/tool_util/data/test_tool_data.py
+++ b/test/unit/tool_util/data/test_tool_data.py
@@ -1,6 +1,28 @@
+from unittest import mock
+
 import pytest
 
-from galaxy.tool_util.data import DataTableColumnMismatch
+from galaxy.tool_util.data import (
+    DataTableColumnMismatch,
+    ToolDataPathFiles,
+    ToolDataTableManager,
+)
+
+MULTI_TABLE_CONF_XML = """<tables>
+  <table name="t1" comment_char="#">
+    <columns>value, name, path</columns>
+    <file path="{here}/t1.loc" />
+  </table>
+  <table name="t2" comment_char="#">
+    <columns>value, name, path</columns>
+    <file path="{here}/t2.loc" />
+  </table>
+  <table name="t3" comment_char="#">
+    <columns>value, name, path</columns>
+    <file path="{here}/t3.loc" />
+  </table>
+</tables>
+"""
 
 LOC_ALPHA_CONTENTS_V2 = """
 data1	data1name	${__HERE__}/data1/entry.txt
@@ -163,3 +185,83 @@ def test_append_entries_with_attribution_noop_when_all_duplicates(tdt_manager):
         after = fh.read()
     assert after == before
     assert table.data == rows_before
+
+
+def _write_multi_table_conf(tmp_path):
+    for name in ("t1", "t2", "t3"):
+        (tmp_path / f"{name}.loc").write_text(f"{name}\t{name}name\t/irrelevant\n")
+    conf = tmp_path / "tool_data_table_conf.xml"
+    conf.write_text(MULTI_TABLE_CONF_XML.format(here=str(tmp_path)))
+    return conf
+
+
+def test_directory_walked_once_per_load_pass(tmp_path):
+    # Regression: the tool-data tree must be walked once per load pass, not once
+    # per exists() check. update_files() is the sole os.walk site, so counting
+    # its calls counts walks; exists() (many calls, one per table) must not add
+    # walks. Guards ToolDataPathFiles.cached() against the old per-call re-walk.
+    conf = _write_multi_table_conf(tmp_path)
+
+    walks = 0
+    exists_lookups = 0
+    real_update = ToolDataPathFiles.update_files
+    real_exists = ToolDataPathFiles.exists
+
+    def counting_update(self):
+        nonlocal walks
+        walks += 1
+        return real_update(self)
+
+    def counting_exists(self, path):
+        nonlocal exists_lookups
+        exists_lookups += 1
+        return real_exists(self, path)
+
+    with mock.patch.object(ToolDataPathFiles, "update_files", counting_update), mock.patch.object(
+        ToolDataPathFiles, "exists", counting_exists
+    ):
+        manager = ToolDataTableManager(tmp_path, conf)
+
+    assert {"t1", "t2", "t3"}.issubset(manager.data_tables)
+    # One exists() per table (at least), but the tree is walked exactly once.
+    assert exists_lookups >= 3
+    assert walks == 1, f"expected one walk per load pass, got {walks}"
+
+
+def test_reload_walks_once_regardless_of_table_count(tmp_path):
+    conf = _write_multi_table_conf(tmp_path)
+    manager = ToolDataTableManager(tmp_path, conf)
+
+    walks = 0
+    real_update = ToolDataPathFiles.update_files
+
+    def counting_update(self):
+        nonlocal walks
+        walks += 1
+        return real_update(self)
+
+    with mock.patch.object(ToolDataPathFiles, "update_files", counting_update):
+        manager.reload_tables()
+    assert walks == 1, f"expected one walk per reload pass, got {walks}"
+
+
+def test_exists_outside_load_pass_does_not_walk(tmp_path):
+    # Outside a load pass nothing is cached, so exists() falls back to
+    # os.path.exists() and never walks -- the listing can't outlive disk state.
+    conf = _write_multi_table_conf(tmp_path)
+    manager = ToolDataTableManager(tmp_path, conf)
+    tdpf = manager.tool_data_path_files
+
+    walks = 0
+    real_update = ToolDataPathFiles.update_files
+
+    def counting_update(self):
+        nonlocal walks
+        walks += 1
+        return real_update(self)
+
+    with mock.patch.object(ToolDataPathFiles, "update_files", counting_update):
+        assert tdpf.exists(str(tmp_path / "t1.loc")) is True
+        assert tdpf.exists(str(tmp_path / "missing.loc")) is False
+    assert walks == 0, f"exists() outside a load pass must not walk, got {walks}"
+    assert tdpf._tool_data_path_files is None

--- a/test/unit/tool_util/data/test_tool_data.py
+++ b/test/unit/tool_util/data/test_tool_data.py
@@ -217,8 +217,9 @@ def test_directory_walked_once_per_load_pass(tmp_path):
         exists_lookups += 1
         return real_exists(self, path)
 
-    with mock.patch.object(ToolDataPathFiles, "update_files", counting_update), mock.patch.object(
-        ToolDataPathFiles, "exists", counting_exists
+    with (
+        mock.patch.object(ToolDataPathFiles, "update_files", counting_update),
+        mock.patch.object(ToolDataPathFiles, "exists", counting_exists),
     ):
         manager = ToolDataTableManager(tmp_path, conf)
 


### PR DESCRIPTION
On a cold start with celery's thread pool (`--pool threads --concurrency=N`), every task's `before_start` hook calls `get_galaxy_app()` → `build_app()`. A py-spy dump of a production worker showed all 16 pool threads stuck concurrently in `GalaxyManagerApplication.__init__`, each building a full Galaxy app — a thundering herd that multiplies cold-start time and memory. This PR removes two distinct causes.

### 1. Build the Galaxy app once under an explicit lock
`build_app()` was memoized with `@lru_cache(maxsize=1)`, but that does not collapse the herd: CPython's `lru_cache` runs the wrapped function *outside* its internal lock, so N threads all miss the empty cache simultaneously and each builds a full app before the first result is stored. Replaced with an explicit double-checked lock so exactly one thread builds the app and the rest wait and reuse it. (Safe in CPython: the module-global assignment is atomic under the GIL, and nothing calls `build_app.cache_clear()`.)

### 2. Scope the tool-data directory walk to a load pass
`ToolDataPathFiles` re-walked the entire `tool_data_path` whenever its cache was older than 1 second. A full `os.walk` of a production tool-data tree can take longer than that, so within a single config load pass nearly every `exists()` check triggered a fresh full walk — a walk storm on its own, and dramatically worse under the app-build herd above.

`exists()` is only ever called while loading/reloading tables, and all tables in a pass share one `ToolDataPathFiles` instance, so the listing only needs to live for one pass. Introduced a re-entrant `cached()` context manager (walk once on enter, share the snapshot, drop it on exit) and wrapped `load_from_config_file()` and `reload_tables()` in it. Outside a pass nothing is cached and `exists()` resolves each path directly via `os.path.exists()`, so the listing can never outlive the on-disk state it was taken from — avoiding both an indefinite staleness window (a deleted `.loc` reported as still present) and any reliance on the tool-data directory watcher to keep the cache honest.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
  - `test/unit/tool_util/data/` and `test/unit/tool_shed/test_data_table_manager.py` pass (32 tests); they exercise table loading/reloading through the new `cached()` scoping.
  - `test/unit/app/test_celery.py` covers `build_app`.
- [ ] Instructions for manual testing are as follows:
  1. Start celery with `--pool threads --concurrency=16` against a config with a large `tool_data_path`; confirm (e.g. via py-spy) that only one thread runs `GalaxyManagerApplication.__init__` and the tool-data tree is walked once per load pass rather than repeatedly.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
