### PR TITLE
Toolbox filters: document the filter surface as a ToolFilterContext protocol

### DIFF
--- a/lib/galaxy/tool_util/toolbox/filters/__init__.py
+++ b/lib/galaxy/tool_util/toolbox/filters/__init__.py
@@ -1,10 +1,45 @@
 import logging
 import sys
 from copy import deepcopy
+from typing import (
+    Protocol,
+    runtime_checkable,
+)
 
 from galaxy.util import listify
 
 log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ToolFilterContext(Protocol):
+    """The attribute surface that toolbox filters are allowed to read.
+
+    ``galaxy.tools.Tool`` implements this protocol, and any lighter-weight
+    stand-in a toolbox implementation hands to the filter layer must too.
+    Admin / user-configured filter functions should only read fields
+    documented here — it is the contract that lets the filter pass run
+    against something cheaper than a fully-parsed ``Tool``.
+    """
+
+    id: str
+    name: str
+    description: str
+    hidden: bool
+    require_login: bool
+    tool_type: str
+    labels: list[str]
+    tags: list[str]
+
+    def allow_user_access(self, user, attempting_access: bool = True) -> bool:
+        """Return ``True`` if ``user`` may see/run this tool.
+
+        ``Tool`` implements this directly (with subclass overrides for
+        admin-only flavours like ``DataManagerTool``); implementations
+        should answer from their own state so the filter layer never
+        needs to reach through ``context.trans.app.config``.
+        """
+        ...
 
 
 class FilterFactory:
@@ -89,11 +124,11 @@ class FilterFactory:
 
 
 # Stock Filter Functions
-def _not_hidden(context, tool):
+def _not_hidden(context, tool: ToolFilterContext) -> bool:
     return not tool.hidden
 
 
-def _handle_authorization(context, tool):
+def _handle_authorization(context, tool: ToolFilterContext) -> bool:
     user = context.trans.user
     if tool.require_login and not user:
         return False

--- a/test/unit/tool_util/toolbox/test_toolbox_filters.py
+++ b/test/unit/tool_util/toolbox/test_toolbox_filters.py
@@ -56,14 +56,13 @@ def is_filtered(filters, trans, tool):
     return not all(_(context, tool) for _ in filters)
 
 
-def mock_tool(require_login=False, hidden=False, allow_access=True):
-    def allow_user_access(user, attempting_access):
-        assert not attempting_access
+def mock_tool(require_login=False, hidden=False, tool_type="default", allow_access=True):
+    def allow_user_access(user, attempting_access=True):
         return allow_access
 
-    tool = Bunch(
+    return Bunch(
         require_login=require_login,
         hidden=hidden,
+        tool_type=tool_type,
         allow_user_access=allow_user_access,
     )
-    return tool


### PR DESCRIPTION
Adds a typed `ToolFilterContext` protocol describing exactly what admin/user tool-filter functions may read, and annotates the stock filters against it. This gives filter authors an explicit contract and gives lighter-weight tool stand-ins a target to satisfy without handing filters a fully-parsed `Tool`.

Extracted from #22633.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).