### PR TITLE
Extended metadata discovered-output history remains `running`

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2034,6 +2034,30 @@ class MinimalJobWrapper(HasResourceParameters):
 
         self.sa_session.add(dataset)
 
+    def _normalize_successful_output_association_states(self, job: Job, output_dataset_associations) -> None:
+        pending_states = {
+            Dataset.states.NEW,
+            Dataset.states.UPLOAD,
+            Dataset.states.QUEUED,
+            Dataset.states.RUNNING,
+        }
+
+        for dataset_assoc in output_dataset_associations:
+            dataset_instances = (
+                dataset_assoc.dataset.dataset.history_associations + dataset_assoc.dataset.dataset.library_associations
+            )
+            for dataset in dataset_instances:
+                if dataset.state not in pending_states:
+                    continue
+                dataset.state = Dataset.states.OK
+                self.sa_session.add(dataset)
+                log.debug(
+                    "(%s) Normalized output dataset association state dataset_id=%s hda_or_ldda_id=%s to ok",
+                    job.id,
+                    dataset.dataset.id if dataset.dataset else None,
+                    dataset.id,
+                )
+
     def finish(
         self,
         tool_stdout,
@@ -2206,6 +2230,12 @@ class MinimalJobWrapper(HasResourceParameters):
                 ):
                     # We don't set datsets in error state to OK because discover_outputs may have already set the state to error
                     dataset_assoc.dataset.dataset.state = Dataset.states.OK
+
+        if final_job_state != job.states.ERROR and extended_metadata:
+            # In extended-metadata mode, imported output-association state can
+            # remain pending from runner-side updates. Normalize those pending
+            # association states now that the job has completed successfully.
+            self._normalize_successful_output_association_states(job, output_dataset_associations)
 
         if job.states.ERROR == final_job_state:
             for dataset_assoc in output_dataset_associations:

--- a/test/unit/app/jobs/test_job_wrapper_assoc_states.py
+++ b/test/unit/app/jobs/test_job_wrapper_assoc_states.py
@@ -1,0 +1,71 @@
+from typing import cast, TYPE_CHECKING
+
+from galaxy.jobs import JobWrapper
+from galaxy.model import (
+    Dataset,
+    HistoryDatasetAssociation,
+    Job,
+    JobToOutputDatasetAssociation,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import scoped_session
+
+class MockRecordingSession:
+    def __init__(self):
+        self.added = []
+
+    def add(self, dataset_instance):
+        self.added.append(dataset_instance)
+
+
+def _hda(dataset_id, state):
+    hda = HistoryDatasetAssociation(id=dataset_id, extension="txt")
+    hda._state = state
+    return hda
+
+
+def _dataset_assoc_with_instances(*instances):
+    dataset = Dataset(id=42)
+    dataset.history_associations = list(instances)
+    dataset.library_associations = []
+    dataset_instance = HistoryDatasetAssociation(dataset=dataset, extension="txt")
+    return JobToOutputDatasetAssociation(name="out", dataset=dataset_instance)
+
+
+def test_normalize_successful_output_association_states_marks_pending_instances_ok():
+    wrapper = JobWrapper.__new__(JobWrapper)
+    session = MockRecordingSession()
+    wrapper.sa_session = cast('scoped_session', session)
+
+    running_instance = _hda(dataset_id=3, state=Dataset.states.RUNNING)
+    queued_instance = _hda(dataset_id=4, state=Dataset.states.QUEUED)
+    ok_instance = _hda(dataset_id=5, state=Dataset.states.OK)
+    association = _dataset_assoc_with_instances(running_instance, queued_instance, ok_instance)
+
+    job = Job()
+    job.id = 9
+    wrapper._normalize_successful_output_association_states(job, [association])
+
+    assert running_instance.state == Dataset.states.OK
+    assert queued_instance.state == Dataset.states.OK
+    assert ok_instance.state == Dataset.states.OK
+    assert session.added == [running_instance, queued_instance]
+
+
+def test_normalize_successful_output_association_states_leaves_non_pending_unchanged():
+    wrapper = JobWrapper.__new__(JobWrapper)
+    session = MockRecordingSession()
+    wrapper.sa_session = cast('scoped_session', session)
+
+    ok_instance = _hda(dataset_id=11, state=Dataset.states.OK)
+    failed_meta_instance = _hda(dataset_id=12, state=Dataset.states.FAILED_METADATA)
+    association = _dataset_assoc_with_instances(ok_instance, failed_meta_instance)
+
+    job = Job()
+    job.id = 12
+    wrapper._normalize_successful_output_association_states(job, [association])
+
+    assert ok_instance.state == Dataset.states.OK
+    assert failed_meta_instance.state == Dataset.states.FAILED_METADATA
+    assert session.added == []


### PR DESCRIPTION
## Context

Found during the Crypt4GH work in https://github.com/elixir-europe/hdtr-semsec-galaxy-crypt4gh-support/tree/crypth4gh-support-from-26.0. Not sure this is the correct fix, as it was discovered and fixed by an AI Agent (GPT-5.3-codex).

## Problem

In extended-metadata mode, jobs that discover outputs (notably when using `assign_primary_output="true"`) can complete with `job.state == ok`, while one output dataset association still reports a pending association state (`running`/`queued`/`new`/`upload`).

History state aggregation uses dataset-association state, so history can remain `running` even after successful job completion and finalized outputs.

## Why this happens

`HistoryDatasetAssociation.state` resolves association-local `_state` first, then falls back to underlying `dataset.state`.

In this finish path, imported output associations can retain pending `_state`; if that pending state is not normalized on successful completion, the history view remains non-terminal.

## User-visible impact

- `wait_for_history(..., assert_ok=True)` may time out.
- History remains `running` with one stuck output association.
- Automation that waits for terminal history state is delayed or fails.

## Failing reproduction (programmatic)

This test shape fails pre-fix and passes with commit `ac08d30df4`:

```python
def test_extended_metadata_discovered_primary_output_history_not_stuck_running(dataset_populator):
    history_id = dataset_populator.new_history()
    input_hda = dataset_populator.new_dataset(
        history_id,
        content="a\nb\n",
        file_type="txt",
        wait=True,
    )

    run_response = dataset_populator.run_tool(
        "multi_output_assign_primary",
        {
            "num_param": 7,
            "input": {"src": "hda", "id": input_hda["id"]},
        },
        history_id,
    )
    job_id = run_response["jobs"][0]["id"]

    dataset_populator.wait_for_job(job_id, assert_ok=True)

    # Pre-fix failure: TimeoutAssertionError because history remains "running"
    dataset_populator.wait_for_history(history_id, assert_ok=True)
```

Typical failing pre-fix response shape:

- `job.state == "ok"`
- `history.state == "running"`
- `history.state_ids.running` contains one output dataset id
- other outputs already in `ok`

## Manual reproduction (optional)

1. Configure runner with extended metadata enabled.
2. Upload a small input dataset.
3. Run `multi_output_assign_primary`.
4. Wait for job `ok`.
5. Poll `/api/histories/{id}`.

Pre-fix behavior: history can remain `running` with one output association in `state_ids.running`.

## Root cause + fix summary

In extended-metadata finish flow, discovered output associations could retain pending association-local state (`_state`), so `HistoryDatasetAssociation.state` still resolved to `running` after successful job completion. This left history state non-terminal even though job and underlying datasets were complete.

Fix (commit `ac08d30df4`): normalize pending output association states (`new/upload/queued/running`) to `ok` on successful extended-metadata completion, while preserving existing behavior for error/deferred/failed-metadata states.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
