### PR TITLE
Guard against unmatched guid in generate_tool_panel_elem_list

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -315,10 +315,20 @@ class ToolPanelManager:
                     if tool_section is None:
                         tool_section = self.generate_tool_section_element_from_dict(tool_section_dict)
                 # Find the tuple containing the current guid from the list of repository_tools_tups.
+                matched_tup = None
                 for repository_tool_tup in repository_tools_tups:
-                    tool_file_path, tup_guid, tool = repository_tool_tup
-                    if tup_guid == guid:
+                    if repository_tool_tup[1] == guid:
+                        matched_tup = repository_tool_tup
                         break
+                if matched_tup is None:
+                    log.warning(
+                        "Skipping tool panel entry for guid '%s': no matching tool in repository '%s' (revision %s)",
+                        guid,
+                        repository_name,
+                        changeset_revision,
+                    )
+                    continue
+                tool_file_path, _, tool = matched_tup
                 tool_elem = self.generate_tool_elem(
                     tool_shed,
                     repository_name,

--- a/test/unit/tool_shed/test_tool_panel_manager.py
+++ b/test/unit/tool_shed/test_tool_panel_manager.py
@@ -195,6 +195,24 @@ class TestToolPanelManager(BaseToolBoxTestCase):
             message = f"file {filename} does not contain valid XML, content {content}"
             raise AssertionError(message)
 
+    def test_generate_tool_panel_elem_list_skips_unmatched_guid(self):
+        tool = self._init_ts_tool(guid=DEFAULT_GUID)
+        tool_path = self._tool_path()
+        repository_tools_tups = [(tool_path, DEFAULT_GUID, tool)]
+        tool_panel_dict = {
+            DEFAULT_GUID: [{"id": "", "name": "", "version": "", "tool_config": tool_path}],
+            "guid-without-tool": [{"id": "", "name": "", "version": "", "tool_config": "missing.xml"}],
+        }
+        elem_list = self.tpm.generate_tool_panel_elem_list(
+            "example",
+            "toolshed.g2.bx.psu.edu/repos/iuc/example",
+            "0123456789abcdef",
+            tool_panel_dict,
+            repository_tools_tups,
+        )
+        assert len(elem_list) == 1
+        assert elem_list[0].attrib["guid"] == DEFAULT_GUID
+
     def _init_ts_tool(self, guid=DEFAULT_GUID, **kwds):
         tool = self._init_tool(**kwds)
         tool.guid = guid


### PR DESCRIPTION
If `tool_panel_dict` carries a guid with no matching entry in `repository_tools_tups`, the lookup loop left `tool_file_path` / `tool` unbound — `UnboundLocalError` on the first iteration, or silent reuse of the previous guid's values on later iterations. During shed-install failures this surfaced as an opaque 500 on `install_repository_revision` instead of a useful error. Skip the entry with a clear warning; regression test included.

Found while triaging #22633 CI failures.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).