### PR TITLE
Toolbox: mutation-safe tools() iteration

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -881,7 +881,12 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         return []
 
     def tools(self):
-        return self._tools_by_id.copy().items()
+        # Snapshot the id list so a concurrent shed install can't mutate
+        # the dict mid-iteration.
+        for tool_id in list(self._tools_by_id):
+            tool = self._tools_by_id.get(tool_id)
+            if tool is not None:
+                yield tool_id, tool
 
     def dynamic_confs(self, include_migrated_tool_conf=False) -> list[DynamicToolConfDict]:
         confs = []


### PR DESCRIPTION
One small hygiene change to `AbstractToolBox`:

- `tools()` snapshots the id list so a concurrent shed install can't raise `RuntimeError: dictionary changed size during iteration` mid-listing. Every caller is a for-loop, so the items-view → generator change is shape-compatible.

Extracted from #22633.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).