### PR TITLE
[26.1] Fix Workflow.copy() dropping readme, help, logo_url and doi

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9126,6 +9126,14 @@ class Workflow(Base, Dictifiable, RepresentById):
         copied_workflow.reports_config = self.reports_config
         copied_workflow.license = self.license
         copied_workflow.creator_metadata = self.creator_metadata
+        copied_workflow.readme = self.readme
+        copied_workflow.help = self.help
+        copied_workflow.logo_url = self.logo_url
+        copied_workflow.doi = self.doi
+        # uuid identifies a single revision and __init__ mints a fresh one, and
+        # source_metadata records where this exact content was fetched from and is
+        # dropped whenever a workflow is modified (see test_trs_import) - so neither
+        # is copied here. test_workflow_copy_preserves_metadata pins that down.
 
         # Map old step ids to new steps
         step_mapping = {}

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -999,20 +999,34 @@ steps:
 
     def test_update_name(self):
         original_name = "test update name"
+        readme = "This is the body of my readme..."
+        help = "This is my instruction for the workflow!"
+        logo_url = "https://galaxyproject.org/images/galaxy_logo_hub_white.svg"
+        doi = ["doi:10.1000/1"]
         workflow_object = self.workflow_populator.load_workflow(name=original_name)
         workflow_object["license"] = "AAL"
+        workflow_object["readme"] = readme
+        workflow_object["help"] = help
+        workflow_object["logo_url"] = logo_url
+        workflow_object["doi"] = doi
         upload_response = self.__test_upload(workflow=workflow_object, name=original_name)
         workflow = upload_response.json()
         workflow_id = workflow["id"]
         assert workflow["name"] == original_name
         workflow_dict = self.workflow_populator.download_workflow(workflow_id)
         assert workflow_dict["license"] == "AAL"
+        assert workflow_dict["readme"] == readme
 
         data = {"name": "my cool new name"}
         update_response = self._update_workflow(workflow["id"], data).json()
         assert update_response["name"] == "my cool new name"
         workflow_dict = self.workflow_populator.download_workflow(workflow_id)
+        # A rename copies the workflow to a new revision; the copy must not drop metadata.
         assert workflow_dict["license"] == "AAL"
+        assert workflow_dict["readme"] == readme
+        assert workflow_dict["help"] == help
+        assert workflow_dict["logo_url"] == logo_url
+        assert workflow_dict["doi"] == doi
 
     def test_update_name_for_workflow_with_subworkflows(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow("""
@@ -1897,6 +1911,31 @@ steps:
             self._assert_status_code_is(other_import_response, 200)
             workflow = self._download_workflow(other_import_response.json()["id"])
             assert workflow["steps"]["2"]["tool_version"] == "1.0.0"
+
+    def test_import_published_preserves_metadata(self):
+        name = "test_import_published_preserves_metadata"
+        readme = "This is the body of my readme..."
+        help = "This is my instruction for the workflow!"
+        logo_url = "https://galaxyproject.org/images/galaxy_logo_hub_white.svg"
+        doi = ["doi:10.1000/1"]
+        workflow_object = self.workflow_populator.load_workflow(name=name)
+        workflow_object["license"] = "AAL"
+        workflow_object["readme"] = readme
+        workflow_object["help"] = help
+        workflow_object["logo_url"] = logo_url
+        workflow_object["doi"] = doi
+        workflow_id = self.workflow_populator.create_workflow(workflow_object, publish=True)
+
+        with self._different_user():
+            import_response = self.__import_workflow(workflow_id, deprecated_route=False)
+            self._assert_status_code_is(import_response, 200)
+            # Importing a shared workflow copies it; the copy must not drop metadata.
+            imported_workflow = self._download_workflow(import_response.json()["id"])
+            assert imported_workflow["license"] == "AAL"
+            assert imported_workflow["readme"] == readme
+            assert imported_workflow["help"] == help
+            assert imported_workflow["logo_url"] == logo_url
+            assert imported_workflow["doi"] == doi
 
     def test_export(self):
         uploaded_workflow_id = self.workflow_populator.simple_workflow("test_for_export")

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -512,6 +512,42 @@ class TestMappings(BaseModelTestCase):
         assert counts.root["new"] == 2
         assert counts.root["scheduled"] == 1
 
+    def test_workflow_copy_preserves_metadata(self):
+        user = model.User(email=random_email(), password="password")
+        workflow = _workflow_from_steps(user, [])
+        workflow.name = "test_workflow_copy"
+        workflow.has_cycles = False
+        workflow.has_errors = False
+        workflow.license = "MIT"
+        workflow.creator_metadata = [{"class": "Person", "name": "Jane Doe"}]
+        workflow.reports_config = {"markdown": "## Report"}
+        workflow.readme = "A readme"
+        workflow.help = "Some help text"
+        workflow.logo_url = "https://galaxyproject.org/images/galaxy-logo.png"
+        workflow.doi = ["10.1000/xyz123"]
+        workflow.source_metadata = {"url": "https://example.org/workflow.ga"}
+        self.persist(workflow)
+
+        copied_workflow = workflow.copy(user=user)
+        # Driven off the real columns so that a column added by a later migration has to be
+        # classified here rather than being silently dropped by copy(), which is how
+        # readme/help/logo_url/doi were lost between 25.0 and now.
+        not_copied = {
+            "id",  # assigned per row
+            "create_time",
+            "update_time",
+            "stored_workflow_id",  # the caller attaches the copy
+            "parent_workflow_id",
+            "uuid",  # identifies a single revision
+            "source_metadata",  # provenance of this exact content
+        }
+        for column in set(model.Workflow.__table__.columns.keys()) - not_copied:
+            assert getattr(workflow, column) is not None, f"{column} is not covered by this test"
+            assert getattr(copied_workflow, column) == getattr(workflow, column), column
+
+        assert copied_workflow.uuid != workflow.uuid
+        assert copied_workflow.source_metadata is None
+
     def test_role_creation(self):
         security_agent = GalaxyRBACAgent(self.model.session)
 


### PR DESCRIPTION
`readme`, `help`, `logo_url` and `doi` were added to the `workflow` table in 25.0 (`57cf7d38d53`, `e886353b90a`, migration `71eeb8d91f92`), but `Workflow.copy()` was never updated to copy them. Every operation that copies a workflow silently destroys them.

Export is guarded by `if workflow.readme is not None`, so the metadata doesn't come back as `null` — the key is absent from the exported `.ga` entirely, which is what makes this look like an export bug. It isn't: import, export, editor and API paths all handle `readme` correctly.

### Affected paths

- **Rename-only update** (`lib/galaxy/webapps/galaxy/api/workflows.py:466`) — `name_updated and not steps_updated` copies the workflow into a new revision, so **renaming a workflow destroys its readme**.
- **`_import_shared_workflow`** (`lib/galaxy/webapps/base/controller.py:626`) — reached via `/workflow/imp?id=` and `POST /api/workflows {shared_workflow_id}`.
- Subworkflow copy during shared import.

Reported against an IWC workflow with a 7398-character readme on usegalaxy.eu (galaxyproject/iwc#1234). The uuid changing across the round-trip pins the cause to `copy()` rather than to export, and the survival pattern is a fingerprint: everything `copy()` handles survived, only the fields it omits vanished.

### On `source_metadata`

Still deliberately not copied. It records where this exact content was fetched from and is already dropped whenever a workflow is modified (`test_trs_import` asserts this, and the comment at `test_workflows.py:1484` calls it out as intentional). Copying it would also change `get_workflow_by_trs_id_and_version`, which matches on `latest_workflow.source_metadata`.

Worth noting separately: because `source_metadata` isn't copied, renaming a TRS-imported workflow still breaks its TRS dedup lookup. That's arguably its own bug, but it's a behavioral change I didn't fold into this fix.

### Tests

`copy()` has regressed this way three times now — `470baa59216` added `license` + `creator_metadata`, `bbbe7f2182c` added `reports_config` — because the assignments are hand-maintained. The new unit test therefore drives its assertions off `Workflow.__table__.columns` minus an explicitly annotated `not_copied` set, so a column added by a later migration trips `"<column> is not covered by this test"` and has to be classified rather than silently dropped.

- `test_workflow_copy_preserves_metadata` (unit) — verified to fail on an unmodified tree (`AssertionError: help / assert None == 'Some help text'`) and pass with the fix. I also deleted the `doi` assignment with the fix otherwise in place to confirm the guard catches exactly the recurrence mode.
- `test_update_name` (API) — extended; it already covered `license` for precisely this reason.
- `test_import_published_preserves_metadata` (API) — new, covers the shared-import path.

The existing suite is not evidence here: `test_update_name` passed the whole time the bug was live, which is how this regressed.

Bug dates to 25.0 — worth checking whether 25.0/26.0 are still supported and need this too.