### PR TITLE
[26.1] Stop the ssh file source from using local keys or the SSH agent

### DIFF
--- a/lib/galaxy/files/sources/ssh.py
+++ b/lib/galaxy/files/sources/ssh.py
@@ -94,6 +94,8 @@ class SshFilesSource(FsspecFilesSource[SshFileSourceTemplateConfiguration, SshFi
             pkey=pkey,
             port=config.port,
             timeout=config.timeout,
+            allow_agent=False,
+            look_for_keys=False,
             compress=config.compress,
         )
         return fs


### PR DESCRIPTION
After a discussion with @domgz https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2128 & https://github.com/galaxyproject/galaxy/pull/21646#discussion_r3413475398 I checked my logs and noticed that the local keys in `.ssh/` are indeed used which is probably not desired. Also key agents are probably not a good idea.

xref docs https://docs.paramiko.org/en/3.3/api/client.html#paramiko.client.SSHClient.connect
- `allow_agent` bool – set to False to disable connecting to the SSH agent
- `look_for_keys` bool – set to False to disable searching for discoverable private key files in ~/.ssh/


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
