### PR TITLE
[26.1] Backport "Always install ``fastmcp``"

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -318,9 +318,6 @@ class ConditionalDependencies:
             self.config.get("ai_api_key", None) is not None or self.config.get("inference_services", None) is not None
         )
 
-    def check_fastmcp(self):
-        return asbool(self.config.get("enable_mcp_server", False))
-
     def check_weasyprint(self):
         # See notes in ./conditional-requirements.txt for more information.
         return os.environ.get("GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT") == "1"

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -16,7 +16,6 @@ galaxycloudrunner
 pkce
 total-perspective-vortex>=3.2.1,<4
 openai
-fastmcp>=2.13.0
 # upper version constraint because of https://github.com/galaxyproject/galaxy/issues/20600
 redis>=5.3.0,<6
 

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -36,6 +36,7 @@ from galaxy.webapps.base.webapp import (
     _is_embed_request,
     config_allows_origin,
 )
+from galaxy.webapps.galaxy.api.mcp import get_mcp_app
 from galaxy.webapps.openapi._compat.v2 import GenerateJsonSchema
 from galaxy.webapps.openapi.utils import get_openapi
 
@@ -267,13 +268,8 @@ def get_mcp_lifespan(gx_app):
         return None, None
 
     try:
-        from galaxy.webapps.galaxy.api.mcp import get_mcp_app
-
         mcp_app = get_mcp_app(gx_app)
         return mcp_app, mcp_app.lifespan
-    except ImportError:
-        log.info("MCP server dependencies not installed (fastmcp), skipping")
-        return None, None
     except Exception:
         log.exception("Failed to initialize MCP server")
         return None, None

--- a/packages/web_apps/setup.cfg
+++ b/packages/web_apps/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     Babel
     CT3>=3.3.3
     fastapi>=0.133.0
+    fastmcp>=2.13.0
     gunicorn!=25.1.0
     httpx
     gxformat2>=0.27.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "dparse",
     "edam-ontology",
     "fastapi>=0.133.0",  # First version compatible with starlette>=1.0.0
+    "fastmcp>=2.13.0",
     "fissix",
     "fs",
     "future>=1.0.0",  # Python 3.12 support


### PR DESCRIPTION
in preparation for pydantic-ai 2.0.0, which replaced the dependency on `fastmcp` with `fastmcp-slim[client]`.

Otherwise Galaxy fails to start with:

```
Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/fastmcp/server/__init__.py", line 6, in <module>
    from .context import Context
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/fastmcp/server/context.py", line 28, in <module>
    from uncalled_for import SharedContext
ModuleNotFoundError: No module named 'uncalled_for'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/fastmcp/__init__.py", line 57, in __getattr__
    from fastmcp.server.context import Context
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/fastmcp/server/__init__.py", line 9, in <module>
    raise ImportError(_install_hints.SERVER_SUPPORT) from exc
ImportError: FastMCP server support is not installed. Install `fastmcp` or `fastmcp-slim[server]`.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/bin/gunicorn", line 10, in <module>
    sys.exit(run())
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 66, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]", prog=prog).run()
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/app/base.py", line 235, in run
    super().run()
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/app/base.py", line 71, in run
    Arbiter(self).run()
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/arbiter.py", line 63, in __init__
    self.setup(app)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/arbiter.py", line 139, in setup
    self.app.wsgi()
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/app/base.py", line 66, in wsgi
    self.callable = self.load()
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
    return self.load_wsgiapp()
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/gunicorn/util.py", line 464, in import_app
    app = app(*args, **kwargs)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/webapps/galaxy/fast_factory.py", line 63, in factory
    gx_wsgi_webapp, gx_app = app_pair(
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/webapps/galaxy/buildapp.py", line 178, in app_pair
    populate_api_routes(webapp, app)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/webapps/galaxy/buildapp.py", line 362, in populate_api_routes
    webapp.add_api_controllers("galaxy.webapps.galaxy.api", app)
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/webapps/base/webapp.py", line 252, in add_api_controllers
    for name, module in base.walk_controller_modules(package_name):
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/web/framework/base.py", line 624, in walk_controller_modules
    module = import_module(module_name)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/lib/galaxy/webapps/galaxy/api/mcp.py", line 15, in <module>
    from fastmcp import (
  File "/usr/users/ga002/soranzon/software/nsoranzo_galaxy/.venv/lib/python3.10/site-packages/fastmcp/__init__.py", line 59, in __getattr__
    raise ImportError(_install_hints.SERVER_SUPPORT) from exc
ImportError: FastMCP server support is not installed. Install `fastmcp` or `fastmcp-slim[server]`.
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
