### PR TITLE
Fix /api/tools/{id}/test_data crash for tools without tests

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1601,7 +1601,7 @@ class Tool(UsesDictVisibleKeys, MaybeToolParameterBundle):
                 log.exception("Failed to parse tool tests for tool '%s'", self.id)
 
     @property
-    def tests(self):
+    def tests(self) -> list[ToolTestDescription] | None:
         if self.__tests:
             return [ToolTestDescription(d) for d in json.loads(self.__tests)]
         return None

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -667,7 +667,7 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         test_defs = []
         for tool in tools:
-            test_defs.extend([t.to_dict() for t in tool.tests])
+            test_defs.extend([t.to_dict() for t in tool.tests or []])
         return test_defs
 
     @web.require_admin


### PR DESCRIPTION
`Tool.tests` returns `None` when a tool has no `<tests>` block, so `GET /api/tools/{tool_id}/test_data` raised `TypeError: 'NoneType' object is not iterable` for any such tool. Iterate over `tool.tests or []` instead.

Found while profiling tool construction for the lazy-toolbox work; splitting it out as an independent bugfix.

https://claude.ai/code/session_018L7ZmCv2ubKA3JNeSL8Pkr