### PR TITLE
Validate matched multi-input expansion errors before async job prep

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -214,6 +214,7 @@ from galaxy.util.json import (
     swap_inf_nan,
 )
 from galaxy.util.path import StrPath
+from galaxy.util.permutations import InputMatchedException
 from galaxy.util.rules_dsl import RuleSet
 from galaxy.util.template import (
     fill_template,
@@ -2135,9 +2136,12 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         expanded_incomings: list[ToolStateJobInstanceExpansionT]
         job_tool_states: list[ToolStateJobInstanceT]
         collection_info: MatchingCollections | None
-        expanded_incomings, job_tool_states, collection_info = expand_meta_parameters_async(
-            request_context.app, self, tool_request_internal_state
-        )
+        try:
+            expanded_incomings, job_tool_states, collection_info = expand_meta_parameters_async(
+                request_context.app, self, tool_request_internal_state
+            )
+        except InputMatchedException as exc:
+            raise exceptions.RequestParameterInvalidException(str(exc)) from exc
 
         self._ensure_expansion_is_valid(job_tool_states, rerun_remap_job_id)
 
@@ -2184,9 +2188,12 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         # Expand these out to individual parameters for given jobs (tool executions).
         expanded_incomings: list[ToolStateJobInstanceExpansionT]
         collection_info: MatchingCollections | None
-        expanded_incomings, collection_info = expand_meta_parameters(
-            request_context, self, incoming, input_format=input_format
-        )
+        try:
+            expanded_incomings, collection_info = expand_meta_parameters(
+                request_context, self, incoming, input_format=input_format
+            )
+        except InputMatchedException as exc:
+            raise exceptions.RequestParameterInvalidException(str(exc)) from exc
 
         self._ensure_expansion_is_valid(expanded_incomings, rerun_remap_job_id)
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2110,6 +2110,15 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
         if self.check_values:
             visit_input_values(self.inputs, values, callback)
 
+    def _raise_matched_input_errors(self, exc: InputMatchedException) -> None:
+        """Convert matched-input expansion errors to validation errors.
+
+        When multi-input parameters have mismatched lengths, this surfaces
+        the error as a request validation error (400) instead of a generic
+        server error.
+        """
+        raise exceptions.RequestParameterInvalidException(str(exc)) from exc
+
     def expand_incoming_async(
         self,
         request_context: WorkRequestContext,
@@ -2141,7 +2150,7 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
                 request_context.app, self, tool_request_internal_state
             )
         except InputMatchedException as exc:
-            raise exceptions.RequestParameterInvalidException(str(exc)) from exc
+            self._raise_matched_input_errors(exc)
 
         self._ensure_expansion_is_valid(job_tool_states, rerun_remap_job_id)
 
@@ -2193,7 +2202,7 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
                 request_context, self, incoming, input_format=input_format
             )
         except InputMatchedException as exc:
-            raise exceptions.RequestParameterInvalidException(str(exc)) from exc
+            self._raise_matched_input_errors(exc)
 
         self._ensure_expansion_is_valid(expanded_incomings, rerun_remap_job_id)
 

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -1070,6 +1070,42 @@ steps:
         hdca_option = f1_input["options"]["hdca"][0]
         assert hdca_option["id"] == hdca_id and hdca_option["src"] == "hdca"
 
+    @requires_new_history
+    @skip_without_tool("multi_data_param")
+    def test_async_job_submission_rejects_mismatched_multi_inputs(self, history_id):
+        """API-level regression test for async /api/jobs submission.
+
+        Mismatched lengths for matched multi-input parameters should be
+        surfaced as a request validation error (400) instead of a generic
+        server error.
+        """
+        dataset_id_1 = self.__history_with_ok_dataset(history_id)
+        dataset_id_2 = self.__history_with_ok_dataset(history_id)
+
+        inputs = {
+            "f1": {
+                "batch": True,
+                "values": [
+                    {"src": "hda", "id": dataset_id_1},
+                    {"src": "hda", "id": dataset_id_2},
+                ],
+            },
+            "f2": {
+                "batch": True,
+                "values": [
+                    {"src": "hda", "id": dataset_id_1},
+                ],
+            },
+        }
+
+        response = self.dataset_populator.tool_request_raw(
+            tool_id="multi_data_param",
+            inputs=inputs,
+            history_id=history_id,
+        )
+        self._assert_status_code_is(response, 400)
+        assert "should be of equal length" in response.json()["err_msg"]
+
     @skip_without_tool("multiple_versions")
     def test_job_build_for_rerun_switch_version(self, history_id):
         run_response = self._run("multiple_versions", history_id, {}, tool_version="0.1").json()


### PR DESCRIPTION
## Summary
- catch InputMatchedException in tool input expansion paths (expand_incoming and expand_incoming_async)
- convert these to RequestParameterInvalidException so malformed matched-input requests are surfaced as request validation errors instead of bubbling into async prep paths

## Problem
Issue #22884 reports malformed matched inputs reaching async prep and generating noisy internal errors around Celery job preparation. This patch validates the error at API/tool expansion boundary and returns a clear request-level error.

## Notes
- This change applies to both sync and async expansion paths for consistency.
- Related issue: #22884

## Testing
- python -m py_compile lib/galaxy/tools/__init__.py
- Full unit tests are not runnable in this Windows environment because Galaxy's test stack imports POSIX-only pwd in conftest.