### PR TITLE
[26.1] Support multipart upload for Invenio-based file sources

### DIFF
--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -15,7 +15,7 @@
   # for accessing passwords stored in a vault:
   # password: ${user.user_vault.read_secret('preferences/owncloud/password')}
 
-  # By default, the plugin will use temp files to avoid loading entire files into memory. 
+  # By default, the plugin will use temp files to avoid loading entire files into memory.
   # You can change the directory here or omit to use the default temp directory.
   temp_path: /your/temp/path
   # Set writable to true if you have write access to this source
@@ -84,8 +84,8 @@
   enable_resume: true  # Enable resume for interrupted transfers
   # SSH private key for authentication (download ENA key from: https://www.ebi.ac.uk/ena/browser/about/ascp)
   # Embed the key content directly in the configuration (required - not file paths)
-  # Note: SSH key content is required because Galaxy jobs often run on clusters that don't 
-  # mount Galaxy's root or configuration directories. The configuration block is copied 
+  # Note: SSH key content is required because Galaxy jobs often run on clusters that don't
+  # mount Galaxy's root or configuration directories. The configuration block is copied
   # to the job's directory, but referenced key paths wouldn't be accessible.
   ssh_key_content: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -259,6 +259,12 @@
   # token: ${user.preferences['invenio_sandbox|token']} # Alternatively use this for retrieving the token from user preferences instead of the Vault
   public_name: ${user.preferences['invenio_sandbox|public_name']}
   writable: true
+  # Enable multipart upload for files of size >= threshold (values in MB, optional, disabled by default)
+  # multipart_threshold: 100
+  # Part size for multipart uploads (values in MB, optional, defaults to 5 MB minimum)
+  # multipart_chunk_size: 50
+  # Default resource type for new records (optional, defaults to "dataset")
+  # default_resource_type:
 
 - type: zenodo
   id: zenodo

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -27,7 +27,7 @@ class RDMFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
     public_name: Optional[Union[str, TemplateExpansion]] = None
     multipart_threshold: Optional[Union[int, TemplateExpansion]] = None  # MB
     multipart_chunk_size: Optional[Union[int, TemplateExpansion]] = None  # MB
-    default_resource_type: Optional[str] = None
+    default_resource_type: Optional[Union[str, TemplateExpansion]] = None
 
 
 class RDMFileSourceConfiguration(BaseFileSourceConfiguration):

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -25,11 +25,17 @@ log = logging.getLogger(__name__)
 class RDMFileSourceTemplateConfiguration(BaseFileSourceTemplateConfiguration):
     token: Optional[Union[str, TemplateExpansion]] = None
     public_name: Optional[Union[str, TemplateExpansion]] = None
+    multipart_threshold: Optional[Union[int, TemplateExpansion]] = None  # MB
+    multipart_chunk_size: Optional[Union[int, TemplateExpansion]] = None  # MB
+    default_resource_type: Optional[str] = None
 
 
 class RDMFileSourceConfiguration(BaseFileSourceConfiguration):
     token: Optional[str] = None
     public_name: Optional[str] = None
+    multipart_threshold: Optional[int] = None  # MB
+    multipart_chunk_size: Optional[int] = None  # MB
+    default_resource_type: Optional[str] = None
 
 
 class ContainerAndFileIdentifier(NamedTuple):

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -132,7 +132,7 @@ def calculate_multipart_params(file_size: int, preferred_part_size: int | None =
         Files larger than this will still return valid params but would fail server-side.
     """
     if file_size == 0:
-        return 1, 0
+        return 1, MIN_UPLOAD_PART_SIZE
 
     # Start with preferred or minimum part size
     part_size = preferred_part_size or MIN_UPLOAD_PART_SIZE

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -422,7 +422,16 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         if use_multipart:
             self._upload_file_multipart(record_id, filename, file_path, file_size, context)
         else:
-            self._upload_file_single(record_id, filename, file_path, context)
+            try:
+                self._upload_file_single(record_id, filename, file_path, context)
+            except Exception as e:
+                if "413" in str(e):
+                    raise Exception(
+                        f"Failed to upload file '{filename}' ({file_size} bytes): HTTP 413 Payload Too Large. "
+                        f"The server rejected the upload because the file is too large for a single request. "
+                        f"Please configure 'multipart_threshold' in the file source configuration to enable multipart upload for files of this size."
+                    ) from e
+                raise
 
     def _upload_file_single(
         self,
@@ -448,14 +457,6 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         commit_file_upload_url = file_entry["links"]["commit"]
         with open(file_path, "rb") as file:
             response = requests.put(upload_file_content_url, data=file, headers=headers)
-            # Handle 413 (Payload Too Large) - suggest using multipart upload
-            if response.status_code == 413:
-                file_size = os.path.getsize(file_path)
-                raise Exception(
-                    f"Failed to upload file '{filename}' ({file_size} bytes): HTTP 413 Payload Too Large. "
-                    f"The server rejected the upload because the file is too large for a single request. "
-                    f"Please configure 'multipart_threshold' in the file source configuration to enable multipart upload for files of this size."
-                )
             self._ensure_response_has_expected_status_code(response, 200)
 
         # Commit file upload

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -422,7 +422,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         if use_multipart:
             self._upload_file_multipart(record_id, filename, file_path, file_size, context)
         else:
-            self._upload_file_single(record_id, filename, file_path, context, file_size)
+            self._upload_file_single(record_id, filename, file_path, context)
 
     def _upload_file_single(
         self,
@@ -430,11 +430,8 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         filename: str,
         file_path: str,
         context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
-        file_size: Optional[int] = None,
     ):
         """Upload a file using single PUT request."""
-        if file_size is None:
-            file_size = os.path.getsize(file_path)
 
         record = self._get_draft_record(record_id, context)
         upload_file_url = record["links"]["files"]
@@ -453,6 +450,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
             response = requests.put(upload_file_content_url, data=file, headers=headers)
             # Handle 413 (Payload Too Large) - suggest using multipart upload
             if response.status_code == 413:
+                file_size = os.path.getsize(file_path)
                 raise Exception(
                     f"Failed to upload file '{filename}' ({file_size} bytes): HTTP 413 Payload Too Large. "
                     f"The server rejected the upload because the file is too large for a single request. "

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -529,35 +529,31 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         part_links: list[dict],
         headers: dict,
     ):
-        """Upload all parts, sequentially for <=2 parts, parallel otherwise."""
+        """Upload all parts in parallel using a thread pool."""
         num_parts = len(part_links)
+        max_workers = min(4, num_parts)
 
-        if num_parts <= 2:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {}
             for part_index, part_info in enumerate(part_links):
-                self._upload_single_part(file_path, file_size, part_size, part_index, part_info, headers)
-        else:
-            max_workers = min(4, num_parts)
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = {}
-                for part_index, part_info in enumerate(part_links):
-                    future = executor.submit(
-                        self._upload_single_part,
-                        file_path,
-                        file_size,
-                        part_size,
-                        part_index,
-                        part_info,
-                        headers,
-                    )
-                    futures[future] = part_index
+                future = executor.submit(
+                    self._upload_single_part,
+                    file_path,
+                    file_size,
+                    part_size,
+                    part_index,
+                    part_info,
+                    headers,
+                )
+                futures[future] = part_index
 
-                for future in as_completed(futures):
-                    part_index = futures[future]
-                    try:
-                        future.result()
-                    except Exception as e:
-                        log.error(f"Failed to upload part {part_index}: {e}")
-                        raise
+            for future in as_completed(futures):
+                part_index = futures[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    log.error(f"Failed to upload part {part_index}: {e}")
+                    raise
 
     def _upload_single_part(
         self,

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -1,6 +1,13 @@
 import datetime
 import json
+import logging
+import math
+import os
 import re
+from concurrent.futures import (
+    as_completed,
+    ThreadPoolExecutor,
+)
 from typing import (
     Any,
     cast,
@@ -8,6 +15,8 @@ from typing import (
     Optional,
 )
 from urllib.parse import quote
+
+log = logging.getLogger(__name__)
 
 from typing_extensions import (
     TypedDict,
@@ -100,6 +109,53 @@ class RecordLinks(TypedDict):
     versions: str
     access_links: str
     reserve_doi: str
+
+
+# AWS S3 multipart default limits (used by Invenio RDM)
+MIN_UPLOAD_PART_SIZE = 5 * 1024 * 1024  # 5 MiB
+MAX_UPLOAD_PART_SIZE = 5 * 1024**3  # 5 GiB
+MAX_UPLOAD_PARTS = 10_000
+
+
+def calculate_multipart_params(file_size: int, preferred_part_size: int | None = None) -> tuple[int, int]:
+    """Calculate optimal parts count and part size for multipart upload.
+
+    Args:
+        file_size: Total file size in bytes
+        preferred_part_size: Preferred part size in bytes (optional)
+
+    Returns:
+        Tuple of (parts_count, part_size)
+
+    Note:
+        Maximum uploadable file size is MAX_UPLOAD_PARTS * MAX_UPLOAD_PART_SIZE (~48.8 TiB).
+        Files larger than this will still return valid params but would fail server-side.
+    """
+    if file_size == 0:
+        return 1, 0
+
+    # Start with preferred or minimum part size
+    part_size = preferred_part_size or MIN_UPLOAD_PART_SIZE
+
+    # Ensure part_size is within bounds
+    part_size = max(part_size, MIN_UPLOAD_PART_SIZE)
+    part_size = min(part_size, MAX_UPLOAD_PART_SIZE)
+
+    # Calculate parts needed
+    parts = math.ceil(file_size / part_size)
+
+    # If too many parts, increase part size (up to max)
+    while parts > MAX_UPLOAD_PARTS and part_size < MAX_UPLOAD_PART_SIZE:
+        part_size = min(part_size * 2, MAX_UPLOAD_PART_SIZE)
+        parts = math.ceil(file_size / part_size)
+
+    # For extremely large files, cap parts at MAX_UPLOAD_PARTS
+    # This means part_size may effectively be larger than calculated
+    # but such files would likely fail server-side anyway
+    if parts > MAX_UPLOAD_PARTS:
+        parts = MAX_UPLOAD_PARTS
+
+    return parts, part_size
 
 
 class InvenioRecord(TypedDict):
@@ -305,12 +361,13 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
     ) -> dict[str, Any]:
         today = datetime.date.today().isoformat()
         creator = self._get_creator_from_public_name(public_name)
+        resource_type_id = context.config.default_resource_type or "dataset"
         create_record_request = {
             "files": {"enabled": True},
             "metadata": {
                 "title": title,
                 "publication_date": today,
-                "resource_type": {"id": "dataset"},
+                "resource_type": {"id": resource_type_id},
                 "creators": [
                     creator,
                 ],
@@ -331,6 +388,29 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         file_path: str,
         context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
     ):
+        file_size = os.path.getsize(file_path)
+
+        threshold_mb = context.config.multipart_threshold
+        # Convert threshold from MB to bytes (config value is always in MB)
+        threshold_bytes = threshold_mb * 1024 * 1024 if threshold_mb else None
+        use_multipart = file_size >= threshold_bytes if threshold_bytes else False
+        if use_multipart:
+            self._upload_file_multipart(record_id, filename, file_path, file_size, context)
+        else:
+            self._upload_file_single(record_id, filename, file_path, context, file_size)
+
+    def _upload_file_single(
+        self,
+        record_id: str,
+        filename: str,
+        file_path: str,
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
+        file_size: Optional[int] = None,
+    ):
+        """Upload a file using single PUT request."""
+        if file_size is None:
+            file_size = os.path.getsize(file_path)
+
         record = self._get_draft_record(record_id, context)
         upload_file_url = record["links"]["files"]
         headers = self._get_request_headers(context, auth_required=True)
@@ -346,10 +426,141 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         commit_file_upload_url = file_entry["links"]["commit"]
         with open(file_path, "rb") as file:
             response = requests.put(upload_file_content_url, data=file, headers=headers)
+            # Handle 413 (Payload Too Large) - suggest using multipart upload
+            if response.status_code == 413:
+                raise Exception(
+                    f"Failed to upload file '{filename}' ({file_size} bytes): HTTP 413 Payload Too Large. "
+                    f"The server rejected the upload because the file is too large for a single request. "
+                    f"Please configure 'multipart_threshold' in the file source configuration to enable multipart upload for files of this size."
+                )
             self._ensure_response_has_expected_status_code(response, 200)
 
         # Commit file upload
         response = requests.post(commit_file_upload_url, headers=headers)
+        self._ensure_response_has_expected_status_code(response, 200)
+
+    def _upload_file_multipart(
+        self,
+        record_id: str,
+        filename: str,
+        file_path: str,
+        file_size: int,
+        context: FilesSourceRuntimeContext[RDMFileSourceConfiguration],
+    ):
+        """Upload a file using multipart upload.
+
+        Flow:
+        1. Calculate parts/part_size
+        2. POST with transfer metadata
+        3. Server returns links.parts[] with URL for each part
+        4. Upload parts (parallel for > 2 parts)
+        5. POST to commit URL
+        """
+        preferred_part_size_mb = context.config.multipart_chunk_size
+        # Convert chunk size from MB to bytes (config value is always in MB)
+        preferred_part_size = preferred_part_size_mb * 1024 * 1024 if preferred_part_size_mb else None
+        num_parts, part_size = calculate_multipart_params(file_size, preferred_part_size)
+
+        log.info(f"Multipart upload: {num_parts} parts of {part_size} bytes each for '{filename}'")
+
+        record = self._get_draft_record(record_id, context)
+        upload_file_url = record["links"]["files"]
+        headers = self._get_request_headers(context, auth_required=True)
+
+        file_metadata = {
+            "key": filename,
+            "size": file_size,
+            "transfer": {
+                "type": "M",
+                "parts": num_parts,
+                "part_size": part_size,
+            },
+        }
+        response = requests.post(upload_file_url, json=[file_metadata], headers=headers)
+        self._ensure_response_has_expected_status_code(response, 201)
+
+        # Get part upload URLs from response
+        entries = response.json()["entries"]
+        file_entry = next(entry for entry in entries if entry["key"] == filename)
+        commit_url = file_entry["links"]["commit"]
+        part_links = file_entry.get("links", {}).get("parts", [])
+
+        if len(part_links) != num_parts:
+            raise Exception(
+                f"Server returned {len(part_links)} part URLs but expected {num_parts} for file '{filename}'"
+            )
+
+        # Sort part links by part number to ensure correct ordering
+        part_links = sorted(part_links, key=lambda p: p.get("part", 0))
+        self._upload_parts(file_path, file_size, part_size, part_links, headers)
+        response = requests.post(commit_url, json={}, headers=headers)
+        self._ensure_response_has_expected_status_code(response, 200)
+        log.info(f"Multipart upload completed for '{filename}'")
+
+    def _upload_parts(
+        self,
+        file_path: str,
+        file_size: int,
+        part_size: int,
+        part_links: list[dict],
+        headers: dict,
+    ):
+        """Upload all parts, sequentially for <=2 parts, parallel otherwise."""
+        num_parts = len(part_links)
+
+        if num_parts <= 2:
+            for part_index, part_info in enumerate(part_links):
+                self._upload_single_part(file_path, file_size, part_size, part_index, part_info)
+        else:
+            max_workers = min(4, num_parts)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {}
+                for part_index, part_info in enumerate(part_links):
+                    future = executor.submit(
+                        self._upload_single_part,
+                        file_path,
+                        file_size,
+                        part_size,
+                        part_index,
+                        part_info,
+                    )
+                    futures[future] = part_index
+
+                for future in as_completed(futures):
+                    part_index = futures[future]
+                    try:
+                        future.result()
+                    except Exception as e:
+                        log.error(f"Failed to upload part {part_index}: {e}")
+                        raise
+
+    def _upload_single_part(
+        self,
+        file_path: str,
+        file_size: int,
+        part_size: int,
+        part_index: int,
+        part_info: dict,
+    ):
+        """Upload a single part of a multipart upload."""
+        part_url = part_info.get("url")
+        if not part_url:
+            raise Exception(f"No URL provided for part {part_index}")
+
+        start_byte = part_index * part_size
+        end_byte = min(start_byte + part_size, file_size)
+        part_content_length = end_byte - start_byte
+
+        log.debug(f"Uploading part {part_index}: bytes {start_byte}-{end_byte-1} ({part_content_length} bytes)")
+
+        # Read the entire part into memory and upload
+        with open(file_path, "rb") as f:
+            f.seek(start_byte)
+            part_data = f.read(part_content_length)
+
+        # Use empty headers - presigned URLs are authenticated via query parameters
+        # Adding Authorization or other headers would invalidate the signature
+        response = requests.put(part_url, data=part_data)
         self._ensure_response_has_expected_status_code(response, 200)
 
     def download_file_from_container(
@@ -558,11 +769,16 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
 
     def _raise_auth_required(self):
         raise AuthenticationRequired(
-            f"Please provide a personal access token in your user's preferences for '{self.plugin.label}'"
+            f"Access denied. Please make sure you have provided a personal access token in your user's preferences for '{self.plugin.label}'"
         )
 
     def _get_response_error_message(self, response):
-        response_json = response.json()
+        try:
+            response_json = response.json()
+        except Exception:
+            # Response is not JSON, return raw text or status info
+            return response.text or f"HTTP {response.status_code} error"
+
         error_message = response_json.get("message") if response.status_code == 400 else response.text
         errors = response_json.get("errors", [])
         for error in errors:

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -535,7 +535,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
 
         if num_parts <= 2:
             for part_index, part_info in enumerate(part_links):
-                self._upload_single_part(file_path, file_size, part_size, part_index, part_info)
+                self._upload_single_part(file_path, file_size, part_size, part_index, part_info, headers)
         else:
             max_workers = min(4, num_parts)
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -548,6 +548,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
                         part_size,
                         part_index,
                         part_info,
+                        headers,
                     )
                     futures[future] = part_index
 
@@ -566,6 +567,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         part_size: int,
         part_index: int,
         part_info: dict,
+        headers: dict,
     ):
         """Upload a single part of a multipart upload."""
         part_url = part_info.get("url")
@@ -578,13 +580,18 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
 
         log.debug(f"Uploading part {part_index}: bytes {start_byte}-{end_byte-1} ({part_content_length} bytes)")
 
+        # Presigned S3 URLs are authenticated via query parameters; adding
+        # Authorization or other headers would invalidate the signature.
+        # Invenio API proxy URLs require the Authorization header.
+        # Check for both X-Amz-Signature (current) and Signature (legacy v2) query params.
+        is_presigned = "X-Amz-Signature" in part_url or "Signature=" in part_url
+        part_headers = None if is_presigned else headers
+
         # Stream the file slice without loading the entire part into memory
-        # Use empty headers - presigned URLs are authenticated via query parameters
-        # Adding Authorization or other headers would invalidate the signature
         with open(file_path, "rb") as f:
             f.seek(start_byte)
             reader = _LimitedFileReader(f, part_content_length)
-            response = requests.put(part_url, data=reader)
+            response = requests.put(part_url, data=reader, headers=part_headers)
             self._ensure_response_has_expected_status_code(response, 200)
 
     def download_file_from_container(

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -16,11 +16,11 @@ from typing import (
 )
 from urllib.parse import quote
 
-log = logging.getLogger(__name__)
-
 from typing_extensions import (
     TypedDict,
 )
+
+log = logging.getLogger(__name__)
 
 from galaxy.exceptions import (
     AuthenticationRequired,

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -118,7 +118,7 @@ MAX_UPLOAD_PARTS = 10_000
 
 
 def calculate_multipart_params(file_size: int, preferred_part_size: int | None = None) -> tuple[int, int]:
-    """Calculate optimal parts count and part size for multipart upload.
+    """Calculate parts count and part size for multipart upload.
 
     Args:
         file_size: Total file size in bytes
@@ -127,34 +127,34 @@ def calculate_multipart_params(file_size: int, preferred_part_size: int | None =
     Returns:
         Tuple of (parts_count, part_size)
 
+    Raises:
+        ValueError: If the file is larger than MAX_UPLOAD_PARTS * MAX_UPLOAD_PART_SIZE
+            (~48.8 TiB), which exceeds the maximum uploadable size.
+
     Note:
         Maximum uploadable file size is MAX_UPLOAD_PARTS * MAX_UPLOAD_PART_SIZE (~48.8 TiB).
-        Files larger than this will still return valid params but would fail server-side.
+        Files larger than this cannot be uploaded via multipart and raise ValueError.
     """
     if file_size == 0:
         return 1, MIN_UPLOAD_PART_SIZE
 
-    # Start with preferred or minimum part size
+    # Start with preferred or minimum part size, clamped to [min, max]
     part_size = preferred_part_size or MIN_UPLOAD_PART_SIZE
-
-    # Ensure part_size is within bounds
     part_size = max(part_size, MIN_UPLOAD_PART_SIZE)
     part_size = min(part_size, MAX_UPLOAD_PART_SIZE)
 
-    # Calculate parts needed
+    # Grow part_size to the minimum that keeps the part count within MAX_UPLOAD_PARTS.
+    part_size = max(part_size, math.ceil(file_size / MAX_UPLOAD_PARTS))
+    part_size = min(part_size, MAX_UPLOAD_PART_SIZE)
+
+    max_upload_size = MAX_UPLOAD_PARTS * MAX_UPLOAD_PART_SIZE
+    if file_size > max_upload_size:
+        raise ValueError(
+            f"File size {file_size} bytes exceeds the maximum multipart upload size "
+            f"of {max_upload_size} bytes ({MAX_UPLOAD_PARTS} parts x {MAX_UPLOAD_PART_SIZE} bytes)."
+        )
+
     parts = math.ceil(file_size / part_size)
-
-    # If too many parts, increase part size (up to max)
-    while parts > MAX_UPLOAD_PARTS and part_size < MAX_UPLOAD_PART_SIZE:
-        part_size = min(part_size * 2, MAX_UPLOAD_PART_SIZE)
-        parts = math.ceil(file_size / part_size)
-
-    # For extremely large files, cap parts at MAX_UPLOAD_PARTS
-    # This means part_size may effectively be larger than calculated
-    # but such files would likely fail server-side anyway
-    if parts > MAX_UPLOAD_PARTS:
-        parts = MAX_UPLOAD_PARTS
-
     return parts, part_size
 
 

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -573,7 +573,7 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         end_byte = min(start_byte + part_size, file_size)
         part_content_length = end_byte - start_byte
 
-        log.debug(f"Uploading part {part_index}: bytes {start_byte}-{end_byte-1} ({part_content_length} bytes)")
+        log.debug(f"Uploading part {part_index}: bytes {start_byte}-{end_byte - 1} ({part_content_length} bytes)")
 
         # Presigned S3 URLs are authenticated via query parameters; adding
         # Authorization or other headers would invalidate the signature.

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -183,6 +183,14 @@ class _LimitedFileReader:
         return self._length
 
 
+class InvenioRequestError(Exception):
+    """Raised when an Invenio API request returns an unexpected status code."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
 class InvenioRecord(TypedDict):
     id: str
     title: str
@@ -424,8 +432,8 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         else:
             try:
                 self._upload_file_single(record_id, filename, file_path, context)
-            except Exception as e:
-                if "413" in str(e):
+            except InvenioRequestError as e:
+                if e.status_code == 413:
                     raise Exception(
                         f"Failed to upload file '{filename}' ({file_size} bytes): HTTP 413 Payload Too Large. "
                         f"The server rejected the upload because the file is too large for a single request. "
@@ -789,8 +797,9 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
             if response.status_code == 403:
                 self._raise_auth_required()
             error_message = self._get_response_error_message(response)
-            raise Exception(
-                f"Request to {response.url} failed with status code {response.status_code}: {error_message}"
+            raise InvenioRequestError(
+                f"Request to {response.url} failed with status code {response.status_code}: {error_message}",
+                status_code=response.status_code,
             )
 
     def _raise_auth_required(self):

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -158,6 +158,31 @@ def calculate_multipart_params(file_size: int, preferred_part_size: int | None =
     return parts, part_size
 
 
+class _LimitedFileReader:
+    """File-like wrapper that limits reads to a specified number of bytes.
+
+    Enables streaming a slice of a file for upload without loading the
+    entire slice into memory. The __len__ method lets requests determine
+    the correct Content-Length for the upload.
+    """
+
+    def __init__(self, file_obj, length: int):
+        self._file = file_obj
+        self._length = length
+
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = self._length
+        else:
+            size = min(size, self._length)
+        data = self._file.read(size)
+        self._length -= len(data)
+        return data
+
+    def __len__(self) -> int:
+        return self._length
+
+
 class InvenioRecord(TypedDict):
     id: str
     title: str
@@ -553,15 +578,14 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
 
         log.debug(f"Uploading part {part_index}: bytes {start_byte}-{end_byte-1} ({part_content_length} bytes)")
 
-        # Read the entire part into memory and upload
-        with open(file_path, "rb") as f:
-            f.seek(start_byte)
-            part_data = f.read(part_content_length)
-
+        # Stream the file slice without loading the entire part into memory
         # Use empty headers - presigned URLs are authenticated via query parameters
         # Adding Authorization or other headers would invalidate the signature
-        response = requests.put(part_url, data=part_data)
-        self._ensure_response_has_expected_status_code(response, 200)
+        with open(file_path, "rb") as f:
+            f.seek(start_byte)
+            reader = _LimitedFileReader(f, part_content_length)
+            response = requests.put(part_url, data=reader)
+            self._ensure_response_has_expected_status_code(response, 200)
 
     def download_file_from_container(
         self,

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -60,19 +60,22 @@ class TestCalculateMultipartParams:
         assert part_size >= MIN_UPLOAD_PART_SIZE
 
     def test_calculate_multipart_params_extremely_large_file(self):
-        """Extremely large files should hit both MAX limits.
+        """Files larger than the maximum uploadable size raise ValueError instead of truncating."""
+        # 100 TiB file - exceeds theoretical s3 maximum (~48.8 TiB)
+        file_size = 100 * 1024**4
+        with pytest.raises(ValueError, match="exceeds the maximum multipart upload size"):
+            calculate_multipart_params(file_size)
 
-        Note: Files larger than MAX_UPLOAD_PARTS * MAX_UPLOAD_PART_SIZE (~48.8 TiB)
-        cannot be uploaded via multipart, but we cap params rather than fail here.
-        The upload would fail server-side anyway.
-        """
-        # 100 TiB file - exceeds theoretical maximum (~48.8 TiB)
-        file_size = 100 * 1024**4  # 100 TiB
-        parts, part_size = calculate_multipart_params(file_size)
-        # Parts should be capped at MAX_UPLOAD_PARTS
+    def test_calculate_multipart_params_raises_at_max_boundary(self):
+        """One byte over the maximum uploadable size raises; exactly at the max does not."""
+        max_upload_size = MAX_UPLOAD_PARTS * MAX_UPLOAD_PART_SIZE
+        # Exactly at the boundary is allowed (parts == MAX_UPLOAD_PARTS at MAX part size).
+        parts, part_size = calculate_multipart_params(max_upload_size)
         assert parts == MAX_UPLOAD_PARTS
-        # Part size should hit max
         assert part_size == MAX_UPLOAD_PART_SIZE
+        # One byte over raises.
+        with pytest.raises(ValueError):
+            calculate_multipart_params(max_upload_size + 1)
 
     def test_calculate_multipart_params_respects_preferred_part_size(self):
         """Should use preferred part size when provided and valid."""

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -349,7 +349,7 @@ class TestUploadSinglePart:
         with patch("galaxy.files.sources.invenio.requests") as mock_requests:
             mock_requests.put.side_effect = fake_put
 
-            interactor._upload_single_part(str(file_path), len(data), part_size, 2, part_info)
+            interactor._upload_single_part(str(file_path), len(data), part_size, 2, part_info, {})
 
             # Part 2 = bytes 32-48
             assert bytes(captured_data) == data[32:48]

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -207,7 +207,7 @@ class TestUploadFileSingle:
             ]
             mock_requests.put.return_value = _mock_response(200)
 
-            interactor._upload_file_single("abc", "test.txt", str(file_path), context, file_size=11)
+            interactor._upload_file_single("abc", "test.txt", str(file_path), context)
 
             assert mock_requests.post.call_count == 2
             assert mock_requests.put.call_count == 1
@@ -228,8 +228,8 @@ class TestUploadFileSingle:
             mock_requests.post.return_value = _mock_response(201, {"entries": [_make_single_upload_entry()]})
             mock_requests.put.return_value = _mock_response(413)
 
-            with pytest.raises(Exception, match="multipart_threshold"):
-                interactor._upload_file_single("abc", "test.txt", str(file_path), context, file_size=11)
+            with pytest.raises(Exception, match="413"):
+                interactor._upload_file_single("abc", "test.txt", str(file_path), context)
 
 
 class TestUploadFileMultipart:
@@ -459,3 +459,30 @@ class TestUploadFileToDraftContainerRouting:
         with patch.object(interactor, "_upload_file_single") as mock_single:
             interactor.upload_file_to_draft_container("abc", "test.txt", str(file_path), context)
             mock_single.assert_called_once()
+
+    def test_upload_file_single_413_router_raises_helpful_error(self, tmp_path):
+        """Router should wrap 413 with actionable multipart_threshold message."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"hello world")
+
+        interactor = _make_interactor()
+        context = _make_context(
+            config=MagicMock(
+                multipart_threshold=None,  # No threshold configured
+                multipart_chunk_size=None,
+                default_resource_type=None,
+                token="test-token",
+                public_name="Doe, Jane",
+            )
+        )
+
+        with (
+            patch.object(interactor, "_get_draft_record", return_value=_make_draft_record()),
+            patch.object(interactor, "_get_request_headers", return_value={"Authorization": "Bearer x"}),
+            patch("galaxy.files.sources.invenio.requests") as mock_requests,
+        ):
+            mock_requests.post.return_value = _mock_response(201, {"entries": [_make_single_upload_entry()]})
+            mock_requests.put.return_value = _mock_response(413)
+
+            with pytest.raises(Exception, match="multipart_threshold"):
+                interactor.upload_file_to_draft_container("abc", "test.txt", str(file_path), context)

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -1,9 +1,13 @@
 """Unit tests for Invenio multipart upload functionality."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from galaxy.files.sources.invenio import (
+    _LimitedFileReader,
     calculate_multipart_params,
+    InvenioRepositoryInteractor,
     MAX_UPLOAD_PART_SIZE,
     MAX_UPLOAD_PARTS,
     MIN_UPLOAD_PART_SIZE,
@@ -116,3 +120,331 @@ class TestCalculateMultipartParams:
         assert parts <= MAX_UPLOAD_PARTS
         # Part size should have increased
         assert part_size > MIN_UPLOAD_PART_SIZE
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    """Create a mock requests.Response object."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    if json_data is not None:
+        response.json.return_value = json_data
+    return response
+
+
+def _make_interactor():
+    """Create an InvenioRepositoryInteractor with a minimal mock plugin."""
+    plugin = MagicMock()
+    plugin.label = "test-invenio"
+    plugin.get_uri_root.return_value = "inveniordm://test"
+    return InvenioRepositoryInteractor("https://invenio.example.org", plugin)
+
+
+def _make_context(config=None):
+    """Create a mock runtime context with the given config."""
+    context = MagicMock()
+    context.config = config or MagicMock(
+        multipart_threshold=None,
+        multipart_chunk_size=None,
+        default_resource_type=None,
+        token="test-token",
+        public_name="Doe, Jane",
+    )
+    return context
+
+
+def _make_draft_record():
+    """Standard draft record response with files link."""
+    return {"links": {"files": "https://invenio.example.org/api/records/abc/files"}}
+
+
+def _make_single_upload_entry():
+    """File entry returned after POST for single upload."""
+    return {
+        "key": "test.txt",
+        "links": {
+            "content": "https://invenio.example.org/api/records/abc/files/content",
+            "commit": "https://invenio.example.org/api/records/abc/files/commit",
+        },
+    }
+
+
+def _make_multipart_entries(num_parts):
+    """File entry returned after POST for multipart upload, with part links."""
+    parts = [{"part": i, "url": f"https://invenio.example.org/parts/{i}"} for i in range(num_parts)]
+    return {
+        "key": "test.txt",
+        "links": {
+            "commit": "https://invenio.example.org/api/records/abc/files/commit",
+            "self": "https://invenio.example.org/api/records/abc/files/test.txt",
+            "parts": parts,
+        },
+    }
+
+
+class TestUploadFileSingle:
+    """Tests for _upload_file_single."""
+
+    def test_upload_file_single_success(self, tmp_path):
+        """Verify POST (metadata), PUT (content), POST (commit) sequence."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"hello world")
+
+        interactor = _make_interactor()
+        context = _make_context()
+
+        with (
+            patch.object(interactor, "_get_draft_record", return_value=_make_draft_record()),
+            patch.object(interactor, "_get_request_headers", return_value={"Authorization": "Bearer x"}),
+            patch("galaxy.files.sources.invenio.requests") as mock_requests,
+        ):
+            mock_requests.post.side_effect = [
+                _mock_response(201, {"entries": [_make_single_upload_entry()]}),  # metadata
+                _mock_response(200),  # commit
+            ]
+            mock_requests.put.return_value = _mock_response(200)
+
+            interactor._upload_file_single("abc", "test.txt", str(file_path), context, file_size=11)
+
+            assert mock_requests.post.call_count == 2
+            assert mock_requests.put.call_count == 1
+
+    def test_upload_file_single_413_raises_helpful_error(self, tmp_path):
+        """HTTP 413 should raise an error mentioning multipart_threshold."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"hello world")
+
+        interactor = _make_interactor()
+        context = _make_context()
+
+        with (
+            patch.object(interactor, "_get_draft_record", return_value=_make_draft_record()),
+            patch.object(interactor, "_get_request_headers", return_value={"Authorization": "Bearer x"}),
+            patch("galaxy.files.sources.invenio.requests") as mock_requests,
+        ):
+            mock_requests.post.return_value = _mock_response(201, {"entries": [_make_single_upload_entry()]})
+            mock_requests.put.return_value = _mock_response(413)
+
+            with pytest.raises(Exception, match="multipart_threshold"):
+                interactor._upload_file_single("abc", "test.txt", str(file_path), context, file_size=11)
+
+
+class TestUploadFileMultipart:
+    """Tests for _upload_file_multipart."""
+
+    def test_upload_file_multipart_success(self, tmp_path):
+        """Verify transfer metadata, part uploads, and commit call."""
+        file_size = 3 * MIN_UPLOAD_PART_SIZE
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"x" * file_size)
+
+        interactor = _make_interactor()
+        context = _make_context(config=MagicMock(
+            multipart_threshold=1,
+            multipart_chunk_size=None,
+            default_resource_type=None,
+            token="test-token",
+            public_name="Doe, Jane",
+        ))
+
+        entries = _make_multipart_entries(3)
+
+        with (
+            patch.object(interactor, "_get_draft_record", return_value=_make_draft_record()),
+            patch.object(interactor, "_get_request_headers", return_value={"Authorization": "Bearer x"}),
+            patch.object(interactor, "_upload_single_part") as mock_upload_part,
+            patch("galaxy.files.sources.invenio.requests") as mock_requests,
+        ):
+            mock_requests.post.side_effect = [
+                _mock_response(201, {"entries": [entries]}),  # initial POST
+                _mock_response(200),  # commit POST
+            ]
+
+            interactor._upload_file_multipart("abc", "test.txt", str(file_path), file_size, context)
+
+            # Verify transfer metadata in the initial POST
+            initial_post_args = mock_requests.post.call_args_list[0]
+            sent_metadata = initial_post_args.kwargs["json"][0]
+            assert sent_metadata["key"] == "test.txt"
+            assert sent_metadata["size"] == file_size
+            assert sent_metadata["transfer"]["type"] == "M"
+            assert sent_metadata["transfer"]["parts"] == 3
+            assert sent_metadata["transfer"]["part_size"] == MIN_UPLOAD_PART_SIZE
+
+            # All 3 parts uploaded
+            assert mock_upload_part.call_count == 3
+            # Commit called (second POST)
+            assert mock_requests.post.call_count == 2
+
+    def test_upload_file_multipart_wrong_part_count_from_server(self, tmp_path):
+        """Server returning fewer part links than expected should raise."""
+        file_size = 3 * MIN_UPLOAD_PART_SIZE
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"x" * file_size)
+
+        interactor = _make_interactor()
+        context = _make_context(config=MagicMock(
+            multipart_threshold=1,
+            multipart_chunk_size=None,
+            default_resource_type=None,
+            token="test-token",
+            public_name="Doe, Jane",
+        ))
+
+        # Server returns only 2 part links instead of 3
+        entries = _make_multipart_entries(2)
+
+        with (
+            patch.object(interactor, "_get_draft_record", return_value=_make_draft_record()),
+            patch.object(interactor, "_get_request_headers", return_value={"Authorization": "Bearer x"}),
+            patch("galaxy.files.sources.invenio.requests") as mock_requests,
+        ):
+            mock_requests.post.return_value = _mock_response(201, {"entries": [entries]})
+
+            with pytest.raises(Exception, match="2 part URLs"):
+                interactor._upload_file_multipart("abc", "test.txt", str(file_path), file_size, context)
+
+
+class TestUploadParts:
+    """Tests for _upload_parts sequential vs parallel behavior."""
+
+    def test_upload_parts_sequential_for_two_parts(self):
+        """<=2 parts should upload sequentially without ThreadPoolExecutor."""
+        interactor = _make_interactor()
+        part_links = [{"part": 0, "url": "u0"}, {"part": 1, "url": "u1"}]
+
+        with patch.object(interactor, "_upload_single_part") as mock_upload:
+            interactor._upload_parts("/path", 1024, 512, part_links, {})
+            assert mock_upload.call_count == 2
+
+    def test_upload_parts_parallel_for_many_parts(self):
+        """>2 parts should use ThreadPoolExecutor."""
+        interactor = _make_interactor()
+        part_links = [{"part": i, "url": f"u{i}"} for i in range(5)]
+
+        with patch.object(interactor, "_upload_single_part") as mock_upload:
+            interactor._upload_parts("/path", 5120, 1024, part_links, {})
+            assert mock_upload.call_count == 5
+
+
+class TestUploadSinglePart:
+    """Tests for _upload_single_part byte-range streaming."""
+
+    def test_upload_single_part_streams_correct_byte_range(self, tmp_path):
+        """Verify the uploaded data matches the expected byte slice."""
+        data = b"0123456789ABCDEF" * 4  # 64 bytes
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(data)
+
+        interactor = _make_interactor()
+        part_size = 16
+        part_info = {"part": 2, "url": "https://invenio.example.org/parts/2"}
+
+        captured_data = bytearray()
+
+        def fake_put(url, data=None, **kwargs):
+            captured_data.extend(data.read())
+            return _mock_response(200)
+
+        with patch("galaxy.files.sources.invenio.requests") as mock_requests:
+            mock_requests.put.side_effect = fake_put
+
+            interactor._upload_single_part(str(file_path), len(data), part_size, 2, part_info)
+
+            # Part 2 = bytes 32-48
+            assert bytes(captured_data) == data[32:48]
+
+
+class TestLimitedFileReader:
+    """Tests for _LimitedFileReader streaming wrapper."""
+
+    def test_read_limited_bytes(self, tmp_path):
+        """Reader should only return the specified number of bytes."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"0123456789")
+
+        with open(file_path, "rb") as f:
+            f.seek(3)
+            reader = _LimitedFileReader(f, 4)
+            assert reader.read() == b"3456"
+
+    def test_read_in_chunks(self, tmp_path):
+        """Reader should serve data in small chunks without over-reading."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"0123456789")
+
+        with open(file_path, "rb") as f:
+            f.seek(2)
+            reader = _LimitedFileReader(f, 5)
+            assert reader.read(2) == b"23"
+            assert reader.read(2) == b"45"
+            assert reader.read(2) == b"6"  # only 1 byte remaining
+            assert reader.read(2) == b""  # now exhausted
+
+    def test_len_reports_remaining(self, tmp_path):
+        """__len__ should report remaining bytes."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"0123456789")
+
+        with open(file_path, "rb") as f:
+            f.seek(1)
+            reader = _LimitedFileReader(f, 5)
+            assert len(reader) == 5
+            reader.read(2)
+            assert len(reader) == 3
+
+
+class TestUploadFileToDraftContainerRouting:
+    """Tests for upload_file_to_draft_container threshold routing."""
+
+    def test_routes_to_single_when_below_threshold(self, tmp_path):
+        """Files below threshold should use single upload."""
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"small")
+
+        interactor = _make_interactor()
+        context = _make_context(config=MagicMock(
+            multipart_threshold=100,
+            multipart_chunk_size=None,
+            default_resource_type=None,
+            token="test-token",
+            public_name="Doe, Jane",
+        ))
+
+        with patch.object(interactor, "_upload_file_single") as mock_single:
+            interactor.upload_file_to_draft_container("abc", "test.txt", str(file_path), context)
+            mock_single.assert_called_once()
+
+    def test_routes_to_multipart_when_above_threshold(self, tmp_path):
+        """Files at or above threshold should use multipart upload."""
+        file_size = 2 * 1024 * 1024  # 2 MiB
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"x" * file_size)
+
+        interactor = _make_interactor()
+        context = _make_context(config=MagicMock(
+            multipart_threshold=1,  # 1 MB threshold, file is 2 MB
+            multipart_chunk_size=None,
+            default_resource_type=None,
+            token="test-token",
+            public_name="Doe, Jane",
+        ))
+
+        with patch.object(interactor, "_upload_file_multipart") as mock_multipart:
+            interactor.upload_file_to_draft_container("abc", "test.txt", str(file_path), context)
+            mock_multipart.assert_called_once()
+            # Verify file_size is passed through
+            assert mock_multipart.call_args[0][3] == file_size
+
+    def test_routes_to_single_when_no_threshold(self, tmp_path):
+        """No threshold configured should always use single upload."""
+        file_size = 100 * 1024 * 1024  # 100 MiB
+        file_path = tmp_path / "test.txt"
+        file_path.write_bytes(b"x" * file_size)
+
+        interactor = _make_interactor()
+        context = _make_context()
+
+        with patch.object(interactor, "_upload_file_single") as mock_single:
+            interactor.upload_file_to_draft_container("abc", "test.txt", str(file_path), context)
+            mock_single.assert_called_once()

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -1,0 +1,118 @@
+"""Unit tests for Invenio multipart upload functionality."""
+
+import pytest
+
+from galaxy.files.sources.invenio import (
+    calculate_multipart_params,
+    MAX_UPLOAD_PART_SIZE,
+    MAX_UPLOAD_PARTS,
+    MIN_UPLOAD_PART_SIZE,
+)
+
+
+class TestCalculateMultipartParams:
+    """Tests for calculate_multipart_params function."""
+
+    def test_calculate_multipart_params_zero_byte(self):
+        """Zero-byte files should return (1, 0)."""
+        parts, part_size = calculate_multipart_params(0)
+        assert parts == 1
+        assert part_size == 0
+
+    def test_calculate_multipart_params_small_file(self):
+        """Files under 5 MiB should use minimum part size."""
+        # 2 MiB file
+        file_size = 2 * 1024 * 1024
+        parts, part_size = calculate_multipart_params(file_size)
+        assert parts == 1
+        assert part_size == MIN_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_medium_file(self):
+        """Files between 5 MiB and 10 MiB."""
+        # 7.5 MiB file
+        file_size = 7 * 1024 * 1024 + 512 * 1024
+        parts, part_size = calculate_multipart_params(file_size)
+        assert parts == 2
+        assert part_size == MIN_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_large_file(self):
+        """Large files requiring multiple parts."""
+        # 25 MiB file
+        file_size = 25 * 1024 * 1024
+        parts, part_size = calculate_multipart_params(file_size)
+        assert parts == 5
+        assert part_size == MIN_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_respects_max_parts(self):
+        """Very large files should not exceed MAX_UPLOAD_PARTS."""
+        # File larger than MAX_UPLOAD_PARTS * MIN_UPLOAD_PART_SIZE
+        file_size = MAX_UPLOAD_PARTS * MIN_UPLOAD_PART_SIZE + MIN_UPLOAD_PART_SIZE
+        parts, part_size = calculate_multipart_params(file_size)
+        assert parts <= MAX_UPLOAD_PARTS
+        assert part_size >= MIN_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_extremely_large_file(self):
+        """Extremely large files should hit both MAX limits.
+
+        Note: Files larger than MAX_UPLOAD_PARTS * MAX_UPLOAD_PART_SIZE (~48.8 TiB)
+        cannot be uploaded via multipart, but we cap params rather than fail here.
+        The upload would fail server-side anyway.
+        """
+        # 100 TiB file - exceeds theoretical maximum (~48.8 TiB)
+        file_size = 100 * 1024**4  # 100 TiB
+        parts, part_size = calculate_multipart_params(file_size)
+        # Parts should be capped at MAX_UPLOAD_PARTS
+        assert parts == MAX_UPLOAD_PARTS
+        # Part size should hit max
+        assert part_size == MAX_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_respects_preferred_part_size(self):
+        """Should use preferred part size when provided and valid."""
+        # 150 MiB file with 100 MiB preferred part size
+        file_size = 150 * 1024 * 1024
+        preferred_part_size = 100 * 1024 * 1024  # 100 MiB
+        parts, part_size = calculate_multipart_params(file_size, preferred_part_size)
+        assert parts == 2
+        assert part_size == preferred_part_size
+
+    def test_calculate_multipart_params_preferred_too_small(self):
+        """Should use minimum part size if preferred is too small."""
+        # 100 MiB file with 1 MiB preferred part size (too small)
+        file_size = 100 * 1024 * 1024
+        preferred_part_size = 1 * 1024 * 1024  # 1 MiB - too small
+        parts, part_size = calculate_multipart_params(file_size, preferred_part_size)
+        assert part_size == MIN_UPLOAD_PART_SIZE  # Should be bumped to minimum
+
+    def test_calculate_multipart_params_preferred_exceeds_max(self):
+        """Should cap at MAX_UPLOAD_PART_SIZE if preferred exceeds it."""
+        # Small file with huge preferred part size
+        file_size = 100 * 1024 * 1024
+        preferred_part_size = MAX_UPLOAD_PART_SIZE * 2  # Exceeds max
+        parts, part_size = calculate_multipart_params(file_size, preferred_part_size)
+        assert parts == 1
+        assert part_size == MAX_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_exact_multiple(self):
+        """File size that's an exact multiple of part size."""
+        # Exactly 3 * MIN_UPLOAD_PART_SIZE
+        file_size = 3 * MIN_UPLOAD_PART_SIZE
+        parts, part_size = calculate_multipart_params(file_size)
+        assert parts == 3
+        assert part_size == MIN_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_one_byte_over(self):
+        """File size one byte over an exact multiple."""
+        # 3 * MIN_UPLOAD_PART_SIZE + 1 byte
+        file_size = 3 * MIN_UPLOAD_PART_SIZE + 1
+        parts, part_size = calculate_multipart_params(file_size)
+        assert parts == 4  # Need 4 parts for 3 full + 1 byte
+        assert part_size == MIN_UPLOAD_PART_SIZE
+
+    def test_calculate_multipart_params_at_boundary(self):
+        """Test file at MAX_UPLOAD_PARTS boundary."""
+        # Exactly at the boundary where we need to increase part size
+        file_size = (MAX_UPLOAD_PARTS + 1) * MIN_UPLOAD_PART_SIZE
+        parts, part_size = calculate_multipart_params(file_size)
+        assert parts <= MAX_UPLOAD_PARTS
+        # Part size should have increased
+        assert part_size > MIN_UPLOAD_PART_SIZE

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -21,10 +21,10 @@ class TestCalculateMultipartParams:
     """Tests for calculate_multipart_params function."""
 
     def test_calculate_multipart_params_zero_byte(self):
-        """Zero-byte files should return (1, 0)."""
+        """Zero-byte files return minimum part size."""
         parts, part_size = calculate_multipart_params(0)
         assert parts == 1
-        assert part_size == 0
+        assert part_size == MIN_UPLOAD_PART_SIZE
 
     def test_calculate_multipart_params_small_file(self):
         """Files under 5 MiB should use minimum part size."""

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -11,6 +11,7 @@ from galaxy.files.sources.invenio import (
     _LimitedFileReader,
     calculate_multipart_params,
     InvenioRepositoryInteractor,
+    InvenioRequestError,
     MAX_UPLOAD_PART_SIZE,
     MAX_UPLOAD_PARTS,
     MIN_UPLOAD_PART_SIZE,
@@ -212,8 +213,8 @@ class TestUploadFileSingle:
             assert mock_requests.post.call_count == 2
             assert mock_requests.put.call_count == 1
 
-    def test_upload_file_single_413_raises_helpful_error(self, tmp_path):
-        """HTTP 413 should raise an error mentioning multipart_threshold."""
+    def test_upload_file_single_propagates_413_as_typed_error(self, tmp_path):
+        """A 413 from the content PUT surfaces as an InvenioRequestError carrying the status code."""
         file_path = tmp_path / "test.txt"
         file_path.write_bytes(b"hello world")
 
@@ -228,8 +229,10 @@ class TestUploadFileSingle:
             mock_requests.post.return_value = _mock_response(201, {"entries": [_make_single_upload_entry()]})
             mock_requests.put.return_value = _mock_response(413)
 
-            with pytest.raises(Exception, match="413"):
+            with pytest.raises(InvenioRequestError) as exc_info:
                 interactor._upload_file_single("abc", "test.txt", str(file_path), context)
+
+            assert exc_info.value.status_code == 413
 
 
 class TestUploadFileMultipart:

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -1,6 +1,9 @@
 """Unit tests for Invenio multipart upload functionality."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
 
 import pytest
 
@@ -239,13 +242,15 @@ class TestUploadFileMultipart:
         file_path.write_bytes(b"x" * file_size)
 
         interactor = _make_interactor()
-        context = _make_context(config=MagicMock(
-            multipart_threshold=1,
-            multipart_chunk_size=None,
-            default_resource_type=None,
-            token="test-token",
-            public_name="Doe, Jane",
-        ))
+        context = _make_context(
+            config=MagicMock(
+                multipart_threshold=1,
+                multipart_chunk_size=None,
+                default_resource_type=None,
+                token="test-token",
+                public_name="Doe, Jane",
+            )
+        )
 
         entries = _make_multipart_entries(3)
 
@@ -283,13 +288,15 @@ class TestUploadFileMultipart:
         file_path.write_bytes(b"x" * file_size)
 
         interactor = _make_interactor()
-        context = _make_context(config=MagicMock(
-            multipart_threshold=1,
-            multipart_chunk_size=None,
-            default_resource_type=None,
-            token="test-token",
-            public_name="Doe, Jane",
-        ))
+        context = _make_context(
+            config=MagicMock(
+                multipart_threshold=1,
+                multipart_chunk_size=None,
+                default_resource_type=None,
+                token="test-token",
+                public_name="Doe, Jane",
+            )
+        )
 
         # Server returns only 2 part links instead of 3
         entries = _make_multipart_entries(2)
@@ -403,13 +410,15 @@ class TestUploadFileToDraftContainerRouting:
         file_path.write_bytes(b"small")
 
         interactor = _make_interactor()
-        context = _make_context(config=MagicMock(
-            multipart_threshold=100,
-            multipart_chunk_size=None,
-            default_resource_type=None,
-            token="test-token",
-            public_name="Doe, Jane",
-        ))
+        context = _make_context(
+            config=MagicMock(
+                multipart_threshold=100,
+                multipart_chunk_size=None,
+                default_resource_type=None,
+                token="test-token",
+                public_name="Doe, Jane",
+            )
+        )
 
         with patch.object(interactor, "_upload_file_single") as mock_single:
             interactor.upload_file_to_draft_container("abc", "test.txt", str(file_path), context)
@@ -422,13 +431,15 @@ class TestUploadFileToDraftContainerRouting:
         file_path.write_bytes(b"x" * file_size)
 
         interactor = _make_interactor()
-        context = _make_context(config=MagicMock(
-            multipart_threshold=1,  # 1 MB threshold, file is 2 MB
-            multipart_chunk_size=None,
-            default_resource_type=None,
-            token="test-token",
-            public_name="Doe, Jane",
-        ))
+        context = _make_context(
+            config=MagicMock(
+                multipart_threshold=1,  # 1 MB threshold, file is 2 MB
+                multipart_chunk_size=None,
+                default_resource_type=None,
+                token="test-token",
+                public_name="Doe, Jane",
+            )
+        )
 
         with patch.object(interactor, "_upload_file_multipart") as mock_multipart:
             interactor.upload_file_to_draft_container("abc", "test.txt", str(file_path), context)

--- a/test/unit/files/test_invenio_multipart.py
+++ b/test/unit/files/test_invenio_multipart.py
@@ -312,28 +312,6 @@ class TestUploadFileMultipart:
                 interactor._upload_file_multipart("abc", "test.txt", str(file_path), file_size, context)
 
 
-class TestUploadParts:
-    """Tests for _upload_parts sequential vs parallel behavior."""
-
-    def test_upload_parts_sequential_for_two_parts(self):
-        """<=2 parts should upload sequentially without ThreadPoolExecutor."""
-        interactor = _make_interactor()
-        part_links = [{"part": 0, "url": "u0"}, {"part": 1, "url": "u1"}]
-
-        with patch.object(interactor, "_upload_single_part") as mock_upload:
-            interactor._upload_parts("/path", 1024, 512, part_links, {})
-            assert mock_upload.call_count == 2
-
-    def test_upload_parts_parallel_for_many_parts(self):
-        """>2 parts should use ThreadPoolExecutor."""
-        interactor = _make_interactor()
-        part_links = [{"part": i, "url": f"u{i}"} for i in range(5)]
-
-        with patch.object(interactor, "_upload_single_part") as mock_upload:
-            interactor._upload_parts("/path", 5120, 1024, part_links, {})
-            assert mock_upload.call_count == 5
-
-
 class TestUploadSinglePart:
     """Tests for _upload_single_part byte-range streaming."""
 


### PR DESCRIPTION
Since version 13 InvenioRDM supports enabling multipart s3 upload (https://inveniordm.docs.cern.ch/releases/v13/version-v13.0.0/).

When such configuration is enabled on the invenio instance the current Galaxy implementation will start failing since there is no guaranteed fallback -- multipart may be the only supported upload paradigm.

This PR implements support for s3 multipart upload.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
