### PR TITLE
[26.1] Fix recent tools for My Tools default panel

### DIFF
--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -17,6 +17,7 @@ import {
     buildToolEntries,
     buildToolLabel,
     buildToolSection,
+    countUniqueToolsInList,
     countUniqueToolsInPanel,
     FAVORITES_KEYS,
     filterPanelByToolIds,
@@ -180,6 +181,8 @@ const defaultSectionsById = computed<Record<string, ToolPanelItem> | null>(() =>
     return Object.keys(validSections).length > 0 ? validSections : null;
 });
 
+const myToolsDefaultSectionsById = computed(() => defaultSectionsById.value || localSectionsById.value);
+
 // Use composable for favorites and recent tools — we only need the bits that
 // drive the search-results split (favorites get their own section in mixed
 // results). The full My-Tools landing state lives inside `MyToolsLanding.vue`.
@@ -189,7 +192,10 @@ const { favoritesCollapsed, favoriteToolIdSet, recentToolIdsToShowSet } = useToo
 const { favoriteResults, nonFavoriteResults, hasMixedResults } = useFavoriteSearchResults(results, favoriteToolIdSet);
 
 const toolsCount = computed(() =>
-    countUniqueToolsInPanel(defaultSectionsById.value || localSectionsById.value, toolsList.value.length),
+    countUniqueToolsInPanel(
+        defaultSectionsById.value || localSectionsById.value,
+        countUniqueToolsInList(toolsList.value),
+    ),
 );
 
 const resultsSet = computed(() => new Set(results.value));
@@ -436,7 +442,7 @@ function onLabelToggle(labelId: string) {
                 <MyToolsLanding
                     v-if="showMyToolsLanding"
                     :local-tools-by-id="localToolsById"
-                    :default-sections-by-id="defaultSectionsById"
+                    :default-sections-by-id="myToolsDefaultSectionsById"
                     :local-sections-by-id="localSectionsById"
                     :tools-count="toolsCount"
                     @onClick="onToolClick"

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -92,6 +92,7 @@ describe("ToolPanel", () => {
         captureToolsRequest?: (url: URL) => void,
         panelResponses: Record<string, unknown> = {},
         defaultPanelView: string = DEFAULT_VIEW_ID,
+        capturePanelRequest?: (panelView: string) => void,
     ) {
         server.use(
             http.untyped.get("/api/tools", ({ request }) => {
@@ -134,6 +135,7 @@ describe("ToolPanel", () => {
             server.use(
                 http.untyped.get(/\/api\/tool_panels\/.*/, ({ request }) => {
                     const panelView = new URL(request.url).pathname.split("/").pop() || "";
+                    capturePanelRequest?.(panelView);
                     return HttpResponse.json(panelResponses[panelView] ?? toolsListInPanel);
                 }),
             );
@@ -298,6 +300,31 @@ describe("ToolPanel", () => {
         const discoverButton = wrapper.find('[data-description="toolbox discover tools"]');
         expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);
         expect(discoverButton.text()).not.toBe(`Discover ${toolsListWithExtraVersion.length} Tools`);
+    });
+
+    it("loads default panel sections when My Tools is the backend default view", async () => {
+        storePanelView("");
+        const requestedPanels: string[] = [];
+        await createWrapper(
+            "",
+            false,
+            undefined,
+            {
+                my_panel: {
+                    favorites: {
+                        model_class: "ToolSection",
+                        id: "favorites",
+                        name: "Favorites",
+                        tools: [],
+                    },
+                },
+            },
+            "my_panel",
+            (panelView) => requestedPanels.push(panelView),
+        );
+
+        expect(requestedPanels).toContain(DEFAULT_VIEW_ID);
+        expect(requestedPanels).toContain("my_panel");
     });
 
     it("does not request tool tags during default tool panel startup", async () => {

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -13,7 +13,7 @@ import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { type ToolPanelItem, useToolStore } from "@/stores/toolStore";
 
 import viewsListJson from "./testData/viewsList.json";
-import { getUniqueToolIdsInPanel } from "./utilities";
+import { countUniqueToolsInList, getUniqueToolIdsInPanel } from "./utilities";
 
 import ToolPanel from "./ToolPanel.vue";
 
@@ -38,7 +38,7 @@ const DEFAULT_VIEW_ID = "default";
 const PANEL_VIEW_ERR_MSG = "Error loading panel view";
 
 const firstTool = toolsList[0];
-const toolsListWithExtraVersion = [...toolsList, { ...firstTool, id: `${firstTool?.id}/older-version` }];
+const toolsListWithExtraVersion = [...toolsList, { ...firstTool, id: `${firstTool?.id}/0.9`, version: "0.9" }];
 
 vi.mock("@/composables/config");
 
@@ -91,6 +91,7 @@ describe("ToolPanel", () => {
         failDefault: boolean = false,
         captureToolsRequest?: (url: URL) => void,
         panelResponses: Record<string, unknown> = {},
+        defaultPanelView: string = DEFAULT_VIEW_ID,
     ) {
         server.use(
             http.untyped.get("/api/tools", ({ request }) => {
@@ -102,7 +103,7 @@ describe("ToolPanel", () => {
                 return HttpResponse.json([]);
             }),
             http.untyped.get(TEST_PANELS_URI, () => {
-                return HttpResponse.json({ default_panel_view: DEFAULT_VIEW_ID, views: viewsList });
+                return HttpResponse.json({ default_panel_view: defaultPanelView, views: viewsList });
             }),
             http.get("/api/users/{user_id}", ({ response }) => {
                 return response(200).json(getFakeRegisteredUser());
@@ -272,6 +273,31 @@ describe("ToolPanel", () => {
         const formatted = count < 1000 ? `${count}` : `${Math.floor(count / 1000)}k+`;
         const discoverButton = wrapper.find('[data-description="toolbox discover tools"]');
         expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);
+    });
+
+    it("does not show the raw installed-version count when My Tools is the backend default view", async () => {
+        storePanelView("");
+        const wrapper = await createWrapper(
+            "",
+            false,
+            undefined,
+            {
+                my_panel: {
+                    favorites: {
+                        model_class: "ToolSection",
+                        id: "favorites",
+                        name: "Favorites",
+                        tools: [],
+                    },
+                },
+            },
+            "my_panel",
+        );
+        const count = countUniqueToolsInList(toolsListWithExtraVersion);
+        const formatted = count < 1000 ? `${count}` : `${Math.floor(count / 1000)}k+`;
+        const discoverButton = wrapper.find('[data-description="toolbox discover tools"]');
+        expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);
+        expect(discoverButton.text()).not.toBe(`Discover ${toolsListWithExtraVersion.length} Tools`);
     });
 
     it("does not request tool tags during default tool panel startup", async () => {

--- a/client/src/components/Panels/ToolPanel.test.ts
+++ b/client/src/components/Panels/ToolPanel.test.ts
@@ -13,7 +13,7 @@ import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { type ToolPanelItem, useToolStore } from "@/stores/toolStore";
 
 import viewsListJson from "./testData/viewsList.json";
-import { countUniqueToolsInList, getUniqueToolIdsInPanel } from "./utilities";
+import { getUniqueToolIdsInPanel } from "./utilities";
 
 import ToolPanel from "./ToolPanel.vue";
 
@@ -277,7 +277,7 @@ describe("ToolPanel", () => {
         expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);
     });
 
-    it("does not show the raw installed-version count when My Tools is the backend default view", async () => {
+    it("uses the loaded default panel count when My Tools is the backend default view", async () => {
         storePanelView("");
         const wrapper = await createWrapper(
             "",
@@ -295,11 +295,40 @@ describe("ToolPanel", () => {
             },
             "my_panel",
         );
-        const count = countUniqueToolsInList(toolsListWithExtraVersion);
+        const count = getUniqueToolIdsInPanel(toolsListInPanel).size;
         const formatted = count < 1000 ? `${count}` : `${Math.floor(count / 1000)}k+`;
         const discoverButton = wrapper.find('[data-description="toolbox discover tools"]');
         expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);
         expect(discoverButton.text()).not.toBe(`Discover ${toolsListWithExtraVersion.length} Tools`);
+    });
+
+    it("ignores My Tools panel contents for the header count when My Tools is the backend default view", async () => {
+        storePanelView("");
+        const firstToolId = firstTool?.id;
+        if (!firstToolId) {
+            throw new Error("Expected at least one tool fixture");
+        }
+        const wrapper = await createWrapper(
+            "",
+            false,
+            undefined,
+            {
+                my_panel: {
+                    favorites: {
+                        model_class: "ToolSection",
+                        id: "favorites",
+                        name: "Favorites",
+                        tools: [firstToolId],
+                    },
+                },
+            },
+            "my_panel",
+        );
+        const count = getUniqueToolIdsInPanel(toolsListInPanel).size;
+        const formatted = count < 1000 ? `${count}` : `${Math.floor(count / 1000)}k+`;
+        const discoverButton = wrapper.find('[data-description="toolbox discover tools"]');
+        expect(discoverButton.text()).toBe(`Discover ${formatted} Tools`);
+        expect(discoverButton.text()).not.toBe("Discover 1 Tools");
     });
 
     it("loads default panel sections when My Tools is the backend default view", async () => {

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -9,7 +9,7 @@ import localize from "@/utils/localization";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { MY_PANEL_VIEW_ID } from "./panelViews";
-import { countUniqueToolsInPanel } from "./utilities";
+import { countUniqueToolsInList, countUniqueToolsInPanel } from "./utilities";
 
 import LoadingSpan from "../LoadingSpan.vue";
 import ActivityPanel from "./ActivityPanel.vue";
@@ -43,7 +43,7 @@ const headerToolSections = computed(() => {
     return currentToolSections.value;
 });
 const toolsCount = computed(() =>
-    countUniqueToolsInPanel(headerToolSections.value, Object.keys(toolsById.value).length),
+    countUniqueToolsInPanel(headerToolSections.value, countUniqueToolsInList(toolsById.value)),
 );
 
 function formatToolsCount(count: number) {

--- a/client/src/components/Panels/ToolPanel.vue
+++ b/client/src/components/Panels/ToolPanel.vue
@@ -36,9 +36,17 @@ const isMyPanel = computed(() => currentPanelView.value === MY_PANEL_VIEW_ID);
 const errorMessage = ref("");
 const panelsFetched = ref(false);
 const showFavorites = ref(false);
+const defaultToolSections = computed(() => {
+    return (
+        toolSections.value.default ||
+        (defaultPanelView.value && defaultPanelView.value !== MY_PANEL_VIEW_ID
+            ? toolSections.value[defaultPanelView.value]
+            : null)
+    );
+});
 const headerToolSections = computed(() => {
     if (isMyPanel.value) {
-        return toolSections.value[defaultPanelView.value] || toolSections.value.default || currentToolSections.value;
+        return defaultToolSections.value || currentToolSections.value;
     }
     return currentToolSections.value;
 });

--- a/client/src/components/Panels/utilities.test.ts
+++ b/client/src/components/Panels/utilities.test.ts
@@ -4,6 +4,7 @@ import toolsListInPanelUntyped from "@/components/ToolsView/testData/toolsListIn
 import { describe, expect, it } from "vitest";
 
 import {
+    countUniqueToolsInList,
     createSortedResultPanel,
     createWhooshQuery,
     determineWidth,
@@ -96,6 +97,12 @@ describe("test helpers in tool searching utilities", () => {
     it("builds tag-only whoosh queries without an empty leading clause", async () => {
         expect(createWhooshQuery({ tag: ["data cleanup"] })).toEqual('(tool_tags:("data cleanup"))');
         expect(createWhooshQuery({ section: '"Get Data"' })).toEqual('(section:("Get Data"))');
+    });
+
+    it("counts versioned tools once when falling back to the full tools list", async () => {
+        const firstTool = toolsList[0]!;
+        const toolsWithOlderVersion = [...toolsList, { ...firstTool, id: `${firstTool.id}/0.9`, version: "0.9" }];
+        expect(countUniqueToolsInList(toolsWithOlderVersion)).toBe(toolsList.length);
     });
 
     it("lowercases tag clauses to match the Whoosh field analyzer", async () => {

--- a/client/src/components/Panels/utilities.ts
+++ b/client/src/components/Panels/utilities.ts
@@ -67,6 +67,24 @@ export function getUniqueToolIdsInPanel(panel: Record<string, ToolPanelItem> | n
     return toolIds;
 }
 
+type CountableTool = Pick<Tool, "id"> & Partial<Pick<Tool, "version">>;
+
+export function getVersionlessToolId(toolId: string, tool: CountableTool | undefined) {
+    if (tool?.version && toolId.endsWith(`/${tool.version}`)) {
+        return toolId.slice(0, -tool.version.length - 1);
+    }
+    return toolId;
+}
+
+export function countUniqueToolsInList<T extends CountableTool>(tools: Record<string, T> | T[]) {
+    const toolEntries = Array.isArray(tools) ? tools.map((tool) => [tool.id, tool] as const) : Object.entries(tools);
+    const toolIds = new Set<string>();
+    for (const [toolId, tool] of toolEntries) {
+        toolIds.add(getVersionlessToolId(toolId, tool));
+    }
+    return toolIds.size;
+}
+
 export function countUniqueToolsInPanel(panel: Record<string, ToolPanelItem> | null | undefined, fallbackCount = 0) {
     return getUniqueToolIdsInPanel(panel).size || fallbackCount;
 }

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -109,6 +109,8 @@ const MY_PANEL_VIEW: Panel = {
     searchable: true,
 };
 
+const DEFAULT_PANEL_VIEW_ID = "default";
+
 export const useToolStore = defineStore("toolStore", () => {
     const currentPanelView: Ref<string> = useUserLocalStorage("tool-store-view", "");
     const defaultPanelView: Ref<string> = ref("");
@@ -369,8 +371,16 @@ export const useToolStore = defineStore("toolStore", () => {
 
     async function setPanel(panelView: string) {
         try {
-            if (panelView === MY_PANEL_VIEW_ID && defaultPanelView.value && panelView !== defaultPanelView.value) {
-                await fetchToolSections(defaultPanelView.value);
+            if (panelView === MY_PANEL_VIEW_ID) {
+                const sectionedPanelView =
+                    defaultPanelView.value && defaultPanelView.value !== MY_PANEL_VIEW_ID
+                        ? defaultPanelView.value
+                        : panels.value[DEFAULT_PANEL_VIEW_ID]
+                          ? DEFAULT_PANEL_VIEW_ID
+                          : null;
+                if (sectionedPanelView) {
+                    await fetchToolSections(sectionedPanelView);
+                }
             }
             await fetchToolSections(panelView);
             currentPanelView.value = panelView;


### PR DESCRIPTION
Fixes #23072.

When an instance uses `my_panel` as the backend default panel view, e.g., https://ssh.usegalaxy.eu/, the toolbox is initialized directly into My Tools without loading the real sectioned default panel. Recent tools are filtered against loaded panel tool IDs, so on refresh or after running a tool, they were filtered against the `My Tools`-only panel and disappeared.

Switching to the `Full Tool Panel` fetched the `default` panel sections, which is why switching back to `My Tools` made `Recent tools` appear again.

This updates `My Tools` panel selection to preload a real sectioned panel: the backend default view when it is not `my_panel`, otherwise the `default` panel view when available. This keeps `Recent tools` filtering aligned with the `Full Tool Panel` sections on subdomains where `default_panel_view: "my_panel"`.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open an instance whose `/api/tool_panels` returns `default_panel_view: "my_panel"`, e.g. `https://ssh.usegalaxy.eu/`.
  2. Run a tool or refresh while My Tools is selected.
  3. Confirm Recent tools remain visible without first switching to Full Tool Panel.
  4. Confirm switching between Full Tool Panel and My Tools still works.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).