### PR TITLE
[26.0] Require gravity 1.2.2

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -96,7 +96,7 @@ google-auth==2.47.0
 google-cloud-batch==0.20.0
 google-genai==1.60.0
 googleapis-common-protos==1.72.0
-gravity==1.2.0
+gravity==1.2.2
 greenlet==3.3.1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
 griffe==1.15.0
 groq==1.0.0


### PR DESCRIPTION
1.2.2 Contains fix for rolling restart which is critical for galaxy 26.0
(see https://github.com/galaxyproject/gravity/issues/147)

Requiring 1.2.2 instead of 1.2.0 is safe.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
