### PR TITLE
[26.1] Fix Markdown help rendering in tools list

### DIFF
--- a/client/src/components/ToolsList/ToolsListCard.test.ts
+++ b/client/src/components/ToolsList/ToolsListCard.test.ts
@@ -27,6 +27,7 @@ const localVue = getLocalVue();
 function mountCard(options?: {
     currentUser?: any;
     favorites?: { tools: string[]; tags: string[]; edam_operations: string[]; edam_topics: string[] };
+    propsData?: Record<string, unknown>;
 }) {
     const pinia = createTestingPinia({ createSpy: vi.fn });
     setActivePinia(pinia);
@@ -74,12 +75,28 @@ function mountCard(options?: {
                 workflowCompatible: true,
                 local: true,
                 fetching: false,
+                ...options?.propsData,
             },
         }),
     };
 }
 
 describe("ToolsListCard", () => {
+    it("renders Markdown tool help", async () => {
+        const { wrapper } = mountCard({
+            propsData: {
+                help: "**Important** tool help",
+                helpFormat: "markdown",
+            },
+        });
+
+        await wrapper.find('[data-description="tools list toggle tool help"]').trigger("click");
+
+        const help = wrapper.find('[data-description="tools list tool help"]');
+        expect(help.find("strong").text()).toBe("Important");
+        expect(help.text()).not.toContain("**Important**");
+    });
+
     it("renders tool tags and emits an exact tag filter when a tag is clicked", async () => {
         const { wrapper } = mountCard();
 

--- a/client/src/components/ToolsList/ToolsListCard.vue
+++ b/client/src/components/ToolsList/ToolsListCard.vue
@@ -17,7 +17,6 @@ import { BPopover, BSkeleton } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, ref } from "vue";
 
-import { useFormattedToolHelp } from "@/composables/formattedToolHelp";
 import { useToast } from "@/composables/toast";
 import { useToolStore } from "@/stores/toolStore";
 import { useUserStore } from "@/stores/userStore";
@@ -28,6 +27,7 @@ import { useToolsListCardActions } from "./useToolsListCardActions";
 
 import GButton from "../BaseComponents/GButton.vue";
 import GCard from "../Common/GCard.vue";
+import ToolHelp from "../Tool/ToolHelp.vue";
 import GLink from "@/components/BaseComponents/GLink.vue";
 
 type OntologyBadge = {
@@ -45,6 +45,7 @@ interface Props {
     description?: string;
     summary?: string;
     help?: string;
+    helpFormat?: string;
     version?: string;
     link?: string;
     workflowCompatible: boolean;
@@ -61,6 +62,7 @@ const props = withDefaults(defineProps<Props>(), {
     description: undefined,
     summary: undefined,
     help: undefined,
+    helpFormat: "restructuredtext",
     version: undefined,
     link: undefined,
     workflowCompatible: false,
@@ -99,15 +101,6 @@ const edamTopicsBadges = computed(() => getOntologyBadges("ontology:edam_topics"
 
 const showHelp = ref(false);
 const showPopover = ref(false);
-
-const formattedToolHelp = computed(() => {
-    if (showHelp.value) {
-        const { formattedContent } = useFormattedToolHelp(props.help);
-        return formattedContent.value;
-    } else {
-        return "";
-    }
-});
 
 /** We add double quotes to the ontology id filter as well since the backend Whoosh search
  * requires it for exact matches, and the `Filtering` class only does single quotes. */
@@ -396,12 +389,9 @@ const {
                     Hide tool help
                 </GLink>
 
-                <!-- eslint-disable-next-line vue/no-v-html -->
-                <div
-                    v-if="showHelp"
-                    data-description="tools list tool help"
-                    class="mt-2"
-                    v-html="formattedToolHelp"></div>
+                <div v-if="showHelp" data-description="tools list tool help" class="mt-2">
+                    <ToolHelp :content="props.help ?? ''" :format="props.helpFormat" />
+                </div>
             </div>
         </template>
 

--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -81,6 +81,7 @@ const toolsKey = computed(() => `${props.tools.length}-${props.tools[0]?.id}`);
                 :form-style="item.form_style"
                 :summary="helpDataCached[item.id]?.summary"
                 :help="helpDataCached[item.id]?.help"
+                :help-format="helpDataCached[item.id]?.helpFormat"
                 :local="item.target === 'galaxy_main'"
                 :link="item.link"
                 :owner="props.hasOwnerFilter && item.tool_shed_repository ? item.tool_shed_repository.owner : undefined"

--- a/client/src/stores/toolStore.test.ts
+++ b/client/src/stores/toolStore.test.ts
@@ -1,0 +1,39 @@
+import axios from "axios";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useToolStore } from "./toolStore";
+
+vi.mock("axios", () => ({
+    default: {
+        get: vi.fn(),
+    },
+}));
+
+vi.mock("@/components/ToolsList/utilities", () => ({
+    parseHelpForSummary: vi.fn(() => ""),
+}));
+
+describe("toolStore", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        vi.mocked(axios.get).mockReset();
+    });
+
+    it("caches tool help format from the build response", async () => {
+        vi.mocked(axios.get).mockResolvedValue({
+            data: {
+                help: "**Important** tool help",
+                help_format: "markdown",
+            },
+        });
+        const store = useToolStore();
+
+        await store.fetchHelpForId("test-tool");
+
+        expect(store.helpDataCached["test-tool"]).toMatchObject({
+            help: "**Important** tool help",
+            helpFormat: "markdown",
+        });
+    });
+});

--- a/client/src/stores/toolStore.ts
+++ b/client/src/stores/toolStore.ts
@@ -97,7 +97,13 @@ export type ToolPanelItem = Tool | ToolSection | ToolSectionLabel;
 
 export type ToolHelpData = {
     help?: string;
+    helpFormat?: string;
     summary?: string;
+};
+
+type ToolHelpResponse = {
+    help?: string;
+    help_format?: string;
 };
 
 const MY_PANEL_VIEW: Panel = {
@@ -313,9 +319,10 @@ export const useToolStore = defineStore("toolStore", () => {
 
                 const { data } = (await axios.get(
                     `${getAppRoot()}api/tools/${encodeURIComponent(toolId)}/build`,
-                )) as AxiosResponse<ToolHelpData>;
+                )) as AxiosResponse<ToolHelpResponse>;
 
                 const help = data.help;
+                toolHelpData.helpFormat = data.help_format;
                 if (help && help !== "\n") {
                     toolHelpData.help = help;
                     toolHelpData.summary = parseHelpForSummary(help);


### PR DESCRIPTION
Fixes #23086.

The tools list fetched raw tool help from `/api/tools/{id}/build` but discarded `help_format`. Markdown help was consequently treated as pre-rendered HTML and displayed as raw Markdown.

This change:

- preserves `help_format` in the tool help cache;
- passes the format through the tools-list components;
- renders help using the shared `ToolHelp` component;
- adds regression coverage for format caching and Markdown rendering.

| Before | After |
| --- | --- |
|<img width="1310" height="686" alt="fix:tools-list-markdown-help_before" src="https://github.com/user-attachments/assets/1b9843fe-e21b-4221-8c6e-ffe1addb700c" />| <img width="1310" height="686" alt="fix:tools-list-markdown-help_after" src="https://github.com/user-attachments/assets/e99441cb-b8c8-4626-be2c-bb283e64c982" />|

## How to test the changes?

- [x] I've included appropriate automated tests.
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy with a tool containing `<help format="markdown">`.
  2. Open `/tools/list`.
  3. Select **Show tool help**.
  4. Confirm headings, emphasis, lists, and links render as formatted Markdown.

## License

- [x] I agree to license these and all my past contributions to the core Galaxy codebase under the MIT license.