### PR TITLE
[26.1] Fix activation email lookup regression

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -184,11 +184,15 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         session.add_all([user, private_role])
         if trans.app.config.user_activation_on:
             user.active = False
-            if send_activation_email and not self.send_activation_email(trans, user.email, user.username):
-                error_message = "Unable to send activation email, please contact your local Galaxy administrator."
-                if trans.app.config.error_email_to is not None:
-                    error_message += f" Contact: {trans.app.config.error_email_to}"
-                raise exceptions.InternalServerError(error_message)
+            if send_activation_email:
+                # Flush so the new email is visible to the DB query in
+                # __get_activation_token (the session has autoflush=False).
+                session.flush()
+                if not self.send_activation_email(trans, user.email, user.username):
+                    error_message = "Unable to send activation email, please contact your local Galaxy administrator."
+                    if trans.app.config.error_email_to is not None:
+                        error_message += f" Contact: {trans.app.config.error_email_to}"
+                    raise exceptions.InternalServerError(error_message)
         if commit:
             session.commit()
 

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -185,10 +185,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if trans.app.config.user_activation_on:
             user.active = False
             if send_activation_email:
-                # Flush so the new email is visible to the DB query in
-                # __get_activation_token (the session has autoflush=False).
-                session.flush()
                 if not self.send_activation_email(trans, user.email, user.username):
+                    session.rollback()
                     error_message = "Unable to send activation email, please contact your local Galaxy administrator."
                     if trans.app.config.error_email_to is not None:
                         error_message += f" Contact: {trans.app.config.error_email_to}"
@@ -580,6 +578,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         subject = "Galaxy Account Activation"
         try:
             util.send_mail(self.app.config.email_from, to, subject, body, self.app.config, html=html)
+            self.session().commit()
             return True
         except Exception:
             log.debug(body)
@@ -589,14 +588,18 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
     def __get_activation_token(self, trans, email):
         """
         Check for the activation token. Create new activation token and store it in the database if no token found.
+        Flushes but does not commit—the caller is responsible for committing the transaction.
         """
-        user = get_user_by_email(trans.sa_session, email, self.app.model.User)
+        session = trans.sa_session
+        # Flush pending changes so the user is visible to the DB query below.
+        session.flush()
+        user = get_user_by_email(session, email, self.app.model.User)
         activation_token = user.activation_token
         if activation_token is None:
             activation_token = util.hash_util.new_secure_hash_v2(str(random.getrandbits(256)))
             user.activation_token = activation_token
-            trans.sa_session.add(user)
-            trans.sa_session.commit()
+            session.add(user)
+            session.flush()
         return activation_token
 
     def send_reset_email(self, trans, payload, **kwd):

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -261,6 +261,24 @@ class TestUserManager(BaseTestCase):
         assert user.active is True
         mock_send.assert_not_called()
 
+    def test_update_email_sends_activation_email(self):
+        """update_email should flush the session before looking up the user by
+        the new email, so __get_activation_token can find the user (see #22678
+        regression where the autoflush=False session caused an AttributeError)."""
+        self.app.config.user_activation_on = True
+        user = self.user_manager.create(email="original@example.com", username="updater")
+
+        with patch("galaxy.util.send_mail") as mock_send_mail:
+            self.user_manager.update_email(self.trans, user, "updated@example.com", send_activation_email=True)
+        # The activation email was sent to the new address ...
+        mock_send_mail.assert_called_once()
+        assert mock_send_mail.call_args.args[1] == "updated@example.com"
+        # ... and the user can be found by the new email with an activation token.
+        refreshed = self.user_manager.by_email("updated@example.com")
+        assert refreshed is not None
+        assert refreshed.activation_token is not None
+        assert refreshed.active is False
+
     def test_reset_email(self):
         self.log("should produce the password reset email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -262,9 +262,6 @@ class TestUserManager(BaseTestCase):
         mock_send.assert_not_called()
 
     def test_update_email_sends_activation_email(self):
-        """update_email should flush the session before looking up the user by
-        the new email, so __get_activation_token can find the user (see #22678
-        regression where the autoflush=False session caused an AttributeError)."""
         self.app.config.user_activation_on = True
         user = self.user_manager.create(email="original@example.com", username="updater")
 


### PR DESCRIPTION
Fixes #23127

The disabled autoflush setting prevents newly updated email addresses from being visible to database queries within the same transaction. This caused an AttributeError when generating activation tokens during user email updates.

Explicitly flushing the session before sending the activation email resolves the issue and ensures the new address is correctly recognized.

Includes a dedicated test to verify the update flow.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
