### PR TITLE
[26.1] Collapse duplicate tool versions in tool panel search results

### DIFF
--- a/client/src/components/Panels/utilities.test.ts
+++ b/client/src/components/Panels/utilities.test.ts
@@ -12,6 +12,7 @@ import {
     getValidPanelItems,
     getValidToolsInEachSection,
     searchObjectsByKeys,
+    searchTools,
     type SearchCommonKeys,
 } from "./utilities";
 import type { Tool, ToolPanelItem, ToolSection, ToolSectionLabel } from "@/stores/toolStore";
@@ -491,5 +492,70 @@ describe("getValidPanelItems", () => {
         expect(result["collection_operations"]).toBeUndefined();
         expect(result["liftOver"]).toBeUndefined();
         expect(result["testlabel1"]).toBeDefined();
+    });
+});
+
+describe("searchTools tool-lineage de-duplication", () => {
+    // Regression for issue #23151: an instance can install and place more than one
+    // version of the same tool (sometimes across different sections). Searching the
+    // tool's name previously returned every placed version as a separate result,
+    // rendering as a duplicate. Search results should collapse to a single entry
+    // per tool lineage.
+    const pgt38 = "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy2";
+    const pgt39 = "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.9+galaxy0";
+
+    const twoVersionTools = [
+        { id: pgt38, name: "pyGenomeTracks", description: "Plot genomic tracks", version: "3.8+galaxy2" },
+        { id: pgt39, name: "pyGenomeTracks", description: "Plot genomic tracks", version: "3.9+galaxy0" },
+    ] as unknown as Tool[];
+
+    const twoSectionPanel = {
+        graph_display_data: {
+            model_class: "ToolSection",
+            id: "graph_display_data",
+            name: "Graph/Display Data",
+            tools: [pgt38],
+        },
+        plots: {
+            model_class: "ToolSection",
+            id: "plots",
+            name: "Plots",
+            tools: [pgt39],
+        },
+    } as unknown as Record<string, ToolPanelItem>;
+
+    it("collapses a tool placed at multiple versions across sections to a single result", () => {
+        const { results, resultPanel } = searchTools(twoVersionTools, "pyGenomeTracks", twoSectionPanel);
+
+        // Only one lineage entry survives (the first / highest-ranked occurrence)
+        expect(results).toEqual([pgt38]);
+
+        // The sectioned result panel no longer renders the dropped version;
+        // the section left empty by the dropped version is removed.
+        const remainingToolIds = Object.values(resultPanel).flatMap((item) => (item as ToolSection).tools ?? []);
+        expect(remainingToolIds).toEqual([pgt38]);
+    });
+
+    it("keeps distinct tools that merely share a search term", () => {
+        const distinctTools = [
+            { id: "pygenometracks/1.0", name: "pyGenomeTracks", description: "Plot tracks", version: "1.0" },
+            {
+                id: "pygenometracks_utils/1.0",
+                name: "pyGenomeTracks utils",
+                description: "Track helpers",
+                version: "1.0",
+            },
+        ] as unknown as Tool[];
+        const panel = {
+            plots: {
+                model_class: "ToolSection",
+                id: "plots",
+                name: "Plots",
+                tools: ["pygenometracks/1.0", "pygenometracks_utils/1.0"],
+            },
+        } as unknown as Record<string, ToolPanelItem>;
+
+        const { results } = searchTools(distinctTools, "pyGenomeTracks", panel);
+        expect(results).toHaveLength(2);
     });
 });

--- a/client/src/components/Panels/utilities.ts
+++ b/client/src/components/Panels/utilities.ts
@@ -429,7 +429,65 @@ export function searchTools(
         "description",
     ]);
     const { idResults, resultPanel } = createSortedResultPanel(matchedResults, currentPanel);
-    return { results: idResults, resultPanel: resultPanel, closestTerm: closestTerm };
+    // An instance may install and place more than one version of the same tool,
+    // sometimes across different sections. Collapse those to a single result so a
+    // tool doesn't surface as a duplicate in the search results (issue #23151).
+    const { results, resultPanel: dedupedPanel } = dedupeResultsByToolLineage(idResults, resultPanel, tools);
+    return { results, resultPanel: dedupedPanel, closestTerm: closestTerm };
+}
+
+/**
+ * Collapses search results that belong to the same tool lineage (the same tool
+ * installed at multiple versions) down to a single result, keeping the first
+ * (highest-ranked) occurrence. Also prunes the sectioned `resultPanel` so the
+ * dropped ids no longer render, removing any section left empty as a result.
+ *
+ * @param idResults ordered result tool ids from `createSortedResultPanel`
+ * @param resultPanel sectioned result panel from `createSortedResultPanel`
+ * @param tools the searched tools, used to resolve each id's version
+ * @returns the de-duplicated `results` and matching `resultPanel`
+ */
+export function dedupeResultsByToolLineage(
+    idResults: string[],
+    resultPanel: Record<string, Tool | ToolSection>,
+    tools: Tool[],
+): { results: string[]; resultPanel: Record<string, Tool | ToolSection> } {
+    const toolById = new Map(tools.map((tool) => [tool.id, tool]));
+    const keptLineages = new Set<string>();
+    const results: string[] = [];
+    for (const id of idResults) {
+        const lineage = getVersionlessToolId(id, toolById.get(id));
+        if (keptLineages.has(lineage)) {
+            continue;
+        }
+        keptLineages.add(lineage);
+        results.push(id);
+    }
+
+    // Nothing collapsed: keep the original panel untouched.
+    if (results.length === idResults.length) {
+        return { results: idResults, resultPanel };
+    }
+
+    const keptIds = new Set(results);
+    const prunedPanel: Record<string, Tool | ToolSection> = {};
+    for (const [key, item] of Object.entries(resultPanel)) {
+        if (isToolSection(item)) {
+            const sectionTools = (item.tools ?? []).filter(
+                (toolId) => typeof toolId !== "string" || keptIds.has(toolId),
+            );
+            if (sectionTools.length > 0) {
+                prunedPanel[key] = { ...item, tools: sectionTools };
+            }
+        } else if (isTool(item)) {
+            if (keptIds.has(item.id)) {
+                prunedPanel[key] = item;
+            }
+        } else {
+            prunedPanel[key] = item;
+        }
+    }
+    return { results, resultPanel: prunedPanel };
 }
 
 export function searchSections(sections: ToolSection[], query: string) {


### PR DESCRIPTION
Fixes #23151 (`pyGenomeTracks` appearing twice in the tool panel search on usegalaxy.org).

### What

Collapse tool-panel search results by tool *lineage* so a tool installed at more than one version — even when placed in more than one panel section — surfaces as a single result. The de-duplication happens in `searchTools` (via a new `dedupeResultsByToolLineage` helper): it keeps the first (highest-ranked) occurrence per lineage and prunes the sectioned result panel so any section left empty by a dropped version is removed. It reuses the existing `getVersionlessToolId` helper and is a no-op whenever nothing collapses.

### Why

On usegalaxy.org, `pyGenomeTracks` is placed in two panel sections at two versions:

| Section | Version |
| --- | --- |
| Graph/Display Data (`graph_display_data`) | `3.8+galaxy2` |
| Plots (`plots`) | `3.9+galaxy0` |

The tool panel loads every installed version into its searchable set (`/api/tools?in_panel=false`, keyed by fully-versioned id). A search for the tool name matched every installed version; results were then filtered to the versions actually placed in the panel (two here), and the result assembly never collapsed by lineage — so the tool rendered twice. It reads most obviously in the **My Tools** view, which renders results flat (no section headers), matching the reporter's observation that it disappears when logged out / in incognito.

This is distinct from #23045, which fixed a *recent-tools* version-duplication path; the search-result assembly did not have equivalent lineage handling.

The underlying instance data (the same tool placed in two sections) is an instance tool-configuration matter for usegalaxy.org, but the client should not render the tool as a duplicate regardless — that's what this PR addresses.

### How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - On an instance where one tool lineage is installed at multiple versions and placed in more than one panel section (e.g. usegalaxy.org's `pyGenomeTracks`), log in and open the tool panel OR checkout on this PR and use `GALAXY_URL="https://usegalaxy.eu/" make client-dev-server`.
  2. Switch between **Full Tool Panel** and **My Tools** and search the tool name.
  3. Before this change, the tool appears twice; after, it appears once.

### License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).