### PR TITLE
Handle underscore-prefixed section/conditional/repeat param names in Pydantic models

### DIFF
--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -2124,6 +2124,7 @@ class ConditionalParameterModel(BaseGalaxyToolParameterModelDefinition):
     def pydantic_template(self, state_representation: StateRepresentationT) -> DynamicModelInformation:
         is_boolean = isinstance(self.test_parameter, BooleanParameterModel)
         test_param_name = self.test_parameter.name
+        safe_test_name = safe_field_name(test_param_name)
         test_info = self.test_parameter.pydantic_template(state_representation)
         extra_validators = test_info.validators
         if state_representation in ("job_internal", "job_runtime"):
@@ -2140,7 +2141,8 @@ class ConditionalParameterModel(BaseGalaxyToolParameterModelDefinition):
             else:
                 initialize_test = None
             tag = str(discriminator) if not is_boolean else str(discriminator).lower()
-            extra_kwd = {test_param_name: (Literal[when.discriminator], initialize_test)}
+            test_field_alias = test_param_name if safe_test_name != test_param_name else None
+            extra_kwd = {safe_test_name: (Literal[when.discriminator], Field(initialize_test, alias=test_field_alias))}
             when_types.append(
                 cast(
                     type[BaseModel],
@@ -2211,9 +2213,11 @@ class ConditionalParameterModel(BaseGalaxyToolParameterModelDefinition):
                 initialize_cond = None
 
         field_kwargs = self.field_kwargs()
+        name = safe_field_name(self.name)
+        alias = self.name if self.name != name else None
         return DynamicModelInformation(
-            self.name,
-            (py_type, Field(initialize_cond, **field_kwargs)),
+            name,
+            (py_type, Field(initialize_cond, alias=alias, **field_kwargs)),
             {},
         )
 
@@ -2262,9 +2266,11 @@ class RepeatParameterModel(BaseGalaxyToolParameterModelDefinition):
             root: list[instance_class] = Field(initialize_repeat, min_length=min_length, max_length=max_length)  # type: ignore[valid-type]
 
         field_kwargs = self.field_kwargs()
+        name = safe_field_name(self.name)
+        alias = self.name if self.name != name else None
         return DynamicModelInformation(
-            self.name,
-            (RepeatType, Field(initialize_repeat, **field_kwargs)),
+            name,
+            (RepeatType, Field(initialize_repeat, alias=alias, **field_kwargs)),
             {},
         )
 
@@ -2299,9 +2305,11 @@ class SectionParameterModel(BaseGalaxyToolParameterModelDefinition):
         else:
             initialize_section = None
         field_kwargs = self.field_kwargs()
+        name = safe_field_name(self.name)
+        alias = self.name if self.name != name else None
         return DynamicModelInformation(
-            self.name,
-            (instance_class, Field(initialize_section, **field_kwargs)),
+            name,
+            (instance_class, Field(initialize_section, alias=alias, **field_kwargs)),
             {},
         )
 

--- a/test/functional/tools/parameters/gx_conditional_underscore_name.xml
+++ b/test/functional/tools/parameters/gx_conditional_underscore_name.xml
@@ -1,0 +1,20 @@
+<tool id="gx_conditional_underscore_name" name="gx_conditional_underscore_name" version="1.0.0" profile="24.2">
+    <command detect_errors="exit_code"><![CDATA[echo '$__cond_opts__.__selector__' > '$output']]></command>
+    <inputs>
+        <conditional name="__cond_opts__">
+            <param name="__selector__" type="select" label="Choose">
+                <option value="a" selected="true">A</option>
+                <option value="b">B</option>
+            </param>
+            <when value="a">
+                <param name="param_a" type="text" value="val_a" label="Param A"/>
+            </when>
+            <when value="b">
+                <param name="param_b" type="text" value="val_b" label="Param B"/>
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt"/>
+    </outputs>
+</tool>

--- a/test/functional/tools/parameters/gx_section_underscore_name.xml
+++ b/test/functional/tools/parameters/gx_section_underscore_name.xml
@@ -1,0 +1,11 @@
+<tool id="gx_section_underscore_name" name="gx_section_underscore_name" version="1.0.0" profile="24.2">
+    <command detect_errors="exit_code"><![CDATA[echo '$__section_opts__.param' > '$output']]></command>
+    <inputs>
+        <section name="__section_opts__" title="Options" expanded="true">
+            <param name="param" type="text" value="default_val" label="A parameter"/>
+        </section>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt"/>
+    </outputs>
+</tool>

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -4281,3 +4281,32 @@ cwl_directory:
    - parameter: true
    - parameter: 5
    - parameter: "5"
+
+gx_section_underscore_name:
+  request_valid:
+  - { __section_opts__: { param: "hello" } }
+  - {}
+  request_invalid:
+  - { __section_opts__: { param: "hello", not_a_param: "x" } }
+  workflow_step_valid:
+  - { __section_opts__: { param: "hello" } }
+  - {}
+  workflow_step_linked_valid:
+  - { __section_opts__: { param: "hello" } }
+  - { __section_opts__: { param: {__class__: ConnectedValue} } }
+  - {}
+
+gx_conditional_underscore_name:
+  request_valid:
+  - { __cond_opts__: { __selector__: "a", param_a: "test" } }
+  - { __cond_opts__: { __selector__: "b", param_b: "test" } }
+  - {}
+  request_invalid:
+  - { __cond_opts__: { __selector__: "not_a_or_b" } }
+  workflow_step_valid:
+  - { __cond_opts__: { __selector__: "a", param_a: "test" } }
+  - {}
+  workflow_step_linked_valid:
+  - { __cond_opts__: { __selector__: "a", param_a: "test" } }
+  - { __cond_opts__: { __selector__: "a", param_a: {__class__: ConnectedValue} } }
+  - {}


### PR DESCRIPTION
Apply safe_field_name+alias in the pydantic_template of Section, Conditional, and Repeat models (and the conditional test field inside When models) so underscore-prefixed compound-parameter names don't crash Pydantic v2 with "Fields must not use names with leading underscores".

safe_field_name already covered leaf params; compound params still used the raw name. This closes the QIIME2 __q2galaxy__GUI__section__* crash (#22883), which the leaf-only handling did not.

Add parameter_specification cases + test tools for underscore-named section and conditional. The conditional fixture uses an underscore-prefixed test param (__selector__) to exercise the When-field alias path, and both blocks carry a request_invalid case.

Extracted from #22996 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
