### PR TITLE
Guard filepath resolution against purged datasets

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -741,7 +741,7 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer[T], 
             # NOTE: no files
             if isinstance(val, model.MetadataFile):
                 # only when explicitly set: fetching filepaths can be expensive
-                if not self.app.config.expose_dataset_path:
+                if not self.app.config.expose_dataset_path or dataset_assoc.purged:
                     continue
                 val = val.get_file_name()
             # TODO:? possibly split this off?

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -478,6 +478,27 @@ class TestHDASerializer(HDATestCase):
         serialized = self.hda_serializer.serialize(hda, keys, user=self.admin_user)
         assert "file_name" in serialized
 
+    def test_serialize_metadata_skips_file_path_for_purged(self):
+        # Purged datasets have no object store path, so metadata serialization must skip it.
+        assert self.app.config.expose_dataset_path
+
+        def _serialize(purged):
+            metadata_file = model.MetadataFile(name="bam_index")
+            metadata_file.get_file_name = mock.Mock(return_value="/objects/bam_index.dat")
+            item = mock.MagicMock(purged=purged)
+            item.metadata.spec.items.return_value = [("bam_index", {})]
+            item.metadata.get.return_value = metadata_file
+            result = self.hda_serializer.serialize_metadata(item, "metadata")
+            return metadata_file.get_file_name, result
+
+        get_file_name, result = _serialize(purged=True)
+        get_file_name.assert_not_called()
+        assert "bam_index" not in result
+
+        get_file_name, result = _serialize(purged=False)
+        get_file_name.assert_called_once()
+        assert result["bam_index"] == "/objects/bam_index.dat"
+
     def test_serializing_inaccessible(self):
         owner = self.user_manager.create(**user2_data)
         non_owner = self.user_manager.create(**user3_data)


### PR DESCRIPTION
For purged datasets, `object_store.get_store_by()` returns `None`. This caused `MetadataFile.get_file_name()` to call `getattr(self, None)`, raising a `TypeError` during metadata serialization when `expose_dataset_path` is enabled. Skip the path for purged datasets.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
