### PR TITLE
Return a clear error for malformed tool ids in guid_to_repository

### DIFF
--- a/lib/tool_shed/managers/repositories.py
+++ b/lib/tool_shed/managers/repositories.py
@@ -224,7 +224,10 @@ def check_updates(app: ToolShedApp, request: UpdatesRequest) -> str | dict[str, 
 
 def guid_to_repository(app: ToolShedApp, tool_id: str) -> Repository:
     # tool_id = remove_protocol_and_user_from_clone_url(tool_id)
-    shed, _, owner, name, rest = tool_id.split("/", 5)
+    parts = tool_id.split("/", 5)
+    if len(parts) < 5:
+        raise RequestParameterInvalidException(f"Malformed tool id '{tool_id}'")
+    _shed, _, owner, name = parts[:4]
     return _get_repository_by_name_and_owner(app.model.context, name, owner)
 
 

--- a/test/unit/tool_shed/test_repositories_manager.py
+++ b/test/unit/tool_shed/test_repositories_manager.py
@@ -3,6 +3,7 @@ from typing import cast
 import pytest
 
 from galaxy.exceptions import RequestParameterInvalidException
+from tool_shed.managers import repositories as repositories_manager
 from tool_shed.managers.repositories import guid_to_repository
 from tool_shed.structured_app import ToolShedApp
 
@@ -15,3 +16,34 @@ def test_guid_to_repository_rejects_malformed_guid():
     app = cast(ToolShedApp, None)
     with pytest.raises(RequestParameterInvalidException):
         guid_to_repository(app, "localhost/repos/owner")
+
+
+def test_guid_to_repository_parses_owner_and_name(monkeypatch):
+    # A well-formed guid is "shed/repos/owner/name/rest...". The manager should
+    # extract owner and name and look the repository up by name and owner,
+    # ignoring the shed host and everything after the name.
+    captured = {}
+    sentinel_repository = object()
+    sentinel_context = object()
+
+    def fake_lookup(context, name, owner):
+        captured["context"] = context
+        captured["name"] = name
+        captured["owner"] = owner
+        return sentinel_repository
+
+    monkeypatch.setattr(repositories_manager, "_get_repository_by_name_and_owner", fake_lookup)
+
+    class _Model:
+        context = sentinel_context
+
+    class _App:
+        model = _Model()
+
+    app = cast(ToolShedApp, _App())
+    result = guid_to_repository(app, "localhost:9009/repos/owner/name/1234abcd/tool_id")
+
+    assert result is sentinel_repository
+    assert captured["owner"] == "owner"
+    assert captured["name"] == "name"
+    assert captured["context"] is sentinel_context

--- a/test/unit/tool_shed/test_repositories_manager.py
+++ b/test/unit/tool_shed/test_repositories_manager.py
@@ -1,0 +1,11 @@
+import pytest
+
+from galaxy.exceptions import RequestParameterInvalidException
+from tool_shed.managers.repositories import guid_to_repository
+
+
+def test_guid_to_repository_rejects_malformed_guid():
+    # A guid without enough slashes used to raise a bare ValueError from the
+    # tuple unpacking, surfacing as a 500 in the TRS API (see issue #23139).
+    with pytest.raises(RequestParameterInvalidException):
+        guid_to_repository(app=None, tool_id="localhost/repos/owner")

--- a/test/unit/tool_shed/test_repositories_manager.py
+++ b/test/unit/tool_shed/test_repositories_manager.py
@@ -1,11 +1,17 @@
+from typing import cast
+
 import pytest
 
 from galaxy.exceptions import RequestParameterInvalidException
 from tool_shed.managers.repositories import guid_to_repository
+from tool_shed.structured_app import ToolShedApp
 
 
 def test_guid_to_repository_rejects_malformed_guid():
     # A guid without enough slashes used to raise a bare ValueError from the
     # tuple unpacking, surfacing as a 500 in the TRS API (see issue #23139).
+    # The malformed-id check runs before app is dereferenced, so a cast None
+    # is enough to exercise this path.
+    app = cast(ToolShedApp, None)
     with pytest.raises(RequestParameterInvalidException):
-        guid_to_repository(app=None, tool_id="localhost/repos/owner")
+        guid_to_repository(app, "localhost/repos/owner")


### PR DESCRIPTION
A TRS tool id whose decoded guid has fewer than four slashes (for example `localhost/repos/owner`) reaches `guid_to_repository`, where `tool_id.split("/", 5)` returns too few values to unpack. The bare `ValueError: not enough values to unpack (expected 5, got 3)` propagates out of the `/api/ga4gh/trs/v2/tools/{id}/versions` endpoint as a 500 instead of a request error. Fixes #23139.

This raises `RequestParameterInvalidException` for malformed ids so the API returns a 400, and reads the owner/name by index so a guid that still carries a trailing version segment keeps working.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
