### PR TITLE
Use GALAXY_PYTHON for remote_tool_eval

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -209,7 +209,10 @@ def __externalize_commands(
 def __handle_remote_command_line_building(commands_builder, job_wrapper: "MinimalJobWrapper", for_pulsar=False):
     if job_wrapper.remote_command_line:
         sep = "" if for_pulsar else "&&"
-        command = 'PYTHONPATH="$GALAXY_LIB:$PYTHONPATH" python "$GALAXY_LIB"/galaxy/tools/remote_tool_eval.py'
+        command = (
+            'PYTHONPATH="$GALAXY_LIB:$PYTHONPATH" '
+            '"${GALAXY_PYTHON:-python}" "$GALAXY_LIB"/galaxy/tools/remote_tool_eval.py'
+        )
         if for_pulsar:
             # TODO: that's not how to do this, pulsar doesn't execute an externalized script by default.
             # This also breaks rewriting paths etc, so it doesn't really work if there are no shared paths

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -85,6 +85,20 @@ class TestCommandFactory(TestCase):
         self.job_wrapper.prepare_input_files_cmds = ["/opt/split1", "/opt/split2"]
         self._assert_command_is(self._surround_command(f"/opt/split1; /opt/split2; {MOCK_COMMAND_LINE}"))
 
+    def test_remote_tool_eval_uses_galaxy_python_when_remote_command_line_is_enabled(self):
+        self.include_work_dir_outputs = False
+        self.job_wrapper.remote_command_line = True
+
+        command = self.__command()
+
+        assert (
+            'PYTHONPATH="$GALAXY_LIB:$PYTHONPATH" '
+            '"${GALAXY_PYTHON:-python}" "$GALAXY_LIB"/galaxy/tools/remote_tool_eval.py'
+        ) in command
+        assert (
+            'PYTHONPATH="$GALAXY_LIB:$PYTHONPATH" python "$GALAXY_LIB"/galaxy/tools/remote_tool_eval.py' not in command
+        )
+
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo", "bar")]


### PR DESCRIPTION
## Context

Found during the Crypt4GH work in https://github.com/elixir-europe/hdtr-semsec-galaxy-crypt4gh-support/tree/crypth4gh-support-from-26.0.

The remote-tool bootstrap in `lib/galaxy/jobs/command_factory.py` previously invoked:

```bash
PYTHONPATH="$GALAXY_LIB:$PYTHONPATH" python "$GALAXY_LIB"/galaxy/tools/remote_tool_eval.py
```

That `python` resolves from `PATH` at job runtime and can point to a tool/dependency interpreter instead of the Galaxy framework interpreter.

## Why this is a bug

If `python` resolves to a non-framework interpreter, `remote_tool_eval.py` may fail before tool execution because framework dependencies are unavailable (or incompatible).

The failure mode can vary by environment, for example:

- missing framework dependencies,
- incompatible interpreter/runtime behavior.

## Fix

The launcher now uses Galaxy's selected interpreter variable, matching existing Galaxy patterns:

```bash
PYTHONPATH="$GALAXY_LIB:$PYTHONPATH" "${GALAXY_PYTHON:-python}" "$GALAXY_LIB"/galaxy/tools/remote_tool_eval.py
```

This aligns the remote-tool bootstrap with other framework-side command launchers

## How to test the changes?
(Select all options that apply)
- [ x ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ x ] Instructions for manual testing are as follows:
  1. Install an old tool that depends on an unsupported version of galaxy, e.g. https://toolshed.g2.bx.psu.edu/repositories/2879731cf1d4367f (depends on Python 3.5)
  2. Run with "tool_evaluation_strategy: remote" and "metadata_strategy: extended" (required by the former)
  3. Watch tool fail with strange syntax error (in perfectly valid code)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

## AI use

Detected and fixed by GPT-5.3-Codex.