### PR TITLE
Add CKAN file source with import and export support

### DIFF
--- a/client/packages/api-client/src/schema/schema.ts
+++ b/client/packages/api-client/src/schema/schema.ts
@@ -13270,7 +13270,8 @@ export interface components {
                 | "iiif"
                 | "mavedb"
                 | "omero"
-                | "ssh";
+                | "ssh"
+                | "ckan";
             /** Variables */
             variables?:
                 | (
@@ -25978,7 +25979,8 @@ export interface components {
                 | "iiif"
                 | "mavedb"
                 | "omero"
-                | "ssh";
+                | "ssh"
+                | "ckan";
             /** Uri Root */
             uri_root: string;
             /**

--- a/client/src/api/fileSources.ts
+++ b/client/src/api/fileSources.ts
@@ -107,6 +107,10 @@ export const templateTypes: FileSourceTypesDetail = {
         icon: faNetworkWired,
         message: "This is a file repository plugin that connects with an iRODS server.",
     },
+    ckan: {
+        icon: faNetworkWired,
+        message: "This is a repository plugin that connects with a CKAN instance.",
+    },
 };
 
 export const FileSourcesValidFilters = {

--- a/lib/galaxy/files/sources/ckan.py
+++ b/lib/galaxy/files/sources/ckan.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from typing import (
     Any,
-    Optional,
-    Union,
 )
 from urllib.parse import urlparse
 
@@ -21,7 +19,7 @@ from galaxy.util.config_templates import TemplateExpansion
 
 
 class CKANFileSystem(AbstractFileSystem):
-    def __init__(self, base_url: str, token: Optional[str] = None, **kwargs: Any):
+    def __init__(self, base_url: str, token: str | None = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.base_url = base_url.rstrip("/")  # prevents double slashes in URLs
         self.token = token
@@ -44,7 +42,7 @@ class CKANFileSystem(AbstractFileSystem):
     def _get_response(
         self,
         action: str,
-        params: Optional[dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
     ) -> Any:
         url = f"{self.base_url}/api/3/action/{action}"
         headers = self._get_request_headers()
@@ -121,11 +119,11 @@ class CKANFileSystem(AbstractFileSystem):
         return path in ("", "/")
 
     # in case resource name is missing, use id
-    def _resource_name(self, resource: dict[str, Any]) -> Optional[str]:
+    def _resource_name(self, resource: dict[str, Any]) -> str | None:
         return resource.get("name") or resource.get("id")
 
     # returns last modified as a date object, or None if missing/invalid
-    def _parse_modified(self, value: Optional[str]) -> Optional[datetime]:
+    def _parse_modified(self, value: str | None) -> datetime | None:
         if not value:
             return None
         try:
@@ -148,7 +146,7 @@ class CKANFileSystem(AbstractFileSystem):
         return entry
 
     # returns dataset entry with optional metadata
-    def _dataset_entry(self, name: str, dataset: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    def _dataset_entry(self, name: str, dataset: dict[str, Any] | None = None) -> dict[str, Any]:
         entry: dict[str, Any] = {"name": f"/{name}", "type": "directory", "size": None}
         if dataset:
             # adds these parameter in case detail=True
@@ -157,7 +155,7 @@ class CKANFileSystem(AbstractFileSystem):
         return entry
 
     # splits path into dataset_id and optional resource_name
-    def _split_path(self, path: str) -> tuple[str, Optional[str]]:
+    def _split_path(self, path: str) -> tuple[str, str | None]:
         parts = path.strip("/").split("/", 1)
         dataset_id = parts[0]
         resource_name = None  # path is /dataset
@@ -225,13 +223,13 @@ class CKANFileSystem(AbstractFileSystem):
 
 
 class CKANFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
-    endpoint: Union[str, TemplateExpansion]
-    token: Union[str, TemplateExpansion, None] = None
+    endpoint: str | TemplateExpansion
+    token: str | TemplateExpansion | None = None
 
 
 class CKANFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
     endpoint: str
-    token: Optional[str] = None
+    token: str | None = None
 
 
 class CKANFilesSource(FsspecFilesSource[CKANFileSourceTemplateConfiguration, CKANFileSourceConfiguration]):

--- a/lib/galaxy/files/sources/ckan.py
+++ b/lib/galaxy/files/sources/ckan.py
@@ -7,7 +7,10 @@ from urllib.parse import urlparse
 import requests
 from fsspec import AbstractFileSystem
 
-from galaxy.files.models import FilesSourceRuntimeContext
+from galaxy.files.models import (
+    AnyRemoteEntry,
+    FilesSourceRuntimeContext,
+)
 from galaxy.files.sources._fsspec import (
     CacheOptionsDictType,
     FsspecBaseFileSourceConfiguration,
@@ -253,7 +256,29 @@ class CKANFilesSource(FsspecFilesSource[CKANFileSourceTemplateConfiguration, CKA
         dataset_id, resource_name = fs._split_path(target_path)
         if not resource_name:
             raise ValueError("Select a dataset as the upload target, not the root.")
+        dataset = fs._get_dataset(dataset_id)
+        if not dataset.get("private", False):
+            raise ValueError("Cannot export to a public CKAN dataset. Select a private dataset instead.")
         fs._post_resource(dataset_id, resource_name, native_path)
+
+    # for the export destination picker only offer datasets the user can write to
+    def _list(
+        self,
+        context: FilesSourceRuntimeContext[CKANFileSourceConfiguration],
+        path="/",
+        recursive=False,
+        write_intent: bool = False,
+        limit: int | None = None,
+        offset: int | None = None,
+        query: str | None = None,
+        sort_by: str | None = None,
+    ) -> tuple[list[AnyRemoteEntry], int]:
+        if write_intent and path in ("", "/"):
+            fs = self._open_fs(context, {})
+            entries = [self._info_to_entry(fs._dataset_entry(name), context.config) for name in fs._list_private_datasets()]
+            total_count = len(entries)
+            return self._apply_pagination(entries, limit, offset), total_count
+        return super()._list(context, path, recursive, write_intent, limit, offset, query, sort_by)
 
 
 __all__ = ("CKANFilesSource",)

--- a/lib/galaxy/files/sources/ckan.py
+++ b/lib/galaxy/files/sources/ckan.py
@@ -1,270 +1,97 @@
-from datetime import datetime
 from typing import (
     Any,
+    cast,
 )
 from urllib.parse import urlparse
 
-import requests
-from fsspec import AbstractFileSystem
-
+from galaxy.exceptions import (
+    AuthenticationRequired,
+    MessageException,
+    ObjectNotFound,
+)
 from galaxy.files.models import (
     AnyRemoteEntry,
+    Entry,
+    EntryData,
     FilesSourceRuntimeContext,
+    RemoteDirectory,
+    RemoteFile,
 )
-from galaxy.files.sources._fsspec import (
-    CacheOptionsDictType,
-    FsspecBaseFileSourceConfiguration,
-    FsspecBaseFileSourceTemplateConfiguration,
-    FsspecFilesSource,
+from galaxy.files.sources._defaults import DEFAULT_SCHEME
+from galaxy.files.sources._rdm import (
+    ContainerAndFileIdentifier,
+    RDMFileSourceConfiguration,
+    RDMFileSourceTemplateConfiguration,
+    RDMFilesSource,
+    RDMRepositoryInteractor,
 )
-from galaxy.util import DEFAULT_SOCKET_TIMEOUT
-from galaxy.util.config_templates import TemplateExpansion
+from galaxy.files.uris import validate_non_local
+from galaxy.util import (
+    DEFAULT_SOCKET_TIMEOUT,
+    requests,
+    stream_to_open_named_file,
+)
+
+# CKAN caps package_search at ckan.search.rows_max, which defaults to 1000
+MAX_ROWS_PER_REQUEST = 1000
+
+# CKAN indexes the visibility as "capacity", ascending puts "private" before "public". Score comes
+# first to keep the relevance order when searching, while browsing gives every dataset the same score
+DEFAULT_SORT = "score desc, capacity asc, title_string asc"
 
 
-class CKANFileSystem(AbstractFileSystem):
-    def __init__(self, base_url: str, token: str | None = None, **kwargs: Any):
-        super().__init__(**kwargs)
-        self.base_url = base_url.rstrip("/")  # prevents double slashes in URLs
-        self.token = token
+class CKANRDMFilesSource(RDMFilesSource):
+    """A files source for CKAN open data portals.
 
-    def _get_request_headers(self) -> dict[str, str]:
-        headers = {}
-        # auth header, only if token is provided
-        if self.token:
-            headers["Authorization"] = self.token  # raw api token, CKAN doesnt need bearer prefix
-        return headers
+    In CKAN a "dataset" (also called package) represents what we refer to as container in the rdm base class.
+    """
 
-    def _raise_for_ckan_error(self, response: requests.Response) -> None:
-        if response.status_code in (401, 403):
-            raise PermissionError(f"Access denied (HTTP {response.status_code}).")
-        if response.status_code == 404:
-            raise FileNotFoundError(f"Not found (HTTP {response.status_code}): {response.url}")
-        response.raise_for_status()  # any other 4xx/5xx still raises a generic HTTPError
-
-    # call ckan action api and return response result
-    def _get_response(
-        self,
-        action: str,
-        params: dict[str, Any] | None = None,
-    ) -> Any:
-        url = f"{self.base_url}/api/3/action/{action}"
-        headers = self._get_request_headers()
-        response = requests.get(url, headers=headers, timeout=DEFAULT_SOCKET_TIMEOUT, params=params)
-        self._raise_for_ckan_error(response)  # raise exception for HTTP errors
-        payload = response.json()
-        # ckan could return HTTP 200 even for errors, so check success field in payload
-        if not payload.get("success", False):  # success is False or missing
-            error = payload.get("error", {})
-            raise Exception(f"CKAN API call failed: {error.get('message') or error}")
-        return payload["result"]
-
-    # upload a file to an existing dataset as new resource
-    def _post_resource(self, dataset_id: str, resource_name: str, file_path: str) -> None:
-        url = f"{self.base_url}/api/3/action/resource_create"
-        headers = self._get_request_headers()
-        with open(file_path, "rb") as f:
-            response = requests.post(
-                url,
-                headers=headers,
-                data={"package_id": dataset_id, "name": resource_name},  # target dataset and display name
-                files={"upload": (resource_name, f)},  # filename for download and file content
-                timeout=DEFAULT_SOCKET_TIMEOUT,
-            )
-        self._raise_for_ckan_error(response)  # raise exception for HTTP errors
-        payload = response.json()
-        # ckan could return HTTP 200 even for errors, so check success field in payload
-        if not payload.get("success", False):  # success is False or missing
-            error = payload.get("error", {})
-            raise Exception(f"CKAN API call failed: {error.get('message') or error}")
-
-    def _list_public_datasets(self) -> list[str]:
-        # cheap call that returns just the names of public datasets
-        return self._get_response("package_list")
-
-    def _list_private_datasets(self) -> list[str]:
-        # for listing private datasets, package_search is needed which returns all metadata, not just names
-        # since package_search paginates results, its needed to loop until all datasets are retrieved
-        names = []
-        start = 0
-        while True:
-            # if no private datasets just returns empty list
-            result = self._get_response(
-                "package_search",
-                params={
-                    "fq": "private:true",  # filter query to return only private datasets
-                    "include_private": True,  # without this CKAN hides private datasets
-                    "rows": 1000,  # rows is page size, 1000 is max allowed in default CKAN
-                    "start": start,  # pagination offset
-                },
-            )
-            names.extend([dataset["name"] for dataset in result["results"]])
-            # result["count"] is total number of private datasets, tells if all are retrieved
-            if len(names) >= result["count"]:
-                break
-            start += 1000
-        return names
-
-    # lists all datasets that are available to the user
-    # users private datasets are listed first, then the public ones
-    def _list_all_datasets(self) -> list[str]:
-        return self._list_private_datasets() + self._list_public_datasets()
-
-    # fetch dataset metadata
-    def _get_dataset(self, dataset_id: str) -> dict[str, Any]:
-        return self._get_response("package_show", params={"id": dataset_id})
-
-    # extract resources from dataset payload
-    def _list_resources(self, dataset_id: str) -> list[dict[str, Any]]:
-        dataset = self._get_dataset(dataset_id)
-        return dataset.get("resources", [])
-
-    def _is_root(self, path: str) -> bool:
-        return path in ("", "/")
-
-    # in case resource name is missing, use id
-    def _resource_name(self, resource: dict[str, Any]) -> str | None:
-        return resource.get("name") or resource.get("id")
-
-    # returns last modified as a date object, or None if missing/invalid
-    def _parse_modified(self, value: str | None) -> datetime | None:
-        if not value:
-            return None
-        try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-
-    # returns resource entry with optional metadata
-    def _resource_entry(self, dataset_id: str, resource: dict[str, Any]) -> dict[str, Any]:
-        size = resource.get("size") or resource.get("filesize")
-        entry = {
-            "name": f"/{dataset_id}/{self._resource_name(resource)}",
-            "type": "file",
-            "modified": self._parse_modified(resource.get("last_modified") or resource.get("metadata_modified")),
-            "id": resource.get("id"),
-        }
-        # size isnt always known, so this prevents int(None) error
-        if size is not None:
-            entry["size"] = size
-        return entry
-
-    # returns dataset entry with optional metadata
-    def _dataset_entry(self, name: str, dataset: dict[str, Any] | None = None) -> dict[str, Any]:
-        entry: dict[str, Any] = {"name": f"/{name}", "type": "directory", "size": None}
-        if dataset:
-            # adds these parameter in case detail=True
-            entry["modified"] = self._parse_modified(dataset.get("metadata_modified") or dataset.get("last_modified"))
-            entry["id"] = dataset.get("id")
-        return entry
-
-    # splits path into dataset_id and optional resource_name
-    def _split_path(self, path: str) -> tuple[str, str | None]:
-        parts = path.strip("/").split("/", 1)
-        dataset_id = parts[0]
-        resource_name = None  # path is /dataset
-        if len(parts) > 1:
-            resource_name = parts[1]  # path is /dataset/resource
-        return dataset_id, resource_name
-
-    # find a resource by name in a dataset
-    def _find_resource(self, dataset_id: str, resource_name: str) -> dict[str, Any]:
-        resources = self._list_resources(dataset_id)
-        for resource in resources:
-            if self._resource_name(resource) == resource_name:
-                return resource
-        raise FileNotFoundError(f"/{dataset_id}/{resource_name}")
-
-    def _is_same_host(self, url: str) -> bool:
-        return urlparse(url).hostname == urlparse(self.base_url).hostname
-
-    # list datasets in root or resources in a dataset
-    def ls(self, path: str = "", detail: bool = True, **kwargs: Any) -> list[dict[str, Any]] | list[str]:
-        if not self._is_root(path):
-            # list resources in dataset
-            dataset_id, _ = self._split_path(path)  # only need dataset_id, resource_name isnt needed
-            resources = self._list_resources(dataset_id)
-            if detail:
-                return [self._resource_entry(dataset_id, r) for r in resources]
-            return [self._resource_entry(dataset_id, r)["name"] for r in resources]
-
-        # list datasets in root
-        datasets = self._list_all_datasets()
-        if detail:
-            return [self._dataset_entry(name) for name in datasets]
-        return [self._dataset_entry(name)["name"] for name in datasets]
-
-    # get dataset or resource metadata
-    def info(self, path: str, **kwargs: Any) -> dict[str, Any]:
-        if self._is_root(path):
-            return {"name": "/", "type": "directory", "size": None}
-        dataset_id, resource_name = self._split_path(path)
-        # /dataset
-        if not resource_name:
-            return self._dataset_entry(dataset_id, self._get_dataset(dataset_id))
-        # /dataset/resource
-        resource = self._find_resource(dataset_id, resource_name)
-        return self._resource_entry(dataset_id, resource)
-
-    # stream resource content using requests, returns a file-like object
-    def _open(self, path: str, mode: str = "rb", **kwargs: Any):
-        if mode != "rb":
-            raise NotImplementedError("Only read binary mode 'rb' is supported")
-        dataset_id, resource_name = self._split_path(path)
-        if resource_name is None:
-            raise FileNotFoundError(path)
-        resource = self._find_resource(dataset_id, resource_name)
-        url = resource.get("url") or resource.get("download_url") or None
-        if not url:
-            raise FileNotFoundError(path)
-        # only add the auth token if the resource is hosted on the same domain as the CKAN instance
-        # to prevent leaking tokens to external URLs
-        headers = self._get_request_headers() if self._is_same_host(url) else {}
-        response = requests.get(url, stream=True, headers=headers, timeout=DEFAULT_SOCKET_TIMEOUT)
-        self._raise_for_ckan_error(response)  # raise exception for HTTP errors
-        response.raw.decode_content = True
-        return response.raw
-
-
-class CKANFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
-    endpoint: str | TemplateExpansion
-    token: str | TemplateExpansion | None = None
-
-
-class CKANFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
-    endpoint: str
-    token: str | None = None
-
-
-class CKANFilesSource(FsspecFilesSource[CKANFileSourceTemplateConfiguration, CKANFileSourceConfiguration]):
     plugin_type = "ckan"
-    required_module = CKANFileSystem
-    required_package = "requests"
+    supports_pagination = True
+    supports_search = True
 
-    template_config_class = CKANFileSourceTemplateConfiguration
-    resolved_config_class = CKANFileSourceConfiguration
+    def __init__(self, template_config: RDMFileSourceTemplateConfiguration):
+        super().__init__(template_config)
+        self.repository: CKANRepositoryInteractor
 
-    def _open_fs(
-        self, context: FilesSourceRuntimeContext[CKANFileSourceConfiguration], cache_options: CacheOptionsDictType
-    ) -> CKANFileSystem:
-        config = context.config
-        return CKANFileSystem(base_url=config.endpoint, token=config.token, **cache_options)
+    @property
+    def allowlist(self) -> list:
+        """The urls Galaxy is allowed to fetch, used to validate the resource urls from CKAN."""
+        return self._file_sources_config.fetch_url_allowlist or []
 
-    def _write_from(
-        self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[CKANFileSourceConfiguration]
-    ) -> None:
-        fs = self._open_fs(context, {})
-        dataset_id, resource_name = fs._split_path(target_path)
-        if not resource_name:
-            raise ValueError("Select a dataset as the upload target, not the root.")
-        dataset = fs._get_dataset(dataset_id)
-        if not dataset.get("private", False):
-            raise ValueError("Cannot export to a public CKAN dataset. Select a private dataset instead.")
-        fs._post_resource(dataset_id, resource_name, native_path)
+    def get_scheme(self) -> str:
+        return self.scheme if self.scheme and self.scheme != DEFAULT_SCHEME else self.plugin_type
 
-    # for the export destination picker only offer datasets the user can write to
+    def get_repository_interactor(self, repository_url: str) -> RDMRepositoryInteractor:
+        return CKANRepositoryInteractor(repository_url, self)
+
+    def parse_path(self, source_path: str, container_id_only: bool = False) -> ContainerAndFileIdentifier:
+        """Parses the given source path into the dataset id and the resource name.
+
+        The path is either '/<dataset_id>' or '/<dataset_id>/<resource_name>'. Dataset ids are slugs
+        without slashes, so splitting on the first one is enough and resource names may contain slashes.
+        """
+        if not source_path.startswith("/"):
+            raise ValueError(f"Invalid source path: '{source_path}'. Must start with '/'.")
+        path_without_slash = source_path[1:]
+
+        if container_id_only:
+            if not path_without_slash:
+                raise ValueError(f"Invalid source path: '{source_path}'. Expected format: '/<dataset_id>'.")
+            dataset_id = path_without_slash.split("/", 1)[0]
+            return ContainerAndFileIdentifier(container_id=dataset_id, file_identifier="")
+
+        parts = path_without_slash.split("/", 1)
+        if len(parts) < 2 or not parts[1]:
+            raise ValueError(f"Invalid source path: '{source_path}'. Expected format: '/<dataset_id>/<resource_name>'.")
+        return ContainerAndFileIdentifier(container_id=parts[0], file_identifier=parts[1])
+
+    def get_container_id_from_path(self, source_path: str) -> str:
+        return self.parse_path(source_path, container_id_only=True).container_id
+
     def _list(
         self,
-        context: FilesSourceRuntimeContext[CKANFileSourceConfiguration],
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
         path="/",
         recursive=False,
         write_intent: bool = False,
@@ -273,12 +100,323 @@ class CKANFilesSource(FsspecFilesSource[CKANFileSourceTemplateConfiguration, CKA
         query: str | None = None,
         sort_by: str | None = None,
     ) -> tuple[list[AnyRemoteEntry], int]:
-        if write_intent and path in ("", "/"):
-            fs = self._open_fs(context, {})
-            entries = [self._info_to_entry(fs._dataset_entry(name), context.config) for name in fs._list_private_datasets()]
-            total_count = len(entries)
-            return self._apply_pagination(entries, limit, offset), total_count
-        return super()._list(context, path, recursive, write_intent, limit, offset, query, sort_by)
+        """This method lists the datasets or the resources of a dataset from CKAN."""
+        is_root_path = path == "/"
+        if is_root_path:
+            datasets, total_hits = self.repository.get_file_containers(
+                context, write_intent, limit=limit, offset=offset, query=query, sort_by=sort_by
+            )
+            return cast(list[AnyRemoteEntry], datasets), total_hits
+        dataset_id = self.get_container_id_from_path(path)
+        files = self.repository.get_files_in_container(context, dataset_id, write_intent, query)
+        return cast(list[AnyRemoteEntry], files), len(files)
+
+    def _realize_to(
+        self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]
+    ):
+        """Used when downloading resources from CKAN."""
+        dataset_id, resource_name = self.parse_path(source_path)
+        self.repository.download_file_from_container(dataset_id, resource_name, native_path, context)
+
+    def _write_from(
+        self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]
+    ):
+        """Used when uploading files to CKAN as a new resource of an existing dataset."""
+        dataset_id, resource_name = self.parse_path(target_path)
+        self.repository.upload_file_to_draft_container(dataset_id, resource_name, native_path, context)
+
+    def _create_entry(
+        self, entry_data: EntryData, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]
+    ) -> Entry:
+        """Rejects the creation of datasets, the export dialogs cannot ask for an organization."""
+        # the base class would raise NotImplementedError, which the api reports as a server error
+        raise MessageException(
+            "Creating new CKAN datasets from Galaxy is not supported, a new dataset has to be "
+            "assigned to an organization. Create the dataset in CKAN and export into it instead."
+        )
 
 
-__all__ = ("CKANFilesSource",)
+class CKANRepositoryInteractor(RDMRepositoryInteractor):
+    """In CKAN a "dataset" (also called package) represents what we refer to as container in the rdm base class."""
+
+    def __init__(self, repository_url: str, plugin: CKANRDMFilesSource):
+        super().__init__(repository_url, plugin)
+        # precomputed once, used to decide if the api token may be sent to a resource url
+        self._repository_origin = self._to_origin(self.repository_url)
+        self._allowlist = plugin.allowlist
+        self._user_id: str | None = None
+
+    @property
+    def api_base_url(self) -> str:
+        return f"{self.repository_url}/api/3/action"
+
+    def to_plugin_uri(self, container_id: str, filename: str | None = None) -> str:
+        if filename:
+            return f"{self.plugin.get_uri_root()}/{container_id}/{filename}"
+        return f"{self.plugin.get_uri_root()}/{container_id}"
+
+    def get_file_containers(
+        self,
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
+        write_intent: bool,
+        limit: int | None = None,
+        offset: int | None = None,
+        query: str | None = None,
+        sort_by: str | None = None,
+    ) -> tuple[list[RemoteDirectory], int]:
+        """Lists the datasets of the CKAN instance.
+
+        The pagination happens in CKAN, so only the requested page is fetched. Without a limit the
+        maximum number of rows CKAN allows per request is used.
+        """
+        params: dict[str, Any] = {
+            "q": query or "*:*",
+            "rows": limit if limit is not None else MAX_ROWS_PER_REQUEST,
+            "start": offset or 0,
+            "include_private": True,
+            "sort": sort_by or DEFAULT_SORT,
+        }
+        if write_intent:
+            # a dataset is writable through the user's role in its organization, not through the private flag
+            filter_query = self._get_writable_filter_query(context)
+            if not filter_query:
+                return [], 0
+            params["fq"] = filter_query
+        result = self._get_response(context, "package_search", params)
+        return self._get_datasets_from_response(result), result["count"]
+
+    def get_files_in_container(
+        self,
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
+        container_id: str,
+        writeable: bool,
+        query: str | None = None,
+    ) -> list[RemoteFile]:
+        """This method lists the resources of a CKAN dataset."""
+        dataset = self._get_dataset(context, container_id)
+        files = self._get_files_from_response(container_id, dataset.get("resources", []))
+        if query:
+            files = [file for file in files if query in file.name]
+        return files
+
+    def upload_file_to_draft_container(
+        self,
+        container_id: str,
+        filename: str,
+        file_path: str,
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
+    ) -> None:
+        """Uploads a file as a new resource of an existing CKAN dataset."""
+        headers = self._get_request_headers(context, auth_required=True)
+        with open(file_path, "rb") as file:
+            response = requests.post(
+                f"{self.api_base_url}/resource_create",
+                data={"package_id": container_id, "name": filename},  # target dataset and display name
+                files={"upload": (filename, file)},  # filename for the download and the file content
+                headers=headers,
+                timeout=DEFAULT_SOCKET_TIMEOUT,
+            )
+        self._ensure_response_has_expected_status_code(response, 200)
+
+    def download_file_from_container(
+        self,
+        container_id: str,
+        file_identifier: str,
+        file_path: str,
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
+    ) -> None:
+        """Downloads a resource of a CKAN dataset to the given file path."""
+        resource = self._get_resource(context, container_id, file_identifier)
+        download_url = resource.get("url")
+        if not download_url:
+            raise ObjectNotFound(f"The resource '{file_identifier}' does not have a download url.")
+        if not download_url.startswith(("http://", "https://")):
+            # requests refuses other schemes anyway, but with a generic error message
+            raise MessageException(
+                f"The resource '{file_identifier}' is linked with an unsupported url scheme, "
+                "only http and https can be downloaded"
+            )
+        # the url is taken from the CKAN metadata, so it has to be validated before Galaxy requests it
+        validate_non_local(download_url, self._allowlist)
+        # CKAN resources can also be hosted on other servers, the token must not leak to them
+        is_hosted_by_ckan = self._is_same_origin(download_url)
+        headers = self._get_request_headers(context) if is_hosted_by_ckan else {}
+        with requests.get(
+            download_url,
+            headers=headers,
+            stream=True,
+            timeout=DEFAULT_SOCKET_TIMEOUT,
+        ) as response:
+            self._ensure_download_response_is_ok(response, is_hosted_by_ckan)
+            validate_non_local(response.url, self._allowlist)  # the request could have been redirected
+            response.raw.decode_content = True  # without this gzipped responses stay compressed
+            target_file = open(file_path, "wb")  # the file descriptor is closed by stream_to_open_named_file
+            stream_to_open_named_file(response.raw, target_file.fileno(), file_path)
+
+    def _get_writable_filter_query(self, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]) -> str | None:
+        """Builds the search filter for the datasets the user may add a resource to.
+
+        The whole expression has to be wrapped in parentheses, CKAN appends its own required
+        filters (site id, state, permission labels) to it and the grouping would be lost otherwise.
+        """
+        clauses = []
+        organization_ids = self._get_writable_organization_ids(context)
+        if organization_ids:
+            quoted_ids = " OR ".join(f'"{organization_id}"' for organization_id in organization_ids)
+            clauses.append(f"owner_org:({quoted_ids})")
+        user_id = self._get_current_user_id(context)
+        if user_id:
+            # datasets without an organization are not covered by the filter above. CKAN itself would
+            # let any logged in user edit them, but only offering the own ones matches expectations
+            clauses.append(f'(creator_user_id:"{user_id}" AND -owner_org:[* TO *])')
+        if not clauses:
+            return None
+        return "({})".format(" OR ".join(clauses))
+
+    def _get_writable_organization_ids(
+        self, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]
+    ) -> list[str]:
+        """Returns the organizations in which the user is allowed to add resources to a dataset.
+
+        An export adds a resource to an existing dataset, so update_dataset is the matching
+        permission. In CKAN it is held by the editor and the admin role.
+        """
+        organizations = self._get_response(
+            context, "organization_list_for_user", {"permission": "update_dataset"}, auth_required=True
+        )
+        return [organization["id"] for organization in organizations]
+
+    def _get_current_user_id(self, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]) -> str | None:
+        """Returns the id of the CKAN user the api token belongs to.
+
+        Called without an id, user_show returns the authenticated user, which is the only way to
+        find out the own user id.
+        """
+        if self._user_id is None:
+            self._user_id = self._get_response(context, "user_show", auth_required=True).get("id")
+        return self._user_id
+
+    def _get_dataset(
+        self, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration], dataset_id: str
+    ) -> dict[str, Any]:
+        return self._get_response(context, "package_show", {"id": dataset_id})
+
+    def _get_resource(
+        self, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration], dataset_id: str, resource_name: str
+    ) -> dict[str, Any]:
+        """Looks up a resource by its name, CKAN download urls are not predictable from the name."""
+        dataset = self._get_dataset(context, dataset_id)
+        for resource in dataset.get("resources", []):
+            if self._get_resource_name(resource) == resource_name:
+                return resource
+        raise ObjectNotFound(f"The dataset '{dataset_id}' does not contain a resource '{resource_name}'.")
+
+    def _get_resource_name(self, resource: dict[str, Any]) -> str:
+        # resources are not required to have a name in CKAN, then the id is used instead
+        return resource.get("name") or resource["id"]
+
+    def _get_datasets_from_response(self, response: dict) -> list[RemoteDirectory]:
+        rval: list[RemoteDirectory] = []
+        for dataset in response["results"]:
+            # the name is the slug of the dataset and is used to address it in the api
+            uri = self.to_plugin_uri(dataset["name"])
+            rval.append(
+                RemoteDirectory(
+                    name=dataset.get("title") or dataset["name"],
+                    uri=uri,
+                    path=self.plugin.to_relative_path(uri),
+                )
+            )
+        return rval
+
+    def _get_files_from_response(self, dataset_id: str, resources: list[dict[str, Any]]) -> list[RemoteFile]:
+        rval: list[RemoteFile] = []
+        for resource in resources:
+            resource_name = self._get_resource_name(resource)
+            uri = self.to_plugin_uri(dataset_id, resource_name)
+            rval.append(
+                RemoteFile(
+                    name=resource_name,
+                    size=int(resource.get("size") or 0),  # the size is not always known in CKAN
+                    ctime=resource.get("last_modified") or resource.get("created"),
+                    uri=uri,
+                    path=self.plugin.to_relative_path(uri),
+                )
+            )
+        return rval
+
+    def _get_response(
+        self,
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
+        action: str,
+        params: dict[str, Any] | None = None,
+        auth_required: bool = False,
+    ) -> Any:
+        """Calls an action of the CKAN Action API and returns the result of the payload."""
+        headers = self._get_request_headers(context, auth_required)
+        response = requests.get(
+            f"{self.api_base_url}/{action}",
+            params=params,
+            headers=headers,
+            timeout=DEFAULT_SOCKET_TIMEOUT,
+        )
+        self._ensure_response_has_expected_status_code(response, 200)
+        payload = response.json()
+        # a host that is not CKAN can answer with 200 as well, the success flag identifies a real payload
+        if not payload.get("success", False):
+            error = payload.get("error", {})
+            raise MessageException(f"CKAN API call failed: {error.get('message') or error}")
+        return payload["result"]
+
+    def _get_request_headers(
+        self, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration], auth_required: bool = False
+    ) -> dict[str, str]:
+        token = self.plugin.get_authorization_token(context)
+        # CKAN expects the raw api token in the Authorization header, without a "Bearer" prefix
+        headers = {"Authorization": token} if token else {}
+        if auth_required and not token:
+            self._raise_auth_required()
+        return headers
+
+    def _ensure_response_has_expected_status_code(self, response, expected_status_code: int) -> None:
+        if response.status_code == expected_status_code:
+            return
+        if response.status_code in (401, 403):
+            # CKAN ignores an invalid token and answers anonymously, so it never reports a bad token
+            self._raise_auth_required(
+                f"CKAN denied the request (HTTP {response.status_code}). The access token for "
+                f"'{self.plugin.label}' may be invalid or may not have the required permission."
+            )
+        if response.status_code == 404:
+            raise ObjectNotFound(f"Not found (HTTP {response.status_code}): {response.url}")
+        raise MessageException(f"Request to {response.url} failed with status code {response.status_code}")
+
+    def _ensure_download_response_is_ok(self, response, is_hosted_by_ckan: bool) -> None:
+        """Checks the response of a resource download.
+
+        A resource can link to a server outside of CKAN. Asking the user for a CKAN token would not
+        help there, so such a denial is not reported as a missing authentication.
+        """
+        if not is_hosted_by_ckan and response.status_code in (401, 403):
+            raise MessageException(
+                f"Access to the resource at '{response.url}' was denied (HTTP {response.status_code}). "
+                "It is hosted outside of the CKAN instance, so the CKAN access token does not apply to it."
+            )
+        self._ensure_response_has_expected_status_code(response, 200)
+
+    def _raise_auth_required(self, message: str | None = None) -> None:
+        raise AuthenticationRequired(
+            message or f"Please provide a personal access token in your user's preferences for '{self.plugin.label}'"
+        )
+
+    def _is_same_origin(self, url: str) -> bool:
+        """Checks if a url points to the CKAN instance itself and not to an external server."""
+        return self._to_origin(url) == self._repository_origin
+
+    @staticmethod
+    def _to_origin(url: str) -> tuple[str | None, str | None, int | None]:
+        parsed_url = urlparse(url)
+        return parsed_url.scheme, parsed_url.hostname, parsed_url.port
+
+
+__all__ = ("CKANRDMFilesSource",)

--- a/lib/galaxy/files/sources/ckan.py
+++ b/lib/galaxy/files/sources/ckan.py
@@ -109,7 +109,11 @@ class CKANRDMFilesSource(RDMFilesSource):
             return cast(list[AnyRemoteEntry], datasets), total_hits
         dataset_id = self.get_container_id_from_path(path)
         files = self.repository.get_files_in_container(context, dataset_id, write_intent, query)
-        return cast(list[AnyRemoteEntry], files), len(files)
+        # CKAN embeds the resources in package_show and has no endpoint that pages through them,
+        # so the requested page is cut out here instead of in CKAN
+        start = offset or 0
+        end = start + limit if limit is not None else None
+        return cast(list[AnyRemoteEntry], files[start:end]), len(files)
 
     def _realize_to(
         self, source_path: str, native_path: str, context: FilesSourceRuntimeContext[RDMFileSourceConfiguration]

--- a/lib/galaxy/files/sources/ckan.py
+++ b/lib/galaxy/files/sources/ckan.py
@@ -1,0 +1,261 @@
+from datetime import datetime
+from typing import (
+    Any,
+    Optional,
+    Union,
+)
+from urllib.parse import urlparse
+
+import requests
+from fsspec import AbstractFileSystem
+
+from galaxy.files.models import FilesSourceRuntimeContext
+from galaxy.files.sources._fsspec import (
+    CacheOptionsDictType,
+    FsspecBaseFileSourceConfiguration,
+    FsspecBaseFileSourceTemplateConfiguration,
+    FsspecFilesSource,
+)
+from galaxy.util import DEFAULT_SOCKET_TIMEOUT
+from galaxy.util.config_templates import TemplateExpansion
+
+
+class CKANFileSystem(AbstractFileSystem):
+    def __init__(self, base_url: str, token: Optional[str] = None, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.base_url = base_url.rstrip("/")  # prevents double slashes in URLs
+        self.token = token
+
+    def _get_request_headers(self) -> dict[str, str]:
+        headers = {}
+        # auth header, only if token is provided
+        if self.token:
+            headers["Authorization"] = self.token  # raw api token, CKAN doesnt need bearer prefix
+        return headers
+
+    def _raise_for_ckan_error(self, response: requests.Response) -> None:
+        if response.status_code in (401, 403):
+            raise PermissionError(f"Access denied (HTTP {response.status_code}).")
+        if response.status_code == 404:
+            raise FileNotFoundError(f"Not found (HTTP {response.status_code}): {response.url}")
+        response.raise_for_status()  # any other 4xx/5xx still raises a generic HTTPError
+
+    # call ckan action api and return response result
+    def _get_response(
+        self,
+        action: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> Any:
+        url = f"{self.base_url}/api/3/action/{action}"
+        headers = self._get_request_headers()
+        response = requests.get(url, headers=headers, timeout=DEFAULT_SOCKET_TIMEOUT, params=params)
+        self._raise_for_ckan_error(response)  # raise exception for HTTP errors
+        payload = response.json()
+        # ckan could return HTTP 200 even for errors, so check success field in payload
+        if not payload.get("success", False):  # success is False or missing
+            error = payload.get("error", {})
+            raise Exception(f"CKAN API call failed: {error.get('message') or error}")
+        return payload["result"]
+
+    # upload a file to an existing dataset as new resource
+    def _post_resource(self, dataset_id: str, resource_name: str, file_path: str) -> None:
+        url = f"{self.base_url}/api/3/action/resource_create"
+        headers = self._get_request_headers()
+        with open(file_path, "rb") as f:
+            response = requests.post(
+                url,
+                headers=headers,
+                data={"package_id": dataset_id, "name": resource_name},  # target dataset and display name
+                files={"upload": (resource_name, f)},  # filename for download and file content
+                timeout=DEFAULT_SOCKET_TIMEOUT,
+            )
+        self._raise_for_ckan_error(response)  # raise exception for HTTP errors
+        payload = response.json()
+        # ckan could return HTTP 200 even for errors, so check success field in payload
+        if not payload.get("success", False):  # success is False or missing
+            error = payload.get("error", {})
+            raise Exception(f"CKAN API call failed: {error.get('message') or error}")
+
+    def _list_public_datasets(self) -> list[str]:
+        # cheap call that returns just the names of public datasets
+        return self._get_response("package_list")
+
+    def _list_private_datasets(self) -> list[str]:
+        # for listing private datasets, package_search is needed which returns all metadata, not just names
+        # since package_search paginates results, its needed to loop until all datasets are retrieved
+        names = []
+        start = 0
+        while True:
+            # if no private datasets just returns empty list
+            result = self._get_response(
+                "package_search",
+                params={
+                    "fq": "private:true",  # filter query to return only private datasets
+                    "include_private": True,  # without this CKAN hides private datasets
+                    "rows": 1000,  # rows is page size, 1000 is max allowed in default CKAN
+                    "start": start,  # pagination offset
+                },
+            )
+            names.extend([dataset["name"] for dataset in result["results"]])
+            # result["count"] is total number of private datasets, tells if all are retrieved
+            if len(names) >= result["count"]:
+                break
+            start += 1000
+        return names
+
+    # lists all datasets that are available to the user
+    # users private datasets are listed first, then the public ones
+    def _list_all_datasets(self) -> list[str]:
+        return self._list_private_datasets() + self._list_public_datasets()
+
+    # fetch dataset metadata
+    def _get_dataset(self, dataset_id: str) -> dict[str, Any]:
+        return self._get_response("package_show", params={"id": dataset_id})
+
+    # extract resources from dataset payload
+    def _list_resources(self, dataset_id: str) -> list[dict[str, Any]]:
+        dataset = self._get_dataset(dataset_id)
+        return dataset.get("resources", [])
+
+    def _is_root(self, path: str) -> bool:
+        return path in ("", "/")
+
+    # in case resource name is missing, use id
+    def _resource_name(self, resource: dict[str, Any]) -> Optional[str]:
+        return resource.get("name") or resource.get("id")
+
+    # returns last modified as a date object, or None if missing/invalid
+    def _parse_modified(self, value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
+    # returns resource entry with optional metadata
+    def _resource_entry(self, dataset_id: str, resource: dict[str, Any]) -> dict[str, Any]:
+        size = resource.get("size") or resource.get("filesize")
+        entry = {
+            "name": f"/{dataset_id}/{self._resource_name(resource)}",
+            "type": "file",
+            "modified": self._parse_modified(resource.get("last_modified") or resource.get("metadata_modified")),
+            "id": resource.get("id"),
+        }
+        # size isnt always known, so this prevents int(None) error
+        if size is not None:
+            entry["size"] = size
+        return entry
+
+    # returns dataset entry with optional metadata
+    def _dataset_entry(self, name: str, dataset: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        entry: dict[str, Any] = {"name": f"/{name}", "type": "directory", "size": None}
+        if dataset:
+            # adds these parameter in case detail=True
+            entry["modified"] = self._parse_modified(dataset.get("metadata_modified") or dataset.get("last_modified"))
+            entry["id"] = dataset.get("id")
+        return entry
+
+    # splits path into dataset_id and optional resource_name
+    def _split_path(self, path: str) -> tuple[str, Optional[str]]:
+        parts = path.strip("/").split("/", 1)
+        dataset_id = parts[0]
+        resource_name = None  # path is /dataset
+        if len(parts) > 1:
+            resource_name = parts[1]  # path is /dataset/resource
+        return dataset_id, resource_name
+
+    # find a resource by name in a dataset
+    def _find_resource(self, dataset_id: str, resource_name: str) -> dict[str, Any]:
+        resources = self._list_resources(dataset_id)
+        for resource in resources:
+            if self._resource_name(resource) == resource_name:
+                return resource
+        raise FileNotFoundError(f"/{dataset_id}/{resource_name}")
+
+    def _is_same_host(self, url: str) -> bool:
+        return urlparse(url).hostname == urlparse(self.base_url).hostname
+
+    # list datasets in root or resources in a dataset
+    def ls(self, path: str = "", detail: bool = True, **kwargs: Any) -> list[dict[str, Any]] | list[str]:
+        if not self._is_root(path):
+            # list resources in dataset
+            dataset_id, _ = self._split_path(path)  # only need dataset_id, resource_name isnt needed
+            resources = self._list_resources(dataset_id)
+            if detail:
+                return [self._resource_entry(dataset_id, r) for r in resources]
+            return [self._resource_entry(dataset_id, r)["name"] for r in resources]
+
+        # list datasets in root
+        datasets = self._list_all_datasets()
+        if detail:
+            return [self._dataset_entry(name) for name in datasets]
+        return [self._dataset_entry(name)["name"] for name in datasets]
+
+    # get dataset or resource metadata
+    def info(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        if self._is_root(path):
+            return {"name": "/", "type": "directory", "size": None}
+        dataset_id, resource_name = self._split_path(path)
+        # /dataset
+        if not resource_name:
+            return self._dataset_entry(dataset_id, self._get_dataset(dataset_id))
+        # /dataset/resource
+        resource = self._find_resource(dataset_id, resource_name)
+        return self._resource_entry(dataset_id, resource)
+
+    # stream resource content using requests, returns a file-like object
+    def _open(self, path: str, mode: str = "rb", **kwargs: Any):
+        if mode != "rb":
+            raise NotImplementedError("Only read binary mode 'rb' is supported")
+        dataset_id, resource_name = self._split_path(path)
+        if resource_name is None:
+            raise FileNotFoundError(path)
+        resource = self._find_resource(dataset_id, resource_name)
+        url = resource.get("url") or resource.get("download_url") or None
+        if not url:
+            raise FileNotFoundError(path)
+        # only add the auth token if the resource is hosted on the same domain as the CKAN instance
+        # to prevent leaking tokens to external URLs
+        headers = self._get_request_headers() if self._is_same_host(url) else {}
+        response = requests.get(url, stream=True, headers=headers, timeout=DEFAULT_SOCKET_TIMEOUT)
+        self._raise_for_ckan_error(response)  # raise exception for HTTP errors
+        response.raw.decode_content = True
+        return response.raw
+
+
+class CKANFileSourceTemplateConfiguration(FsspecBaseFileSourceTemplateConfiguration):
+    endpoint: Union[str, TemplateExpansion]
+    token: Union[str, TemplateExpansion, None] = None
+
+
+class CKANFileSourceConfiguration(FsspecBaseFileSourceConfiguration):
+    endpoint: str
+    token: Optional[str] = None
+
+
+class CKANFilesSource(FsspecFilesSource[CKANFileSourceTemplateConfiguration, CKANFileSourceConfiguration]):
+    plugin_type = "ckan"
+    required_module = CKANFileSystem
+    required_package = "requests"
+
+    template_config_class = CKANFileSourceTemplateConfiguration
+    resolved_config_class = CKANFileSourceConfiguration
+
+    def _open_fs(
+        self, context: FilesSourceRuntimeContext[CKANFileSourceConfiguration], cache_options: CacheOptionsDictType
+    ) -> CKANFileSystem:
+        config = context.config
+        return CKANFileSystem(base_url=config.endpoint, token=config.token, **cache_options)
+
+    def _write_from(
+        self, target_path: str, native_path: str, context: FilesSourceRuntimeContext[CKANFileSourceConfiguration]
+    ) -> None:
+        fs = self._open_fs(context, {})
+        dataset_id, resource_name = fs._split_path(target_path)
+        if not resource_name:
+            raise ValueError("Select a dataset as the upload target, not the root.")
+        fs._post_resource(dataset_id, resource_name, native_path)
+
+
+__all__ = ("CKANFilesSource",)

--- a/lib/galaxy/files/templates/examples/production_ckan.yml
+++ b/lib/galaxy/files/templates/examples/production_ckan.yml
@@ -4,8 +4,6 @@
   description: |
       [CKAN](https://ckan.org) is an open-source data portal platform for managing and sharing datasets.
       This configuration allows you to connect Galaxy to a CKAN instance of your choice.
-
-      **Note:** Your **registered email address** will be used to create datasets in CKAN.
   variables:
       url:
           label: CKAN instance endpoint (e.g. https://demo.ckan.org)
@@ -32,4 +30,4 @@
       type: ckan
       token: "{{ secrets.token }}"
       writable: "{{ variables.writable }}"
-      endpoint: "{{ variables.url }}"
+      url: "{{ variables.url }}"

--- a/lib/galaxy/files/templates/examples/production_ckan.yml
+++ b/lib/galaxy/files/templates/examples/production_ckan.yml
@@ -1,0 +1,35 @@
+- id: ckan
+  version: 0
+  name: CKAN
+  description: |
+      [CKAN](https://ckan.org) is an open-source data portal platform for managing and sharing datasets.
+      This configuration allows you to connect Galaxy to a CKAN instance of your choice.
+
+      **Note:** Your **registered email address** will be used to create datasets in CKAN.
+  variables:
+      url:
+          label: CKAN instance endpoint (e.g. https://demo.ckan.org)
+          type: string
+          help: |
+              The endpoint of the CKAN server you are connecting to. This should be the full URL including the protocol
+              (http or https) and the domain name.
+      writable:
+          label: Allow Galaxy to export data to CKAN?
+          type: boolean
+          optional: true
+          default: true
+          help: |
+              Allow Galaxy to write data to this CKAN instance. Set it to "Yes" if you want to export data from Galaxy to
+              CKAN, set it to "No" if you only need to import data from CKAN to Galaxy.
+  secrets:
+      token:
+          label: CKAN Access Token
+          optional: true
+          help: |
+              The personal access token to use to connect to the CKAN instance. You can generate a new token in your CKAN account settings.
+              This will allow Galaxy to access private datasets if you have the necessary permissions.
+  configuration:
+      type: ckan
+      token: "{{ secrets.token }}"
+      writable: "{{ variables.writable }}"
+      endpoint: "{{ variables.url }}"

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -528,7 +528,7 @@ class OmeroFileSourceConfiguration(StrictModel):
 
 class CKANFileSourceTemplateConfiguration(StrictModel):
     type: Literal["ckan"]
-    endpoint: str | TemplateExpansion
+    url: str | TemplateExpansion
     token: str | TemplateExpansion | None = None
     writable: bool | TemplateExpansion = True
     template_start: str | None = None
@@ -537,7 +537,7 @@ class CKANFileSourceTemplateConfiguration(StrictModel):
 
 class CKANFileSourceConfiguration(StrictModel):
     type: Literal["ckan"]
-    endpoint: str
+    url: str
     token: str | None = None
     writable: bool = True
 

--- a/lib/galaxy/files/templates/models.py
+++ b/lib/galaxy/files/templates/models.py
@@ -54,6 +54,7 @@ FileSourceTemplateType = Literal[
     "mavedb",
     "omero",
     "ssh",
+    "ckan",
 ]
 
 FileSourceTemplateAlertVariant = Literal[
@@ -525,6 +526,22 @@ class OmeroFileSourceConfiguration(StrictModel):
     writable: bool = False
 
 
+class CKANFileSourceTemplateConfiguration(StrictModel):
+    type: Literal["ckan"]
+    endpoint: str | TemplateExpansion
+    token: str | TemplateExpansion | None = None
+    writable: bool | TemplateExpansion = True
+    template_start: str | None = None
+    template_end: str | None = None
+
+
+class CKANFileSourceConfiguration(StrictModel):
+    type: Literal["ckan"]
+    endpoint: str
+    token: str | None = None
+    writable: bool = True
+
+
 FileSourceTemplateConfiguration = Annotated[
     PosixFileSourceTemplateConfiguration
     | S3FSFileSourceTemplateConfiguration
@@ -548,7 +565,8 @@ FileSourceTemplateConfiguration = Annotated[
     | IIIFFileSourceTemplateConfiguration
     | MaveDBFileSourceTemplateConfiguration
     | OmeroFileSourceTemplateConfiguration
-    | SshFileSourceTemplateConfiguration,
+    | SshFileSourceTemplateConfiguration
+    | CKANFileSourceTemplateConfiguration,
     Field(discriminator="type"),
 ]
 
@@ -575,7 +593,8 @@ FileSourceConfiguration = Annotated[
     | IIIFFileSourceConfiguration
     | MaveDBFileSourceConfiguration
     | OmeroFileSourceConfiguration
-    | SshFileSourceConfiguration,
+    | SshFileSourceConfiguration
+    | CKANFileSourceConfiguration,
     Field(discriminator="type"),
 ]
 
@@ -663,6 +682,7 @@ TypesToConfigurationClasses: dict[FileSourceTemplateType, type[FileSourceConfigu
     "mavedb": MaveDBFileSourceConfiguration,
     "omero": OmeroFileSourceConfiguration,
     "ssh": SshFileSourceConfiguration,
+    "ckan": CKANFileSourceConfiguration,
 }
 
 


### PR DESCRIPTION
This PR adds a new CKAN file source, based on Galaxy's `RDMFilesSource` like the Dataverse, Invenio and Zenodo plugins, connecting Galaxy to a [CKAN](https://ckan.org) instance. It uses CKAN's Action API and was tested against CKAN 2.11.3. The first version of this PR was built on the `fsspec` pattern and was reworked after review, which is why the diff replaces most of the file.

<img width="1101" height="824" alt="Screenshot 2026-08-17 at 04-39-40 Galaxy" src="https://github.com/user-attachments/assets/b9df2061-e572-43a3-99bd-a34da4f4dc5a" />

**Key capabilities:**
- List public and private CKAN datasets (private datasets require an API token). A dataset holds resources, which appear as the files inside it.
- Download resources from a dataset.
- Export Galaxy datasets and history archives to CKAN as new resources in an existing CKAN dataset.
- Pagination and search happen server side through CKAN's `package_search`, so only the requested page is fetched.
- Datasets the user has private access to are listed first, then public ones, each sorted by title. Sorting by title instead of CKAN's default `metadata_modified desc` also keeps pagination stable while browsing.

**How export targets are chosen:**
- Browsing applies no filter of its own, because CKAN already restricts `package_search` through its permission labels to what the token may read, and an anonymous request returns public datasets only.
- Exporting is different, since CKAN has no way to express "may I write here". The plugin asks `organization_list_for_user` with `permission=update_dataset` and matches the result against `owner_org`.
- The filter goes by write permission, not by the private flag. In CKAN a private dataset is readable by every member of its organization but writable only by editors and admins, while a public dataset of an organization you are an editor in is perfectly fine to write to. The two sets are genuinely different.
- Datasets that belong to no organization need a second condition, since `owner_org` cannot match them. CKAN is permissive here: `package_update` applies no creator check to such datasets, so with the default configuration any logged in user may edit any of them. Offering all of them would follow CKAN but be unhelpful in a dropdown, so only the ones the user created are offered. This applies to sysadmins as well.

**Security:**
- The download url comes from CKAN's metadata and can point anywhere, so it is checked with `validate_non_local()` before the request, and again afterwards in case the request was redirected.
- A CKAN resource can be hosted on a different server than CKAN itself, so the API token is only sent when the resource is hosted by the CKAN instance.

**Known limitations:**
- Export only uploads resources into an existing CKAN dataset. Creating a new dataset from Galaxy is not supported, because it would have to be assigned to an organization and no export dialog has a field for one. The history and workflow invocation export wizards do offer to create a new record for RDM repositories, so the plugin answers that attempt with a clear message instead of an internal server error.
- Datasets shared through CKAN's collaborators feature (`ckan.auth.allow_dataset_collaborators`, off by default) are not offered as export targets.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Get access to a CKAN instance, either local (e.g. the PMD-CKAN Docker Compose setup, which uses a self-signed certificate, so access it over `http://` rather than `https://`) or an existing server, and generate an API token for a user who is an editor or admin in at least one organization and has at least one private dataset. A sysadmin account is not suitable for step 5, since `organization_list_for_user` returns all organizations for sysadmins and every dataset then looks writable.
  2. If your CKAN runs on a private address, add that address to `fetch_url_allowlist` in your `galaxy.yml` and restart. CKAN stores resource urls pointing at its own host, so without this every download is refused by `validate_non_local()`.
  3. Set up a vault, add the CKAN entry from `lib/galaxy/files/templates/examples/production_ckan.yml` to your file source templates, and create a CKAN file source instance with the url and token.
  4. Browse the file source, try the search box, open a dataset and download one of its resources.
  5. Export a Galaxy dataset to an existing CKAN dataset via *Export datasets to repositories*. The list of targets should only contain datasets you may write to, so a public dataset of an organization you are not an editor in should not appear. Confirm the exported resource shows up in CKAN and can be downloaded again.
  6. Check the export filter with a second account that is only a member of an organization. The list of targets should be empty, since a member may read but not write.
  7. To try the history archive export, `enable_celery_tasks` has to be on. Without it the history export page uses a form that excludes RDM file sources, so no CKAN instance shows up there. With it on, export a history via *Export History to File* into an existing CKAN dataset and import it back through *Import History*.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).