### PR TITLE
[RFC] Unify object store and file sources on a shared transport

### DIFF
--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -27,3 +27,4 @@ A multi-hour long video playlist covering these slides can be found at
   debugging_galaxy_slurm
   translating
   create_release
+  objectstore_filesource_unification

--- a/doc/source/dev/objectstore_filesource_unification.md
+++ b/doc/source/dev/objectstore_filesource_unification.md
@@ -1,0 +1,360 @@
+# Unifying ObjectStore and FilesSource on a Shared Transport
+
+**Status:** Proposal / design sketch
+**Scope:** `lib/galaxy/objectstore/`, `lib/galaxy/files/`
+
+## 1. Motivation
+
+Galaxy has two storage abstractions that have grown independently:
+
+- **ObjectStore** (`lib/galaxy/objectstore/`) — the canonical, Galaxy-owned home for
+  dataset bytes. Keyed by `Dataset`/`Job` objects, quota-bearing, cache-backed, and
+  contractually obliged to hand callers a **real, local, seekable POSIX path**
+  (`get_filename`) plus **byte-range reads** (`get_data`).
+- **FilesSource** (`lib/galaxy/files/`) — user-facing reach-out to foreign storage to
+  import/export **whole files**. Keyed by URI, browse-oriented, with rich per-user
+  auth (vault, OIDC, roles/groups, templating).
+
+The two abstractions **re-implement the same backend adapters twice**. S3 exists as
+both `objectstore/s3_boto3.py` (boto3) and `files/sources/s3fs.py` (fsspec); the same
+duplication holds for Azure, Google Cloud Storage, and iRODS. Each cloud is maintained,
+tested, and credential-configured in two places.
+
+This document proposes collapsing that duplication by extracting a **shared whole-file
+transport** that both abstractions sit on top of — **without merging the two domain
+contracts**, which encode genuinely different intents.
+
+## 2. Key insight: the seam already exists inside the object store
+
+`CachingConcreteObjectStore` already splits internally into an **addressing** half and a
+**transport** half. Every public call funnels through the same shape
+(`BaseObjectStore.exists` → `_invoke` → `_exists`, `__init__.py:504`):
+
+```
+exists(obj, base_dir=, dir_only=, extra_dir=, alt_name=, obj_dir=)   # public, obj-addressed
+  → self._exists(obj, **kwargs)
+     → rel_path = self._construct_path(obj, **kwargs)                 # ADDRESSING
+     → self._exists_remotely(rel_path)                               # TRANSPORT
+```
+
+`_construct_path` (`_caching_base.py:53`) reduces `(obj, store_by, directory_hash_id,
+extra_dir, obj_dir, alt_name)` to a plain relative key such as `000/001/dataset_1.dat`.
+Everything below that line is keyed only on `rel_path`, and those methods are a
+**whole-file, key-addressed transport** — which is almost exactly the `FilesSource`
+contract:
+
+| Caching seam method (`_caching_base.py`)                  | FilesSource equivalent               |
+| --------------------------------------------------------- | ------------------------------------ |
+| `_download(rel_path)` → cache (`:421`)                    | `realize_to(rel_path, cache_path)`   |
+| `_push_file_to_path(rel_path, src)` (`:435`)              | `write_from(rel_path, src)`          |
+| `_push_string_to_path(rel_path, s)` (`:432`)              | `write_from` from a temp file        |
+| `_exists_remotely(rel_path)` (`:396`)                     | **needs** `exists(path)`             |
+| `_get_remote_size(rel_path)` (`:393`)                     | **needs** `size(path)`               |
+| `_delete_existing_remote` / `_delete_remote_all` (`:425`) | **needs** `remove(path, recursive=)` |
+| `_download_directory_into_cache` (`:308`)                 | recursive `list` + `realize_to`      |
+| `_get_object_url` (presigned, `s3_boto3.py:383`)          | optional `get_public_url(path)`      |
+
+The S3 implementations of these (`s3_boto3.py:299-365`) are a FilesSource with the method
+names filed off — and `S3FsFilesSource` already exists and performs the same operations
+against the same service.
+
+## 3. Design
+
+### 3.1 Composition, not inheritance
+
+**An ObjectStore _owns_ a FilesSource; it is not one.** This is the coherence guarantee.
+The object store keeps everything that is genuinely its own and never leaks it into the
+transport:
+
+- addressing (`_construct_path`, `store_by` id/uuid, `directory_hash_id`, old-style
+  backward-compat)
+- quota / `get_store_usage_percent`, `object_store_id` routing (distributed /
+  hierarchical), `device`
+- `private`, `badges`, `enable_direct_download` policy, `get_concrete_store_*`
+
+A file source never grows a quota; an object store never grows per-user OIDC templating.
+
+### 3.2 Contract additions to `FilesSource`
+
+All default-derivable, so the ~30 existing sources do not break. Added to
+`SingleFileSource`:
+
+```python
+# --- raw transport ---
+def exists(self, path, ...) -> bool: ...          # default: via list(parent) / native fs.exists
+def size(self, path, ...) -> int: ...             # default: from list entry / native
+def remove(self, path, recursive=False, ...):     # writable sources only
+    raise NotImplementedError
+def get_public_url(self, path, ...) -> Optional[str]:  # presign opt-in
+    return None
+
+# --- resolve: the "source owns the path" method ---
+def get_local_path(self, path, ...) -> str:
+    """Return a local fs path for `path` that the caller may READ IN PLACE.
+    The SOURCE owns the lifecycle — unlike realize_to, the caller must not
+    move/delete it. Equivalent to ObjectStore.get_filename's contract."""
+```
+
+`fsspec`/`PyFilesystem2` provide `exists`/`size`/`rm` natively, so the two base helper
+classes (`_fsspec.py`, `_pyfilesystem2.py`) implement these once for most sources.
+
+### 3.3 `get_local_path` vs `realize_to` — keep them distinct
+
+- `realize_to(source_path, native_path)` — the **caller** allocates `native_path` and
+  receives a **disposable copy** it owns. Existing contract (`files/sources/__init__.py:111`).
+  Posix honours it literally with `shutil.copyfile` (`posix.py:120`).
+- `get_local_path(path) -> str` — the **source** returns a path it owns; for posix this is
+  the real file (**zero copy**), for a remote source it is the cache path. Callers must not
+  move or delete it.
+
+This distinction is load-bearing: posix's `delete_on_realize` move (`posix.py:121`) is fine
+for `realize_to` and **catastrophic** for `get_local_path` (it would move canonical data out
+from under Galaxy).
+
+### 3.4 `CachingFilesSource` — the object store's cache, relocated
+
+For a remote source, `get_local_path` needs a cache. So the cache half of
+`CachingConcreteObjectStore` — `_get_cache_path` / `_in_cache` / `_pull_into_cache` /
+`_atomic_download` / `cache_target` / `InProcessCacheMonitor` / `check_cache`
+(`_caching_base.py:107-419`, `caching.py`) — moves into a mixin that **wraps a raw
+FilesSource**:
+
+```python
+class CachingFilesSource(BaseFilesSource):
+    def __init__(self, inner: BaseFilesSource, staging_path, cache_size, ...):
+        self._inner = inner          # the raw transport (s3, azure, …)
+        # staging_path, cache_target, InProcessCacheMonitor — reused verbatim
+
+    def get_local_path(self, path, ...) -> str:      # == _get_filename body, :272-306
+        cache_path = self._get_cache_path(path)
+        if self._in_cache(path) and os.path.getsize(cache_path) > 0:
+            return cache_path
+        if self._inner.exists(path):
+            with self._atomic_download(cache_path) as tmp:
+                self._inner.realize_to(path, tmp)    # ← transport, was _download
+            return cache_path
+        raise ObjectNotFound(path)
+
+    def write_from(self, path, native_path, ...):    # == _push_to_storage
+        self._inner.write_from(path, native_path)
+    def exists(self, p): return self._in_cache(p) or self._inner.exists(p)
+    def size(self, p):   return self._get_size_in_cache(p) if self._in_cache(p) else self._inner.size(p)
+```
+
+This is the same composition the object store has today (cache base + backend methods),
+re-expressed as _wrapping a FilesSource_ instead of _mixing in `_download`_. The LRU
+monitor, the atomic `.tmp` rename, and `cache_targets()` are reused unchanged.
+
+### 3.5 Reimplementation sketch: `DiskObjectStore`
+
+```python
+class DiskObjectStore(ConcreteObjectStore):
+    def __init__(self, config, config_dict):
+        ...
+        self._io = PosixFilesSource(root=self.file_path)   # one local source
+
+    def _get_filename(self, obj, **kw):
+        return self._io.get_local_path(self._rel_path(obj, **kw))   # returns REAL file, no copy
+    def _exists(self, obj, **kw):  return self._io.exists(self._rel_path(obj, **kw))
+    def _size(self, obj, **kw):    return self._io.size(self._rel_path(obj, **kw))
+    def _delete(self, obj, **kw):  return self._io.remove(self._rel_path(obj, **kw), recursive=...)
+    def _update_from_file(self, obj, file_name, **kw):
+        self._io.write_from(self._rel_path(obj, **kw), file_name)
+    def _get_store_usage_percent(self): return statvfs(self.file_path)...   # STAYS here
+```
+
+Posix's `get_local_path` is the zero-copy one-liner `return self._to_native_path(path)`.
+Compare to today's `DiskObjectStore._get_filename` (`__init__.py:1155`): same outcome,
+minus the special-casing. The disk store stops being a special case — it is simply the
+source whose cache is the identity function.
+
+### 3.6 Reimplementation sketch: `S3ObjectStore`
+
+```python
+class S3ObjectStore(ConcreteObjectStore):     # no longer needs CachingConcreteObjectStore
+    def __init__(self, config, config_dict):
+        raw = S3RawFilesSource(bucket=…, creds=…)      # realize_to/write_from/exists/size/remove/sign
+        self._io = CachingFilesSource(raw, staging_path=…, cache_size=…)
+    # _get_filename/_exists/_size/_delete/_update_from_file: identical to Disk above
+    def _get_object_url(self, obj, **kw): return self._io.get_public_url(self._rel_path(obj, **kw))
+    def _get_store_usage_percent(self): return 0.0
+```
+
+`S3RawFilesSource` is `s3_boto3.py:299-365` renamed to the FilesSource contract — or,
+better, the **already-existing `S3FsFilesSource`**, now consumed by both the file-source
+registry and the object store. One S3 adapter instead of two; likewise Azure, GCS, iRODS.
+
+## 4. Risk ledger
+
+1. **The cache migration is the bulk of the work and the real risk** — relocating
+   LRU/monitor/`cache_targets()` into the files layer, and `cache_targets()` (admin cache
+   management) now reaching _through_ the object store into its source. This is the
+   reliability-sensitive part, not the disk store.
+2. **`get_local_path` (owned) vs `realize_to` (disposable) must never be conflated** — see
+   §3.3. `delete_on_realize` semantics are safe for one and lethal for the other.
+3. **Perms & symlinks ride on `FilesSourceOptions`** — `update_from_file`'s
+   `preserve_symlinks` (`__init__.py:1184`) and `umask_fix_perms` / `fix_permissions` must
+   pass through opts, or stay thin in the object-store wrapper.
+4. **Preserve `_exists`'s side effects** — today `_exists` auto-creates job dirs and does an
+   opportunistic sync-push (`_caching_base.py:147-169`). The transport `exists` must be
+   **pure**; that bookkeeping stays in the object-store wrapper.
+5. **The file source's per-user auth path is unused in this mode** — the object store
+   instantiates its source from admin config with no `user_context`. Fine for posix/s3 raw
+   sources, but worth stating so nobody expects vault/roles to apply on the dataset I/O path.
+   (Bring-Your-Own-Storage object stores are where the two credential worlds _do_ converge —
+   a bonus prize.)
+6. **`job_work` / `temp` are always-local** (`__init__.py:451`) — always a posix source
+   rooted at `jobs_directory`, regardless of the dataset backend. This _clarifies_ the model
+   rather than complicating it.
+7. **`get_data` byte ranges** — served by reading the resolved local path and seeking
+   (`_caching_base.py:128`, `__init__.py:1147`). No remote range support is needed.
+
+## 5. Staged rollout
+
+### Stage 1 — delegate the transport, keep the cache (low risk, immediate payoff)
+
+Keep `CachingConcreteObjectStore` as-is, but make its backend methods
+(`_download` / `_push_file_to_path` / `_push_string_to_path` / `_exists_remotely` /
+`_get_remote_size` / `_delete_*`) delegate to a raw whole-file transport. Nothing above the
+cache changes. Prove it with a local/in-memory transport standing in for the "remote", then
+point it at the existing fsspec S3 source. This dedups the cloud adapters with **zero
+visible contract change** to the rest of Galaxy.
+
+### Stage 2 — introduce `get_local_path` + `CachingFilesSource` (the unification)
+
+Add `get_local_path` and the `CachingFilesSource` mixin, collapse `DiskObjectStore` and
+`S3ObjectStore` onto it, and delete the disk special-case. This is where the cache
+physically moves into the files layer.
+
+## 6. Testing strategy (TDD)
+
+- **Stage 1** starts with a failing round-trip test: a `CachingConcreteObjectStore`-derived
+  store whose transport is a **local FilesSource** rooted at a temp "remote" dir, with a
+  separate cache dir. Assert `create` → `update_from_file` → `get_filename` returns a cache
+  path with the expected content, that the bytes also landed in the "remote" dir, and that
+  `exists` / `size` / `delete` propagate through to the remote. No cloud credentials needed.
+- Reuse the existing object-store unit harness in `test/unit/objectstore/`.
+- Contract additions to `FilesSource` (`exists` / `size` / `remove`) get their own
+  per-source tests via the existing file-source test fixtures.
+
+## 7. Open questions
+
+- Where does `cache_targets()` live once the cache is in the files layer — does the object
+  store forward to the source, or does an admin cache-management API address sources directly?
+- How do distributed/hierarchical stores (`object_store_id` routing) compose with sources —
+  unchanged (they wrap concrete stores), but worth confirming.
+
+## 8. Implementation progress
+
+**Stage 1 landed (proof-of-concept):**
+
+- `objectstore/_transport.py` — the `ObjectStoreTransport` protocol (the narrow whole-file
+  seam), a `LocalTransport`, and a `FilesSourceTransport` that satisfies it by wrapping any
+  FilesSource. The adapter is typed against `BaseFilesSource` under `TYPE_CHECKING`, so the
+  object store keeps **no runtime dependency** on `galaxy.files`.
+- `objectstore/delegating.py` — `DelegatingObjectStore(CachingConcreteObjectStore)`, routing
+  the backend hooks to an injected transport with the cache layer untouched.
+- **Contract additions to `FilesSource`** — `exists` / `size` / `remove` on `BaseFilesSource`
+  (default `NotImplementedError`, so the ~30 existing sources are unaffected), implemented
+  natively in `PosixFilesSource` and as base-class defaults on `FsspecFilesSource`
+  (`fs.exists` / `fs.size` / `fs.rm`), which every fsspec source (s3fs, azure, gcs, ...)
+  inherits for free.
+- **Tests** (`test/unit/objectstore/test_delegating_objectstore.py`) — the full
+  create → write → exists → size → get_filename → byte-range → delete lifecycle runs through
+  (a) a local transport, (b) a real `PosixFilesSource`, and (c) an fsspec `MemoryFilesSource`,
+  verifying the backend directly in each case. This resolves the open question above: Stage 1
+  uses the narrow `ObjectStoreTransport` protocol and the FilesSource satisfies it via the
+  `FilesSourceTransport` adapter.
+
+**Stage 2 landed (proof-of-concept) — the collapse:**
+
+- **`get_local_path` on the `FilesSource` contract** — the "source owns the returned path"
+  resolve method (`BaseFilesSource`, default `NotImplementedError`). `PosixFilesSource`
+  implements it as a **zero-copy** return of the real backing file; it is kept distinct from
+  `realize_to` (which copies to a caller-chosen destination).
+- `objectstore/_caching_source.py` — `CachingFilesSource`, which wraps a raw source with a
+  staging cache (atomic downloads, `CacheTarget`) and implements `get_local_path` as
+  pull-into-cache. This is the object store's cache **relocated to wrap a source**. It lives
+  in the object store package for now (reuses `objectstore.caching`) and keeps no runtime
+  dependency on `galaxy.files`.
+- `objectstore/source_store.py` — `SourceObjectStore(ConcreteObjectStore)` owns a source
+  (via the `ObjectStoreFilesSource` protocol) and resolves `get_filename` through
+  `get_local_path`. It has **no cache of its own**; addressing / quota / `store_by` stay here.
+- **Tests** (`test/unit/objectstore/test_source_objectstore.py`) — the _same_
+  `SourceObjectStore` class does the full lifecycle in both roles: backed by
+  `PosixFilesSource` (`get_filename` returns the real backing file — asserted zero copy) and
+  backed by `CachingFilesSource(MemoryFilesSource)` (`get_filename` returns a cache path). The
+  disk special-case is gone.
+
+**Shared cache extracted (`CacheArea`):**
+
+- `objectstore/caching.py` gains **`CacheArea`** — the single cache implementation (path
+  resolution, in-cache check, atomic writes, size accounting, `CacheTarget` fits-policy).
+- `CachingConcreteObjectStore` (`_caching_base.py`) now delegates its cache primitives
+  (`_get_cache_path` / `_in_cache` / `_get_size_in_cache` / `cache_target` /
+  `_atomic_download` / `_ensure_staging_path_writable`) to a lazily-built `CacheArea`; the
+  monitor lifecycle is unchanged. Behavior-preserving — the existing cloud config-parse and
+  the Stage 1 cache-pull tests are the guardrail (one abspath regression was caught and fixed).
+- `CachingFilesSource` now uses the _same_ `CacheArea` instead of a reimplemented lean cache,
+  so there is one cache implementation across the object store and files layers.
+
+**Deferred / productionization (not yet done):**
+
+- **Cut the real `DiskObjectStore` / `S3ObjectStore` over to `SourceObjectStore`** and delete
+  the duplicated cloud adapters. This is the final step: it touches Galaxy's production data
+  path, so it must be gated by the full integration/e2e suite (and `moto` for S3), not unit
+  tests alone. The recommended path is to register `SourceObjectStore` as a new store type and
+  migrate via config, rather than rewrite the battle-tested classes in place.
+
+**`DiskObjectStore` parity reached (verified against the disk contract):**
+
+- `SourceObjectStore` now handles the full disk surface: dataset lifecycle, `store_by=uuid`,
+  `alt_name` (with `safe_relpath` validation), real `get_store_usage_percent` (via an optional
+  `usage_percent` source capability — `PosixFilesSource` reports `statvfs`, remote sources
+  return `None`), and **`base_dir` (`job_work` / `temp`)** handled on the local filesystem
+  (these are always-local scratch dirs for every backend, so they bypass the source).
+- `test/unit/objectstore/test_source_objectstore.py` asserts parity: dataset round-trip,
+  zero-copy `get_filename`, `store_by=uuid`, `alt_name`, usage %, and job-work directory
+  create/exists/get_filename/delete.
+
+**Config-selectable (`type: source`):**
+
+- `type_to_object_store_class` recognizes `type: source`; `SourceObjectStore` builds its
+  backing FilesSource from a `files_source` plugin block (via the file-source plugin loader).
+  A `cache` block wraps a remote source in `CachingFilesSource`; a local (posix) source needs
+  none. This is the **safe adoption path** — no rewrite of `DiskObjectStore`/`S3ObjectStore`;
+  admins opt in per store. `test_source_objectstore.py` builds both roles through
+  `build_object_store_from_config` and runs the full round-trip.
+
+```yaml
+# disk role -- one posix source, no cache
+type: source
+files_source:
+  type: posix
+  root: /data/galaxy/files
+  writable: true
+
+# cloud role -- a remote source behind a local cache
+type: source
+files_source:
+  type: s3fs
+  bucket: my-galaxy-bucket
+  # ... s3fs credentials/params
+cache:
+  path: /srv/galaxy/cache
+  size: 100
+```
+
+**Still deferred:**
+
+- `dir_only` create for the _dataset_ source (composite / extra-files dirs) and the
+  `object_store_check_old_style` backward-compat path; `get_object_url` (presigned) for the
+  cloud role; XML configuration (`SourceObjectStore` is YAML-only for now).
+- **Relocate the cache primitives to a neutral module** (e.g. `galaxy.util` or a shared
+  package) so `CacheArea` / `CachingFilesSource` can move fully into `galaxy.files` without
+  `galaxy.files` importing `galaxy.objectstore`. Also fold the object store's background
+  eviction monitor into `CacheArea` (today it stays on the object store).
+- An s3fs-behind-`moto` integration test (gated like the other real-cloud tests) to exercise
+  the _actual_ duplicated S3 adapter end to end. `moto` is not currently a test dependency.
+- `_push_string_to_path` / `_create` stage through a temp file (`write_from` is whole-file
+  only); acceptable, but a `write_from_string` fast-path could be added.

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -611,6 +611,84 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
     ):
         pass
 
+    def exists(
+        self,
+        path: str,
+        user_context: "OptionalUserContext" = None,
+        opts: FilesSourceOptions | None = None,
+    ) -> bool:
+        """Return whether an object exists at ``path`` (relative to the URI root)."""
+        self._check_user_access(user_context)
+        self._check_credentials_fresh()
+        context = self._get_runtime_context(opts, user_context)
+        return self._exists(path, context)
+
+    def _exists(self, path: str, context: FilesSourceRuntimeContext[TResolvedConfig]) -> bool:
+        raise NotImplementedError()
+
+    def size(
+        self,
+        path: str,
+        user_context: "OptionalUserContext" = None,
+        opts: FilesSourceOptions | None = None,
+    ) -> int:
+        """Return the size in bytes of the object at ``path`` (relative to the URI root)."""
+        self._check_user_access(user_context)
+        self._check_credentials_fresh()
+        context = self._get_runtime_context(opts, user_context)
+        return self._size(path, context)
+
+    def _size(self, path: str, context: FilesSourceRuntimeContext[TResolvedConfig]) -> int:
+        raise NotImplementedError()
+
+    def remove(
+        self,
+        path: str,
+        recursive: bool = False,
+        user_context: "OptionalUserContext" = None,
+        opts: FilesSourceOptions | None = None,
+    ) -> bool:
+        """Delete the object at ``path`` (relative to the URI root).
+
+        With ``recursive=True``, delete every object beneath ``path``.
+        """
+        self._ensure_writeable()
+        self._check_user_access(user_context)
+        self._check_credentials_fresh()
+        context = self._get_runtime_context(opts, user_context)
+        return self._remove(path, context, recursive=recursive)
+
+    def _remove(self, path: str, context: FilesSourceRuntimeContext[TResolvedConfig], recursive: bool = False) -> bool:
+        raise NotImplementedError()
+
+    def get_local_path(
+        self,
+        path: str,
+        user_context: "OptionalUserContext" = None,
+        opts: FilesSourceOptions | None = None,
+    ) -> str:
+        """Resolve ``path`` to a local filesystem path the caller may read IN PLACE.
+
+        Unlike :meth:`realize_to` (which copies to a caller-chosen destination), the returned
+        path is owned by the file source -- callers must not move or delete it. Local sources
+        return their real path (zero copy); cache-backed sources return a cache path. Sources
+        without a stable local representation do not implement this.
+        """
+        self._check_user_access(user_context)
+        self._check_credentials_fresh()
+        context = self._get_runtime_context(opts, user_context)
+        return self._get_local_path(path, context)
+
+    def _get_local_path(self, path: str, context: FilesSourceRuntimeContext[TResolvedConfig]) -> str:
+        raise NotImplementedError()
+
+    def usage_percent(self, user_context: "OptionalUserContext" = None) -> float | None:
+        """Return the percent of backing storage used, or None if unknown / not applicable.
+
+        Local sources can report this (e.g. via ``statvfs``); remote sources typically cannot.
+        """
+        return None
+
     def _ensure_writeable(self):
         if not self.get_writable():
             raise Exception("Cannot write to a non-writable file source.")

--- a/lib/galaxy/files/sources/_fsspec.py
+++ b/lib/galaxy/files/sources/_fsspec.py
@@ -198,6 +198,35 @@ class FsspecFilesSource(BaseFilesSource[FsspecTemplateConfigType, FsspecResolved
         target_path = self._to_filesystem_path(target_path, context.config)
         fs.put_file(native_path, target_path)
 
+    def _exists(
+        self,
+        path: str,
+        context: FilesSourceRuntimeContext[FsspecResolvedConfigurationType],
+    ) -> bool:
+        cache_options = self._get_cache_options(context.config)
+        fs = self._open_fs(context, cache_options)
+        return fs.exists(self._to_filesystem_path(path, context.config))
+
+    def _size(
+        self,
+        path: str,
+        context: FilesSourceRuntimeContext[FsspecResolvedConfigurationType],
+    ) -> int:
+        cache_options = self._get_cache_options(context.config)
+        fs = self._open_fs(context, cache_options)
+        return int(fs.size(self._to_filesystem_path(path, context.config)) or 0)
+
+    def _remove(
+        self,
+        path: str,
+        context: FilesSourceRuntimeContext[FsspecResolvedConfigurationType],
+        recursive: bool = False,
+    ) -> bool:
+        cache_options = self._get_cache_options(context.config)
+        fs = self._open_fs(context, cache_options)
+        fs.rm(self._to_filesystem_path(path, context.config), recursive=recursive)
+        return True
+
     def _adapt_entry_path(self, filesystem_path: str, config: FsspecResolvedConfigurationType) -> str:
         """Adapt the filesystem path to the desired entry path.
 

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -142,6 +142,39 @@ class PosixFilesSource(BaseFilesSource[PosixTemplateConfiguration, PosixConfigur
         shutil.copyfile(native_path, target_native_path_part)
         os.rename(target_native_path_part, target_native_path)
 
+    def usage_percent(self, user_context=None) -> float | None:
+        context = self._get_runtime_context(None, user_context)
+        st = os.statvfs(self._effective_root(context.config))
+        return (float(st.f_blocks - st.f_bavail) / st.f_blocks) * 100
+
+    def _get_local_path(self, path: str, context: FilesSourceRuntimeContext[PosixConfiguration]) -> str:
+        native_path = self._to_native_path(path, context.config)
+        if context.config.enforce_symlink_security:
+            if not safe_contains(self._effective_root(context.config), native_path, allowlist=self._allowlist):
+                raise Exception("Operation not allowed.")
+        if not os.path.exists(native_path):
+            raise FileNotFoundError(native_path)
+        return native_path
+
+    def _exists(self, path: str, context: FilesSourceRuntimeContext[PosixConfiguration]) -> bool:
+        return os.path.exists(self._to_native_path(path, context.config))
+
+    def _size(self, path: str, context: FilesSourceRuntimeContext[PosixConfiguration]) -> int:
+        return os.path.getsize(self._to_native_path(path, context.config))
+
+    def _remove(
+        self, path: str, context: FilesSourceRuntimeContext[PosixConfiguration], recursive: bool = False
+    ) -> bool:
+        native_path = self._to_native_path(path, context.config)
+        if context.config.enforce_symlink_security:
+            if not safe_contains(self._effective_root(context.config), native_path, allowlist=self._allowlist):
+                raise Exception("Operation not allowed.")
+        if recursive:
+            shutil.rmtree(native_path, ignore_errors=True)
+        else:
+            os.remove(native_path)
+        return True
+
     def _to_native_path(self, source_path: str, config: PosixConfiguration):
         source_path = os.path.normpath(source_path)
         if source_path.startswith("/"):

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1847,6 +1847,10 @@ def type_to_object_store_class(
     objectstore_constructor_kwds: dict[str, Any] = {}
     if store == "disk":
         objectstore_class = DiskObjectStore
+    elif store == "source":
+        from .source_store import SourceObjectStore
+
+        objectstore_class = SourceObjectStore
     elif store == "boto3":
         from .s3_boto3 import S3ObjectStore as Boto3ObjectStore
 

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-from contextlib import contextmanager
 from datetime import datetime
 from typing import (
     Any,
@@ -19,6 +18,7 @@ from galaxy.util import (
 from galaxy.util.path import safe_relpath
 from ._util import fix_permissions
 from .caching import (
+    CacheArea,
     CacheTarget,
     InProcessCacheMonitor,
 )
@@ -35,18 +35,16 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
     cache_size: int
     cache_monitor: InProcessCacheMonitor | None = None
     cache_monitor_interval: int
+    _cache_area: CacheArea | None = None
+
+    @property
+    def _cache(self) -> CacheArea:
+        if self._cache_area is None:
+            self._cache_area = CacheArea(self.staging_path, self.cache_size)
+        return self._cache_area
 
     def _ensure_staging_path_writable(self):
-        staging_path = self.staging_path
-        if not os.path.exists(staging_path):
-            os.makedirs(staging_path, exist_ok=True)
-            if not os.path.exists(staging_path):
-                raise Exception(f"Caching object store created with path '{staging_path}' that does not exist")
-
-        if not os.access(staging_path, os.R_OK):
-            raise Exception(f"Caching object store created with path '{staging_path}' that does not readable")
-        if not os.access(staging_path, os.W_OK):
-            raise Exception(f"Caching object store created with path '{staging_path}' that does not writable")
+        self._cache.ensure_writable()
 
     def _construct_path(
         self,
@@ -103,12 +101,11 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         return rel_path
 
     def _get_cache_path(self, rel_path: str) -> str:
-        return os.path.abspath(os.path.join(self.staging_path, rel_path))
+        return self._cache.path(rel_path)
 
     def _in_cache(self, rel_path: str) -> bool:
         """Check if the given dataset is in the local cache and return True if so."""
-        cache_path = self._get_cache_path(rel_path)
-        return os.path.exists(cache_path)
+        return self._cache.contains(rel_path)
 
     def _pull_into_cache(self, rel_path, **kwargs) -> bool:
         # Ensure the cache directory structure exists (e.g., dataset_#_files/)
@@ -253,7 +250,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             raise ObjectNotFound(f"objectstore.empty, object does not exist: {obj}, kwargs: {kwargs}")
 
     def _get_size_in_cache(self, rel_path):
-        return os.path.getsize(self._get_cache_path(rel_path))
+        return self._cache.size(rel_path)
 
     def _size(self, obj, **kwargs) -> int:
         rel_path = self._construct_path(obj, **kwargs)
@@ -375,11 +372,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
     @property
     def cache_target(self) -> CacheTarget:
-        return CacheTarget(
-            self.staging_path,
-            self.cache_size,
-            0.9,
-        )
+        return self._cache.target
 
     def _shutdown_cache_monitor(self) -> None:
         self.cache_monitor and self.cache_monitor.shutdown()
@@ -394,7 +387,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
     def _exists_remotely(self, rel_path: str) -> bool:
         raise NotImplementedError()
 
-    @contextmanager
     def _atomic_download(self, cache_path):
         """Download to a temp file then atomically rename to prevent serving partial files.
 
@@ -403,18 +395,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             with self._atomic_download(local_destination) as tmp_path:
                 do_download(tmp_path)
         """
-        tmp_path = cache_path + ".tmp"
-        try:
-            yield tmp_path
-            os.rename(tmp_path, cache_path)
-        except BaseException:
-            # Catch BaseException (not just Exception) so that KeyboardInterrupt
-            # and SystemExit also trigger cleanup — we re-raise immediately, so
-            # propagation is not blocked. Without this, interrupted downloads
-            # leave .tmp files that poison the cache on next startup.
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-            raise
+        return self._cache.atomic_write(cache_path)
 
     def _download(self, rel_path: str) -> bool:
         raise NotImplementedError()

--- a/lib/galaxy/objectstore/_caching_source.py
+++ b/lib/galaxy/objectstore/_caching_source.py
@@ -1,0 +1,97 @@
+"""A cache wrapper that gives any whole-file FilesSource a stable local path.
+
+Stage 2 of the ObjectStore/FilesSource unification (see
+``doc/source/dev/objectstore_filesource_unification.md``). This wraps a raw FilesSource with
+a :class:`~galaxy.objectstore.caching.CacheArea` -- the *same* cache implementation the
+caching object stores use -- and adds the one primitive a raw remote source lacks:
+``get_local_path``, which resolves a key to a real, seekable local path by pulling it into
+the cache on demand. A local source (posix) needs no wrapper; a remote source (s3, ...) is
+wrapped so an object store built on it can honor ``get_filename``.
+
+Placed in the object store package for now because it reuses ``galaxy.objectstore.caching``;
+a full Stage 2 would relocate the cache primitives to a neutral module so this can live in
+``galaxy.files``. It keeps no runtime dependency on ``galaxy.files`` (the wrapped source is
+imported only under ``TYPE_CHECKING``).
+"""
+
+import logging
+import os
+import shutil
+from typing import TYPE_CHECKING
+
+from .caching import CacheArea
+
+if TYPE_CHECKING:
+    from galaxy.files import OptionalUserContext
+    from galaxy.files.sources import BaseFilesSource
+
+log = logging.getLogger(__name__)
+
+
+class CachingFilesSource:
+    """Wraps a raw FilesSource with a local cache so it can resolve stable local paths."""
+
+    def __init__(
+        self,
+        inner: "BaseFilesSource",
+        staging_path: str,
+        cache_size: int = -1,
+        user_context: "OptionalUserContext" = None,
+    ):
+        self._inner = inner
+        self._cache = CacheArea(staging_path, cache_size)
+        self._cache.ensure_writable()
+        self._user_context = user_context
+
+    def _caching_allowed(self, path: str) -> bool:
+        remote_size = self._inner.size(path, user_context=self._user_context)
+        return self._cache.fits(remote_size or 0)
+
+    # --- FilesSource-shaped interface consumed by the object store ---
+
+    def exists(self, path: str, user_context: "OptionalUserContext" = None) -> bool:
+        return self._cache.contains_nonempty(path) or self._inner.exists(
+            path, user_context=user_context or self._user_context
+        )
+
+    def size(self, path: str, user_context: "OptionalUserContext" = None) -> int:
+        if self._cache.contains_nonempty(path):
+            return self._cache.size(path)
+        return self._inner.size(path, user_context=user_context or self._user_context)
+
+    def get_local_path(self, path: str, user_context: "OptionalUserContext" = None) -> str:
+        cache_path = self._cache.path(path)
+        if self._cache.contains_nonempty(path):
+            return cache_path
+        if not self._caching_allowed(path):
+            raise Exception(f"File {path} is larger than the configured cache allows.")
+        self._cache.makedirs_for(path)
+        with self._cache.atomic_write(cache_path) as tmp:
+            self._inner.realize_to(path, tmp, user_context=user_context or self._user_context)
+        return cache_path
+
+    def realize_to(self, source_path: str, native_path: str, user_context: "OptionalUserContext" = None, opts=None):
+        self._inner.realize_to(source_path, native_path, user_context=user_context or self._user_context, opts=opts)
+
+    def write_from(
+        self, target_path: str, native_path: str, user_context: "OptionalUserContext" = None, opts=None
+    ) -> str:
+        # Push to the backing store (the source of truth), then warm the cache.
+        result = self._inner.write_from(
+            target_path, native_path, user_context=user_context or self._user_context, opts=opts
+        )
+        cache_path = self._cache.path(target_path)
+        self._cache.makedirs_for(target_path)
+        if os.path.abspath(native_path) != cache_path:
+            shutil.copyfile(native_path, cache_path)
+        return result or target_path
+
+    def remove(self, path: str, recursive: bool = False, user_context: "OptionalUserContext" = None) -> bool:
+        if recursive:
+            self._cache.evict_dir(path)
+        else:
+            self._cache.evict(path)
+        return self._inner.remove(path, recursive=recursive, user_context=user_context or self._user_context)
+
+    def usage_percent(self, user_context: "OptionalUserContext" = None) -> float | None:
+        return self._inner.usage_percent(user_context=user_context or self._user_context)

--- a/lib/galaxy/objectstore/_transport.py
+++ b/lib/galaxy/objectstore/_transport.py
@@ -1,0 +1,167 @@
+"""Whole-file, key-addressed transport for caching object stores.
+
+Stage 1 of the ObjectStore/FilesSource unification (see
+``doc/source/dev/objectstore_filesource_unification.md``). Below its cache, a
+:class:`~galaxy.objectstore._caching_base.CachingConcreteObjectStore` needs only a
+whole-file get/put/exists/size/delete interface keyed on a relative path -- which is
+essentially the ``FilesSource`` contract with the method names filed off. This module
+names that seam as :class:`ObjectStoreTransport` and provides a local-filesystem
+implementation used both as a test stand-in for remote stores and, eventually, as the
+``DiskObjectStore`` backend.
+"""
+
+import os
+import shutil
+import tempfile
+from typing import (
+    Iterable,
+    Protocol,
+    runtime_checkable,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    from galaxy.files import OptionalUserContext
+    from galaxy.files.sources import BaseFilesSource
+
+
+@runtime_checkable
+class ObjectStoreTransport(Protocol):
+    """The whole-file transport a caching object store delegates its backend I/O to.
+
+    Every method is keyed on ``rel_path`` -- a path relative to the transport root such
+    as ``000/001/dataset_1.dat``. Directory keys carry a trailing ``/`` (matching how
+    ``CachingConcreteObjectStore._construct_path`` builds them).
+    """
+
+    def download(self, rel_path: str, dest_path: str) -> None:
+        """Copy the object at ``rel_path`` to the local ``dest_path``; raise if absent."""
+
+    def upload_file(self, rel_path: str, source_path: str) -> bool:
+        """Store the local file ``source_path`` as the object at ``rel_path``."""
+
+    def upload_string(self, rel_path: str, data: str) -> bool:
+        """Store ``data`` as the object at ``rel_path``."""
+
+    def exists(self, rel_path: str) -> bool:
+        """Return whether ``rel_path`` (or, for a trailing-slash key, any object under it) exists."""
+
+    def size(self, rel_path: str) -> int:
+        """Return the size of the object at ``rel_path`` in bytes."""
+
+    def delete(self, rel_path: str) -> bool:
+        """Delete the single object at ``rel_path``."""
+
+    def delete_prefix(self, rel_path: str) -> bool:
+        """Delete every object under the ``rel_path`` prefix."""
+
+    def list_prefix(self, rel_path: str) -> Iterable[str]:
+        """Yield the key of every object under the ``rel_path`` prefix."""
+
+
+class LocalTransport:
+    """A local-filesystem :class:`ObjectStoreTransport` rooted at a directory.
+
+    Keys are paths relative to ``root``. This doubles as the future
+    ``DiskObjectStore`` backend and as a credential-free stand-in for remote stores
+    in tests.
+    """
+
+    def __init__(self, root: str):
+        self.root = os.path.abspath(root)
+
+    def _full(self, rel_path: str) -> str:
+        return os.path.join(self.root, rel_path)
+
+    def download(self, rel_path: str, dest_path: str) -> None:
+        shutil.copyfile(self._full(rel_path), dest_path)
+
+    def upload_file(self, rel_path: str, source_path: str) -> bool:
+        full = self._full(rel_path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        shutil.copyfile(source_path, full)
+        return True
+
+    def upload_string(self, rel_path: str, data: str) -> bool:
+        full = self._full(rel_path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w") as fh:
+            fh.write(data)
+        return True
+
+    def exists(self, rel_path: str) -> bool:
+        if rel_path.endswith("/"):
+            return any(True for _ in self.list_prefix(rel_path))
+        return os.path.isfile(self._full(rel_path))
+
+    def size(self, rel_path: str) -> int:
+        return os.path.getsize(self._full(rel_path))
+
+    def delete(self, rel_path: str) -> bool:
+        os.remove(self._full(rel_path))
+        return True
+
+    def delete_prefix(self, rel_path: str) -> bool:
+        shutil.rmtree(self._full(rel_path), ignore_errors=True)
+        return True
+
+    def list_prefix(self, rel_path: str) -> Iterable[str]:
+        base = self._full(rel_path)
+        if not os.path.isdir(base):
+            return
+        for dirpath, _, filenames in os.walk(base):
+            for filename in filenames:
+                yield os.path.relpath(os.path.join(dirpath, filename), self.root)
+
+
+class FilesSourceTransport:
+    """An :class:`ObjectStoreTransport` backed by a ``galaxy.files`` FilesSource.
+
+    This is the crux of the unification: the object store's whole-file transport seam is
+    satisfied directly by a FilesSource's ``realize_to`` / ``write_from`` / ``exists`` /
+    ``size`` / ``remove`` / ``list``. The ``BaseFilesSource`` type is imported only under
+    ``TYPE_CHECKING`` so the object store keeps no runtime dependency on ``galaxy.files``.
+
+    Object stores are admin-configured and not user-scoped, so ``user_context`` defaults to
+    ``None`` (the FilesSource then skips per-user access checks). See
+    ``doc/source/dev/objectstore_filesource_unification.md``.
+    """
+
+    def __init__(self, files_source: "BaseFilesSource", user_context: "OptionalUserContext" = None):
+        self._source = files_source
+        self._user_context = user_context
+
+    def download(self, rel_path: str, dest_path: str) -> None:
+        self._source.realize_to(rel_path, dest_path, user_context=self._user_context)
+
+    def upload_file(self, rel_path: str, source_path: str) -> bool:
+        self._source.write_from(rel_path, source_path, user_context=self._user_context)
+        return True
+
+    def upload_string(self, rel_path: str, data: str) -> bool:
+        fd, tmp = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, "w") as fh:
+                fh.write(data)
+            self._source.write_from(rel_path, tmp, user_context=self._user_context)
+        finally:
+            os.remove(tmp)
+        return True
+
+    def exists(self, rel_path: str) -> bool:
+        return self._source.exists(rel_path, user_context=self._user_context)
+
+    def size(self, rel_path: str) -> int:
+        return self._source.size(rel_path, user_context=self._user_context)
+
+    def delete(self, rel_path: str) -> bool:
+        return self._source.remove(rel_path, user_context=self._user_context)
+
+    def delete_prefix(self, rel_path: str) -> bool:
+        return self._source.remove(rel_path, recursive=True, user_context=self._user_context)
+
+    def list_prefix(self, rel_path: str) -> Iterable[str]:
+        entries, _ = self._source.list(rel_path, recursive=True, user_context=self._user_context)
+        for entry in entries:
+            if getattr(entry, "class_", None) == "File":
+                yield entry.path

--- a/lib/galaxy/objectstore/_transport.py
+++ b/lib/galaxy/objectstore/_transport.py
@@ -13,8 +13,8 @@ implementation used both as a test stand-in for remote stores and, eventually, a
 import os
 import shutil
 import tempfile
+from collections.abc import Iterable
 from typing import (
-    Iterable,
     Protocol,
     runtime_checkable,
     TYPE_CHECKING,

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -2,8 +2,10 @@
 
 import logging
 import os
+import shutil
 import threading
 import time
+from contextlib import contextmanager
 from math import inf
 
 from typing_extensions import NamedTuple
@@ -11,6 +13,7 @@ from typing_extensions import NamedTuple
 from galaxy.util import (
     nice_size,
     string_as_bool,
+    unlink,
 )
 from galaxy.util.sleeper import Sleeper
 
@@ -41,6 +44,83 @@ class CacheTarget(NamedTuple):
     @property
     def log_description(self) -> str:
         return f"{self.limit} percent of {self.size} gigabytes"
+
+
+class CacheArea:
+    """A local staging directory that caches objects addressed by relative path.
+
+    The single cache implementation shared by the caching object stores
+    (``_caching_base.CachingConcreteObjectStore``) and ``CachingFilesSource``: path
+    resolution, the in-cache check, atomic writes, size accounting, and the ``CacheTarget``
+    fits-in-cache policy. Whole-area eviction is handled by ``check_cache`` /
+    ``InProcessCacheMonitor`` against :attr:`target`.
+    """
+
+    def __init__(self, staging_path: str, cache_size: int, cache_limit_percent: float = 0.9):
+        # Keep staging_path as configured (may be relative); only per-object paths are
+        # abspath-ed, matching the historical CachingConcreteObjectStore behavior.
+        self.staging_path = staging_path
+        self.cache_size = cache_size
+        self.cache_limit_percent = cache_limit_percent
+
+    @property
+    def target(self) -> CacheTarget:
+        return CacheTarget(self.staging_path, self.cache_size, self.cache_limit_percent)
+
+    def ensure_writable(self) -> None:
+        staging_path = self.staging_path
+        if not os.path.exists(staging_path):
+            os.makedirs(staging_path, exist_ok=True)
+            if not os.path.exists(staging_path):
+                raise Exception(f"Caching object store created with path '{staging_path}' that does not exist")
+        if not os.access(staging_path, os.R_OK):
+            raise Exception(f"Caching object store created with path '{staging_path}' that does not readable")
+        if not os.access(staging_path, os.W_OK):
+            raise Exception(f"Caching object store created with path '{staging_path}' that does not writable")
+
+    def path(self, rel_path: str) -> str:
+        return os.path.abspath(os.path.join(self.staging_path, rel_path))
+
+    def contains(self, rel_path: str) -> bool:
+        return os.path.exists(self.path(rel_path))
+
+    def contains_nonempty(self, rel_path: str) -> bool:
+        cache_path = self.path(rel_path)
+        return os.path.exists(cache_path) and os.path.getsize(cache_path) > 0
+
+    def size(self, rel_path: str) -> int:
+        return os.path.getsize(self.path(rel_path))
+
+    def fits(self, size: int) -> bool:
+        return self.target.fits_in_cache(size)
+
+    def makedirs_for(self, rel_path: str) -> None:
+        os.makedirs(os.path.dirname(self.path(rel_path)), exist_ok=True)
+
+    def evict(self, rel_path: str) -> None:
+        unlink(self.path(rel_path), ignore_errors=True)
+
+    def evict_dir(self, rel_path: str) -> None:
+        shutil.rmtree(self.path(rel_path), ignore_errors=True)
+
+    @contextmanager
+    def atomic_write(self, cache_path: str):
+        """Write to a temp file then atomically rename, to avoid serving partial files.
+
+        ``cache_path`` is an absolute path within the staging area; the caller is responsible
+        for ensuring its parent directory exists (see :meth:`makedirs_for`).
+        """
+        tmp_path = cache_path + ".tmp"
+        try:
+            yield tmp_path
+            os.rename(tmp_path, cache_path)
+        except BaseException:
+            # Catch BaseException (not just Exception) so KeyboardInterrupt and SystemExit also
+            # trigger cleanup -- we re-raise immediately, so propagation is not blocked. Without
+            # this, interrupted downloads leave .tmp files that poison the cache on next startup.
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
 
 
 def check_caches(targets: list[CacheTarget]):

--- a/lib/galaxy/objectstore/delegating.py
+++ b/lib/galaxy/objectstore/delegating.py
@@ -1,0 +1,77 @@
+"""An object store whose remote transport is pluggable.
+
+Stage 1 of the ObjectStore/FilesSource unification (see
+``doc/source/dev/objectstore_filesource_unification.md``). The entire caching layer of
+:class:`~galaxy.objectstore._caching_base.CachingConcreteObjectStore` is left unchanged;
+only the backend I/O hooks are routed to an injected
+:class:`~galaxy.objectstore._transport.ObjectStoreTransport`. Pointing that transport at
+a local directory (or, later, at a ``FilesSource`` adapter) exercises the exact seam a
+cloud backend uses, with no credentials required.
+"""
+
+import logging
+import os
+
+from ._caching_base import CachingConcreteObjectStore
+from ._transport import ObjectStoreTransport
+from .caching import enable_cache_monitor
+
+log = logging.getLogger(__name__)
+
+
+class DelegatingObjectStore(CachingConcreteObjectStore):
+    store_type = "delegating"
+
+    def __init__(self, config, config_dict, transport: ObjectStoreTransport):
+        super().__init__(config, config_dict)
+        self.cache_monitor = None
+        cache_dict = config_dict.get("cache") or {}
+        self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
+        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
+        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
+        self.cache_updated_data = cache_dict.get("cache_updated_data", True)
+        extra_dirs = {e["type"]: e["path"] for e in config_dict.get("extra_dirs", [])}
+        self.extra_dirs.update(extra_dirs)
+        self._transport = transport
+        self._ensure_staging_path_writable()
+        self._start_cache_monitor_if_needed()
+
+    def _download(self, rel_path: str) -> bool:
+        if not self._caching_allowed(rel_path):
+            return False
+        cache_path = self._get_cache_path(rel_path)
+        try:
+            with self._atomic_download(cache_path) as tmp:
+                self._transport.download(rel_path, tmp)
+            return True
+        except Exception:
+            log.exception("Failed to download '%s' through transport", rel_path)
+            return False
+
+    def _push_file_to_path(self, rel_path: str, source_file: str) -> bool:
+        return self._transport.upload_file(rel_path, source_file)
+
+    def _push_string_to_path(self, rel_path: str, from_string: str) -> bool:
+        return self._transport.upload_string(rel_path, from_string)
+
+    def _exists_remotely(self, rel_path: str) -> bool:
+        return self._transport.exists(rel_path)
+
+    def _get_remote_size(self, rel_path: str) -> int:
+        return self._transport.size(rel_path)
+
+    def _delete_existing_remote(self, rel_path: str) -> bool:
+        return self._transport.delete(rel_path)
+
+    def _delete_remote_all(self, rel_path: str) -> bool:
+        return self._transport.delete_prefix(rel_path)
+
+    def _download_directory_into_cache(self, rel_path: str, cache_path: str) -> None:
+        for key in self._transport.list_prefix(rel_path):
+            local_file_path = os.path.join(cache_path, os.path.relpath(key, rel_path))
+            os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
+            with self._atomic_download(local_file_path) as tmp:
+                self._transport.download(key, tmp)
+
+    def shutdown(self):
+        self._shutdown_cache_monitor()

--- a/lib/galaxy/objectstore/source_store.py
+++ b/lib/galaxy/objectstore/source_store.py
@@ -1,0 +1,268 @@
+"""An object store that owns a FilesSource and delegates all I/O to it.
+
+Stage 2 of the ObjectStore/FilesSource unification (see
+``doc/source/dev/objectstore_filesource_unification.md``). Unlike the Stage 1
+``DelegatingObjectStore`` (which keeps the cache in the object store), this store has no
+cache of its own: ``get_filename`` resolves through the source's ``get_local_path``. So a
+``PosixFilesSource`` yields a zero-copy real path (the ``DiskObjectStore`` role) and a
+``CachingFilesSource`` yields a cache path (the ``S3ObjectStore`` role) -- one object store
+class for both, and the disk special-case disappears.
+
+Addressing (the ``directory_hash_id`` key), quota, ``store_by`` and the other
+object-store-only concerns stay here; the transport and any cache live in the source.
+
+``base_dir`` operations (``job_work`` / ``temp``) are always-local scratch directories,
+independent of the dataset backend -- every object store handles them on the local
+filesystem -- so they bypass the source and use ``self.extra_dirs[base_dir]`` directly.
+"""
+
+import logging
+import os
+import shutil
+import tempfile
+from typing import (
+    Protocol,
+    runtime_checkable,
+)
+
+from galaxy.exceptions import (
+    ObjectInvalid,
+    ObjectNotFound,
+)
+from galaxy.objectstore import ConcreteObjectStore
+from galaxy.util import (
+    directory_hash_id,
+    unlink,
+)
+from galaxy.util.path import safe_relpath
+
+log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ObjectStoreFilesSource(Protocol):
+    """The FilesSource surface an object store needs: whole-file I/O plus local-path resolve.
+
+    Both a raw ``BaseFilesSource`` (e.g. ``PosixFilesSource``) and a ``CachingFilesSource``
+    satisfy this structurally.
+    """
+
+    def exists(self, path: str, user_context=None) -> bool: ...
+
+    def size(self, path: str, user_context=None) -> int: ...
+
+    def write_from(self, target_path: str, native_path: str, user_context=None, opts=None) -> str: ...
+
+    def remove(self, path: str, recursive: bool = False, user_context=None) -> bool: ...
+
+    def get_local_path(self, path: str, user_context=None) -> str: ...
+
+    def usage_percent(self, user_context=None) -> float | None: ...
+
+
+class SourceObjectStore(ConcreteObjectStore):
+    store_type = "source"
+
+    def __init__(self, config, config_dict, source: ObjectStoreFilesSource | None = None):
+        super().__init__(config, config_dict)
+        extra_dirs = {e["type"]: e["path"] for e in config_dict.get("extra_dirs", [])}
+        self.extra_dirs.update(extra_dirs)
+        # Retained for to_dict round-tripping when the source is built from config.
+        self._files_source_config = config_dict.get("files_source")
+        self._cache_config = config_dict.get("cache")
+        self._source = source if source is not None else self._build_source(config, config_dict)
+
+    @classmethod
+    def parse_xml(cls, config_xml):
+        raise NotImplementedError("The 'source' object store type must be configured via YAML, not XML.")
+
+    @staticmethod
+    def _build_source(config, config_dict) -> ObjectStoreFilesSource:
+        """Construct the backing FilesSource from a ``files_source`` plugin config.
+
+        A ``cache`` section wraps the (remote) source in a ``CachingFilesSource`` so its
+        objects resolve to a local path; a bare local source (posix) needs no cache.
+        """
+        from galaxy.files.plugins import (
+            FileSourcePluginLoader,
+            FileSourcePluginsConfig,
+        )
+        from galaxy.util.plugin_config import plugin_source_from_dict
+
+        files_source_config = config_dict.get("files_source")
+        if not files_source_config:
+            raise Exception("A 'source' object store requires a 'files_source' configuration.")
+        if hasattr(config, "user_library_import_symlink_allowlist"):
+            fs_config = FileSourcePluginsConfig.from_app_config(config)
+        else:
+            fs_config = FileSourcePluginsConfig()
+        source_dict = dict(files_source_config)
+        source_dict.setdefault("id", "objectstore_source")
+        loader = FileSourcePluginLoader()
+        inner = loader.load_plugins(plugin_source_from_dict([source_dict]), fs_config)[0]
+
+        cache_dict = config_dict.get("cache")
+        if cache_dict is not None:
+            from ._caching_source import CachingFilesSource
+
+            staging_path = cache_dict.get("path") or config.object_store_cache_path
+            cache_size = cache_dict.get("size") or config.object_store_cache_size
+            return CachingFilesSource(inner, staging_path=staging_path, cache_size=cache_size)
+        return inner
+
+    def to_dict(self):
+        rval = super().to_dict()
+        if self._files_source_config is not None:
+            rval["files_source"] = self._files_source_config
+        if self._cache_config is not None:
+            rval["cache"] = self._cache_config
+        return rval
+
+    def _rel_path(
+        self, obj, dir_only=False, extra_dir=None, extra_dir_at_root=False, alt_name=None, obj_dir=False, **kwargs
+    ) -> str:
+        if alt_name and not safe_relpath(alt_name):
+            log.warning("alt_name would locate path outside dir: %s", alt_name)
+            raise ObjectInvalid("The requested object is invalid")
+        object_id = self._get_object_id(obj)
+        rel_path = os.path.join(*directory_hash_id(object_id))
+        if obj_dir:
+            rel_path = os.path.join(rel_path, str(object_id))
+        if extra_dir is not None:
+            rel_path = os.path.join(extra_dir, rel_path) if extra_dir_at_root else os.path.join(rel_path, extra_dir)
+        # Directories are represented with a trailing slash, matching the remote stores.
+        rel_path = f"{rel_path}/"
+        if not dir_only:
+            rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{object_id}.dat")
+        return rel_path
+
+    # --- always-local scratch dirs (job_work / temp) ----------------------------------------
+
+    def _local_path(
+        self,
+        obj,
+        base_dir=None,
+        dir_only=False,
+        extra_dir=None,
+        extra_dir_at_root=False,
+        alt_name=None,
+        obj_dir=False,
+        **kwargs,
+    ) -> str:
+        if alt_name and not safe_relpath(alt_name):
+            raise ObjectInvalid("The requested object is invalid")
+        base = os.path.abspath(self.extra_dirs[base_dir])
+        object_id = self._get_object_id(obj)
+        rel_path = os.path.join(*directory_hash_id(object_id))
+        if obj_dir:
+            rel_path = os.path.join(rel_path, str(object_id))
+        if extra_dir is not None:
+            rel_path = os.path.join(extra_dir, rel_path) if extra_dir_at_root else os.path.join(rel_path, extra_dir)
+        path = os.path.join(base, rel_path)
+        if not dir_only:
+            path = os.path.join(path, alt_name if alt_name else f"dataset_{object_id}.dat")
+        return os.path.abspath(path)
+
+    # --- ObjectStore contract ---------------------------------------------------------------
+
+    def _exists(self, obj, **kwargs) -> bool:
+        if kwargs.get("base_dir"):
+            return os.path.exists(self._local_path(obj, **kwargs))
+        return self._source.exists(self._rel_path(obj, **kwargs))
+
+    def _create(self, obj, **kwargs):
+        if kwargs.get("base_dir"):
+            path = self._local_path(obj, **kwargs)
+            directory = path if kwargs.get("dir_only") else os.path.dirname(path)
+            os.makedirs(directory, exist_ok=True)
+            if not kwargs.get("dir_only") and not os.path.exists(path):
+                open(path, "w").close()
+            return self
+        if not self._exists(obj, **kwargs):
+            if kwargs.get("dir_only"):
+                # dir_only creation for the dataset source (composite / extra-files dirs) is
+                # deferred in this prototype.
+                return self
+            rel_path = self._rel_path(obj, **kwargs)
+            fd, tmp = tempfile.mkstemp()
+            try:
+                os.close(fd)
+                self._source.write_from(rel_path, tmp)
+            finally:
+                unlink(tmp, ignore_errors=True)
+        return self
+
+    def _empty(self, obj, **kwargs) -> bool:
+        if self._exists(obj, **kwargs):
+            return self._size(obj, **kwargs) == 0
+        raise ObjectNotFound(f"objectstore.empty, object does not exist: {obj}, kwargs: {kwargs}")
+
+    def _size(self, obj, **kwargs) -> int:
+        if not self._exists(obj, **kwargs):
+            return 0
+        path_fn = self._local_path if kwargs.get("base_dir") else None
+        try:
+            if path_fn is not None:
+                return os.path.getsize(path_fn(obj, **kwargs))
+            return self._source.size(self._rel_path(obj, **kwargs))
+        except OSError:
+            return 0
+
+    def _get_filename(self, obj, **kwargs) -> str:
+        if kwargs.get("base_dir"):
+            path = self._local_path(obj, **kwargs)
+            if not os.path.exists(path):
+                raise ObjectNotFound(f"objectstore.get_filename, object does not exist: {obj}, kwargs: {kwargs}")
+            return path
+        try:
+            return self._source.get_local_path(self._rel_path(obj, **kwargs))
+        except FileNotFoundError:
+            raise ObjectNotFound(f"objectstore.get_filename, object does not exist: {obj}, kwargs: {kwargs}")
+
+    def _get_data(self, obj, start=0, count=-1, **kwargs):
+        with open(self._get_filename(obj, **kwargs)) as data_file:
+            data_file.seek(start)
+            return data_file.read(count)
+
+    def _update_from_file(self, obj, file_name=None, create: bool = False, preserve_symlinks: bool = False, **kwargs):
+        if kwargs.get("base_dir"):
+            if create:
+                self._create(obj, **kwargs)
+            if file_name:
+                path = self._local_path(obj, **kwargs)
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                shutil.copy(os.path.abspath(file_name), path)
+            return
+        if file_name:
+            if create or self._exists(obj, **kwargs):
+                self._source.write_from(self._rel_path(obj, **kwargs), os.path.abspath(file_name))
+        elif create:
+            self._create(obj, **kwargs)
+
+    def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
+        if kwargs.get("base_dir"):
+            path = self._local_path(obj, **kwargs)
+            try:
+                if entire_dir and (kwargs.get("extra_dir") or kwargs.get("obj_dir")):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+                return True
+            except FileNotFoundError:
+                return True
+            except OSError:
+                log.exception("%s delete error", path)
+                return False
+        rel_path = self._rel_path(obj, **kwargs)
+        recursive = bool(entire_dir and (kwargs.get("extra_dir") or kwargs.get("obj_dir")))
+        try:
+            return self._source.remove(rel_path, recursive=recursive)
+        except FileNotFoundError:
+            return True
+
+    def _get_object_url(self, obj, **kwargs):
+        return None
+
+    def _get_store_usage_percent(self, **kwargs):
+        usage = self._source.usage_percent()
+        return usage if usage is not None else 0.0

--- a/test/unit/objectstore/_unification_utils.py
+++ b/test/unit/objectstore/_unification_utils.py
@@ -6,9 +6,17 @@ See doc/source/dev/objectstore_filesource_unification.md.
 import os
 from uuid import uuid4
 
-from galaxy.files.plugins import FileSourcePluginsConfig
-from galaxy.files.unittest_utils import TestConfiguredFileSources
+import pytest
+
 from galaxy.util import directory_hash_id
+
+# These helpers need galaxy-files + fsspec; skip cleanly when the galaxy-objectstore package
+# is tested in isolation without them (this module is collected directly by pytest).
+pytest.importorskip("fsspec")
+pytest.importorskip("galaxy.files")
+
+from galaxy.files.plugins import FileSourcePluginsConfig  # noqa: E402  (after importorskip)
+from galaxy.files.unittest_utils import TestConfiguredFileSources  # noqa: E402  (after importorskip)
 
 
 class Dataset:

--- a/test/unit/objectstore/_unification_utils.py
+++ b/test/unit/objectstore/_unification_utils.py
@@ -1,0 +1,83 @@
+"""Shared helpers for the ObjectStore/FilesSource unification tests (Stages 1 & 2).
+
+See doc/source/dev/objectstore_filesource_unification.md.
+"""
+
+import os
+from uuid import uuid4
+
+from galaxy.files.plugins import FileSourcePluginsConfig
+from galaxy.files.unittest_utils import TestConfiguredFileSources
+from galaxy.util import directory_hash_id
+
+
+class Dataset:
+    def __init__(self, id):
+        self.id = id
+        self.object_store_id = None
+        self.uuid = uuid4()
+        self.tags = []
+
+
+def key(dataset_id):
+    """The relative key an id-addressed object store constructs for a dataset."""
+    return os.path.join(*directory_hash_id(dataset_id), f"dataset_{dataset_id}.dat")
+
+
+def remote_file(remote, dataset_id):
+    return remote / key(dataset_id)
+
+
+def posix_files_source(root):
+    plugin = {"type": "posix", "root": str(root), "writable": True}
+    sources = TestConfiguredFileSources(FileSourcePluginsConfig(), {"test1": plugin}, str(root))
+    return sources.find_best_match("gxfiles://test1/")
+
+
+def memory_files_source():
+    plugin = {"type": "memory", "writable": True}
+    sources = TestConfiguredFileSources(FileSourcePluginsConfig(), {"mem1": plugin}, None)
+    return sources.find_best_match("memory://mem1/")
+
+
+def assert_object_store_round_trip(store, tmp_path, remote_content, remote_exists):
+    """Full lifecycle through an object store, verifying the backing store directly.
+
+    ``remote_content(id) -> str`` and ``remote_exists(id) -> bool`` read the backend (not the
+    cache), so the assertions hold for any transport or source.
+    """
+    # Absent dataset does not exist.
+    assert not store.exists(Dataset(1))
+
+    # Empty dataset created via create().
+    empty = Dataset(2)
+    store.create(empty)
+    assert store.exists(empty)
+    assert store.empty(empty)
+
+    # Writing a dataset lands the bytes in the backend and makes it retrievable.
+    ds = Dataset(3)
+    src = tmp_path / "src.txt"
+    src.write_text("Hello World!")
+    store.update_from_file(ds, file_name=str(src), create=True)
+
+    assert store.exists(ds)
+    assert not store.empty(ds)
+    assert store.size(ds) == len("Hello World!")
+
+    # The backend (not just the cache) received the bytes.
+    assert remote_content(3) == "Hello World!"
+
+    # get_filename yields a real, readable local path.
+    fname = store.get_filename(ds)
+    assert os.path.exists(fname)
+    with open(fname) as fh:
+        assert fh.read() == "Hello World!"
+
+    # Byte-range reads are served from the resolved local path.
+    assert store.get_data(ds, start=1, count=6) == "ello W"
+
+    # Deleting removes the object from the backend as well.
+    assert store.delete(ds)
+    assert not store.exists(ds)
+    assert not remote_exists(3)

--- a/test/unit/objectstore/conftest.py
+++ b/test/unit/objectstore/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from fsspec.implementations.memory import MemoryFileSystem
+
+
+@pytest.fixture
+def clean_memory_fs():
+    # MemoryFileSystem shares one process-global store across instances; isolate each test.
+    MemoryFileSystem.store.clear()
+    MemoryFileSystem.pseudo_dirs[:] = [""]
+    yield
+    MemoryFileSystem.store.clear()
+    MemoryFileSystem.pseudo_dirs[:] = [""]

--- a/test/unit/objectstore/conftest.py
+++ b/test/unit/objectstore/conftest.py
@@ -1,9 +1,12 @@
 import pytest
-from fsspec.implementations.memory import MemoryFileSystem
 
 
 @pytest.fixture
 def clean_memory_fs():
+    # Imported lazily so this conftest doesn't require fsspec when the objectstore package
+    # is tested in isolation (only the tests that use this fixture need fsspec).
+    from fsspec.implementations.memory import MemoryFileSystem
+
     # MemoryFileSystem shares one process-global store across instances; isolate each test.
     MemoryFileSystem.store.clear()
     MemoryFileSystem.pseudo_dirs[:] = [""]

--- a/test/unit/objectstore/test_delegating_objectstore.py
+++ b/test/unit/objectstore/test_delegating_objectstore.py
@@ -1,0 +1,113 @@
+"""Stage 1 of the ObjectStore/FilesSource unification.
+
+These tests prove that a CachingConcreteObjectStore's *transport* (the whole-file,
+key-addressed I/O below its cache) can be satisfied by an injected object, with the
+entire cache layer left untouched:
+
+- ``test_round_trip_local_transport`` uses a plain local-filesystem transport.
+- ``test_round_trip_files_source_transport`` uses a *real* ``PosixFilesSource`` wrapped
+  as a transport -- the central thesis of the proposal, that the object store's transport
+  seam *is* the FilesSource contract.
+- ``test_round_trip_fsspec_memory_transport`` / ``test_fsspec_size_served_from_cold_cache``
+  do the same through an fsspec-backed source (``MemoryFilesSource``), exercising the
+  ``FsspecFilesSource`` base-class ``exists``/``size``/``remove`` defaults that every cloud
+  source (s3fs, azure, gcs, ...) inherits. A real S3-behind-moto run is a gated follow-up.
+
+A local directory or the in-process memory filesystem stands in for a remote store, so no
+cloud credentials are needed. See doc/source/dev/objectstore_filesource_unification.md.
+"""
+
+import shutil
+
+from fsspec.implementations.memory import MemoryFileSystem
+
+from galaxy.objectstore._transport import (
+    FilesSourceTransport,
+    LocalTransport,
+)
+from galaxy.objectstore.delegating import DelegatingObjectStore
+from galaxy.objectstore.unittest_utils import MockConfig
+from ._unification_utils import (
+    assert_object_store_round_trip,
+    Dataset,
+    key,
+    memory_files_source,
+    posix_files_source,
+    remote_file,
+)
+
+
+def _make_store(tmp_path, transport):
+    config = MockConfig(str(tmp_path), "unused.yaml")
+    config_dict = {"cache": {"path": str(tmp_path / "cache")}}
+    return DelegatingObjectStore(config, config_dict, transport=transport)
+
+
+def test_round_trip_local_transport(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = _make_store(tmp_path, LocalTransport(str(remote)))
+    assert_object_store_round_trip(
+        store,
+        tmp_path,
+        remote_content=lambda i: remote_file(remote, i).read_text(),
+        remote_exists=lambda i: remote_file(remote, i).exists(),
+    )
+
+
+def test_round_trip_files_source_transport(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = _make_store(tmp_path, FilesSourceTransport(posix_files_source(remote)))
+    assert_object_store_round_trip(
+        store,
+        tmp_path,
+        remote_content=lambda i: remote_file(remote, i).read_text(),
+        remote_exists=lambda i: remote_file(remote, i).exists(),
+    )
+
+
+def test_round_trip_fsspec_memory_transport(clean_memory_fs, tmp_path):
+    store = _make_store(tmp_path, FilesSourceTransport(memory_files_source()))
+    assert_object_store_round_trip(
+        store,
+        tmp_path,
+        remote_content=lambda i: MemoryFileSystem().cat(key(i)).decode(),
+        remote_exists=lambda i: MemoryFileSystem().exists(key(i)),
+    )
+
+
+def test_fsspec_size_served_from_cold_cache(clean_memory_fs, tmp_path):
+    # With a cold cache, exists/size/get_filename must be served from the fsspec backend,
+    # exercising FsspecFilesSource._exists / _size / _realize_to.
+    store = _make_store(tmp_path, FilesSourceTransport(memory_files_source()))
+    ds = Dataset(5)
+    src = tmp_path / "s"
+    src.write_text("12345678")
+    store.update_from_file(ds, file_name=str(src), create=True)
+
+    shutil.rmtree(tmp_path / "cache")  # evict everything from the local cache
+
+    assert store.exists(ds)  # -> source.exists
+    assert store.size(ds) == 8  # -> source.size (remote branch)
+    with open(store.get_filename(ds)) as fh:  # -> source.realize_to + caching-allowed size check
+        assert fh.read() == "12345678"
+
+
+def test_get_filename_pulls_from_remote_into_cache(tmp_path):
+    # A dataset present only in the remote is pulled into the local cache on demand.
+    remote = tmp_path / "remote"
+    rf = remote_file(remote, 7)
+    rf.parent.mkdir(parents=True)
+    rf.write_text("remote-only")
+
+    store = _make_store(tmp_path, LocalTransport(str(remote)))
+    ds = Dataset(7)
+
+    assert store.exists(ds)
+    fname = store.get_filename(ds)
+    # It returns the cache path, not the remote path...
+    assert fname.startswith(str(tmp_path / "cache"))
+    # ...populated from the transport.
+    with open(fname) as fh:
+        assert fh.read() == "remote-only"

--- a/test/unit/objectstore/test_delegating_objectstore.py
+++ b/test/unit/objectstore/test_delegating_objectstore.py
@@ -19,7 +19,7 @@ cloud credentials are needed. See doc/source/dev/objectstore_filesource_unificat
 
 import shutil
 
-from fsspec.implementations.memory import MemoryFileSystem
+import pytest
 
 from galaxy.objectstore._transport import (
     FilesSourceTransport,
@@ -27,7 +27,15 @@ from galaxy.objectstore._transport import (
 )
 from galaxy.objectstore.delegating import DelegatingObjectStore
 from galaxy.objectstore.unittest_utils import MockConfig
-from ._unification_utils import (
+
+# These tests exercise the object store <-> FilesSource integration, so they need galaxy-files
+# and fsspec. Skip cleanly when the objectstore package is tested in isolation without them.
+pytest.importorskip("fsspec")
+pytest.importorskip("galaxy.files")
+
+from fsspec.implementations.memory import MemoryFileSystem  # noqa: E402  (after importorskip)
+
+from ._unification_utils import (  # noqa: E402  (after importorskip)
     assert_object_store_round_trip,
     Dataset,
     key,

--- a/test/unit/objectstore/test_source_objectstore.py
+++ b/test/unit/objectstore/test_source_objectstore.py
@@ -1,0 +1,199 @@
+"""Stage 2 of the ObjectStore/FilesSource unification -- the collapse.
+
+``SourceObjectStore`` owns a FilesSource and resolves ``get_filename`` via the source's
+``get_local_path``. The same class serves both roles:
+
+- backed by a ``PosixFilesSource`` it is the ``DiskObjectStore`` -- ``get_filename`` returns
+  the real backing file (zero copy), no object-store cache;
+- backed by a ``CachingFilesSource`` (wrapping an fsspec source) it is the ``S3ObjectStore``
+  -- ``get_filename`` returns a cache path populated on demand.
+
+The "disk role" tests below assert parity with the canonical ``DiskObjectStore`` contract
+(dataset round-trip, ``store_by=uuid``, ``alt_name``, job-work directories, usage %). See
+doc/source/dev/objectstore_filesource_unification.md.
+"""
+
+import os
+
+from fsspec.implementations.memory import MemoryFileSystem
+
+from galaxy.objectstore import build_object_store_from_config
+from galaxy.objectstore._caching_source import CachingFilesSource
+from galaxy.objectstore.source_store import SourceObjectStore
+from galaxy.objectstore.unittest_utils import MockConfig
+from galaxy.util import directory_hash_id
+from ._unification_utils import (
+    assert_object_store_round_trip,
+    Dataset,
+    key,
+    memory_files_source,
+    posix_files_source,
+    remote_file,
+)
+
+
+def _config(tmp_path, **overrides):
+    config = MockConfig(str(tmp_path), "unused.yaml", store_by=overrides.pop("store_by", "id"))
+    for attr, value in overrides.items():
+        setattr(config, attr, value)
+    return config
+
+
+def _make_store(tmp_path, source, **config_overrides):
+    return SourceObjectStore(_config(tmp_path, **config_overrides), {}, source)
+
+
+# --- disk role (posix-backed) ---
+
+
+def test_disk_role_round_trip_posix(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = _make_store(tmp_path, posix_files_source(remote))
+    assert_object_store_round_trip(
+        store,
+        tmp_path,
+        remote_content=lambda i: remote_file(remote, i).read_text(),
+        remote_exists=lambda i: remote_file(remote, i).exists(),
+    )
+
+
+def test_disk_role_get_filename_is_zero_copy(tmp_path):
+    # Backed by posix, get_filename returns the REAL backing file, not a copy.
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = _make_store(tmp_path, posix_files_source(remote))
+    ds = Dataset(9)
+    src = tmp_path / "s"
+    src.write_text("data")
+    store.update_from_file(ds, file_name=str(src), create=True)
+
+    assert store.get_filename(ds) == str(remote_file(remote, 9))
+
+
+def test_disk_role_store_by_uuid(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = _make_store(tmp_path, posix_files_source(remote), store_by="uuid")
+    ds = Dataset(3)
+    src = tmp_path / "s"
+    src.write_text("hi")
+    store.update_from_file(ds, file_name=str(src), create=True)
+
+    assert store.exists(ds)
+    assert store.size(ds) == 2
+    rel = os.path.join(*directory_hash_id(ds.uuid), f"dataset_{ds.uuid}.dat")
+    assert (remote / rel).read_text() == "hi"
+
+
+def test_disk_role_alt_name(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = _make_store(tmp_path, posix_files_source(remote))
+    ds = Dataset(3)
+    src = tmp_path / "s"
+    src.write_text("alt")
+    store.update_from_file(ds, file_name=str(src), create=True, alt_name="custom.txt")
+
+    assert store.exists(ds, alt_name="custom.txt")
+    fname = store.get_filename(ds, alt_name="custom.txt")
+    assert fname.endswith("custom.txt")
+    with open(fname) as fh:
+        assert fh.read() == "alt"
+
+
+def test_disk_role_store_usage_percent(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    store = _make_store(tmp_path, posix_files_source(remote))
+    pct = store.get_store_usage_percent()
+    assert 0.0 < pct < 100.0
+
+
+def test_disk_role_job_work_directory(tmp_path):
+    # job_work / temp are always-local scratch dirs, independent of the dataset source.
+    remote = tmp_path / "datasets"
+    remote.mkdir()
+    jobs = tmp_path / "jobs"
+    jobs.mkdir()
+    store = _make_store(tmp_path, posix_files_source(remote), jobs_directory=str(jobs))
+    job = Dataset(42)
+
+    jw_kwargs = dict(base_dir="job_work", dir_only=True, obj_dir=True)
+    assert not store.exists(job, **jw_kwargs)
+
+    store.create(job, **jw_kwargs)
+    assert store.exists(job, **jw_kwargs)
+
+    work_dir = store.get_filename(job, **jw_kwargs)
+    assert work_dir.startswith(str(jobs))  # local, not the dataset source
+    assert os.path.isdir(work_dir)
+
+    assert store.delete(job, entire_dir=True, **jw_kwargs)
+    assert not store.exists(job, **jw_kwargs)
+
+
+# --- cloud role (caching-source-backed) ---
+
+
+def test_cloud_role_round_trip_caching_memory(clean_memory_fs, tmp_path):
+    source = CachingFilesSource(memory_files_source(), staging_path=str(tmp_path / "srccache"))
+    store = _make_store(tmp_path, source)
+    assert_object_store_round_trip(
+        store,
+        tmp_path,
+        remote_content=lambda i: MemoryFileSystem().cat(key(i)).decode(),
+        remote_exists=lambda i: MemoryFileSystem().exists(key(i)),
+    )
+
+
+def test_cloud_role_get_filename_is_cache_path(clean_memory_fs, tmp_path):
+    # Backed by a caching source, get_filename returns a cache path (not a backing path).
+    cache = tmp_path / "srccache"
+    source = CachingFilesSource(memory_files_source(), staging_path=str(cache))
+    store = _make_store(tmp_path, source)
+    ds = Dataset(9)
+    src = tmp_path / "s"
+    src.write_text("data")
+    store.update_from_file(ds, file_name=str(src), create=True)
+
+    fname = store.get_filename(ds)
+    assert fname.startswith(str(cache))
+    with open(fname) as fh:
+        assert fh.read() == "data"
+
+
+# --- built from config (build_object_store_from_config) ---
+
+
+def test_build_from_config_posix_disk_role(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    config_dict = {
+        "type": "source",
+        "files_source": {"type": "posix", "root": str(remote), "writable": True},
+    }
+    store = build_object_store_from_config(_config(tmp_path), config_dict=config_dict)
+    assert isinstance(store, SourceObjectStore)
+    assert_object_store_round_trip(
+        store,
+        tmp_path,
+        remote_content=lambda i: remote_file(remote, i).read_text(),
+        remote_exists=lambda i: remote_file(remote, i).exists(),
+    )
+
+
+def test_build_from_config_caching_cloud_role(clean_memory_fs, tmp_path):
+    config_dict = {
+        "type": "source",
+        "files_source": {"type": "memory", "writable": True},
+        "cache": {"path": str(tmp_path / "cache")},
+    }
+    store = build_object_store_from_config(_config(tmp_path), config_dict=config_dict)
+    assert isinstance(store, SourceObjectStore)
+    assert_object_store_round_trip(
+        store,
+        tmp_path,
+        remote_content=lambda i: MemoryFileSystem().cat(key(i)).decode(),
+        remote_exists=lambda i: MemoryFileSystem().exists(key(i)),
+    )

--- a/test/unit/objectstore/test_source_objectstore.py
+++ b/test/unit/objectstore/test_source_objectstore.py
@@ -15,14 +15,22 @@ doc/source/dev/objectstore_filesource_unification.md.
 
 import os
 
-from fsspec.implementations.memory import MemoryFileSystem
+import pytest
 
 from galaxy.objectstore import build_object_store_from_config
 from galaxy.objectstore._caching_source import CachingFilesSource
 from galaxy.objectstore.source_store import SourceObjectStore
 from galaxy.objectstore.unittest_utils import MockConfig
 from galaxy.util import directory_hash_id
-from ._unification_utils import (
+
+# These tests exercise the object store <-> FilesSource integration, so they need galaxy-files
+# and fsspec. Skip cleanly when the objectstore package is tested in isolation without them.
+pytest.importorskip("fsspec")
+pytest.importorskip("galaxy.files")
+
+from fsspec.implementations.memory import MemoryFileSystem  # noqa: E402  (after importorskip)
+
+from ._unification_utils import (  # noqa: E402  (after importorskip)
     assert_object_store_round_trip,
     Dataset,
     key,


### PR DESCRIPTION
**RFC / prototype — opening as a draft to share the design and a working proof-of-concept for discussion.**

## What & why

Galaxy maintains two storage abstractions that have grown independently and now **re-implement the same backend adapter per cloud**: S3 exists as both `objectstore/s3_boto3.py` (boto3) and `files/sources/s3fs.py` (fsspec), and the same duplication holds for Azure, GCS, and iRODS. Each cloud is maintained, tested, and credential-configured in two places.

This introduces a **shared whole-file transport** that both abstractions sit on top of, **without merging the two domain contracts** — they encode genuinely different intents (the object store owns dataset bytes, is quota-bearing and cache-backed and must hand out a real local seekable path; a file source is a user-facing, browse/auth-heavy reach-out to foreign storage). The key result: a single object store class backed by a `FilesSource` — a posix source gives the `DiskObjectStore` role (zero-copy `get_filename`), a cache-wrapped remote source gives the `S3ObjectStore` role — so the disk special-case disappears.

Put differently, the idea it to make the relationship compositional. An ObjectStore's transport layer is delegated to a FileSource, so that each abstraction has a well-defined responsibility. Section 3.5 Reimplementation sketch: `DiskObjectStore` and 3.6 Reimplementation sketch: `S3ObjectStore` in `objectstore_filesource_unification.md` are illustrative sketches.

Full design rationale (including the "the seam already exists inside `CachingConcreteObjectStore`" analysis and the staged rollout) is in `doc/source/dev/objectstore_filesource_unification.md`.

## What's implemented

- **FilesSource contract additions** — `exists` / `size` / `remove` (posix native, fsspec base-class defaults so every fsspec source inherits them), `get_local_path` (posix zero-copy "source owns the path" resolve, kept distinct from `realize_to`), and an optional `usage_percent`.
- **`SourceObjectStore`** — owns a `FilesSource` and resolves `get_filename` via `get_local_path`; handles addressing, `store_by`, `alt_name` (with `safe_relpath`), and always-local `base_dir` (`job_work`/`temp`) routing. Verified against the `DiskObjectStore` behavioral contract.
- **`CachingFilesSource`** + a single **`CacheArea`**, now shared by `CachingConcreteObjectStore` and the new source wrapper (one cache implementation instead of two).
- **`DelegatingObjectStore`** + `ObjectStoreTransport` / `FilesSourceTransport` — the narrow transport seam (Stage 1).
- **`type: source`** wired into `build_object_store_from_config`; the source is built from a `files_source` plugin block with an optional `cache` wrapper. This is intended as the *safe adoption path*: opt in per store via config, with no rewrite of the existing stores.

## Deferred (see doc §8)

The battle-tested `DiskObjectStore` / `S3ObjectStore` are **not** rewritten in place, and the duplicated cloud adapters are **not** yet deleted — that cutover should be gated by the full integration/e2e suite (and `moto` for S3). Also deferred: `dir_only` dataset create (composite / extra-files dirs), the `object_store_check_old_style` backward-compat path, presigned `get_object_url` for the cloud role, relocating the cache primitives into `galaxy.files`, and an s3fs-behind-`moto` integration test.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

New unit tests under `test/unit/objectstore/` exercise both roles via local, posix, and fsspec (memory) sources, plus `DiskObjectStore` parity (dataset lifecycle, `store_by=uuid`, `alt_name`, usage %, job-work dirs) and construction through `build_object_store_from_config`.

CI note: the substantive suites (Unit, Unit w/postgres, tool/workflow framework, toolshed, playwright), linting and docs all pass. The one red **Test Galaxy packages** job is a **pre-existing, unrelated** failure — the `web_apps` package cannot collect `lib/galaxy/webapps/galaxy/api/mcp.py` due to a missing transitive `uncalled_for` (pulled by `fastmcp`); this branch only *unmasked* it by fixing an earlier objectstore-package collection error.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
