### PR TITLE
[26.1] Fix workflow preview layout spacing

### DIFF
--- a/client/src/components/Workflow/Published/WorkflowPublished.vue
+++ b/client/src/components/Workflow/Published/WorkflowPublished.vue
@@ -177,34 +177,47 @@ defineExpose({
     .container-root {
         container-type: inline-size;
         width: 100%;
+        height: 100%;
+        min-height: 0;
         overflow: auto;
     }
 
     .published-workflow {
         display: grid;
         gap: 0.5rem 1rem;
-        grid-template-columns: auto auto 30%;
+        grid-template-columns: minmax(0, 1fr) minmax(18rem, 30%);
+        grid-template-rows: auto minmax(0, 1fr);
 
         height: 100%;
+        min-height: 0;
 
         .workflow-header {
-            grid-column: 1 / span 3;
+            grid-column: 1 / -1;
 
             display: flex;
+            align-items: center;
+            gap: 1rem;
             justify-content: flex-end;
         }
 
         .workflow-preview {
-            grid-column: 1 / span 2;
+            grid-column: 1;
+            min-height: 0;
 
             &.only-preview {
-                grid-column: 1 / span 3;
+                grid-column: 1 / -1;
+            }
+
+            &:deep(.card-body) {
+                height: 100%;
+                min-height: 0;
             }
         }
 
         &:deep(.workflow-information-container) {
             height: 100%;
             max-width: 500px;
+            align-self: stretch;
             overflow: auto;
         }
     }
@@ -212,10 +225,11 @@ defineExpose({
     @container (max-width: 900px) {
         .published-workflow {
             height: unset;
-            grid-template-columns: auto;
+            grid-template-columns: minmax(0, 1fr);
+            grid-template-rows: auto auto auto;
 
             .workflow-preview {
-                grid-column: 1 / span 3;
+                grid-column: 1;
                 height: 450px;
             }
 
@@ -225,7 +239,7 @@ defineExpose({
             }
 
             .workflow-information-container {
-                grid-column: 1 / span 3;
+                grid-column: 1;
             }
         }
     }


### PR DESCRIPTION
Fixes #20563.

This PR updates the published workflow preview layout so the header no longer consumes the remaining grid height, leaving a large blank gap before the preview canvas.

|Before|After|
|---|---|
|<img width="1808" height="921" alt="image" src="https://github.com/user-attachments/assets/61c50a85-3cce-4859-b587-80fd4ff6a870" />|<img width="1808" height="921" alt="image" src="https://github.com/user-attachments/assets/69901f09-b3ab-4a67-b802-11e7dca01787" />|

Changes:
- Uses an explicit two-column desktop grid for preview + workflow info.
- Adds explicit grid rows so the header stays compact and the content row fills the remaining space.
- Adds the missing height/min-height chain needed for the workflow canvas to fill its card.
- Keeps the mobile layout stacked with the existing fixed preview height.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Go to Published workflows
  2. Click on any 'Link to Workflow' button to copy the link
  3. Open the link in the browser

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
