### PR TITLE
Avoid duplicate dataset preview requests

### DIFF
--- a/client/src/components/Dataset/DatasetDisplay.vue
+++ b/client/src/components/Dataset/DatasetDisplay.vue
@@ -6,6 +6,7 @@ import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 
 import { useDatasetStore } from "@/stores/datasetStore";
+import { useDatatypeStore } from "@/stores/datatypeStore";
 import { useUserStore } from "@/stores/userStore";
 import STATES from "@/utils/datasetStates";
 import { absPath, withPrefix } from "@/utils/redirect";
@@ -23,6 +24,7 @@ interface Props {
 }
 
 const { getDataset, isLoadingDataset } = useDatasetStore();
+const datatypeStore = useDatatypeStore();
 
 const emit = defineEmits(["load"]);
 
@@ -32,7 +34,7 @@ const contentTruncated = ref<number | null>(null);
 const contentChunked = ref<boolean>(false);
 const errorMessage = ref<string>("");
 const previewLoaded = ref<boolean>(false);
-const previewBlobUrl = ref<string | null>(null);
+const previewFrameUrl = ref<string | null>(null);
 const sanitizedJobImported = ref<boolean>(false);
 const sanitizedToolId = ref<string | null>(null);
 
@@ -65,22 +67,26 @@ watch(
         sanitizedJobImported.value = false;
         sanitizedToolId.value = null;
         errorMessage.value = "";
+        const existingFrameUrl = previewFrameUrl.value;
+        previewFrameUrl.value = null;
 
         const controller = new AbortController();
-        const existingBlobUrl = previewBlobUrl.value;
-        previewBlobUrl.value = null;
-        if (existingBlobUrl) {
-            URL.revokeObjectURL(existingBlobUrl);
+        if (existingFrameUrl?.startsWith("blob:")) {
+            URL.revokeObjectURL(existingFrameUrl);
         }
         onCleanup(() => {
             controller.abort();
-            if (previewBlobUrl.value) {
-                URL.revokeObjectURL(previewBlobUrl.value);
-                previewBlobUrl.value = null;
+            if (previewFrameUrl.value?.startsWith("blob:")) {
+                URL.revokeObjectURL(previewFrameUrl.value);
             }
+            previewFrameUrl.value = null;
         });
 
         try {
+            const extension = dataset.value?.file_ext;
+            const datatypeDetails = extension ? await datatypeStore.fetchDatatypeDetails(extension) : null;
+            // HTML-like and composite previews need a real /display/ URL so relative assets keep working.
+            const useDirectPreview = Boolean(extension?.endsWith("html") || datatypeDetails?.composite_files?.length);
             const response = await fetch(absPath(previewUrl.value), { method: "GET", signal: controller.signal });
             const { headers } = response;
             contentChunked.value = !!headers.get("x-content-chunked");
@@ -92,9 +98,13 @@ watch(
             if (!response.ok) {
                 throw new Error(`${response.status} ${response.statusText}`);
             }
-            if (!contentChunked.value) {
+            if (useDirectPreview) {
+                // Iframe request delayed until after this fetch completes so the duplicate download is sequential
+                // (which helps to make use of the objectstore cache for the second request).
+                previewFrameUrl.value = previewUrl.value;
+            } else if (!contentChunked.value) {
                 const blob = await response.blob();
-                previewBlobUrl.value = URL.createObjectURL(blob);
+                previewFrameUrl.value = URL.createObjectURL(blob);
             }
         } catch (e) {
             if (!controller.signal.aborted) {
@@ -148,7 +158,7 @@ watch(
                 </div>
                 <a :href="downloadUrl">Download</a>
             </div>
-            <CenterFrame v-if="previewBlobUrl" :src="previewBlobUrl" @load="emit('load')" />
+            <CenterFrame v-if="previewFrameUrl" :src="previewFrameUrl" @load="emit('load')" />
         </div>
     </div>
 </template>

--- a/client/src/components/Dataset/DatasetDisplay.vue
+++ b/client/src/components/Dataset/DatasetDisplay.vue
@@ -8,7 +8,7 @@ import { computed, ref, watch } from "vue";
 import { useDatasetStore } from "@/stores/datasetStore";
 import { useUserStore } from "@/stores/userStore";
 import STATES from "@/utils/datasetStates";
-import { withPrefix } from "@/utils/redirect";
+import { absPath, withPrefix } from "@/utils/redirect";
 import { errorMessageAsString } from "@/utils/simple-error";
 import { bytesToString } from "@/utils/utils";
 
@@ -31,6 +31,8 @@ const props = defineProps<Props>();
 const contentTruncated = ref<number | null>(null);
 const contentChunked = ref<boolean>(false);
 const errorMessage = ref<string>("");
+const previewLoaded = ref<boolean>(false);
+const previewBlobUrl = ref<string | null>(null);
 const sanitizedJobImported = ref<boolean>(false);
 const sanitizedToolId = ref<string | null>(null);
 
@@ -56,19 +58,52 @@ const sanitizedMessage = computed(() => {
 
 watch(
     () => props.datasetId,
-    async () => {
+    async (_, __, onCleanup) => {
+        previewLoaded.value = false;
+        contentChunked.value = false;
+        contentTruncated.value = null;
+        sanitizedJobImported.value = false;
+        sanitizedToolId.value = null;
+        errorMessage.value = "";
+
+        const controller = new AbortController();
+        const existingBlobUrl = previewBlobUrl.value;
+        previewBlobUrl.value = null;
+        if (existingBlobUrl) {
+            URL.revokeObjectURL(existingBlobUrl);
+        }
+        onCleanup(() => {
+            controller.abort();
+            if (previewBlobUrl.value) {
+                URL.revokeObjectURL(previewBlobUrl.value);
+                previewBlobUrl.value = null;
+            }
+        });
+
         try {
-            const { headers } = await fetch(withPrefix(previewUrl.value), { method: "HEAD" });
+            const response = await fetch(absPath(previewUrl.value), { method: "GET", signal: controller.signal });
+            const { headers } = response;
             contentChunked.value = !!headers.get("x-content-chunked");
             contentTruncated.value = headers.get("x-content-truncated")
                 ? Number(headers.get("x-content-truncated"))
                 : null;
             sanitizedJobImported.value = !!headers.get("x-sanitized-job-imported");
             sanitizedToolId.value = headers.get("x-sanitized-tool-id");
-            errorMessage.value = "";
+            if (!response.ok) {
+                throw new Error(`${response.status} ${response.statusText}`);
+            }
+            if (!contentChunked.value) {
+                const blob = await response.blob();
+                previewBlobUrl.value = URL.createObjectURL(blob);
+            }
         } catch (e) {
-            errorMessage.value = errorMessageAsString(e);
-            console.error(e);
+            if (!controller.signal.aborted) {
+                errorMessage.value = errorMessageAsString(e);
+                console.error(e);
+            }
+        }
+        if (!controller.signal.aborted) {
+            previewLoaded.value = true;
         }
     },
     { immediate: true },
@@ -88,6 +123,7 @@ watch(
         <FontAwesomeIcon :icon="faExclamationTriangle" />
         <span>Dataset is unavailable. Please check the history panel for details.</span>
     </BAlert>
+    <LoadingSpan v-else-if="!previewLoaded" message="Loading dataset content" />
     <div v-else class="dataset-display h-100">
         <Alert v-if="sanitizedMessage" :dismissible="true" variant="warning" data-description="sanitization warning">
             {{ sanitizedMessage }}
@@ -112,7 +148,7 @@ watch(
                 </div>
                 <a :href="downloadUrl">Download</a>
             </div>
-            <CenterFrame :src="previewUrl" @load="emit('load')" />
+            <CenterFrame v-if="previewBlobUrl" :src="previewBlobUrl" @load="emit('load')" />
         </div>
     </div>
 </template>

--- a/client/src/components/Dataset/DatasetDisplay.vue
+++ b/client/src/components/Dataset/DatasetDisplay.vue
@@ -87,7 +87,8 @@ watch(
             const datatypeDetails = extension ? await datatypeStore.fetchDatatypeDetails(extension) : null;
             // HTML-like and composite previews need a real /display/ URL so relative assets keep working.
             const useDirectPreview = Boolean(extension?.endsWith("html") || datatypeDetails?.composite_files?.length);
-            const response = await fetch(absPath(previewUrl.value), { method: "GET", signal: controller.signal });
+            const method = useDirectPreview ? "HEAD" : "GET";
+            const response = await fetch(absPath(previewUrl.value), { method, signal: controller.signal });
             const { headers } = response;
             contentChunked.value = !!headers.get("x-content-chunked");
             contentTruncated.value = headers.get("x-content-truncated")

--- a/client/src/components/Dataset/DatasetView.test.js
+++ b/client/src/components/Dataset/DatasetView.test.js
@@ -2,6 +2,7 @@ import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
+import { http as mswHttp,HttpResponse } from "msw";
 import { setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import VueRouter from "vue-router";
@@ -193,12 +194,23 @@ describe("DatasetView", () => {
         }
         global.IntersectionObserver = IO;
         global.MutationObserver = IO;
+        global.URL.createObjectURL = vi.fn(() => "blob:http://localhost/test-preview");
+        global.URL.revokeObjectURL = vi.fn();
         server.use(
             http.get("/api/datasets/:dataset_id", ({ response }) => {
                 return response(200).json(mockDataset);
             }),
             http.get("/api/configuration", ({ response }) => response(200).json({})),
             http.get("/api/plugins", ({ response }) => response(200).json([])),
+            mswHttp.get("http://localhost/datasets/:dataset_id/display/", ({ request }) => {
+                expect(request.url).toContain("preview=True");
+                return HttpResponse.text("preview data", {
+                    status: 200,
+                    headers: {
+                        "content-type": "text/plain",
+                    },
+                });
+            }),
         );
     });
 
@@ -323,17 +335,17 @@ describe("DatasetView", () => {
             expect(wrapper.find("iframe").exists()).toBe(false);
         });
 
-        it.skip("falls back to default preview for unsupported datatypes", async () => {
+        it("falls back to default preview for unsupported datatypes", async () => {
             const wrapper = await mountDatasetView("preview");
             await flushPromises(); // Wait for preferred visualization check
 
             // No preferred visualization should be set
-            expect(wrapper.vm.preferredVisualization).toBeNull();
+            expect(wrapper.vm.preferredVisualization).toBeUndefined();
 
             // Check that we're using the default iframe
             expect(wrapper.findComponent({ name: "VisualizationFrame" }).exists()).toBe(false);
             expect(wrapper.find("iframe").exists()).toBe(true);
-            expect(wrapper.find("iframe").attributes("src")).toBe(`/datasets/${DATASET_ID}/display/?preview=true`);
+            expect(wrapper.find("iframe").attributes("src")).toBe("blob:http://localhost/test-preview");
         });
     });
 

--- a/client/src/components/Dataset/DatasetView.test.js
+++ b/client/src/components/Dataset/DatasetView.test.js
@@ -2,7 +2,7 @@ import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import { http as mswHttp,HttpResponse } from "msw";
+import { http as mswHttp, HttpResponse } from "msw";
 import { setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import VueRouter from "vue-router";

--- a/client/src/entry/analysis/modules/CenterFrame.vue
+++ b/client/src/entry/analysis/modules/CenterFrame.vue
@@ -25,7 +25,7 @@ function onLoad(ev: Event) {
     const iframe = ev.currentTarget as HTMLIFrameElement;
     const location = iframe?.contentWindow && iframe.contentWindow.location;
     try {
-        if (location && location.host && location.pathname != "/") {
+        if (location && (location.href.startsWith("blob:") || (location.host && location.pathname != "/"))) {
             emit("load");
         }
     } catch (err) {


### PR DESCRIPTION
Reworks dataset preview loading in `DatasetDisplay.vue` to avoid issuing duplicate requests for the same preview content.

Previously the component made a HEAD request to /datasets/:id/display/?preview=True to inspect headers and then loaded the same URL again in the iframe, which caused two preview requests for a single view. This change switches the flow to a single GET, reads the preview-related headers from that response, and uses a blob URL for the iframe source. 

Why: This fixes the duplicate preview request behavior when opening dataset previews, reducing unnecessary network traffic and avoiding repeated backend work (specifically objectstore double downloads) for the same dataset display.

_Update:_

HTML-like and composite dataset previews keep loading through the real /display/ URL so relative assets continue to work. The component still performs an initial GET to collect sanitization and truncation headers, then delays the iframe load until that request completes.

This means composite previews can issue a second request, but the requests are sequential rather than parallel, which still lets object store-backed downloads benefit from cache reuse on the follow-up iframe load.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
