### PR TITLE
[26.0] Fix ToolPanelElements._section_by_tool being class-level shared state

### DIFF
--- a/lib/galaxy/tool_util/toolbox/panel.py
+++ b/lib/galaxy/tool_util/toolbox/panel.py
@@ -166,7 +166,9 @@ class ToolPanelElements(odict[str, Any], HasPanelItems):
     used both by tool panel itself (normal and integrated) and its sections.
     """
 
-    _section_by_tool: Dict[str, Tuple[str, str]] = {}
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._section_by_tool: Dict[str, Tuple[str, str]] = {}
 
     def record_section_for_tool_id(self, tool_id: str, key: str, val: str):
         self._section_by_tool[tool_id] = (key, val)


### PR DESCRIPTION
`ToolPanelElements._section_by_tool` was a class-level mutable dict, silently shared by the tool panel, the integrated panel, every section's `elems` and every rendered panel view. Concretely: EDAM view rendering records ontology buckets through the same dict the real panel's `get_section_for_tool_id` reads, and records survive toolbox reloads. Scope it per instance; regression test included.

Found while reviewing the panel logic for #22633.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).