### PR TITLE
[26.1] Make verify_collection fail usefully on output-shape mismatches

### DIFF
--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -868,6 +868,18 @@ class RequiredFiles:
         return files
 
 
+def resolve_element_tests(as_dict):
+    """Return the nested element tests, preferring the "element_tests" key over its "elements" alias.
+
+    "element_tests" is the preferred key; "elements" is the accepted alias (see
+    https://github.com/galaxyproject/planemo/pull/1417). Both the top-level test definition and each
+    nested collection element may use either, so resolution goes through this single function.
+    """
+    if as_dict.get("element_tests") is not None:
+        return as_dict["element_tests"]
+    return as_dict.get("elements", {})
+
+
 class TestCollectionOutputDef:
     __test__ = False  # Prevent pytest from discovering this class (issue #12071)
 
@@ -900,10 +912,9 @@ class TestCollectionOutputDef:
         if "attributes" not in as_dict:
             as_dict["attributes"] = {}
         attributes = as_dict["attributes"]
-        # setup preferred name "elements" in accordance with work in https://github.com/galaxyproject/planemo/pull/1417
-        # TODO: test this works recursively...
-        if "elements" in as_dict and "element_tests" not in as_dict:
-            as_dict["element_tests"] = as_dict["elements"]
+        # setup preferred name "element_tests" in accordance with work in https://github.com/galaxyproject/planemo/pull/1417
+        if "elements" in as_dict or "element_tests" in as_dict:
+            as_dict["element_tests"] = resolve_element_tests(as_dict)
         if "collection_type" in as_dict:
             attributes["type"] = as_dict["collection_type"]
         return TestCollectionOutputDef.from_dict(as_dict)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -46,6 +46,7 @@ from galaxy.tool_util.parameters import (
     ToolParameterBundle,
 )
 from galaxy.tool_util.parser.interface import (
+    resolve_element_tests,
     TestCollectionDef,
     TestCollectionOutputDef,
     TestSourceTestOutputColllection,
@@ -1493,6 +1494,13 @@ def verify_hid(
 def verify_collection(output_collection_def, data_collection, verify_dataset):
     name = output_collection_def.name
 
+    if "elements" not in data_collection:
+        message = (
+            f"Output collection '{name}': expected a collection, but the output was a single dataset — "
+            "use 'asserts' instead of 'element_tests'."
+        )
+        raise AssertionError(message)
+
     expected_collection_type = output_collection_def.collection_type
     if expected_collection_type:
         collection_type = data_collection["collection_type"]
@@ -1540,7 +1548,7 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
             else:
                 elements = element["object"]["elements"]
                 element_count = len(elements)
-                verify_elements(elements, element_attrib.get("elements", {}))
+                verify_elements(elements, resolve_element_tests(element_attrib))
             expected_count = element_attrib.get("count")
             if expected_count is not None and expected_count != element_count:
                 raise AssertionError(

--- a/test/unit/tool_util/test_verify.py
+++ b/test/unit/tool_util/test_verify.py
@@ -16,6 +16,7 @@ import numpy
 import pytest
 from PIL import Image
 
+from galaxy.tool_util.parser.interface import TestCollectionOutputDef
 from galaxy.tool_util.verify import (
     files_contains,
     files_delta,
@@ -24,6 +25,7 @@ from galaxy.tool_util.verify import (
     files_re_match,
     files_re_match_multiline,
 )
+from galaxy.tool_util.verify.interactor import verify_collection
 
 F1 = b"A\nB\nC"
 F2 = b"A\nB\nD\nE" * 61
@@ -257,3 +259,56 @@ def test_files_image_diff(file1, file2, attributes, expect):
             files_image_diff(file1.path, file2.path, attributes)
     else:
         files_image_diff(file1.path, file2.path, attributes)
+
+
+def test_verify_collection_element_tests_on_single_dataset():
+    output_def = TestCollectionOutputDef.from_dict(
+        {
+            "name": "My Report",
+            "element_tests": {"sample1": {"asserts": {"has_text": {"text": "hello"}}}},
+        }
+    )
+    with pytest.raises(AssertionError) as exc_info:
+        verify_collection(output_def, {"path": "/tmp/whatever", "class": "File"}, lambda *a, **k: None)
+    assert "My Report" in str(exc_info.value)
+
+
+def _nested_data_collection():
+    return {
+        "collection_type": "list:list",
+        "elements": [
+            {
+                "element_identifier": "sample1",
+                "element_type": "dataset_collection",
+                "object": {
+                    "elements": [
+                        {"element_identifier": "dnacomp", "element_type": "hda", "_output_object": {}},
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def test_verify_collection_nested_element_tests_are_checked():
+    output_def = TestCollectionOutputDef.from_dict(
+        {
+            "name": "mapDamage Visualisation",
+            "element_tests": {"sample1": {"element_tests": {"dnacomp": {"asserts": {"has_text": {"text": "x"}}}}}},
+        }
+    )
+    calls = []
+    verify_collection(output_def, _nested_data_collection(), lambda el, a, o: calls.append(el["element_identifier"]))
+    assert calls == ["dnacomp"]
+
+
+def test_verify_collection_nested_elements_alias_still_checked():
+    output_def = TestCollectionOutputDef.from_dict(
+        {
+            "name": "mapDamage Visualisation",
+            "element_tests": {"sample1": {"elements": {"dnacomp": {"asserts": {"has_text": {"text": "x"}}}}}},
+        }
+    )
+    calls = []
+    verify_collection(output_def, _nested_data_collection(), lambda el, a, o: calls.append(el["element_identifier"]))
+    assert calls == ["dnacomp"]


### PR DESCRIPTION
## What

`verify_collection` (in `tool_util/verify/interactor.py`) had two failure modes when a test's output definition did not match the actual output shape. Both are fixed here, each with a regression test that fails on `main`/an unmodified tree and passes with the fix.

### Case 1 — `element_tests` on a non-collection output raised a bare `KeyError`

A workflow test whose output is a single dataset (HDA) but whose test uses `element_tests:` aborted the **entire** planemo run with an uncaught traceback:

```
File ".../tool_util/verify/interactor.py", line ..., in verify_collection
    actual_element_count = len(data_collection["elements"])
KeyError: 'elements'
```

planemo's caller only catches `AssertionError`, so the `KeyError` propagated out and killed the run — taking the results of every other output in a multi-output workflow with it. (Real case: a 12-output workflow ran green, 49/49 steps / 36/36 jobs; one output was an HDA because the tool reduced a collection, and diagnosing the crash needed reading planemo's source and querying the invocation over the API.)

Now it raises an `AssertionError` that names the output and says what to do instead, so it's collected as an ordinary test failure and the other outputs still get checked:

> `Output collection 'My Report': expected a collection, but the output was a single dataset — use 'asserts' instead of 'element_tests'.`

A single guard on the missing `elements` key covers both raw subscripts in the function (`collection_type` and `elements`), since a single dataset has neither.

### Case 2 — nested `element_tests` was silently ignored (test passed, asserted nothing)

For a nested collection (e.g. `list:list`), writing `element_tests:` at the nested level — the obvious guess, since that is the key one level up — caused the assertion to be **skipped silently**: no error, no warning, the test reported success while checking nothing. This is the more damaging of the two because it manufactures false confidence.

Root cause: the top level read `element_tests`, but the recursion inside `verify_elements` read `elements` only, so `.get("elements", {})` returned `{}` and the recursion did nothing.

**Fix — accept `element_tests` as an alias for `elements` at nested levels (conservative option).** The nested pydantic model (`TestCollectionCollectionElementAssertions`) already declares **both** `elements` and `element_tests` as valid keys, and `from_yaml_test_format` carried a literal `# TODO: test this works recursively...` above the top-level aliasing. So nested `element_tests` was never an unknown key or a typo — it was schema-valid but ignored at runtime. This change just makes the runtime honor the schema that already exists.

I deliberately did **not** take the stricter "raise on unknown keys" route: it wouldn't even fire here (the key is valid, not unknown), so catching this case would require first *removing* `element_tests` from the model — an API break, not a strictness tweak — which is inappropriate on a release branch. If we want loud typo detection, that belongs in a separate `dev`-targeted change.

The precedence ("`element_tests` preferred, `elements` the accepted alias") is now expressed once in a shared `resolve_element_tests` helper used by both the top-level `from_yaml_test_format` and the nested recursion, so the two levels are symmetric rather than papering over the asymmetry.

## Behavior change to be aware of

Both fixes surface previously-hidden failures — that is the point. Nested `element_tests` assertions that were silently skipped will now actually run, so a test that was quietly "passing" may now report a real (possibly failing) check. This is why the alias (backwards-compatible) route was chosen over the harder break for a release branch.

## Tests

New unit tests in `test/unit/tool_util/test_verify.py` (no Galaxy instance needed; the repro runs standalone):

- `test_verify_collection_element_tests_on_single_dataset` — asserts an `AssertionError` (not `KeyError`) whose message names the output.
- `test_verify_collection_nested_element_tests_are_checked` — asserts `verify_dataset` is actually invoked for the nested element.
- `test_verify_collection_nested_elements_alias_still_checked` — backwards-compat guard for the existing `elements` key.

Verified that the two bug-regression tests **fail on an unmodified tree for the right reason** (Case 1 raises the uncaught `KeyError`; Case 2 shows `verify_dataset` was never called) and pass with the fix.

## Targeting / backports

Base is `release_26.1` (oldest affected supported release), to be merged forward per convention. Both bugs are also present in `release_25.0`, `release_25.1`, and `release_26.0` — if those are still receiving fixes they likely want this too.

## Not a planemo change

planemo imports `verify_collection` and only dispatches on the presence of the `element_tests` key; both faulty subscripts were in galaxy, so no planemo change is needed.
