### PR TITLE
[26.0] Use requests rather than urllib for Invenio authenticated downloads

### DIFF
--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -368,7 +368,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
             ) as response:
                 response.raise_for_status()
                 with open(file_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=8192):
+                    for chunk in response.iter_content(chunk_size=2**20):
                         if chunk:
                             f.write(chunk)
         except requests.exceptions.HTTPError as e:

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -1,14 +1,12 @@
 import datetime
 import json
 import re
-import urllib.request
 from typing import (
     Any,
     cast,
     Literal,
     Optional,
 )
-from urllib.error import HTTPError
 from urllib.parse import quote
 
 from typing_extensions import (
@@ -38,9 +36,7 @@ from galaxy.files.sources._rdm import (
 )
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
-    get_charset_from_http_headers,
     requests,
-    stream_to_open_named_file,
 )
 
 AccessStatus = Literal["public", "restricted"]
@@ -367,17 +363,20 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
             # pass the token as a header only when using the API
             headers = self._get_request_headers(context)
         try:
-            req = urllib.request.Request(download_file_content_url, headers=headers)
-            with urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT) as page:
-                f = open(file_path, "wb")
-                return stream_to_open_named_file(
-                    page, f.fileno(), file_path, source_encoding=get_charset_from_http_headers(page.headers)
-                )
-        except HTTPError as e:
-            if e.code in [401, 403, 404]:
+            response = requests.get(
+                download_file_content_url, headers=headers, stream=True, timeout=DEFAULT_SOCKET_TIMEOUT
+            )
+            response.raise_for_status()
+            with open(file_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code in [401, 403, 404]:
                 raise Exception(
                     f"Cannot download file '{file_identifier}' from record '{container_id}'. Please make sure the record exists and you have access to it."
                 )
+            raise
 
     def _get_download_file_url(
         self, record_id: str, filename: str, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -363,14 +363,14 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
             # pass the token as a header only when using the API
             headers = self._get_request_headers(context)
         try:
-            response = requests.get(
+            with requests.get(
                 download_file_content_url, headers=headers, stream=True, timeout=DEFAULT_SOCKET_TIMEOUT
-            )
-            response.raise_for_status()
-            with open(file_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        f.write(chunk)
+            ) as response:
+                response.raise_for_status()
+                with open(file_path, "wb") as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code in [401, 403, 404]:
                 raise Exception(


### PR DESCRIPTION
Importing files from invenio repositories from authenticated paths was not working for our invenio instances that return redirects to presigned S3 buckets (which invenio natively supports but is a matter of instance configuration).

The likely issue was that urllib.request.urlopen has limited HTTP/2 support and may not properly handle cross-origin redirects (from test1.datarepo.du.cesnet.cz to s3.nrp1.du.cesnet.cz).When the redirect failed or wasn't followed correctly, the result was an empty file (and empty green dataset in Galaxy).

Published records worked because they use a different endpoint (/records/{id}/files/{filename}/content?download=1) which doesn't require authentication and may be handled differently by the server.

**Fix:** Switch from urllib.request to the requests library, which has robust HTTP/2 support and properly handles cross-origin redirects while preserving authentication headers for the initial request.



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. connect Galaxy to invenio instance that returns authenticated download requests as redirects to presigned s3 buckets
  2. create a draft record, upload a file to it
  3. attempt importing mentioned file from galaxy upload activity
  4. observe the size of the dataset is non-zero

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
