### PR TITLE
Add API tests for format2-to-native conversion artifacts

### DIFF
--- a/lib/galaxy_test/api/test_tool_execute.py
+++ b/lib/galaxy_test/api/test_tool_execute.py
@@ -73,19 +73,21 @@ def test_galaxy_expression_metadata(target_history: TargetHistory, required_tool
 
 
 @requires_tool_id("multi_select")
-def test_multi_select_as_list(required_tool: RequiredTool):
-    execution = required_tool.execute().with_inputs({"select_ex": ["--ex1", "ex2"]})
+def test_multi_select_as_list(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    inputs = tool_input_format.when.any({"select_ex": ["--ex1", "ex2"]})
+    execution = required_tool.execute().with_inputs(inputs)
     execution.assert_has_single_job.with_output("output").with_contents("--ex1,ex2")
 
 
 @requires_tool_id("multi_select")
-def test_multi_select_optional(required_tool: RequiredTool):
-    execution = required_tool.execute().with_inputs(
+def test_multi_select_optional(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    inputs = tool_input_format.when.any(
         {
             "select_ex": ["--ex1"],
             "select_optional": None,
         }
     )
+    execution = required_tool.execute().with_inputs(inputs)
     job = execution.assert_has_single_job
     job.assert_has_output("output").with_contents("--ex1")
     job.assert_has_output("output2").with_contents_stripped("None")
@@ -997,3 +999,44 @@ def test_map_over_dce_on_non_multiple_data_param(
     output_collection = execute.assert_creates_implicit_collection(0)
     output_collection.assert_has_dataset_element("forward").with_contents_stripped("123")
     output_collection.assert_has_dataset_element("reverse").with_contents_stripped("456")
+
+
+@requires_tool_id("gx_repeat_optional")
+def test_empty_repeat_explicit(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    """Empty repeat as explicit [] executes — tool sees zero repeat instances.
+
+    Contrasts with workflow execution where an absent repeat key in tool_state
+    causes Cheetah template failure (see test_wf_conversion_artifacts.py).
+    Direct API execution handles both empty [] and absent repeat identically
+    because populate_state initializes all params with defaults.
+    """
+    inputs = tool_input_format.when.flat({}).when.nested({"parameter": []}).when.request({"parameter": []})
+    execute = required_tool.execute().with_inputs(inputs)
+    execute.assert_has_single_job.with_single_output.containing("length: 0")
+
+
+@requires_tool_id("gx_repeat_optional")
+def test_absent_repeat(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    """Absent repeat key executes via API — populate_state initializes defaults.
+
+    Unlike workflow execution (which uses params_from_strings and skips absent
+    keys), direct API execution uses populate_state which initializes all params
+    with get_initial_value() before processing inputs. So an absent repeat
+    becomes [] and the tool runs fine.
+    """
+    inputs = tool_input_format.when.any({})
+    execute = required_tool.execute().with_inputs(inputs)
+    execute.assert_has_single_job.with_single_output.containing("length: 0")
+
+
+@requires_tool_id("gx_repeat_optional")
+def test_repeat_with_instances(required_tool: RequiredTool, tool_input_format: DescribeToolInputs):
+    """Repeat with instances provided works across all formats."""
+    inputs = (
+        tool_input_format.when.flat({"parameter_0|text_parameter": "hello", "parameter_1|text_parameter": "world"})
+        .when.nested({"parameter": [{"text_parameter": "hello"}, {"text_parameter": "world"}]})
+        .when.request({"parameter": [{"text_parameter": "hello"}, {"text_parameter": "world"}]})
+    )
+    execute = required_tool.execute().with_inputs(inputs)
+    output = execute.assert_has_single_job.with_single_output
+    output.containing("length: 2").containing("hello").containing("world")

--- a/lib/galaxy_test/api/test_wf_conversion_artifacts.py
+++ b/lib/galaxy_test/api/test_wf_conversion_artifacts.py
@@ -1,0 +1,178 @@
+"""API tests for workflow format2→native conversion artifacts.
+
+The .ga workflows in wf_conversion/ contain tool_state with representation
+artifacts from schema-unaware gxformat2 format2→native conversion:
+
+- Multiple select values as JSON lists instead of comma-delimited strings
+- Absent sections (all values were None, gxformat2 omitted the key)
+- Absent empty repeats (gxformat2 omitted empty lists)
+- Lowercase JSON booleans instead of capitalized string booleans
+
+These tests verify Galaxy executes these workflows correctly.
+"""
+
+import json
+from typing import Any
+
+from galaxy.util.resources import resource_string
+from .test_workflows import BaseWorkflowsApiTestCase
+
+
+def _load_ga_workflow(name: str) -> dict:
+    content = resource_string("galaxy_test.base", f"data/wf_conversion/{name}.ga")
+    return json.loads(content)
+
+
+class TestWfConversionArtifacts(BaseWorkflowsApiTestCase):
+    """Verify Galaxy executes workflows with format2 conversion artifacts."""
+
+    def _invoke_conversion_workflow(
+        self,
+        name: str,
+        *,
+        allow_tool_state_corrections: bool = True,
+        history_id: str | None = None,
+        inputs: dict[str, Any] | None = None,
+        assert_ok: bool = True,
+    ) -> str:
+        """Import a .ga workflow, invoke it, wait for completion.
+
+        Most cases use allow_tool_state_corrections because gxformat2's
+        schema-unaware conversion omits default/None values that Galaxy's
+        upgrade checker flags.
+
+        TODO: add a UI/selenium test to verify these workflows can be opened in
+        the workflow editor and the upgrade banner is handled correctly.
+        """
+        workflow_id = self.workflow_populator.create_workflow(_load_ga_workflow(name))
+        if history_id is None:
+            history_id = self.dataset_populator.new_history()
+        request = {"allow_tool_state_corrections": True} if allow_tool_state_corrections else None
+        invocation_id = self.workflow_populator.invoke_workflow_and_assert_ok(
+            workflow_id,
+            history_id=history_id,
+            inputs=inputs,
+            request=request,
+        )
+        self.workflow_populator.wait_for_invocation_and_completion(invocation_id, assert_ok=assert_ok)
+        return history_id
+
+    def _history_content(self, history_id: str, hid: int) -> str:
+        return self.dataset_populator.get_history_dataset_content(history_id, hid=hid, wait=False)
+
+    def _history_dataset_state(self, history_id: str, hid: int) -> str:
+        return self.dataset_populator.get_history_dataset_details(history_id, hid=hid, wait=False)["state"]
+
+    def test_multiple_select_list_form(self):
+        """Tool with multiple:true select as JSON list in tool_state executes.
+
+        Artifact: tool_state has '["--ex1"]' (JSON list) instead of '"--ex1"'
+        (comma-delimited string) for a multiple select parameter.
+        """
+        history_id = self._invoke_conversion_workflow("multiple_select")
+        # Step select_single outputs "--ex1", step select_multi outputs "--ex1,ex2"
+        content1 = self._history_content(history_id, hid=1)
+        assert "--ex1" in content1
+        content2 = self._history_content(history_id, hid=2)
+        assert "--ex1" in content2
+        assert "ex2" in content2
+
+    def test_absent_allnone_section(self):
+        """Tool with absent all-None section in tool_state uses defaults.
+
+        Artifact: the 'parameter' section key is absent from tool_state because
+        gxformat2 omitted it (all values were None/default). Galaxy should treat
+        the absent section as defaults.
+        """
+        history_id = self._invoke_conversion_workflow("allnone_section")
+        content = self._history_content(history_id, hid=1)
+        # Default boolean is false -> "myfalse"
+        assert "myfalse" in content
+
+    def test_absent_empty_repeat_without_corrections(self):
+        """Absent repeat invokes successfully but job errors at Cheetah rendering.
+
+        Artifact: the 'files' repeat key is absent from tool_state because
+        gxformat2 omitted the empty list. Galaxy's upgrade checker does NOT
+        flag this (visit_input_values silently defaults missing repeats to []),
+        so invocation succeeds without needing allow_tool_state_corrections.
+        However the correction to the in-memory state doesn't propagate to
+        the persisted tool_state used by the job runner — the Cheetah template
+        still can't resolve $files and the job errors.
+
+        This is a workflow-specific problem: direct API tool execution goes
+        through populate_state() which initializes all params with defaults
+        before processing inputs. Workflow execution goes through
+        params_from_strings() which only processes keys present in the stored
+        tool_state dict — absent keys are never initialized.
+        """
+        history_id = self._invoke_conversion_workflow(
+            "empty_repeat", allow_tool_state_corrections=False, assert_ok=False
+        )
+        assert (
+            self._history_dataset_state(history_id, hid=1) == "error"
+        ), "Expected error — Cheetah can't resolve absent repeat"
+
+    def test_absent_empty_repeat_with_corrections(self):
+        """Absent repeat with allow_tool_state_corrections also errors.
+
+        Same outcome as without corrections — the flag makes no difference
+        for this artifact because Galaxy doesn't generate an upgrade message
+        for the absent repeat in the first place. The job still errors at
+        Cheetah template rendering.
+        """
+        history_id = self._invoke_conversion_workflow("empty_repeat", assert_ok=False)
+        assert (
+            self._history_dataset_state(history_id, hid=1) == "error"
+        ), "Expected error — corrections don't fix absent repeat"
+
+    def test_absent_empty_repeat_safe_template(self):
+        """Absent repeat with a well-written template succeeds via workflow.
+
+        Uses gx_repeat_optional which handles empty repeats gracefully (uses
+        len() and #for loop, no direct indexing). This isolates the absent-key
+        issue from the simple_constructs template bug (dangling &&).
+
+        The job succeeds because visit_input_values defaults the repeat to []
+        during check_and_update_param_values, and the Cheetah template can
+        handle len($parameter) == 0 and an empty #for loop. The correction
+        to in-memory state IS sufficient when the template doesn't directly
+        index into the repeat.
+        """
+        history_id = self._invoke_conversion_workflow("empty_repeat_optional")
+        content = self._history_content(history_id, hid=1)
+        assert "length: 0" in content
+
+    def test_boolean_case_normalization(self):
+        """Tool with lowercase JSON booleans in tool_state executes.
+
+        Artifact: tool_state has 'true'/'false' (lowercase JSON booleans) instead
+        of '"True"'/'"False"' (capitalized strings) that some native workflows use.
+        """
+        history_id = self._invoke_conversion_workflow("boolean_case")
+        content_true = self._history_content(history_id, hid=1)
+        assert "mytrue" in content_true
+        content_false = self._history_content(history_id, hid=2)
+        assert "myfalse" in content_false
+
+    def test_connection_only_section_omitted(self):
+        """Tool with connection-only section absent from tool_state executes correctly.
+
+        Artifact: the 'parameter' section key is absent from tool_state because
+        gxformat2 safely structurally omitted it (as connections are declared in 'in'
+        and all native tool_state primitives were connection markers during export).
+        Galaxy should resolve the nested connection parameters successfully from
+        the step's explicit input_connections metadata.
+        """
+        history_id = self.dataset_populator.new_history()
+        # Create an input dataset to map to the workflow
+        input_hda = self.dataset_populator.new_dataset(history_id, content="Connection only test content")
+        self._invoke_conversion_workflow(
+            "connection_only_section",
+            history_id=history_id,
+            inputs={"0": {"id": input_hda["id"], "src": "hda"}},
+        )
+
+        # Verify the tool executed and emitted our data
+        content = self._history_content(history_id, hid=2)
+        assert "Connection only test content" in content

--- a/lib/galaxy_test/base/data/wf_conversion/README.md
+++ b/lib/galaxy_test/base/data/wf_conversion/README.md
@@ -1,0 +1,60 @@
+# Workflow Conversion Artifact Test Data
+
+This directory contains native .ga workflows whose tool_state has representation
+artifacts from schema-unaware gxformat2 format2→native conversion. The API tests
+in `test/api/test_wf_conversion_artifacts.py` verify Galaxy executes these
+workflows correctly despite the non-standard encoding.
+
+## What's being tested
+
+When gxformat2's `python_to_workflow()` converts a format2 workflow to native
+.ga format without access to tool definitions, certain parameter values get
+encoded differently than Galaxy's own serialization would produce:
+
+| Artifact                | Native (Galaxy)                           | After gxformat2 conversion              |
+| ----------------------- | ----------------------------------------- | --------------------------------------- |
+| Multiple select         | `"--ex1"` (comma-delimited string)        | `["--ex1"]` (JSON list)                 |
+| All-None section        | `{"param": null, ...}` (section present)  | absent (section omitted)                |
+| Empty repeat            | `[]` (empty list)                         | absent (key omitted)                    |
+| Boolean                 | `"True"` / `"False"` (capitalized string) | `true` / `false` (JSON boolean)         |
+| Connection-only section | section state for connected data param    | absent section plus `input_connections` |
+
+## How the .ga files were generated
+
+1. Human-authored format2 workflows live in `format2/`
+2. Each was converted to native format using:
+   ```python
+   from gxformat2.converter import python_to_workflow
+   from gxformat2.yaml import ordered_load
+   native = python_to_workflow(ordered_load(open(f2_path)), galaxy_interface=None)
+   ```
+3. The resulting .ga files were inspected to verify artifacts are present
+4. Both the format2 source and .ga output are committed when a format2 source exists
+
+The `empty_repeat_optional.ga` fixture currently has no companion format2 source.
+It is kept as a native snapshot for the `gx_repeat_optional` safe-template coverage.
+
+## How to add a new test workflow
+
+1. Write a minimal format2 workflow in `format2/` exercising the artifact
+2. Convert it:
+   ```python
+   from gxformat2.converter import python_to_workflow
+   from gxformat2.yaml import ordered_load
+   import json
+   with open("format2/your_workflow.gxwf.yml") as f:
+       f2 = ordered_load(f)
+   native = python_to_workflow(f2, galaxy_interface=None)
+   with open("your_workflow.ga", "w") as f:
+       json.dump(native, f, indent=4)
+   ```
+3. Inspect the .ga to confirm the expected artifact is present in tool_state
+4. Add a test method in `test/api/test_wf_conversion_artifacts.py`
+5. Commit both the format2 source and .ga file unless documenting a native-only fixture
+
+## Important
+
+The .ga files are frozen snapshots — do not regenerate them automatically.
+They represent what the old schema-unaware conversion produces. Even as the
+converter improves, these tests continue to verify Galaxy handles legacy
+artifacts.

--- a/lib/galaxy_test/base/data/wf_conversion/allnone_section.ga
+++ b/lib/galaxy_test/base/data/wf_conversion/allnone_section.ga
@@ -1,0 +1,25 @@
+{
+    "steps": {
+        "0": {
+            "tool_id": "gx_section_boolean",
+            "label": "section_defaults",
+            "id": 0,
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "type": "tool",
+            "name": "gx_section_boolean",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"__page__\": 0}"
+        }
+    },
+    "a_galaxy_workflow": "true",
+    "format-version": "0.1",
+    "name": "Test all-None section roundtrip artifact",
+    "uuid": "70258961-47d3-4c8d-9e54-f0b8dd6e961d",
+    "annotation": ""
+}

--- a/lib/galaxy_test/base/data/wf_conversion/boolean_case.ga
+++ b/lib/galaxy_test/base/data/wf_conversion/boolean_case.ga
@@ -1,0 +1,41 @@
+{
+    "steps": {
+        "0": {
+            "tool_id": "gx_boolean",
+            "label": "bool_true",
+            "id": 0,
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "type": "tool",
+            "name": "gx_boolean",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"__page__\": 0, \"parameter\": \"true\"}"
+        },
+        "1": {
+            "tool_id": "gx_boolean",
+            "label": "bool_false",
+            "id": 1,
+            "position": {
+                "left": 10,
+                "top": 10
+            },
+            "type": "tool",
+            "name": "gx_boolean",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"__page__\": 0, \"parameter\": \"false\"}"
+        }
+    },
+    "a_galaxy_workflow": "true",
+    "format-version": "0.1",
+    "name": "Test boolean case normalization roundtrip artifact",
+    "uuid": "a51856d1-55b4-463b-bf0a-ed7e25efa563",
+    "annotation": ""
+}

--- a/lib/galaxy_test/base/data/wf_conversion/connection_only_section.ga
+++ b/lib/galaxy_test/base/data/wf_conversion/connection_only_section.ga
@@ -1,0 +1,46 @@
+{
+    "steps": {
+        "0": {
+            "tool_id": null,
+            "label": "input_data",
+            "id": 0,
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "type": "data_input",
+            "name": "Input dataset",
+            "post_job_actions": {},
+            "tool_version": "1.0.0",
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"name\": \"input_data\"}"
+        },
+        "1": {
+            "tool_id": "gx_section_data",
+            "label": "test_tool",
+            "id": 1,
+            "position": {
+                "left": 10,
+                "top": 10
+            },
+            "type": "tool",
+            "name": "gx_section_data",
+            "post_job_actions": {},
+            "tool_version": "1.0.0",
+            "annotation": "",
+            "input_connections": {
+                "parameter|data_parameter": {
+                    "output_name": "output",
+                    "id": 0
+                }
+            },
+            "tool_state": "{\"__page__\": 0}"
+        }
+    },
+    "a_galaxy_workflow": "true",
+    "format-version": "0.1",
+    "name": "Test connection-only section omission artifact",
+    "uuid": "41da8099-1cf0-4cc2-bcd0-a931a2608bd7",
+    "annotation": ""
+}

--- a/lib/galaxy_test/base/data/wf_conversion/empty_repeat.ga
+++ b/lib/galaxy_test/base/data/wf_conversion/empty_repeat.ga
@@ -1,0 +1,25 @@
+{
+    "steps": {
+        "0": {
+            "tool_id": "simple_constructs",
+            "label": "empty_repeat",
+            "id": 0,
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "type": "tool",
+            "name": "simple_constructs",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"__page__\": 0, \"p1\": \"{\\\"p1use\\\": false, \\\"p1val\\\": \\\"p1notused\\\"}\", \"booltest\": \"false\", \"inttest\": \"42\", \"floattest\": \"3.14\", \"radio_select\": \"\\\"a_radio\\\"\", \"check_select\": \"[\\\"a_check\\\"]\", \"drop_select\": \"\\\"a_drop\\\"\"}"
+        }
+    },
+    "a_galaxy_workflow": "true",
+    "format-version": "0.1",
+    "name": "Test empty repeat roundtrip artifact",
+    "uuid": "b2a93e10-ed98-4c25-9405-2dc1a81e2956",
+    "annotation": ""
+}

--- a/lib/galaxy_test/base/data/wf_conversion/empty_repeat_optional.ga
+++ b/lib/galaxy_test/base/data/wf_conversion/empty_repeat_optional.ga
@@ -1,0 +1,25 @@
+{
+    "steps": {
+        "0": {
+            "tool_id": "gx_repeat_optional",
+            "label": "empty_repeat",
+            "id": 0,
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "type": "tool",
+            "name": "gx_repeat_optional",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"__page__\": 0}"
+        }
+    },
+    "a_galaxy_workflow": "true",
+    "format-version": "0.1",
+    "name": "Test empty repeat with gx_repeat_optional",
+    "uuid": "30821bc0-bc67-41c7-9bc7-025d94f0c940",
+    "annotation": ""
+}

--- a/lib/galaxy_test/base/data/wf_conversion/format2/allnone_section.gxwf.yml
+++ b/lib/galaxy_test/base/data/wf_conversion/format2/allnone_section.gxwf.yml
@@ -1,0 +1,5 @@
+class: GalaxyWorkflow
+label: Test all-None section roundtrip artifact
+steps:
+  section_defaults:
+    tool_id: gx_section_boolean

--- a/lib/galaxy_test/base/data/wf_conversion/format2/boolean_case.gxwf.yml
+++ b/lib/galaxy_test/base/data/wf_conversion/format2/boolean_case.gxwf.yml
@@ -1,0 +1,11 @@
+class: GalaxyWorkflow
+label: Test boolean case normalization roundtrip artifact
+steps:
+  bool_true:
+    tool_id: gx_boolean
+    state:
+      parameter: true
+  bool_false:
+    tool_id: gx_boolean
+    state:
+      parameter: false

--- a/lib/galaxy_test/base/data/wf_conversion/format2/connection_only_section.gxwf.yml
+++ b/lib/galaxy_test/base/data/wf_conversion/format2/connection_only_section.gxwf.yml
@@ -1,0 +1,10 @@
+class: GalaxyWorkflow
+label: Test connection-only section omission artifact
+inputs:
+  input_data:
+    type: File
+steps:
+  test_tool:
+    tool_id: gx_section_data
+    in:
+      parameter|data_parameter: input_data

--- a/lib/galaxy_test/base/data/wf_conversion/format2/empty_repeat.gxwf.yml
+++ b/lib/galaxy_test/base/data/wf_conversion/format2/empty_repeat.gxwf.yml
@@ -1,0 +1,16 @@
+class: GalaxyWorkflow
+label: Test empty repeat roundtrip artifact
+steps:
+  empty_repeat:
+    tool_id: simple_constructs
+    state:
+      p1:
+        p1use: false
+        p1val: p1notused
+      booltest: false
+      inttest: 42
+      floattest: 3.14
+      radio_select: a_radio
+      check_select:
+        - a_check
+      drop_select: a_drop

--- a/lib/galaxy_test/base/data/wf_conversion/format2/multiple_select.gxwf.yml
+++ b/lib/galaxy_test/base/data/wf_conversion/format2/multiple_select.gxwf.yml
@@ -1,0 +1,14 @@
+class: GalaxyWorkflow
+label: Test multiple select roundtrip artifact
+steps:
+  select_single:
+    tool_id: gx_select_multiple
+    state:
+      parameter:
+        - --ex1
+  select_multi:
+    tool_id: gx_select_multiple
+    state:
+      parameter:
+        - --ex1
+        - ex2

--- a/lib/galaxy_test/base/data/wf_conversion/multiple_select.ga
+++ b/lib/galaxy_test/base/data/wf_conversion/multiple_select.ga
@@ -1,0 +1,41 @@
+{
+    "steps": {
+        "0": {
+            "tool_id": "gx_select_multiple",
+            "label": "select_single",
+            "id": 0,
+            "position": {
+                "left": 0,
+                "top": 0
+            },
+            "type": "tool",
+            "name": "gx_select_multiple",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"__page__\": 0, \"parameter\": \"[\\\"--ex1\\\"]\"}"
+        },
+        "1": {
+            "tool_id": "gx_select_multiple",
+            "label": "select_multi",
+            "id": 1,
+            "position": {
+                "left": 10,
+                "top": 10
+            },
+            "type": "tool",
+            "name": "gx_select_multiple",
+            "post_job_actions": {},
+            "tool_version": null,
+            "annotation": "",
+            "input_connections": {},
+            "tool_state": "{\"__page__\": 0, \"parameter\": \"[\\\"--ex1\\\", \\\"ex2\\\"]\"}"
+        }
+    },
+    "a_galaxy_workflow": "true",
+    "format-version": "0.1",
+    "name": "Test multiple select roundtrip artifact",
+    "uuid": "adeb649c-ddac-4991-9bc3-cdbdf8b3d4be",
+    "annotation": ""
+}

--- a/test/functional/tools/parameters/gx_repeat_optional.xml
+++ b/test/functional/tools/parameters/gx_repeat_optional.xml
@@ -1,0 +1,26 @@
+<tool id="gx_repeat_optional" name="gx_repeat_optional" version="1.0.0">
+    <command><![CDATA[
+#set $repeat_length = len($parameter)
+echo 'length: $repeat_length' >> '$output'
+#for $item in $parameter
+echo '$item.text_parameter' >> '$output'
+#end for
+    ]]></command>
+    <inputs>
+        <repeat name="parameter" title="Repeat Parameter">
+            <param name="text_parameter" type="text" value="default_val" />
+        </repeat>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="output">
+                <assert_contents>
+                    <has_text text="length: 0" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>


### PR DESCRIPTION
Verify Galaxy correctly executes workflows whose tool_state contains representation differences from schema-***unaware*** gxformat2 conversion.

Workflow tests cover list-form multiple selects, absent all-None sections, absent empty repeats with and without corrections, a safe-template empty repeat, lowercase JSON booleans, and connection-only section omission. Test data lives in wf_conversion/ with frozen native .ga snapshots and available format2 sources.

Tool execution tests cover explicit empty repeat, absent repeat, repeat instances, and list-form multiple select handling across legacy, 21.01, and request input formats.

Duplication check:

- No exact existing Galaxy test already imports native .ga workflows with gxformat2 conversion-artifact tool_state and executes them.

- Multiple-select coverage is adjacent to existing multi_select workflow/tool tests, but those use normal format2/tool execution paths rather than list-encoded native workflow tool_state.

- Boolean coverage is adjacent to gx_boolean tool tests for JSON booleans, but those do not cover native workflow execution from converted .ga tool_state.

- Repeat coverage is adjacent to existing repeat tools and API tests, but existing tests either require instances, index the first repeat item, or cover min-filled repeats; they do not cover omitted repeat keys in native workflow tool_state.

- The two absent-empty-repeat workflow tests intentionally overlap except for allow_tool_state_corrections, documenting that the flag does not change the current failure mode.

- The connection-only section test is not duplicated elsewhere; it covers omitted section state resolved through input_connections.

The empty_repeat_optional fixture is documented as native-only because wf_tool_state does not contain a companion format2 source.

(cherry picked from commit ef93b9f6bcfe9686069b9af2c9efadc9501a1d35 in #22996)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
