### PR TITLE
[26.1] Deprecate toolbox filters

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5430,6 +5430,9 @@
 ~~~~~~~~~~~~~~~~
 
 :Description:
+    Deprecated in Galaxy 26.1 and will be removed in a future
+    release. Toolbox filters only affect toolbox display and do not
+    enforce access restrictions.
     Define toolbox filters
     (https://galaxyproject.org/user-defined-toolbox-filters/) that
     admins may use to restrict the tools to display.
@@ -5442,6 +5445,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
+    Deprecated in Galaxy 26.1 and will be removed in a future
+    release. Toolbox filters only affect toolbox display and do not
+    enforce access restrictions.
     Define toolbox filters
     (https://galaxyproject.org/user-defined-toolbox-filters/) that
     admins may use to restrict the tool labels to display.
@@ -5454,6 +5460,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
+    Deprecated in Galaxy 26.1 and will be removed in a future
+    release. Toolbox filters only affect toolbox display and do not
+    enforce access restrictions.
     Define toolbox filters
     (https://galaxyproject.org/user-defined-toolbox-filters/) that
     admins may use to restrict the tool sections to display.
@@ -5466,6 +5475,9 @@
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
+    Deprecated in Galaxy 26.1 and will be removed in a future
+    release. Toolbox filters only affect toolbox display and do not
+    enforce access restrictions.
     Define toolbox filters
     (https://galaxyproject.org/user-defined-toolbox-filters/) that
     users may use to restrict the tools to display.
@@ -5478,6 +5490,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
+    Deprecated in Galaxy 26.1 and will be removed in a future
+    release. Toolbox filters only affect toolbox display and do not
+    enforce access restrictions.
     Define toolbox filters
     (https://galaxyproject.org/user-defined-toolbox-filters/) that
     users may use to restrict the tool sections to display.
@@ -5490,6 +5505,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
+    Deprecated in Galaxy 26.1 and will be removed in a future
+    release. Toolbox filters only affect toolbox display and do not
+    enforce access restrictions.
     Define toolbox filters
     (https://galaxyproject.org/user-defined-toolbox-filters/) that
     users may use to restrict the tool labels to display.
@@ -5502,6 +5520,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
+    Deprecated in Galaxy 26.1 and will be removed in a future
+    release. Toolbox filters only affect toolbox display and do not
+    enforce access restrictions.
     The base module(s) that are searched for modules for toolbox
     filtering
     (https://galaxyproject.org/user-defined-toolbox-filters/)
@@ -6293,6 +6314,5 @@
     for user defined tools.
 :Default: ``false``
 :Type: bool
-
 
 

--- a/doc/source/releases/26.1_announce.rst
+++ b/doc/source/releases/26.1_announce.rst
@@ -4,3 +4,16 @@
 ===========================================================
 26.1 Galaxy Release
 ===========================================================
+
+Deprecations
+============
+
+Toolbox filters are deprecated in Galaxy 26.1 and will be removed in a future release.
+This includes the ``tool_filters``, ``tool_label_filters``, ``tool_section_filters``,
+``user_tool_filters``, ``user_tool_section_filters``, ``user_tool_label_filters``,
+and ``toolbox_filter_base_modules`` configuration options, as well as the user
+preference UI for toolbox filters.
+
+Toolbox filters only affect toolbox display and do not enforce access restrictions.
+Admins should use tool panel views for alternate toolbox layouts, and use TPV or
+dynamic job destinations for hard tool execution policy.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2950,37 +2950,51 @@ galaxy:
   # files.
   #toolbox_auto_sort: true
 
-  # Define toolbox filters
+  # Deprecated in Galaxy 26.1 and will be removed in a future release.
+  # Toolbox filters only affect toolbox display and do not enforce access
+  # restrictions. Define toolbox filters
   # (https://galaxyproject.org/user-defined-toolbox-filters/) that
   # admins may use to restrict the tools to display.
   #tool_filters: null
 
-  # Define toolbox filters
+  # Deprecated in Galaxy 26.1 and will be removed in a future release.
+  # Toolbox filters only affect toolbox display and do not enforce access
+  # restrictions. Define toolbox filters
   # (https://galaxyproject.org/user-defined-toolbox-filters/) that
   # admins may use to restrict the tool labels to display.
   #tool_label_filters: null
 
-  # Define toolbox filters
+  # Deprecated in Galaxy 26.1 and will be removed in a future release.
+  # Toolbox filters only affect toolbox display and do not enforce access
+  # restrictions. Define toolbox filters
   # (https://galaxyproject.org/user-defined-toolbox-filters/) that
   # admins may use to restrict the tool sections to display.
   #tool_section_filters: null
 
-  # Define toolbox filters
+  # Deprecated in Galaxy 26.1 and will be removed in a future release.
+  # Toolbox filters only affect toolbox display and do not enforce access
+  # restrictions. Define toolbox filters
   # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
   # may use to restrict the tools to display.
   #user_tool_filters: examples:restrict_upload_to_admins, examples:restrict_encode
 
-  # Define toolbox filters
+  # Deprecated in Galaxy 26.1 and will be removed in a future release.
+  # Toolbox filters only affect toolbox display and do not enforce access
+  # restrictions. Define toolbox filters
   # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
   # may use to restrict the tool sections to display.
   #user_tool_section_filters: examples:restrict_text
 
-  # Define toolbox filters
+  # Deprecated in Galaxy 26.1 and will be removed in a future release.
+  # Toolbox filters only affect toolbox display and do not enforce access
+  # restrictions. Define toolbox filters
   # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
   # may use to restrict the tool labels to display.
   #user_tool_label_filters: examples:restrict_upload_to_admins, examples:restrict_encode
 
-  # The base module(s) that are searched for modules for toolbox
+  # Deprecated in Galaxy 26.1 and will be removed in a future release.
+  # Toolbox filters only affect toolbox display and do not enforce access
+  # restrictions. The base module(s) that are searched for modules for toolbox
   # filtering (https://galaxyproject.org/user-defined-toolbox-filters/)
   # functions.
   #toolbox_filter_base_modules: galaxy.tools.filters,galaxy.tools.toolbox.filters,galaxy.tool_util.toolbox.filters
@@ -3383,4 +3397,3 @@ galaxy:
   # Enable beta tool formats (yaml, cwl, ...) which is a prerequisite
   # for user defined tools.
   #enable_beta_tool_formats: false
-

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4022,6 +4022,8 @@ mapping:
         type: str
         required: false
         desc: |
+          Deprecated in Galaxy 26.1 and will be removed in a future release.
+          Toolbox filters only affect toolbox display and do not enforce access restrictions.
           Define toolbox filters (https://galaxyproject.org/user-defined-toolbox-filters/)
           that admins may use to restrict the tools to display.
 
@@ -4029,6 +4031,8 @@ mapping:
         type: str
         required: false
         desc: |
+          Deprecated in Galaxy 26.1 and will be removed in a future release.
+          Toolbox filters only affect toolbox display and do not enforce access restrictions.
           Define toolbox filters (https://galaxyproject.org/user-defined-toolbox-filters/)
           that admins may use to restrict the tool labels to display.
 
@@ -4036,6 +4040,8 @@ mapping:
         type: str
         required: false
         desc: |
+          Deprecated in Galaxy 26.1 and will be removed in a future release.
+          Toolbox filters only affect toolbox display and do not enforce access restrictions.
           Define toolbox filters (https://galaxyproject.org/user-defined-toolbox-filters/)
           that admins may use to restrict the tool sections to display.
 
@@ -4044,6 +4050,8 @@ mapping:
         default: examples:restrict_upload_to_admins, examples:restrict_encode
         required: false
         desc: |
+          Deprecated in Galaxy 26.1 and will be removed in a future release.
+          Toolbox filters only affect toolbox display and do not enforce access restrictions.
           Define toolbox filters (https://galaxyproject.org/user-defined-toolbox-filters/)
           that users may use to restrict the tools to display.
 
@@ -4052,6 +4060,8 @@ mapping:
         default: examples:restrict_text
         required: false
         desc: |
+          Deprecated in Galaxy 26.1 and will be removed in a future release.
+          Toolbox filters only affect toolbox display and do not enforce access restrictions.
           Define toolbox filters (https://galaxyproject.org/user-defined-toolbox-filters/)
           that users may use to restrict the tool sections to display.
 
@@ -4060,6 +4070,8 @@ mapping:
         default: examples:restrict_upload_to_admins, examples:restrict_encode
         required: false
         desc: |
+          Deprecated in Galaxy 26.1 and will be removed in a future release.
+          Toolbox filters only affect toolbox display and do not enforce access restrictions.
           Define toolbox filters (https://galaxyproject.org/user-defined-toolbox-filters/)
           that users may use to restrict the tool labels to display.
 
@@ -4068,6 +4080,8 @@ mapping:
         default: galaxy.tools.filters,galaxy.tools.toolbox.filters,galaxy.tool_util.toolbox.filters
         required: false
         desc: |
+          Deprecated in Galaxy 26.1 and will be removed in a future release.
+          Toolbox filters only affect toolbox display and do not enforce access restrictions.
           The base module(s) that are searched for modules for toolbox filtering
           (https://galaxyproject.org/user-defined-toolbox-filters/) functions.
 

--- a/lib/galaxy/tool_util/toolbox/filters/__init__.py
+++ b/lib/galaxy/tool_util/toolbox/filters/__init__.py
@@ -6,6 +6,13 @@ from galaxy.util import listify
 
 log = logging.getLogger(__name__)
 
+TOOLBOX_FILTERS_DEPRECATION_MESSAGE = (
+    "Toolbox filters are deprecated in Galaxy 26.1 and will be removed in a future release. "
+    "Toolbox filters only affect toolbox display and do not enforce access restrictions. "
+    "Use tool panel views for alternate toolbox layouts and TPV or dynamic job destinations "
+    "to enforce tool execution policy."
+)
+
 
 class FilterFactory:
     """
@@ -19,6 +26,7 @@ class FilterFactory:
         # Prepopulate dict containing filters that are always checked,
         # other filters that get checked depending on context.
         self.default_filters = dict(tool=[_not_hidden, _handle_authorization], section=[], label=[])
+        self.__deprecation_logged = False
         # Add dynamic filters to these default filters.
         config = toolbox.app.config
         self.__base_modules = listify(
@@ -53,12 +61,18 @@ class FilterFactory:
     def __init_filters(self, key, filters, toolbox_filters, validate=None):
         for filter in filters:
             if validate is None or filter in validate or filter in self.default_filters:
+                self.__log_deprecation_warning()
                 filter_function = self.build_filter_function(filter)
                 if filter_function is not None:
                     toolbox_filters[key].append(filter_function)
             else:
                 log.warning("Refusing to load %s filter '%s' which is not defined in config", key, filter)
         return toolbox_filters
+
+    def __log_deprecation_warning(self):
+        if not self.__deprecation_logged:
+            log.warning(TOOLBOX_FILTERS_DEPRECATION_MESSAGE)
+            self.__deprecation_logged = True
 
     def build_filter_function(self, filter_name):
         """Obtain python function (importing a submodule if needed)

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -1131,7 +1131,11 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             {
                 "type": "hidden",
                 "name": "helptext",
-                "label": "In this section you may enable or disable Toolbox filters. Please contact your admin to configure filters as necessary.",
+                "label": (
+                    "Toolbox filters are deprecated in Galaxy 26.1 and will be removed in a future release. "
+                    "Toolbox filters only affect toolbox display and do not enforce access restrictions. "
+                    "Please contact your admin to configure filters as necessary."
+                ),
             }
         ]
         errors = {}

--- a/test/unit/config/config_manage/1607_root_filters/config/galaxy.ini
+++ b/test/unit/config/config_manage/1607_root_filters/config/galaxy.ini
@@ -1179,6 +1179,9 @@ use_interactive = True
 # runtime.  Example shown below are not real defaults (no custom
 # filters are applied by default), but can be enabled by renaming the
 # example.py.sample in the filters directory to example.py.
+# Deprecated in Galaxy 26.1 and will be removed in a future release.
+# Toolbox filters only affect toolbox display and do not enforce access
+# restrictions.
 
 #tool_filters =
 #tool_label_filters =
@@ -1190,6 +1193,9 @@ use_interactive = True
 # The base modules that are searched for modules as described above
 # can be modified and modules external to Galaxy can be searched by
 # modifying the following option.
+# Deprecated in Galaxy 26.1 and will be removed in a future release.
+# Toolbox filters only affect toolbox display and do not enforce access
+# restrictions.
 #toolbox_filter_base_modules = galaxy.tools.toolbox.filters,galaxy.tools.filters
 
 # -- Galaxy Application Internal Message Queue

--- a/test/unit/config/config_manage/1607_root_samples/config/galaxy.ini
+++ b/test/unit/config/config_manage/1607_root_samples/config/galaxy.ini
@@ -1179,6 +1179,9 @@ use_interactive = True
 # runtime.  Example shown below are not real defaults (no custom
 # filters are applied by default), but can be enabled by renaming the
 # example.py.sample in the filters directory to example.py.
+# Deprecated in Galaxy 26.1 and will be removed in a future release.
+# Toolbox filters only affect toolbox display and do not enforce access
+# restrictions.
 
 #tool_filters =
 #tool_label_filters =
@@ -1190,6 +1193,9 @@ use_interactive = True
 # The base modules that are searched for modules as described above
 # can be modified and modules external to Galaxy can be searched by
 # modifying the following option.
+# Deprecated in Galaxy 26.1 and will be removed in a future release.
+# Toolbox filters only affect toolbox display and do not enforce access
+# restrictions.
 #toolbox_filter_base_modules = galaxy.tools.toolbox.filters,galaxy.tools.filters
 
 # -- Galaxy Application Internal Message Queue


### PR DESCRIPTION
## Summary
- announces toolbox filters as deprecated for Galaxy 26.1
- adds a runtime warning when configured or selected toolbox filters are loaded
- adds deprecation text to the user preference help text and config documentation

## Testing
- ./run_tests.sh -unit test/unit/tool_util/toolbox/test_toolbox_filters.py
- ./run_tests.sh -unit test/unit/config/config_manage/test_config_manage.py