### PR TITLE
[25.0] Fix NameError, move assignation of days prior to get_failed_jobs call

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -530,8 +530,8 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
         except OSError as e:
             log.error(f"Error deleting job working directory: {path} : {e.strerror}")
 
-    failed_jobs = get_failed_jobs()
     days = config.failed_jobs_working_directory_cleanup_days
+    failed_jobs = get_failed_jobs()
 
     if not failed_jobs:
         log.info("No failed jobs found within the last %s days", days)


### PR DESCRIPTION
Following https://github.com/galaxyproject/galaxy/pull/19594 I tested the configuration, and when the celery tasked ran it failed with
```
Task galaxy.cleanup_jwds[98226009-bfa8-4988-b798-1092e0065b2f] raised unexpected: NameError("free variable 'days' referenced before assignment in enclosing scope")
```
 because `days` was assigned *after* calling `get_failed_jobs()`, whose closure captures it.
```
    def get_failed_jobs():
        return sa_session.query(model.Job.id).filter(
            model.Job.state == "error",
            model.Job.update_time < datetime.datetime.now() - datetime.timedelta(days=days),
            model.Job.object_store_id.isnot(None),
        )

    failed_jobs = get_failed_jobs()
    days = config.failed_jobs_working_directory_cleanup_days
```

(Duplicate of #23000 which targeted the wrong branch.)

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Enable `enable_failed_jobs_working_directory_cleanup: true` in `galaxy.yml`
  2. Trigger the `cleanup_jwds` Celery task and confirm it runs without a `NameError`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).