### PR TITLE
Support workflow_step_linked state for data_column parameters

### DIFF
--- a/lib/galaxy/tool_util_models/parameters.py
+++ b/lib/galaxy/tool_util_models/parameters.py
@@ -2028,6 +2028,9 @@ class DataColumnParameterModel(BaseGalaxyToolParameterModelDefinition):
             return dynamic_model_information_from_py_type(
                 self, self.py_type, validators={}, requires_value=requires_value
             )
+        elif state_representation == "workflow_step_linked":
+            py_type = allow_connected_value(self.py_type)
+            return dynamic_model_information_from_py_type(self, py_type, requires_value=False)
         else:
             requires_value = self.request_requires_value
             if state_representation in ("job_internal", "job_runtime"):

--- a/test/unit/tool_util/parameter_specification.yml
+++ b/test/unit/tool_util/parameter_specification.yml
@@ -2363,6 +2363,11 @@ gx_data_column:
   - { ref_parameter: {class: "File", path: "1.bed"}, parameter: 3 }
   test_case_json_invalid:
   - { ref_parameter: {class: "File", path: "1.bed"}, parameter: "3" }
+  workflow_step_linked_valid:
+  - { ref_parameter: {__class__: ConnectedValue}, parameter: 0 }
+  - { ref_parameter: {__class__: ConnectedValue}, parameter: {__class__: ConnectedValue} }
+  workflow_step_linked_invalid:
+  - { ref_parameter: {__class__: ConnectedValue}, parameter: "0" }
 
 gx_data_column_optional:
   request_valid:
@@ -2409,6 +2414,11 @@ gx_data_column_multiple:
   - { ref_parameter: {class: "File", path: "1.bed"}, parameter: [1, 2, 3] }
   test_case_json_invalid:
   - { ref_parameter: {class: "File", path: "1.bed"}, parameter: "1,2,3" }
+  workflow_step_linked_valid:
+  - { ref_parameter: {__class__: ConnectedValue}, parameter: [0, 1] }
+  - { ref_parameter: {__class__: ConnectedValue}, parameter: {__class__: ConnectedValue} }
+  workflow_step_linked_invalid:
+  - { ref_parameter: {__class__: ConnectedValue}, parameter: "0,1" }
 
 gx_data_column_multiple_accept_default:
   request_valid:


### PR DESCRIPTION
Add a workflow_step_linked branch to DataColumnParameterModel.pydantic_template that wraps the column py_type with allow_connected_value, so a data_column can carry a ConnectedValue (or a connected ref_parameter) when validated as linked workflow-step state. requires_value is relaxed since the value may arrive via a connection.

Add parameter_specification workflow_step_linked cases for gx_data_column and gx_data_column_multiple.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
