### PR TITLE
 Pass object store auth context through dataset file operations

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -140,11 +140,14 @@ def purge_hda(
 
 @galaxy_task(ignore_result=True, action="completely removes a set of datasets from the object_store")
 def purge_datasets(
+    sa_session: galaxy_scoped_session,
     dataset_manager: DatasetManager,
     request: PurgeDatasetsTaskRequest,
-    user: model.User | None = None,
     task_user_id: int | None = None,
 ):
+    user = None
+    if task_user_id:
+        user = sa_session.get(User, task_user_id)
     dataset_manager.purge_datasets(request, user)
 
 
@@ -558,12 +561,15 @@ def export_history(
 
 @galaxy_task(action="preparing compressed file for collection download")
 def prepare_dataset_collection_download(
+    sa_session: galaxy_scoped_session,
     request: PrepareDatasetCollectionDownload,
     collection_manager: DatasetCollectionManager,
-    task_user_id: int | None = None,
-    user: model.User | None = None,
+    task_user_id: int | None = None
 ):
     """Create a short term storage file tracked and available for download of target collection."""
+    user = None
+    if task_user_id:
+        user = sa_session.get(User, task_user_id)
     collection_manager.write_dataset_collection(request, user=user)
 
 

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -139,8 +139,13 @@ def purge_hda(
 
 
 @galaxy_task(ignore_result=True, action="completely removes a set of datasets from the object_store")
-def purge_datasets(dataset_manager: DatasetManager, request: PurgeDatasetsTaskRequest, task_user_id: int | None = None):
-    dataset_manager.purge_datasets(request)
+def purge_datasets(
+    dataset_manager: DatasetManager,
+    request: PurgeDatasetsTaskRequest,
+    user: model.User | None = None,
+    task_user_id: int | None = None,
+):
+    dataset_manager.purge_datasets(request, user)
 
 
 @galaxy_task(action="purge all datasets in a history")
@@ -556,9 +561,10 @@ def prepare_dataset_collection_download(
     request: PrepareDatasetCollectionDownload,
     collection_manager: DatasetCollectionManager,
     task_user_id: int | None = None,
+    user: model.User | None = None,
 ):
     """Create a short term storage file tracked and available for download of target collection."""
-    collection_manager.write_dataset_collection(request)
+    collection_manager.write_dataset_collection(request, user=user)
 
 
 @galaxy_task(action="preparing Galaxy Markdown PDF for download")

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -564,7 +564,7 @@ def prepare_dataset_collection_download(
     sa_session: galaxy_scoped_session,
     request: PrepareDatasetCollectionDownload,
     collection_manager: DatasetCollectionManager,
-    task_user_id: int | None = None
+    task_user_id: int | None = None,
 ):
     """Create a short term storage file tracked and available for download of target collection."""
     user = None

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -722,9 +722,7 @@ class BamNative(CompressedArchive, _BamOrSam):
         except Exception:
             return f"Binary bam alignments file ({nice_size(dataset.get_size())})"
 
-    def to_archive(
-        self, dataset: DatasetProtocol, name: str = "", auth: ObjectStoreAuth | None = None
-    ) -> Iterable:
+    def to_archive(self, dataset: DatasetProtocol, name: str = "", auth: ObjectStoreAuth | None = None) -> Iterable:
         file_name = dataset.get_file_name(auth=auth)
         rel_paths = []
         file_paths = []

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -76,6 +76,7 @@ from galaxy.datatypes.sniff import (
     FilePrefix,
 )
 from galaxy.datatypes.text import Html
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util import (
     compression_utils,
     nice_size,
@@ -721,15 +722,18 @@ class BamNative(CompressedArchive, _BamOrSam):
         except Exception:
             return f"Binary bam alignments file ({nice_size(dataset.get_size())})"
 
-    def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
+    def to_archive(
+        self, dataset: DatasetProtocol, name: str = "", auth: ObjectStoreAuth | None = None
+    ) -> Iterable:
+        file_name = dataset.get_file_name(auth=auth)
         rel_paths = []
         file_paths = []
-        rel_paths.append(f"{name or dataset.get_file_name()}.{dataset.extension}")
-        file_paths.append(dataset.get_file_name())
+        rel_paths.append(f"{name or file_name}.{dataset.extension}")
+        file_paths.append(file_name)
         # We may or may not have a bam index file (BamNative doesn't have it, but also index generation may have failed)
         if dataset.metadata.bam_index:
-            rel_paths.append(f"{name or dataset.get_file_name()}.{dataset.extension}.bai")
-            file_paths.append(dataset.metadata.bam_index.get_file_name())
+            rel_paths.append(f"{name or file_name}.{dataset.extension}.bai")
+            file_paths.append(dataset.metadata.bam_index.get_file_name(auth=auth))
         return zip(file_paths, rel_paths)
 
     def groom_dataset_content(self, file_name: str) -> None:
@@ -767,7 +771,11 @@ class BamNative(CompressedArchive, _BamOrSam):
     def get_chunk(self, trans, dataset: HasFileName, offset: int = 0, ck_size: int | None = None) -> str:
         if not offset == -1:
             try:
-                with pysam.AlignmentFile(dataset.get_file_name(), "rb", check_sq=False) as bamfile:
+                with pysam.AlignmentFile(
+                    dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user) if trans else None),
+                    "rb",
+                    check_sq=False,
+                ) as bamfile:
                     if ck_size is None:
                         ck_size = 300  # 300 lines
                     if offset < bamfile.tell():
@@ -2224,11 +2232,12 @@ class H5MLM(H5):
 
         if to_ext or not preview:
             to_ext = to_ext or dataset.extension
-            return self._serve_raw(dataset, to_ext, headers, **kwd)
+            return self._serve_raw(dataset, to_ext, headers, auth=ObjectStoreAuth(user=trans.user), **kwd)
 
         out_dict: dict = {}
+        fname = dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user))
         try:
-            with h5py.File(dataset.get_file_name(), "r", locking=False) as handle:
+            with h5py.File(fname, "r", locking=False) as handle:
                 out_dict["Attributes"] = {}
                 attributes = handle.attrs
                 for k in set(attributes.keys()) - {self.HTTP_REPR, self.REPR, self.URL}:
@@ -2236,13 +2245,13 @@ class H5MLM(H5):
         except Exception as e:
             log.warning(e)
 
-        config = self.get_config_string(dataset.get_file_name())
+        config = self.get_config_string(fname)
         out_dict["Config"] = json.loads(config) if config else ""
         out = json.dumps(out_dict, sort_keys=True, indent=2)
         out = out[: self.max_preview_size]
 
-        repr = self.get_repr(dataset.get_file_name())
-        html_repr = self.get_html_repr(dataset.get_file_name())
+        repr = self.get_repr(fname)
+        html_repr = self.get_html_repr(fname)
 
         return f"<div>{html_repr}</div><div><pre>{repr}</pre></div><div><pre>{out}</pre></div>", headers
 

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -44,6 +44,7 @@ from galaxy.datatypes.sniff import (
     build_sniff_from_prefix,
     FilePrefix,
 )
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util import smart_str
 from .data import (
     Data,
@@ -242,7 +243,7 @@ class _BlastDb(Data):
         msg = ""
         try:
             # Try to use any text recorded in the dummy index file:
-            with open(dataset.get_file_name(), encoding="utf-8") as handle:
+            with open(dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user)), encoding="utf-8") as handle:
                 msg = handle.read().strip()
         except Exception:
             pass

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -466,9 +466,7 @@ class Data(metaclass=DataMeta):
         headers["Content-Disposition"] = to_content_disposition(filename)
         return open(file_name, mode="rb"), headers
 
-    def to_archive(
-        self, dataset: DatasetProtocol, name: str = "", auth: ObjectStoreAuth | None = None
-    ) -> Iterable:
+    def to_archive(self, dataset: DatasetProtocol, name: str = "", auth: ObjectStoreAuth | None = None) -> Iterable:
         """
         Collect archive paths and file handles that need to be exported when archiving `dataset`.
 
@@ -545,9 +543,12 @@ class Data(metaclass=DataMeta):
 
         preview = util.string_as_bool(preview)
         if not preview or isinstance(data.datatype, images.Image) or file_size < max_peek_size:
-            return self._yield_user_file_content(
-                trans, data, data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), headers
-            ), headers
+            return (
+                self._yield_user_file_content(
+                    trans, data, data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), headers
+                ),
+                headers,
+            )
 
         with compression_utils.get_fileobj(data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), "rb") as fh:
             # preview large text file - serve as text/plain so the browser

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -43,6 +43,7 @@ from galaxy.datatypes.sniff import (
     FilePrefix,
 )
 from galaxy.exceptions import ObjectNotFound
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util import (
     compression_utils,
     file_reader,
@@ -443,9 +444,15 @@ class Data(metaclass=DataMeta):
                 yield fpath, rpath
 
     def _serve_raw(
-        self, dataset: DatasetHasHidProtocol, to_ext: str | None, headers: Headers, **kwd
+        self,
+        dataset: DatasetHasHidProtocol,
+        to_ext: str | None,
+        headers: Headers,
+        auth: ObjectStoreAuth | None = None,
+        **kwd,
     ) -> tuple[IO, Headers]:
-        headers["Content-Length"] = str(os.stat(dataset.get_file_name()).st_size)
+        file_name = dataset.get_file_name(auth=auth)
+        headers["Content-Length"] = str(os.stat(file_name).st_size)
         headers["content-type"] = (
             "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
         )
@@ -457,28 +464,32 @@ class Data(metaclass=DataMeta):
             filename_pattern=kwd.get("filename_pattern"),
         )
         headers["Content-Disposition"] = to_content_disposition(filename)
-        return open(dataset.get_file_name(), mode="rb"), headers
+        return open(file_name, mode="rb"), headers
 
-    def to_archive(self, dataset: DatasetProtocol, name: str = "") -> Iterable:
+    def to_archive(
+        self, dataset: DatasetProtocol, name: str = "", auth: ObjectStoreAuth | None = None
+    ) -> Iterable:
         """
         Collect archive paths and file handles that need to be exported when archiving `dataset`.
 
         :param dataset: HistoryDatasetAssociation
         :param name: archive name, in collection context corresponds to collection name(s) and element_identifier,
                      joined by '/', e.g 'fastq_collection/sample1/forward'
+        :param auth: object store auth context
         """
         rel_paths = []
         file_paths = []
         if dataset.datatype.composite_type or dataset.extension.endswith("html"):
             main_file = f"{name}.html"
             rel_paths.append(main_file)
-            file_paths.append(dataset.get_file_name())
+            file_paths.append(dataset.get_file_name(auth=auth))
             for fpath, rpath in self.__archive_extra_files_path(dataset.extra_files_path):
                 rel_paths.append(os.path.join(name, rpath))
                 file_paths.append(fpath)
         else:
-            rel_paths.append(f"{name or dataset.get_file_name()}.{dataset.extension}")
-            file_paths.append(dataset.get_file_name())
+            file_name = dataset.get_file_name(auth=auth)
+            rel_paths.append(f"{name or file_name}.{dataset.extension}")
+            file_paths.append(file_name)
         return zip(file_paths, rel_paths)
 
     def is_archive_download(self, datatypes_registry, extension) -> bool:
@@ -518,7 +529,7 @@ class Data(metaclass=DataMeta):
                 "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
             )
             headers["Content-Disposition"] = self.download_content_disposition(data, to_ext, **kwd)
-            return open(data.get_file_name(), "rb"), headers
+            return open(data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), "rb"), headers
 
     def _serve_binary_file_contents_as_text(self, trans, data, headers, file_size, max_peek_size):
         # Use text/plain so the browser preserves whitespace and line endings
@@ -526,7 +537,7 @@ class Data(metaclass=DataMeta):
         headers["content-type"] = "text/plain; charset=utf-8"
         if file_size > max_peek_size:
             headers["x-content-truncated"] = str(max_peek_size)
-        with open(data.get_file_name(), "rb") as fh:
+        with open(data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), "rb") as fh:
             return unicodify(fh.read(max_peek_size)), headers
 
     def _serve_file_contents(self, trans, data, headers, preview, file_size, max_peek_size):
@@ -534,9 +545,11 @@ class Data(metaclass=DataMeta):
 
         preview = util.string_as_bool(preview)
         if not preview or isinstance(data.datatype, images.Image) or file_size < max_peek_size:
-            return self._yield_user_file_content(trans, data, data.get_file_name(), headers), headers
+            return self._yield_user_file_content(
+                trans, data, data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), headers
+            ), headers
 
-        with compression_utils.get_fileobj(data.get_file_name(), "rb") as fh:
+        with compression_utils.get_fileobj(data.get_file_name(auth=ObjectStoreAuth(user=trans.user)), "rb") as fh:
             # preview large text file - serve as text/plain so the browser
             # preserves whitespace/newlines and does not interpret content as HTML.
             headers["content-type"] = "text/plain; charset=utf-8"
@@ -569,7 +582,9 @@ class Data(metaclass=DataMeta):
         if filename and filename != "index":
             # For files in extra_files_path
             extra_dir = dataset.dataset.extra_files_path_name
-            file_path = trans.app.object_store.get_filename(dataset.dataset, extra_dir=extra_dir, alt_name=filename)
+            file_path = trans.app.object_store.get_filename(
+                dataset.dataset, extra_dir=extra_dir, alt_name=filename, auth=ObjectStoreAuth(user=trans.user)
+            )
             if os.path.exists(file_path):
                 if os.path.isdir(file_path):
                     with tempfile.NamedTemporaryFile(
@@ -612,7 +627,7 @@ class Data(metaclass=DataMeta):
         downloading = to_ext is not None
         file_size = _get_file_size(dataset)
 
-        if not os.path.exists(dataset.get_file_name()):
+        if not os.path.exists(dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user))):
             raise ObjectNotFound(f"File Not Found ({dataset.get_file_name()}).")
 
         if downloading:

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -33,6 +33,7 @@ from galaxy.datatypes.protocols import (
     HasExtraFilesAndMetadata,
     HasExtraFilesPath,
 )
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util.compression_utils import CompressedFile
 from galaxy.util.sanitize_html import sanitize_html
 
@@ -217,6 +218,9 @@ class _Isa(Data):
         # if it is not required a preview use the default behaviour of `display_data`
         if not preview:
             return super().display_data(trans, dataset, preview, filename, to_ext, **kwd)
+
+        # this forces sync with objectstore
+        dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user))
 
         # prepare the preview of the ISA dataset
         try:

--- a/lib/galaxy/datatypes/protocols.py
+++ b/lib/galaxy/datatypes/protocols.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from typing_extensions import Protocol
 
+from galaxy.objectstore import ObjectStoreAuth
+
 
 class HasClearAssociatedFiles(Protocol):
     def clear_associated_files(self, metadata_safe: bool = False, purge: bool = False) -> None: ...
@@ -31,7 +33,7 @@ class HasExtraFilesPath(Protocol):
 
 
 class HasFileName(Protocol):
-    def get_file_name(self, sync_cache=True) -> str: ...
+    def get_file_name(self, sync_cache=True, auth: ObjectStoreAuth | None = None) -> str: ...
 
 
 class HasHid(Protocol):

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -13,6 +13,7 @@ from galaxy.datatypes.protocols import (
     DatasetProtocol,
     HasExtraFilesAndMetadata,
 )
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util import smart_str
 
 log = logging.getLogger(__name__)
@@ -148,7 +149,7 @@ class _SpalnDb(Data):
         msg = ""
         try:
             # Try to use any text recorded in the dummy index file:
-            with open(dataset.get_file_name(), encoding="utf-8") as handle:
+            with open(dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user)), encoding="utf-8") as handle:
                 msg = handle.read().strip()
         except Exception:
             pass

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -62,6 +62,7 @@ from galaxy.datatypes.sniff import (
     validate_tabular,
 )
 from galaxy.exceptions import InvalidFileFormatError
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util import compression_utils
 from galaxy.util.compression_utils import (
     FileObjType,
@@ -183,23 +184,24 @@ class TabularData(Text):
     ):
         headers = kwd.pop("headers", {})
         preview = util.string_as_bool(preview)
+        fname = dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user))
         if offset is not None:
             return self.get_chunk(trans, dataset, offset, ck_size), headers
         elif to_ext or not preview:
             to_ext = to_ext or dataset.extension
-            return self._serve_raw(dataset, to_ext, headers, **kwd)
+            return self._serve_raw(dataset, to_ext, headers, auth=ObjectStoreAuth(user=trans.user), **kwd)
         elif dataset.metadata.columns > 100:
             # Fancy tabular display is only suitable for datasets without an incredibly large number of columns.
             # We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
             # For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.
             max_peek_size = 1000000  # 1 MB
-            if os.stat(dataset.get_file_name()).st_size < max_peek_size:
+            if os.stat(fname).st_size < max_peek_size:
                 self._clean_and_set_mime_type(trans, dataset.get_mime(), headers)
-                return open(dataset.get_file_name(), mode="rb"), headers
+                return open(fname, mode="rb"), headers
             else:
                 headers["content-type"] = "text/html"
                 headers["x-content-truncated"] = max_peek_size
-                with compression_utils.get_fileobj(dataset.get_file_name(), "rb") as fh:
+                with compression_utils.get_fileobj(fname, "rb") as fh:
                     return util.unicodify(fh.read(max_peek_size)), headers
         else:
             headers["x-content-chunked"] = "true"

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -35,6 +35,7 @@ from galaxy.datatypes.sniff import (
     FilePrefix,
     iter_headers,
 )
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.util import (
     nice_size,
     string_as_bool,
@@ -231,8 +232,9 @@ class Ipynb(Json):
     ) -> tuple[IO, Headers]:
         headers = kwd.pop("headers", {})
         preview = string_as_bool(preview)
+        fname = dataset.get_file_name(auth=ObjectStoreAuth(user=trans.user))
         if to_ext or not preview:
-            return self._serve_raw(dataset, to_ext, headers, **kwd)
+            return self._serve_raw(dataset, to_ext, headers, auth=ObjectStoreAuth(user=trans.user), **kwd)
         else:
             with tempfile.NamedTemporaryFile(delete=False) as ofile_handle:
                 ofilename = ofile_handle.name
@@ -244,7 +246,7 @@ class Ipynb(Json):
                     "html",
                     "--template",
                     "full",
-                    dataset.get_file_name(),
+                    fname,
                     "--output",
                     ofilename,
                 ]

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2725,7 +2725,7 @@ class MinimalJobWrapper(HasResourceParameters):
                 # is a bit of hack - our object store abstractions would be stronger
                 # and more consistent if tools weren't writing there directly.
                 try:
-                    dataset.full_delete()
+                    dataset.full_delete(user=hda.user)
                 except ObjectNotFound:
                     pass
 

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -953,10 +953,10 @@ class DatasetCollectionManager:
             qry = qry.offset(int(offset))
         return qry
 
-    def write_dataset_collection(self, request: PrepareDatasetCollectionDownload):
+    def write_dataset_collection(self, request: PrepareDatasetCollectionDownload, user: model.User | None = None):
         short_term_storage_monitor = self.short_term_storage_monitor
         instance_id = request.history_dataset_collection_association_id
         with storage_context(request.short_term_storage_request_id, short_term_storage_monitor) as target:
             collection_instance = self.model.context.get(model.HistoryDatasetCollectionAssociation, instance_id)
             with ZipFile(target.path, "w") as zip_f:
-                write_dataset_collection(collection_instance, zip_f)
+                write_dataset_collection(collection_instance, zip_f, user)

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -36,6 +36,7 @@ from galaxy.model.db.role import (
     get_private_role_user_emails_dict,
     role_name_id_pairs,
 )
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.schema.tasks import (
     ComputeDatasetHashTaskRequest,
     PurgeDatasetsTaskRequest,
@@ -71,7 +72,7 @@ class DatasetManager(
     def copy(self, item, **kwargs):
         raise exceptions.NotImplemented("Datasets cannot be copied")
 
-    def purge(self, item, flush=True, **kwargs):
+    def purge(self, item, flush=True, user=None, **kwargs):
         """
         Remove the object_store/file for this dataset from storage and mark
         as purged.
@@ -81,14 +82,14 @@ class DatasetManager(
         self.error_unless_dataset_purge_allowed(item)
 
         # the following also marks dataset as purged and deleted
-        item.full_delete()
+        item.full_delete(user=user)
         self.session().add(item)
         if flush:
             session = self.session()
             session.commit()
         return item
 
-    def purge_datasets(self, request: PurgeDatasetsTaskRequest):
+    def purge_datasets(self, request: PurgeDatasetsTaskRequest, user: model.User | None = None):
         """
         Caution: any additional security checks must be done before executing this action.
 
@@ -100,7 +101,7 @@ class DatasetManager(
             dataset: Dataset | None = self.session().get(Dataset, dataset_id)
             if dataset and dataset.user_can_purge:
                 try:
-                    dataset.full_delete()
+                    dataset.full_delete(user)
                 except Exception:
                     log.exception(f"Unable to purge dataset ({dataset.id})")
         self.session().commit()
@@ -170,9 +171,14 @@ class DatasetManager(
         try:
             if extra_files_path:
                 extra_dir = dataset.extra_files_path_name
-                file_path = self.app.object_store.get_filename(dataset, extra_dir=extra_dir, alt_name=extra_files_path)
+                file_path = self.app.object_store.get_filename(
+                    dataset,
+                    extra_dir=extra_dir,
+                    alt_name=extra_files_path,
+                    auth=ObjectStoreAuth(user=request.user) if request.user else None,
+                )
             else:
-                file_path = dataset.get_file_name()
+                file_path = dataset.get_file_name(auth=ObjectStoreAuth(user=request.user) if request.user else None)
         except ObjectInvalid:
             log.warning(
                 "Unable to calculate hash for dataset [%s]: object is invalid (dataset may have failed or been purged).",

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -166,6 +166,11 @@ class DatasetManager(
         if dataset.purged:
             log.warning("Unable to calculate hash for purged dataset [%s].", dataset.id)
             return
+        sa_session = self.session()
+        user = None
+        if request.user and request.user.user_id:
+            user = sa_session.get(model.User, request.user.user_id)
+        auth = ObjectStoreAuth(user=user) if user else None
         # For files in extra_files_path
         extra_files_path = request.extra_files_path
         try:
@@ -175,10 +180,10 @@ class DatasetManager(
                     dataset,
                     extra_dir=extra_dir,
                     alt_name=extra_files_path,
-                    auth=ObjectStoreAuth(user=request.user) if request.user else None,
+                    auth=auth,
                 )
             else:
-                file_path = dataset.get_file_name(auth=ObjectStoreAuth(user=request.user) if request.user else None)
+                file_path = dataset.get_file_name(auth=auth)
         except ObjectInvalid:
             log.warning(
                 "Unable to calculate hash for dataset [%s]: object is invalid (dataset may have failed or been purged).",
@@ -195,7 +200,6 @@ class DatasetManager(
         dataset_hash.dataset = dataset
         # TODO: replace/update if the combination of dataset_id/hash_function has already
         # been stored.
-        sa_session = self.session()
         hash = get_dataset_hash(sa_session, dataset.id, hash_function, extra_files_path)
         if hash is None:
             sa_session.add(dataset_hash)

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -494,7 +494,7 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
 
             purge_datasets.delay(request=request, task_user_id=getattr(user, "id", None))
         else:
-            self.dataset_manager.purge_datasets(request)
+            self.dataset_manager.purge_datasets(request, user=user)
 
 
 class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerializer,

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -19,6 +19,7 @@ from galaxy.managers import (
 )
 from galaxy.managers.collections_util import get_hda_and_element_identifiers
 from galaxy.model.tags import GalaxyTagHandler
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.schema.schema import OldestCreateTimeByObjectStoreId
 from galaxy.structured_app import (
     MinimalManagerApp,
@@ -29,25 +30,26 @@ from galaxy.util.zipstream import ZipstreamWrapper
 log = logging.getLogger(__name__)
 
 
-def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=False, upstream_gzip=False):
+def stream_dataset_collection(dataset_collection_instance, upstream_mod_zip=False, upstream_gzip=False, user=None):
     archive_name = f"{dataset_collection_instance.hid}: {dataset_collection_instance.name}"
     archive = ZipstreamWrapper(
         archive_name=archive_name,
         upstream_mod_zip=upstream_mod_zip,
         upstream_gzip=upstream_gzip,
     )
-    write_dataset_collection(dataset_collection_instance, archive)
+    write_dataset_collection(dataset_collection_instance, archive, user)
     return archive
 
 
-def write_dataset_collection(dataset_collection_instance, archive):
+def write_dataset_collection(dataset_collection_instance, archive, user):
+    auth = ObjectStoreAuth(user=user) if user else None
     if not dataset_collection_instance.collection.populated_optimized:
         raise RequestParameterInvalidException("Attempt to write dataset collection that has not been populated yet")
     names, hdas = get_hda_and_element_identifiers(dataset_collection_instance)
     for name, hda in zip(names, hdas):
         if hda.state != hda.states.OK or hda.purged or hda.dataset.purged:
             continue
-        for file_path, relpath in hda.datatype.to_archive(dataset=hda, name=name):
+        for file_path, relpath in hda.datatype.to_archive(dataset=hda, name=name, auth=auth):
             archive.write(file_path, relpath)
     return archive
 

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -48,7 +48,6 @@ from galaxy.managers.base import (
 )
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.export_tracker import StoreExportTracker
-from galaxy.objectstore import ObjectStoreAuth
 from galaxy.model import (
     History,
     HistoryUserShareAssociation,
@@ -60,6 +59,7 @@ from galaxy.model.index_filter_util import (
     tag_filter,
     text_column_filter,
 )
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.schema.fields import Security
 from galaxy.schema.history import HistoryIndexQueryPayload
 from galaxy.schema.schema import (

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -48,6 +48,7 @@ from galaxy.managers.base import (
 )
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.export_tracker import StoreExportTracker
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.model import (
     History,
     HistoryUserShareAssociation,
@@ -398,7 +399,7 @@ class HistoryManager(sharable.SharableModelManager[model.History], deletable.Pur
             trans.response.set_content_type("application/x-tar")
         disposition = f'attachment; filename="{jeha.export_name}"'
         trans.response.headers["Content-Disposition"] = disposition
-        archive = trans.app.object_store.get_filename(jeha.dataset)
+        archive = trans.app.object_store.get_filename(jeha.dataset, auth=ObjectStoreAuth(user=trans.user))
         return open(archive, mode="rb")
 
     def get_ready_history_export_file_path(self, trans, jeha) -> str:
@@ -407,7 +408,7 @@ class HistoryManager(sharable.SharableModelManager[model.History], deletable.Pur
         doesn't need to be loaded into memory.
         """
         assert jeha.ready
-        return trans.app.object_store.get_filename(jeha.dataset)
+        return trans.app.object_store.get_filename(jeha.dataset, auth=ObjectStoreAuth(user=trans.user))
 
     def queue_history_export(
         self, trans, history, gzip=True, include_hidden=False, include_deleted=False, directory_uri=None, file_name=None

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -166,7 +166,10 @@ from galaxy.model.item_attrs import (
     UsesAnnotations,
 )
 from galaxy.model.orm.util import add_object_to_object_session
-from galaxy.objectstore import USER_OBJECTS_SCHEME
+from galaxy.objectstore import (
+    ObjectStoreAuth,
+    USER_OBJECTS_SCHEME,
+)
 from galaxy.objectstore.templates import (
     ObjectStoreConfiguration,
     ObjectStoreTemplate,
@@ -3152,9 +3155,9 @@ class FakeDatasetAssociation:
         self.metadata: dict = {}
         self.has_deferred_data = False
 
-    def get_file_name(self, sync_cache: bool = True) -> str:
+    def get_file_name(self, sync_cache: bool = True, auth: ObjectStoreAuth | None = None) -> str:
         assert self.dataset
-        return self.dataset.get_file_name(sync_cache)
+        return self.dataset.get_file_name(sync_cache=sync_cache, auth=auth)
 
     def __eq__(self, other):
         return isinstance(other, FakeDatasetAssociation) and self.dataset == other.dataset
@@ -4847,14 +4850,14 @@ class Dataset(Base, StorableObject, Serializable):
         if not self.shareable:
             raise galaxy.exceptions.MessageException(CANNOT_SHARE_PRIVATE_DATASET_MESSAGE)
 
-    def get_file_name(self, sync_cache: bool = True) -> str:
+    def get_file_name(self, sync_cache: bool = True, auth: ObjectStoreAuth | None = None) -> str:
         if self.purged:
             log.warning(f"Attempt to get file name of purged dataset {self.id}")
             return ""
         if not self.external_filename:
             object_store = self._assert_object_store_set()
             if object_store.exists(self):
-                file_name = object_store.get_filename(self, sync_cache=sync_cache)
+                file_name = object_store.get_filename(self, sync_cache=sync_cache, auth=auth)
             else:
                 file_name = ""
             if not file_name and self.state not in (self.states.NEW, self.states.QUEUED):
@@ -5029,10 +5032,10 @@ class Dataset(Base, StorableObject, Serializable):
             and len(self.history_associations) == len(self.purged_history_associations)
         )
 
-    def full_delete(self):
+    def full_delete(self, user=None):
         """Remove the file and extra files, marks deleted and purged"""
         try:
-            self.object_store.delete(self)
+            self.object_store.delete(self, auth=ObjectStoreAuth(user=user) if user else None)
         except galaxy.exceptions.ObjectNotFound:
             pass
         if (rel_path := self._extra_files_rel_path) is not None:
@@ -5576,9 +5579,9 @@ class DatasetInstance(RepresentById, UsesCreateAndUpdateTime, _HasTable):
         self.peek = null
         self.set_total_size()
 
-    def get_file_name(self, sync_cache: bool = True) -> str:
+    def get_file_name(self, sync_cache: bool = True, auth: ObjectStoreAuth | None = None) -> str:
         assert self.dataset is not None
-        return self.dataset.get_file_name(sync_cache=sync_cache)
+        return self.dataset.get_file_name(sync_cache=sync_cache, auth=auth)
 
     def set_file_name(self, filename: str):
         assert self.dataset is not None
@@ -6202,7 +6205,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, UsesAnnotations, HasNa
             copied_hda.copy_from(self, include_tags=include_tags, include_metadata=include_metadata)
 
         if old_dataset:
-            old_dataset.full_delete()
+            old_dataset.full_delete(user=self.user)
 
     def copy(self, parent_id=None, copy_tags=None, flush=True, copy_hid=True, new_name=None):
         """
@@ -11229,7 +11232,7 @@ class MetadataFile(Base, StorableObject, Serializable):
                 alt_name=os.path.basename(self.get_file_name()),
             )
 
-    def get_file_name(self, sync_cache: bool = True) -> str:
+    def get_file_name(self, sync_cache: bool = True, auth: ObjectStoreAuth | None = None) -> str:
         # Ensure the directory structure and the metadata file object exist
         try:
             da = self.history_dataset or self.library_dataset
@@ -11247,7 +11250,12 @@ class MetadataFile(Base, StorableObject, Serializable):
             if not object_store.exists(self, extra_dir="_metadata_files", extra_dir_at_root=True, alt_name=alt_name):
                 object_store.create(self, extra_dir="_metadata_files", extra_dir_at_root=True, alt_name=alt_name)
             path = object_store.get_filename(
-                self, extra_dir="_metadata_files", extra_dir_at_root=True, alt_name=alt_name, sync_cache=sync_cache
+                self,
+                extra_dir="_metadata_files",
+                extra_dir_at_root=True,
+                alt_name=alt_name,
+                sync_cache=sync_cache,
+                auth=auth,
             )
             return path
         except (AssertionError, AttributeError):

--- a/lib/galaxy/model/none_like.py
+++ b/lib/galaxy/model/none_like.py
@@ -38,5 +38,5 @@ class NoneDataset(RecursiveNone):
     def missing_meta(self):
         return False
 
-    def get_file_name(self, sync_cache=True):
+    def get_file_name(self, sync_cache=True, auth=None):
         return "None"

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -12,6 +12,7 @@ import random
 import shutil
 import threading
 import time
+from dataclasses import dataclass
 from typing import (
     Any,
     Literal,
@@ -61,6 +62,7 @@ if TYPE_CHECKING:
     from galaxy.model import (
         Dataset,
         DatasetInstance,
+        User,
     )
 
 NO_SESSION_ERROR_MESSAGE = (
@@ -73,6 +75,12 @@ DEFAULT_DEVICE_ID = None
 USER_OBJECTS_SCHEME = "user_objects://"
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ObjectStoreAuth:
+    user: Optional["User"] = None
+    token: Optional[str] = None
 
 
 def is_user_object_store(object_store_id: str | None) -> bool:
@@ -224,6 +232,7 @@ class ObjectStore(metaclass=abc.ABCMeta):
         extra_dir_at_root=False,
         alt_name=None,
         obj_dir: bool = False,
+        auth: ObjectStoreAuth | None = None,
     ) -> bool:
         """
         Delete the object identified by `obj`.
@@ -272,6 +281,7 @@ class ObjectStore(metaclass=abc.ABCMeta):
         alt_name=None,
         obj_dir: bool = False,
         sync_cache: bool = True,
+        auth: ObjectStoreAuth | None = None,
     ) -> str:
         """
         Get the expected filename with absolute path for object with id `obj.id`.
@@ -592,6 +602,7 @@ class BaseObjectStore(ObjectStore):
         extra_dir_at_root=False,
         alt_name=None,
         obj_dir: bool = False,
+        auth: ObjectStoreAuth | None = None,
     ) -> bool:
         return self._invoke(
             "delete",
@@ -603,6 +614,7 @@ class BaseObjectStore(ObjectStore):
             extra_dir_at_root=extra_dir_at_root,
             alt_name=alt_name,
             obj_dir=obj_dir,
+            auth=auth,
         )
 
     def get_data(
@@ -638,6 +650,7 @@ class BaseObjectStore(ObjectStore):
         alt_name=None,
         obj_dir: bool = False,
         sync_cache: bool = True,
+        auth: ObjectStoreAuth | None = None,
     ) -> str:
         return self._invoke(
             "get_filename",
@@ -649,6 +662,7 @@ class BaseObjectStore(ObjectStore):
             alt_name=alt_name,
             obj_dir=obj_dir,
             sync_cache=sync_cache,
+            auth=auth,
         )
 
     def update_from_file(
@@ -998,6 +1012,7 @@ class DiskObjectStore(ConcreteObjectStore):
         obj_dir: bool = False,
         in_cache: bool = False,
         old_style=False,
+        auth: ObjectStoreAuth | None = None,
     ) -> str:
         """
         Construct the absolute path for accessing the object identified by `obj.id`.

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -4,6 +4,7 @@ objectstore package, abstraction for storing blobs of data for use in Galaxy.
 all providers ensure that data can be accessed on the filesystem for running
 tools
 """
+
 from __future__ import annotations
 
 import abc
@@ -18,7 +19,6 @@ from typing import (
     Any,
     Literal,
     NamedTuple,
-    Optional,
     TYPE_CHECKING,
 )
 from uuid import uuid4
@@ -92,19 +92,19 @@ class UserObjectStoreResolver(Protocol):
     def resolve_object_store_uri_config(self, uri: str) -> ObjectStoreConfiguration:
         pass
 
-    def resolve_object_store_uri(self, uri: str) -> "ConcreteObjectStore":
+    def resolve_object_store_uri(self, uri: str) -> ConcreteObjectStore:
         pass
 
 
 class BaseUserObjectStoreResolver(UserObjectStoreResolver, metaclass=abc.ABCMeta):
-    _app_config: "UserObjectStoresAppConfig"
+    _app_config: UserObjectStoresAppConfig
 
     @abc.abstractmethod
     def resolve_object_store_uri_config(self, uri: str) -> ObjectStoreConfiguration:
         """Resolve the supplied object store URI into a concrete object store configuration."""
         pass
 
-    def resolve_object_store_uri(self, uri: str) -> "ConcreteObjectStore":
+    def resolve_object_store_uri(self, uri: str) -> ConcreteObjectStore:
         object_store_configuration = self.resolve_object_store_uri_config(uri)
         return concrete_object_store(object_store_configuration, self._app_config)
 
@@ -395,7 +395,7 @@ class ObjectStore(metaclass=abc.ABCMeta):
         """Return a non-emtpy list of allowed selectable object store IDs during creation."""
         return []
 
-    def get_concrete_store_by_object_store_id(self, object_store_id: str) -> Optional["ConcreteObjectStore"]:
+    def get_concrete_store_by_object_store_id(self, object_store_id: str) -> ConcreteObjectStore | None:
         """If this is a distributed object store, get ConcreteObjectStore by object_store_id."""
         return None
 
@@ -422,11 +422,11 @@ class ObjectStore(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_quota_source_map(self) -> "QuotaSourceMap":
+    def get_quota_source_map(self) -> QuotaSourceMap:
         """Return QuotaSourceMap describing mapping of object store IDs to quota sources."""
 
     @abc.abstractmethod
-    def get_device_source_map(self) -> "DeviceSourceMap":
+    def get_device_source_map(self) -> DeviceSourceMap:
         """Return DeviceSourceMap describing mapping of object store IDs to device sources."""
 
 
@@ -756,7 +756,7 @@ class BaseObjectStore(ObjectStore):
             badges.append({"type": type, "message": message})
         return badges
 
-    def get_quota_source_map(self) -> "QuotaSourceMap":
+    def get_quota_source_map(self) -> QuotaSourceMap:
         # I'd rather keep this abstract... but register_singleton wants it to be instantiable...
         raise NotImplementedError()
 
@@ -826,7 +826,7 @@ class ConcreteObjectStore(BaseObjectStore):
         rval["object_expires_after_days"] = self.object_expires_after_days
         return rval
 
-    def to_model(self, object_store_id: str) -> "ConcreteObjectStoreModel":
+    def to_model(self, object_store_id: str) -> ConcreteObjectStoreModel:
         return ConcreteObjectStoreModel(
             object_store_id=object_store_id,
             private=self.private,
@@ -884,7 +884,7 @@ class ConcreteObjectStore(BaseObjectStore):
         )
         return quota_source_map
 
-    def get_device_source_map(self) -> "DeviceSourceMap":
+    def get_device_source_map(self) -> DeviceSourceMap:
         return DeviceSourceMap(self.device_id)
 
 
@@ -1400,8 +1400,8 @@ class DistributedObjectStore(NestedObjectStore):
 
     backends: dict[str, Any]  # BaseObjectStore or ConcreteObjectStore?
     store_type = "distributed"
-    _quota_source_map: Optional["QuotaSourceMap"]
-    _device_source_map: Optional["DeviceSourceMap"]
+    _quota_source_map: QuotaSourceMap | None
+    _device_source_map: DeviceSourceMap | None
 
     def __init__(
         self, config, config_dict, fsmon=False, user_object_store_resolver: UserObjectStoreResolver | None = None
@@ -1618,7 +1618,7 @@ class DistributedObjectStore(NestedObjectStore):
                 return self.user_object_store_resolver.resolve_object_store_uri(object_store_id)
             raise
 
-    def get_quota_source_map(self) -> "QuotaSourceMap":
+    def get_quota_source_map(self) -> QuotaSourceMap:
         if self._quota_source_map is None:
             quota_source_map = QuotaSourceMap()
             self._merge_quota_source_map(quota_source_map, self)
@@ -1626,7 +1626,7 @@ class DistributedObjectStore(NestedObjectStore):
         assert self._quota_source_map is not None
         return self._quota_source_map
 
-    def get_device_source_map(self) -> "DeviceSourceMap":
+    def get_device_source_map(self) -> DeviceSourceMap:
         if self._device_source_map is None:
             device_source_map = DeviceSourceMap()
             self._merge_device_source_map(device_source_map, self)
@@ -1643,7 +1643,7 @@ class DistributedObjectStore(NestedObjectStore):
                 quota_source_map.backends[backend_id] = backend.get_quota_source_map()
 
     @classmethod
-    def _merge_device_source_map(clz, device_source_map: "DeviceSourceMap", object_store):
+    def _merge_device_source_map(clz, device_source_map: DeviceSourceMap, object_store):
         for backend_id, backend in object_store.backends.items():
             if isinstance(backend, DistributedObjectStore):
                 clz._merge_device_source_map(device_source_map, backend)
@@ -1726,7 +1726,7 @@ class DistributedObjectStore(NestedObjectStore):
         """Return a non-empty list of allowed selectable object store IDs during creation."""
         return self.user_selection_allowed
 
-    def get_concrete_store_by_object_store_id(self, object_store_id: str) -> Optional["ConcreteObjectStore"]:
+    def get_concrete_store_by_object_store_id(self, object_store_id: str) -> ConcreteObjectStore | None:
         """If this is a distributed object store, get ConcreteObjectStore by object_store_id."""
         return self.backends.get(object_store_id)
 
@@ -2170,11 +2170,11 @@ class ObjectStorePopulator:
         self.object_store_id = None
         self.user = user
 
-    def set_object_store_id(self, data: "DatasetInstance", require_shareable: bool = False) -> None:
+    def set_object_store_id(self, data: DatasetInstance, require_shareable: bool = False) -> None:
         assert data.dataset is not None
         self.set_dataset_object_store_id(data.dataset, require_shareable=require_shareable)
 
-    def set_dataset_object_store_id(self, dataset: "Dataset", require_shareable: bool = True) -> None:
+    def set_dataset_object_store_id(self, dataset: Dataset, require_shareable: bool = True) -> None:
         # Create an empty file immediately.  The first dataset will be
         # created in the "default" store, all others will be created in
         # the same store as the first.
@@ -2191,7 +2191,7 @@ class ObjectStorePopulator:
 def persist_extra_files(
     object_store: ObjectStore,
     src_extra_files_path: str,
-    primary_data: "DatasetInstance",
+    primary_data: DatasetInstance,
     extra_files_path_name: str | None = None,
 ) -> None:
     assert primary_data.dataset is not None
@@ -2205,7 +2205,7 @@ def persist_extra_files(
 def persist_extra_files_for_dataset(
     object_store: ObjectStore,
     src_extra_files_path: str,
-    dataset: "Dataset",
+    dataset: Dataset,
     extra_files_path_name: str,
 ):
     for root, _dirs, files in safe_walk(src_extra_files_path):

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -4,6 +4,7 @@ objectstore package, abstraction for storing blobs of data for use in Galaxy.
 all providers ensure that data can be accessed on the filesystem for running
 tools
 """
+from __future__ import annotations
 
 import abc
 import logging
@@ -79,8 +80,8 @@ log = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class ObjectStoreAuth:
-    user: Optional["User"] = None
-    token: Optional[str] = None
+    user: User | None = None
+    token: str | None = None
 
 
 def is_user_object_store(object_store_id: str | None) -> bool:

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -58,6 +58,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         alt_name=None,
         obj_dir: bool = False,
         in_cache: bool = False,
+        **_kwargs,
     ) -> str:
         # extra_dir should never be constructed from provided data but just
         # make sure there are no shenannigans afoot

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -483,31 +483,26 @@ class RucioObjectStore(CachingConcreteObjectStore):
         return False
 
     def _get_token(self, **kwargs):
-        auth_token = kwargs.get("auth_token", None)
-        if auth_token:
-            return auth_token
+        auth = kwargs.get("auth", None)
+        if auth and auth.token:
+            return auth.token
 
-        arg_user = kwargs.get("user", None)
-        try:
-            if not arg_user:
-                trans = kwargs.get("trans")
-                assert trans
-                user = trans.user
-            else:
-                user = arg_user
-            for oidc_provider in self.oidc_providers:
-                backend = provider_name_to_backend(oidc_provider)
-                tokens = user.get_oidc_tokens(backend)
-                if tokens["id"]:
-                    return tokens["id"]
-        except Exception as e:
-            log.debug("Failed to get auth token: %s", e)
-            return None
+        if auth and auth.user:
+            try:
+                user = auth.user
+                for oidc_provider in self.oidc_providers:
+                    backend = provider_name_to_backend(oidc_provider)
+                    tokens = user.get_oidc_tokens(backend)
+                    if tokens["id"]:
+                        return tokens["id"]
+            except Exception as e:
+                log.debug("Failed to get auth token: %s", e)
+                return None
+        return None
 
     def _get_filename(self, obj, sync_cache: bool = True, **kwargs) -> str:
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
-        auth_token = self._get_token(**kwargs)
         rel_path = self._construct_path(obj, **kwargs)
 
         log.debug("rucio _get_filename: %s", rel_path)
@@ -540,7 +535,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
             if dir_only:  # Directories do not get pulled into cache
                 return cache_path
             else:
-                if self._pull_into_cache(rel_path, auth_token=auth_token):
+                if self._pull_into_cache(rel_path, auth=kwargs.get("auth")):
                     return cache_path
         raise ObjectNotFound(f"objectstore.get_filename, no cache_path: {obj}, kwargs: {kwargs}")
 

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -1047,7 +1047,7 @@ class DirectoryAsExtraFiles(HasExtraFiles):
 class OutputDataset(HasExtraFiles, Protocol):
     ext: str
 
-    def get_file_name(self, sync_cache=True) -> str: ...
+    def get_file_name(self, sync_cache=True, auth=None) -> str: ...
 
 
 class ToolDataTableManager(Dictifiable):

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -239,7 +239,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                 trans.sa_session.commit()
                 if hda.dataset.user_can_purge:
                     try:
-                        hda.dataset.full_delete()
+                        hda.dataset.full_delete(user=hda.user)
                         trans.log_event(
                             f"Dataset id {hda.dataset.id} has been purged upon the purge of HDA id {hda.id}"
                         )

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -47,6 +47,7 @@ from galaxy.managers.markdown_util import (
     ready_galaxy_markdown_for_export,
     resolve_job_markdown,
 )
+from galaxy.objectstore import ObjectStoreAuth
 from galaxy.objectstore.badges import BadgeDict
 from galaxy.schema import (
     FilterQueryParams,
@@ -538,7 +539,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def report(self, trans: ProvidesHistoryContext, dataset_id: DecodedDatabaseIdField) -> ToolReportForDataset:
         dataset_instance = self.hda_manager.get_accessible(dataset_id, trans.user)
         self.hda_manager.ensure_dataset_on_disk(trans, dataset_instance)
-        file_path = trans.app.object_store.get_filename(dataset_instance.dataset)
+        file_path = trans.app.object_store.get_filename(dataset_instance.dataset, auth=ObjectStoreAuth(user=trans.user))
         raw_content = open(file_path).read(1024 * 10)
         internal_markdown = resolve_job_markdown(trans, dataset_instance.creating_job, raw_content)
         content, extra_attributes = ready_galaxy_markdown_for_export(trans, internal_markdown)
@@ -736,10 +737,13 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                     object_store = trans.app.object_store
                     dir_name = dataset_instance.dataset.extra_files_path_name
                     file_path = object_store.get_filename(
-                        dataset_instance.dataset, extra_dir=dir_name, alt_name=filename
+                        dataset_instance.dataset,
+                        extra_dir=dir_name,
+                        alt_name=filename,
+                        auth=ObjectStoreAuth(user=trans.user),
                     )
                 else:
-                    file_path = dataset_instance.get_file_name()
+                    file_path = dataset_instance.get_file_name(auth=ObjectStoreAuth(user=trans.user))
                 rval = open(file_path, "rb")
             else:
                 if offset is not None:
@@ -765,7 +769,9 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         if filename and filename != "index":
             object_store = trans.app.object_store
             dir_name = hda.dataset.extra_files_path_name
-            file_path = object_store.get_filename(hda.dataset, extra_dir=dir_name, alt_name=filename)
+            file_path = object_store.get_filename(
+                hda.dataset, extra_dir=dir_name, alt_name=filename, auth=ObjectStoreAuth(user=user)
+            )
             truncated, dataset_data = self.hda_manager.text_data_truncated(file_path, preview=True)
         else:
             truncated, dataset_data = self.hda_manager.text_data(hda, preview=True)
@@ -811,7 +817,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
             raise galaxy_exceptions.RequestParameterInvalidException(
                 f"Metadata file {metadata_file} is not set for this dataset"
             )
-        file_path = mf.get_file_name()
+        file_path = mf.get_file_name(auth=ObjectStoreAuth(user=trans.user))
         if open_file:
             return open(file_path, "rb"), headers
         return file_path, headers

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -510,7 +510,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             history_dataset_collection_association_id=dataset_collection_instance.id,
         )
         result = prepare_dataset_collection_download.delay(
-            request=request, task_user_id=getattr(trans.user, "id", None), user=trans.user
+            request=request, task_user_id=getattr(trans.user, "id", None)
         )
         return AsyncFile(storage_request_id=short_term_storage_target.request_id, task=async_task_summary(result))
 

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -510,7 +510,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             history_dataset_collection_association_id=dataset_collection_instance.id,
         )
         result = prepare_dataset_collection_download.delay(
-            request=request, task_user_id=getattr(trans.user, "id", None)
+            request=request, task_user_id=getattr(trans.user, "id", None), user=trans.user
         )
         return AsyncFile(storage_request_id=short_term_storage_target.request_id, task=async_task_summary(result))
 
@@ -519,6 +519,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             dataset_collection_instance=dataset_collection_instance,
             upstream_mod_zip=trans.app.config.upstream_mod_zip,
             upstream_gzip=trans.app.config.upstream_gzip,
+            user=trans.user,
         )
         return archive
 

--- a/test/unit/app/jobs/dynamic_tool_destination/mockGalaxy.py
+++ b/test/unit/app/jobs/dynamic_tool_destination/mockGalaxy.py
@@ -40,7 +40,7 @@ class Dataset:
     def get_metadata(self):
         return self.metadata
 
-    def get_file_name(self, sync_cache=True):
+    def get_file_name(self, sync_cache=True, auth=None):
         return self.file_name_
 
 

--- a/test/unit/app/tools/test_wrappers.py
+++ b/test/unit/app/tools/test_wrappers.py
@@ -306,7 +306,7 @@ class MockDataset:
         self.tags = []
         self.has_deferred_data = False
 
-    def get_file_name(self, sync_cache=True):
+    def get_file_name(self, sync_cache=True, auth=None):
         return MOCK_DATASET_PATH
 
 

--- a/test/unit/data/datatypes/test_connectivity_table.py
+++ b/test/unit/data/datatypes/test_connectivity_table.py
@@ -9,7 +9,7 @@ from galaxy.util import galaxy_directory
 @pytest.fixture
 def dataset():
     class MockDataset:
-        def get_file_name(self, sync_cache=True):
+        def get_file_name(self, sync_cache=True, auth=None):
             return os.path.join(galaxy_directory(), "test-data/1.ct")
 
     return MockDataset()

--- a/test/unit/data/datatypes/test_validation.py
+++ b/test/unit/data/datatypes/test_validation.py
@@ -60,5 +60,5 @@ class MockDataset:
         self.file_name_ = file_name
         self.datatype = datatype
 
-    def get_file_name(self, sync_cache=True):
+    def get_file_name(self, sync_cache=True, auth=None):
         return self.file_name_

--- a/test/unit/data/datatypes/util.py
+++ b/test/unit/data/datatypes/util.py
@@ -13,7 +13,7 @@ class MockDatasetDataset:
         self.purged = False
         self.file_name_ = file_name
 
-    def get_file_name(self, sync_cache=True):
+    def get_file_name(self, sync_cache=True, auth=None):
         return self.file_name_
 
     def set_file_name(self, file_name):
@@ -23,7 +23,7 @@ class MockDatasetDataset:
 class MockMetadata(Bunch):
     file_name_: str | None = None
 
-    def get_file_name(self, sync_cache=True):
+    def get_file_name(self, sync_cache=True, auth=None):
         return self.file_name_
 
     def set_file_name(self, file_name):
@@ -37,7 +37,7 @@ class MockDataset:
         self.dataset = None
         self.file_name_: str | None = None
 
-    def get_file_name(self, sync_cache=True):
+    def get_file_name(self, sync_cache=True, auth=None):
         return self.file_name_
 
     def set_file_name(self, file_name):

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -530,7 +530,7 @@ def test_distributed_store_start_propagates_to_backends():
 
 
 def test_distributed_store_get_filename_forwards_auth_to_backend():
-    auth = ObjectStoreAuth(user=object())
+    auth = ObjectStoreAuth(user=None)
     dataset = MockDataset(1)
     dataset.object_store_id = "files1"
     with TestConfig(DISTRIBUTED_TEST_CONFIG) as (directory, object_store):

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -16,7 +16,10 @@ import pytest
 from requests import get
 
 from galaxy.exceptions import ObjectInvalid
-from galaxy.objectstore import persist_extra_files_for_dataset
+from galaxy.objectstore import (
+    ObjectStoreAuth,
+    persist_extra_files_for_dataset,
+)
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.caching import (
     CacheTarget,
@@ -524,6 +527,21 @@ def test_distributed_store_start_propagates_to_backends():
         object_store.start()
         for backend in object_store.backends.values():
             backend.start.assert_called_once()
+
+
+def test_distributed_store_get_filename_forwards_auth_to_backend():
+    auth = ObjectStoreAuth(user=object())
+    dataset = MockDataset(1)
+    dataset.object_store_id = "files1"
+    with TestConfig(DISTRIBUTED_TEST_CONFIG) as (directory, object_store):
+        directory.write("Hello World!", "files1/000/dataset_1.dat")
+        backend = object_store.backends["files1"]
+        backend._get_filename = MagicMock(wraps=backend._get_filename)
+
+        object_store.get_filename(dataset, auth=auth)
+
+        backend._get_filename.assert_called_once()
+        assert backend._get_filename.call_args.kwargs["auth"] is auth
 
 
 HIERARCHICAL_MUST_HAVE_UNIFIED_QUOTA_SOURCE = """<?xml version="1.0"?>

--- a/test/unit/tool_util/data/test_tool_data_bundles.py
+++ b/test/unit/tool_util/data/test_tool_data_bundles.py
@@ -85,7 +85,7 @@ class OutputDataset:
     extra_files_path: str
     ext: str = "data_manager_json"
 
-    def get_file_name(self, sync_cache=True) -> str:
+    def get_file_name(self, sync_cache=True, auth=None) -> str:
         return self.file_name_
 
     def extra_files_path_exists(self) -> bool:


### PR DESCRIPTION
This updates dataset file access and purge paths so backend object stores can receive user or token context when resolving, caching, downloading, archiving, previewing, or deleting dataset-backed files. This is needed for backends such as Rucio where object retrieval may depend on the requesting user’s OIDC credentials (or another type of credentials).

The implementation keeps unauthenticated behavior unchanged while allowing authenticated object stores to use the supplied context when available.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
