### PR TITLE
[26.0] Fix clean jwd task

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -615,18 +615,27 @@ def dispatch_pending_notifications(notification_manager: NotificationManager):
         log.info(f"Successfully dispatched {count} notifications.")
 
 
-@galaxy_task(action="clean up job working directories")
-def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore, config: GalaxyAppConfiguration):
-    """Cleanup job working directories for failed jobs that are older than X days"""
+def _cleanup_jwds(
+    sa_session: galaxy_scoped_session,
+    object_store: BaseObjectStore,
+    days: int,
+) -> int:
+    """Cleanup job working directories for failed jobs that are older than `days` days.
+
+    Returns the number of job working directories deleted.
+    """
 
     def get_failed_jobs():
-        return sa_session.query(model.Job.id).filter(
-            model.Job.state == "error",
-            model.Job.update_time < datetime.datetime.now() - datetime.timedelta(days=days),
-            model.Job.object_store_id.isnot(None),
+        return (
+            sa_session.query(model.Job)
+            .filter(
+                model.Job.state == "error",
+                model.Job.update_time < datetime.datetime.now() - datetime.timedelta(days=days),
+            )
+            .all()
         )
 
-    def delete_jwd(job):
+    def delete_jwd(job: model.Job):
         try:
             # Get job working directory from object store
             path = object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
@@ -637,15 +646,26 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
         except OSError as e:
             log.error(f"Error deleting job working directory: {path} : {e.strerror}")
 
-    days = config.failed_jobs_working_directory_cleanup_days
     failed_jobs = get_failed_jobs()
 
     if not failed_jobs:
         log.info("No failed jobs found within the last %s days", days)
+        return 0
 
+    deleted_count = 0
     for job in failed_jobs:
         delete_jwd(job)
         log.info("Deleted job working directory for job %s", job.id)
+        deleted_count += 1
+
+    return deleted_count
+
+
+@galaxy_task(action="clean up job working directories")
+def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore, config: GalaxyAppConfiguration):
+    """Cleanup job working directories for failed jobs that are older than X days"""
+    days = config.failed_jobs_working_directory_cleanup_days
+    _cleanup_jwds(sa_session, object_store, days)
 
 
 @galaxy_task(action="execute workflow completion hook")

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -625,39 +625,29 @@ def _cleanup_jwds(
     Returns the number of job working directories deleted.
     """
 
-    def get_failed_jobs():
-        return (
-            sa_session.query(model.Job)
-            .filter(
-                model.Job.state == "error",
-                model.Job.update_time < datetime.datetime.now() - datetime.timedelta(days=days),
-            )
-            .all()
-        )
+    cutoff = datetime.datetime.now() - datetime.timedelta(days=days)
 
-    def delete_jwd(job: model.Job):
+    def _delete_jwd(job: model.Job) -> bool:
         try:
-            # Get job working directory from object store
             path = object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
             shutil.rmtree(path)
+            return True
         except ObjectNotFound:
-            # job working directory already deleted
-            pass
+            return False
         except OSError as e:
             log.error(f"Error deleting job working directory: {path} : {e.strerror}")
-
-    failed_jobs = get_failed_jobs()
-
-    if not failed_jobs:
-        log.info("No failed jobs found within the last %s days", days)
-        return 0
+            return False
 
     deleted_count = 0
-    for job in failed_jobs:
-        delete_jwd(job)
-        log.info("Deleted job working directory for job %s", job.id)
-        deleted_count += 1
+    stmt = select(model.Job).where(
+        model.Job.state == "error",
+        model.Job.update_time < cutoff,
+    )
+    for job in sa_session.scalars(stmt).yield_per(100):
+        if _delete_jwd(job):
+            deleted_count += 1
 
+    log.info("Deleted %d job working directories older than %d days", deleted_count, days)
     return deleted_count
 
 

--- a/test/unit/app/test_tasks.py
+++ b/test/unit/app/test_tasks.py
@@ -1,5 +1,21 @@
+from datetime import (
+    datetime,
+    timedelta,
+)
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from galaxy import model
 from galaxy.app_unittest_utils.galaxy_mock import MockApp
-from galaxy.celery.tasks import clean_object_store_caches
+from galaxy.celery.tasks import (
+    _cleanup_jwds,
+    clean_object_store_caches,
+)
+from galaxy.exceptions import ObjectNotFound
+from galaxy.model.unittest_utils.model_testing_utils import initialize_model
 from galaxy.objectstore import BaseObjectStore
 from galaxy.objectstore.caching import CacheTarget
 
@@ -34,3 +50,170 @@ def test_clean_object_store_caches(tmp_path):
     clean_object_store_caches()
 
     assert not path.exists()
+
+
+@pytest.fixture
+def sa_session():
+    engine = create_engine("sqlite:///:memory:")
+    initialize_model(model.mapper_registry, engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _make_job(state: str, age_days: int) -> model.Job:
+    job = model.Job()
+    job.state = state
+    job.update_time = datetime.now() - timedelta(days=age_days)
+    job.object_store_id = "mock_store"
+    return job
+
+
+class TestCleanupJwds:
+    """Tests for _cleanup_jwds using a real in-memory database with actual Job model instances.
+
+    The query must return Job objects (not Row tuples), must call .all() (so `if not failed_jobs`
+    works — a bare Query is always truthy), and must filter on state, age, and object_store_id.
+    """
+
+    def test_no_failed_jobs_returns_early(self, sa_session):
+        object_store = MagicMock()
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+        assert result == 0
+        object_store.get_filename.assert_not_called()
+
+    def test_deletes_jwd_for_old_failed_jobs(self, sa_session, tmp_path):
+        job = _make_job(state="error", age_days=10)
+        sa_session.add(job)
+        sa_session.commit()
+
+        jwd_path = tmp_path / "job_work" / str(job.id)
+        jwd_path.mkdir(parents=True)
+        (jwd_path / "some_file.txt").write_text("job output")
+
+        object_store = MagicMock()
+        object_store.get_filename.return_value = str(jwd_path)
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 1
+        object_store.get_filename.assert_called_once()
+        # Must pass a Job object, not a Row tuple (query(model.Job) vs query(model.Job.id))
+        assert isinstance(object_store.get_filename.call_args[0][0], model.Job)
+        assert not jwd_path.exists()
+
+    def test_deletes_multiple_old_failed_jobs(self, sa_session, tmp_path):
+        jobs = [_make_job(state="error", age_days=10) for _ in range(3)]
+        sa_session.add_all(jobs)
+        sa_session.commit()
+
+        jwd_paths = []
+        for job in jobs:
+            jwd_path = tmp_path / "job_work" / str(job.id)
+            jwd_path.mkdir(parents=True)
+            jwd_paths.append(jwd_path)
+
+        object_store = MagicMock()
+        object_store.get_filename.side_effect = [str(p) for p in jwd_paths]
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 3
+        assert object_store.get_filename.call_count == 3
+        assert all(not p.exists() for p in jwd_paths)
+
+    def test_skips_jobs_not_old_enough(self, sa_session, tmp_path):
+        job = _make_job(state="error", age_days=1)
+        sa_session.add(job)
+        sa_session.commit()
+
+        jwd_path = tmp_path / "job_work" / str(job.id)
+        jwd_path.mkdir(parents=True)
+
+        object_store = MagicMock()
+        object_store.get_filename.return_value = str(jwd_path)
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 0
+        object_store.get_filename.assert_not_called()
+        assert jwd_path.exists()
+
+    def test_skips_non_failed_jobs(self, sa_session, tmp_path):
+        job = _make_job(state="ok", age_days=30)
+        sa_session.add(job)
+        sa_session.commit()
+
+        jwd_path = tmp_path / "job_work" / str(job.id)
+        jwd_path.mkdir(parents=True)
+
+        object_store = MagicMock()
+        object_store.get_filename.return_value = str(jwd_path)
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 0
+        object_store.get_filename.assert_not_called()
+        assert jwd_path.exists()
+
+    def test_deletes_jwd_for_jobs_without_object_store_id(self, sa_session, tmp_path):
+        """Jobs using the default object store have object_store_id=None but should still be cleaned up."""
+        job = _make_job(state="error", age_days=10)
+        job.object_store_id = None
+        sa_session.add(job)
+        sa_session.commit()
+
+        jwd_path = tmp_path / "job_work" / str(job.id)
+        jwd_path.mkdir(parents=True)
+
+        object_store = MagicMock()
+        object_store.get_filename.return_value = str(jwd_path)
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 1
+        object_store.get_filename.assert_called_once()
+        assert not jwd_path.exists()
+
+    def test_only_deletes_matching_jobs_when_mixed(self, sa_session, tmp_path):
+        """With both matching and non-matching jobs in the DB, only matching ones are deleted.
+
+        This catches the 'Query is always truthy' bug: without .all(), the `if not failed_jobs`
+        check never triggers, and iterating a Query that should be empty may yield wrong rows.
+        """
+        # Matching: old + failed + has object_store_id
+        old_failed = _make_job(state="error", age_days=10)
+        # Matching: old + failed but no object_store_id (default object store)
+        no_store = _make_job(state="error", age_days=10)
+        no_store.object_store_id = None
+        # Non-matching: old + ok
+        old_ok = _make_job(state="ok", age_days=10)
+        # Non-matching: recent + failed
+        recent_failed = _make_job(state="error", age_days=1)
+        sa_session.add_all([old_failed, no_store, old_ok, recent_failed])
+        sa_session.commit()
+
+        jwd_matching = tmp_path / "job_work" / str(old_failed.id)
+        jwd_matching.mkdir(parents=True)
+        jwd_no_store = tmp_path / "job_work" / str(no_store.id)
+        jwd_no_store.mkdir(parents=True)
+
+        object_store = MagicMock()
+        object_store.get_filename.side_effect = [str(jwd_matching), str(jwd_no_store)]
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 2
+        assert object_store.get_filename.call_count == 2
+        assert not jwd_matching.exists()
+        assert not jwd_no_store.exists()
+
+    def test_handles_already_deleted_jwd(self, sa_session):
+        job = _make_job(state="error", age_days=10)
+        sa_session.add(job)
+        sa_session.commit()
+
+        object_store = MagicMock()
+        object_store.get_filename.side_effect = ObjectNotFound("JWD not found")
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+        assert result == 1

--- a/test/unit/app/test_tasks.py
+++ b/test/unit/app/test_tasks.py
@@ -69,13 +69,9 @@ def _make_job(state: str, age_days: int) -> model.Job:
 
 
 class TestCleanupJwds:
-    """Tests for _cleanup_jwds using a real in-memory database with actual Job model instances.
+    """Tests for _cleanup_jwds using a real in-memory database with actual Job model instances."""
 
-    The query must return Job objects (not Row tuples), must call .all() (so `if not failed_jobs`
-    works — a bare Query is always truthy), and must filter on state, age, and object_store_id.
-    """
-
-    def test_no_failed_jobs_returns_early(self, sa_session):
+    def test_no_failed_jobs_returns_zero(self, sa_session):
         object_store = MagicMock()
         result = _cleanup_jwds(sa_session, object_store, days=7)
         assert result == 0
@@ -97,7 +93,6 @@ class TestCleanupJwds:
 
         assert result == 1
         object_store.get_filename.assert_called_once()
-        # Must pass a Job object, not a Row tuple (query(model.Job) vs query(model.Job.id))
         assert isinstance(object_store.get_filename.call_args[0][0], model.Job)
         assert not jwd_path.exists()
 
@@ -216,4 +211,4 @@ class TestCleanupJwds:
         object_store.get_filename.side_effect = ObjectNotFound("JWD not found")
 
         result = _cleanup_jwds(sa_session, object_store, days=7)
-        assert result == 1
+        assert result == 0


### PR DESCRIPTION
Fixes the issues detected during the planning here https://github.com/galaxyproject/galaxy/discussions/23107#discussioncomment-17638639

- **`NameError: name 'days' is not defined`** — `days` was read inside nested closures (`get_failed_jobs`, `delete_jwd`) but assigned in the outer function body after the closures were defined, causing an unbound variable error on every run.
- **Query returned `Row` tuples instead of `Job` objects** — `query(model.Job.id)` produced tuples that were passed to `object_store.get_filename()`, which expects a `Job` instance → `AttributeError`.
- **Missing `.all()` on the query** — a bare `Query` is always truthy, so the `if not failed_jobs` early-return check never triggered.
- **Jobs with `object_store_id=None` were excluded** — the `isnot(None)` filter skipped jobs using the default object store from cleanup.
- **No visibility into how many JWDs were deleted** — refactored the core logic into `_cleanup_jwds()` which returns the count of deleted directories, enabling proper testing and logging.

A comprehensive test suite (`TestCleanupJwds`) was added covering all five scenarios above plus edge cases (mixed job states, already-deleted JWDs, etc.).


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
