### PR TITLE
Update Galaxy citation to 2026 in main galaxy.yml config

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1288,7 +1288,7 @@
     destination level for heterogeneous clusters. conda job resolution
     requires bash or zsh so if this is switched to /bin/sh for
     instance - conda resolution should be disabled. Containerized jobs
-    always use /bin/sh - for maximum portability tool authors
+    always use /bin/sh - so for maximum portability tool authors
     should assume generated commands run in sh.
 :Default: ``/bin/bash``
 :Type: str
@@ -2550,7 +2550,7 @@
 :Description:
     The BibTeX citation for Galaxy, to be displayed in the History
     Tool Reference List
-:Default: ``@article{Galaxy2024, title="The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update", author="{The Galaxy Community}", journal="Nucleic Acids Research", year="2024", doi="10.1093/nar/gkae410", url="https://doi.org/10.1093/nar/gkae410"}``
+:Default: ``@article{Galaxy2026, title="Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update", author="{The Galaxy Community}", journal="Nucleic Acids Research", year="2026", doi="10.1093/nar/gkag469", url="https://doi.org/10.1093/nar/gkag469"}``
 :Type: str
 
 

--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -16,8 +16,8 @@
 :Description:
     Database connection. Galaxy Reports are intended for production
     Galaxy instances, so sqlite (and the default value below) is not
-    supported. An SQLAlchemy connection string should be used to specify
-    an external database.
+    supported. An SQLAlchemy connection string should be used to
+    specify an external database.
 :Default: ``sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE``
 :Type: str
 

--- a/lib/galaxy/agents/prompts/router.md
+++ b/lib/galaxy/agents/prompts/router.md
@@ -226,4 +226,4 @@ rather than guessing.
 
 If asked to cite Galaxy:
 
-> Nekrutenko, A., et al. (2024). The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update. Nucleic Acids Research. https://doi.org/10.1093/nar/gkae410
+> The Galaxy Community. Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update. *Nucleic Acids Research*, 2026; gkag469, https://doi.org/10.1093/nar/gkag469

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -274,6 +274,7 @@ class GalaxyAppConfigurationAttributes:
     statsd_influxdb: bool
     statsd_mock_calls: bool
     queue_metrics_interval: int
+    enable_sse_connection_metrics: bool
     library_import_dir: str | None
     user_library_import_dir: str | None
     user_library_import_dir_auto_creation: bool
@@ -434,6 +435,8 @@ class GalaxyAppConfigurationAttributes:
     agent_model_capabilities_file: str
     gtn_database_path: str
     gtn_database_url: str
+    gtn_database_refresh_interval: int
+    iwc_manifest_refresh_interval: int
     enable_tool_recommendations: bool
     tool_recommendation_model_path: str
     topk_recommendations: int

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -719,7 +719,7 @@ galaxy:
 
   # Location of files available for a short time as downloads (short
   # term storage). This directory is exclusively used for serving
-  # dynamically generated downloadable content. Galaxy may uses the
+  # dynamically generated downloadable content. Galaxy may use the
   # new_file_path parameter as a general temporary directory and that
   # directory should be monitored by a tool such as tmpwatch in
   # production environments. short_term_storage_dir on the other hand is
@@ -866,7 +866,7 @@ galaxy:
   #hours_between_check: 12
 
   # XML config file that contains data table entries for the
-  # ToolDataTableManager.  This file is manually # maintained by the
+  # ToolDataTableManager.  This file is manually maintained by the
   # Galaxy administrator (.sample used if default does not exist).
   # The value of this option will be resolved with respect to
   # <config_dir>.
@@ -999,7 +999,7 @@ galaxy:
   # destination level for heterogeneous clusters. conda job resolution
   # requires bash or zsh so if this is switched to /bin/sh for instance
   # - conda resolution should be disabled. Containerized jobs always use
-  # /bin/sh - so more maximum portability tool authors should assume
+  # /bin/sh - so for maximum portability tool authors should assume
   # generated commands run in sh.
   #default_job_shell: /bin/bash
 
@@ -1024,7 +1024,7 @@ galaxy:
   #biotools_content_directory: null
 
   # Set this to true to attempt to resolve bio.tools metadata for tools
-  # for tool not resovled via biotools_content_directory.
+  # for tool not resolved via biotools_content_directory.
   #biotools_use_api: false
 
   # bio.tools web service request related caching. The type of beaker
@@ -1593,7 +1593,7 @@ galaxy:
 
   # The BibTeX citation for Galaxy, to be displayed in the History Tool
   # Reference List
-  #citation_bibtex: '@article{Galaxy2024, title="The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update", author="{The Galaxy Community}", journal="Nucleic Acids Research", year="2024", doi="10.1093/nar/gkae410", url="https://doi.org/10.1093/nar/gkae410"}'
+  #citation_bibtex: '@article{Galaxy2026, title="Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update", author="{The Galaxy Community}", journal="Nucleic Acids Research", year="2026", doi="10.1093/nar/gkag469", url="https://doi.org/10.1093/nar/gkag469"}'
 
   # The URL linked by the "Galaxy Version" link in the "Help" menu.
   #release_doc_base_url: https://docs.galaxyproject.org/en/release_

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -6,8 +6,8 @@ reports:
 
   # Database connection. Galaxy Reports are intended for production
   # Galaxy instances, so sqlite (and the default value below) is not
-  # supported. An SQLAlchemy connection string should be used specify an
-  # external database.
+  # supported. An SQLAlchemy connection string should be used to specify
+  # an external database.
   #database_connection: sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE
 
   # Where dataset files are stored.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -519,7 +519,7 @@ mapping:
         desc: |
           Location of files available for a short time as downloads (short term storage).
           This directory is exclusively used for serving dynamically generated downloadable
-          content. Galaxy may uses the new_file_path parameter as a general temporary directory
+          content. Galaxy may use the new_file_path parameter as a general temporary directory
           and that directory should be monitored by a tool such as tmpwatch in production
           environments. short_term_storage_dir on the other hand is monitored by Galaxy's task
           framework and should not require such external tooling.
@@ -738,7 +738,7 @@ mapping:
         required: false
         desc: |
           XML config file that contains data table entries for the
-          ToolDataTableManager.  This file is manually # maintained by the Galaxy
+          ToolDataTableManager.  This file is manually maintained by the Galaxy
           administrator (.sample used if default does not exist).
 
       shed_tool_data_table_config:
@@ -934,7 +934,7 @@ mapping:
           defaults to bash for all jobs and can be overridden at the destination
           level for heterogeneous clusters. conda job resolution requires bash or zsh
           so if this is switched to /bin/sh for instance - conda resolution
-          should be disabled. Containerized jobs always use /bin/sh - so more maximum
+          should be disabled. Containerized jobs always use /bin/sh - so for maximum
           portability tool authors should assume generated commands run in sh.
 
       tool_search_index_dir:
@@ -971,7 +971,7 @@ mapping:
         required: false
         desc: |
           Set this to true to attempt to resolve bio.tools metadata for tools for tool not
-          resovled via biotools_content_directory.
+          resolved via biotools_content_directory.
 
       biotools_service_cache_type:
         type: str
@@ -1894,7 +1894,7 @@ mapping:
 
       citation_bibtex:
         type: str
-        default: '@article{Galaxy2024, title="The Galaxy platform for accessible, reproducible, and collaborative data analyses: 2024 update", author="{The Galaxy Community}", journal="Nucleic Acids Research", year="2024", doi="10.1093/nar/gkae410", url="https://doi.org/10.1093/nar/gkae410"}'
+        default: '@article{Galaxy2026, title="Galaxy for accessible, reproducible, and collaborative data analyses: 2026 update", author="{The Galaxy Community}", journal="Nucleic Acids Research", year="2026", doi="10.1093/nar/gkag469", url="https://doi.org/10.1093/nar/gkag469"}'
         required: false
         per_host: true
         desc: |

--- a/lib/galaxy/config/schemas/reports_config_schema.yml
+++ b/lib/galaxy/config/schemas/reports_config_schema.yml
@@ -20,7 +20,7 @@ mapping:
         desc: |
           Database connection.
           Galaxy Reports are intended for production Galaxy instances, so sqlite (and the default value
-          below) is not supported. An SQLAlchemy connection string should be used specify an external
+          below) is not supported. An SQLAlchemy connection string should be used to specify an external
           database.
 
       file_path:


### PR DESCRIPTION
The main way to cite the Galaxy Project is not up to date yet with the latest 2026 update NAR paper (ref: https://github.com/galaxyproject/galaxy-hub/pull/4105 and  https://github.com/galaxyproject/training-material/pull/6971/changes). 

When using the 'Export Tool References' feature, this makes use of the `galaxy.yml.sample` entry if I'm not mistaken:
<img width="247" height="391" alt="afbeelding" src="https://github.com/user-attachments/assets/d9bad769-39b6-4d35-8e2a-6c547b257357" />

Updated the old citation syntax style to the new one in this PR, but please check if that is in line with the latest citation style guide that Galaxy adheres to. This is how the old one looks (which is also how the new one would look):
<img width="1140" height="51" alt="afbeelding" src="https://github.com/user-attachments/assets/437e1279-a5ff-41ee-a0e0-cdc8dd38fd35" />

which slightly deviates from the ones found on the Hub and in the GTN as linked above. 

Flagging that the previous paper is still referenced in other places as well (like [here](https://github.com/galaxyproject/galaxy/blob/6b81c55d23b74bdc5b6486f00c4f38d0f6d10213/lib/galaxy/agents/prompts/router.md?plain=1#L229) and [here](https://github.com/galaxyproject/galaxy/blob/6b81c55d23b74bdc5b6486f00c4f38d0f6d10213/lib/galaxy/config/schemas/config_schema.yml#L1897)) but not always clear what the impact would be of changing it in these places and if it even should, so scoping this PR to that single config entry first but welcoming contributions here to change those as well!


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
