### PR TITLE
[26.0] Handle sample_sheet and paired_or_unpaired collections in output_to_cwl_json

### DIFF
--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -637,7 +637,7 @@ def output_to_cwl_json(
 
     elif output_metadata["history_content_type"] == "dataset_collection":
         collection_type = output_metadata["collection_type"].split(":", 1)[0]
-        if collection_type in ["list", "paired"]:
+        if collection_type in ["list", "paired", "sample_sheet", "paired_or_unpaired"]:
             rval_l = []
             for element in output_metadata["elements"]:
                 rval_l.append(element_to_cwl_json(element))
@@ -647,7 +647,7 @@ def output_to_cwl_json(
             for element in output_metadata["elements"]:
                 rval_d[element["element_identifier"]] = element_to_cwl_json(element)
             return rval_d
-        return None
+        raise NotImplementedError(f"Unsupported collection type encountered ({collection_type})")
     else:
         raise NotImplementedError("Unknown history content type encountered")
 

--- a/test/unit/tool_util/test_cwl_util.py
+++ b/test/unit/tool_util/test_cwl_util.py
@@ -1,9 +1,13 @@
 import tempfile
 
+import pytest
+
 from galaxy.tool_util.cwl.util import (
     FileLiteralTarget,
     galactic_job_json,
+    GalaxyOutput,
     output_properties,
+    output_to_cwl_json,
     UploadTarget,
 )
 
@@ -151,3 +155,56 @@ def test_galactic_job_json_collection_element_filetype():
     for target in captured_targets:
         assert isinstance(target, FileLiteralTarget)
         assert target.properties.get("filetype") == "fastqsanger"
+
+
+def _mock_dataset_metadata(element_id):
+    return {
+        "history_content_type": "dataset",
+        "id": element_id,
+        "file_ext": "txt",
+        "name": element_id,
+    }
+
+
+def _collection_output(collection_type, element_identifiers):
+    metadata = {
+        "history_content_type": "dataset_collection",
+        "collection_type": collection_type,
+        "elements": [
+            {"element_identifier": identifier, "object": _mock_dataset_metadata(identifier)}
+            for identifier in element_identifiers
+        ],
+    }
+    return GalaxyOutput("history_id", "dataset_collection", "collection_id", metadata)
+
+
+def _output_to_cwl_json(galaxy_output):
+    def get_metadata(history_content_type, history_content_id):
+        return _mock_dataset_metadata(history_content_id)
+
+    def get_dataset(dataset_details, filename=None):
+        return {"content": b"hello world", "basename": dataset_details["name"]}
+
+    def get_extra_files(dataset_details):
+        return []
+
+    return output_to_cwl_json(galaxy_output, get_metadata, get_dataset, get_extra_files)
+
+
+def test_output_to_cwl_json_sample_sheet():
+    rval = _output_to_cwl_json(_collection_output("sample_sheet", ["sample1", "sample2"]))
+    assert isinstance(rval, list)
+    assert len(rval) == 2
+    assert rval[0]["basename"] == "sample1"
+
+
+def test_output_to_cwl_json_paired_or_unpaired():
+    rval = _output_to_cwl_json(_collection_output("paired_or_unpaired", ["unpaired"]))
+    assert isinstance(rval, list)
+    assert len(rval) == 1
+    assert rval[0]["basename"] == "unpaired"
+
+
+def test_output_to_cwl_json_unsupported_collection_type():
+    with pytest.raises(NotImplementedError, match="not_a_real_type"):
+        _output_to_cwl_json(_collection_output("not_a_real_type", ["e1"]))

--- a/test/unit/tool_util/test_cwl_util.py
+++ b/test/unit/tool_util/test_cwl_util.py
@@ -191,18 +191,70 @@ def _output_to_cwl_json(galaxy_output):
     return output_to_cwl_json(galaxy_output, get_metadata, get_dataset, get_extra_files)
 
 
+def _nested_collection_output(collection_type, sub_collection_type, element_identifiers):
+    metadata = {
+        "history_content_type": "dataset_collection",
+        "collection_type": collection_type,
+        "elements": [
+            {
+                "element_identifier": identifier,
+                "object": {
+                    "id": identifier,
+                    "collection_type": sub_collection_type,
+                    "elements": [
+                        {
+                            "element_identifier": sub_identifier,
+                            "object": _mock_dataset_metadata(f"{identifier}_{sub_identifier}"),
+                        }
+                        for sub_identifier in ["forward", "reverse"]
+                    ],
+                },
+            }
+            for identifier in element_identifiers
+        ],
+    }
+    return GalaxyOutput("history_id", "dataset_collection", "collection_id", metadata)
+
+
+def _assert_cwl_file(rval, basename):
+    assert rval["class"] == "File"
+    assert rval["basename"] == basename
+    assert rval["checksum"] == "sha1$2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+    assert rval["size"] == 11
+
+
 def test_output_to_cwl_json_sample_sheet():
     rval = _output_to_cwl_json(_collection_output("sample_sheet", ["sample1", "sample2"]))
     assert isinstance(rval, list)
     assert len(rval) == 2
-    assert rval[0]["basename"] == "sample1"
+    _assert_cwl_file(rval[0], "sample1")
+    _assert_cwl_file(rval[1], "sample2")
+
+
+def test_output_to_cwl_json_sample_sheet_paired():
+    rval = _output_to_cwl_json(_nested_collection_output("sample_sheet", "paired", ["sample1", "sample2"]))
+    assert isinstance(rval, list)
+    assert len(rval) == 2
+    for index, identifier in enumerate(["sample1", "sample2"]):
+        assert isinstance(rval[index], list)
+        assert len(rval[index]) == 2
+        _assert_cwl_file(rval[index][0], f"{identifier}_forward")
+        _assert_cwl_file(rval[index][1], f"{identifier}_reverse")
 
 
 def test_output_to_cwl_json_paired_or_unpaired():
     rval = _output_to_cwl_json(_collection_output("paired_or_unpaired", ["unpaired"]))
     assert isinstance(rval, list)
     assert len(rval) == 1
-    assert rval[0]["basename"] == "unpaired"
+    _assert_cwl_file(rval[0], "unpaired")
+
+
+def test_output_to_cwl_json_paired_or_unpaired_paired():
+    rval = _output_to_cwl_json(_collection_output("paired_or_unpaired", ["forward", "reverse"]))
+    assert isinstance(rval, list)
+    assert len(rval) == 2
+    _assert_cwl_file(rval[0], "forward")
+    _assert_cwl_file(rval[1], "reverse")
 
 
 def test_output_to_cwl_json_unsupported_collection_type():


### PR DESCRIPTION
`output_to_cwl_json` keyed only on the *outer* segment of a collection type and silently returned `None` for anything that wasn't `list`, `paired` or `record`:

```python
collection_type = output_metadata["collection_type"].split(":", 1)[0]
if collection_type in ["list", "paired"]:
    ...
elif collection_type == "record":
    ...
return None
```

For a promoted `sample_sheet:paired` workflow output, the outer segment is `sample_sheet`, which matches neither branch. The `None` then propagates into consumers of `galaxy-tool-util` — in planemo it surfaces as:

```
TypeError: object of type 'NoneType' has no len()
  planemo/galaxy/activity.py:653 in attach_file_properties
    assert len(elements) == len(cwl_output)
```

Three frames away from the actual problem, naming neither the collection nor its type. The workflow itself ran fine — 18/18 steps scheduled, 15/15 jobs green — but no assertion was ever adjudicated, so the test result was unusable. Galaxy's collection model handles `sample_sheet` correctly throughout; this is purely a CWL-JSON translation gap.

## Changes

**Handle `sample_sheet` and `paired_or_unpaired` in the flat-list branch.** Both are flat ordered lists of elements — `SampleSheetDatasetCollectionType` is documented as *"A flat list of named elements starting rows with column metadata"*, and `paired_or_unpaired` yields 1 or 2 elements — so the existing `rval_l` loop is already the correct shape. `paired_or_unpaired` folds in rather than getting its own branch: a missing reverse element just means a shorter list, which is exactly what `paired` already produces element-wise, and CWL has no shape distinction to preserve here.

**Nested types need no extra handling.** Keying on the outer segment is right, because `element_to_cwl_json` recurses back into `output_to_cwl_json` with each sub-collection's own `collection_type`. A `sample_sheet:paired` output correctly yields a list of paired lists.

**Replace the bare `return None` with `NotImplementedError` naming the collection type.** This mirrors the `else` immediately below, which already does exactly that for an unknown `history_content_type`. Silently returning `None` is what turned "unsupported collection type" into a `TypeError` in a different codebase; the next unsupported type now fails where it happens, with the type named. This is arguably the more valuable half of the change.

## Test

Five tests in `test/unit/tool_util/test_cwl_util.py` (no server needed — the module is already unit-tested there with mock helpers). The collaborators `get_metadata` / `get_dataset` / `get_extra_files` are ordinary parameters of `output_to_cwl_json`, so these are injected fakes, not patched globals.

Coverage includes the nested `sample_sheet:paired` shape that actually triggered the report, plus both arms of `paired_or_unpaired` (1 and 2 elements). Assertions check the full CWL `File` shape — `class`, `basename`, `checksum`, `size` — rather than only `basename`, which on its own would just echo the fake's input; `checksum` and `class` confirm the elements really went through `output_properties`.

Against **unmodified** code, all five fail:

```
FAILED test_output_to_cwl_json_sample_sheet
FAILED test_output_to_cwl_json_sample_sheet_paired
FAILED test_output_to_cwl_json_paired_or_unpaired
FAILED test_output_to_cwl_json_paired_or_unpaired_paired
FAILED test_output_to_cwl_json_unsupported_collection_type

    assert isinstance(rval, list)
E   assert False
E    +  where False = isinstance(None, list)

    with pytest.raises(NotImplementedError, match="not_a_real_type"):
E   Failed: DID NOT RAISE <class 'NotImplementedError'>

5 failed, 6 passed
```

After the fix: `11 passed`, so the pre-existing 6 tests in the file are intact. This also confirms empirically that `paired_or_unpaired` hit the same hole — that had only been inferred from reading the code.

## Risk of the raise

The registry defines exactly five collection types — `list`, `paired`, `record`, `sample_sheet`, `paired_or_unpaired` (`lib/galaxy/model/dataset_collections/types/`) — and this change now handles all five. The new `NotImplementedError` is therefore unreachable for any currently registered type; it can only fire for a type added later, which is exactly the case where the old silent `None` was harmful. Neither in-tree caller depended on the `None`: `lib/galaxy_test/base/populators.py:375` just tests `isinstance(output, dict)`, so a `None` fell through there silently too.

## Other branches

The same `return None` exists on `release_25.0`, `release_25.1`, `release_26.1` and `dev`. `sample_sheet` is registered from `release_25.1` onward and `paired_or_unpaired` from `release_25.0` onward, so the earlier releases carry the bug too. Targeting `release_26.0` only, deliberately — the older releases are consciously out of scope here.
