### PR TITLE
[26.1] Fix web_apps package unit tests with unpinned fastmcp

### DIFF
--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -58,6 +58,7 @@ test =
     httpx
     pytest
     pytest-asyncio
+    fastmcp>=2.13.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Problem

The "Test Galaxy packages" CI job fails at the `web_apps` package with 3 collection errors (job exit 1):

```
ERROR collecting src/galaxy/webapps/galaxy/api/mcp.py
  ModuleNotFoundError: No module named 'uncalled_for'
  ImportError: FastMCP server support is not installed. Install `fastmcp` or `fastmcp-slim[server]`.
```

`packages/web_apps/pytest.ini` uses `--doctest-modules`, so pytest imports every `src/**/*.py`, including `api/mcp.py`, which imports server-side fastmcp APIs (`FastMCP`, `Context`, `settings`, `fastmcp.server.http._current_http_request`) at module top level. `tests/webapps/api/test_mcp.py` imports the module too.

fastmcp 3.x is split into `fastmcp-slim` (client-only core) and `fastmcp` (full = `fastmcp-slim[server]`). The web_apps test env installs `.[test]`, which does not declare fastmcp — it's a conditional dependency gated at runtime by `enable_mcp_server` (with `try/except ImportError`) in `fast_app.py`. The unpinned env only transitively pulls `fastmcp-slim` (no server), so collection fails. Pinned CI passes because `pinned-requirements.txt` carries the full `fastmcp`.

## Fix

Add `fastmcp>=2.13.0` (the spec already used in `conditional-requirements.txt`) to the web_apps `test` extra, so the package test environment installs FastMCP server support. Kept out of `install_requires` — runtime MCP stays optional and guarded.

## Verification

Reproduced and confirmed locally:
- `fastmcp-slim` alone → the exact `ImportError: FastMCP server support is not installed`.
- `fastmcp>=2.13.0` → resolves `fastmcp==3.4.3` (full) + `fastmcp-slim==3.4.3` + `uncalled-for==0.3.2`; all server-side symbols used by `mcp.py` import cleanly.

Works for both unpinned (now installs full fastmcp) and pinned (already satisfied).