### PR TITLE
[26.1] Add configurable activation for OIDC accounts

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -189,6 +189,7 @@ class AuthnzManager:
             "client_secret": config_xml.find("client_secret").text,
             "redirect_uri": config_xml.find("redirect_uri").text,
             "enable_idp_logout": asbool(config_xml.findtext("enable_idp_logout", "false")),
+            "require_user_activation": asbool(config_xml.findtext("require_user_activation", "false")),
         }
         if config_xml.find("label") is not None:
             rtv["label"] = config_xml.find("label").text

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -13,6 +13,7 @@ from social_core.actions import (
     do_disconnect,
 )
 from social_core.backends.utils import get_backend
+from social_core.pipeline.user import create_user as social_create_user
 from social_core.strategy import BaseStrategy
 from social_core.utils import (
     module_member,
@@ -139,7 +140,7 @@ AUTH_PIPELINE = (
     # redirect to confirmation page instead of creating user immediately.
     "galaxy.authnz.psa_authnz.check_user_creation_confirmation",
     # Create a user account if we haven't found one yet.
-    "social_core.pipeline.user.create_user",
+    "galaxy.authnz.psa_authnz.create_user_and_activate",
     # Create the record that associated the social account with this user.
     "social_core.pipeline.social_auth.associate_user",
     # Populate the extra_data field in the social record with the values
@@ -228,6 +229,7 @@ class PSAAuthnz(IdentityProvider):
 
         # Galaxy-specific pipeline settings (affect all backends)
         self.config["REQUIRE_CREATE_CONFIRMATION"] = oidc_backend_config.get("require_create_confirmation", False)
+        self.config["REQUIRE_USER_ACTIVATION"] = oidc_backend_config.get("require_user_activation", False)
 
         # Optional generic settings
         if oidc_backend_config.get("prompt") is not None:
@@ -540,10 +542,8 @@ class PSAAuthnz(IdentityProvider):
                 count += 1
             username = f"{username}{count}"
 
-        # Create the user
-        user = trans.app.user_manager.create(email=email, username=username)
-        if trans.app.config.user_activation_on:
-            trans.app.user_manager.send_activation_email(trans, email, username)
+        # Create the user and apply the activation policy
+        user = create_and_activate_oidc_user(trans, email, username, self.config["REQUIRE_USER_ACTIVATION"])
 
         # Create the UserAuthnzToken record
         user_id = userinfo.get("sub")
@@ -637,6 +637,64 @@ def on_the_fly_config(sa_session):
     PSANonce.sa_session = sa_session
     PSAPartial.sa_session = sa_session
     PSAAssociation.sa_session = sa_session
+
+
+def create_user_and_activate(strategy=None, details=None, backend=None, user=None, *args, **kwargs):
+    """Pipeline step: let PSA create the user, then apply Galaxy's OIDC activation policy.
+
+    Replaces ``social_core.pipeline.user.create_user`` in ``AUTH_PIPELINE``. The
+    deferred (``require_create_confirmation``) path does not go through the pipeline;
+    it calls :func:`create_and_activate_oidc_user` instead. Both funnel the activation
+    decision through :func:`apply_user_activation_policy`.
+    """
+    result = social_create_user(strategy, details, backend, user, *args, **kwargs)
+    if not result or not result.get("is_new"):
+        return result
+
+    # GALAXY_TRANS is set by callback() before the pipeline runs, and PSA always
+    # returns the created user for a new association, so both are invariants here.
+    trans = strategy.config["GALAXY_TRANS"]
+    created_user = result["user"]
+    apply_user_activation_policy(trans, created_user, strategy.config.get("REQUIRE_USER_ACTIVATION", False))
+    return result
+
+
+def create_and_activate_oidc_user(
+    trans: "ProvidesAppContext", email: str, username: str, require_user_activation: bool
+) -> User:
+    """Create a Galaxy user for an OIDC login, routing activation through the user manager.
+
+    Used by the deferred (``require_create_confirmation``) creation path, which builds the
+    user via ``user_manager.create``. Unless the provider requires activation, the
+    IdP-verified email is trusted and the account is activated immediately. The normal
+    login path instead lets ``social_core`` create the user (outside the user manager) and
+    applies :func:`apply_user_activation_policy` to the result.
+    """
+    return trans.app.user_manager.create(
+        email=email,
+        username=username,
+        trans=trans,
+        trusted_email=not require_user_activation,
+        send_activation_email=require_user_activation,
+    )
+
+
+def apply_user_activation_policy(trans: "ProvidesAppContext", user: User, require_user_activation: bool) -> None:
+    """Activation authority for the pipeline path, where ``social_core`` already created the user.
+
+    ``user_manager.create`` handles activation for users it creates (see
+    :func:`create_and_activate_oidc_user`), but the normal login pipeline creates the user
+    through ``social_core``'s storage adapter, so its activation state is set here instead.
+    When the Galaxy instance requires activation (``user_activation_on``) *and* the provider
+    opts in (``require_user_activation``), the user is left inactive and sent an activation
+    email; otherwise the IdP-verified email is trusted and the account is activated immediately.
+    """
+    requires_activation = trans.app.config.user_activation_on and require_user_activation
+    user.active = not requires_activation
+    trans.sa_session.add(user)
+    trans.sa_session.commit()
+    if requires_activation:
+        trans.app.user_manager.send_activation_email(trans, user.email, user.username)
 
 
 def contains_required_data(response=None, is_new=False, backend=None, **kwargs):
@@ -1011,7 +1069,7 @@ def check_user_creation_confirmation(
     and this is a new user (no existing Galaxy account), the pipeline is interrupted
     and the user is redirected to a confirmation page with the token stored for later.
 
-    This step should be placed before create_user in the pipeline.
+    This step should be placed before create_user_and_activate in the pipeline.
     """
     require_confirmation = strategy.config.get("REQUIRE_CREATE_CONFIRMATION", False)
 

--- a/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
+++ b/lib/galaxy/authnz/xsd/oidc_backends_config.xsd
@@ -65,6 +65,13 @@
                                     </xs:documentation>
                                 </xs:annotation>
                             </xs:element>
+                            <xs:element name="require_user_activation" minOccurs="0" type="xs:boolean">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Require Galaxy email activation for accounts created through this provider.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
                             <xs:element name="require_session_refresh" minOccurs="0" type="xs:boolean">
                                 <xs:annotation>
                                     <xs:documentation>

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -28,6 +28,10 @@ _______________
 
 - require_create_confirmation:            A boolean value that decides whether a NewUserConfirmation page shows up.
 
+- require_user_activation:                A boolean value that requires Galaxy email activation for accounts
+                                          created through this provider. Defaults to false because the IdP email
+                                          address is trusted.
+
 - require_session_refresh:                A boolean value that decides whether failed token refresh requires the
                                           user to reauthenticate with this provider.
 
@@ -122,6 +126,8 @@ Please mind `http` and `https`.
         <!-- <label>My provider name</label> -->
         <!-- (Optional): whether to show a create account confirmation page -->
         <!-- <require_create_confirmation>false</require_create_confirmation> -->
+        <!-- (Optional): require Galaxy email activation for accounts created through this provider -->
+        <!-- <require_user_activation>false</require_user_activation> -->
         <!-- (Optional) Trusted CA certificate file or directory to use when verifying the keycloak authorization server.
              See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification for more information. -->
         <!-- <ca_bundle>/path/to/ca_bundle</ca_bundle> -->

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -122,14 +122,29 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             message = self.send_subscription_email(email)
             if message:
                 return None, message
-        user = self.create(email=email, username=username, password=password)
-        if self.app.config.user_activation_on:
-            self.send_activation_email(trans, email, username)
+        user = self.create(email=email, username=username, password=password, trans=trans, send_activation_email=True)
         return user, None
 
-    def create(self, email=None, username=None, password=None, **kwargs):
+    def create(
+        self,
+        email=None,
+        username=None,
+        password=None,
+        *,
+        trans=None,
+        trusted_email=False,
+        send_activation_email=False,
+        **kwargs,
+    ):
         """
         Create a new user.
+
+        The account is active unless email activation is enabled
+        (``user_activation_on``). ``trusted_email`` activates the account
+        regardless, for emails already verified by a trusted source such as an
+        OIDC identity provider. When the account is created inactive and
+        ``send_activation_email`` is set, an activation email is sent (requires
+        ``trans``).
         """
         self._error_on_duplicate_email(email)
         user = self.model_class(email=email, username=username)
@@ -137,11 +152,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             user.set_password_cleartext(password)
         else:
             user.set_random_password()
-        if self.app.config.user_activation_on:
-            user.active = False
-        else:
-            # Activation is off, every new user is active by default.
-            user.active = True
+        user.active = trusted_email or not self.app.config.user_activation_on
         session = self.session()
         session.add(user)
         try:
@@ -149,6 +160,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             self.app.security_agent.create_user_role(user, self.app)
         except exc.IntegrityError as db_err:
             raise exceptions.Conflict(str(db_err))
+        if send_activation_email and not user.active:
+            self.send_activation_email(trans, email, username)
         return user
 
     def update_email(

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -224,6 +224,43 @@ class TestUserManager(BaseTestCase):
                 mock_hash_util.assert_called_once()
         assert result is True
 
+    def test_create_active_by_default_when_activation_off(self):
+        self.app.config.user_activation_on = False
+        user = self.user_manager.create(email="off@example.com", username="actoff")
+        assert user.active is True
+
+    def test_create_inactive_when_activation_on(self):
+        self.app.config.user_activation_on = True
+        user = self.user_manager.create(email="on@example.com", username="acton")
+        assert user.active is False
+
+    def test_create_trusted_email_active_despite_activation_on(self):
+        self.app.config.user_activation_on = True
+        user = self.user_manager.create(email="trust@example.com", username="trusted", trusted_email=True)
+        assert user.active is True
+
+    def test_create_sends_activation_email_only_when_inactive(self):
+        self.app.config.user_activation_on = True
+        with patch.object(self.user_manager, "send_activation_email") as mock_send:
+            user = self.user_manager.create(
+                email="mail@example.com", username="mailer", trans=self.trans, send_activation_email=True
+            )
+        assert user.active is False
+        mock_send.assert_called_once_with(self.trans, "mail@example.com", "mailer")
+
+    def test_create_skips_activation_email_when_trusted(self):
+        self.app.config.user_activation_on = True
+        with patch.object(self.user_manager, "send_activation_email") as mock_send:
+            user = self.user_manager.create(
+                email="trustmail@example.com",
+                username="trustmail",
+                trans=self.trans,
+                trusted_email=True,
+                send_activation_email=True,
+            )
+        assert user.active is True
+        mock_send.assert_not_called()
+
     def test_reset_email(self):
         self.log("should produce the password reset email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")

--- a/test/unit/authnz/test_authnz.py
+++ b/test/unit/authnz/test_authnz.py
@@ -47,6 +47,7 @@ OIDC_BACKEND_CONFIG_TEMPLATE = """<?xml version="1.0"?>
         <redirect_uri>$galaxy_url/authnz/keycloak/callback</redirect_uri>
         <enable_idp_logout>{enable_idp_logout}</enable_idp_logout>
         <require_create_confirmation>{require_create_confirmation}</require_create_confirmation>
+        <require_user_activation>{require_user_activation}</require_user_activation>
         <require_session_refresh>{require_session_refresh}</require_session_refresh>
         <accepted_audiences>{accepted_audiences}</accepted_audiences>
         <username_key>{username_key}</username_key>
@@ -77,6 +78,7 @@ def create_backend_config(
     client_secret="client_secret",
     enable_idp_logout="true",
     require_create_confirmation="false",
+    require_user_activation="false",
     require_session_refresh="false",
     accepted_audiences="https://audience.example.com",
     username_key="custom_username",
@@ -88,6 +90,7 @@ def create_backend_config(
         client_secret=client_secret,
         enable_idp_logout=enable_idp_logout,
         require_create_confirmation=require_create_confirmation,
+        require_user_activation=require_user_activation,
         require_session_refresh=require_session_refresh,
         accepted_audiences=accepted_audiences,
         username_key=username_key,
@@ -160,6 +163,7 @@ def test_parse_backend_config(mock_app):
         "client_secret": "abcd1234",
         "enable_idp_logout": "true",
         "require_create_confirmation": "false",
+        "require_user_activation": "true",
         "require_session_refresh": "true",
         "accepted_audiences": "https://audience.example.com",
         "username_key": "custom_username",
@@ -177,6 +181,7 @@ def test_parse_backend_config(mock_app):
     # Boolean values should be parsed into bools
     assert parsed["enable_idp_logout"] == asbool(config_values["enable_idp_logout"])
     assert parsed["require_create_confirmation"] == asbool(config_values["require_create_confirmation"])
+    assert parsed["require_user_activation"] == asbool(config_values["require_user_activation"])
     assert parsed["require_session_refresh"] == asbool(config_values["require_session_refresh"])
 
 
@@ -203,6 +208,7 @@ def test_parse_backend_config_bool_defaults(mock_app):
     # Boolean values should be False by default
     assert parsed["enable_idp_logout"] is False
     assert parsed.get("require_create_confirmation", False) is False
+    assert parsed["require_user_activation"] is False
     assert parsed.get("require_session_refresh", False) is False
 
 
@@ -216,6 +222,7 @@ def test_psa_authnz_config(mock_app):
         "client_secret": "abcd1234",
         "enable_idp_logout": "true",
         "require_create_confirmation": "false",
+        "require_user_activation": "true",
         "accepted_audiences": "https://audience.example.com",
         "username_key": "custom_username",
     }
@@ -231,6 +238,7 @@ def test_psa_authnz_config(mock_app):
         app_config=mock_app.config,
     )
     assert psa_authnz.config[setting_name("USERNAME_KEY")] == config_values["username_key"]
+    assert psa_authnz.config["REQUIRE_USER_ACTIVATION"] is True
 
 
 def _create_backend_config_with_idphint(idphint_value: Optional[str] = None) -> tuple[str, str]:

--- a/test/unit/authnz/test_psa_authnz.py
+++ b/test/unit/authnz/test_psa_authnz.py
@@ -8,7 +8,11 @@ from datetime import (
     timedelta,
 )
 from types import SimpleNamespace
-from typing import Optional
+from typing import (
+    cast,
+    Optional,
+    TYPE_CHECKING,
+)
 from unittest.mock import MagicMock
 
 import jwt
@@ -33,11 +37,17 @@ from galaxy import model
 from galaxy.authnz.managers import AuthnzManager
 from galaxy.authnz.oidc_utils import decode_access_token as decode_access_token_oidc
 from galaxy.authnz.psa_authnz import (
+    apply_user_activation_policy,
     AUTH_PIPELINE,
+    create_and_activate_oidc_user,
+    create_user_and_activate,
     decode_access_token,
     PSAAuthnz,
     sync_user_profile,
 )
+
+if TYPE_CHECKING:
+    from galaxy.managers.context import ProvidesAppContext
 
 
 @pytest.fixture(scope="module")
@@ -410,6 +420,85 @@ def make_psa_authnz(mock_oidc_config_file, mock_oidc_backend_config_file):
         oidc_config=manager.oidc_config,
         oidc_backend_config=manager.oidc_backends_config,
         app_config=mock_app.config,
+    )
+
+
+@pytest.mark.parametrize(
+    "global_activation, require_user_activation, expected_active, expected_emails",
+    [
+        (True, False, True, 0),
+        (True, True, False, 1),
+        (False, False, True, 0),
+        (False, True, True, 0),
+    ],
+)
+def test_apply_user_activation_policy(global_activation, require_user_activation, expected_active, expected_emails):
+    user = SimpleNamespace(email="new@example.com", username="newuser", active=False)
+    session = MagicMock()
+    user_manager = MagicMock()
+    trans = SimpleNamespace(
+        app=SimpleNamespace(config=SimpleNamespace(user_activation_on=global_activation), user_manager=user_manager),
+        sa_session=session,
+    )
+
+    apply_user_activation_policy(cast("ProvidesAppContext", trans), cast(model.User, user), require_user_activation)
+
+    assert user.active is expected_active
+    session.add.assert_called_once_with(user)
+    session.commit.assert_called_once()
+    assert user_manager.send_activation_email.call_count == expected_emails
+
+
+def test_create_user_and_activate_only_applies_activation_policy_to_new_users(monkeypatch):
+    new_user = SimpleNamespace(email="new@example.com", username="newuser", active=False)
+    social_create = MagicMock(return_value={"is_new": True, "user": new_user})
+    monkeypatch.setattr("galaxy.authnz.psa_authnz.social_create_user", social_create)
+    session = MagicMock()
+    user_manager = MagicMock()
+    trans = SimpleNamespace(
+        app=SimpleNamespace(config=SimpleNamespace(user_activation_on=True), user_manager=user_manager),
+        sa_session=session,
+    )
+    strategy = SimpleNamespace(config={"GALAXY_TRANS": trans, "REQUIRE_USER_ACTIVATION": False})
+
+    result = create_user_and_activate(strategy=strategy, details={}, backend=MagicMock())
+
+    assert result == {"is_new": True, "user": new_user}
+    assert new_user.active is True
+    user_manager.send_activation_email.assert_not_called()
+
+    existing_user = SimpleNamespace(email="existing@example.com", username="existing", active=False)
+    social_create.return_value = {"is_new": False}
+    result = create_user_and_activate(strategy=strategy, details={}, backend=MagicMock(), user=existing_user)
+
+    assert result == {"is_new": False}
+    assert existing_user.active is False
+    assert session.add.call_count == 1
+    assert session.commit.call_count == 1
+    user_manager.send_activation_email.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "require_user_activation, expected_trusted, expected_send",
+    [(True, False, True), (False, True, False)],
+)
+def test_create_and_activate_oidc_user_delegates_to_user_manager(
+    require_user_activation, expected_trusted, expected_send
+):
+    user_manager = MagicMock()
+    trans = SimpleNamespace(app=SimpleNamespace(user_manager=user_manager), sa_session=MagicMock())
+
+    user = create_and_activate_oidc_user(
+        cast("ProvidesAppContext", trans), "new@example.com", "newuser", require_user_activation
+    )
+
+    assert user is user_manager.create.return_value
+    user_manager.create.assert_called_once_with(
+        email="new@example.com",
+        username="newuser",
+        trans=trans,
+        trusted_email=expected_trusted,
+        send_activation_email=expected_send,
     )
 
 


### PR DESCRIPTION
Accounts created through an OIDC provider were subjected to Galaxy's email
activation flow whenever `user_activation_on` was enabled globally, even
though the identity provider has already verified the user's email address.
This left Google-auth (and other OIDC) users with an inactive account waiting
for an activation email they never needed.

OIDC accounts are now activated on creation by default, since the IdP email is
trusted. A per-provider `require_user_activation` option (default `false`)
restores the email activation flow for providers where it is still wanted.

The policy is applied through a new `create_user` pipeline step and a shared
`apply_user_activation_policy` helper, covering both the normal login pipeline
and the deferred `require_create_confirmation` creation path.

Fixes #22678

## How to test the changes?

Unit tests cover the activation policy across the global-activation /
per-provider matrix and both creation paths:

```
pytest test/unit/authnz/test_psa_authnz.py test/unit/authnz/test_authnz.py
```

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
