### PR TITLE
Avoid redundant conda availability probes at startup

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -104,6 +104,12 @@ class CondaContext(installable.InstallableContext):
         self.debug = debug
         self.shell_exec = shell_exec or commands.shell
         self.copy_dependencies = copy_dependencies
+        # ``conda info`` is a subprocess spawning the conda binary (~1-2s).
+        # It is queried several times over a context's life (availability
+        # probe, conda version, conda-build availability), so cache the
+        # result. ``_reset_conda_properties`` clears it after any install so
+        # a re-probe reflects the new state.
+        self._conda_info: dict[str, Any] | None = None
 
         if conda_exec is not None:
             self.conda_exec = conda_exec
@@ -121,6 +127,7 @@ class CondaContext(installable.InstallableContext):
         self._reset_conda_properties()
 
     def _reset_conda_properties(self) -> None:
+        self._conda_info = None
         self._conda_version = None
         self._conda_build_available = None
         self._libmamba_solver_available = None
@@ -183,10 +190,11 @@ class CondaContext(installable.InstallableContext):
             return 0
 
     def conda_info(self) -> dict[str, Any]:
-        cmd = listify(self.conda_exec) + ["info", "--json"]
-        info_out = commands.execute(cmd)
-        info = json.loads(info_out)
-        return info
+        if self._conda_info is None:
+            cmd = listify(self.conda_exec) + ["info", "--json"]
+            info_out = commands.execute(cmd)
+            self._conda_info = json.loads(info_out)
+        return self._conda_info
 
     def is_conda_installed(self) -> bool:
         """

--- a/lib/galaxy/tool_util/deps/resolvers/conda.py
+++ b/lib/galaxy/tool_util/deps/resolvers/conda.py
@@ -145,13 +145,32 @@ class CondaDependencyResolver(
         auto_install = _string_as_bool(get_option("auto_install"))
         self.auto_init = _string_as_bool(get_option("auto_init"))
         self.conda_context = conda_context
-        self.disabled = not galaxy.tool_util.deps.installable.ensure_installed(
-            conda_context, install_conda, self.auto_init
-        )
-        if self.auto_init and not self.disabled:
-            self.conda_context.ensure_conda_build_installed_if_needed()
         self.auto_install = auto_install
         self.copy_dependencies = copy_dependencies
+        # Determining ``disabled`` probes conda availability, which shells out
+        # to ``conda info`` (spawning the conda binary, ~1-2s). When
+        # ``auto_init`` is set the resolver is expected to initialize conda at
+        # startup, so probe (and install if needed) eagerly here. Otherwise
+        # nothing on the boot or job dependency-resolution path reads
+        # ``disabled`` — only the dependency-resolvers admin view — so it is
+        # probed lazily on first access.
+        self._disabled: bool | None = None
+        if self.auto_init:
+            self.disabled  # noqa: B018 — eager conda init + probe at startup
+
+    @property
+    def disabled(self) -> bool:
+        if self._disabled is None:
+            self._disabled = not galaxy.tool_util.deps.installable.ensure_installed(
+                self.conda_context, install_conda, self.auto_init
+            )
+            if self.auto_init and not self._disabled:
+                self.conda_context.ensure_conda_build_installed_if_needed()
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, value: bool) -> None:
+        self._disabled = value
 
     def clean(self, **kwds):
         return self.conda_context.exec_clean()


### PR DESCRIPTION
`CondaDependencyResolver.__init__` calls `ensure_installed()`, which shells out to `conda info --json` — spawning the conda binary (~1-2s) — solely to set `self.disabled`. Two independent reductions:

**1. Gate the probe on `auto_init`.** `ensure_installed` always runs the `conda info` probe, and *if* the probe reports conda missing and `auto_init` is set, installs it. So the probe is exactly what decides whether to install — it can't be deferred without also deferring the install.
- With `auto_init` set (the default), the resolver is expected to initialize conda at startup, so it still probes (and installs if needed) eagerly in `__init__` — **behaviour unchanged**.
- With `auto_init` off, nothing on the boot or job dependency-resolution path reads `disabled` (only the `/api/dependency_resolvers` admin view), so `disabled` becomes a cached property probed lazily on first access.

**2. Memoize `CondaContext.conda_info()`.** It is queried several times over a context's life (availability probe, conda version, conda-build availability), each spawning conda. The result is now cached and cleared in `_reset_conda_properties()` (already called after installs) so a re-probe reflects the new state. Caching only successful results keeps the fresh-install path correct — the pre-install failing call never populates the cache. This reduction applies even to the `auto_init`/eager path.