### PR TITLE
Pin sentry-sdk to >= 2.63.0

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -3,7 +3,7 @@ psycopg2-binary==2.9.10
 psycopg[binary]
 mysqlclient
 fluent-logger
-sentry-sdk
+sentry-sdk>=2.63.0
 pbs_python
 drmaa
 statsd


### PR DESCRIPTION
For https://github.com/getsentry/sentry-python/pull/6569, avoiding a maximum recursion error with fastapi >= 0.137.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
