### PR TITLE
[26.1] Update spatialdata datatype

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -4953,18 +4953,18 @@ class SpatialData(CompressedZarrZipArchive):
             with zipfile.ZipFile(filename) as zf:
                 # Find root zarr directory and detect version (at any nesting level)
                 root_zarr = is_v3 = None
+                candidates = []
                 for file in zf.namelist():
-                    # Look for zarr.json or .zattrs in any directory
                     if file.endswith("/zarr.json"):
-                        # Format: <path>/zarr.json (v3)
-                        root_zarr, is_v3 = file.rsplit("/", 1)[0], True
-                        break
+                        candidates.append((file.rsplit("/", 1)[0], True))
                     elif file.endswith("/.zattrs"):
-                        # Format: <path>/.zattrs (v2)
-                        root_zarr, is_v3 = file.rsplit("/", 1)[0], False
-                        break
-                if not root_zarr:
+                        candidates.append((file.rsplit("/", 1)[0], False))
+
+                if not candidates:
                     return info
+
+                # the true root is the entry with the fewest path components
+                root_zarr, is_v3 = min(candidates, key=lambda c: c[0].count("/"))
 
                 # Extract elements: <root>.zarr/<type>/<name>/...
                 prefix = root_zarr + "/"


### PR DESCRIPTION
The code picked the first zarr.json/.zattrs found in zf.namelist() as the zarr root, but the zip can contain many such files (one per nested group/array), and their order in the archive isn't guaranteed to put the true root first. When a nested element's metadata file happened to appear earlier, the code mistook it for the root, resulting in the wrong prefix and an empty info dict — so set_peek() showed no elements even though sniff() correctly identified the file as SpatialData.

Fix: instead of taking the first match, collect all candidates and pick the one with the shallowest path (fewest / separators), since the true zarr root is always an ancestor of every other metadata file in the store.

Fixed by Claude ;)

Here are screenshots from my local run:
<img width="514" height="327" alt="image" src="https://github.com/user-attachments/assets/dfda1cd1-b519-4943-84c9-3ced9815804a" />
<img width="514" height="327" alt="image" src="https://github.com/user-attachments/assets/42914f1a-ddc7-47a6-8bdf-a1971083820e" />
<img width="514" height="327" alt="image" src="https://github.com/user-attachments/assets/ef7c5d11-57c3-446c-ad97-e99ad83adfd3" />
<img width="514" height="327" alt="image" src="https://github.com/user-attachments/assets/0d88e207-9848-46af-a6bb-b7f67a230710" />
<img width="514" height="327" alt="image" src="https://github.com/user-attachments/assets/c51b8a33-e1fc-4f9e-b47b-5d3111cbc525" />
<img width="511" height="418" alt="image" src="https://github.com/user-attachments/assets/b150f6f1-ca0e-40b4-8b57-96eb637e3767" />

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
