### PR TITLE
Re-parent 28885b317f78 onto fac9c76612f9 to fix multiple gxy heads

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/28885b317f78_add_tool_request_request_state.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/28885b317f78_add_tool_request_request_state.py
@@ -26,7 +26,7 @@ references are repointed first), and only then the UNIQUE is added.
 Downgrade drops the UNIQUE and the new columns; it does not un-dedupe.
 
 Revision ID: 28885b317f78
-Revises: 6925fe4c8a17
+Revises: fac9c76612f9
 Create Date: 2026-05-21 12:30:00.000000
 
 """
@@ -54,7 +54,7 @@ from galaxy.model.migrations.util import (
 
 # revision identifiers, used by Alembic.
 revision = "28885b317f78"
-down_revision = "6925fe4c8a17"
+down_revision = "fac9c76612f9"
 branch_labels = None
 depends_on = None
 

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/fb8621b7c075_ensure_dataset_storage_operation_byte_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/fb8621b7c075_ensure_dataset_storage_operation_byte_.py
@@ -1,0 +1,71 @@
+"""ensure dataset storage operation byte counters are bigint
+
+Repair migration for dev-tracking databases that applied 28885b317f78
+before fac9c76612f9 was re-parented beneath it (the release_26.1 forward
+merge left two gxy heads; linearizing made fac9c76612f9 an ancestor of
+28885b317f78, so alembic considers it applied on those databases and
+never runs its bigint widening). Widens the columns only if they are
+still INTEGER; a no-op everywhere else.
+
+Downgrade is intentionally a no-op: the widening belongs to
+fac9c76612f9, whose own downgrade narrows the columns back.
+
+Revision ID: fb8621b7c075
+Revises: 28885b317f78
+Create Date: 2026-07-06 17:37:19.074881
+
+"""
+
+import logging
+
+import sqlalchemy as sa
+from alembic import (
+    context,
+    op,
+)
+
+from galaxy.model.migrations.util import alter_column
+
+# revision identifiers, used by Alembic.
+revision = "fb8621b7c075"
+down_revision = "28885b317f78"
+branch_labels = None
+depends_on = None
+
+log = logging.getLogger(__name__)
+
+columns = [
+    ("dataset_storage_operation_run", "total_bytes_processed"),
+    ("dataset_storage_operation_run_item", "bytes_processed"),
+]
+
+
+def upgrade():
+    for table_name, column_name in columns:
+        if _needs_widening(table_name, column_name):
+            alter_column(
+                table_name,
+                column_name,
+                existing_type=sa.INTEGER(),
+                type_=sa.BIGINT(),
+                existing_nullable=False,
+            )
+
+
+def downgrade():
+    pass
+
+
+def _needs_widening(table_name: str, column_name: str) -> bool:
+    if context.is_offline_mode():
+        log.info(
+            f"This script is being executed in offline mode, so it cannot inspect the type of "
+            f"{table_name}.{column_name}. Assuming it is already BIGINT, which is the expected "
+            f"state during normal operation."
+        )
+        return False
+    inspector = sa.inspect(op.get_context().bind)
+    for column in inspector.get_columns(table_name):
+        if column["name"] == column_name:
+            return not isinstance(column["type"], sa.BigInteger)
+    return False

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/fb8621b7c075_ensure_dataset_storage_operation_byte_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/fb8621b7c075_ensure_dataset_storage_operation_byte_.py
@@ -64,7 +64,9 @@ def _needs_widening(table_name: str, column_name: str) -> bool:
             f"state during normal operation."
         )
         return False
-    inspector = sa.inspect(op.get_context().bind)
+    bind = op.get_context().bind
+    assert bind is not None  # not offline mode, so a connection exists
+    inspector = sa.inspect(bind)
     for column in inspector.get_columns(table_name):
         if column["name"] == column_name:
             return not isinstance(column["type"], sa.BigInteger)


### PR DESCRIPTION
The release_26.1 forward merge (6d4eb20906f) brought `fac9c76612f9` (increase `dataset_storage_operation_run` byte counters to bigint) into dev alongside the dev-only `28885b317f78` (tool_request.request_state). Both revised `6925fe4c8a17`, so the gxy branch had two heads and every `manage_db.sh` operation failed with:

```
alembic.util.exc.CommandError: Multiple heads are present; please specify a single target revision
```

## Fix

Linearize instead of adding a merge revision, per the approach agreed in https://github.com/galaxyproject/galaxy/issues/22370#issuecomment-4185051430: merge revisions leave two ids in `alembic_version` when downgrading into the window between the merge point and the branch point, which bricks alembic on release checkouts that only contain one of the lineages.

This re-parents the dev-only `28885b317f78` onto `fac9c76612f9`, giving the linear chain `6925fe4c8a17` → `fac9c76612f9` → `28885b317f78`. release_26.1's head stays a real revision in dev's lineage, so dev ⇄ 26.1 up/downgrades traverse cleanly with a single version-table entry per branch at every step.

Dev-tracking databases that applied `28885b317f78` before this re-parent have alembic consider `fac9c76612f9` implicitly applied, so its bigint widening would never run for them. A second, new head migration `fb8621b7c075` repairs this: it widens the two counter columns only if they are still INTEGER and is a no-op everywhere else. Its downgrade is intentionally empty — the widening belongs to `fac9c76612f9`, whose own downgrade narrows the columns back.

## Verification

- `scripts/run_alembic.sh heads` → single gxy head (`fb8621b7c075`) + single tsi head
- Fresh sqlite DB: `manage_db.sh init`, then `downgrade fac9c76612f9` (single version row — the state a 26.1 checkout sees), `downgrade 6925fe4c8a17`, `upgrade` back to head — all traverse without error; the repair migration correctly skips the alter when the columns are already BIGINT
- Repair path: DB at `6925fe4c8a17` (INTEGER columns) stamped to `28885b317f78` — the pre-fix dev state — then `manage_db.sh upgrade` runs only `fb8621b7c075` and widens both columns to BIGINT
- `pytest test/unit/data/model/migrations` — 97 passed

## How to test the changes?

- [x] Instructions for manual testing are as follows:
  1. `sh manage_db.sh upgrade` on a dev database previously failing with the multiple-heads error
