### PR TITLE
Generalize interactive file source template forms

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -13136,30 +13136,12 @@ export interface components {
             /** Url */
             url: string;
         };
-        /**
-         * FileSourceTemplateAlert
-         * @description An administrator-authored alert shown while creating a file source.
-         */
-        FileSourceTemplateAlert: {
-            /** Condition */
-            condition?: string | null;
-            /** Content */
-            content: string;
-            /**
-             * Variant
-             * @default info
-             * @enum {string}
-             */
-            variant: "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "light" | "dark";
-        };
         /** FileSourceTemplateSummaries */
         FileSourceTemplateSummaries: components["schemas"]["FileSourceTemplateSummary"][];
         /** FileSourceTemplateSummary */
         FileSourceTemplateSummary: {
             /** Description */
             description: string | null;
-            /** Form Alerts */
-            form_alerts?: components["schemas"]["FileSourceTemplateAlert"][] | null;
             /**
              * Hidden
              * @default false
@@ -13169,6 +13151,11 @@ export interface components {
             id: string;
             /** Name */
             name: string | null;
+            /**
+             * Requires Oauth2 Authorization
+             * @default false
+             */
+            requires_oauth2_authorization: boolean;
             /** Secrets */
             secrets?: components["schemas"]["TemplateSecret"][] | null;
             /**
@@ -23681,12 +23668,23 @@ export interface components {
         };
         /** TemplateFormDataResponse */
         TemplateFormDataResponse: {
-            /** Alert Conditions */
-            alert_conditions?: string[];
             /** Dynamic Options */
             dynamic_options?: {
                 [key: string]: [string, string][];
             };
+            /** Messages */
+            messages?: components["schemas"]["TemplateFormMessage"][];
+        };
+        /** TemplateFormMessage */
+        TemplateFormMessage: {
+            /** Content */
+            content: string;
+            /**
+             * Variant
+             * @default info
+             * @enum {string}
+             */
+            variant: "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "light" | "dark";
         };
         /** TemplateSecret */
         TemplateSecret: {
@@ -23757,6 +23755,19 @@ export interface components {
                   )[]
                 | null;
         };
+        /**
+         * TemplateVariableOptionsProvider
+         * @description A server-side source for select options and its form dependencies.
+         */
+        TemplateVariableOptionsProvider: {
+            /**
+             * Depends On
+             * @default []
+             */
+            depends_on: string[];
+            /** Kind */
+            kind: string;
+        };
         /** TemplateVariablePathComponent */
         TemplateVariablePathComponent: {
             /** Default */
@@ -23789,8 +23800,6 @@ export interface components {
         TemplateVariableSelect: {
             /** Default */
             default?: string | null;
-            /** Dynamic Options */
-            dynamic_options?: string | null;
             /** Help */
             help?: string | null;
             /** Label */
@@ -23803,6 +23812,7 @@ export interface components {
             optional?: boolean | null;
             /** Options */
             options?: components["schemas"]["TemplateVariableSelectOption"][] | null;
+            options_provider?: components["schemas"]["TemplateVariableOptionsProvider"] | null;
             /**
              * Type
              * @constant

--- a/client/src/components/ConfigTemplates/formUtil.test.ts
+++ b/client/src/components/ConfigTemplates/formUtil.test.ts
@@ -52,7 +52,7 @@ describe("formUtils", () => {
                     {
                         name: "org",
                         type: "select",
-                        dynamic_options: "github_repository_owners",
+                        options_provider: { kind: "github_authorized_repository_owners", depends_on: [] },
                     },
                 ],
                 secrets: [],
@@ -180,7 +180,7 @@ describe("formUtils", () => {
             const selectVariable: TemplateVariable = {
                 name: "org",
                 type: "select",
-                dynamic_options: "github_repository_owners",
+                options_provider: { kind: "github_authorized_repository_owners", depends_on: [] },
             };
             const formEntry = templateVariableFormEntry(selectVariable, undefined, {
                 org: [
@@ -199,7 +199,7 @@ describe("formUtils", () => {
                 name: "org",
                 type: "select",
                 options: [{ label: "Static", value: "static" }],
-                dynamic_options: "github_repository_owners",
+                options_provider: { kind: "github_authorized_repository_owners", depends_on: [] },
             };
             const formEntry = templateVariableFormEntry(selectVariable, undefined, {
                 org: [["dynamic", "dynamic"]],
@@ -210,7 +210,7 @@ describe("formUtils", () => {
             const selectVariable: TemplateVariable = {
                 name: "org",
                 type: "select",
-                dynamic_options: "github_repository_owners",
+                options_provider: { kind: "github_authorized_repository_owners", depends_on: [] },
             };
             const formEntry = templateVariableFormEntry(selectVariable, "galaxyproject");
             expect(formEntry.value).toBe("galaxyproject");
@@ -295,7 +295,7 @@ describe("formUtils", () => {
         const selectVar: TemplateVariable = {
             name: "org",
             type: "select",
-            dynamic_options: "github_repository_owners",
+            options_provider: { kind: "github_authorized_repository_owners", depends_on: [] },
         };
 
         it("should return undefined for an optional integer when the raw value is empty string", () => {

--- a/client/src/components/ConfigTemplates/test_fixtures.ts
+++ b/client/src/components/ConfigTemplates/test_fixtures.ts
@@ -68,6 +68,7 @@ export const STANDARD_FILE_SOURCE_TEMPLATE: FileSourceTemplateSummary = {
     id: "moo",
     version: 2,
     hidden: false,
+    requires_oauth2_authorization: false,
 };
 
 export const GENERIC_FTP_FILE_SOURCE_TEMPLATE: FileSourceTemplateSummary = {
@@ -114,6 +115,7 @@ export const GENERIC_FTP_FILE_SOURCE_TEMPLATE: FileSourceTemplateSummary = {
     ],
     hidden: false,
     version: 1,
+    requires_oauth2_authorization: false,
 };
 
 export const OBJECT_STORE_INSTANCE: UserConcreteObjectStore = {

--- a/client/src/components/FileSources/Instances/CreateForm.vue
+++ b/client/src/components/FileSources/Instances/CreateForm.vue
@@ -29,18 +29,7 @@ function onFormChange(incoming: Record<string, unknown>) {
     formData.value = incoming;
 }
 
-const { alertConditions, dynamicOptions } = useTemplateFormData(
-    toRef(props, "template"),
-    toRef(props, "uuid"),
-    formData,
-);
-
-const formAlerts = computed(() => {
-    const activeConditions = new Set(alertConditions.value);
-    return (props.template.form_alerts ?? []).filter(
-        (alert) => !alert.condition || activeConditions.has(alert.condition),
-    );
-});
+const { dynamicOptions, messages } = useTemplateFormData(toRef(props, "template"), toRef(props, "uuid"), formData);
 
 const { ActionSummary, error, inputs, InstanceForm, onSubmit, submitTitle, loadingMessage, testRunning, testResults } =
     useConfigurationTemplateCreation(
@@ -56,8 +45,8 @@ const { ActionSummary, error, inputs, InstanceForm, onSubmit, submitTitle, loadi
 <template>
     <div id="create-file-source-landing">
         <ActionSummary error-data-description="file-source-creation-error" :test-results="testResults" :error="error" />
-        <BAlert v-for="alert in formAlerts" :key="alert.content" show :variant="alert.variant">
-            <ConfigurationMarkdown :markdown="alert.content" :admin="true" />
+        <BAlert v-for="message in messages" :key="message.content" show :variant="message.variant">
+            <ConfigurationMarkdown :markdown="message.content" :admin="true" />
         </BAlert>
         <InstanceForm
             :inputs="inputs"

--- a/client/src/components/FileSources/Instances/CreateInstance.vue
+++ b/client/src/components/FileSources/Instances/CreateInstance.vue
@@ -18,8 +18,6 @@ interface Props {
     uuid?: string;
 }
 
-const OAUTH2_TYPES = ["dropbox", "googledrive", "onedrive", "github"];
-
 const fileSourceTemplatesStore = useFileSourceTemplatesStore();
 fileSourceTemplatesStore.fetchTemplates();
 
@@ -44,7 +42,7 @@ const redirectMessage = computed(
 );
 const requiresOAuth2AuthorizeRedirect = computed(() => {
     const templateValue = template.value;
-    return props.uuid == undefined && templateValue && OAUTH2_TYPES.indexOf(templateValue.type) >= 0;
+    return props.uuid == undefined && templateValue?.requires_oauth2_authorization;
 });
 
 function onCreated(objectStore: UserFileSourceModel) {

--- a/client/src/components/FileSources/Instances/useTemplateFormData.ts
+++ b/client/src/components/FileSources/Instances/useTemplateFormData.ts
@@ -12,12 +12,26 @@ export function useTemplateFormData(
     formData: Ref<Record<string, unknown>>,
 ) {
     const dynamicOptions = ref<DynamicOptions>({});
-    const alertConditions = ref<string[]>([]);
+    const messages = ref<
+        Array<{
+            content: string;
+            variant: "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "light" | "dark";
+        }>
+    >([]);
     const error = ref<string | null>(null);
+    let requestSequence = 0;
 
     const variables = computed(() => {
         const values: Record<string, string | number | boolean> = {};
+        const dependencies = new Set(
+            (template.value.variables ?? []).flatMap((variable) =>
+                variable.type === "select" ? (variable.options_provider?.depends_on ?? []) : [],
+            ),
+        );
         for (const variable of template.value.variables ?? []) {
+            if (!dependencies.has(variable.name)) {
+                continue;
+            }
             const value = formData.value[variable.name];
             if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
                 values[variable.name] = value;
@@ -30,6 +44,7 @@ export function useTemplateFormData(
         if (!uuid.value) {
             return;
         }
+        const sequence = ++requestSequence;
         error.value = null;
         const { data, error: requestError } = await GalaxyApi().POST(
             "/api/file_source_templates/{template_id}/{template_version}/form-data",
@@ -41,16 +56,21 @@ export function useTemplateFormData(
             },
         );
         if (requestError) {
-            error.value = errorMessageAsString(requestError);
+            if (sequence === requestSequence) {
+                error.value = errorMessageAsString(requestError);
+            }
+            return;
+        }
+        if (sequence !== requestSequence) {
             return;
         }
         // openapi-fetch widens the server's [label, value] tuples to string[][]; they are
         // pairs by construction, so narrow them back to SelectFormOption tuples here.
         dynamicOptions.value = (data.dynamic_options ?? {}) as DynamicOptions;
-        alertConditions.value = data.alert_conditions ?? [];
+        messages.value = data.messages ?? [];
     }
 
     watch([uuid, variables], () => void fetchFormData(), { immediate: true });
 
-    return { alertConditions, dynamicOptions, error };
+    return { dynamicOptions, error, messages };
 }

--- a/lib/galaxy/files/templates/capabilities.py
+++ b/lib/galaxy/files/templates/capabilities.py
@@ -1,0 +1,143 @@
+"""Provider-specific behavior for interactive file-source template forms.
+
+The template manager owns the generic lifecycle; capabilities own remote-service
+lookups and validation that are meaningful only for one file-source type.
+"""
+
+from collections.abc import Callable
+from dataclasses import (
+    dataclass,
+    field,
+)
+from typing import Protocol
+
+from galaxy.exceptions import RequestParameterInvalidException
+from galaxy.files.sources.github_fsspec import list_authorized_repositories
+from galaxy.util.config_templates import (
+    StrictModel,
+    TemplateVariableSelect,
+    TemplateVariableValueType,
+)
+from .models import (
+    FileSourceTemplate,
+    FileSourceTemplateAlertVariant,
+)
+
+
+class TemplateFormMessage(StrictModel):
+    content: str
+    variant: FileSourceTemplateAlertVariant = "info"
+
+
+@dataclass
+class TemplateFormData:
+    dynamic_options: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+    messages: list[TemplateFormMessage] = field(default_factory=list)
+
+
+class FileSourceTemplateCapability(Protocol):
+    def form_data(
+        self,
+        template: FileSourceTemplate,
+        variables: dict[str, TemplateVariableValueType],
+        access_token: Callable[[], str],
+    ) -> TemplateFormData: ...
+
+    def validate_creation(
+        self,
+        template: FileSourceTemplate,
+        variables: dict[str, TemplateVariableValueType],
+        access_token: Callable[[], str],
+    ) -> None: ...
+
+
+def _select_variable_name(template: FileSourceTemplate, provider_kind: str) -> str | None:
+    for variable in template.variables or []:
+        if isinstance(variable, TemplateVariableSelect) and variable.options_provider:
+            if variable.options_provider.kind == provider_kind:
+                return variable.name
+    return None
+
+
+class GithubTemplateCapability:
+    """Populate and validate repository selectors from GitHub App grants."""
+
+    owner_provider = "github_authorized_repository_owners"
+    repository_provider = "github_authorized_repository_names"
+
+    def _field_names(self, template: FileSourceTemplate) -> tuple[str | None, str | None]:
+        return (
+            _select_variable_name(template, self.owner_provider),
+            _select_variable_name(template, self.repository_provider),
+        )
+
+    def _repositories(self, access_token: Callable[[], str]) -> list[dict[str, str]]:
+        return list_authorized_repositories(access_token())
+
+    def form_data(self, template, variables, access_token) -> TemplateFormData:
+        owner_name, repository_name = self._field_names(template)
+        if not owner_name or not repository_name:
+            return TemplateFormData()
+
+        granted_repositories = self._repositories(access_token)
+        if not granted_repositories:
+            return TemplateFormData(
+                messages=[
+                    TemplateFormMessage(
+                        variant="warning",
+                        content=(
+                            "The GitHub App isn't installed on any repository you can access, so there are no owners "
+                            "or repositories to choose. Install it on at least one repository from your "
+                            '<a href="https://github.com/settings/installations" target="_blank" '
+                            'rel="noopener noreferrer">installed GitHub Apps</a>, then reload this page.'
+                        ),
+                    )
+                ]
+            )
+
+        owner = variables.get(owner_name)
+        owners = sorted({repository["owner"] for repository in granted_repositories})
+        options = {owner_name: [(value, value) for value in owners]}
+        options[repository_name] = (
+            [
+                (repository["repo"], repository["repo"])
+                for repository in granted_repositories
+                if repository["owner"] == owner
+            ]
+            if isinstance(owner, str)
+            else []
+        )
+        return TemplateFormData(
+            dynamic_options=options,
+            messages=[
+                TemplateFormMessage(
+                    content=(
+                        "Need access to another repository? Update the GitHub App's repository access from your "
+                        '<a href="https://github.com/settings/installations" target="_blank" '
+                        'rel="noopener noreferrer">installed GitHub Apps</a> in a new tab, then reload this page.'
+                    )
+                )
+            ],
+        )
+
+    def validate_creation(self, template, variables, access_token) -> None:
+        owner_name, repository_name = self._field_names(template)
+        if not owner_name or not repository_name:
+            return
+        owner = variables.get(owner_name)
+        repository = variables.get(repository_name)
+        if not isinstance(owner, str) or not isinstance(repository, str):
+            return
+        full_name = f"{owner}/{repository}"
+        if not any(candidate["full_name"] == full_name for candidate in self._repositories(access_token)):
+            raise RequestParameterInvalidException(
+                f"The GitHub App isn't installed on {full_name}. Authorize access to this "
+                "repository on GitHub, or pick one of the repositories you have granted access to."
+            )
+
+
+_CAPABILITIES: dict[str, FileSourceTemplateCapability] = {"github": GithubTemplateCapability()}
+
+
+def capability_for(template: FileSourceTemplate) -> FileSourceTemplateCapability | None:
+    return _CAPABILITIES.get(template.configuration.type)

--- a/lib/galaxy/files/templates/examples/production_github.yml
+++ b/lib/galaxy/files/templates/examples/production_github.yml
@@ -9,25 +9,12 @@
       You authorize Galaxy to access GitHub on your behalf through GitHub's OAuth flow - no
       personal access token is required. Each repository is a separate file source: create one
       instance of this template per repository you want to access.
-  form_alerts:
-      - condition: repository_picker_empty
-        variant: warning
-        content: |
-            The GitHub App isn't installed on any repository you can access, so there are no owners or
-            repositories to choose. Install it on at least one repository from your
-            <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">installed GitHub Apps</a>,
-            then reload this page.
-      - condition: repository_picker_available
-        variant: info
-        content: |
-            Need access to another repository? Update the GitHub App's repository access from your
-            <a href="https://github.com/settings/installations" target="_blank" rel="noopener noreferrer">installed GitHub Apps</a>
-            in a new tab, then reload this page.
   variables:
       org:
           label: Repository Owner
           type: select
-          dynamic_options: github_repository_owners
+          options_provider:
+              kind: github_authorized_repository_owners
           help: |
               The owner of the repository - a GitHub username or organization name. Choose from
               the owners of the repositories you granted the GitHub App access to.
@@ -35,7 +22,9 @@
       repo:
           label: Repository Name
           type: select
-          dynamic_options: github_repository_names
+          options_provider:
+              kind: github_authorized_repository_names
+              depends_on: [org]
           help: |
               The name of the repository, restricted to repositories the selected owner has
               granted the GitHub App access to.

--- a/lib/galaxy/files/templates/manager.py
+++ b/lib/galaxy/files/templates/manager.py
@@ -19,6 +19,7 @@ from .models import (
     FileSourceTemplate,
     FileSourceTemplateCatalog,
     FileSourceTemplateSummaries,
+    get_oauth2_config_or_none,
 )
 
 SECRETS_NEED_VAULT_MESSAGE = "The file source templates configuration can not be used - a Galaxy vault must be configured for templates that use secrets - please set the vault_config_file configuration option to point at a valid vault configuration."
@@ -64,6 +65,7 @@ class ConfiguredFileSourceTemplates:
             template_dict.pop("environment")
             object_store_type = configuration["type"]
             template_dict["type"] = object_store_type
+            template_dict["requires_oauth2_authorization"] = get_oauth2_config_or_none(template) is not None
             summaries.append(template_dict)
         return FileSourceTemplateSummaries.model_validate(summaries)
 

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -68,16 +68,6 @@ FileSourceTemplateAlertVariant = Literal[
 ]
 
 
-class FileSourceTemplateAlert(StrictModel):
-    """An administrator-authored alert shown while creating a file source."""
-
-    content: MarkdownContent
-    variant: FileSourceTemplateAlertVariant = "info"
-    # A condition is supplied by a client-side template capability. Omit it for an alert that
-    # should always be visible.
-    condition: str | None = None
-
-
 class PosixFileSourceTemplateConfiguration(StrictModel):
     type: Literal["posix"]
     root: str | TemplateExpansion
@@ -609,7 +599,7 @@ class FileSourceTemplateBase(StrictModel):
     # template by hiding but keep it in the catalog for backward
     # compatibility for users with existing stores of that template.
     hidden: bool = False
-    form_alerts: list[FileSourceTemplateAlert] | None = None
+    requires_oauth2_authorization: bool = False
     variables: list[TemplateVariable] | None = None
     secrets: list[TemplateSecret] | None = None
 

--- a/lib/galaxy/managers/file_source_instances.py
+++ b/lib/galaxy/managers/file_source_instances.py
@@ -38,7 +38,6 @@ from galaxy.files.sources import (
     PluginKind,
     SupportsBrowsing,
 )
-from galaxy.files.sources.github_fsspec import list_authorized_repositories
 from galaxy.files.templates import (
     ConfiguredFileSourceTemplates,
     FileSourceConfiguration,
@@ -47,6 +46,10 @@ from galaxy.files.templates import (
     FileSourceTemplateType,
     get_oauth2_config_or_none,
     template_to_configuration,
+)
+from galaxy.files.templates.capabilities import (
+    capability_for,
+    TemplateFormMessage,
 )
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import (
@@ -111,13 +114,6 @@ log = logging.getLogger(__name__)
 USER_FILE_SOURCES_SCHEME = "gxuserfiles"
 
 
-def _variable_name_for_dynamic_options(template: FileSourceTemplate, marker: str) -> str | None:
-    for variable in template.variables or []:
-        if variable.type == "select" and variable.dynamic_options == marker:
-            return variable.name
-    return None
-
-
 class UserFileSourceModel(BaseModel):
     uuid: UUID4
     uri_root: str
@@ -133,15 +129,6 @@ class UserFileSourceModel(BaseModel):
     secrets: list[str]
 
 
-GITHUB_TEMPLATE_TYPE = "github"
-
-
-class GithubRepository(BaseModel):
-    owner: str
-    repo: str
-    full_name: str
-
-
 class TemplateFormDataRequest(BaseModel):
     """Values available while rendering a post-authorization template form."""
 
@@ -151,7 +138,7 @@ class TemplateFormDataRequest(BaseModel):
 
 class TemplateFormDataResponse(BaseModel):
     dynamic_options: dict[str, list[tuple[str, str]]] = Field(default_factory=dict)
-    alert_conditions: list[str] = Field(default_factory=list)
+    messages: list[TemplateFormMessage] = Field(default_factory=list)
 
 
 class UserDefinedFileSourcesConfig(BaseModel):
@@ -258,30 +245,16 @@ class FileSourceInstancesManager:
         redirect_uri = f"{galaxy_root}/oauth2_callback"
         return redirect_uri
 
-    def list_github_repositories(
-        self, trans: ProvidesUserContext, template_id: str, template_version: int, uuid: str
-    ) -> list[GithubRepository]:
-        """List the repositories the user authorized the GitHub App to access.
-
-        Uses the refresh token stored at the pre-allocated ``uuid`` during the OAuth callback to
-        mint an access token, then queries GitHub for the granted repositories.
-        """
-        template = self._catalog.find_template_by(template_id, template_version)
-        if template.configuration.type != GITHUB_TEMPLATE_TYPE:
-            raise RequestParameterInvalidException(
-                "Listing repositories is only supported for GitHub file source templates."
-            )
+    def _access_token_for_template(self, trans: ProvidesUserContext, template: FileSourceTemplate, uuid: str) -> str:
+        """Mint an OAuth token for a capability without exposing provider behavior here."""
         template_server_configuration = self._resolver.template_server_configuration(
-            trans.user, template_id, template_version
+            trans.user, template.id, template.version
         )
         if not template_server_configuration.uses_oauth2:
             raise RequestParameterInvalidException(
-                f"The file source template {template_id} is not configured for OAuth2 authorization."
+                f"The file source template {template.id} is not configured for OAuth2 authorization."
             )
-        access_token = access_token_for_uuid(
-            trans, template_server_configuration, uuid, UserFileSource, self._app_config
-        )
-        return [GithubRepository(**repository) for repository in list_authorized_repositories(access_token)]
+        return access_token_for_uuid(trans, template_server_configuration, uuid, UserFileSource, self._app_config)
 
     def template_form_data(
         self,
@@ -290,56 +263,29 @@ class FileSourceInstancesManager:
         template_version: int,
         payload: TemplateFormDataRequest,
     ) -> TemplateFormDataResponse:
-        """Return dynamic form data supplied by built-in template capabilities."""
+        """Return form data supplied by the template's provider capability."""
         template = self._catalog.find_template_by(template_id, template_version)
-        if template.configuration.type != GITHUB_TEMPLATE_TYPE:
+        capability = capability_for(template)
+        if capability is None:
             return TemplateFormDataResponse()
-
-        repositories = self.list_github_repositories(trans, template_id, template_version, payload.uuid)
-        owner_variable_name = _variable_name_for_dynamic_options(template, "github_repository_owners")
-        repository_variable_name = _variable_name_for_dynamic_options(template, "github_repository_names")
-        if not owner_variable_name or not repository_variable_name:
-            return TemplateFormDataResponse()
-
-        if not repositories:
-            return TemplateFormDataResponse(alert_conditions=["repository_picker_empty"])
-
-        owner = payload.variables.get(owner_variable_name)
-        owners = sorted({repository.owner for repository in repositories})
-        dynamic_options = {owner_variable_name: [(owner, owner) for owner in owners]}
-        if isinstance(owner, str):
-            dynamic_options[repository_variable_name] = [
-                (repository.repo, repository.repo) for repository in repositories if repository.owner == owner
-            ]
-        else:
-            dynamic_options[repository_variable_name] = []
-        return TemplateFormDataResponse(
-            dynamic_options=dynamic_options,
-            alert_conditions=["repository_picker_available"],
+        form_data = capability.form_data(
+            template,
+            payload.variables,
+            lambda: self._access_token_for_template(trans, template, payload.uuid),
         )
+        return TemplateFormDataResponse(dynamic_options=form_data.dynamic_options, messages=form_data.messages)
 
-    def assert_repository_authorized(
-        self, trans: ProvidesUserContext, template_id: str, template_version: int, uuid: str, org: str, repo: str
-    ) -> None:
-        """Raise a clear error if ``org/repo`` is not among the App's authorized repositories."""
-        full_name = f"{org}/{repo}"
-        authorized = self.list_github_repositories(trans, template_id, template_version, uuid)
-        if not any(repository.full_name == full_name for repository in authorized):
-            raise RequestParameterInvalidException(
-                f"The GitHub App isn't installed on {full_name}. Authorize access to this "
-                "repository on GitHub, or pick one of the repositories you have granted access to."
-            )
-
-    def _assert_github_repository_authorized(self, trans: ProvidesUserContext, payload: CreateInstancePayload) -> None:
-        """For a github create/test payload with a pre-allocated uuid, validate the chosen repo."""
+    def _validate_provider_creation(self, trans: ProvidesUserContext, payload: CreateInstancePayload) -> None:
+        """Run provider-specific authorization checks for a create/test payload."""
         template = self._catalog.find_template(payload)
-        if not template or template.configuration.type != GITHUB_TEMPLATE_TYPE or not payload.uuid:
+        if not template or not payload.uuid:
             return
-        org = payload.variables.get("org")
-        repo = payload.variables.get("repo")
-        if org and repo:
-            self.assert_repository_authorized(
-                trans, template.id, template.version, str(payload.uuid), str(org), str(repo)
+        capability = capability_for(template)
+        if capability is not None:
+            capability.validate_creation(
+                template,
+                payload.variables,
+                lambda: self._access_token_for_template(trans, template, str(payload.uuid)),
             )
 
     def index(self, trans: ProvidesUserContext) -> list[UserFileSourceModel]:
@@ -411,7 +357,7 @@ class FileSourceInstancesManager:
         catalog.validate(payload)
         template = catalog.find_template(payload)
         assert template
-        self._assert_github_repository_authorized(trans, payload)
+        self._validate_provider_creation(trans, payload)
         user_vault = trans.user_vault
         persisted_file_source = UserFileSource()
         persisted_file_source.user_id = trans.user.id
@@ -475,7 +421,7 @@ class FileSourceInstancesManager:
 
     def plugin_status(self, trans: ProvidesUserContext, payload: CreateInstancePayload) -> PluginStatus:
         target = CreateTestTarget(payload, UserFileSource)
-        self._assert_github_repository_authorized(trans, payload)
+        self._validate_provider_creation(trans, payload)
         return self._plugin_status(trans, target, payload)
 
     def _plugin_status(

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -108,16 +108,22 @@ class TemplateVariableSelectOption(StrictModel):
     value: str
 
 
+class TemplateVariableOptionsProvider(StrictModel):
+    """A server-side source for select options and its form dependencies."""
+
+    kind: str
+    depends_on: list[str] = []
+
+
 class TemplateVariableSelect(BaseTemplateVariable):
     type: Literal["select"]
     default: str | None = None
-    # Statically declared options. When omitted, options are expected to be
-    # supplied at form-render time by the client based on ``dynamic_options``.
+    # Statically declared options. When omitted, options can be supplied by an
+    # options provider while the form is rendered.
     options: list[TemplateVariableSelectOption] | None = None
-    # Marker naming a client-side provider that populates the options
-    # dynamically (e.g. "github_repository_owners"). The generic framework does
-    # not resolve this - it only carries the marker to the frontend.
-    dynamic_options: str | None = None
+    # A server-side capability populates these options. Dependencies let the client
+    # refresh only when values that affect this field change.
+    options_provider: TemplateVariableOptionsProvider | None = None
 
 
 TemplateVariable = (

--- a/test/unit/app/managers/test_user_file_sources.py
+++ b/test/unit/app/managers/test_user_file_sources.py
@@ -941,9 +941,12 @@ class TestFileSourcesTestCase(BaseTestCase):
         monkeypatch.setattr(config_templates, "get_token_from_refresh_raw", mock_get_token_from_refresh_raw)
         self._stub_github_repositories([("galaxyproject", "galaxy"), ("me", "data")])
 
-        repositories = self.manager.list_github_repositories(self.trans, "github", 0, uuid)
-        assert [r.full_name for r in repositories] == ["galaxyproject/galaxy", "me/data"]
-        self.manager.list_github_repositories(self.trans, "github", 0, uuid)
+        form_data = self.manager.template_form_data(
+            self.trans,
+            "github",
+            0,
+            TemplateFormDataRequest(uuid=uuid, variables={"org": "galaxyproject"}),
+        )
         # The refresh token was exchanged once (the access token is cached) and the minted
         # access token authenticated the request GitHub actually received.
         assert refresh_requests == 1
@@ -951,20 +954,18 @@ class TestFileSourcesTestCase(BaseTestCase):
         # The rotated refresh token is persisted back to the user vault.
         assert user_vault.read_secret(refresh_key) == "rotated_refresh_token"
 
-        form_data = self.manager.template_form_data(
-            self.trans,
-            "github",
-            0,
-            TemplateFormDataRequest(uuid=uuid, variables={"org": "galaxyproject"}),
-        )
         assert form_data.dynamic_options == {
             "org": [("galaxyproject", "galaxyproject"), ("me", "me")],
             "repo": [("galaxy", "galaxy")],
         }
-        assert form_data.alert_conditions == ["repository_picker_available"]
+        assert len(form_data.messages) == 1
+        assert form_data.messages[0].variant == "info"
 
     def test_github_oauth_redirects_to_authorization(self, tmp_path, monkeypatch):
         self._init_github_env(tmp_path, monkeypatch)
+
+        summary = next(summary for summary in self.manager.summaries.root if summary.id == "github")
+        assert summary.requires_oauth2_authorization
 
         authorize_url = self.manager.template_oauth2(self.trans, "github", 0).authorize_url
         from urllib.parse import (
@@ -979,7 +980,7 @@ class TestFileSourcesTestCase(BaseTestCase):
         assert state.route == "file_source_instances/github/0"
 
     @responses.activate
-    def test_github_assert_repository_authorized(self, tmp_path, monkeypatch):
+    def test_github_capability_rejects_unauthorized_repository(self, tmp_path, monkeypatch):
         self._init_github_env(tmp_path, monkeypatch)
         uuid = uuid4().hex
         user_vault = self.trans.user_vault
@@ -987,12 +988,23 @@ class TestFileSourcesTestCase(BaseTestCase):
         user_vault.write_secret(refresh_key, "original_refresh_token")
         self._mock_github_repositories(monkeypatch, [("galaxyproject", "galaxy")])
 
-        # An authorized repository passes validation.
-        self.manager.assert_repository_authorized(self.trans, "github", 0, uuid, "galaxyproject", "galaxy")
+        authorized_payload = CreateInstancePayload(
+            name=SIMPLE_FILE_SOURCE_NAME,
+            description=SIMPLE_FILE_SOURCE_DESCRIPTION,
+            template_id="github",
+            template_version=0,
+            variables={"org": "galaxyproject", "repo": "galaxy"},
+            secrets={},
+            uuid=uuid,
+        )
+        self.manager._validate_provider_creation(self.trans, authorized_payload)
 
         # An un-granted repository raises a clear error naming the repository.
         with pytest.raises(RequestParameterInvalidException) as exc_info:
-            self.manager.assert_repository_authorized(self.trans, "github", 0, uuid, "someone", "private")
+            self.manager._validate_provider_creation(
+                self.trans,
+                authorized_payload.model_copy(update={"variables": {"org": "someone", "repo": "private"}}),
+            )
         assert "someone/private" in str(exc_info.value)
 
     @responses.activate

--- a/test/unit/files/test_template_models.py
+++ b/test/unit/files/test_template_models.py
@@ -13,7 +13,10 @@ from galaxy.files.templates.models import (
     S3FSFileSourceConfiguration,
     template_to_configuration,
 )
-from galaxy.util.config_templates import read_oauth2_info_from_configuration
+from galaxy.util.config_templates import (
+    read_oauth2_info_from_configuration,
+    TemplateVariableSelect,
+)
 
 # API example server - all data is public and anyone can create keys and buckets
 GALAXY_TEST_PLAY_MINIO_KEY = "LEHFJDNqSA4xcJmmezU7"
@@ -296,11 +299,14 @@ def test_production_aws_public_bucket():
 
 def test_production_github_oauth():
     github_template = _get_example_template("production_github.yml")
-    assert github_template.form_alerts is not None
-    assert [alert.condition for alert in github_template.form_alerts] == [
-        "repository_picker_empty",
-        "repository_picker_available",
-    ]
+    assert github_template.variables is not None
+    owner, repository = github_template.variables[:2]
+    assert isinstance(owner, TemplateVariableSelect)
+    assert isinstance(repository, TemplateVariableSelect)
+    assert owner.options_provider is not None
+    assert owner.options_provider.kind == "github_authorized_repository_owners"
+    assert repository.options_provider is not None
+    assert repository.options_provider.depends_on == ["org"]
     configuration_obj = template_to_configuration(
         github_template,
         {"org": "galaxyproject", "repo": "galaxy"},

--- a/test/unit/util/test_config_template_validation.py
+++ b/test/unit/util/test_config_template_validation.py
@@ -163,7 +163,12 @@ def test_variable_typing_path_component():
 def test_variable_typing_select():
     # A select without static options accepts any string (dynamic options are validated elsewhere).
     template = _template_with_variable(
-        TemplateVariableSelect(name="test_var", help=None, type="select", dynamic_options="github_repository_owners")
+        TemplateVariableSelect(
+            name="test_var",
+            help=None,
+            type="select",
+            options_provider={"kind": "github_authorized_repository_owners"},
+        )
     )
     instance = _test_instance_with_variables({"test_var": "galaxyproject/galaxy"})
     validate_secrets_and_variables(instance, template)


### PR DESCRIPTION
Move provider-specific interactive form behavior behind file source template capabilities. The GitHub capability now supplies authorized repository options, creation-time authorization validation, and form messages; the instances manager only supplies an OAuth access-token callback.

Replace opaque dynamic-option markers and alert condition tokens with structured options_provider metadata, declared field dependencies, and server-supplied form messages. The client refreshes form data only when declared dependencies change and ignores stale responses.

Expose OAuth authorization requirements in template summaries so the creation UI no longer maintains a provider-type allowlist.

@jmchilton does that help at all with your dynamic option concern ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
