### PR TITLE
[26.1] Fix tool-form option pagination never updating the select (#23135)

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -380,31 +380,17 @@ export default {
                 this.history_id,
                 this.formData,
                 optionsPagination,
-            ).then((data) => {
-                const newInput = findInputByDottedName(data.inputs, name);
-                const target = findInputByDottedName(this.formConfig.inputs, name);
-                if (!newInput || !target) {
-                    return;
-                }
-                const existing = (target.options && target.options[src]) || [];
-                const incoming = (newInput.options && newInput.options[src]) || [];
-                const seen = new Set(existing.map((o) => `${o.id}_${o.src}`));
-                const appended = existing.concat(incoming.filter((o) => !seen.has(`${o.id}_${o.src}`)));
-                target.options = { ...target.options, [src]: appended };
-                if (newInput.options_meta && newInput.options_meta[src]) {
-                    target.options_meta = {
-                        ...(target.options_meta || {}),
-                        [src]: newInput.options_meta[src],
-                    };
-                }
-            });
+            ).then((data) => this.mergeFetchedOptions(name, src, data));
         },
         /**
          * Handle the user typing in the dropdown's search box. Refetch the
-         * parameter's options against the backend with the search filter and
-         * **replace** (not append) the local options/meta — we want the
-         * narrowed list, not a union with whatever was previously loaded.
-         * An empty query effectively resets to the default first page.
+         * parameter's options against the backend with the search filter, then
+         * MERGE (not replace) the server matches into the already-loaded options.
+         * Merging keeps the list non-empty and preserves any already-loaded or
+         * selected options, so the multiselect (and its focused search input) is
+         * never unmounted mid-typing; the client-side filter still narrows the
+         * union down to the typed query. An empty query fetches the default first
+         * page. Debounced upstream in ``FormSelect``.
          */
         onSearchChange({ name, src, query, limit }) {
             const spec = { offset: 0, limit };
@@ -419,20 +405,46 @@ export default {
                 this.history_id,
                 this.formData,
                 optionsPagination,
-            ).then((data) => {
-                const newInput = findInputByDottedName(data.inputs, name);
-                const target = findInputByDottedName(this.formConfig.inputs, name);
-                if (!newInput || !target) {
-                    return;
-                }
-                target.options = { ...target.options, [src]: newInput.options?.[src] || [] };
-                if (newInput.options_meta && newInput.options_meta[src]) {
-                    target.options_meta = {
-                        ...(target.options_meta || {}),
-                        [src]: newInput.options_meta[src],
-                    };
-                }
-            });
+            ).then((data) => this.mergeFetchedOptions(name, src, data));
+        },
+        /**
+         * Merge a freshly fetched page of options (from load-more or search) into
+         * the matching parameter's option list, de-duplicating by ``id``/``src``.
+         * Both callers merge rather than replace so the dropdown never empties out
+         * from under an open multiselect (which would unmount its focused input),
+         * and so a beyond-the-page selection stays visible. Refreshes the form
+         * afterwards so the rendered clone picks up the new options (see
+         * ``refreshInputs``).
+         */
+        mergeFetchedOptions(name, src, data) {
+            const newInput = findInputByDottedName(data.inputs, name);
+            const target = findInputByDottedName(this.formConfig.inputs, name);
+            if (!newInput || !target) {
+                return;
+            }
+            const existing = (target.options && target.options[src]) || [];
+            const incoming = (newInput.options && newInput.options[src]) || [];
+            const seen = new Set(existing.map((o) => `${o.id}_${o.src}`));
+            const merged = existing.concat(incoming.filter((o) => !seen.has(`${o.id}_${o.src}`)));
+            target.options = { ...target.options, [src]: merged };
+            if (newInput.options_meta && newInput.options_meta[src]) {
+                target.options_meta = {
+                    ...(target.options_meta || {}),
+                    [src]: newInput.options_meta[src],
+                };
+            }
+            this.refreshInputs();
+        },
+        /**
+         * Hand ``FormDisplay`` a fresh ``inputs`` array reference after mutating a
+         * parameter's ``options``/``options_meta`` in place. ``FormDisplay`` renders
+         * from an internal *clone* of ``inputs`` that is only re-synced by its
+         * ``watch(() => props.inputs)``, which fires on array identity change, not on
+         * deep mutation. Without this bump the paginated / searched options are
+         * fetched but never reach the dropdown (issue #23135).
+         */
+        refreshInputs() {
+            this.formConfig.inputs = [...this.formConfig.inputs];
         },
         onChangeVersion(newVersion) {
             this.requestTool(newVersion);

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -319,6 +319,38 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         ), f"Expected dropdown to render exactly 50 options (default page size), got {len(options)}"
 
     @selenium_test
+    def test_data_options_load_more_appends(self):
+        """Scrolling the dropdown's ``Loading more…`` sentinel into view must
+        fetch the next page and *append* it to the select. Regression test for
+        issue #23135 — the load-more request fired but the fetched options never
+        reached the dropdown because ``FormDisplay`` renders from a clone of
+        ``inputs`` that only re-syncs on array-identity change."""
+        history_id = self.current_history_id()
+        # 60 datasets with a default 50-per-page cap leaves a full second page.
+        self.dataset_populator.fetch_hdas(history_id, [{"src": "pasted", "paste_content": "x"}] * 60)
+        self.home()
+        self.tool_open("cat1")
+        select_field = self.components.tool_form.parameter_data_select(parameter="input1").wait_for_visible()
+        trigger = select_field.find_element(By.CSS_SELECTOR, ".multiselect__select")
+        trigger.click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        assert len(select_field.find_elements(By.CSS_SELECTOR, "[role='option']")) == 50
+
+        # Scroll the load-more sentinel into view to trigger the intersection
+        # observer, then confirm additional options were appended. Re-query and
+        # re-scroll on each retry: the sentinel disappears once the final page
+        # loads, and the option list re-renders when the new page arrives.
+        @retry_assertion_during_transitions
+        def assert_more_options_loaded():
+            sentinels = select_field.find_elements(By.CSS_SELECTOR, ".form-data-load-more-sentinel")
+            if sentinels:
+                self.scroll_into_view(sentinels[0])
+            options = select_field.find_elements(By.CSS_SELECTOR, "[role='option']")
+            assert len(options) > 50, f"Expected the dropdown to append a second page (>50 options), got {len(options)}"
+
+        assert_more_options_loaded()
+
+    @selenium_test
     def test_data_options_pinned_via_rerun(self):
         """A dataset selected as a tool input but living deep in history (past
         the first page window) must still appear in the rerun form's dropdown


### PR DESCRIPTION
## Problem

Fixes #23135. On tool forms, data/dataset input dropdowns paginate their options ("Loading more…"), but scrolling to the bottom fired the next-page request **without ever updating the select**. Typing likewise only narrowed the already-loaded slice instead of showing server-side search results.

## Root cause

`ToolForm`'s `onLoadMore` / `onSearchChange` refetch the paginated/searched options and mutate the target parameter's `options` / `options_meta` **in place** on `this.formConfig.inputs`.

But the rendered select does not read from `formConfig.inputs` directly. `FormDisplay` deep-clones its `inputs` prop into an internal `formInputs` (`useFormState.cloneInputs` → `JSON.parse(JSON.stringify(inputs))`), and `FormInputs`/`FormElement`/`FormData` render from that **clone**. The clone is only re-synced from the server nodes by `syncServerAttributes()`, which runs *only* inside `FormDisplay`'s `watch(() => props.inputs)`. That watcher fires on **array-identity change**, not on deep mutation of a nested node — so the in-place append/replace never reached the dropdown.

This single gap explains both symptoms: load-more never appended, and server-side search results never replaced the list (the local `filter` ref in `FormSelect` kept narrowing the stale slice client-side, which looked like "searches only the loaded slice").

## Fix

After each in-place update, hand `FormDisplay` a fresh `inputs` array reference (`this.formConfig.inputs = [...this.formConfig.inputs]`) so its watcher fires and `syncServerAttributes()` copies the appended/replaced `options`/`options_meta` into the rendered clone. The shallow copy keeps the same (already-mutated) node objects and preserves user-entered values (client-owned fields aren't overwritten; `formData` is unchanged so no refetch loop). Works for nested params too, since `syncInputsStructural` recurses.

## Why the existing tests missed it

The two pagination selenium tests only cover the first page: `test_data_options_paginated_smoke` asserts exactly 50 options render on open (guards against *over*-rendering), and `test_data_options_pinned_via_rerun` covers the separate `pinned` mechanism. Neither scrolls the load-more sentinel or types a search — the exact paths this bug broke.

## Test

Adds `test_data_options_load_more_appends`: seeds 60 datasets (default page size 50), opens the dropdown, scrolls the `.form-data-load-more-sentinel` into view to trigger the intersection observer, and asserts the option count grows past 50.

## How to verify manually

On a history with >1 page of datasets, open a tool with a data input, open the dropdown and scroll down → new datasets append; type a name/hid → the list is replaced by server-matched results including items not in the first page.