### PR TITLE
Fix FormData no-options alert height and align the accepted-formats/column-select controls

### DIFF
--- a/client/src/components/Form/Elements/FormData/FormData.test.ts
+++ b/client/src/components/Form/Elements/FormData/FormData.test.ts
@@ -110,6 +110,21 @@ describe("FormData", () => {
         expect(wrapper.findAll(SELECT_OPTIONS).length).toBe(7);
     });
 
+    it("styles the workflow run no-options alert to fill the select height", async () => {
+        const wrapper = createTarget({
+            type: "data",
+            value: null,
+            options: {},
+            workflowRun: true,
+        });
+        const alert = wrapper.find(".form-data-no-options-alert");
+        expect(alert.exists()).toBe(true);
+        expect(alert.text()).toBe("No datasets available");
+
+        await wrapper.setProps({ workflowRun: false });
+        expect(wrapper.find(".form-data-no-options-alert").exists()).toBe(false);
+    });
+
     it("multiple datasets", async () => {
         const wrapper = createTarget({
             value: {

--- a/client/src/components/Form/Elements/FormData/FormData.test.ts
+++ b/client/src/components/Form/Elements/FormData/FormData.test.ts
@@ -110,7 +110,7 @@ describe("FormData", () => {
         expect(wrapper.findAll(SELECT_OPTIONS).length).toBe(7);
     });
 
-    it("styles the workflow run no-options alert to fill the select height", async () => {
+    it("styles the no-options alert to match the control height in both run and tool forms", async () => {
         const wrapper = createTarget({
             type: "data",
             value: null,
@@ -121,8 +121,9 @@ describe("FormData", () => {
         expect(alert.exists()).toBe(true);
         expect(alert.text()).toBe("No datasets available");
 
+        // The alert keeps the aligned styling outside of workflow runs too.
         await wrapper.setProps({ workflowRun: false });
-        expect(wrapper.find(".form-data-no-options-alert").exists()).toBe(false);
+        expect(wrapper.find(".form-data-no-options-alert").exists()).toBe(true);
     });
 
     it("multiple datasets", async () => {

--- a/client/src/components/Form/Elements/FormData/FormData.test.ts
+++ b/client/src/components/Form/Elements/FormData/FormData.test.ts
@@ -7,13 +7,25 @@ import { mount } from "@vue/test-utils";
 import { PiniaVuePlugin } from "pinia";
 import { describe, expect, it, vi } from "vitest";
 
-import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
+import { useServerMock } from "@/api/client/__mocks__";
+import { testDatatypesMapper, typesAndMappingResponse } from "@/components/Datatypes/test_fixtures";
 import { useDatatypesMapperStore } from "@/stores/datatypesMapperStore";
 import { useEventStore } from "@/stores/eventStore";
 
 import MountTarget from "./FormData.vue";
 
 vi.mock("@/composables/filter");
+
+const { server, http } = useServerMock();
+
+// FormData resolves its datatypes mapper on mount; stub the request so the tests
+// never hit a real fetch that gets aborted at teardown and surfaces as an
+// unhandled error that fails the run.
+server.use(
+    http.get("/api/datatypes/types_and_mapping", ({ response }) => {
+        return response(200).json(typesAndMappingResponse);
+    }),
+);
 
 const localVue = getLocalVue();
 localVue.use(PiniaVuePlugin);

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -1141,10 +1141,7 @@ const noOptionsWarningMessage = computed(() => {
                     :placeholder="`Select a ${placeholder}`"
                     @search-change="onSearchChange">
                     <template v-slot:no-options>
-                        <BAlert
-                            :class="props.workflowRun && 'py-0 my-0 d-flex w-100 h-100 align-items-center'"
-                            variant="warning"
-                            show>
+                        <BAlert :class="{ 'form-data-no-options-alert': props.workflowRun }" variant="warning" show>
                             {{ noOptionsWarningMessage }}
                         </BAlert>
                     </template>
@@ -1168,7 +1165,10 @@ const noOptionsWarningMessage = computed(() => {
                     multiple
                     @search-change="onSearchChange">
                     <template v-slot:no-options>
-                        <BAlert class="py-2 my-0" variant="warning" show>
+                        <BAlert
+                            :class="props.workflowRun ? 'form-data-no-options-alert' : 'py-2 my-0'"
+                            variant="warning"
+                            show>
                             {{ noOptionsWarningMessage }}
                         </BAlert>
                     </template>
@@ -1294,6 +1294,16 @@ const noOptionsWarningMessage = computed(() => {
                 padding-left: 5px;
             }
         }
+    }
+
+    .form-data-no-options-alert {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        min-height: 100%;
+        margin: 0;
+        padding-top: 0;
+        padding-bottom: 0;
     }
 }
 

--- a/client/src/components/Form/Elements/FormData/FormData.vue
+++ b/client/src/components/Form/Elements/FormData/FormData.vue
@@ -33,6 +33,7 @@ import { containsDataOption, isDataOption } from "./types";
 import { BATCH, SOURCE, VARIANTS } from "./variants";
 
 import FormSelection from "../FormSelection.vue";
+import FormSelectionPreference from "../FormSelectionPreference.vue";
 import FormDataContextButtons from "./FormDataContextButtons.vue";
 import FormDataExtensions from "./FormDataExtensions.vue";
 import FormDataWorkflowRunTabs from "./FormDataWorkflowRunTabs.vue";
@@ -383,6 +384,26 @@ const usingSimpleSelect = computed(
     () =>
         !formSelectionRef.value ||
         ("displayMany" in formSelectionRef.value && formSelectionRef.value.displayMany === false),
+);
+
+/**
+ * Mirrors `FormSelection`'s simple/column select preference so the control can be
+ * rendered below the "accepted formats" row instead of inside the select field.
+ */
+const formSelectionPreference = ref({ showManyButton: false, showMultiButton: false });
+
+function onPreferenceChange(state: { showManyButton: boolean; showMultiButton: boolean }) {
+    formSelectionPreference.value = state;
+}
+
+function setFormSelectionUseMany(value: boolean) {
+    formSelectionRef.value?.setUseMany(value);
+}
+
+const showSelectionPreference = computed(
+    () =>
+        Boolean(currentVariant.value?.multiple) &&
+        (formSelectionPreference.value.showManyButton || formSelectionPreference.value.showMultiButton),
 );
 
 /**
@@ -1141,7 +1162,7 @@ const noOptionsWarningMessage = computed(() => {
                     :placeholder="`Select a ${placeholder}`"
                     @search-change="onSearchChange">
                     <template v-slot:no-options>
-                        <BAlert :class="{ 'form-data-no-options-alert': props.workflowRun }" variant="warning" show>
+                        <BAlert class="form-data-no-options-alert" variant="warning" show>
                             {{ noOptionsWarningMessage }}
                         </BAlert>
                     </template>
@@ -1161,14 +1182,13 @@ const noOptionsWarningMessage = computed(() => {
                     class="w-100"
                     :data="formattedOptions"
                     :total-estimate="currentSourceTotalEstimate"
+                    defer-preference
                     optional
                     multiple
+                    @preference-change="onPreferenceChange"
                     @search-change="onSearchChange">
                     <template v-slot:no-options>
-                        <BAlert
-                            :class="props.workflowRun ? 'form-data-no-options-alert' : 'py-2 my-0'"
-                            variant="warning"
-                            show>
+                        <BAlert class="form-data-no-options-alert" variant="warning" show>
                             {{ noOptionsWarningMessage }}
                         </BAlert>
                     </template>
@@ -1197,12 +1217,19 @@ const noOptionsWarningMessage = computed(() => {
                 @uploaded-data="handleUploadedDataOptions" />
         </div>
 
-        <FormDataExtensions
-            v-if="restrictsExtensions"
-            class="mt-1"
-            :extensions="props.extensions"
-            :formats-button-id="formatsButtonId"
-            :formats-visible.sync="formatsVisible" />
+        <div v-if="restrictsExtensions || showSelectionPreference" class="d-flex align-items-center flex-gapx-1 mt-1">
+            <FormDataExtensions
+                v-if="restrictsExtensions"
+                :extensions="props.extensions"
+                :formats-button-id="formatsButtonId"
+                :formats-visible.sync="formatsVisible" />
+
+            <FormSelectionPreference
+                v-if="showSelectionPreference"
+                :show-many-button="formSelectionPreference.showManyButton"
+                :show-multi-button="formSelectionPreference.showMultiButton"
+                @use-many="setFormSelectionUseMany" />
+        </div>
 
         <div :class="{ 'd-flex justify-content-between': props.workflowRun }">
             <div v-if="currentVariant && currentVariant.batch !== BATCH.DISABLED">
@@ -1300,7 +1327,10 @@ const noOptionsWarningMessage = computed(() => {
         display: flex;
         align-items: center;
         width: 100%;
-        min-height: 100%;
+        // Match the adjacent context-button / select control height so the warning
+        // aligns with the row instead of over-filling it (multiple mode pushes the
+        // "switch to column select" control below) or leaving default alert padding.
+        min-height: 2.125rem;
         margin: 0;
         padding-top: 0;
         padding-bottom: 0;

--- a/client/src/components/Form/Elements/FormSelection.vue
+++ b/client/src/components/Form/Elements/FormSelection.vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { BDropdown, BDropdownItemButton } from "bootstrap-vue";
 import { storeToRefs } from "pinia";
 import { computed, type PropType, ref, watch } from "vue";
 
@@ -10,6 +7,7 @@ import { useUserFlagsStore } from "@/stores/userFlagsStore";
 import FormCheck from "./FormCheck.vue";
 import FormRadio from "./FormRadio.vue";
 import FormSelect from "./FormSelect.vue";
+import FormSelectionPreference from "./FormSelectionPreference.vue";
 import FormSelectMany from "./FormSelectMany/FormSelectMany.vue";
 
 export interface SelectOption {
@@ -20,6 +18,7 @@ export interface SelectOption {
 const emit = defineEmits<{
     (e: "input", value: any): void;
     (e: "search-change", query: string): void;
+    (e: "preference-change", state: { showManyButton: boolean; showMultiButton: boolean }): void;
 }>();
 
 const props = defineProps({
@@ -55,6 +54,15 @@ const props = defineProps({
     totalEstimate: {
         type: Number as PropType<number | null>,
         default: null,
+    },
+    /**
+     * When set, the simple/column select preference control is not rendered here.
+     * The parent is expected to render it (see ``FormSelectionPreference``) using
+     * the state exposed via ``preference-change`` and the exposed ``setUseMany``.
+     */
+    deferPreference: {
+        type: Boolean,
+        default: false,
     },
 });
 
@@ -123,8 +131,24 @@ const displayMany = computed(() => showSelectPreference.value && useMany.value);
 const showManyButton = computed(() => showSelectPreference.value && !useMany.value);
 const showMultiButton = computed(() => displayMany.value);
 
+function setUseMany(value: boolean) {
+    useMany.value = value;
+}
+
+// Keep the parent in sync when the preference control is rendered externally.
+watch(
+    [showManyButton, showMultiButton],
+    ([many, multi]) => {
+        if (props.deferPreference) {
+            emit("preference-change", { showManyButton: many, showMultiButton: multi });
+        }
+    },
+    { immediate: true },
+);
+
 defineExpose({
     displayMany,
+    setUseMany,
 });
 </script>
 
@@ -157,34 +181,11 @@ defineExpose({
             </template>
         </FormSelect>
 
-        <div v-if="showSelectPreference" class="d-flex">
-            <button v-if="showManyButton" class="ui-link ml-1" @click="useMany = true">switch to column select</button>
-            <button v-else-if="showMultiButton" class="ui-link ml-1" @click="useMany = false">
-                switch to simple select
-            </button>
-
-            <BDropdown toggle-class="inline-icon-button d-block px-1" variant="link" no-caret>
-                <template v-slot:button-content>
-                    <FontAwesomeIcon :icon="faCaretDown"></FontAwesomeIcon>
-                    <span class="sr-only">select element preferences</span>
-                </template>
-                <BDropdownItemButton
-                    :active="preferredFormSelectElement === 'none'"
-                    @click="preferredFormSelectElement = 'none'">
-                    No preference
-                </BDropdownItemButton>
-                <BDropdownItemButton
-                    :active="preferredFormSelectElement === 'multi'"
-                    @click="preferredFormSelectElement = 'multi'">
-                    Default to simple select
-                </BDropdownItemButton>
-                <BDropdownItemButton
-                    :active="preferredFormSelectElement === 'many'"
-                    @click="preferredFormSelectElement = 'many'">
-                    Default to column select
-                </BDropdownItemButton>
-            </BDropdown>
-        </div>
+        <FormSelectionPreference
+            v-if="!deferPreference && showSelectPreference"
+            :show-many-button="showManyButton"
+            :show-multi-button="showMultiButton"
+            @use-many="setUseMany" />
     </div>
 </template>
 

--- a/client/src/components/Form/Elements/FormSelectionPreference.vue
+++ b/client/src/components/Form/Elements/FormSelectionPreference.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BDropdown, BDropdownItemButton } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
+
+import { useUserFlagsStore } from "@/stores/userFlagsStore";
+
+interface Props {
+    /**
+     * Whether the "switch to column select" button is shown
+     */
+    showManyButton: boolean;
+    /**
+     * Whether the "switch to simple select" button is shown
+     */
+    showMultiButton: boolean;
+}
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "use-many", value: boolean): void;
+}>();
+
+const { preferredFormSelectElement } = storeToRefs(useUserFlagsStore());
+</script>
+
+<template>
+    <div class="d-flex">
+        <button v-if="showManyButton" class="ui-link ml-1" @click="emit('use-many', true)">
+            switch to column select
+        </button>
+        <button v-else-if="showMultiButton" class="ui-link ml-1" @click="emit('use-many', false)">
+            switch to simple select
+        </button>
+
+        <BDropdown toggle-class="inline-icon-button d-block px-1" variant="link" no-caret>
+            <template v-slot:button-content>
+                <FontAwesomeIcon :icon="faCaretDown" />
+                <span class="sr-only">select element preferences</span>
+            </template>
+            <BDropdownItemButton
+                :active="preferredFormSelectElement === 'none'"
+                @click="preferredFormSelectElement = 'none'">
+                No preference
+            </BDropdownItemButton>
+            <BDropdownItemButton
+                :active="preferredFormSelectElement === 'multi'"
+                @click="preferredFormSelectElement = 'multi'">
+                Default to simple select
+            </BDropdownItemButton>
+            <BDropdownItemButton
+                :active="preferredFormSelectElement === 'many'"
+                @click="preferredFormSelectElement = 'many'">
+                Default to column select
+            </BDropdownItemButton>
+        </BDropdown>
+    </div>
+</template>


### PR DESCRIPTION
Fixes #23013

## What / why

The `FormData` "no datasets available" warning did not match the height of the control it replaces, so it rendered as a short/oversized alert that broke the row alignment. This was visible in workflow-run forms and also in tool forms and the legacy/expanded workflow form.

While fixing the alignment, the simple/column select preference toggle ("switch to column select") and the "accepted formats" control were also tidied up so they read as one row beneath the field.

|Before | After |
|---|---|
|<img width="1396" height="117" alt="before-single-select" src="https://github.com/user-attachments/assets/6dbe7978-237f-476f-a1ab-eb5a9a56c2f8" /> | <img width="1398" height="149" alt="after-single-datasets " src="https://github.com/user-attachments/assets/d01bec63-04c0-4865-af9f-8c90fcdf6fbc" />|
|<img width="1565" height="178" alt="before-multiple-datasets" src="https://github.com/user-attachments/assets/e641b96b-1a7e-4da8-9f90-375e2aa0645e" />|<img width="1125" height="195" alt="image" src="https://github.com/user-attachments/assets/b7f97531-0b8a-434c-ab86-743a69506b59" />|

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. In an **empty history**, open a workflow run with a required data input that has no compatible datasets (e.g. any FASTA/GFF3 input).
  2. Confirm the "No datasets … available" warning is the same height as the context buttons beside it (single select).
  3. Switch the input to **Multiple datasets**: the warning stays the same height, and "accepted formats" + "switch to column select" appear on one row below the field (switch to the right).
  4. Repeat via the **Expanded workflow form** and in a **tool form** — alignment is consistent.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
