### PR TITLE
Store data-manager bundle paths relative to the extra-files dir

### DIFF
--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -55,6 +55,7 @@ from ._schema import (
 from .bundles.models import (
     DataTableBundle,
     DataTableBundleProcessorDescription,
+    get_path_headers,
     RepoInfo,
 )
 
@@ -1349,7 +1350,9 @@ class ToolDataTableManager(Dictifiable):
                 continue
 
             extra_files_path = dataset.extra_files_path
-            _relativize_bundle_data_table_paths(data_manager_dict.get("data_tables", {}), extra_files_path)
+            _relativize_bundle_data_table_paths(
+                data_manager_dict.get("data_tables", {}), extra_files_path, bundle_description
+            )
             bundle = DataTableBundle(
                 data_tables=data_manager_dict.get("data_tables", {}),
                 output_name=output_name,
@@ -1390,8 +1393,12 @@ def _iter_bundle_rows(data_table_values: Any) -> Iterator[dict[str, Any]]:
         yield from (row for row in data_table_values if isinstance(row, dict))
 
 
-def _relativize_bundle_data_table_paths(data_tables: dict[str, Any], extra_files_path: str) -> None:
-    """Rewrite absolute ``path`` values under ``extra_files_path`` to be relative to it.
+def _relativize_bundle_data_table_paths(
+    data_tables: dict[str, Any],
+    extra_files_path: str,
+    bundle_description: DataTableBundleProcessorDescription,
+) -> None:
+    """Rewrite absolute path values under ``extra_files_path`` to be relative to it.
 
     Some data managers record the absolute path inside the (transient) job
     directory (e.g. MetaPhlAn's ``$out_file.extra_files_path/$index``) rather
@@ -1399,13 +1406,15 @@ def _relativize_bundle_data_table_paths(data_tables: dict[str, Any], extra_files
     the bundle is staged elsewhere, so imports and chained data managers fail.
     Paths already relative, or outside ``extra_files_path``, are left untouched.
     """
-    for data_table_values in data_tables.values():
+    for data_table_name, data_table_values in data_tables.items():
+        path_headers = get_path_headers(bundle_description, data_table_name)
         for row in _iter_bundle_rows(data_table_values):
-            path = row.get("path")
-            if path and os.path.isabs(path):
-                rel = os.path.relpath(path, extra_files_path)
-                if rel != os.pardir and not rel.startswith(os.pardir + os.sep):
-                    row["path"] = rel
+            for header in path_headers:
+                path = row.get(header)
+                if path and os.path.isabs(path):
+                    rel = os.path.relpath(path, extra_files_path)
+                    if rel != os.pardir and not rel.startswith(os.pardir + os.sep):
+                        row[header] = rel
 
 
 def _data_manager_dict(out_data: dict[str, OutputDataset], ensure_single_output: bool = False) -> dict[str, Any]:
@@ -1520,15 +1529,15 @@ def _process_bundle(
         for ref_file in out_data.values():
             if ref_file.extra_files_path_exists():
                 util.move_merge(ref_file.extra_files_path, options.data_manager_path)
-        path_column_names = ["path"]
         for data_table_name, data_table_values in data_tables_dict.items():
+            path_headers = get_path_headers(bundle_description, data_table_name)
             data_table = tool_data_tables.get(data_table_name, None)
             if not isinstance(data_table_values, list):
                 data_table_values = [data_table_values]
             for data_table_row in data_table_values:
                 data_table_value = dict(**data_table_row)  # keep original values here
                 for name, value in data_table_row.items():
-                    if name in path_column_names:
+                    if name in path_headers:
                         data_table_value[name] = os.path.abspath(os.path.join(options.data_manager_path, value))
                 data_table.add_entry(
                     data_table_value,

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -1348,13 +1348,14 @@ class ToolDataTableManager(Dictifiable):
             if dataset.ext != "data_manager_json":
                 continue
 
+            extra_files_path = dataset.extra_files_path
+            _relativize_bundle_data_table_paths(data_manager_dict.get("data_tables", {}), extra_files_path)
             bundle = DataTableBundle(
                 data_tables=data_manager_dict.get("data_tables", {}),
                 output_name=output_name,
                 processor_description=bundle_description,
                 repo_info=repo_info,
             )
-            extra_files_path = dataset.extra_files_path
             bundle_path = os.path.join(extra_files_path, BUNDLE_INDEX_FILE_NAME)
             with open(bundle_path, "w") as fw:
                 fw.write(bundle.model_dump_json())
@@ -1371,6 +1372,40 @@ class BundleProcessingOptions:
     data_manager_path: str
     target_config_file: str
     tool_data_file_path: str | None = None
+
+
+def _iter_bundle_rows(data_table_values: Any) -> Iterator[dict[str, Any]]:
+    """Yield row dicts from a data-table value (list, single dict, or add/remove wrapper)."""
+    if isinstance(data_table_values, dict):
+        if "add" in data_table_values or "remove" in data_table_values:
+            for section in ("add", "remove"):
+                rows = data_table_values.get(section)
+                if isinstance(rows, list):
+                    yield from (row for row in rows if isinstance(row, dict))
+                elif isinstance(rows, dict):
+                    yield rows
+            return
+        yield data_table_values
+    elif isinstance(data_table_values, list):
+        yield from (row for row in data_table_values if isinstance(row, dict))
+
+
+def _relativize_bundle_data_table_paths(data_tables: dict[str, Any], extra_files_path: str) -> None:
+    """Rewrite absolute ``path`` values under ``extra_files_path`` to be relative to it.
+
+    Some data managers record the absolute path inside the (transient) job
+    directory (e.g. MetaPhlAn's ``$out_file.extra_files_path/$index``) rather
+    than the expected relative path; that absolute path no longer resolves once
+    the bundle is staged elsewhere, so imports and chained data managers fail.
+    Paths already relative, or outside ``extra_files_path``, are left untouched.
+    """
+    for data_table_values in data_tables.values():
+        for row in _iter_bundle_rows(data_table_values):
+            path = row.get("path")
+            if path and os.path.isabs(path):
+                rel = os.path.relpath(path, extra_files_path)
+                if rel != os.pardir and not rel.startswith(os.pardir + os.sep):
+                    row["path"] = rel
 
 
 def _data_manager_dict(out_data: dict[str, OutputDataset], ensure_single_output: bool = False) -> dict[str, Any]:

--- a/lib/galaxy/tool_util/data/bundles/models.py
+++ b/lib/galaxy/tool_util/data/bundles/models.py
@@ -18,6 +18,9 @@ from galaxy.util import (
 DEFAULT_VALUE_TRANSLATION_TYPE = "template"
 VALUE_TRANSLATION_FUNCTIONS: dict[str, Callable] = dict(abspath=os.path.abspath)
 DEFAULT_VALUE_TRANSLATION_TYPE = "template"
+# Column header assumed to hold a filesystem path when a data table declares no
+# structure to derive it from (e.g. undeclared tables). See ``get_path_headers``.
+DEFAULT_PATH_HEADER = "path"
 
 
 class DataTableBundleProcessorDataTableOutputColumnTranslation(BaseModel):
@@ -134,6 +137,43 @@ class DataTableBundleProcessorDescription(BaseModel):
                     value_translation = value_translation_str
                 by_column[data_table_name][data_table_column_name].append(value_translation)
         return by_column
+
+    @property
+    def path_headers_by_data_table(self) -> dict[str, set[str]]:
+        """Columns that hold a filesystem path, keyed by data table.
+
+        A column holds a path when the data manager relocates it with a ``<move>``
+        or resolves it with the ``abspath`` value translation. Prefer this over
+        assuming the column is literally named ``path``; see ``get_path_headers``.
+        """
+        headers: dict[str, set[str]] = {}
+        moves = self.move_by_data_table_column
+        translations = self.value_translation_by_data_table_column
+        for data_table_name, column in self._walk_columns():
+            column_name = column.data_table_name
+            is_path = column_name in moves.get(data_table_name, {}) or (
+                os.path.abspath in translations.get(data_table_name, {}).get(column_name, [])
+            )
+            if is_path:
+                headers.setdefault(data_table_name, set()).add(column_name)
+        return headers
+
+
+def get_path_headers(
+    bundle_description: DataTableBundleProcessorDescription | None,
+    data_table_name: str,
+) -> set[str]:
+    """Return the columns to treat as filesystem paths for ``data_table_name``.
+
+    Prefers columns the processor description marks as paths; falls back to the
+    ``path`` naming convention when the table declares none (undeclared tables,
+    or a consumer without the description at hand).
+    """
+    if bundle_description is not None:
+        headers = bundle_description.path_headers_by_data_table.get(data_table_name)
+        if headers:
+            return headers
+    return {DEFAULT_PATH_HEADER}
 
 
 class RepoInfo(BaseModel):

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -27,6 +27,7 @@ from galaxy.model import (
     User,
 )
 from galaxy.model.dataset_collections.adapters import CollectionAdapter
+from galaxy.tool_util.data.bundles.models import get_path_headers
 from galaxy.tools.expressions import do_eval
 from galaxy.tools.parameters.options import ParameterOption
 from galaxy.tools.parameters.workflow_utils import (
@@ -894,14 +895,17 @@ class DynamicOptions:
 
     @staticmethod
     def hda_to_table_entries(hda, table_name):
+        # No processor description at hand here, so path columns fall back to the naming convention.
+        path_headers = get_path_headers(None, table_name)
         table_entries = {}
         for value in hda._metadata["data_tables"][table_name]:
             if dbkey := value.get("dbkey"):
                 table_entries[dbkey] = value
-            if path := value.get("path"):
-                # maybe a hack, should probably pass around dataset or src id combinations ?
-                value["path"] = os.path.join(hda.extra_files_path, path)
-                value["__hda__"] = hda
+            for header in path_headers:
+                if path := value.get(header):
+                    # maybe a hack, should probably pass around dataset or src id combinations ?
+                    value[header] = os.path.join(hda.extra_files_path, path)
+                    value["__hda__"] = hda
         return table_entries
 
     def get_option_from_dataset(self, dataset):

--- a/test/unit/tool_util/data/conftest.py
+++ b/test/unit/tool_util/data/conftest.py
@@ -23,6 +23,10 @@ TOOL_DATA_TABLE_CONF_XML = """<tables>
     <columns>value, name, path</columns>
     <file path="${__HERE__}/testalpha.loc" />
   </table>
+  <table name="testcat" comment_char="#">
+    <columns>value, name, database_folder</columns>
+    <file path="${__HERE__}/testcat.loc" />
+  </table>
 </tables>
 """
 
@@ -66,6 +70,9 @@ def merged_tdt_manager(tmp_path) -> ToolDataTableManager:
 def _write_loc_files(tmp_path):
     loc1 = tmp_path / "testalpha.loc"
     loc1.write_text(LOC_ALPHA_CONTENTS)
+
+    loc_cat = tmp_path / "testcat.loc"
+    loc_cat.write_text("")
 
     loc2 = tmp_path / "testbeta1.loc"
     loc2.write_text(LOC_BETA_CONTENTS_1)

--- a/test/unit/tool_util/data/test_tool_data_bundles.py
+++ b/test/unit/tool_util/data/test_tool_data_bundles.py
@@ -3,6 +3,8 @@ import json
 import os
 from dataclasses import dataclass
 
+import pytest
+
 from galaxy.tool_util.data import (
     BUNDLE_INDEX_FILE_NAME,
     BundleProcessingOptions,
@@ -10,6 +12,7 @@ from galaxy.tool_util.data import (
 from galaxy.tool_util.data.bundles.models import (
     convert_data_tables_xml,
     DataTableBundleProcessorDescription,
+    get_path_headers,
 )
 from galaxy.util import (
     galaxy_directory,
@@ -210,8 +213,13 @@ def test_import_bundle(tdt_manager, tmp_path):
     assert new_row[2] == str(tmp_path / "testalpha" / "newvalue" / "newvalue.txt")
 
 
-def prepare_absolute_path_output_and_description(tmp_path):
-    """Mirror MetaPhlAn: an absolute recorded ``path`` with a ``${path}`` move source."""
+def prepare_absolute_path_output_and_description(tmp_path, table_name="testalpha", path_column="path"):
+    """Mirror a data manager recording an absolute path with a ``${column}`` move source.
+
+    ``path_column`` defaults to the conventional ``path`` (as MetaPhlAn uses); pass
+    another name (e.g. CAT's ``database_folder``) to model a data manager whose path
+    column is not literally called ``path``.
+    """
     index = "mpa_toy"
     extra_files_path = tmp_path / "extra"
     staged = extra_files_path / index
@@ -220,25 +228,25 @@ def prepare_absolute_path_output_and_description(tmp_path):
 
     # Absolute path, as MetaPhlAn records it (points inside extra_files_path).
     recorded_path = str(staged)
-    output = {"data_tables": {"testalpha": [{"value": index, "name": "toy", "path": recorded_path}]}}
+    output = {"data_tables": {table_name: [{"value": index, "name": "toy", path_column: recorded_path}]}}
     output_dataset_path = tmp_path / "output.dat"
     output_dataset_path.write_text(json.dumps(output))
     output_dataset = OutputDataset(output_dataset_path, extra_files_path)
     out_data = {"out1": output_dataset}
     data_table = {
-        "name": "testalpha",
+        "name": table_name,
         "output": {
             "columns": [
                 {"name": "value"},
                 {"name": "name"},
                 {
-                    "name": "path",
+                    "name": path_column,
                     "output_ref": "out1",
                     "moves": [
                         {
                             "type": "directory",
                             "relativize_symlinks": False,
-                            "source_value": "${path}",
+                            "source_value": "${" + path_column + "}",
                             "target_value": "metaphlan/data/${value}",
                             "target_base": "${GALAXY_DATA_MANAGER_DATA_PATH}",
                         }
@@ -257,27 +265,31 @@ def prepare_absolute_path_output_and_description(tmp_path):
     return index, out_data, process_description
 
 
-def test_write_bundle_relativizes_absolute_path(tdt_manager, tmp_path):
-    index, out_data, process_description = prepare_absolute_path_output_and_description(tmp_path)
-    tdt_manager.write_bundle(out_data, process_description, repo_info=None)
+@pytest.mark.parametrize(
+    ("table_name", "path_column"),
+    [
+        ("testalpha", "path"),  # the conventional column, à la MetaPhlAn
+        ("testcat", "database_folder"),  # a differently-named path column, à la CAT
+    ],
+)
+def test_import_bundle_with_absolute_recorded_path(tdt_manager, tmp_path, table_name, path_column):
+    """Write must relativize, and import must stage, an absolute recorded path.
 
-    bundle_index_json_path = tmp_path / "extra" / BUNDLE_INDEX_FILE_NAME
-    with open(bundle_index_json_path) as f:
-        bundle_index = json.load(f)
-    stored_path = bundle_index["data_tables"]["testalpha"][0]["path"]
-    # The absolute job path is stored relative to the extra-files dir.
+    Covers both the conventional ``path`` column and a differently-named one, so a
+    ``path``-only assumption anywhere in the write/import wiring is caught. Renaming
+    the extra-files dir before import models transport to another host, where the
+    recorded absolute job dir no longer exists.
+    """
+    index, out_data, process_description = prepare_absolute_path_output_and_description(
+        tmp_path, table_name=table_name, path_column=path_column
+    )
+    tdt_manager.write_bundle(out_data, process_description, None)
+
+    # Write stored the absolute job path relative to the extra-files dir.
+    bundle_index = json.loads((tmp_path / "extra" / BUNDLE_INDEX_FILE_NAME).read_text())
+    stored_path = bundle_index["data_tables"][table_name][0][path_column]
     assert stored_path == index
     assert not os.path.isabs(stored_path)
-
-
-def test_import_bundle_with_absolute_recorded_path(tdt_manager, tmp_path):
-    """Import must stage the files even when the data manager recorded an absolute path.
-
-    Renaming the extra-files dir before import models transport to another host,
-    where the recorded absolute job dir no longer exists.
-    """
-    index, out_data, process_description = prepare_absolute_path_output_and_description(tmp_path)
-    tdt_manager.write_bundle(out_data, process_description, None)
 
     # Transport the bundle: the location it was written at is gone by import.
     transported = tmp_path / "imported"
@@ -290,11 +302,44 @@ def test_import_bundle_with_absolute_recorded_path(tdt_manager, tmp_path):
     )
     tdt_manager.import_bundle(str(transported), options)
 
-    new_row = _last_row(tmp_path / "testalpha.loc")
+    new_row = _last_row(tmp_path / f"{table_name}.loc")
     assert new_row[0] == index
     loc_target = new_row[-1]
     # The DB files were actually moved to where the loc entry points.
     assert os.path.exists(os.path.join(loc_target, f"{index}.pkl"))
+
+
+def test_path_headers_from_move_and_abspath():
+    """A column is a path column when it has a move or an abspath translation, whatever its name."""
+    description = DataTableBundleProcessorDescription(
+        undeclared_tables=False,
+        data_tables=[
+            {
+                "name": "t",
+                "output": {
+                    "columns": [
+                        {"name": "value"},
+                        {"name": "path", "moves": [{"type": "directory", "relativize_symlinks": False}]},
+                        {"name": "index_path", "value_translations": [{"type": "function", "value": "abspath"}]},
+                        # An output_ref alone does not make a column a path.
+                        {"name": "reference", "output_ref": "out1"},
+                    ]
+                },
+            }
+        ],
+    )
+    assert description.path_headers_by_data_table == {"t": {"path", "index_path"}}
+    assert get_path_headers(description, "t") == {"path", "index_path"}
+
+
+def test_get_path_headers_falls_back_to_convention():
+    """Without a declared path column (undeclared tables, or no description) use the ``path`` convention."""
+    assert get_path_headers(None, "t") == {"path"}
+    description = DataTableBundleProcessorDescription(
+        undeclared_tables=False,
+        data_tables=[{"name": "t", "output": {"columns": [{"name": "value"}]}}],
+    )
+    assert get_path_headers(description, "t") == {"path"}
 
 
 def test_undeclared_tables(tdt_manager, tmp_path):

--- a/test/unit/tool_util/data/test_tool_data_bundles.py
+++ b/test/unit/tool_util/data/test_tool_data_bundles.py
@@ -210,6 +210,93 @@ def test_import_bundle(tdt_manager, tmp_path):
     assert new_row[2] == str(tmp_path / "testalpha" / "newvalue" / "newvalue.txt")
 
 
+def prepare_absolute_path_output_and_description(tmp_path):
+    """Mirror MetaPhlAn: an absolute recorded ``path`` with a ``${path}`` move source."""
+    index = "mpa_toy"
+    extra_files_path = tmp_path / "extra"
+    staged = extra_files_path / index
+    staged.mkdir(parents=True)
+    (staged / f"{index}.pkl").write_text("PICKLE")
+
+    # Absolute path, as MetaPhlAn records it (points inside extra_files_path).
+    recorded_path = str(staged)
+    output = {"data_tables": {"testalpha": [{"value": index, "name": "toy", "path": recorded_path}]}}
+    output_dataset_path = tmp_path / "output.dat"
+    output_dataset_path.write_text(json.dumps(output))
+    output_dataset = OutputDataset(output_dataset_path, extra_files_path)
+    out_data = {"out1": output_dataset}
+    data_table = {
+        "name": "testalpha",
+        "output": {
+            "columns": [
+                {"name": "value"},
+                {"name": "name"},
+                {
+                    "name": "path",
+                    "output_ref": "out1",
+                    "moves": [
+                        {
+                            "type": "directory",
+                            "relativize_symlinks": False,
+                            "source_value": "${path}",
+                            "target_value": "metaphlan/data/${value}",
+                            "target_base": "${GALAXY_DATA_MANAGER_DATA_PATH}",
+                        }
+                    ],
+                    "value_translations": [
+                        {"value": "${GALAXY_DATA_MANAGER_DATA_PATH}/metaphlan/data/${value}", "type": "template"},
+                        {"value": "abspath", "type": "function"},
+                    ],
+                },
+            ]
+        },
+    }
+    process_description = DataTableBundleProcessorDescription(
+        **{"undeclared_tables": False, "data_tables": [data_table]}
+    )
+    return index, out_data, process_description
+
+
+def test_write_bundle_relativizes_absolute_path(tdt_manager, tmp_path):
+    index, out_data, process_description = prepare_absolute_path_output_and_description(tmp_path)
+    tdt_manager.write_bundle(out_data, process_description, repo_info=None)
+
+    bundle_index_json_path = tmp_path / "extra" / BUNDLE_INDEX_FILE_NAME
+    with open(bundle_index_json_path) as f:
+        bundle_index = json.load(f)
+    stored_path = bundle_index["data_tables"]["testalpha"][0]["path"]
+    # The absolute job path is stored relative to the extra-files dir.
+    assert stored_path == index
+    assert not os.path.isabs(stored_path)
+
+
+def test_import_bundle_with_absolute_recorded_path(tdt_manager, tmp_path):
+    """Import must stage the files even when the data manager recorded an absolute path.
+
+    Renaming the extra-files dir before import models transport to another host,
+    where the recorded absolute job dir no longer exists.
+    """
+    index, out_data, process_description = prepare_absolute_path_output_and_description(tmp_path)
+    tdt_manager.write_bundle(out_data, process_description, None)
+
+    # Transport the bundle: the location it was written at is gone by import.
+    transported = tmp_path / "imported"
+    os.rename(tmp_path / "extra", transported)
+
+    options = BundleProcessingOptions(
+        what="data manager 'mock'",
+        data_manager_path=str(tmp_path),
+        target_config_file=str(tmp_path / "sample_data_managers_conf.xml"),
+    )
+    tdt_manager.import_bundle(str(transported), options)
+
+    new_row = _last_row(tmp_path / "testalpha.loc")
+    assert new_row[0] == index
+    loc_target = new_row[-1]
+    # The DB files were actually moved to where the loc entry points.
+    assert os.path.exists(os.path.join(loc_target, f"{index}.pkl"))
+
+
 def test_undeclared_tables(tdt_manager, tmp_path):
     options = BundleProcessingOptions(
         what="data manager 'mock'",


### PR DESCRIPTION
Data managers are expected to record a data-table path relative to their output's extra-files directory, but some record the absolute path inside the transient job working directory -- e.g. the MetaPhlAn database downloader writes "$out_file.extra_files_path/$index". Once the bundle is staged elsewhere that absolute path no longer resolves, which silently breaks both bundle consumers:

  - On import the <move><source>${path}</source> lookup misses (the job directory is gone on the importing host), so the files are never staged, yet a value_translation on another column still writes a plausible-looking .loc entry pointing at an empty directory.
  - A chained downstream data manager is handed the stale path and fails with "No such file".

Relativize any absolute path that lives under the extra-files directory when the bundle is written, so both consumers resolve it against wherever the bundle is later staged. This is the relative-path convention the existing bundle tests already exercise.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
