### PR TITLE
[26.1] Skip RST help linting when help format is not restructuredtext

### DIFF
--- a/lib/galaxy/tool_util/linters/help.py
+++ b/lib/galaxy/tool_util/linters/help.py
@@ -1,6 +1,8 @@
 """This module contains a linting function for a tool's help."""
 
 from typing import (
+    Optional,
+    Tuple,
     TYPE_CHECKING,
     Union,
 )
@@ -14,6 +16,7 @@ from galaxy.util import (
 if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
     from galaxy.tool_util.parser.interface import ToolSource
+    from galaxy.util.etree import Element
 
 
 class HelpMissing(Linter):
@@ -77,35 +80,41 @@ class HelpTODO(Linter):
 class HelpInvalidRST(Linter):
     @classmethod
     def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
-        tool_xml = getattr(tool_source, "xml_tree", None)
-        if not tool_xml:
-            return
-        help = tool_xml.find("./help")
-        if help is None:
-            return
-        help_text = help.text or ""
-        if not help_text.strip():
+        help_text, node = _help_rst(tool_source)
+        if help_text is None:
             return
         invalid_rst = rst_invalid(help_text)
         if invalid_rst:
-            lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].", linter=cls.name(), node=help)
+            lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].", linter=cls.name(), node=node)
 
 
 class HelpValidRST(Linter):
     @classmethod
     def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
-        tool_xml = getattr(tool_source, "xml_tree", None)
-        if not tool_xml:
-            return
-        help = tool_xml.find("./help")
-        if help is None:
-            return
-        help_text = help.text or ""
-        if not help_text.strip():
+        help_text, node = _help_rst(tool_source)
+        if help_text is None:
             return
         invalid_rst = rst_invalid(help_text)
         if not invalid_rst:
-            lint_ctx.valid("Help contains valid reStructuredText.", linter=cls.name(), node=help)
+            lint_ctx.valid("Help contains valid reStructuredText.", linter=cls.name(), node=node)
+
+
+def _help_rst(tool_source: "ToolSource") -> "Tuple[Optional[str], Optional[Element]]":
+    """Return the help text to RST-validate and the XML node to anchor messages to.
+
+    The text is ``None`` (i.e. RST validation should be skipped) when there is no help,
+    when the help is empty, or when its format is not ``restructuredtext`` (e.g. Markdown
+    help, which YAML tool sources default to). ``node`` is the ``<help>`` element for XML
+    tool sources and ``None`` for others.
+    """
+    help_content = tool_source.parse_help()
+    tool_xml = getattr(tool_source, "xml_tree", None)
+    node = tool_xml.find("./help") if tool_xml is not None else None
+    if help_content is None or not help_content.content.strip():
+        return None, node
+    if help_content.format != "restructuredtext":
+        return None, node
+    return help_content.content, node
 
 
 def rst_invalid(text: str) -> Union[bool, str]:

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -203,6 +203,36 @@ HELP_INVALID_RST = """
 </tool>
 """
 
+HELP_MARKDOWN_INVALID_RST = """
+<tool id="id" name="name">
+    <help format="markdown">
+        **xxl__
+    </help>
+</tool>
+"""
+
+HELP_YAML_MARKDOWN_INVALID_RST = """
+class: GalaxyTool
+id: id
+name: name
+version: '1.0'
+command: echo test
+help: |
+  **xxl__
+"""
+
+HELP_YAML_RST_INVALID = """
+class: GalaxyTool
+id: id
+name: name
+version: '1.0'
+command: echo test
+help:
+  format: restructuredtext
+  content: |
+    **xxl__
+"""
+
 # test tool xml for inputs linter
 INPUTS_NO_INPUTS = """
 <tool id="id" name="name">
@@ -1451,6 +1481,29 @@ def test_help_invalid_rst(lint_ctx):
     assert len(lint_ctx.valid_messages) == 1
     assert len(lint_ctx.warn_messages) == 1
     assert not lint_ctx.error_messages
+
+
+def test_help_markdown_skips_rst_validation(lint_ctx):
+    tool_source = get_xml_tool_source(HELP_MARKDOWN_INVALID_RST)
+    run_lint_module(lint_ctx, help, tool_source)
+    assert "Tool contains help section." in lint_ctx.valid_messages
+    assert "Help contains valid reStructuredText." not in lint_ctx.valid_messages
+    assert "Invalid reStructuredText found in help" not in lint_ctx.warn_messages
+    assert not lint_ctx.error_messages
+
+
+def test_help_yaml_markdown_skips_rst_validation(lint_ctx):
+    tool_source = get_tool_source(HELP_YAML_MARKDOWN_INVALID_RST)
+    run_lint_module(lint_ctx, help, tool_source)
+    assert "Help contains valid reStructuredText." not in lint_ctx.valid_messages
+    assert "Invalid reStructuredText found in help" not in lint_ctx.warn_messages
+
+
+def test_help_yaml_rst_invalid(lint_ctx):
+    tool_source = get_tool_source(HELP_YAML_RST_INVALID)
+    run_lint_module(lint_ctx, help, tool_source)
+    assert "Invalid reStructuredText found in help" in lint_ctx.warn_messages
+    assert "Help contains valid reStructuredText." not in lint_ctx.valid_messages
 
 
 def test_inputs_no_inputs(lint_ctx):


### PR DESCRIPTION
## What did you do?

The `HelpInvalidRST` / `HelpValidRST` linters read the `<help>` text straight off the tool's XML tree and always validated it as reStructuredText. Help declared as Markdown (`<help format="markdown">`), and YAML tool sources — which default to Markdown — were therefore flagged with spurious `Invalid reStructuredText found in help` warnings, and forced tool authors to avoid Markdown constructs like tables.

Both linters now go through a shared `_help_rst()` helper that obtains the help content and its declared format via `tool_source.parse_help()`, and RST validation is skipped unless the format is `restructuredtext`. This also lets the linters work against non-XML tool sources.

## Why did you make this change?

Fixes #23071 — `planemo lint` reporting valid Markdown help as invalid RST.

## How to test the changes?

New unit tests in `test/unit/tool_util/test_tool_linters.py`:
- `test_help_markdown_skips_rst_validation` — XML tool with `format="markdown"` is not RST-validated.
- `test_help_yaml_markdown_skips_rst_validation` — YAML tool source (Markdown default) is not RST-validated.
- `test_help_yaml_rst_invalid` — YAML tool source with `format: restructuredtext` still gets RST validation.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
