### PR TITLE
[26.0] Fix typo in irods object store cache size

### DIFF
--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -227,7 +227,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         self.logical_path = logical_dict.get("path") or f"/{self.zone}/home/{self.username}"
 
         cache_dict = config_dict.get("cache") or {}
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_path
+        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
         self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
         extra_dirs = {e["type"]: e["path"] for e in config_dict.get("extra_dirs", [])}


### PR DESCRIPTION
Corrects a configuration error where the cache size was being initialized with the cache path instead of the intended cache size value.

Detected in https://github.com/galaxyproject/galaxy/discussions/23107#discussioncomment-17638639

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
