### PR TITLE
Pass GCP Batch runner-level params through to the Pulsar client (custom_vm_image)

### DIFF
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -217,6 +217,10 @@ PULSAR_PARAM_SPECS = dict(
         map=specs.to_str_or_none,
         default=None,
     ),
+    custom_vm_image=dict(
+        map=specs.to_str_or_none,
+        default=None,
+    ),
 )
 
 
@@ -1190,6 +1194,19 @@ class PulsarGcpBatchJobRunner(PulsarCoexecutionJobRunner):
 
     client_manager_kwargs = GCP_BATCH_CLIENT_MANAGER_KWARGS
     destination_defaults = GCP_DESTINATION_DEFAULTS
+
+    # Runner-level params that should be passed through to the Pulsar client
+    # as destination params (destination overrides runner).
+    PASSTHROUGH_PARAMS = ["custom_vm_image"]
+
+    def _populate_parameter_defaults(self, job_destination):
+        updated = super()._populate_parameter_defaults(job_destination)
+        params = job_destination.params
+        for key in self.PASSTHROUGH_PARAMS:
+            if key not in params and self.runner_params.get(key):
+                params[key] = self.runner_params[key]
+                updated = True
+        return updated
 
 
 class PulsarRESTJobRunner(PulsarJobRunner):


### PR DESCRIPTION
# Pass GCP Batch runner-level params through to the Pulsar client (`custom_vm_image`)

Companion to Pulsar PR **galaxyproject/pulsar#472** (galaxyproject/pulsar:
"Support a custom VM boot disk image and size for GCP Batch"). Part of the broader
GCP Batch effort tracked in galaxyproject/pulsar#465.

## Summary

The Pulsar GCP Batch runner now understands a `custom_vm_image` destination param so
jobs can boot from a custom VM image (e.g. one with CVMFS pre-installed) instead of the
default Debian image. This PR lets Galaxy supply that value.

Today, anything Pulsar reads from `destination_params` must be set on the **destination**
— which means duplicating the image URI in every TPV destination that targets GCP
Batch. This PR adds a small `PASSTHROUGH_PARAMS` mechanism to
`PulsarGcpBatchJobRunner` so a handful of GCP-specific params can be configured **once
at the runner level** (in `job_conf.yml`) and are then merged into the per-job client
destination params. `custom_vm_image` is the first such param.

## Changes

1. **Add `custom_vm_image` to `PULSAR_PARAM_SPECS`** so it is a recognized Pulsar
   destination param.

2. **Add a `PASSTHROUGH_PARAMS` mechanism to `PulsarGcpBatchJobRunner`.** Runner-level
   params named in `PASSTHROUGH_PARAMS` (initially `custom_vm_image`) are copied into
   the client destination params when building the job, unless already set on the
   destination (destination value wins). This avoids repeating the image URI across
   every TPV destination.

## Example configuration

`job_conf.yml`:

```yaml
runners:
  pulsar_gcp_batch:
    load: galaxy.jobs.runners.pulsar:PulsarGcpBatchJobRunner
    # runner-level param, applied to every job this runner submits
    custom_vm_image: projects/my-project/global/images/galaxy-cvmfs-image
```

A TPV destination no longer needs to repeat `custom_vm_image`; it is inherited from the
runner. A destination may still override it when needed.

## Backward compatibility

Fully backward compatible. With no `custom_vm_image` configured, behavior is unchanged
and VMs boot from the default image. The `PASSTHROUGH_PARAMS` merge only fills in params
that aren't already set on the destination, so existing destinations are unaffected.

## Testing

Verified that a `custom_vm_image` set at the runner level reaches the Pulsar client and
that the resulting GCP Batch VM boots from the custom image. A destination-level
override takes precedence over the runner-level value as expected.

## Notes / follow-ups

- Pairs with galaxyproject/pulsar#472; merge after that lands so the param is actually consumed.
- `PASSTHROUGH_PARAMS` is deliberately extensible — other GCP-specific Pulsar params
  (e.g. `boot_disk_size_gb`, `job_id_prefix`, `delete_batch_job`) can be added to the
  list in later PRs if a runner-level default is useful.
- Separate, later PR (after Pulsar's dynamic-sizing change merges): update
  `lib/galaxy/jobs/runners/util/gcp_batch/helpers.py` to re-export
  `compute_machine_type`, `convert_cpu_to_milli`, and `convert_memory_to_mib` from
  `pulsar.managers.util.gcp_util`, so Galaxy's direct `GoogleCloudBatchJobRunner` and
  the Pulsar runner share one VM-sizing implementation.