### PR TITLE
Make JWD a job concern

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import shutil
 from collections.abc import Callable
 from concurrent.futures import TimeoutError
 from functools import lru_cache
@@ -34,6 +33,7 @@ from galaxy.config import GalaxyAppConfiguration
 from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import Registry as DatatypesRegistry
 from galaxy.exceptions import ObjectNotFound
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.jobs import MinimalJobWrapper
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.dataset_storage_operations import DatasetStorageOperationManager
@@ -810,13 +810,12 @@ def _cleanup_jwds(
 
     def _delete_jwd(job: model.Job) -> bool:
         try:
-            path = object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
-            shutil.rmtree(path)
+            JobWorkingDirectory(job, object_store).delete()
             return True
         except ObjectNotFound:
             return False
         except OSError as e:
-            log.error(f"Error deleting job working directory: {path} : {e.strerror}")
+            log.error(f"Error deleting job working directory for job {job.id}: {e.strerror}")
             return False
 
     deleted_count = 0

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -810,8 +810,7 @@ def _cleanup_jwds(
 
     def _delete_jwd(job: model.Job) -> bool:
         try:
-            JobWorkingDirectory(job, object_store).delete()
-            return True
+            return JobWorkingDirectory(job, object_store).delete()
         except ObjectNotFound:
             return False
         except OSError as e:

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -469,11 +469,14 @@ class JobWorkingDirectory:
         the JWD's own ``<base>/<hash>/<obj_id>/``.
 
         For the custom-path case, the archive is a **sibling** of the JWD
-        (``<parent>/_cleared_contents/<basename>``), not a subdirectory of
+        (``<parent>/_cleared_contents/<job.id>``), not a subdirectory of
         it. This is critical: ``clear_working_directory`` does
         ``shutil.move(jwd, arc_dir)`` — if ``arc_dir`` were inside ``jwd``,
         the move would attempt to relocate a directory into its own subtree
         and fail.
+
+        The archive is keyed by ``job.id`` (not the JWD basename) so that
+        resubmits of the same job don't collide on the archive name.
 
         Note: if the custom path's parent directory is on a different filesystem
         than the JWD, ``shutil.move`` will fall back to copy-then-delete rather
@@ -482,8 +485,8 @@ class JobWorkingDirectory:
         if self._custom_path:
             _validate_custom_path(self._custom_path)
             parent = os.path.dirname(self._custom_path)
-            name = os.path.basename(self._custom_path)
-            path = os.path.join(parent, _CLEARED_CONTENTS_EXTRA_DIR, name)
+            job_id = str(self._job.id)
+            path = os.path.join(parent, _CLEARED_CONTENTS_EXTRA_DIR, job_id)
             os.makedirs(path, exist_ok=True)
             return path
         self._object_store.create(

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -377,8 +377,17 @@ class JobWorkingDirectory:
         """True when the JWD is a filesystem path set via destination params."""
         return self._custom_path is not None
 
-    def resolve(self) -> str:
-        """Return the working directory path, creating nothing on disk."""
+    def resolve(self, extra_dir: str | None = None) -> str:
+        """Return the working directory path, creating nothing on disk.
+
+        Args:
+            extra_dir: Optional subdirectory for legacy object-store paths.
+                For legacy (object-store) paths, this is passed through to
+                ``object_store.get_filename`` as ``extra_dir``. For custom
+                paths, this is ignored because the custom path is already
+                the full JWD (the ``extra_dir=str(job.id)`` legacy quirk
+                was an object-store artifact, not a conceptual JWD model).
+        """
         if self._custom_path:
             return self._custom_path
         return self._object_store.get_filename(
@@ -386,6 +395,7 @@ class JobWorkingDirectory:
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
+            extra_dir=extra_dir,
         )
 
     def exists(self) -> bool:
@@ -399,10 +409,16 @@ class JobWorkingDirectory:
             obj_dir=True,
         )
 
-    def create(self) -> str:
+    def create(self, extra_dir: str | None = None) -> str:
         """Create the working directory and return its path.
 
         Idempotent: a pre-existing custom path is not an error.
+
+        Args:
+            extra_dir: Optional subdirectory for legacy object-store paths.
+                For legacy paths, passes ``extra_dir`` through to the object
+                store. For custom paths, this is ignored because the custom
+                path is already the full JWD.
         """
         if self._custom_path:
             _validate_custom_path(self._custom_path)
@@ -413,12 +429,14 @@ class JobWorkingDirectory:
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
+            extra_dir=extra_dir,
         )
         return self._object_store.get_filename(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
+            extra_dir=extra_dir,
         )
 
     def delete(self) -> None:

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -347,12 +347,10 @@ class JobWorkingDirectory:
 
     All create / resolve / exists / delete / cleared-contents logic lives here.
 
-    Construction order: ``job.working_directory`` must be populated (or
-    definitively None) before a ``JobWorkingDirectory`` is constructed. In
-    practice this is guaranteed because ``_set_working_directory`` runs
-    inside ``_setup_working_directory`` before any ``JobWorkingDirectory``
-    is instantiated, and for already-persisted jobs the column is loaded
-    from the database.
+    ``_custom_path`` is read fresh on each access, so a ``JobWorkingDirectory``
+    may be constructed before ``job.working_directory`` is mutated and will
+    observe the up-to-date value on the next method call. This eliminates
+    construction-order sensitivity.
     """
 
     __slots__ = ("_job", "_object_store")
@@ -365,37 +363,32 @@ class JobWorkingDirectory:
     def _custom_path(self) -> str | None:
         """Read ``job.working_directory`` fresh on each access.
 
-        Not cached: the column may be mutated by ``_set_working_directory``
-        after this object is constructed (though current call sites construct
-        after the mutation). Reading fresh eliminates construction-order
-        sensitivity entirely.
+        Not cached: the column may be mutated after this object is constructed.
+        Reading fresh eliminates construction-order sensitivity entirely.
         """
         return self._job.working_directory
 
-    @property
-    def uses_custom_path(self) -> bool:
-        """True when the JWD is a filesystem path set via destination params."""
-        return self._custom_path is not None
-
-    def resolve(self, extra_dir: str | None = None) -> str:
+    def resolve(self, legacy_extra_dir: str | None = None) -> str:
         """Return the working directory path, creating nothing on disk.
 
         Args:
-            extra_dir: Optional subdirectory for legacy object-store paths.
-                For legacy (object-store) paths, this is passed through to
-                ``object_store.get_filename`` as ``extra_dir``. For custom
-                paths, this is ignored because the custom path is already
-                the full JWD (the ``extra_dir=str(job.id)`` legacy quirk
-                was an object-store artifact, not a conceptual JWD model).
+            legacy_extra_dir: Optional subdirectory for legacy object-store
+                paths only. Passed through to ``object_store.get_filename`` as
+                ``extra_dir``. Ignored for custom paths (the custom path is
+                already the full JWD; the ``extra_dir=str(job.id)`` legacy
+                quirk was an object-store artifact, not a conceptual JWD
+                model). Passing this for a custom-path job is a caller bug and
+                raises ``AssertionError``.
         """
         if self._custom_path:
+            assert legacy_extra_dir is None, "legacy_extra_dir is ignored for custom-path JWDs; caller bug"
             return self._custom_path
         return self._object_store.get_filename(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
-            extra_dir=extra_dir,
+            extra_dir=legacy_extra_dir,
         )
 
     def exists(self) -> bool:
@@ -409,19 +402,20 @@ class JobWorkingDirectory:
             obj_dir=True,
         )
 
-    def create(self, extra_dir: str | None = None) -> str:
+    def create(self, legacy_extra_dir: str | None = None) -> str:
         """Create the working directory and return its path.
 
         Idempotent: a pre-existing custom path is not an error.
 
         Args:
-            extra_dir: Optional subdirectory for legacy object-store paths.
-                For legacy paths, passes ``extra_dir`` through to the object
-                store. For custom paths, this is ignored because the custom
-                path is already the full JWD.
+            legacy_extra_dir: Optional subdirectory for legacy object-store
+                paths only. Passed through to the object store as ``extra_dir``.
+                Ignored for custom paths. Passing this for a custom-path job is
+                a caller bug and raises ``AssertionError``.
         """
         if self._custom_path:
-            _validate_custom_path(self._custom_path)
+            assert legacy_extra_dir is None, "legacy_extra_dir is ignored for custom-path JWDs; caller bug"
+            validate_working_directory_path(self._custom_path)
             os.makedirs(self._custom_path, exist_ok=True)
             return self._custom_path
         self._object_store.create(
@@ -429,14 +423,14 @@ class JobWorkingDirectory:
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
-            extra_dir=extra_dir,
+            extra_dir=legacy_extra_dir,
         )
         return self._object_store.get_filename(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
-            extra_dir=extra_dir,
+            extra_dir=legacy_extra_dir,
         )
 
     def delete(self) -> None:
@@ -447,7 +441,7 @@ class JobWorkingDirectory:
         admin-supplied string and ``shutil.rmtree`` will obey it literally.
         """
         if self._custom_path:
-            _validate_custom_path(self._custom_path)
+            validate_working_directory_path(self._custom_path)
             shutil.rmtree(self._custom_path)
             return
         self._object_store.delete(
@@ -483,7 +477,7 @@ class JobWorkingDirectory:
         than a rename. This is slower but correct.
         """
         if self._custom_path:
-            _validate_custom_path(self._custom_path)
+            validate_working_directory_path(self._custom_path)
             parent = os.path.dirname(self._custom_path)
             job_id = str(self._job.id)
             path = os.path.join(parent, _CLEARED_CONTENTS_EXTRA_DIR, job_id)
@@ -507,8 +501,14 @@ class JobWorkingDirectory:
         )
 
 
-def _validate_custom_path(path: str) -> None:
+def validate_working_directory_path(path: str) -> None:
     """Validate a custom ``job.working_directory`` path before disk operations.
+
+    This is the single canonical validator for ``job.working_directory``. It is
+    called both at set-time (before persisting the column) and at use-time
+    (before each disk operation on a custom path), so callers can rely on the
+    column value being validated without assuming set-time validation is the
+    only guard.
 
     ``job.working_directory`` is a ``String(1024)`` populated from destination
     params (admin/TPV-controlled). Refuse to operate on anything that is not an

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -29,7 +29,10 @@ from galaxy.model import (
     MetadataFile,
 )
 from galaxy.objectstore import ObjectStore
-from galaxy.util import safe_makedirs
+from galaxy.util import (
+    directory_hash_id,
+    safe_makedirs,
+)
 from galaxy.util.dictifiable import UsesDictVisibleKeys
 from galaxy.util.path import StrPath
 
@@ -368,10 +371,25 @@ class JobWorkingDirectory:
         """
         return self._job.working_directory
 
+    def _per_job_subpath(self) -> str:
+        """Return the per-job relative subpath ``<directory_hash_id(job.id)>/<job.id>/``."""
+        obj_id = self._job.id
+        return os.path.join(*directory_hash_id(obj_id), str(obj_id))
+
+    def _per_job_path(self) -> str:
+        """Resolve the per-job working directory under a custom base.
+
+        Returns ``<custom_base>/<directory_hash_id(job.id)>/<job.id>/``. The
+        custom base (``job.working_directory``) is the admin/TPV-supplied
+        parent; the per-job subdirectory isolates concurrent jobs that share
+        the same base.
+        """
+        return os.path.join(self._custom_path, self._per_job_subpath())
+
     def resolve(self) -> str:
         """Return the working directory path, creating nothing on disk."""
         if self._custom_path:
-            return self._custom_path
+            return self._per_job_path()
         return self._object_store.get_filename(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
@@ -382,7 +400,7 @@ class JobWorkingDirectory:
     def exists(self) -> bool:
         """Check whether the working directory exists on disk."""
         if self._custom_path:
-            return os.path.exists(self._custom_path)
+            return os.path.exists(self._per_job_path())
         return self._object_store.exists(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
@@ -393,12 +411,24 @@ class JobWorkingDirectory:
     def create(self) -> str:
         """Create the working directory and return its path.
 
-        Idempotent: a pre-existing custom path is not an error.
+        For custom paths, the per-job subdirectory (``<base>/<hash>/<job.id>/``)
+        is created. A pre-existing per-job directory is a loud error (job id
+        collision or leftover from a crashed run) rather than a silent
+        overwrite, since resubmits go through ``clear_working_directory`` first
+        and should not leave a stale directory behind.
         """
         if self._custom_path:
             validate_working_directory_path(self._custom_path)
-            os.makedirs(self._custom_path, exist_ok=True)
-            return self._custom_path
+            path = self._per_job_path()
+            try:
+                os.makedirs(path, exist_ok=False)
+            except FileExistsError as exc:
+                raise FileExistsError(
+                    f"Job working directory already exists for job {self._job.id} "
+                    f"at {path!r}; this indicates a job id collision or a leftover "
+                    f"directory from a previous run."
+                ) from exc
+            return path
         self._object_store.create(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
@@ -415,14 +445,16 @@ class JobWorkingDirectory:
     def delete(self) -> None:
         """Recursively delete the working directory.
 
-        For custom paths, validates the target is a non-empty absolute path
-        before removing it, since ``job.working_directory`` is an
-        admin-supplied string and ``shutil.rmtree`` will obey it literally.
+        For custom paths, only the per-job subdirectory
+        (``<base>/<hash>/<job.id>/``) is removed — the admin-supplied base is
+        preserved for other jobs. The base is validated before any disk
+        operation since ``job.working_directory`` is an admin-supplied string.
         """
         if self._custom_path:
             validate_working_directory_path(self._custom_path)
-            if os.path.exists(self._custom_path):
-                shutil.rmtree(self._custom_path)
+            resolved = self._per_job_path()
+            if os.path.exists(resolved):
+                shutil.rmtree(resolved)
             return
         self._object_store.delete(
             self._job,
@@ -442,25 +474,27 @@ class JobWorkingDirectory:
         ``<base>/_cleared_contents/<hash>/<obj_id>/``, which is **outside**
         the JWD's own ``<base>/<hash>/<obj_id>/``.
 
-        For the custom-path case, the archive is a **sibling** of the JWD
-        (``<parent>/_cleared_contents/<job.id>``), not a subdirectory of
-        it. This is critical: ``clear_working_directory`` does
-        ``shutil.move(jwd, arc_dir)`` — if ``arc_dir`` were inside ``jwd``,
-        the move would attempt to relocate a directory into its own subtree
-        and fail.
+        For the custom-path case, the archive mirrors the object-store
+        root-divergent layout with the custom base in place of ``<base>``:
+        ``<custom>/_cleared_contents/<hash>/<job.id>/``. This is a **sibling
+        tree** of the JWD tree (both rooted at ``<custom>``), so
+        ``shutil.move(jwd, archive)`` in ``clear_working_directory`` never
+        moves a directory into its own subtree.
 
-        The archive is keyed by ``job.id`` (not the JWD basename) so that
-        resubmits of the same job don't collide on the archive name.
+        The archive is keyed by ``<hash>/<job.id>`` so that resubmits of the
+        same job don't collide on the archive name.
 
-        Note: if the custom path's parent directory is on a different filesystem
-        than the JWD, ``shutil.move`` will fall back to copy-then-delete rather
-        than a rename. This is slower but correct.
+        Note: if the custom base is on a different filesystem than the JWD,
+        ``shutil.move`` will fall back to copy-then-delete rather than a rename.
+        This is slower but correct.
         """
         if self._custom_path:
             validate_working_directory_path(self._custom_path)
-            parent = os.path.dirname(self._custom_path)
-            job_id = str(self._job.id)
-            path = os.path.join(parent, _CLEARED_CONTENTS_EXTRA_DIR, job_id)
+            path = os.path.join(
+                self._custom_path,
+                _CLEARED_CONTENTS_EXTRA_DIR,
+                self._per_job_subpath(),
+            )
             os.makedirs(path, exist_ok=True)
             return path
         self._object_store.create(
@@ -491,8 +525,10 @@ def validate_working_directory_path(path: str) -> None:
     only guard.
 
     ``job.working_directory`` is a ``String(1024)`` populated from destination
-    params (admin/TPV-controlled). Refuse to operate on anything that is not an
-    absolute, non-root, non-empty path.
+    params (admin/TPV-controlled) and is treated as a **parent/base** path:
+    Galaxy appends ``<directory_hash_id(job.id)>/<job.id>/`` for per-job
+    isolation. Refuse to operate on anything that is not an absolute,
+    non-root, non-empty path.
     """
     if not path:
         raise ValueError("Refusing to operate on empty job working_directory")

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -364,14 +364,14 @@ class JobWorkingDirectory:
         obj_id = self._job.id
         return os.path.join(*directory_hash_id(obj_id), str(obj_id))
 
-    def _per_job_path(self) -> str:
+    def _per_job_path(self, custom_path: str) -> str:
         """Return ``<custom_base>/<directory_hash_id(job.id)>/<job.id>/``."""
-        return os.path.join(self._custom_path, self._per_job_subpath())
+        return os.path.join(custom_path, self._per_job_subpath())
 
     def resolve(self) -> str:
         """Return the working directory path, creating nothing on disk."""
-        if self._custom_path:
-            return self._per_job_path()
+        if custom_path := self._custom_path:
+            return self._per_job_path(custom_path)
         return self._object_store.get_filename(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
@@ -381,8 +381,8 @@ class JobWorkingDirectory:
 
     def exists(self) -> bool:
         """Check whether the working directory exists on disk."""
-        if self._custom_path:
-            return os.path.exists(self._per_job_path())
+        if custom_path := self._custom_path:
+            return os.path.exists(self._per_job_path(custom_path))
         return self._object_store.exists(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
@@ -396,9 +396,9 @@ class JobWorkingDirectory:
         Raises ``FileExistsError`` if the per-job directory already exists
         (job id collision or leftover from a crashed run).
         """
-        if self._custom_path:
-            validate_working_directory_path(self._custom_path)
-            path = self._per_job_path()
+        if custom_path := self._custom_path:
+            validate_working_directory_path(custom_path)
+            path = self._per_job_path(custom_path)
             try:
                 os.makedirs(path, exist_ok=False)
             except FileExistsError as exc:
@@ -427,9 +427,9 @@ class JobWorkingDirectory:
         For custom paths, only the per-job subdirectory is removed; the
         admin-supplied base is preserved for other jobs.
         """
-        if self._custom_path:
-            validate_working_directory_path(self._custom_path)
-            resolved = self._per_job_path()
+        if custom_path := self._custom_path:
+            validate_working_directory_path(custom_path)
+            resolved = self._per_job_path(custom_path)
             if os.path.exists(resolved):
                 shutil.rmtree(resolved)
             return
@@ -448,10 +448,10 @@ class JobWorkingDirectory:
         sibling tree of the JWD (keyed by ``<hash>/<job.id>``) so resubmits
         don't collide on the archive name.
         """
-        if self._custom_path:
-            validate_working_directory_path(self._custom_path)
+        if custom_path := self._custom_path:
+            validate_working_directory_path(custom_path)
             path = os.path.join(
-                self._custom_path,
+                custom_path,
                 _CLEARED_CONTENTS_EXTRA_DIR,
                 self._per_job_subpath(),
             )

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -343,17 +343,9 @@ _CLEARED_CONTENTS_EXTRA_DIR = "_cleared_contents"
 class JobWorkingDirectory:
     """Unified handle for a job's working directory.
 
-    Encapsulates the two backing strategies — a custom path persisted on
-    ``job.working_directory`` (set from the ``job_working_directory``
-    destination param) and the legacy object-store-derived path — behind a
-    single object so callers never branch on ``job.working_directory``.
-
-    All create / resolve / exists / delete / cleared-contents logic lives here.
-
-    ``_custom_path`` is read fresh on each access, so a ``JobWorkingDirectory``
-    may be constructed before ``job.working_directory`` is mutated and will
-    observe the up-to-date value on the next method call. This eliminates
-    construction-order sensitivity.
+    Hides the two backing strategies — a custom path on ``job.working_directory``
+    (from the ``job_working_directory`` destination param) and the legacy
+    object-store-derived path — behind a single object.
     """
 
     __slots__ = ("_job", "_object_store")
@@ -364,11 +356,7 @@ class JobWorkingDirectory:
 
     @property
     def _custom_path(self) -> str | None:
-        """Read ``job.working_directory`` fresh on each access.
-
-        Not cached: the column may be mutated after this object is constructed.
-        Reading fresh eliminates construction-order sensitivity entirely.
-        """
+        """Read ``job.working_directory`` fresh on each access (not cached)."""
         return self._job.working_directory
 
     def _per_job_subpath(self) -> str:
@@ -377,13 +365,7 @@ class JobWorkingDirectory:
         return os.path.join(*directory_hash_id(obj_id), str(obj_id))
 
     def _per_job_path(self) -> str:
-        """Resolve the per-job working directory under a custom base.
-
-        Returns ``<custom_base>/<directory_hash_id(job.id)>/<job.id>/``. The
-        custom base (``job.working_directory``) is the admin/TPV-supplied
-        parent; the per-job subdirectory isolates concurrent jobs that share
-        the same base.
-        """
+        """Return ``<custom_base>/<directory_hash_id(job.id)>/<job.id>/``."""
         return os.path.join(self._custom_path, self._per_job_subpath())
 
     def resolve(self) -> str:
@@ -411,11 +393,8 @@ class JobWorkingDirectory:
     def create(self) -> str:
         """Create the working directory and return its path.
 
-        For custom paths, the per-job subdirectory (``<base>/<hash>/<job.id>/``)
-        is created. A pre-existing per-job directory is a loud error (job id
-        collision or leftover from a crashed run) rather than a silent
-        overwrite, since resubmits go through ``clear_working_directory`` first
-        and should not leave a stale directory behind.
+        Raises ``FileExistsError`` if the per-job directory already exists
+        (job id collision or leftover from a crashed run).
         """
         if self._custom_path:
             validate_working_directory_path(self._custom_path)
@@ -445,10 +424,8 @@ class JobWorkingDirectory:
     def delete(self) -> None:
         """Recursively delete the working directory.
 
-        For custom paths, only the per-job subdirectory
-        (``<base>/<hash>/<job.id>/``) is removed — the admin-supplied base is
-        preserved for other jobs. The base is validated before any disk
-        operation since ``job.working_directory`` is an admin-supplied string.
+        For custom paths, only the per-job subdirectory is removed; the
+        admin-supplied base is preserved for other jobs.
         """
         if self._custom_path:
             validate_working_directory_path(self._custom_path)
@@ -467,26 +444,9 @@ class JobWorkingDirectory:
     def cleared_contents_base(self) -> str:
         """Return the directory under which cleared JWDs are archived.
 
-        Creates the archive directory if it does not exist.
-
-        For the object-store case, mirrors the ``extra_dir="_cleared_contents",
-        extra_dir_at_root=True`` layout: the archive lives at
-        ``<base>/_cleared_contents/<hash>/<obj_id>/``, which is **outside**
-        the JWD's own ``<base>/<hash>/<obj_id>/``.
-
-        For the custom-path case, the archive mirrors the object-store
-        root-divergent layout with the custom base in place of ``<base>``:
-        ``<custom>/_cleared_contents/<hash>/<job.id>/``. This is a **sibling
-        tree** of the JWD tree (both rooted at ``<custom>``), so
-        ``shutil.move(jwd, archive)`` in ``clear_working_directory`` never
-        moves a directory into its own subtree.
-
-        The archive is keyed by ``<hash>/<job.id>`` so that resubmits of the
-        same job don't collide on the archive name.
-
-        Note: if the custom base is on a different filesystem than the JWD,
-        ``shutil.move`` will fall back to copy-then-delete rather than a rename.
-        This is slower but correct.
+        Creates the archive directory if it does not exist. The archive is a
+        sibling tree of the JWD (keyed by ``<hash>/<job.id>``) so resubmits
+        don't collide on the archive name.
         """
         if self._custom_path:
             validate_working_directory_path(self._custom_path)

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -368,27 +368,15 @@ class JobWorkingDirectory:
         """
         return self._job.working_directory
 
-    def resolve(self, legacy_extra_dir: str | None = None) -> str:
-        """Return the working directory path, creating nothing on disk.
-
-        Args:
-            legacy_extra_dir: Optional subdirectory for legacy object-store
-                paths only. Passed through to ``object_store.get_filename`` as
-                ``extra_dir``. Ignored for custom paths (the custom path is
-                already the full JWD; the ``extra_dir=str(job.id)`` legacy
-                quirk was an object-store artifact, not a conceptual JWD
-                model). Passing this for a custom-path job is a caller bug and
-                raises ``AssertionError``.
-        """
+    def resolve(self) -> str:
+        """Return the working directory path, creating nothing on disk."""
         if self._custom_path:
-            assert legacy_extra_dir is None, "legacy_extra_dir is ignored for custom-path JWDs; caller bug"
             return self._custom_path
         return self._object_store.get_filename(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
-            extra_dir=legacy_extra_dir,
         )
 
     def exists(self) -> bool:
@@ -402,19 +390,12 @@ class JobWorkingDirectory:
             obj_dir=True,
         )
 
-    def create(self, legacy_extra_dir: str | None = None) -> str:
+    def create(self) -> str:
         """Create the working directory and return its path.
 
         Idempotent: a pre-existing custom path is not an error.
-
-        Args:
-            legacy_extra_dir: Optional subdirectory for legacy object-store
-                paths only. Passed through to the object store as ``extra_dir``.
-                Ignored for custom paths. Passing this for a custom-path job is
-                a caller bug and raises ``AssertionError``.
         """
         if self._custom_path:
-            assert legacy_extra_dir is None, "legacy_extra_dir is ignored for custom-path JWDs; caller bug"
             validate_working_directory_path(self._custom_path)
             os.makedirs(self._custom_path, exist_ok=True)
             return self._custom_path
@@ -423,14 +404,12 @@ class JobWorkingDirectory:
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
-            extra_dir=legacy_extra_dir,
         )
         return self._object_store.get_filename(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
             dir_only=True,
             obj_dir=True,
-            extra_dir=legacy_extra_dir,
         )
 
     def delete(self) -> None:

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -442,7 +442,8 @@ class JobWorkingDirectory:
         """
         if self._custom_path:
             validate_working_directory_path(self._custom_path)
-            shutil.rmtree(self._custom_path)
+            if os.path.exists(self._custom_path):
+                shutil.rmtree(self._custom_path)
             return
         self._object_store.delete(
             self._job,

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import threading
 from typing import (
     Any,
@@ -27,6 +28,7 @@ from galaxy.model import (
     JobExportHistoryArchive,
     MetadataFile,
 )
+from galaxy.objectstore import ObjectStore
 from galaxy.util import safe_makedirs
 from galaxy.util.dictifiable import UsesDictVisibleKeys
 from galaxy.util.path import StrPath
@@ -328,7 +330,172 @@ def ensure_configs_directory(work_dir: str) -> str:
     return configs_dir
 
 
-def create_working_directory_for_job(object_store, job) -> str:
-    object_store.create(job, base_dir="job_work", dir_only=True, obj_dir=True)
-    working_directory = object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
-    return working_directory
+# Sentinel object-store keys for the job working directory. Centralized so that
+# every JWD operation goes through the same code path instead of open-coding
+# ``if job.working_directory:`` forks at each call site.
+_JOB_WORK_BASE_DIR = "job_work"
+_CLEARED_CONTENTS_EXTRA_DIR = "_cleared_contents"
+
+
+class JobWorkingDirectory:
+    """Unified handle for a job's working directory.
+
+    Encapsulates the two backing strategies — a custom path persisted on
+    ``job.working_directory`` (set from the ``job_working_directory``
+    destination param) and the legacy object-store-derived path — behind a
+    single object so callers never branch on ``job.working_directory``.
+
+    All create / resolve / exists / delete / cleared-contents logic lives here.
+
+    Construction order: ``job.working_directory`` must be populated (or
+    definitively None) before a ``JobWorkingDirectory`` is constructed. In
+    practice this is guaranteed because ``_set_working_directory`` runs
+    inside ``_setup_working_directory`` before any ``JobWorkingDirectory``
+    is instantiated, and for already-persisted jobs the column is loaded
+    from the database.
+    """
+
+    __slots__ = ("_job", "_object_store")
+
+    def __init__(self, job: Job, object_store: ObjectStore) -> None:
+        self._job = job
+        self._object_store = object_store
+
+    @property
+    def _custom_path(self) -> str | None:
+        """Read ``job.working_directory`` fresh on each access.
+
+        Not cached: the column may be mutated by ``_set_working_directory``
+        after this object is constructed (though current call sites construct
+        after the mutation). Reading fresh eliminates construction-order
+        sensitivity entirely.
+        """
+        return self._job.working_directory
+
+    @property
+    def uses_custom_path(self) -> bool:
+        """True when the JWD is a filesystem path set via destination params."""
+        return self._custom_path is not None
+
+    def resolve(self) -> str:
+        """Return the working directory path, creating nothing on disk."""
+        if self._custom_path:
+            return self._custom_path
+        return self._object_store.get_filename(
+            self._job,
+            base_dir=_JOB_WORK_BASE_DIR,
+            dir_only=True,
+            obj_dir=True,
+        )
+
+    def exists(self) -> bool:
+        """Check whether the working directory exists on disk."""
+        if self._custom_path:
+            return os.path.exists(self._custom_path)
+        return self._object_store.exists(
+            self._job,
+            base_dir=_JOB_WORK_BASE_DIR,
+            dir_only=True,
+            obj_dir=True,
+        )
+
+    def create(self) -> str:
+        """Create the working directory and return its path.
+
+        Idempotent: a pre-existing custom path is not an error.
+        """
+        if self._custom_path:
+            _validate_custom_path(self._custom_path)
+            os.makedirs(self._custom_path, exist_ok=True)
+            return self._custom_path
+        self._object_store.create(
+            self._job,
+            base_dir=_JOB_WORK_BASE_DIR,
+            dir_only=True,
+            obj_dir=True,
+        )
+        return self._object_store.get_filename(
+            self._job,
+            base_dir=_JOB_WORK_BASE_DIR,
+            dir_only=True,
+            obj_dir=True,
+        )
+
+    def delete(self) -> None:
+        """Recursively delete the working directory.
+
+        For custom paths, validates the target is a non-empty absolute path
+        before removing it, since ``job.working_directory`` is an
+        admin-supplied string and ``shutil.rmtree`` will obey it literally.
+        """
+        if self._custom_path:
+            _validate_custom_path(self._custom_path)
+            shutil.rmtree(self._custom_path)
+            return
+        self._object_store.delete(
+            self._job,
+            base_dir=_JOB_WORK_BASE_DIR,
+            entire_dir=True,
+            dir_only=True,
+            obj_dir=True,
+        )
+
+    def cleared_contents_base(self) -> str:
+        """Return the directory under which cleared JWDs are archived.
+
+        Creates the archive directory if it does not exist.
+
+        For the object-store case, mirrors the ``extra_dir="_cleared_contents",
+        extra_dir_at_root=True`` layout: the archive lives at
+        ``<base>/_cleared_contents/<hash>/<obj_id>/``, which is **outside**
+        the JWD's own ``<base>/<hash>/<obj_id>/``.
+
+        For the custom-path case, the archive is a **sibling** of the JWD
+        (``<parent>/_cleared_contents/<basename>``), not a subdirectory of
+        it. This is critical: ``clear_working_directory`` does
+        ``shutil.move(jwd, arc_dir)`` — if ``arc_dir`` were inside ``jwd``,
+        the move would attempt to relocate a directory into its own subtree
+        and fail.
+
+        Note: if the custom path's parent directory is on a different filesystem
+        than the JWD, ``shutil.move`` will fall back to copy-then-delete rather
+        than a rename. This is slower but correct.
+        """
+        if self._custom_path:
+            _validate_custom_path(self._custom_path)
+            parent = os.path.dirname(self._custom_path)
+            name = os.path.basename(self._custom_path)
+            path = os.path.join(parent, _CLEARED_CONTENTS_EXTRA_DIR, name)
+            os.makedirs(path, exist_ok=True)
+            return path
+        self._object_store.create(
+            self._job,
+            base_dir=_JOB_WORK_BASE_DIR,
+            dir_only=True,
+            obj_dir=True,
+            extra_dir=_CLEARED_CONTENTS_EXTRA_DIR,
+            extra_dir_at_root=True,
+        )
+        return self._object_store.get_filename(
+            self._job,
+            base_dir=_JOB_WORK_BASE_DIR,
+            dir_only=True,
+            obj_dir=True,
+            extra_dir=_CLEARED_CONTENTS_EXTRA_DIR,
+            extra_dir_at_root=True,
+        )
+
+
+def _validate_custom_path(path: str) -> None:
+    """Validate a custom ``job.working_directory`` path before disk operations.
+
+    ``job.working_directory`` is a ``String(1024)`` populated from destination
+    params (admin/TPV-controlled). Refuse to operate on anything that is not an
+    absolute, non-root, non-empty path.
+    """
+    if not path:
+        raise ValueError("Refusing to operate on empty job working_directory")
+    if not os.path.isabs(path):
+        raise ValueError(f"Refusing to operate on relative job working_directory: {path!r}")
+    if os.path.normpath(path) == os.path.normpath(os.sep):
+        raise ValueError("Refusing to operate on filesystem root as job working_directory")

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -421,8 +421,11 @@ class JobWorkingDirectory:
             obj_dir=True,
         )
 
-    def delete(self) -> None:
+    def delete(self) -> bool:
         """Recursively delete the working directory.
+
+        Returns ``True`` if something was deleted, ``False`` if the directory
+        did not exist or the object store reported a non-deletion.
 
         For custom paths, only the per-job subdirectory is removed; the
         admin-supplied base is preserved for other jobs.
@@ -432,8 +435,9 @@ class JobWorkingDirectory:
             resolved = self._per_job_path(custom_path)
             if os.path.exists(resolved):
                 shutil.rmtree(resolved)
-            return
-        self._object_store.delete(
+                return True
+            return False
+        return self._object_store.delete(
             self._job,
             base_dir=_JOB_WORK_BASE_DIR,
             entire_dir=True,

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -393,20 +393,13 @@ class JobWorkingDirectory:
     def create(self) -> str:
         """Create the working directory and return its path.
 
-        Raises ``FileExistsError`` if the per-job directory already exists
-        (job id collision or leftover from a crashed run).
+        Idempotent: if the per-job directory already exists (e.g. wrapper
+        reconstruction for a resubmitted job), it is returned without error.
         """
         if custom_path := self._custom_path:
             validate_working_directory_path(custom_path)
             path = self._per_job_path(custom_path)
-            try:
-                os.makedirs(path, exist_ok=False)
-            except FileExistsError as exc:
-                raise FileExistsError(
-                    f"Job working directory already exists for job {self._job.id} "
-                    f"at {path!r}; this indicates a job id collision or a leftover "
-                    f"directory from a previous run."
-                ) from exc
+            os.makedirs(path, exist_ok=True)
             return path
         self._object_store.create(
             self._job,

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1875,7 +1875,7 @@ class MinimalJobWrapper(HasResourceParameters):
         ``clear_working_directory``) must flush/commit themselves. The enqueue
         path is covered by the ``commit()`` in ``enqueue()``.
         """
-        working_directory = self.get_destination_configuration("job_working_directory", None)
+        working_directory = self.job_destination.params.get("job_working_directory", None)
         if isinstance(working_directory, str):
             validate_working_directory_path(working_directory)
             job.working_directory = working_directory

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -987,6 +987,22 @@ class HasResourceParameters:
         return resource_params
 
 
+def _validate_working_directory_path(path: str) -> None:
+    """Validate a custom ``job.working_directory`` path before persisting it.
+
+    ``job.working_directory`` is a ``String(1024)`` populated from destination
+    params (admin/TPV-controlled). Refuse to persist anything that is not an
+    absolute, non-root, non-empty path. Validation at set-time means downstream
+    callers can trust the column value without re-validating.
+    """
+    if not path:
+        raise ValueError("Refusing to set empty job working_directory")
+    if not os.path.isabs(path):
+        raise ValueError(f"Refusing to set relative job working_directory: {path!r}")
+    if os.path.normpath(path) == os.path.normpath(os.sep):
+        raise ValueError("Refusing to set filesystem root as job working_directory")
+
+
 class MinimalJobWrapper(HasResourceParameters):
     """
     Wraps a 'model.Job' with convenience methods for running processes and
@@ -1322,14 +1338,14 @@ class MinimalJobWrapper(HasResourceParameters):
         if job is None:
             job = self.get_job()
         # Resolve and set job.working_directory from destination params before
-        # creating anything on disk. The mutation is persisted by the caller's
-        # sa_session.commit() (e.g. prepare() at the end of job setup, or
-        # set_job_destination's flush in the resubmit path). Callers must
-        # ensure that commit happens before the job row is reused by another
-        # thread/handler, otherwise the in-memory working_directory value can
-        # be lost on session expiry.
+        # creating anything on disk. The mutation is flushed so the value is
+        # durable in the current transaction. This is critical for the resubmit
+        # path: set_job_destination() flushes destination_params, then
+        # clear_working_directory() → _setup_working_directory() →
+        # _set_working_directory() reads those params via get_destination_configuration().
+        # The flush ensures the column survives mark_as_resubmitted()'s
+        # sa_session.refresh() even when no handler commit runs between them.
         self._set_working_directory(job)
-        self._check_jwd_deprecated_config(job)
         try:
             working_directory = self._create_working_directory(job)
             self.__working_directory = working_directory
@@ -1855,17 +1871,18 @@ class MinimalJobWrapper(HasResourceParameters):
     def _set_working_directory(self, job: Job):
         """Resolve and persist ``job_working_directory`` from destination params.
 
-        Mutates ``job.working_directory`` and flushes the session so the value
-        is durable in the current transaction. This is invoked via
-        ``_setup_working_directory``, whose callers (``prepare``,
-        ``_set_object_store_ids_*``, and the resubmit flow via
-        ``set_job_destination``) commit the session as part of their own
-        lifecycle. The explicit flush ensures the column survives a
-        ``sa_session.refresh()`` (e.g. ``mark_as_resubmitted``) even when the
-        caller does not commit before the refresh.
+        Validates the resolved path before persisting it. An invalid custom
+        path (relative, empty, or filesystem root) is rejected at set-time
+        rather than at every disk operation, so downstream callers can trust
+        the column value.
+
+        Flushes the session so the value is durable in the current transaction.
+        This is load-bearing for the resubmit path: mark_as_resubmitted() calls
+        sa_session.refresh() which would discard an unflushed mutation.
         """
         working_directory = self.get_destination_configuration("job_working_directory", None)
         if isinstance(working_directory, str):
+            _validate_working_directory_path(working_directory)
             job.working_directory = working_directory
         else:
             # Reset to None so a resubmitted job whose new destination no longer
@@ -1880,31 +1897,6 @@ class MinimalJobWrapper(HasResourceParameters):
                     working_directory,
                 )
         self.sa_session.flush()
-
-    def _check_jwd_deprecated_config(self, job: Job) -> None:
-        """Emit a deprecation warning if legacy per-backend JWD config is detected.
-
-        The legacy ``extra_dirs['job_work']`` path in ``object_store_conf`` is
-        deprecated in favor of the ``job_working_directory`` destination param.
-        When both are configured, the destination param takes precedence and
-        the legacy path is ignored. We warn once per job to avoid log spam.
-        """
-        # Check if the object store has a custom 'job_work' extra_dir configured
-        # (i.e., not the default config.jobs_directory value).
-        object_store = self.app.object_store
-        job_work_extra = object_store.extra_dirs.get("job_work")
-        default_jobs_dir = getattr(self.app.config, "jobs_directory", None)
-        if job_work_extra and job_work_extra != default_jobs_dir:
-            # Legacy per-backend JWD config is in use.
-            working_directory = self.get_destination_configuration("job_working_directory", None)
-            if isinstance(working_directory, str):
-                log.warning(
-                    "(%s) Legacy per-backend 'job_work' extra_dirs configuration is deprecated. "
-                    "The 'job_working_directory' destination param (%s) takes precedence. "
-                    "Migrate to destination-param-based JWD configuration.",
-                    self.job_id,
-                    working_directory,
-                )
 
     def _set_object_store_ids_full(self, job: Job):
         user = job.user

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1327,13 +1327,7 @@ class MinimalJobWrapper(HasResourceParameters):
         if job is None:
             job = self.get_job()
         # Resolve and set job.working_directory from destination params before
-        # creating anything on disk. The mutation is not flushed here; callers
-        # that need it durable before a refresh (the resubmit path via
-        # clear_working_directory) flush themselves, and enqueue()'s commit()
-        # covers the enqueue path. This is critical for the resubmit path:
-        # set_job_destination() flushes destination_params, then
-        # clear_working_directory() → _setup_working_directory() →
-        # _set_working_directory() reads those params via get_destination_configuration().
+        # creating anything on disk.
         self._set_working_directory(job)
         try:
             working_directory = self._create_working_directory(job)
@@ -1389,11 +1383,8 @@ class MinimalJobWrapper(HasResourceParameters):
         arc_dir = os.path.join(base, date_str)
         shutil.move(self.working_directory, arc_dir)
         self._setup_working_directory(job=job)
-        # Flush so the working_directory column (mutated by _set_working_directory
-        # above) survives the sa_session.refresh() that mark_as_resubmitted()
-        # performs at the end of the resubmit flow. This is the only caller that
-        # needs the flush: enqueue()'s commit() covers the enqueue path, and the
-        # JobWrapper.__init__ path is followed by a prepare() commit.
+        # Flush so the working_directory column survives the sa_session.refresh()
+        # that mark_as_resubmitted() performs at the end of the resubmit flow.
         self.sa_session.flush()
         log.debug("(%s) Previous working directory moved to %s", self.job_id, arc_dir)
 

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1361,11 +1361,6 @@ class MinimalJobWrapper(HasResourceParameters):
     def working_directory(self):
         if self.__working_directory is None:
             job = self.get_job()
-            # For legacy jobs with working_directory=None and no object_store_id,
-            # JobWorkingDirectory.resolve() falls back to object_store.get_filename()
-            # which uses the config.jobs_directory default. This is equivalent to
-            # the old behavior where _set_object_store_ids was called here as a
-            # no-op guard when object_store_id was already set.
             self.__working_directory = JobWorkingDirectory(job, self.app.object_store).resolve()
         return self.__working_directory
 
@@ -1875,7 +1870,18 @@ class MinimalJobWrapper(HasResourceParameters):
         ``clear_working_directory``) must flush/commit themselves. The enqueue
         path is covered by the ``commit()`` in ``enqueue()``.
         """
-        working_directory = self.job_destination.params.get("job_working_directory", None)
+        # Reads from ``job.destination_params`` (persisted) directly, not via
+        # ``get_destination_configuration``. The latter would fall back to
+        # ``app.config.job_working_directory`` (mapped to ``jobs_directory``) when
+        # no destination param specifies the key, causing the column to be set to
+        # the config default even for destinations that don't specify one. We only
+        # want to persist the column when a destination param explicitly sets it.
+
+        # Reading the persisted params is also what makes the resubmit reorder
+        # load-bearing: ``set_job_destination`` persists the new params but does
+        # not update the mapper's cached destination, so reading
+        # ``self.job_destination.params`` directly would return stale values.
+        working_directory = (job.destination_params or {}).get("job_working_directory", None)
         if isinstance(working_directory, str):
             validate_working_directory_path(working_directory)
             job.working_directory = working_directory

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -66,6 +66,7 @@ from galaxy.job_execution.setup import (
     JobWorkingDirectory,
     TOOL_PROVIDED_JOB_METADATA_FILE,
     TOOL_PROVIDED_JOB_METADATA_KEYS,
+    validate_working_directory_path,
 )
 from galaxy.jobs.job_destination import JobDestination
 from galaxy.jobs.mapper import (
@@ -987,22 +988,6 @@ class HasResourceParameters:
         return resource_params
 
 
-def _validate_working_directory_path(path: str) -> None:
-    """Validate a custom ``job.working_directory`` path before persisting it.
-
-    ``job.working_directory`` is a ``String(1024)`` populated from destination
-    params (admin/TPV-controlled). Refuse to persist anything that is not an
-    absolute, non-root, non-empty path. Validation at set-time means downstream
-    callers can trust the column value without re-validating.
-    """
-    if not path:
-        raise ValueError("Refusing to set empty job working_directory")
-    if not os.path.isabs(path):
-        raise ValueError(f"Refusing to set relative job working_directory: {path!r}")
-    if os.path.normpath(path) == os.path.normpath(os.sep):
-        raise ValueError("Refusing to set filesystem root as job working_directory")
-
-
 class MinimalJobWrapper(HasResourceParameters):
     """
     Wraps a 'model.Job' with convenience methods for running processes and
@@ -1338,13 +1323,13 @@ class MinimalJobWrapper(HasResourceParameters):
         if job is None:
             job = self.get_job()
         # Resolve and set job.working_directory from destination params before
-        # creating anything on disk. The mutation is flushed so the value is
-        # durable in the current transaction. This is critical for the resubmit
-        # path: set_job_destination() flushes destination_params, then
+        # creating anything on disk. The mutation is not flushed here; callers
+        # that need it durable before a refresh (the resubmit path via
+        # clear_working_directory) flush themselves, and enqueue()'s commit()
+        # covers the enqueue path. This is critical for the resubmit path:
+        # set_job_destination() flushes destination_params, then
         # clear_working_directory() → _setup_working_directory() →
         # _set_working_directory() reads those params via get_destination_configuration().
-        # The flush ensures the column survives mark_as_resubmitted()'s
-        # sa_session.refresh() even when no handler commit runs between them.
         self._set_working_directory(job)
         try:
             working_directory = self._create_working_directory(job)
@@ -1405,6 +1390,12 @@ class MinimalJobWrapper(HasResourceParameters):
         arc_dir = os.path.join(base, date_str)
         shutil.move(self.working_directory, arc_dir)
         self._setup_working_directory(job=job)
+        # Flush so the working_directory column (mutated by _set_working_directory
+        # above) survives the sa_session.refresh() that mark_as_resubmitted()
+        # performs at the end of the resubmit flow. This is the only caller that
+        # needs the flush: enqueue()'s commit() covers the enqueue path, and the
+        # JobWrapper.__init__ path is followed by a prepare() commit.
+        self.sa_session.flush()
         log.debug("(%s) Previous working directory moved to %s", self.job_id, arc_dir)
 
     def default_compute_environment(self, job=None):
@@ -1871,18 +1862,18 @@ class MinimalJobWrapper(HasResourceParameters):
     def _set_working_directory(self, job: Job):
         """Resolve and persist ``job_working_directory`` from destination params.
 
-        Validates the resolved path before persisting it. An invalid custom
-        path (relative, empty, or filesystem root) is rejected at set-time
-        rather than at every disk operation, so downstream callers can trust
-        the column value.
+        Validates the resolved path before persisting it via the canonical
+        ``validate_working_directory_path`` (also enforced at disk-operation
+        time by ``JobWorkingDirectory``).
 
-        Flushes the session so the value is durable in the current transaction.
-        This is load-bearing for the resubmit path: mark_as_resubmitted() calls
-        sa_session.refresh() which would discard an unflushed mutation.
+        Does not flush the session. Callers that need the column to survive a
+        subsequent ``sa_session.refresh()`` (notably the resubmit path via
+        ``clear_working_directory``) must flush/commit themselves. The enqueue
+        path is covered by the ``commit()`` in ``enqueue()``.
         """
         working_directory = self.get_destination_configuration("job_working_directory", None)
         if isinstance(working_directory, str):
-            _validate_working_directory_path(working_directory)
+            validate_working_directory_path(working_directory)
             job.working_directory = working_directory
         else:
             # Reset to None so a resubmitted job whose new destination no longer
@@ -1896,7 +1887,6 @@ class MinimalJobWrapper(HasResourceParameters):
                     self.job_id,
                     working_directory,
                 )
-        self.sa_session.flush()
 
     def _set_object_store_ids_full(self, job: Job):
         user = job.user

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1018,6 +1018,11 @@ class MinimalJobWrapper(HasResourceParameters):
         # Tool versioning variables
         self.version_string = ""
         self.__galaxy_lib_dir = None
+        # params is unused but is referenced by the job_destination property
+        # (via job_runner_mapper.get_job_destination(self.params)), which
+        # _setup_working_directory -> _set_working_directory -> get_destination_configuration
+        # now triggers during __init__. Initialize it before that call.
+        self.params = None  # unused
         # If the job has an object_store_id ensure working directory is setup, otherwise
         # wait for that to be assigned before configuring it. Either way the working
         # directory does not to be configured on this object before prepare() is called.
@@ -1027,7 +1032,6 @@ class MinimalJobWrapper(HasResourceParameters):
         # resolved
         self._job_io: JobIO | None = None
         self.tool_provided_job_metadata = None
-        self.params = None  # unused
         self.runner_command_line = None
 
         # Wrapper holding the info required to restore and clean up from files used for setting metadata externally

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1018,11 +1018,6 @@ class MinimalJobWrapper(HasResourceParameters):
         # Tool versioning variables
         self.version_string = ""
         self.__galaxy_lib_dir = None
-        # params is unused but is referenced by the job_destination property
-        # (via job_runner_mapper.get_job_destination(self.params)), which
-        # _setup_working_directory -> _set_working_directory -> get_destination_configuration
-        # now triggers during __init__. Initialize it before that call.
-        self.params = None  # unused
         # If the job has an object_store_id ensure working directory is setup, otherwise
         # wait for that to be assigned before configuring it. Either way the working
         # directory does not to be configured on this object before prepare() is called.
@@ -1032,6 +1027,7 @@ class MinimalJobWrapper(HasResourceParameters):
         # resolved
         self._job_io: JobIO | None = None
         self.tool_provided_job_metadata = None
+        self.params = None  # unused
         self.runner_command_line = None
 
         # Wrapper holding the info required to restore and clean up from files used for setting metadata externally

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -61,9 +61,9 @@ from galaxy.job_execution.output_collect import (
     collect_shrinked_content_from_path,
 )
 from galaxy.job_execution.setup import (
-    create_working_directory_for_job,
     ensure_configs_directory,
     JobIO,
+    JobWorkingDirectory,
     TOOL_PROVIDED_JOB_METADATA_FILE,
     TOOL_PROVIDED_JOB_METADATA_KEYS,
 )
@@ -1321,6 +1321,15 @@ class MinimalJobWrapper(HasResourceParameters):
     def _setup_working_directory(self, job=None):
         if job is None:
             job = self.get_job()
+        # Resolve and set job.working_directory from destination params before
+        # creating anything on disk. The mutation is persisted by the caller's
+        # sa_session.commit() (e.g. prepare() at the end of job setup, or
+        # set_job_destination's flush in the resubmit path). Callers must
+        # ensure that commit happens before the job row is reused by another
+        # thread/handler, otherwise the in-memory working_directory value can
+        # be lost on session expiry.
+        self._set_working_directory(job)
+        self._check_jwd_deprecated_config(job)
         try:
             working_directory = self._create_working_directory(job)
             self.__working_directory = working_directory
@@ -1347,29 +1356,24 @@ class MinimalJobWrapper(HasResourceParameters):
     def working_directory(self):
         if self.__working_directory is None:
             job = self.get_job()
-
-            # object_store_id needs to be set before get_filename can be called, this
-            # will also create the directory on the worker.
-            # It is possible these next two lines are not needed - if a job a cannot be recovered
-            # before enqueue is called (seems likely) - this shouldn't be needed.
-            if job.object_store_id:
-                self._set_object_store_ids(job)
-
-            self.__working_directory = self.app.object_store.get_filename(
-                job, base_dir="job_work", dir_only=True, obj_dir=True
-            )
+            # For legacy jobs with working_directory=None and no object_store_id,
+            # JobWorkingDirectory.resolve() falls back to object_store.get_filename()
+            # which uses the config.jobs_directory default. This is equivalent to
+            # the old behavior where _set_object_store_ids was called here as a
+            # no-op guard when object_store_id was already set.
+            self.__working_directory = JobWorkingDirectory(job, self.app.object_store).resolve()
         return self.__working_directory
 
     def working_directory_exists(self) -> bool:
         job = self.get_job()
-        return self.app.object_store.exists(job, base_dir="job_work", dir_only=True, obj_dir=True)
+        return JobWorkingDirectory(job, self.app.object_store).exists()
 
     @property
     def tool_working_directory(self):
         return os.path.join(self.working_directory, "working")
 
     def _create_working_directory(self, job):
-        return create_working_directory_for_job(self.object_store, job)
+        return JobWorkingDirectory(job, self.object_store).create()
 
     def clear_working_directory(self):
         job = self.get_job()
@@ -1379,12 +1383,8 @@ class MinimalJobWrapper(HasResourceParameters):
             )
             return
 
-        self.object_store.create(
-            job, base_dir="job_work", dir_only=True, obj_dir=True, extra_dir="_cleared_contents", extra_dir_at_root=True
-        )
-        base = self.object_store.get_filename(
-            job, base_dir="job_work", dir_only=True, obj_dir=True, extra_dir="_cleared_contents", extra_dir_at_root=True
-        )
+        jwd = JobWorkingDirectory(job, self.object_store)
+        base = jwd.cleared_contents_base()
         date_str = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
         arc_dir = os.path.join(base, date_str)
         shutil.move(self.working_directory, arc_dir)
@@ -1851,6 +1851,60 @@ class MinimalJobWrapper(HasResourceParameters):
 
         job.object_store_id = object_store_populator.object_store_id
         self._setup_working_directory(job=job)
+
+    def _set_working_directory(self, job: Job):
+        """Resolve and persist ``job_working_directory`` from destination params.
+
+        Mutates ``job.working_directory`` and flushes the session so the value
+        is durable in the current transaction. This is invoked via
+        ``_setup_working_directory``, whose callers (``prepare``,
+        ``_set_object_store_ids_*``, and the resubmit flow via
+        ``set_job_destination``) commit the session as part of their own
+        lifecycle. The explicit flush ensures the column survives a
+        ``sa_session.refresh()`` (e.g. ``mark_as_resubmitted``) even when the
+        caller does not commit before the refresh.
+        """
+        working_directory = self.get_destination_configuration("job_working_directory", None)
+        if isinstance(working_directory, str):
+            job.working_directory = working_directory
+        else:
+            # Reset to None so a resubmitted job whose new destination no longer
+            # specifies a custom path falls back to the object-store strategy
+            # instead of retaining the stale value from the prior attempt.
+            job.working_directory = None
+            if working_directory is not None:
+                log.warning(
+                    "(%s) job_working_directory destination param is not a string (%r), "
+                    "falling back to object-store path.",
+                    self.job_id,
+                    working_directory,
+                )
+        self.sa_session.flush()
+
+    def _check_jwd_deprecated_config(self, job: Job) -> None:
+        """Emit a deprecation warning if legacy per-backend JWD config is detected.
+
+        The legacy ``extra_dirs['job_work']`` path in ``object_store_conf`` is
+        deprecated in favor of the ``job_working_directory`` destination param.
+        When both are configured, the destination param takes precedence and
+        the legacy path is ignored. We warn once per job to avoid log spam.
+        """
+        # Check if the object store has a custom 'job_work' extra_dir configured
+        # (i.e., not the default config.jobs_directory value).
+        object_store = self.app.object_store
+        job_work_extra = object_store.extra_dirs.get("job_work")
+        default_jobs_dir = getattr(self.app.config, "jobs_directory", None)
+        if job_work_extra and job_work_extra != default_jobs_dir:
+            # Legacy per-backend JWD config is in use.
+            working_directory = self.get_destination_configuration("job_working_directory", None)
+            if isinstance(working_directory, str):
+                log.warning(
+                    "(%s) Legacy per-backend 'job_work' extra_dirs configuration is deprecated. "
+                    "The 'job_working_directory' destination param (%s) takes precedence. "
+                    "Migrate to destination-param-based JWD configuration.",
+                    self.job_id,
+                    working_directory,
+                )
 
     def _set_object_store_ids_full(self, job: Job):
         user = job.user
@@ -2388,9 +2442,8 @@ class MinimalJobWrapper(HasResourceParameters):
                         if e.errno != errno.ENOENT:
                             raise
             if delete_files:
-                self.object_store.delete(
-                    self.get_job(), base_dir="job_work", entire_dir=True, dir_only=True, obj_dir=True
-                )
+                job = self.get_job()
+                JobWorkingDirectory(job, self.object_store).delete()
         except Exception:
             log.exception("Unable to cleanup job %d", self.job_id)
 

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -98,16 +98,9 @@ def _handle_resubmit_definitions(
         # precedence on conflicts so the chain re-walk picks up the right rule.
         prior_destination_params = (job_state.job_wrapper.get_job().destination_params or {}).copy()
         new_destination.params = {**prior_destination_params, **new_destination.params}
-        # Reset job state
-        job_state.job_wrapper.clear_working_directory()
-        job = job_state.job_wrapper.get_job()
-        if handler := resubmit.get("handler"):
-            log.debug("%s Job reassigned to handler %s", job_log_prefix, handler)
-            job.set_handler(handler)
-            job_runner.sa_session.add(job)
-            # Is this safe to do here?
-            job_runner.sa_session.commit()
-        # Handle delaying before resubmission if needed.
+        # Handle delaying before resubmission if needed — must happen BEFORE
+        # set_job_destination so the delay param is persisted along with the
+        # destination.
         raw_delay = resubmit.get("delay")
         if raw_delay:
             delay = str(expression_context.safe_eval(str(raw_delay)))
@@ -117,7 +110,27 @@ def _handle_resubmit_definitions(
                 new_destination.params["__resubmit_delay_seconds"] = str(delay)
             except ValueError:
                 log.warning(f"Cannot delay job with delay [{delay}], does not appear to be a number.")
+        # Persist the new destination before clearing the working directory.
+        # set_job_destination() assigns job.destination_params = new_destination.params
+        # and flushes, so when clear_working_directory() → _setup_working_directory()
+        # → _set_working_directory() calls get_destination_configuration(), the model's
+        # get_destination_configuration (model/__init__.py) reads job.destination_params
+        # first — which now holds the *new* params, not the stale values from the prior
+        # attempt. This is what makes a resubmitted job resolve its new JWD correctly.
         job_state.job_wrapper.set_job_destination(new_destination)
+        # Reset job state. _set_working_directory (called inside
+        # clear_working_directory → _setup_working_directory) flushes the
+        # session itself, so the working_directory column survives the
+        # sa_session.refresh() that mark_as_resubmitted() performs at the end
+        # of this flow even when no handler commit runs below.
+        job_state.job_wrapper.clear_working_directory()
+        job = job_state.job_wrapper.get_job()
+        if handler := resubmit.get("handler"):
+            log.debug("%s Job reassigned to handler %s", job_log_prefix, handler)
+            job.set_handler(handler)
+            job_runner.sa_session.add(job)
+            # Is this safe to do here?
+            job_runner.sa_session.commit()
         # Clear external ID (state change below flushes the change)
         job.job_runner_external_id = None
         # Allow the UI to query for resubmitted state

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -113,10 +113,9 @@ def _handle_resubmit_definitions(
         # Persist the new destination before clearing the working directory.
         # set_job_destination() assigns job.destination_params = new_destination.params
         # and flushes, so when clear_working_directory() → _setup_working_directory()
-        # → _set_working_directory() calls get_destination_configuration(), the model's
-        # get_destination_configuration (model/__init__.py) reads job.destination_params
-        # first — which now holds the *new* params, not the stale values from the prior
-        # attempt. This is what makes a resubmitted job resolve its new JWD correctly.
+        # → _set_working_directory() reads self.job_destination.params, which now
+        # holds the *new* params, not the stale values from the prior attempt.
+        # This is what makes a resubmitted job resolve its new JWD correctly.
         job_state.job_wrapper.set_job_destination(new_destination)
         # Reset job state. clear_working_directory() flushes the session after
         # _setup_working_directory() → _set_working_directory() mutates the

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -84,18 +84,9 @@ def _handle_resubmit_definitions(
         )
 
         # Defer evaluation: do NOT call set_cached_job_destination here. The
-        # resubmit destination is persisted as the dynamic intent (e.g.
-        # "tpv_dispatcher", runner="dynamic") via set_job_destination below;
+        # resubmit destination is persisted via set_job_destination below;
         # __recover_job_wrapper(resubmit=True) will walk the chain afresh when
-        # the job is picked up from the queue. This is what enables multiple
-        # resubmits through chained dynamic destinations (refs galaxyproject/galaxy#7118,
-        # galaxyproject/galaxy#15208).
-        #
-        # Carry the prior attempt's destination_params forward so dynamic rules
-        # that branch on prior context (e.g. TPV reading job.destination_params
-        # to escalate memory across retries) keep working. The static
-        # dispatcher's params (function, rules_module, type, ...) take
-        # precedence on conflicts so the chain re-walk picks up the right rule.
+        # the job is picked up from the queue (refs #7118, #15208).
         prior_destination_params = (job_state.job_wrapper.get_job().destination_params or {}).copy()
         new_destination.params = {**prior_destination_params, **new_destination.params}
         # Handle delaying before resubmission if needed — must happen BEFORE

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -118,11 +118,11 @@ def _handle_resubmit_definitions(
         # first — which now holds the *new* params, not the stale values from the prior
         # attempt. This is what makes a resubmitted job resolve its new JWD correctly.
         job_state.job_wrapper.set_job_destination(new_destination)
-        # Reset job state. _set_working_directory (called inside
-        # clear_working_directory → _setup_working_directory) flushes the
-        # session itself, so the working_directory column survives the
-        # sa_session.refresh() that mark_as_resubmitted() performs at the end
-        # of this flow even when no handler commit runs below.
+        # Reset job state. clear_working_directory() flushes the session after
+        # _setup_working_directory() → _set_working_directory() mutates the
+        # working_directory column, so the column survives the sa_session.refresh()
+        # that mark_as_resubmitted() performs at the end of this flow even when no
+        # handler commit runs below.
         job_state.job_wrapper.clear_working_directory()
         job = job_state.job_wrapper.get_job()
         if handler := resubmit.get("handler"):

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -111,17 +111,8 @@ def _handle_resubmit_definitions(
             except ValueError:
                 log.warning(f"Cannot delay job with delay [{delay}], does not appear to be a number.")
         # Persist the new destination before clearing the working directory.
-        # set_job_destination() assigns job.destination_params = new_destination.params
-        # and flushes, so when clear_working_directory() → _setup_working_directory()
-        # → _set_working_directory() reads self.job_destination.params, which now
-        # holds the *new* params, not the stale values from the prior attempt.
         # This is what makes a resubmitted job resolve its new JWD correctly.
         job_state.job_wrapper.set_job_destination(new_destination)
-        # Reset job state. clear_working_directory() flushes the session after
-        # _setup_working_directory() → _set_working_directory() mutates the
-        # working_directory column, so the column survives the sa_session.refresh()
-        # that mark_as_resubmitted() performs at the end of this flow even when no
-        # handler commit runs below.
         job_state.job_wrapper.clear_working_directory()
         job = job_state.job_wrapper.get_job()
         if handler := resubmit.get("handler"):

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -45,6 +45,7 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
     RequestParameterMissingException,
 )
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.job_metrics import (
     RawMetric,
     Safety,
@@ -398,9 +399,7 @@ class JobManager:
         console_output = {}
         console_output["state"] = job.state
         if job.state == job.states.RUNNING:
-            working_directory = trans.app.object_store.get_filename(
-                job, base_dir="job_work", dir_only=True, obj_dir=True
-            )
+            working_directory = JobWorkingDirectory(job, trans.app.object_store).resolve()
             if stdout_length > -1 and stdout_position > -1:
                 try:
                     stdout_path = Path(working_directory) / STDOUT_LOCATION

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1662,6 +1662,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     destination_id: Mapped[str | None] = mapped_column(String(255))
     destination_params: Mapped[dict[str, Any] | None] = mapped_column(MutableJSONType)
     object_store_id: Mapped[str | None] = mapped_column(TrimmedString(255), index=True)
+    working_directory: Mapped[str | None] = mapped_column(String(1024))
     imported: Mapped[bool | None] = mapped_column(default=False, index=True)
     handler: Mapped[str | None] = mapped_column(TrimmedString(255), index=True)
     preferred_object_store_id: Mapped[str | None] = mapped_column(String(255))

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/e96dd6fd5863_add_working_directory_column_to_job.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/e96dd6fd5863_add_working_directory_column_to_job.py
@@ -1,0 +1,36 @@
+"""add working_directory column to job
+
+Revision ID: e96dd6fd5863
+Revises: fb8621b7c075
+Create Date: 2026-07-16 14:16:16.929329
+
+"""
+
+from sqlalchemy import (
+    Column,
+    String,
+)
+
+from galaxy.model.migrations.util import (
+    add_column,
+    column_exists,
+    drop_column,
+)
+
+# revision identifiers, used by Alembic.
+revision = "e96dd6fd5863"
+down_revision = "fb8621b7c075"
+branch_labels = None
+depends_on = None
+
+table_name = "job"
+column_name = "working_directory"
+
+
+def upgrade():
+    if not column_exists(table_name, column_name, False):
+        add_column(table_name, Column(column_name, String(1024)))
+
+
+def downgrade():
+    drop_column(table_name, column_name)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -48,6 +48,7 @@ from galaxy.job_execution.output_collect import (
     MetadataSourceProvider,
     PermissionProvider,
 )
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.managers.credentials import build_credentials_context_response
 from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.model import (
@@ -3661,7 +3662,7 @@ class SetMetadataTool(Tool):
             self.app.job_manager.enqueue(job=job, tool=self)
 
     def exec_after_process(self, app, inp_data, out_data, param_dict, job, final_job_state=None):
-        working_directory = app.object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
+        working_directory = JobWorkingDirectory(job, app.object_store).resolve()
         for name, dataset in inp_data.items():
             external_metadata = get_metadata_compute_strategy(app.config, job.id, tool_id=self.id)
             sa_session = app.model.context

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -3,7 +3,7 @@ import logging
 import os
 import tempfile
 
-from galaxy.job_execution.setup import create_working_directory_for_job
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.model import (
     History,
     Job,
@@ -186,7 +186,7 @@ class ExportHistoryToolAction(ToolAction):
             # creating a dataset (like above for dataset export case).
             # ensure job.id is available
             trans.sa_session.commit()
-            job_directory = create_working_directory_for_job(trans.app.object_store, job)
+            job_directory = JobWorkingDirectory(job, trans.app.object_store).create()
             store_directory = os.path.join(job_directory, "working", "_object_export")
             os.makedirs(store_directory)
 

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -5,7 +5,6 @@ from typing import (
 )
 
 from galaxy.job_execution.datasets import DatasetPath
-from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.model import (
     Dataset,
@@ -162,13 +161,13 @@ class SetMetadataToolAction(ToolAction):
         # Store original dataset state, so we can restore it. A separate table might be better (no chance of 'losing' the original state)?
         incoming["__ORIGINAL_DATASET_STATE__"] = dataset.state
         input_paths = [DatasetPath(dataset.id, real_path=dataset.get_file_name(), mutable=False)]
-        # Out-of-band metadata job: no destination params, so working_directory is None.
-        # JobWorkingDirectory falls back to the object-store path (config.jobs_directory),
-        # which is the correct location for metadata jobs that run in the web thread.
-        # Use extra_dir=str(job.id) to match the legacy path that this site historically used;
-        # this produces a different JWD than the obj_dir=True path used by regular jobs,
-        # but changing it would break existing metadata job file lookups.
-        job_working_dir = JobWorkingDirectory(job, app.object_store).create(legacy_extra_dir=str(job.id))
+        # Out-of-band metadata job: runs in the web thread before any destination
+        # is resolved, so job.working_directory is None. This site uses
+        # extra_dir=str(job.id), a different path scheme than the obj_dir=True sites
+        # that JobWorkingDirectory manages. Keep the direct object-store call so the
+        # path matches what later metadata file lookups expect.
+        app.object_store.create(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
+        job_working_dir = app.object_store.get_filename(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
         datatypes_config = os.path.join(job_working_dir, "registry.xml")
         app.datatypes_registry.to_xml_file(path=datatypes_config)
         external_metadata_wrapper = get_metadata_compute_strategy(app.config, job.id, tool_id=tool.id)

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -5,6 +5,7 @@ from typing import (
 )
 
 from galaxy.job_execution.datasets import DatasetPath
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.model import (
     Dataset,
@@ -161,8 +162,10 @@ class SetMetadataToolAction(ToolAction):
         # Store original dataset state, so we can restore it. A separate table might be better (no chance of 'losing' the original state)?
         incoming["__ORIGINAL_DATASET_STATE__"] = dataset.state
         input_paths = [DatasetPath(dataset.id, real_path=dataset.get_file_name(), mutable=False)]
-        app.object_store.create(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
-        job_working_dir = app.object_store.get_filename(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
+        # Out-of-band metadata job: no destination params, so working_directory is None.
+        # JobWorkingDirectory falls back to the object-store path (config.jobs_directory),
+        # which is the correct location for metadata jobs that run in the web thread.
+        job_working_dir = JobWorkingDirectory(job, app.object_store).create()
         datatypes_config = os.path.join(job_working_dir, "registry.xml")
         app.datatypes_registry.to_xml_file(path=datatypes_config)
         external_metadata_wrapper = get_metadata_compute_strategy(app.config, job.id, tool_id=tool.id)

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -165,7 +165,10 @@ class SetMetadataToolAction(ToolAction):
         # Out-of-band metadata job: no destination params, so working_directory is None.
         # JobWorkingDirectory falls back to the object-store path (config.jobs_directory),
         # which is the correct location for metadata jobs that run in the web thread.
-        job_working_dir = JobWorkingDirectory(job, app.object_store).create()
+        # Use extra_dir=str(job.id) to match the legacy path that this site historically used;
+        # this produces a different JWD than the obj_dir=True path used by regular jobs,
+        # but changing it would break existing metadata job file lookups.
+        job_working_dir = JobWorkingDirectory(job, app.object_store).create(extra_dir=str(job.id))
         datatypes_config = os.path.join(job_working_dir, "registry.xml")
         app.datatypes_registry.to_xml_file(path=datatypes_config)
         external_metadata_wrapper = get_metadata_compute_strategy(app.config, job.id, tool_id=tool.id)

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -5,6 +5,7 @@ from typing import (
 )
 
 from galaxy.job_execution.datasets import DatasetPath
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.model import (
     Dataset,
@@ -162,12 +163,9 @@ class SetMetadataToolAction(ToolAction):
         incoming["__ORIGINAL_DATASET_STATE__"] = dataset.state
         input_paths = [DatasetPath(dataset.id, real_path=dataset.get_file_name(), mutable=False)]
         # Out-of-band metadata job: runs in the web thread before any destination
-        # is resolved, so job.working_directory is None. This site uses
-        # extra_dir=str(job.id), a different path scheme than the obj_dir=True sites
-        # that JobWorkingDirectory manages. Keep the direct object-store call so the
-        # path matches what later metadata file lookups expect.
-        app.object_store.create(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
-        job_working_dir = app.object_store.get_filename(job, base_dir="job_work", dir_only=True, extra_dir=str(job.id))
+        # is resolved, so job.working_directory is None and JobWorkingDirectory
+        # falls through to the object-store path.
+        job_working_dir = JobWorkingDirectory(job, app.object_store).create()
         datatypes_config = os.path.join(job_working_dir, "registry.xml")
         app.datatypes_registry.to_xml_file(path=datatypes_config)
         external_metadata_wrapper = get_metadata_compute_strategy(app.config, job.id, tool_id=tool.id)

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -168,7 +168,7 @@ class SetMetadataToolAction(ToolAction):
         # Use extra_dir=str(job.id) to match the legacy path that this site historically used;
         # this produces a different JWD than the obj_dir=True path used by regular jobs,
         # but changing it would break existing metadata job file lookups.
-        job_working_dir = JobWorkingDirectory(job, app.object_store).create(extra_dir=str(job.id))
+        job_working_dir = JobWorkingDirectory(job, app.object_store).create(legacy_extra_dir=str(job.id))
         datatypes_config = os.path.join(job_working_dir, "registry.xml")
         app.datatypes_registry.to_xml_file(path=datatypes_config)
         external_metadata_wrapper = get_metadata_compute_strategy(app.config, job.id, tool_id=tool.id)

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -11,6 +11,7 @@ from galaxy import (
     exceptions,
     util,
 )
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.model import (
     Job,
@@ -244,7 +245,5 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         return False
 
     def __in_working_directory(self, job: Job, path: str, app: MinimalManagerApp):
-        working_directory = app.object_store.get_filename(
-            job, base_dir="job_work", dir_only=True, extra_dir=str(job.id)
-        )
+        working_directory = JobWorkingDirectory(job, app.object_store).resolve()
         return util.in_directory(path, working_directory)

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -247,5 +247,5 @@ class JobFilesAPIController(BaseGalaxyAPIController):
     def __in_working_directory(self, job: Job, path: str, app: MinimalManagerApp):
         # Use extra_dir=str(job.id) to match the legacy path that this site historically used;
         # this produces a different JWD than the obj_dir=True path used by regular jobs.
-        working_directory = JobWorkingDirectory(job, app.object_store).resolve(extra_dir=str(job.id))
+        working_directory = JobWorkingDirectory(job, app.object_store).resolve(legacy_extra_dir=str(job.id))
         return util.in_directory(path, working_directory)

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -11,7 +11,6 @@ from galaxy import (
     exceptions,
     util,
 )
-from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.model import (
     Job,
@@ -245,7 +244,12 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         return False
 
     def __in_working_directory(self, job: Job, path: str, app: MinimalManagerApp):
-        # Use extra_dir=str(job.id) to match the legacy path that this site historically used;
-        # this produces a different JWD than the obj_dir=True path used by regular jobs.
-        working_directory = JobWorkingDirectory(job, app.object_store).resolve(legacy_extra_dir=str(job.id))
+        # This site uses extra_dir=str(job.id), a different path scheme than the
+        # obj_dir=True sites that JobWorkingDirectory manages. Pulsar stages files
+        # to this path, so the security check must match it exactly. Do not route
+        # through JobWorkingDirectory — it would either assert (custom path) or
+        # resolve to the wrong location (obj_dir=True).
+        working_directory = app.object_store.get_filename(
+            job, base_dir="job_work", dir_only=True, extra_dir=str(job.id)
+        )
         return util.in_directory(path, working_directory)

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -245,5 +245,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         return False
 
     def __in_working_directory(self, job: Job, path: str, app: MinimalManagerApp):
-        working_directory = JobWorkingDirectory(job, app.object_store).resolve()
+        # Use extra_dir=str(job.id) to match the legacy path that this site historically used;
+        # this produces a different JWD than the obj_dir=True path used by regular jobs.
+        working_directory = JobWorkingDirectory(job, app.object_store).resolve(extra_dir=str(job.id))
         return util.in_directory(path, working_directory)

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -11,6 +11,7 @@ from galaxy import (
     exceptions,
     util,
 )
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.model import (
     Job,
@@ -244,12 +245,5 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         return False
 
     def __in_working_directory(self, job: Job, path: str, app: MinimalManagerApp):
-        # This site uses extra_dir=str(job.id), a different path scheme than the
-        # obj_dir=True sites that JobWorkingDirectory manages. Pulsar stages files
-        # to this path, so the security check must match it exactly. Do not route
-        # through JobWorkingDirectory — it would either assert (custom path) or
-        # resolve to the wrong location (obj_dir=True).
-        working_directory = app.object_store.get_filename(
-            job, base_dir="job_work", dir_only=True, extra_dir=str(job.id)
-        )
+        working_directory = JobWorkingDirectory(job, app.object_store).resolve()
         return util.in_directory(path, working_directory)

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -25,6 +25,7 @@ from sqlalchemy import select
 from tusclient import client
 
 from galaxy import model
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy.model.base import ensure_object_added_to_session
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
@@ -203,8 +204,7 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
         job.add_output_dataset("output1", output_hda)
         sa_session.commit()
         self._app.object_store.create(output_hda.dataset)
-        self._app.object_store.create(job, base_dir="job_work", dir_only=True, obj_dir=True)
-        working_directory = self._app.object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
+        working_directory = JobWorkingDirectory(job, self._app.object_store).create()
         return job, output_hda, working_directory
 
     def _api_job_keys(self, job):

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -5,6 +5,7 @@ import os
 from sqlalchemy import select
 
 from galaxy import model
+from galaxy.job_execution.setup import JobWorkingDirectory
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
@@ -66,10 +67,8 @@ class TestEmbeddedPulsarIntegrationInstance(integration_util.IntegrationTestCase
             sa_session = self._app.model.session
             job = sa_session.scalars(select(model.Job).filter_by(id=job_id_decoded)).one()
 
-            # Get the job working directory using the object store
-            job_working_directory = self._app.object_store.get_filename(
-                job, base_dir="job_work", dir_only=True, obj_dir=True
-            )
+            # Get the job working directory
+            job_working_directory = JobWorkingDirectory(job, self._app.object_store).resolve()
             assert job_working_directory is not None, "Could not determine job working directory"
 
             # Verify that do_not_collect_me.txt does NOT exist in the Galaxy job working directory

--- a/test/unit/app/test_tasks.py
+++ b/test/unit/app/test_tasks.py
@@ -1,3 +1,4 @@
+import os
 from datetime import (
     datetime,
     timedelta,
@@ -75,101 +76,71 @@ class TestCleanupJwds:
         object_store = MagicMock()
         result = _cleanup_jwds(sa_session, object_store, days=7)
         assert result == 0
-        object_store.get_filename.assert_not_called()
+        object_store.delete.assert_not_called()
 
-    def test_deletes_jwd_for_old_failed_jobs(self, sa_session, tmp_path):
+    def test_deletes_jwd_for_old_failed_jobs(self, sa_session):
+        """Legacy job (working_directory=None): object_store.delete is called."""
         job = _make_job(state="error", age_days=10)
         sa_session.add(job)
         sa_session.commit()
 
-        jwd_path = tmp_path / "job_work" / str(job.id)
-        jwd_path.mkdir(parents=True)
-        (jwd_path / "some_file.txt").write_text("job output")
-
         object_store = MagicMock()
-        object_store.get_filename.return_value = str(jwd_path)
-
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 1
-        object_store.get_filename.assert_called_once()
-        assert isinstance(object_store.get_filename.call_args[0][0], model.Job)
-        assert not jwd_path.exists()
+        object_store.delete.assert_called_once()
+        call_args = object_store.delete.call_args
+        assert isinstance(call_args[0][0], model.Job)
+        assert call_args[1]["base_dir"] == "job_work"
+        assert call_args[1]["entire_dir"] is True
 
-    def test_deletes_multiple_old_failed_jobs(self, sa_session, tmp_path):
+    def test_deletes_multiple_old_failed_jobs(self, sa_session):
         jobs = [_make_job(state="error", age_days=10) for _ in range(3)]
         sa_session.add_all(jobs)
         sa_session.commit()
 
-        jwd_paths = []
-        for job in jobs:
-            jwd_path = tmp_path / "job_work" / str(job.id)
-            jwd_path.mkdir(parents=True)
-            jwd_paths.append(jwd_path)
-
         object_store = MagicMock()
-        object_store.get_filename.side_effect = [str(p) for p in jwd_paths]
-
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 3
-        assert object_store.get_filename.call_count == 3
-        assert all(not p.exists() for p in jwd_paths)
+        assert object_store.delete.call_count == 3
 
-    def test_skips_jobs_not_old_enough(self, sa_session, tmp_path):
+    def test_skips_jobs_not_old_enough(self, sa_session):
         job = _make_job(state="error", age_days=1)
         sa_session.add(job)
         sa_session.commit()
 
-        jwd_path = tmp_path / "job_work" / str(job.id)
-        jwd_path.mkdir(parents=True)
-
         object_store = MagicMock()
-        object_store.get_filename.return_value = str(jwd_path)
-
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 0
-        object_store.get_filename.assert_not_called()
-        assert jwd_path.exists()
+        object_store.delete.assert_not_called()
 
-    def test_skips_non_failed_jobs(self, sa_session, tmp_path):
+    def test_skips_non_failed_jobs(self, sa_session):
         job = _make_job(state="ok", age_days=30)
         sa_session.add(job)
         sa_session.commit()
 
-        jwd_path = tmp_path / "job_work" / str(job.id)
-        jwd_path.mkdir(parents=True)
-
         object_store = MagicMock()
-        object_store.get_filename.return_value = str(jwd_path)
-
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 0
-        object_store.get_filename.assert_not_called()
-        assert jwd_path.exists()
+        object_store.delete.assert_not_called()
 
-    def test_deletes_jwd_for_jobs_without_object_store_id(self, sa_session, tmp_path):
+    def test_deletes_jwd_for_jobs_without_object_store_id(self, sa_session):
         """Jobs using the default object store have object_store_id=None but should still be cleaned up."""
         job = _make_job(state="error", age_days=10)
         job.object_store_id = None
         sa_session.add(job)
         sa_session.commit()
 
-        jwd_path = tmp_path / "job_work" / str(job.id)
-        jwd_path.mkdir(parents=True)
-
         object_store = MagicMock()
-        object_store.get_filename.return_value = str(jwd_path)
-
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 1
-        object_store.get_filename.assert_called_once()
-        assert not jwd_path.exists()
+        object_store.delete.assert_called_once()
 
-    def test_only_deletes_matching_jobs_when_mixed(self, sa_session, tmp_path):
+    def test_only_deletes_matching_jobs_when_mixed(self, sa_session):
         """With both matching and non-matching jobs in the DB, only matching ones are deleted.
 
         This catches the 'Query is always truthy' bug: without .all(), the `if not failed_jobs`
@@ -187,28 +158,57 @@ class TestCleanupJwds:
         sa_session.add_all([old_failed, no_store, old_ok, recent_failed])
         sa_session.commit()
 
-        jwd_matching = tmp_path / "job_work" / str(old_failed.id)
-        jwd_matching.mkdir(parents=True)
-        jwd_no_store = tmp_path / "job_work" / str(no_store.id)
-        jwd_no_store.mkdir(parents=True)
-
         object_store = MagicMock()
-        object_store.get_filename.side_effect = [str(jwd_matching), str(jwd_no_store)]
-
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 2
-        assert object_store.get_filename.call_count == 2
-        assert not jwd_matching.exists()
-        assert not jwd_no_store.exists()
+        assert object_store.delete.call_count == 2
 
     def test_handles_already_deleted_jwd(self, sa_session):
+        """When object_store.delete raises ObjectNotFound, the job is skipped."""
         job = _make_job(state="error", age_days=10)
         sa_session.add(job)
         sa_session.commit()
 
         object_store = MagicMock()
-        object_store.get_filename.side_effect = ObjectNotFound("JWD not found")
+        object_store.delete.side_effect = ObjectNotFound("JWD not found")
 
         result = _cleanup_jwds(sa_session, object_store, days=7)
         assert result == 0
+
+    def test_deletes_custom_path_jwd(self, sa_session, tmp_path):
+        """Custom-path job (working_directory set): shutil.rmtree is used on the custom path."""
+        job = _make_job(state="error", age_days=10)
+        jwd_path = tmp_path / "custom_jwd" / str(job.id)
+        jwd_path.mkdir(parents=True)
+        (jwd_path / "some_file.txt").write_text("job output")
+        job.working_directory = str(jwd_path)
+        sa_session.add(job)
+        sa_session.commit()
+
+        object_store = MagicMock()
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 1
+        object_store.delete.assert_not_called()
+        assert not jwd_path.exists()
+
+    def test_handles_os_error_on_delete(self, sa_session, tmp_path):
+        """OSError during delete is logged and the job is skipped."""
+        job = _make_job(state="error", age_days=10)
+        jwd_path = tmp_path / "custom_jwd" / str(job.id)
+        jwd_path.mkdir(parents=True)
+        job.working_directory = str(jwd_path)
+        sa_session.add(job)
+        sa_session.commit()
+
+        object_store = MagicMock()
+        # Make shutil.rmtree fail by making the directory read-only
+        os.chmod(jwd_path, 0o000)
+
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 0
+        object_store.delete.assert_not_called()
+        # Restore permissions for cleanup
+        os.chmod(jwd_path, 0o755)

--- a/test/unit/app/test_tasks.py
+++ b/test/unit/app/test_tasks.py
@@ -75,10 +75,12 @@ class TestCleanupJwds:
     def mock_jwd_delete(self, mocker):
         """Patch ``JobWorkingDirectory.delete`` and return the mock.
 
-        The patched method is a no-op by default; individual tests can configure
-        side effects to simulate errors.
+        The patched method returns ``True`` by default (simulating a successful
+        deletion); individual tests can configure side effects to simulate errors.
         """
-        return mocker.patch("galaxy.celery.tasks.JobWorkingDirectory.delete")
+        mock = mocker.patch("galaxy.celery.tasks.JobWorkingDirectory.delete")
+        mock.return_value = True
+        return mock
 
     def test_no_failed_jobs_returns_zero(self, sa_session, mock_jwd_delete):
         object_store = MagicMock()
@@ -180,6 +182,18 @@ class TestCleanupJwds:
         result = _cleanup_jwds(sa_session, object_store, days=7)
         assert result == 0
 
+    def test_delete_returning_false_is_not_counted(self, sa_session, mock_jwd_delete):
+        """When JobWorkingDirectory.delete returns False (nothing deleted), the job is not counted."""
+        job = _make_job(state="error", age_days=10)
+        sa_session.add(job)
+        sa_session.commit()
+
+        mock_jwd_delete.return_value = False
+
+        object_store = MagicMock()
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+        assert result == 0
+
     def test_handles_os_error_on_delete(self, sa_session, mock_jwd_delete):
         """OSError from JobWorkingDirectory.delete is logged and the job is skipped."""
         job = _make_job(state="error", age_days=10)
@@ -200,7 +214,7 @@ class TestCleanupJwds:
         sa_session.commit()
 
         # The second job fails; the first and third should still be counted.
-        mock_jwd_delete.side_effect = [None, OSError("disk failure"), None]
+        mock_jwd_delete.side_effect = [True, OSError("disk failure"), True]
 
         object_store = MagicMock()
         result = _cleanup_jwds(sa_session, object_store, days=7)

--- a/test/unit/app/test_tasks.py
+++ b/test/unit/app/test_tasks.py
@@ -1,4 +1,3 @@
-import os
 from datetime import (
     datetime,
     timedelta,
@@ -19,7 +18,6 @@ from galaxy.exceptions import ObjectNotFound
 from galaxy.model.unittest_utils.model_testing_utils import initialize_model
 from galaxy.objectstore import BaseObjectStore
 from galaxy.objectstore.caching import CacheTarget
-from galaxy.util import directory_hash_id
 
 
 class MockObjectStore:
@@ -73,14 +71,23 @@ def _make_job(state: str, age_days: int) -> model.Job:
 class TestCleanupJwds:
     """Tests for _cleanup_jwds using a real in-memory database with actual Job model instances."""
 
-    def test_no_failed_jobs_returns_zero(self, sa_session):
+    @pytest.fixture
+    def mock_jwd_delete(self, mocker):
+        """Patch ``JobWorkingDirectory.delete`` and return the mock.
+
+        The patched method is a no-op by default; individual tests can configure
+        side effects to simulate errors.
+        """
+        return mocker.patch("galaxy.celery.tasks.JobWorkingDirectory.delete")
+
+    def test_no_failed_jobs_returns_zero(self, sa_session, mock_jwd_delete):
         object_store = MagicMock()
         result = _cleanup_jwds(sa_session, object_store, days=7)
         assert result == 0
-        object_store.delete.assert_not_called()
+        mock_jwd_delete.assert_not_called()
 
-    def test_deletes_jwd_for_old_failed_jobs(self, sa_session):
-        """Legacy job (working_directory=None): object_store.delete is called."""
+    def test_deletes_jwd_for_old_failed_jobs(self, sa_session, mock_jwd_delete):
+        """A matching job is delegated to JobWorkingDirectory.delete and counted."""
         job = _make_job(state="error", age_days=10)
         sa_session.add(job)
         sa_session.commit()
@@ -89,13 +96,9 @@ class TestCleanupJwds:
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 1
-        object_store.delete.assert_called_once()
-        call_args = object_store.delete.call_args
-        assert isinstance(call_args[0][0], model.Job)
-        assert call_args[1]["base_dir"] == "job_work"
-        assert call_args[1]["entire_dir"] is True
+        mock_jwd_delete.assert_called_once()
 
-    def test_deletes_multiple_old_failed_jobs(self, sa_session):
+    def test_deletes_multiple_old_failed_jobs(self, sa_session, mock_jwd_delete):
         jobs = [_make_job(state="error", age_days=10) for _ in range(3)]
         sa_session.add_all(jobs)
         sa_session.commit()
@@ -104,9 +107,9 @@ class TestCleanupJwds:
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 3
-        assert object_store.delete.call_count == 3
+        assert mock_jwd_delete.call_count == 3
 
-    def test_skips_jobs_not_old_enough(self, sa_session):
+    def test_skips_jobs_not_old_enough(self, sa_session, mock_jwd_delete):
         job = _make_job(state="error", age_days=1)
         sa_session.add(job)
         sa_session.commit()
@@ -115,9 +118,9 @@ class TestCleanupJwds:
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 0
-        object_store.delete.assert_not_called()
+        mock_jwd_delete.assert_not_called()
 
-    def test_skips_non_failed_jobs(self, sa_session):
+    def test_skips_non_failed_jobs(self, sa_session, mock_jwd_delete):
         job = _make_job(state="ok", age_days=30)
         sa_session.add(job)
         sa_session.commit()
@@ -126,9 +129,9 @@ class TestCleanupJwds:
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 0
-        object_store.delete.assert_not_called()
+        mock_jwd_delete.assert_not_called()
 
-    def test_deletes_jwd_for_jobs_without_object_store_id(self, sa_session):
+    def test_deletes_jwd_for_jobs_without_object_store_id(self, sa_session, mock_jwd_delete):
         """Jobs using the default object store have object_store_id=None but should still be cleaned up."""
         job = _make_job(state="error", age_days=10)
         job.object_store_id = None
@@ -139,9 +142,9 @@ class TestCleanupJwds:
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 1
-        object_store.delete.assert_called_once()
+        mock_jwd_delete.assert_called_once()
 
-    def test_only_deletes_matching_jobs_when_mixed(self, sa_session):
+    def test_only_deletes_matching_jobs_when_mixed(self, sa_session, mock_jwd_delete):
         """With both matching and non-matching jobs in the DB, only matching ones are deleted.
 
         This catches the 'Query is always truthy' bug: without .all(), the `if not failed_jobs`
@@ -163,62 +166,44 @@ class TestCleanupJwds:
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 2
-        assert object_store.delete.call_count == 2
+        assert mock_jwd_delete.call_count == 2
 
-    def test_handles_already_deleted_jwd(self, sa_session):
-        """When object_store.delete raises ObjectNotFound, the job is skipped."""
+    def test_handles_already_deleted_jwd(self, sa_session, mock_jwd_delete):
+        """When JobWorkingDirectory.delete raises ObjectNotFound, the job is skipped."""
         job = _make_job(state="error", age_days=10)
         sa_session.add(job)
         sa_session.commit()
 
-        object_store = MagicMock()
-        object_store.delete.side_effect = ObjectNotFound("JWD not found")
+        mock_jwd_delete.side_effect = ObjectNotFound("JWD not found")
 
+        object_store = MagicMock()
         result = _cleanup_jwds(sa_session, object_store, days=7)
         assert result == 0
 
-    def test_deletes_custom_path_jwd(self, sa_session, tmp_path):
-        """Custom-path job (working_directory set): shutil.rmtree is used on the per-job subdir."""
+    def test_handles_os_error_on_delete(self, sa_session, mock_jwd_delete):
+        """OSError from JobWorkingDirectory.delete is logged and the job is skipped."""
         job = _make_job(state="error", age_days=10)
-        # The column holds the parent base; the per-job dir is <base>/<hash>/<job.id>/.
-        base = tmp_path / "custom_jwd"
-        base.mkdir(parents=True)
-        job.working_directory = str(base)
         sa_session.add(job)
         sa_session.commit()
 
-        jwd_path = base.joinpath(*directory_hash_id(job.id), str(job.id))
-        jwd_path.mkdir(parents=True)
-        (jwd_path / "some_file.txt").write_text("job output")
+        mock_jwd_delete.side_effect = OSError("disk failure")
 
         object_store = MagicMock()
-        result = _cleanup_jwds(sa_session, object_store, days=7)
-
-        assert result == 1
-        object_store.delete.assert_not_called()
-        assert not jwd_path.exists()
-        # The parent base must survive — other jobs may share it.
-        assert base.exists()
-
-    def test_handles_os_error_on_delete(self, sa_session, tmp_path):
-        """OSError during delete is logged and the job is skipped."""
-        job = _make_job(state="error", age_days=10)
-        base = tmp_path / "custom_jwd"
-        base.mkdir(parents=True)
-        job.working_directory = str(base)
-        sa_session.add(job)
-        sa_session.commit()
-
-        jwd_path = base.joinpath(*directory_hash_id(job.id), str(job.id))
-        jwd_path.mkdir(parents=True)
-
-        object_store = MagicMock()
-        # Make shutil.rmtree fail by making the per-job directory read-only
-        os.chmod(jwd_path, 0o000)
-
         result = _cleanup_jwds(sa_session, object_store, days=7)
 
         assert result == 0
-        object_store.delete.assert_not_called()
-        # Restore permissions for cleanup
-        os.chmod(jwd_path, 0o755)
+
+    def test_continues_after_error_on_one_job(self, sa_session, mock_jwd_delete):
+        """An error deleting one job's JWD does not prevent deleting subsequent jobs."""
+        jobs = [_make_job(state="error", age_days=10) for _ in range(3)]
+        sa_session.add_all(jobs)
+        sa_session.commit()
+
+        # The second job fails; the first and third should still be counted.
+        mock_jwd_delete.side_effect = [None, OSError("disk failure"), None]
+
+        object_store = MagicMock()
+        result = _cleanup_jwds(sa_session, object_store, days=7)
+
+        assert result == 2
+        assert mock_jwd_delete.call_count == 3

--- a/test/unit/app/test_tasks.py
+++ b/test/unit/app/test_tasks.py
@@ -19,6 +19,7 @@ from galaxy.exceptions import ObjectNotFound
 from galaxy.model.unittest_utils.model_testing_utils import initialize_model
 from galaxy.objectstore import BaseObjectStore
 from galaxy.objectstore.caching import CacheTarget
+from galaxy.util import directory_hash_id
 
 
 class MockObjectStore:
@@ -177,14 +178,18 @@ class TestCleanupJwds:
         assert result == 0
 
     def test_deletes_custom_path_jwd(self, sa_session, tmp_path):
-        """Custom-path job (working_directory set): shutil.rmtree is used on the custom path."""
+        """Custom-path job (working_directory set): shutil.rmtree is used on the per-job subdir."""
         job = _make_job(state="error", age_days=10)
-        jwd_path = tmp_path / "custom_jwd" / str(job.id)
-        jwd_path.mkdir(parents=True)
-        (jwd_path / "some_file.txt").write_text("job output")
-        job.working_directory = str(jwd_path)
+        # The column holds the parent base; the per-job dir is <base>/<hash>/<job.id>/.
+        base = tmp_path / "custom_jwd"
+        base.mkdir(parents=True)
+        job.working_directory = str(base)
         sa_session.add(job)
         sa_session.commit()
+
+        jwd_path = base.joinpath(*directory_hash_id(job.id), str(job.id))
+        jwd_path.mkdir(parents=True)
+        (jwd_path / "some_file.txt").write_text("job output")
 
         object_store = MagicMock()
         result = _cleanup_jwds(sa_session, object_store, days=7)
@@ -192,18 +197,23 @@ class TestCleanupJwds:
         assert result == 1
         object_store.delete.assert_not_called()
         assert not jwd_path.exists()
+        # The parent base must survive — other jobs may share it.
+        assert base.exists()
 
     def test_handles_os_error_on_delete(self, sa_session, tmp_path):
         """OSError during delete is logged and the job is skipped."""
         job = _make_job(state="error", age_days=10)
-        jwd_path = tmp_path / "custom_jwd" / str(job.id)
-        jwd_path.mkdir(parents=True)
-        job.working_directory = str(jwd_path)
+        base = tmp_path / "custom_jwd"
+        base.mkdir(parents=True)
+        job.working_directory = str(base)
         sa_session.add(job)
         sa_session.commit()
 
+        jwd_path = base.joinpath(*directory_hash_id(job.id), str(job.id))
+        jwd_path.mkdir(parents=True)
+
         object_store = MagicMock()
-        # Make shutil.rmtree fail by making the directory read-only
+        # Make shutil.rmtree fail by making the per-job directory read-only
         os.chmod(jwd_path, 0o000)
 
         result = _cleanup_jwds(sa_session, object_store, days=7)

--- a/test/unit/job_execution/test_job_working_directory.py
+++ b/test/unit/job_execution/test_job_working_directory.py
@@ -68,15 +68,17 @@ class TestJobWorkingDirectoryCustomPath:
         # The base must exist too (as parent of the per-job dir).
         assert os.path.isdir(base)
 
-    def test_create_raises_on_preexisting_per_job_dir(self, tmp_path, object_store):
+    def test_create_is_idempotent_on_preexisting_per_job_dir(self, tmp_path, object_store):
+        """create() returns the same path without error if the directory already exists."""
         base = str(tmp_path / "jobs")
         job = _make_job(100)
         job.working_directory = base
         jwd = JobWorkingDirectory(job, object_store)
 
-        jwd.create()
-        with pytest.raises(FileExistsError, match="already exists for job 100"):
-            jwd.create()
+        path1 = jwd.create()
+        path2 = jwd.create()
+        assert path1 == path2
+        assert os.path.isdir(path1)
 
     def test_exists_reflects_per_job_dir(self, tmp_path, object_store):
         base = str(tmp_path / "jobs")

--- a/test/unit/job_execution/test_job_working_directory.py
+++ b/test/unit/job_execution/test_job_working_directory.py
@@ -98,8 +98,7 @@ class TestJobWorkingDirectoryCustomPath:
         with open(os.path.join(path, "output.txt"), "w") as f:
             f.write("data")
 
-        jwd.delete()
-
+        assert jwd.delete() is True
         assert not os.path.exists(path)
         # The base must survive — other jobs may share it.
         assert os.path.isdir(base)
@@ -112,7 +111,7 @@ class TestJobWorkingDirectoryCustomPath:
         jwd = JobWorkingDirectory(job, object_store)
 
         # Should not raise even though the per-job dir was never created.
-        jwd.delete()
+        assert jwd.delete() is False
         assert os.path.isdir(base)
 
     def test_cleared_contents_base_returns_root_divergent_path(self, tmp_path, object_store):

--- a/test/unit/job_execution/test_job_working_directory.py
+++ b/test/unit/job_execution/test_job_working_directory.py
@@ -1,0 +1,168 @@
+"""Unit tests for `JobWorkingDirectory` per-job isolation of custom paths.
+
+These tests verify that a custom ``job.working_directory`` (set from the
+``job_working_directory`` destination param) is treated as a parent/base and
+that Galaxy appends ``<directory_hash_id(job.id)>/<job.id>/`` for per-job
+isolation, mirroring the object-store layout.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from galaxy.job_execution.setup import JobWorkingDirectory
+from galaxy.model import Job
+from galaxy.util import directory_hash_id
+
+
+def _make_job(job_id: int) -> Job:
+    job = Job()
+    job.id = job_id
+    return job
+
+
+def _expected_per_job_path(base: str, job_id: int) -> str:
+    return os.path.join(base, *directory_hash_id(job_id), str(job_id))
+
+
+def _expected_cleared_path(base: str, job_id: int) -> str:
+    return os.path.join(base, "_cleared_contents", *directory_hash_id(job_id), str(job_id))
+
+
+@pytest.fixture
+def object_store() -> MagicMock:
+    return MagicMock()
+
+
+class TestJobWorkingDirectoryCustomPath:
+    """Custom-path branch (``job.working_directory`` set)."""
+
+    def test_resolve_returns_per_job_path(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job = _make_job(100)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        assert jwd.resolve() == _expected_per_job_path(base, 100)
+
+    def test_resolve_uses_hash_for_large_ids(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job = _make_job(777777777)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        assert jwd.resolve() == _expected_per_job_path(base, 777777777)
+        # Sanity check the sharding for a large numeric id.
+        assert directory_hash_id(777777777) == ["000", "777", "777"]
+
+    def test_create_makes_per_job_dir(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job = _make_job(100)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        path = jwd.create()
+        assert path == _expected_per_job_path(base, 100)
+        assert os.path.isdir(path)
+        # The base must exist too (as parent of the per-job dir).
+        assert os.path.isdir(base)
+
+    def test_create_raises_on_preexisting_per_job_dir(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job = _make_job(100)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        jwd.create()
+        with pytest.raises(FileExistsError, match="already exists for job 100"):
+            jwd.create()
+
+    def test_exists_reflects_per_job_dir(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job = _make_job(100)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        assert not jwd.exists()
+        jwd.create()
+        assert jwd.exists()
+
+    def test_delete_removes_per_job_dir_only(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job = _make_job(100)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        path = jwd.create()
+        with open(os.path.join(path, "output.txt"), "w") as f:
+            f.write("data")
+
+        jwd.delete()
+
+        assert not os.path.exists(path)
+        # The base must survive — other jobs may share it.
+        assert os.path.isdir(base)
+
+    def test_delete_is_noop_when_per_job_dir_missing(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        os.makedirs(base)
+        job = _make_job(100)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        # Should not raise even though the per-job dir was never created.
+        jwd.delete()
+        assert os.path.isdir(base)
+
+    def test_cleared_contents_base_returns_root_divergent_path(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job = _make_job(100)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        cleared = jwd.cleared_contents_base()
+        assert cleared == _expected_cleared_path(base, 100)
+        assert os.path.isdir(cleared)
+        # The cleared path must NOT be inside the per-job JWD path.
+        jwd_path = _expected_per_job_path(base, 100)
+        assert not cleared.startswith(jwd_path + os.sep)
+
+    def test_cleared_contents_base_is_sibling_of_jwd(self, tmp_path, object_store):
+        """Both the JWD and the archive are rooted at <base>; neither contains the other."""
+        base = str(tmp_path / "jobs")
+        job = _make_job(777777777)
+        job.working_directory = base
+        jwd = JobWorkingDirectory(job, object_store)
+
+        jwd_path = jwd.resolve()
+        cleared = jwd.cleared_contents_base()
+
+        # Both share the base as a common ancestor and diverge below it.
+        assert os.path.commonpath([jwd_path, cleared]) == base
+
+    def test_two_jobs_sharing_base_get_distinct_paths(self, tmp_path, object_store):
+        base = str(tmp_path / "jobs")
+        job_a = _make_job(100)
+        job_a.working_directory = base
+        job_b = _make_job(101)
+        job_b.working_directory = base
+
+        jwd_a = JobWorkingDirectory(job_a, object_store)
+        jwd_b = JobWorkingDirectory(job_b, object_store)
+
+        assert jwd_a.resolve() != jwd_b.resolve()
+        assert jwd_a.cleared_contents_base() != jwd_b.cleared_contents_base()
+
+
+class TestJobWorkingDirectoryObjectStore:
+    """Object-store branch (``job.working_directory`` unset) delegates unchanged."""
+
+    def test_resolve_delegates_to_object_store(self, object_store):
+        job = _make_job(100)
+        job.working_directory = None
+        jwd = JobWorkingDirectory(job, object_store)
+
+        object_store.get_filename.return_value = "/data/job_work/000/100"
+        assert jwd.resolve() == "/data/job_work/000/100"
+        object_store.get_filename.assert_called_once()


### PR DESCRIPTION
Implements **Phase A** of the plan discussed in [#23107](https://github.com/galaxyproject/galaxy/discussions/23107): decouple the job working directory (JWD) from the object store and make it a job-level concern, resolved once from destination params and persisted on the `Job` row. This closes the proposed use case from [#15616](https://github.com/galaxyproject/galaxy/issues/15616) (overriding `job_working_directory` per destination via TPV) and lays the groundwork for the weighted-pool / drain behavior requested in [#20062](https://github.com/galaxyproject/galaxy/issues/20062).

The approach follows the counter-proposal in the discussion: mirror how `object_store_id` already flows (read from destination params in `enqueue()`, persisted on the row) rather than hash-deriving from a weighted pool. No config schema, no resolver service, no weighting code in Galaxy.

Related TPV pull request https://github.com/galaxyproject/total-perspective-vortex/pull/202

## What changed

- **New `Job.working_directory` column** (`String(1024)`, mirroring the existing `Task.working_directory`) added via migration `e96dd6fd5863`. Persisted when a destination specifies `job_working_directory`; `NULL` means "use the legacy object-store path".

- **`JobWorkingDirectory` class** in `lib/galaxy/job_execution/setup.py` centralizes all JWD operations (`resolve`, `exists`, `create`, `delete`, `cleared_contents_base`) behind a single handle, replacing the open-coded `object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)` calls scattered across the codebase. It transparently picks the custom-path strategy when `job.working_directory` is set and falls back to the object-store strategy otherwise, so callers never branch on the column.

  The custom path is treated as a **parent/base**: Galaxy appends `<directory_hash_id(job.id)>/<job.id>/` for per-job isolation, mirroring the object-store layout. This means a `job_working_directory` destination param (e.g. set by TPV from a weighted pool, see https://github.com/galaxyproject/total-perspective-vortex/pull/202) is the base directory, and each job gets its own subdirectory under it.

- **`_set_working_directory`** in `MinimalJobWrapper` resolves `job_working_directory` from the persisted `job.destination_params` (not via `get_destination_configuration`, which would fall back to the config default and persist it even for destinations that don't specify one) and writes it to `job.working_directory`. Called from `_setup_working_directory` before anything is created on disk. Reset to `None` on resubmit when the new destination no longer specifies a custom path, so stale values don't survive.

- **`validate_working_directory_path`** guards every disk operation on a custom path (and at set-time): refuses empty, relative, or filesystem-root paths, since `job.working_directory` is an admin/TPV-supplied string that `shutil.rmtree` obeys literally.

- **Resubmit reorder** in `resubmit.py`: `set_job_destination` (which persists the new `destination_params`) now runs before `clear_working_directory`, so the latter's `_setup_working_directory` → `_set_working_directory` reads the new params and resolves the new JWD correctly. Previously the order was inverted, so a resubmitted job resolved its JWD against the stale destination. `clear_working_directory` now flushes so the mutated `working_directory` column survives the `sa_session.refresh()` that `mark_as_resubmitted()` performs.

- **Init-order fix** in `MinimalJobWrapper.__init__`: `self.params` is now initialized before `_setup_working_directory`, since that call chain reaches `get_destination_configuration` via the `job_destination` property.

- **Callers migrated to `JobWorkingDirectory`**: `MinimalJobWrapper` (`working_directory`, `working_directory_exists`, `_create_working_directory`, `clear_working_directory`, `finish` cleanup), `JobManager` stdout/stderr tail, `SetMetadataTool.exec_after_process`, `ExportHistoryToolAction`, the Celery `cleanup_jwds` task, `tools/actions/metadata.py` (out-of-band metadata job), and `webapps/galaxy/api/job_files.py` (Pulsar staging security check). The previously out-of-band sites that used `extra_dir=str(job.id)` are now also routed through `JobWorkingDirectory`, which resolves to the same path via `obj_dir=True`.

## Why

- The JWD is a **job concern, not an object store concern**. The object store manages datasets and their lifecycle; the working directory is transient scratch space tied to a specific job execution. Coupling them forces every JWD lookup to go through object-store resolution, which assumes a backing store has already been assigned — an assumption that doesn't hold during enqueue, resubmit, or cleanup.
- **Distribution across multiple JWD mounts.** Persisting a per-job path lets admins (via TPV or destination params, see https://github.com/galaxyproject/total-perspective-vortex/pull/202) spread jobs across several `job_working_directory` mounts, enabling load balancing across disks or nodes. Because each job's JWD is resolved once and stored on the row, in-flight jobs are unaffected when the distribution rule changes.
- Persistence stops being optional. Galaxy cannot re-derive what TPV decided, so the value is persisted — the "mutate weights and lose in-flight JWDs" bug from the original Phase A draft becomes unrepresentable.
- Drain works. Change the rule; in-flight jobs keep their persisted path.
- Recovery is free. TPV params land in `job.destination_params`, and recovery rebuilds from `from_job=job` without re-running the rule.
- Reads stop depending on the destination. `working_directory` no longer raises `ObjectNotFound` for jobs whose object store hasn't been assigned yet.

## Tests

- New unit tests in `test/unit/job_execution/test_job_working_directory.py` covering `JobWorkingDirectory` per-job isolation of custom paths (resolve, create, delete, cleared_contents_base, validation).
- Updated `test/unit/app/test_tasks.py` (cleanup task), `test/integration/test_job_files.py`, and `test/integration/test_pulsar_embedded.py` to use the `JobWorkingDirectory` abstraction.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  See https://github.com/galaxyproject/galaxy/pull/23133#issuecomment-5043970443 for configuration examples.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
