### PR TITLE
[25.0] Pin Ansible version

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -10,67 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  ghcrbuild:
-    name: Build container image for GHCR
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
-      - name: Set outputs
-        id: commit
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Set branch name
-        id: branch
-        run: |
-          if [[ "$GITHUB_REF" == "refs/tags/"* ]]; then
-            echo "name=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-          elif [[ "$GITHUB_REF" == "refs/heads/dev" ]]; then
-            echo "name=dev" >> $GITHUB_OUTPUT
-          elif [[ "$GITHUB_REF" == "refs/heads/release_"* ]]; then
-            echo "name=${GITHUB_REF#refs/heads/release_}-auto" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-      - name: Extract metadata for container image
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=${{steps.branch.outputs.name}}
-      - name: Build args
-        id: buildargs
-        run: |
-            echo "gitcommit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT 
-            echo "builddate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64
-
-      - name: Login to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push container image to ghcr
-        uses: docker/build-push-action@v4
-        with:
-          build-args: |
-              GIT_COMMIT=${{ steps.buildargs.outputs.gitcommit }}
-              BUILD_DATE=${{ steps.buildargs.outputs.builddate }}
-              IMAGE_TAG=${{ steps.branch.outputs.name }}
-          file: .k8s_ci.Dockerfile
-          push: true
-          context: .
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-
   build:
     name: Build container image for Galaxy repos
     runs-on: ubuntu-latest

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -51,7 +51,7 @@ RUN set -xe; \
         libc-dev \
         bzip2 \
         gcc \
-    && pip install --no-cache virtualenv ansible \
+    && pip install --no-cache virtualenv ansible==11.11.0 \
     && apt-get autoremove -y && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
Doing a `pip install ansible` pulls in the latest Ansible Core v2.19+, which contains several breaking changes.  This PR pins Ansible to `ansible==11.11.0` which pulls in a working v2.18. 

The `dev` and `release_26.x` branches already contain  this modification.

Also drops the broken GHCR Docker build while we are at it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
