### PR TITLE
[26.1] Backport architecture-aware mulled builds

### DIFF
--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -41,8 +41,8 @@ is not available already.
 Automatic build of Linux containers
 -----------------------------------
 
-We utilize mulled_ with involucro_ to automatically convert all packages in Bioconda_ into Linux containers images 
-(Docker and rkt at the moment) and make them available at the `BioContainers Quay.io account`_.
+We utilize involucro_ to automatically convert all packages in Bioconda_ into Linux container images
+and make them available at the `BioContainers Quay.io account`_.
 
 We have developed small utilities around this technology stack, which is currently included in the ``galaxy-tool-util``
 package, which can be installed simply using ``pip install galaxy-tool-util``. Here is a short introduction:
@@ -50,11 +50,11 @@ package, which can be installed simply using ``pip install galaxy-tool-util``. H
 Search for containers
 ^^^^^^^^^^^^^^^^^^^^^
 
-This will search for Docker containers (in the biocontainers organisation on quay.io), Singularity containers (located at https://depot.galaxyproject.org/singularity/), Conda packages (in the bioconda channel), and GitHub files (on the bioconda-recipes repository. 
+This will search for Docker containers (in the biocontainers organisation on quay.io), Singularity containers (located at https://depot.galaxyproject.org/singularity/), Conda packages (in the bioconda channel), and GitHub files (on the bioconda-recipes repository).
 
 .. code-block:: bash
 
-   $ mulled-search --destination docker conda --search vsearch
+   $ mulled-search --destination quay conda --search vsearch
 
 The user can specify the location(s) for a search using the ``--destination`` option. The search term is specified using ``--search``. Multiple search terms can be specified simultaneously; in this case, the search will also encompass multi-package containers. For example, ``--search samtools bamtools``, will return ``mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0``, in addition to all individual samtools and bamtools results.
 
@@ -74,7 +74,7 @@ Each mulled container is identified with a hash such as ``mulled-v2-8186960447c5
 The user can specify whether to generate hashes for either version 1 or version 2 containers with ``--hash``; version 2 is the default.
 
 
-Build all packages from bioconda from the last 24h
+Build all packages from bioconda from the last 25h
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The BioConda community is building a container for every package they create with a command similar to this.
@@ -82,13 +82,14 @@ The BioConda community is building a container for every package they create wit
 .. code-block:: bash
 
    $ mulled-build-channel --channel bioconda --namespace biocontainers \
-      --involucro-path ./involucro --recipes-dir ./bioconda-recipes --diff-hours 25 build
+      --involucro-path ./involucro --recipes-dir ./bioconda-recipes \
+      --diff-hours 25 --repo-data bioconda build
 
 
 Building Docker containers for local Conda packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Conda packages can be tested with creating a *busybox* based container for this particular package in the following way.
+Conda packages can be tested by creating a *busybox* based container for this particular package in the following way.
 This also demonstrates how you can build a container locally and on-the-fly.
 
   > we modified the ``samtools`` package to version 3.0 to make it clear we are using a local version
@@ -96,22 +97,21 @@ This also demonstrates how you can build a container locally and on-the-fly.
 1) Build your recipe
 
 .. code-block:: bash
-   
+
    $ conda build recipes/samtools
 
 2) Index your local builds
 
 .. code-block:: bash
-   
-   $ conda index /home/bag/miniconda2/conda-bld/linux-64/
 
+   $ conda index /home/bag/miniconda2/conda-bld/linux-64/
 
 3) Build a container for your local package
 
 .. code-block:: bash
-   
+
    $ mulled-build build-and-test 'samtools=3.0--0' \
-      --extra-channel file://home/bag/miniconda2/conda-bld/ --test 'samtools --help'
+      --channels conda-forge,bioconda,file:///home/user/conda-bld/ --test 'samtools --help'
 
 The ``--0`` indicates the build version of the conda package. It is recommended to specify this number, otherwise
 you will override already existing images. For Python Conda packages this extension might look like this ``--py35_1``.
@@ -122,16 +122,15 @@ Build, test, and push a conda-forge package to biocontainers
  > You need to have write access to the biocontainers repository
 
 You can build packages from other Conda channels as well, not only from BioConda. ``pandoc`` tool is available from the
-conda-forge channel and conda-forge is also enabled by default in Galaxy. To build ``pandoc`` and push it to biocontainrs
+conda-forge channel and conda-forge is also enabled by default in Galaxy. To build ``pandoc`` and push it to biocontainers
 you could do something along these lines.
-
 
 .. code-block:: bash
 
    $ mulled-build build-and-test 'pandoc=1.17.2--0' --test 'pandoc --help' -n biocontainers
 
 .. code-block:: bash
-  
+
    $ mulled-build push 'pandoc=1.17.2--0' --test 'pandoc --help' -n biocontainers
 
 Build Singularity containers from Docker containers
@@ -143,7 +142,7 @@ To generate a single container:
 
 .. code-block:: bash
 
-   $ mulled-update-singularity-containers --containers samtools:1.6--0 --logfile /tmp/sing/test.log --filepath /tmp/sing/ --installation /usr/local/bin/singularity
+   $ mulled-update-singularity-containers --containers samtools:1.6--0 --filepath /tmp/sing/ --installation /usr/local/bin/singularity
 
 ``--containers`` indicates the container name (here ``samtools:1.6--0``), ``--filepath`` the location where the containers should be placed, and ``--installation`` the location of the Singularity installation. (This can be found using ``whereis singularity``.)
 
@@ -167,7 +166,7 @@ In order to generate the list file the ``mulled-list`` command may be useful. Th
 
    $ mulled-list --source docker --not-singularity --blacklist blacklist.txt --file output.txt
 
-The list of containers will be saved as ``output.txt``. The (optional) ``--blacklist`` option may be used to exclude containers which should not included in the output; ``blacklist.txt`` should contain a list of the 'blacklisted' containers, each on a new line.
+The list of containers will be saved as ``output.txt``. The (optional) ``--blacklist`` option may be used to exclude containers which should not be included in the output; ``blacklist.txt`` should contain a list of the 'blacklisted' containers, each on a new line.
 
 The generated containers should also be tested. This can be achieved by affixing ``--testing test-output.log`` to the ``mulled-update-singularity-containers`` command:
 
@@ -175,10 +174,386 @@ The generated containers should also be tested. This can be achieved by affixing
 
    $ mulled-update-singularity-containers --container-list list.txt --filepath /tmp/sing/ --installation /usr/local/bin/singularity --testing test-output.log
 
+
+Command Reference
+=================
+
+The sections below provide a detailed reference for each command.
+
+mulled-search
+-------------
+
+.. code-block:: bash
+
+   $ mulled-search --destination quay conda --search vsearch
+
+Multi-package search::
+
+   $ mulled-search --search samtools bamtools --destination quay
+
+Options:
+
+``-d, --destination``
+  Where to search. Choices: ``quay``, ``singularity``, ``github``, ``conda``.
+  Defaults: all of the above (``conda`` only if the ``conda`` binary is on ``PATH``).
+  Multiple values can be given.
+
+``-s, --search`` (required)
+  Search term(s). Multiple terms trigger a multi-package container hash lookup.
+
+``-o, --organization``
+  Quay.io organization to search. Default: ``biocontainers``.
+
+``-c, --channel``
+  Conda channel to search. Default: ``bioconda``.
+
+``--non-strict``
+  Enable autocorrection of typos. Lists more results but can be confusing.
+  Quay.io may block requests with too many queries.
+
+``--cache-time``
+  Number of seconds to reuse cached results. Default: ``900``.
+
+``-j, --json``
+  Return results in JSON format.
+
+
+mulled-hash
+-----------
+
+Compute the mulled hash for a set of packages.
+
+.. code-block:: bash
+
+   $ mulled-hash samtools=1.3.1,bedtools=2.22
+   mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:d52e471b5bfa168ac813d54fc5dfe7f96ade56e6
+
+Options:
+
+``TARGETS`` (positional)
+  Comma-separated packages for calculating the mulled hash,
+  e.g. ``samtools=1.3.1,bedtools=2.22``.
+
+``--hash``
+  Hash version. Choices: ``v1``, ``v2`` (default).
+
+
+mulled-build-channel
+--------------------
+
+Build mulled images for all recent conda recipe updates that do not
+already have published containers on quay.io.
+
+.. code-block:: bash
+
+   $ mulled-build-channel --channel bioconda --namespace biocontainers \
+      --involucro-path ./involucro --recipes-dir ./bioconda-recipes \
+      --diff-hours 25 --repo-data bioconda build
+
+Commands:
+
+``list``
+  Print package names that would be affected.
+
+``build``
+  Build containers for new packages.
+
+``build-and-test``
+  Build and test containers.
+
+``all``
+  Build, test, and push containers.
+
+Options:
+
+``--channel``
+  Conda channel to fetch repodata from. Default: ``bioconda``.
+
+``--repo-data`` (required)
+  Path to published repodata. If the file does not exist, it will be
+  auto-downloaded from the channel specified by ``--channel``.
+
+``--diff-hours``
+  Look back this many hours for changed recipes. Default: ``25``.
+
+``--recipes-dir``
+  Directory containing bioconda recipes. Default: ``./bioconda-recipes``.
+
+``--force-rebuild``
+  Rebuild packages even if they already exist on quay.io.
+
+``--targets``
+  Build a single container with specific package(s) instead of scanning the channel.
+
+``--repository-name``
+  Name of a single container. Leave blank to auto-generate based on packages.
+
+Inherits all shared build options from mulled-build (``--namespace``,
+``--channels``, ``--dry-run``, ``--verbose``, ``--singularity``,
+``--target-platform``, etc.).
+
+
+mulled-build
+------------
+
+Build a mulled container for specific conda packages.
+
+.. code-block:: bash
+
+   $ mulled-build build-and-test 'samtools=3.0--0' \
+      --channels conda-forge,bioconda,file:///home/user/conda-bld/ \
+      --test 'samtools --help'
+
+Commands:
+
+``build``
+  Build the container image.
+
+``build-and-test``
+  Build and run a test command inside the container.
+
+``push``
+  Push the built image to the repository.
+
+``all``
+  Build, test, and push.
+
+Target specification::
+
+   # Single package
+   mulled-build build 'samtools=1.3.1--4'
+
+   # Multiple packages (comma-separated)
+   mulled-build build 'samtools=1.3.1--4,bedtools=2.22'
+
+   # Version-less (will use latest)
+   mulled-build build 'samtools'
+
+Options:
+
+``TARGETS`` (positional)
+  Package target(s) as ``name=version--build``. Multiple targets comma-separated.
+
+``COMMAND`` (positional)
+  ``build``, ``build-and-test``, ``push``, or ``all``.
+
+Build options:
+
+``-c, --channels``
+  Comma-separated list of conda channels. Default: ``conda-forge,bioconda``.
+
+``-n, --namespace``
+  Quay.io namespace. Default: ``biocontainers``.
+
+``-r, --repository-template``
+  Docker repository template. Default: ``quay.io/${namespace}/${image}``.
+
+``--target-platform``
+  Target platform for cross-architecture builds.
+  Choices: ``linux/amd64``, ``linux/arm64``, ``linux/arm/v7``, ``linux/ppc64le``.
+  Requires binfmt/QEMU support on the Docker daemon host.
+  Cannot be combined with ``--singularity``.
+
+``--hash``
+  Hash version for multi-package containers. Choices: ``v1``, ``v2`` (default).
+
+``--name-override``
+  Override mulled image name. Not recommended — metadata will not be
+  detectable from the name of resulting images.
+
+``--image-build``
+  Build a versioned variant of this image.
+
+``--repository-name``
+  Name of the container. Leave blank to auto-generate based on packages.
+
+``--involucro-path``
+  Path to involucro binary. If not set, searches working directory and PATH.
+
+``--involucro-lua-file``
+  Path to invfile.lua. Default: uses bundled file.
+
+Testing:
+
+``--test``
+  Test command to run inside the container.
+
+``--test-files``
+  Test files to mount inside the container. Comma-separated, supports
+  ``source:dest`` Docker syntax. Relative paths are mounted under ``/source/``.
+
+Output control:
+
+``--dry-run``
+  Print commands instead of executing them.
+
+``--verbose``
+  Verbose output.
+
+Execution:
+
+``--singularity``
+  Additionally build a Singularity image. Cannot be combined with
+  ``--target-platform``.
+
+``--singularity-image-dir``
+  Directory to write Singularity images to.
+
+``--disable-strict-channel-priority``
+  Disable strict channel priority. Slows resolver; use only in exceptional cases.
+
+``--conda-version``
+  Use a specific version of Conda inside the build container.
+
+``--mamba-version``
+  Use a specific version of Mamba inside the build container.
+
+``--use-mamba``
+  Use Mamba instead of Conda for package installation.
+
+``--oauth-token``
+  Token for communicating with the quay.io API.
+
+``--check-published``
+  If set, check whether the image already exists on quay.io before building.
+  By default images are always rebuilt.
+
+
+mulled-build-files
+------------------
+
+Build composite mulled containers from recipe combinations defined in TSV files.
+Unlike ``mulled-build-channel`` (which builds single-package images for a whole
+channel), this tool builds multi-package images from explicit combinations.
+
+.. code-block:: bash
+
+   $ mulled-build-files build
+   $ mulled-build-files build /path/to/recipes.tsv
+
+Each TSV line describes one container. Columns (tab-separated):
+
+``targets``
+  Package specification, e.g. ``samtools=1.3.1,bedtools=2.26.0``.
+
+``image_build``
+  Build number to append to the image tag (optional).
+
+``name_override``
+  Custom image name instead of auto-generated hash (optional).
+
+``base_image``
+  Base Docker image to use instead of the default busybox (optional).
+
+Header lines (starting with ``#``) can redefine the column order.
+
+Options:
+
+``COMMAND`` (positional)
+  ``build``, ``build-and-test``, or ``all``.
+
+``FILES`` (positional)
+  Path to a TSV file or a directory of TSV files. Default: current directory.
+
+Inherits all shared build options from mulled-build (``--channels``,
+``--namespace``, ``--target-platform``, ``--dry-run``, ``--verbose``,
+``--singularity``, etc.).
+
+
+mulled-build-tool
+-----------------
+
+Build a mulled container directly from a Galaxy or CWL tool definition.
+
+.. code-block:: bash
+
+   $ mulled-build-tool build path/to/tool.xml
+
+The tool's ``<requirement type="package">`` tags are extracted and used
+to build a matching container.
+
+Options:
+
+``COMMAND`` (positional)
+  ``build``, ``build-and-test``, or ``all``.
+
+``TOOL`` (positional)
+  Path to a Galaxy tool XML file or CWL descriptor.
+
+Inherits all shared build options and single-image options from mulled-build
+(``--channels``, ``--namespace``, ``--target-platform``, ``--name-override``,
+``--image-build``, etc.).
+
+
+mulled-list
+-----------
+
+List containers from quay.io, filtered by whether they already exist as
+Singularity images or Conda environments.
+
+.. code-block:: bash
+
+   $ mulled-list --source docker --not-singularity --blacklist blocklist.txt --file output.txt
+
+Options:
+
+``--source, -s``
+  Source to list from. Choices: ``docker``, ``singularity``, ``conda``.
+
+``--not-singularity``
+  Exclude Docker containers that already have a Singularity build on
+  https://depot.galaxyproject.org/singularity/.
+
+``--not-conda``
+  Exclude Docker containers that already have a Conda environment extracted.
+
+``--conda-filepath``
+  Path to directory of Conda environments. Required if ``--not-conda`` is used.
+
+``-b, --blocklist, --blacklist``
+  Path to a file listing containers to exclude (one per line).
+
+``-f, --file``
+  Output file. If not given, results are printed to stdout.
+
+
+mulled-update-singularity-containers
+------------------------------------
+
+Convert Docker containers to Singularity images.
+
+.. code-block:: bash
+
+   $ mulled-update-singularity-containers --containers samtools:1.6--0 \
+      --filepath /tmp/sing/ --installation /usr/local/bin/singularity
+
+Options:
+
+``-c, --containers``
+  Container names to convert (one or more).
+
+``-l, --container-list``
+  Path to a file listing containers to convert (one per line).
+  Alternative to ``--containers``.
+
+``-f, --filepath``
+  Output directory for the Singularity images.
+
+``-i, --installation``
+  Path to the Singularity installation (find with ``which singularity``).
+
+``--no-sudo``
+  Build containers without sudo.
+
+``--testing, -t``
+  Enable automatic testing. Value is the output file for test results.
+  Uses a shallow search on Anaconda for test commands/imports from the
+  package's ``meta.yaml`` or ``run_test.sh``.
+
+
 .. _IUC: https://galaxyproject.org/iuc/
 .. _container annotation:  https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/catDocker.xml#L4
 .. _BioContainers: https://github.com/biocontainers
-.. _mulled: https://github.com/mulled/mulled
 .. _involucro: https://github.com/involucro/involucro
 .. _Bioconda: https://bioconda.github.io/
 .. _BioContainers Quay.io account: https://quay.io/organization/biocontainers

--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -350,7 +350,7 @@ Build options:
 
 ``--target-platform``
   Target platform for cross-architecture builds.
-  Choices: ``linux/amd64``, ``linux/arm64``, ``linux/arm/v7``, ``linux/ppc64le``.
+  Choices: ``linux/amd64``, ``linux/arm64``, ``linux/arm/v7``, ``linux/ppc64le``, ``linux/riscv64``.
   Requires binfmt/QEMU support on the Docker daemon host.
   Cannot be combined with ``--singularity``.
 

--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -74,7 +74,7 @@ Each mulled container is identified with a hash such as ``mulled-v2-8186960447c5
 The user can specify whether to generate hashes for either version 1 or version 2 containers with ``--hash``; version 2 is the default.
 
 
-Build all packages from bioconda from the last 25h
+Build all packages from bioconda from the last 24h
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The BioConda community is building a container for every package they create with a command similar to this.

--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -41,7 +41,7 @@ is not available already.
 Automatic build of Linux containers
 -----------------------------------
 
-We utilize involucro_ to automatically convert all packages in Bioconda_ into Linux container images
+We utilize mulled_ (with involucro_) to automatically convert all packages in Bioconda_ into Linux container images
 and make them available at the `BioContainers Quay.io account`_.
 
 We have developed small utilities around this technology stack, which is currently included in the ``galaxy-tool-util``

--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -83,7 +83,7 @@ The BioConda community is building a container for every package they create wit
 
    $ mulled-build-channel --channel bioconda --namespace biocontainers \
       --involucro-path ./involucro --recipes-dir ./bioconda-recipes \
-      --diff-hours 25 --repo-data bioconda build
+      --diff-hours 24 --repo-data bioconda build
 
 
 Building Docker containers for local Conda packages

--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -104,7 +104,7 @@ This also demonstrates how you can build a container locally and on-the-fly.
 
 .. code-block:: bash
 
-   $ conda index /home/bag/miniconda2/conda-bld/linux-64/
+   $ conda index /home/bag/miniconda3/conda-bld/linux-64/
 
 3) Build a container for your local package
 

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -37,6 +37,7 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.commands import argv_to_str
+from .mulled_build import conda_platform
 from .util import (
     CondaInDockerContext,
     get_files_from_conda_package,
@@ -102,12 +103,14 @@ def get_run_test(file: str) -> Dict[str, Any]:
     return package_tests
 
 
-def get_anaconda_url(container, anaconda_channel="bioconda"):
+def get_anaconda_url(container, anaconda_channel="bioconda", conda_platform_str=None):
     """
     Download tarball from anaconda for test
     """
-    name = split_container_name(container)  # list consisting of [name, version, (build, if present)]
-    return f"https://anaconda.org/{anaconda_channel}/{name[0]}/{name[1]}/download/linux-64/{'-'.join(name)}.tar.bz2"
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
+    name = split_container_name(container)
+    return f"https://anaconda.org/{anaconda_channel}/{name[0]}/{name[1]}/download/{conda_platform_str}/{'-'.join(name)}.tar.bz2"
 
 
 def get_test_from_anaconda(url: str) -> Optional[Dict[str, Any]]:
@@ -128,11 +131,17 @@ def get_test_from_anaconda(url: str) -> Optional[Dict[str, Any]]:
 
 
 def find_anaconda_download_url(
-    name: str, version: str, build: Optional[str] = None, anaconda_channel: str = "bioconda"
+    name: str,
+    version: str,
+    build: Optional[str] = None,
+    anaconda_channel: str = "bioconda",
+    conda_platform_str: Optional[str] = None,
 ) -> Optional[str]:
     """
     Find the anaconda download url for a given package.
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     r = requests.get(
         f"https://api.anaconda.org/package/{anaconda_channel}/{name}/files",
         timeout=MULLED_SOCKET_TIMEOUT,
@@ -143,7 +152,7 @@ def find_anaconda_download_url(
         if (
             package_file["version"] == version
             and (build is None or package_file["attrs"]["build"] == build)
-            and package_file["attrs"]["subdir"] in ["linux-64", "noarch"]
+            and package_file["attrs"]["subdir"] in [conda_platform_str, "noarch"]
         ):
             return f"https:{package_file['download_url']}"
     return None
@@ -207,11 +216,17 @@ def try_a_func(func1, func2, param, container):
 
 
 def deep_test_search(
-    container, recipes_path=None, anaconda_channel="bioconda", github_repo="bioconda/bioconda-recipes"
+    container,
+    recipes_path=None,
+    anaconda_channel="bioconda",
+    github_repo="bioconda/bioconda-recipes",
+    conda_platform_str=None,
 ):
     """
     Look in bioconda-recipes repo as well as anaconda for the tests, checking in multiple possible locations. If no test is found for the specified version, search if other package versions have a test available.
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     name_tuple = split_container_name(container)
     assert len(name_tuple) in (2, 3)
     name = name_tuple[0]
@@ -237,7 +252,7 @@ def deep_test_search(
             container,
         ),
         (get_run_test, open_recipe_file, (f"recipes/{name}/run_test.sh", recipes_path, github_repo), container),
-        (get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel), container),
+        (get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel, conda_platform_str), container),
     ]:
         result = try_a_func(*f)
         if result:
@@ -257,7 +272,9 @@ def deep_test_search(
         if result:
             return result
 
-    url = find_anaconda_download_url(name, version, build=build, anaconda_channel=anaconda_channel)
+    url = find_anaconda_download_url(
+        name, version, build=build, anaconda_channel=anaconda_channel, conda_platform_str=conda_platform_str
+    )
     result = try_a_func(get_test_from_anaconda, lambda x: x, (url,), container)
     if result:
         return result
@@ -267,15 +284,24 @@ def deep_test_search(
 
 
 def main_test_search(
-    container, recipes_path=None, deep=False, anaconda_channel="bioconda", github_repo="bioconda/bioconda-recipes"
+    container,
+    recipes_path=None,
+    deep=False,
+    anaconda_channel="bioconda",
+    github_repo="bioconda/bioconda-recipes",
+    conda_platform_str=None,
 ):
     """
     Download tarball from anaconda for test
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     if deep:  # do a deep search
-        return deep_test_search(container, recipes_path, anaconda_channel, github_repo)
+        return deep_test_search(container, recipes_path, anaconda_channel, github_repo, conda_platform_str)
     # else shallow
-    result = try_a_func(get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel), container)
+    result = try_a_func(
+        get_test_from_anaconda, get_anaconda_url, (container, anaconda_channel, conda_platform_str), container
+    )
     if result:
         return result
     return {"container": container}
@@ -291,11 +317,18 @@ def import_test_to_command_list(import_lang: str, import_: str) -> List[str]:
 
 
 def hashed_test_search(
-    container: str, recipes_path=None, deep=False, anaconda_channel="bioconda", github_repo="bioconda/bioconda-recipes"
+    container: str,
+    recipes_path=None,
+    deep=False,
+    anaconda_channel="bioconda",
+    github_repo="bioconda/bioconda-recipes",
+    conda_platform_str=None,
 ) -> Dict[str, Any]:
     """
     Get test for hashed containers
     """
+    if conda_platform_str is None:
+        conda_platform_str = conda_platform()
     package_tests: Dict[str, Any] = {"commands": [], "imports": [], "container": container, "import_lang": "python -c"}
 
     response = requests.get(
@@ -314,8 +347,7 @@ def hashed_test_search(
     containers = []
     for package_name, package_version in packages:
         conda_target = CondaTarget(package_name, package_version)
-        # include only linux-64 builds since that is hardcoded in get_anaconda_url and the only target for container builds
-        hit, exact = best_search_result(conda_target, conda_context, platform="linux-64")
+        hit, exact = best_search_result(conda_target, conda_context, platform=conda_platform_str)
         if not hit or not exact:
             raise Exception(f"Could not find {conda_target}")
         build = hit["build"]
@@ -325,7 +357,7 @@ def hashed_test_search(
             containers.append(f"{package_name}:{package_version}")
 
     for container in containers:
-        tests = main_test_search(container, recipes_path, deep, anaconda_channel, github_repo)
+        tests = main_test_search(container, recipes_path, deep, anaconda_channel, github_repo, conda_platform_str)
         package_tests["commands"] += tests.get("commands", [])  # not a very nice solution but probably the simplest
         # Given that this could be a mix of Python and Perl packages, translate imports to commands
         for imp in tests.get("imports", []):

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -103,7 +103,7 @@ def get_run_test(file: str) -> Dict[str, Any]:
     return package_tests
 
 
-def get_anaconda_url(container, anaconda_channel="bioconda", conda_platform_str=None):
+def get_anaconda_url(container: str, anaconda_channel: str = "bioconda", conda_platform_str: Optional[str] = None) -> str:
     """
     Download tarball from anaconda for test
     """
@@ -216,12 +216,12 @@ def try_a_func(func1, func2, param, container):
 
 
 def deep_test_search(
-    container,
-    recipes_path=None,
-    anaconda_channel="bioconda",
-    github_repo="bioconda/bioconda-recipes",
-    conda_platform_str=None,
-):
+    container: str,
+    recipes_path: Optional[str] = None,
+    anaconda_channel: str = "bioconda",
+    github_repo: str = "bioconda/bioconda-recipes",
+    conda_platform_str: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Look in bioconda-recipes repo as well as anaconda for the tests, checking in multiple possible locations. If no test is found for the specified version, search if other package versions have a test available.
     """
@@ -284,13 +284,13 @@ def deep_test_search(
 
 
 def main_test_search(
-    container,
-    recipes_path=None,
-    deep=False,
-    anaconda_channel="bioconda",
-    github_repo="bioconda/bioconda-recipes",
-    conda_platform_str=None,
-):
+    container: str,
+    recipes_path: Optional[str] = None,
+    deep: bool = False,
+    anaconda_channel: str = "bioconda",
+    github_repo: str = "bioconda/bioconda-recipes",
+    conda_platform_str: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Download tarball from anaconda for test
     """
@@ -318,11 +318,11 @@ def import_test_to_command_list(import_lang: str, import_: str) -> List[str]:
 
 def hashed_test_search(
     container: str,
-    recipes_path=None,
-    deep=False,
-    anaconda_channel="bioconda",
-    github_repo="bioconda/bioconda-recipes",
-    conda_platform_str=None,
+    recipes_path: Optional[str] = None,
+    deep: bool = False,
+    anaconda_channel: str = "bioconda",
+    github_repo: str = "bioconda/bioconda-recipes",
+    conda_platform_str: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Get test for hashed containers

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -103,7 +103,9 @@ def get_run_test(file: str) -> Dict[str, Any]:
     return package_tests
 
 
-def get_anaconda_url(container: str, anaconda_channel: str = "bioconda", conda_platform_str: Optional[str] = None) -> str:
+def get_anaconda_url(
+    container: str, anaconda_channel: str = "bioconda", conda_platform_str: Optional[str] = None
+) -> str:
     """
     Download tarball from anaconda for test
     """

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -232,7 +232,7 @@ def docker_platform_tag_suffix(target_platform: Optional[str]) -> Optional[str]:
     )
     if target_platform == "linux/amd64":
         return None
-    return target_platform.removeprefix("linux/").replace("/", "-")
+    return target_platform[len("linux/"):].replace("/", "-")
 
 
 def apply_platform_tag_suffix(image: str, target_platform: Optional[str]) -> str:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -100,9 +100,9 @@ From: %(base_image)s
 
 
 def involucro_link():
-    repo = "https://github.com/involucro/involucro/releases/download"
+    url_start = f"https://github.com/involucro/involucro/releases/download/v{INVOLUCRO_VERSION}/"
     if IS_OS_X:
-        url = f"{repo}/v{INVOLUCRO_VERSION}/involucro.darwin"
+        url = f"{url_start}involucro.darwin"
     else:
         machine = _platform_module.machine()
         arch_map = {
@@ -113,7 +113,7 @@ def involucro_link():
             "armv7l": "involucro.linux-armv7",
         }
         asset = arch_map.get(machine, "involucro")
-        url = f"{repo}/v{INVOLUCRO_VERSION}/{asset}"
+        url = f"{url_start}{asset}"
     return url
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -177,12 +177,13 @@ def conda_versions(pkg_name, file_name):
 
 
 def conda_platform() -> str:
-    machine = _platform_module.machine()
+    machine = _platform_module.machine().lower()
     if IS_OS_X:
         conda_arch_map = {
             "x86_64": "osx-64",
             "arm64": "osx-arm64",
         }
+        default_platform = "osx-64"
     else:
         conda_arch_map = {
             "x86_64": "linux-64",
@@ -191,7 +192,8 @@ def conda_platform() -> str:
             "arm64": "linux-aarch64",
             "armv7l": "linux-armv7l",
         }
-    return conda_arch_map.get(machine, "linux-64")
+        default_platform = "linux-64"
+    return conda_arch_map.get(machine, default_platform)
 
 
 def get_conda_hits_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> List[Dict[str, Any]]:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -86,6 +86,7 @@ DOCKER_TO_CONDA_PLATFORM = {
     "linux/arm64": "linux-aarch64",
     "linux/arm/v7": "linux-armv7l",
     "linux/ppc64le": "linux-ppc64le",
+    "linux/riscv64": "linux-riscv64",
 }
 MACHINE_TO_DOCKER_PLATFORM = {
     "x86_64": "linux/amd64",
@@ -94,6 +95,7 @@ MACHINE_TO_DOCKER_PLATFORM = {
     "arm64": "linux/arm64",
     "armv7l": "linux/arm/v7",
     "ppc64le": "linux/ppc64le",
+    "riscv64": "linux/riscv64",
 }
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -176,8 +176,27 @@ def conda_versions(pkg_name, file_name):
     return ret
 
 
+def _conda_platform() -> str:
+    machine = _platform_module.machine()
+    if IS_OS_X:
+        conda_arch_map = {
+            "x86_64": "osx-64",
+            "arm64": "osx-arm64",
+        }
+    else:
+        conda_arch_map = {
+            "x86_64": "linux-64",
+            "amd64": "linux-64",
+            "aarch64": "linux-aarch64",
+            "arm64": "linux-aarch64",
+            "armv7l": "linux-armv7l",
+        }
+    return conda_arch_map.get(machine, "linux-64")
+
+
 def get_conda_hits_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> List[Dict[str, Any]]:
-    search_results = (best_search_result(t, conda_context, platform="linux-64")[0] for t in targets)
+    platform = _conda_platform()
+    search_results = (best_search_result(t, conda_context, platform=platform)[0] for t in targets)
     return [r for r in search_results if r]
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -12,12 +12,12 @@ Build a mulled image with:
 import json
 import logging
 import os
+import platform as _platform_module
 import shutil
 import stat
 import string
 import subprocess
 import sys
-import platform as _platform_module
 from sys import platform as _platform
 from typing import (
     Any,
@@ -176,7 +176,7 @@ def conda_versions(pkg_name, file_name):
     return ret
 
 
-def _conda_platform() -> str:
+def conda_platform() -> str:
     machine = _platform_module.machine()
     if IS_OS_X:
         conda_arch_map = {
@@ -195,7 +195,7 @@ def _conda_platform() -> str:
 
 
 def get_conda_hits_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> List[Dict[str, Any]]:
-    platform = _conda_platform()
+    platform = conda_platform()
     search_results = (best_search_result(t, conda_context, platform=platform)[0] for t in targets)
     return [r for r in search_results if r]
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -81,14 +81,22 @@ INVOLUCRO_VERSION = "1.2.0"
 DEST_BASE_IMAGE = os.environ.get("DEST_BASE_IMAGE", None)
 # Explicit Docker build targets use OCI platform notation. This is separate
 # from conda_platform(), which detects the native host OS and architecture.
-DOCKER_TO_CONDA_PLATFORM = {
+DockerPlatform = Literal[
+    "linux/amd64",
+    "linux/arm64",
+    "linux/arm/v7",
+    "linux/ppc64le",
+    "linux/riscv64",
+]
+
+DOCKER_TO_CONDA_PLATFORM: dict[DockerPlatform, str] = {
     "linux/amd64": "linux-64",
     "linux/arm64": "linux-aarch64",
     "linux/arm/v7": "linux-armv7l",
     "linux/ppc64le": "linux-ppc64le",
     "linux/riscv64": "linux-riscv64",
 }
-MACHINE_TO_DOCKER_PLATFORM = {
+MACHINE_TO_DOCKER_PLATFORM: dict[str, DockerPlatform] = {
     "x86_64": "linux/amd64",
     "amd64": "linux/amd64",
     "aarch64": "linux/arm64",
@@ -216,7 +224,7 @@ def conda_platform() -> str:
     return conda_arch_map.get(machine, default_platform)
 
 
-def docker_platform_to_conda_subdir(target_docker_platform: Optional[str]) -> str:
+def docker_platform_to_conda_subdir(target_docker_platform: Optional[DockerPlatform]) -> str:
     """Return the conda subdir for an explicit Docker target, or for the host when unset."""
     if target_docker_platform is None:
         return conda_platform()
@@ -226,7 +234,7 @@ def docker_platform_to_conda_subdir(target_docker_platform: Optional[str]) -> st
         raise ValueError(f"Unsupported target platform '{target_docker_platform}'") from None
 
 
-def docker_platform_tag_suffix(target_platform: Optional[str]) -> Optional[str]:
+def docker_platform_tag_suffix(target_platform: Optional[DockerPlatform]) -> Optional[str]:
     """Return an image-tag suffix, preserving unsuffixed tags for legacy amd64 images."""
     target_platform = target_platform or MACHINE_TO_DOCKER_PLATFORM.get(
         _platform_module.machine().lower(), "linux/amd64"
@@ -236,7 +244,7 @@ def docker_platform_tag_suffix(target_platform: Optional[str]) -> Optional[str]:
     return target_platform[len("linux/") :].replace("/", "-")
 
 
-def apply_platform_tag_suffix(image: str, target_platform: Optional[str]) -> str:
+def apply_platform_tag_suffix(image: str, target_platform: Optional[DockerPlatform]) -> str:
     suffix = docker_platform_tag_suffix(target_platform)
     if suffix is None:
         return image
@@ -321,7 +329,7 @@ def mull_targets(
     determine_base_image: bool = True,
     invfile: str = INVFILE,
     strict_channel_priority: bool = True,
-    target_platform: Optional[str] = None,
+    target_platform: Optional[DockerPlatform] = None,
 ) -> int:
     conda_platform_str = docker_platform_to_conda_subdir(target_platform)
     if singularity and target_platform:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -18,7 +18,6 @@ import stat
 import string
 import subprocess
 import sys
-from copy import copy
 from sys import platform as _platform
 from typing import (
     Any,
@@ -322,21 +321,12 @@ def mull_targets(
     strict_channel_priority: bool = True,
     target_platform: Optional[str] = None,
 ) -> int:
-    if involucro_context is not None and involucro_context.platform is not None:
-        if target_platform is not None and target_platform != involucro_context.platform:
-            raise ValueError(
-                f"Target platform '{target_platform}' conflicts with Involucro platform '{involucro_context.platform}'"
-            )
-        target_platform = involucro_context.platform
     conda_platform_str = docker_platform_to_conda_subdir(target_platform)
     if singularity and target_platform:
         raise ValueError("--target-platform cannot be used with --singularity")
 
     if involucro_context is None:
-        involucro_context = InvolucroContext(platform=target_platform)
-    else:
-        involucro_context = copy(involucro_context)
-        involucro_context.platform = target_platform
+        involucro_context = InvolucroContext()
 
     image_function = v1_image_name if hash_func == "v1" else v2_image_name
     if len(targets) > 1 and image_build is None:
@@ -390,6 +380,8 @@ def mull_targets(
         "-set",
         f"BINDS={bind_str}",
     ]
+    if target_platform:
+        involucro_args = ["--platform", target_platform] + involucro_args
     dest_base_image = None
     if base_image:
         dest_base_image = base_image
@@ -478,9 +470,7 @@ def mull_targets(
 
 def context_from_args(args):
     verbose = "2" if not args.verbose else "3"
-    return InvolucroContext(
-        involucro_bin=args.involucro_path, verbose=verbose, platform=getattr(args, "target_platform", None)
-    )
+    return InvolucroContext(involucro_bin=args.involucro_path, verbose=verbose)
 
 
 class InvolucroContext(installable.InstallableContext):
@@ -491,7 +481,6 @@ class InvolucroContext(installable.InstallableContext):
         involucro_bin: Optional[str] = None,
         shell_exec: Optional[Callable[[List[str]], int]] = None,
         verbose: str = "3",
-        platform: Optional[str] = None,
     ) -> None:
         if involucro_bin is None:
             if os.path.exists("./involucro"):
@@ -502,12 +491,9 @@ class InvolucroContext(installable.InstallableContext):
             self.involucro_bin = involucro_bin
         self.shell_exec = shell_exec or commands.shell
         self.verbose = verbose
-        self.platform = platform
 
     def build_command(self, involucro_args: List[str]) -> List[str]:
         cmd = [self.involucro_bin, f"-v={self.verbose}"]
-        if self.platform:
-            cmd.extend(["--platform", self.platform])
         return cmd + involucro_args
 
     def exec_command(self, involucro_args: List[str]) -> int:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -232,7 +232,7 @@ def docker_platform_tag_suffix(target_platform: Optional[str]) -> Optional[str]:
     )
     if target_platform == "linux/amd64":
         return None
-    return target_platform[len("linux/"):].replace("/", "-")
+    return target_platform[len("linux/") :].replace("/", "-")
 
 
 def apply_platform_tag_suffix(image: str, target_platform: Optional[str]) -> str:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -17,6 +17,7 @@ import stat
 import string
 import subprocess
 import sys
+import platform as _platform_module
 from sys import platform as _platform
 from typing import (
     Any,
@@ -76,7 +77,7 @@ DEFAULT_REPOSITORY_TEMPLATE = "quay.io/${namespace}/${image}"
 DEFAULT_BINDS = ["build/dist:/usr/local/"]
 DEFAULT_WORKING_DIR = "/source/"
 IS_OS_X = _platform == "darwin"
-INVOLUCRO_VERSION = "1.1.2"
+INVOLUCRO_VERSION = "1.2.0"
 DEST_BASE_IMAGE = os.environ.get("DEST_BASE_IMAGE", None)
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker
@@ -99,10 +100,20 @@ From: %(base_image)s
 
 
 def involucro_link():
+    repo = "https://github.com/involucro/involucro/releases/download"
     if IS_OS_X:
-        url = f"https://github.com/mvdbeek/involucro/releases/download/v{INVOLUCRO_VERSION}/involucro.darwin"
+        url = f"{repo}/v{INVOLUCRO_VERSION}/involucro.darwin"
     else:
-        url = f"https://github.com/involucro/involucro/releases/download/v{INVOLUCRO_VERSION}/involucro"
+        machine = _platform_module.machine()
+        arch_map = {
+            "x86_64": "involucro.linux-amd64",
+            "amd64": "involucro.linux-amd64",
+            "aarch64": "involucro.linux-arm64",
+            "arm64": "involucro.linux-arm64",
+            "armv7l": "involucro.linux-armv7",
+        }
+        asset = arch_map.get(machine, "involucro")
+        url = f"{repo}/v{INVOLUCRO_VERSION}/{asset}"
     return url
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -584,7 +584,7 @@ def add_build_arguments(parser):
     parser.add_argument("-n", "--namespace", dest="namespace", default="biocontainers", help="quay.io namespace.")
     parser.add_argument(
         "-r",
-        "--repository_template",
+        "--repository-template",
         dest="repository_template",
         default=DEFAULT_REPOSITORY_TEMPLATE,
         help="Docker repository target for publication (only quay.io or compat. API is currently supported).",
@@ -597,7 +597,7 @@ def add_build_arguments(parser):
         help="Comma separated list of target conda channels.",
     )
     parser.add_argument(
-        "--disable_strict_channel_priority",
+        "--disable-strict-channel-priority",
         dest="strict_channel_priority",
         default=True,
         action="store_false",

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -89,14 +89,14 @@ DockerPlatform = Literal[
     "linux/riscv64",
 ]
 
-DOCKER_TO_CONDA_PLATFORM: dict[DockerPlatform, str] = {
+DOCKER_TO_CONDA_PLATFORM: Dict[DockerPlatform, str] = {
     "linux/amd64": "linux-64",
     "linux/arm64": "linux-aarch64",
     "linux/arm/v7": "linux-armv7l",
     "linux/ppc64le": "linux-ppc64le",
     "linux/riscv64": "linux-riscv64",
 }
-MACHINE_TO_DOCKER_PLATFORM: dict[str, DockerPlatform] = {
+MACHINE_TO_DOCKER_PLATFORM: Dict[str, DockerPlatform] = {
     "x86_64": "linux/amd64",
     "amd64": "linux/amd64",
     "aarch64": "linux/arm64",

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -18,6 +18,7 @@ import stat
 import string
 import subprocess
 import sys
+from copy import copy
 from sys import platform as _platform
 from typing import (
     Any,
@@ -79,6 +80,22 @@ DEFAULT_WORKING_DIR = "/source/"
 IS_OS_X = _platform == "darwin"
 INVOLUCRO_VERSION = "1.2.0"
 DEST_BASE_IMAGE = os.environ.get("DEST_BASE_IMAGE", None)
+# Explicit Docker build targets use OCI platform notation. This is separate
+# from conda_platform(), which detects the native host OS and architecture.
+DOCKER_TO_CONDA_PLATFORM = {
+    "linux/amd64": "linux-64",
+    "linux/arm64": "linux-aarch64",
+    "linux/arm/v7": "linux-armv7l",
+    "linux/ppc64le": "linux-ppc64le",
+}
+MACHINE_TO_DOCKER_PLATFORM = {
+    "x86_64": "linux/amd64",
+    "amd64": "linux/amd64",
+    "aarch64": "linux/arm64",
+    "arm64": "linux/arm64",
+    "armv7l": "linux/arm/v7",
+    "ppc64le": "linux/ppc64le",
+}
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker
 From: %(base_image)s
@@ -177,6 +194,7 @@ def conda_versions(pkg_name, file_name):
 
 
 def conda_platform() -> str:
+    """Return the conda subdir for the native host OS and architecture."""
     machine = _platform_module.machine().lower()
     if IS_OS_X:
         conda_arch_map = {
@@ -191,24 +209,62 @@ def conda_platform() -> str:
             "aarch64": "linux-aarch64",
             "arm64": "linux-aarch64",
             "armv7l": "linux-armv7l",
+            "ppc64le": "linux-ppc64le",
         }
         default_platform = "linux-64"
     return conda_arch_map.get(machine, default_platform)
 
 
-def get_conda_hits_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> List[Dict[str, Any]]:
-    platform = conda_platform()
+def docker_platform_to_conda_subdir(target_docker_platform: Optional[str]) -> str:
+    """Return the conda subdir for an explicit Docker target, or for the host when unset."""
+    if target_docker_platform is None:
+        return conda_platform()
+    try:
+        return DOCKER_TO_CONDA_PLATFORM[target_docker_platform]
+    except KeyError:
+        raise ValueError(f"Unsupported target platform '{target_docker_platform}'") from None
+
+
+def docker_platform_tag_suffix(target_platform: Optional[str]) -> Optional[str]:
+    """Return an image-tag suffix, preserving unsuffixed tags for legacy amd64 images."""
+    target_platform = target_platform or MACHINE_TO_DOCKER_PLATFORM.get(
+        _platform_module.machine().lower(), "linux/amd64"
+    )
+    if target_platform == "linux/amd64":
+        return None
+    return target_platform.removeprefix("linux/").replace("/", "-")
+
+
+def apply_platform_tag_suffix(image: str, target_platform: Optional[str]) -> str:
+    suffix = docker_platform_tag_suffix(target_platform)
+    if suffix is None:
+        return image
+    last_slash = image.rfind("/")
+    last_colon = image.rfind(":")
+    if last_colon > last_slash:
+        image_name, tag = image.rsplit(":", 1)
+    else:
+        image_name, tag = image, "latest"
+    return f"{image_name}:{tag}-{suffix}"
+
+
+def get_conda_hits_for_targets(
+    targets: Iterable[CondaTarget], conda_context: CondaContext, conda_platform_str: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    platform = conda_platform_str or conda_platform()
     search_results = (best_search_result(t, conda_context, platform=platform)[0] for t in targets)
     return [r for r in search_results if r]
 
 
-def base_image_for_targets(targets: Iterable[CondaTarget], conda_context: CondaContext) -> str:
+def base_image_for_targets(
+    targets: Iterable[CondaTarget], conda_context: CondaContext, conda_platform_str: Optional[str] = None
+) -> str:
     """
     determine base image (DEFAULT_BASE_IMAGE/DEFAULT_EXTENDED_BASE_IMAGE) for a
     list of targets by inspecting the conda package (i.e. if the use of an
     extended image is indicated in info/about.json or info/recipe/meta.yaml
     """
-    hits = get_conda_hits_for_targets(targets, conda_context)
+    hits = get_conda_hits_for_targets(targets, conda_context, conda_platform_str)
     for hit in hits:
         try:
             content_dict = get_files_from_conda_package(hit["url"], ["info/about.json", "info/recipe/meta.yaml"])
@@ -264,9 +320,23 @@ def mull_targets(
     determine_base_image: bool = True,
     invfile: str = INVFILE,
     strict_channel_priority: bool = True,
+    target_platform: Optional[str] = None,
 ) -> int:
+    if involucro_context is not None and involucro_context.platform is not None:
+        if target_platform is not None and target_platform != involucro_context.platform:
+            raise ValueError(
+                f"Target platform '{target_platform}' conflicts with Involucro platform '{involucro_context.platform}'"
+            )
+        target_platform = involucro_context.platform
+    conda_platform_str = docker_platform_to_conda_subdir(target_platform)
+    if singularity and target_platform:
+        raise ValueError("--target-platform cannot be used with --singularity")
+
     if involucro_context is None:
-        involucro_context = InvolucroContext()
+        involucro_context = InvolucroContext(platform=target_platform)
+    else:
+        involucro_context = copy(involucro_context)
+        involucro_context.platform = target_platform
 
     image_function = v1_image_name if hash_func == "v1" else v2_image_name
     if len(targets) > 1 and image_build is None:
@@ -276,7 +346,9 @@ def mull_targets(
 
     repo_template_kwds = {
         "namespace": namespace,
-        "image": image_function(targets, image_build=image_build, name_override=name_override),
+        "image": apply_platform_tag_suffix(
+            image_function(targets, image_build=image_build, name_override=name_override), target_platform
+        ),
     }
     repo = string.Template(repository_template).safe_substitute(repo_template_kwds)
 
@@ -325,7 +397,7 @@ def mull_targets(
         dest_base_image = DEST_BASE_IMAGE
     elif determine_base_image:
         conda_context = CondaInDockerContext(ensure_channels=channels)
-        dest_base_image = base_image_for_targets(targets, conda_context)
+        dest_base_image = base_image_for_targets(targets, conda_context, conda_platform_str)
 
     if dest_base_image:
         involucro_args.extend(["-set", f"DEST_BASE_IMAGE={dest_base_image}"])
@@ -406,7 +478,9 @@ def mull_targets(
 
 def context_from_args(args):
     verbose = "2" if not args.verbose else "3"
-    return InvolucroContext(involucro_bin=args.involucro_path, verbose=verbose)
+    return InvolucroContext(
+        involucro_bin=args.involucro_path, verbose=verbose, platform=getattr(args, "target_platform", None)
+    )
 
 
 class InvolucroContext(installable.InstallableContext):
@@ -417,6 +491,7 @@ class InvolucroContext(installable.InstallableContext):
         involucro_bin: Optional[str] = None,
         shell_exec: Optional[Callable[[List[str]], int]] = None,
         verbose: str = "3",
+        platform: Optional[str] = None,
     ) -> None:
         if involucro_bin is None:
             if os.path.exists("./involucro"):
@@ -427,9 +502,13 @@ class InvolucroContext(installable.InstallableContext):
             self.involucro_bin = involucro_bin
         self.shell_exec = shell_exec or commands.shell
         self.verbose = verbose
+        self.platform = platform
 
     def build_command(self, involucro_args: List[str]) -> List[str]:
-        return [self.involucro_bin, f"-v={self.verbose}"] + involucro_args
+        cmd = [self.involucro_bin, f"-v={self.verbose}"]
+        if self.platform:
+            cmd.extend(["--platform", self.platform])
+        return cmd + involucro_args
 
     def exec_command(self, involucro_args: List[str]) -> int:
         cmd = self.build_command(involucro_args)
@@ -490,6 +569,13 @@ def add_build_arguments(parser):
         "--dry-run", dest="dry_run", action="store_true", help="Just print commands instead of executing them."
     )
     parser.add_argument("--verbose", dest="verbose", action="store_true", help="Cause process to be verbose.")
+    parser.add_argument(
+        "--target-platform",
+        dest="target_platform",
+        default=None,
+        choices=sorted(DOCKER_TO_CONDA_PLATFORM),
+        help="Target platform for Docker/Involucro builds (e.g. 'linux/arm64'). Requires binfmt/QEMU support on the Docker daemon host.",
+    )
     parser.add_argument("--singularity", action="store_true", help="Additionally build a singularity image.")
     parser.add_argument(
         "--singularity-image-dir", dest="singularity_image_dir", help="Directory to write singularity images too."
@@ -614,6 +700,8 @@ def args_to_mull_targets_kwds(args):
         kwds["invfile"] = args.invfile
     if hasattr(args, "verbose"):
         kwds["verbose"] = args.verbose
+    if hasattr(args, "target_platform"):
+        kwds["target_platform"] = args.target_platform
     kwds["strict_channel_priority"] = args.strict_channel_priority
 
     kwds["involucro_context"] = context_from_args(args)

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -333,6 +333,10 @@ def mull_targets(
 ) -> int:
     conda_platform_str = docker_platform_to_conda_subdir(target_platform)
     if singularity and target_platform:
+        # Singularity build (invfile.lua:110-118) runs `singularity build` locally from a
+        # .def file.  Singularity has `--arch` only for remote builds (--remote); there is
+        # no --platform flag for local builds.  The resulting .sif is always the host arch,
+        # so cross-platform builds would produce a .sif for the wrong architecture.
         raise ValueError("--target-platform cannot be used with --singularity")
 
     if involucro_context is None:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
@@ -19,7 +19,6 @@ See recent changes that would be built with:
 
 import os
 import subprocess
-import sys
 import time
 
 from galaxy.util import requests
@@ -28,6 +27,7 @@ from .mulled_build import (
     add_build_arguments,
     args_to_mull_targets_kwds,
     build_target,
+    conda_platform,
     conda_versions,
     get_affected_packages,
     mull_targets,
@@ -42,7 +42,7 @@ def _fetch_repo_data(args):
     repo_data = args.repo_data
     channel = args.channel
     if not os.path.exists(repo_data):
-        platform_tag = "osx-64" if sys.platform == "darwin" else "linux-64"
+        platform_tag = conda_platform()
         subprocess.check_call(
             [
                 "wget",

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
@@ -64,7 +64,7 @@ def _new_versions(quay, conda, tag_suffix=None):
         # Unsuffixed legacy tags represent amd64 builds and must not suppress
         # publication of the requested non-amd64 variant.
         suffix = f"-{tag_suffix}"
-        squay = {tag.removesuffix(suffix) for tag in squay if tag.endswith(suffix)}
+        squay = {tag[: -len(suffix)] for tag in squay if tag.endswith(suffix)}
     return [v for v in conda if v not in squay]
 
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
@@ -57,15 +57,15 @@ def _fetch_repo_data(args):
     return repo_data
 
 
-def _new_versions(quay, conda, tag_suffix=None):
+def _unpublished_versions(quay, conda, platform_suffix=None):
     """Calculate the versions that are in conda but not on quay.io."""
     squay = set(quay) if quay else set()
-    if tag_suffix:
-        # Unsuffixed legacy tags represent amd64 builds and must not suppress
-        # publication of the requested non-amd64 variant.
-        suffix = f"-{tag_suffix}"
-        squay = {tag[: -len(suffix)] for tag in squay if tag.endswith(suffix)}
-    return [v for v in conda if v not in squay]
+    if platform_suffix is None:
+        return [v for v in conda if v not in squay]
+    suffix = f"-{platform_suffix}"
+    # Unsuffixed legacy tags represent amd64 builds and must not suppress
+    # publication of the requested non-amd64 variant.
+    return [v for v in conda if f"{v}{suffix}" not in squay]
 
 
 def run_channel(args, build_last_n_versions: int = 1) -> None:
@@ -80,7 +80,7 @@ def run_channel(args, build_last_n_versions: int = 1) -> None:
         if not args.force_rebuild:
             time.sleep(1)
             q = quay_versions(args.namespace, pkg_name, session)
-            versions = _new_versions(q, c, docker_platform_tag_suffix(getattr(args, "target_platform", None)))
+            versions = _unpublished_versions(q, c, docker_platform_tag_suffix(getattr(args, "target_platform", None)))
         else:
             versions = c
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_channel.py
@@ -27,8 +27,9 @@ from .mulled_build import (
     add_build_arguments,
     args_to_mull_targets_kwds,
     build_target,
-    conda_platform,
     conda_versions,
+    docker_platform_tag_suffix,
+    docker_platform_to_conda_subdir,
     get_affected_packages,
     mull_targets,
 )
@@ -42,7 +43,7 @@ def _fetch_repo_data(args):
     repo_data = args.repo_data
     channel = args.channel
     if not os.path.exists(repo_data):
-        platform_tag = conda_platform()
+        platform_tag = docker_platform_to_conda_subdir(getattr(args, "target_platform", None))
         subprocess.check_call(
             [
                 "wget",
@@ -56,11 +57,15 @@ def _fetch_repo_data(args):
     return repo_data
 
 
-def _new_versions(quay, conda):
+def _new_versions(quay, conda, tag_suffix=None):
     """Calculate the versions that are in conda but not on quay.io."""
-    sconda = set(conda)
     squay = set(quay) if quay else set()
-    return sconda - squay  # sconda.symmetric_difference(squay)
+    if tag_suffix:
+        # Unsuffixed legacy tags represent amd64 builds and must not suppress
+        # publication of the requested non-amd64 variant.
+        suffix = f"-{tag_suffix}"
+        squay = {tag.removesuffix(suffix) for tag in squay if tag.endswith(suffix)}
+    return [v for v in conda if v not in squay]
 
 
 def run_channel(args, build_last_n_versions: int = 1) -> None:
@@ -75,7 +80,7 @@ def run_channel(args, build_last_n_versions: int = 1) -> None:
         if not args.force_rebuild:
             time.sleep(1)
             q = quay_versions(args.namespace, pkg_name, session)
-            versions = _new_versions(q, c)
+            versions = _new_versions(q, c, docker_platform_tag_suffix(getattr(args, "target_platform", None)))
         else:
             versions = c
 

--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -1,5 +1,8 @@
 import os.path
-from unittest import SkipTest, mock
+from unittest import (
+    mock,
+    SkipTest,
+)
 
 from galaxy.tool_util.deps.mulled.get_tests import (
     deep_test_search,

--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -1,5 +1,5 @@
 import os.path
-from unittest import SkipTest
+from unittest import SkipTest, mock
 
 from galaxy.tool_util.deps.mulled.get_tests import (
     deep_test_search,
@@ -47,8 +47,14 @@ def test_get_run_test():
 
 
 def test_get_anaconda_url():
-    url = get_anaconda_url("samtools:1.7--1")
+    url = get_anaconda_url("samtools:1.7--1", conda_platform_str="linux-64")
     assert url == "https://anaconda.org/bioconda/samtools/1.7/download/linux-64/samtools-1.7-1.tar.bz2"
+
+
+def test_get_anaconda_url_delegates_to_conda_platform():
+    with mock.patch("galaxy.tool_util.deps.mulled.get_tests.conda_platform", return_value="linux-aarch64"):
+        url = get_anaconda_url("samtools:1.7--1")
+    assert url == "https://anaconda.org/bioconda/samtools/1.7/download/linux-aarch64/samtools-1.7-1.tar.bz2"
 
 
 @external_dependency_management

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -1,14 +1,23 @@
 import os.path
+from argparse import (
+    ArgumentParser,
+    Namespace,
+)
 from unittest import mock
 
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_build import (
+    add_build_arguments,
+    apply_platform_tag_suffix,
+    args_to_mull_targets_kwds,
     base_image_for_targets,
     build_target,
     conda_platform,
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
+    docker_platform_to_conda_subdir,
+    get_conda_hits_for_targets,
     InvolucroContext,
     mull_targets,
     target_str_to_targets,
@@ -63,3 +72,113 @@ def test_conda_platform_fallback_to_linux64(mock_machine):
     mock_machine.return_value = "riscv64"
     with mock.patch("galaxy.tool_util.deps.mulled.mulled_build.IS_OS_X", False):
         assert conda_platform() == "linux-64"
+
+
+@pytest.mark.parametrize(
+    "target_platform,conda_subdir",
+    [
+        ("linux/amd64", "linux-64"),
+        ("linux/arm64", "linux-aarch64"),
+        ("linux/arm/v7", "linux-armv7l"),
+        ("linux/ppc64le", "linux-ppc64le"),
+    ],
+)
+def test_docker_platform_to_conda_subdir(target_platform, conda_subdir):
+    assert docker_platform_to_conda_subdir(target_platform) == conda_subdir
+
+
+def test_docker_platform_to_conda_subdir_defaults_to_host_platform():
+    with mock.patch("galaxy.tool_util.deps.mulled.mulled_build.conda_platform", return_value="osx-arm64"):
+        assert docker_platform_to_conda_subdir(None) == "osx-arm64"
+
+
+def test_docker_platform_to_conda_subdir_rejects_unsupported_platform():
+    with pytest.raises(ValueError, match="Unsupported target platform 'linux/riscv64'"):
+        docker_platform_to_conda_subdir("linux/riscv64")
+
+
+def test_target_platform_cli_argument_rejects_unsupported_platform():
+    parser = ArgumentParser()
+    add_build_arguments(parser)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--target-platform", "linux/riscv64"])
+
+
+@pytest.mark.parametrize(
+    "image,expected",
+    [
+        ("samtools:1.3--0", "samtools:1.3--0-arm64"),
+        ("mulled-v2-xxx:hash", "mulled-v2-xxx:hash-arm64"),
+        ("some-image", "some-image:latest-arm64"),
+        ("registry.example:5000/namespace/some-image", "registry.example:5000/namespace/some-image:latest-arm64"),
+    ],
+)
+def test_apply_platform_tag_suffix(image, expected):
+    assert apply_platform_tag_suffix(image, "linux/arm64") == expected
+
+
+def test_apply_platform_tag_suffix_keeps_default_platform_tag():
+    assert apply_platform_tag_suffix("samtools:1.3--0", "linux/amd64") == "samtools:1.3--0"
+
+
+@mock.patch("galaxy.tool_util.deps.mulled.mulled_build._platform_module.machine", return_value="aarch64")
+def test_apply_platform_tag_suffix_uses_native_non_amd64_platform(_mock_machine):
+    assert apply_platform_tag_suffix("samtools:1.3--0", None) == "samtools:1.3--0-arm64"
+
+
+def test_involucro_context_build_command_includes_platform():
+    context = InvolucroContext(involucro_bin="involucro", platform="linux/arm64")
+    assert context.build_command(["build"]) == ["involucro", "-v=3", "--platform", "linux/arm64", "build"]
+
+
+def test_get_conda_hits_for_targets_uses_explicit_conda_platform():
+    target = build_target("samtools")
+    conda_context = mock.Mock()
+    with mock.patch(
+        "galaxy.tool_util.deps.mulled.mulled_build.best_search_result", return_value=({"name": "samtools"}, True)
+    ) as best_search_result:
+        assert get_conda_hits_for_targets([target], conda_context, "linux-aarch64") == [{"name": "samtools"}]
+    best_search_result.assert_called_once_with(target, conda_context, platform="linux-aarch64")
+
+
+def test_mull_targets_dry_run_uses_target_platform(capsys):
+    target = build_target("samtools", version="1.3", build="0")
+    assert mull_targets([target], target_platform="linux/arm64", determine_base_image=False, dry_run=True) == 0
+    output = capsys.readouterr().out
+    assert "--platform linux/arm64" in output
+    assert "REPO=quay.io/biocontainers/samtools:1.3--0-arm64" in output
+
+
+def test_mull_targets_rejects_target_platform_with_singularity():
+    with pytest.raises(ValueError, match="--target-platform cannot be used with --singularity"):
+        mull_targets([build_target("samtools")], target_platform="linux/arm64", singularity=True, dry_run=True)
+
+
+def test_mull_targets_rejects_conflicting_involucro_platform():
+    context = InvolucroContext(platform="linux/arm64")
+    with pytest.raises(ValueError, match="conflicts with Involucro platform"):
+        mull_targets([build_target("samtools")], involucro_context=context, target_platform="linux/amd64", dry_run=True)
+
+
+def test_mull_targets_does_not_mutate_involucro_context_platform():
+    context = InvolucroContext()
+    mull_targets(
+        [build_target("samtools")],
+        involucro_context=context,
+        target_platform="linux/arm64",
+        determine_base_image=False,
+        dry_run=True,
+    )
+    assert context.platform is None
+
+
+def test_args_to_mull_targets_kwds_passes_target_platform_to_context():
+    args = Namespace(
+        involucro_path="custom-involucro",
+        strict_channel_priority=True,
+        target_platform="linux/arm64",
+        verbose=False,
+    )
+    kwds = args_to_mull_targets_kwds(args)
+    assert kwds["target_platform"] == "linux/arm64"
+    assert kwds["involucro_context"].platform == "linux/arm64"

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -126,11 +126,6 @@ def test_apply_platform_tag_suffix_uses_native_non_amd64_platform(_mock_machine)
     assert apply_platform_tag_suffix("samtools:1.3--0", None) == "samtools:1.3--0-arm64"
 
 
-def test_involucro_context_build_command_includes_platform():
-    context = InvolucroContext(involucro_bin="involucro", platform="linux/arm64")
-    assert context.build_command(["build"]) == ["involucro", "-v=3", "--platform", "linux/arm64", "build"]
-
-
 def test_get_conda_hits_for_targets_uses_explicit_conda_platform():
     target = build_target("samtools")
     conda_context = mock.Mock()
@@ -154,25 +149,7 @@ def test_mull_targets_rejects_target_platform_with_singularity():
         mull_targets([build_target("samtools")], target_platform="linux/arm64", singularity=True, dry_run=True)
 
 
-def test_mull_targets_rejects_conflicting_involucro_platform():
-    context = InvolucroContext(platform="linux/arm64")
-    with pytest.raises(ValueError, match="conflicts with Involucro platform"):
-        mull_targets([build_target("samtools")], involucro_context=context, target_platform="linux/amd64", dry_run=True)
-
-
-def test_mull_targets_does_not_mutate_involucro_context_platform():
-    context = InvolucroContext()
-    mull_targets(
-        [build_target("samtools")],
-        involucro_context=context,
-        target_platform="linux/arm64",
-        determine_base_image=False,
-        dry_run=True,
-    )
-    assert context.platform is None
-
-
-def test_args_to_mull_targets_kwds_passes_target_platform_to_context():
+def test_args_to_mull_targets_kwds_passes_target_platform():
     args = Namespace(
         involucro_path="custom-involucro",
         strict_channel_priority=True,
@@ -181,4 +158,3 @@ def test_args_to_mull_targets_kwds_passes_target_platform_to_context():
     )
     kwds = args_to_mull_targets_kwds(args)
     assert kwds["target_platform"] == "linux/arm64"
-    assert kwds["involucro_context"].platform == "linux/arm64"

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -93,15 +93,15 @@ def test_docker_platform_to_conda_subdir_defaults_to_host_platform():
 
 
 def test_docker_platform_to_conda_subdir_rejects_unsupported_platform():
-    with pytest.raises(ValueError, match="Unsupported target platform 'linux/riscv64'"):
-        docker_platform_to_conda_subdir("linux/riscv64")
+    with pytest.raises(ValueError, match="Unsupported target platform"):
+        docker_platform_to_conda_subdir("linux/s390x")
 
 
 def test_target_platform_cli_argument_rejects_unsupported_platform():
     parser = ArgumentParser()
     add_build_arguments(parser)
     with pytest.raises(SystemExit):
-        parser.parse_args(["--target-platform", "linux/riscv64"])
+        parser.parse_args(["--target-platform", "linux/s390x"])
 
 
 @pytest.mark.parametrize(

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -94,7 +94,7 @@ def test_docker_platform_to_conda_subdir_defaults_to_host_platform():
 
 def test_docker_platform_to_conda_subdir_rejects_unsupported_platform():
     with pytest.raises(ValueError, match="Unsupported target platform"):
-        docker_platform_to_conda_subdir("linux/s390x")
+        docker_platform_to_conda_subdir("linux/s390x")  # type: ignore[arg-type]
 
 
 def test_target_platform_cli_argument_rejects_unsupported_platform():

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -1,10 +1,12 @@
 import os.path
+from unittest import mock
 
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_build import (
     base_image_for_targets,
     build_target,
+    conda_platform,
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
     InvolucroContext,
@@ -54,3 +56,10 @@ def test_target_str_to_targets():
     targets = target_str_to_targets(target_str)
     assert (targets[0].package, targets[0].version, targets[0].build) == ("samtools", "1.3.1", "4")
     assert (targets[1].package, targets[1].version, targets[1].build) == ("bedtools", "2.22", None)
+
+
+@mock.patch("galaxy.tool_util.deps.mulled.mulled_build._platform_module.machine")
+def test_conda_platform_fallback_to_linux64(mock_machine):
+    mock_machine.return_value = "riscv64"
+    with mock.patch("galaxy.tool_util.deps.mulled.mulled_build.IS_OS_X", False):
+        assert conda_platform() == "linux-64"

--- a/test/unit/tool_util/mulled/test_mulled_build_channel.py
+++ b/test/unit/tool_util/mulled/test_mulled_build_channel.py
@@ -26,11 +26,9 @@ def test_fetch_repo_data_uses_target_platform(tmp_path):
 def test_fetch_repo_data_defaults_to_host_platform(tmp_path):
     repo_data = tmp_path / "repodata.json"
     args = Namespace(channel="bioconda", repo_data=str(repo_data))
-    with (
-        mock.patch("galaxy.tool_util.deps.mulled.mulled_build.conda_platform", return_value="osx-arm64"),
-        mock.patch("galaxy.tool_util.deps.mulled.mulled_build_channel.subprocess.check_call") as check_call,
-    ):
-        assert _fetch_repo_data(args) == str(repo_data)
+    with mock.patch("galaxy.tool_util.deps.mulled.mulled_build.conda_platform", return_value="osx-arm64"):
+        with mock.patch("galaxy.tool_util.deps.mulled.mulled_build_channel.subprocess.check_call") as check_call:
+            assert _fetch_repo_data(args) == str(repo_data)
     assert check_call.call_args_list[0] == mock.call(
         [
             "wget",

--- a/test/unit/tool_util/mulled/test_mulled_build_channel.py
+++ b/test/unit/tool_util/mulled/test_mulled_build_channel.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from galaxy.tool_util.deps.mulled.mulled_build_channel import (
     _fetch_repo_data,
-    _new_versions,
+    _unpublished_versions,
 )
 
 
@@ -40,9 +40,9 @@ def test_fetch_repo_data_defaults_to_host_platform(tmp_path):
     )
 
 
-def test_new_versions_compares_platform_suffixed_quay_tags():
-    assert _new_versions(["1.2--0-arm64"], ["1.2--0", "1.3--0"], "arm64") == ["1.3--0"]
+def test_unpublished_versions_compares_platform_suffixed_quay_tags():
+    assert _unpublished_versions(["1.2--0-arm64"], ["1.2--0", "1.3--0"], "arm64") == ["1.3--0"]
 
 
-def test_new_versions_ignores_legacy_unsuffixed_tags_for_non_amd64_builds():
-    assert _new_versions(["1.2--0"], ["1.2--0"], "arm64") == ["1.2--0"]
+def test_unpublished_versions_ignores_legacy_unsuffixed_tags_for_non_amd64_builds():
+    assert _unpublished_versions(["1.2--0"], ["1.2--0"], "arm64") == ["1.2--0"]

--- a/test/unit/tool_util/mulled/test_mulled_build_channel.py
+++ b/test/unit/tool_util/mulled/test_mulled_build_channel.py
@@ -1,0 +1,50 @@
+from argparse import Namespace
+from unittest import mock
+
+from galaxy.tool_util.deps.mulled.mulled_build_channel import (
+    _fetch_repo_data,
+    _new_versions,
+)
+
+
+def test_fetch_repo_data_uses_target_platform(tmp_path):
+    repo_data = tmp_path / "repodata.json"
+    args = Namespace(channel="bioconda", repo_data=str(repo_data), target_platform="linux/arm64")
+    with mock.patch("galaxy.tool_util.deps.mulled.mulled_build_channel.subprocess.check_call") as check_call:
+        assert _fetch_repo_data(args) == str(repo_data)
+    assert check_call.call_args_list[0] == mock.call(
+        [
+            "wget",
+            "--quiet",
+            "https://conda.anaconda.org/bioconda/linux-aarch64/repodata.json.bz2",
+            "-O",
+            f"{repo_data}.bz2",
+        ]
+    )
+
+
+def test_fetch_repo_data_defaults_to_host_platform(tmp_path):
+    repo_data = tmp_path / "repodata.json"
+    args = Namespace(channel="bioconda", repo_data=str(repo_data))
+    with (
+        mock.patch("galaxy.tool_util.deps.mulled.mulled_build.conda_platform", return_value="osx-arm64"),
+        mock.patch("galaxy.tool_util.deps.mulled.mulled_build_channel.subprocess.check_call") as check_call,
+    ):
+        assert _fetch_repo_data(args) == str(repo_data)
+    assert check_call.call_args_list[0] == mock.call(
+        [
+            "wget",
+            "--quiet",
+            "https://conda.anaconda.org/bioconda/osx-arm64/repodata.json.bz2",
+            "-O",
+            f"{repo_data}.bz2",
+        ]
+    )
+
+
+def test_new_versions_compares_platform_suffixed_quay_tags():
+    assert _new_versions(["1.2--0-arm64"], ["1.2--0", "1.3--0"], "arm64") == ["1.3--0"]
+
+
+def test_new_versions_ignores_legacy_unsuffixed_tags_for_non_amd64_builds():
+    assert _new_versions(["1.2--0"], ["1.2--0"], "arm64") == ["1.2--0"]


### PR DESCRIPTION
## What

  Backports these two PRs
  - https://github.com/galaxyproject/galaxy/pull/22792
  - https://github.com/galaxyproject/galaxy/pull/22841


Change summary
  - updates Involucro to 1.2.0 and passes the target platform to Involucro;
  - detects the native host architecture instead of assuming x86-64;
  - uses the appropriate Conda subdirectory when searching for packages;
  - adds explicit Docker target-platform support for mulled builds;
  - adds architecture suffixes to non-amd64 image tags while preserving
    existing unsuffixed amd64 tags;
  - accounts for platform-specific tags when determining whether an image
    has already been published;
  - rejects unsupported target-platform and Singularity combinations;
  - documents the existing and newly added mulled build options;

  Two minor conflicts in mulled_build_channel.py were resolved by retaining
  the 26.1-compatible function signatures while preserving the final
  upstream platform-tag behavior.


## Why

I am working on ARM biocontainers as part of my bachelor's thesis. Biocontainers are built with mulled, which until now had hardcoded x86 assumptions in some places and was unable to propagate platform metadata. 
The next galaxy release will likely be after the deadline for my thesis, which is why I am backporting this to the 26.1 release. 

## Backport cleanlyness


  - ec7355a335 feat: add platform metadata to mulled
      - One conflict in mulled_build_channel.py.
      - The development branch used newer typed function signatures unavailable in the 26.1 version.
      - Resolution retained the 26.1-compatible signature while preserving platform-aware unpublished-version detection.

  - 9a06eeb544 refactor: some renames
      - One conflict in the same file and function.
      - Resolution applied the upstream rename to _unpublished_versions and its final platform-suffix algorithm while retaining the 26.1-compatible signature.

others were clean cherry-picks

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
