### PR TITLE
[26.1] Update pulsar-galaxy-client dependency to 0.15.15

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -196,7 +196,7 @@ proto-plus==1.28.0
 protobuf==6.33.6
 prov==1.5.1
 psutil==7.2.2
-pulsar-galaxy-lib==0.15.14
+pulsar-galaxy-lib==0.15.15
 py-key-value-aio==0.4.4
 pyasn1==0.6.3
 pyasn1-modules==0.4.2

--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     packaging
     paramiko!=2.9.0,!=2.9.1
     pebble
-    pulsar-galaxy-lib>=0.15.0.dev0
+    pulsar-galaxy-lib>=0.15.15
     pydantic>=2.7.4
     pydantic-ai>=0.1.16
     pysam>=0.21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "pebble",
     "pillow",
     "psutil",
-    "pulsar-galaxy-lib>=0.15.10",
+    "pulsar-galaxy-lib>=0.15.15",
     "pycryptodome",
     "pydantic[email]>=2.7.4",  # https://github.com/pydantic/pydantic/pull/9639
     "pydantic-ai>=1.56.0",  # https://github.com/pydantic/pydantic-ai/security/advisories/GHSA-2jrp-274c-jhv3


### PR DESCRIPTION
This enables various stability enhancements for the galaxy-pulsar interaction (https://github.com/galaxyproject/pulsar/releases/tag/0.15.15)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
