### PR TITLE
Fix check_test_class_names test

### DIFF
--- a/.ci/check_test_class_names.sh
+++ b/.ci/check_test_class_names.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
+set -e
+
 TEST=$(mktemp)
 TEST_EXTRA_CLASSES=$(mktemp)
 
-pytest --collect-only --ignore=test/functional lib/galaxy_test/ test/ > "$TEST"
-pytest -o python_classes='Test* *Test *TestCase' --collect-only --ignore=test/functional lib/galaxy_test/ test/ > "$TEST_EXTRA_CLASSES"
+pytest --collect-only --ignore=test/functional lib/galaxy_test/ $(find test/ -mindepth 1 -maxdepth 1 -type d) > "$TEST"
+pytest -o python_classes='Test* *Test *TestCase' --collect-only --ignore=test/functional lib/galaxy_test/ $(find test/ -mindepth 1 -maxdepth 1 -type d) > "$TEST_EXTRA_CLASSES"
 
 n_tests=$(grep 'tests collected' "$TEST" | sed -e 's/[^0-9]*\([0-9]*\) tests collected.*/\1/')
 n_tests_extra_classes=$(grep 'tests collected' "$TEST_EXTRA_CLASSES" | sed -e 's/[^0-9]*\([0-9]*\) tests collected.*/\1/')

--- a/.github/workflows/check_test_class_names.yaml
+++ b/.github/workflows/check_test_class_names.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '.ci/check_test_class_names.sh'
+      - .github/workflows/check_test_class_names.yaml
       - 'lib/galaxy_test/**'
       - 'test/**'
 concurrency:
@@ -24,9 +25,12 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Python
-        run: uv python install
       - name: Install Python dependencies
-        run: uv pip install --system -r requirements.txt -r lib/galaxy/dependencies/pinned-test-requirements.txt
+        run: |
+          uv venv .venv
+          . .venv/bin/activate
+          uv pip install -r requirements.txt -r lib/galaxy/dependencies/pinned-test-requirements.txt
       - name: Run tests
-        run: .ci/check_test_class_names.sh
+        run: |
+          . .venv/bin/activate
+          .ci/check_test_class_names.sh


### PR DESCRIPTION
I broke the CI workflow by mistake in https://github.com/galaxyproject/galaxy/pull/23028 .
While fixing that, I noticed that the `.ci/check_test_class_names.sh` script wasn't properly collecting integration and integration Selenium tests because of these errors:

```
ERROR test/integration - Failed: Defining 'pytest_plugins' in a non-top-level conftest is no longer supported:
ERROR test/integration_selenium - Failed: Defining 'pytest_plugins' in a non-top-level conftest is no longer supported:
```

Fixed them by passing to `pytest` all the direct subdirectories instead of `test/`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
