### PR TITLE
[26.0] Fix fasta preview rendering for sequences larger than 100 KB

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -336,12 +336,13 @@ class Sequence(data.Text):
                     chunk = fh.read(max_peek_size + 1)
                 except UnicodeDecodeError:
                     raise InvalidFileFormatError("Dataset appears to contain binary data, cannot display.")
+                # Always serve as text/plain so the browser preserves whitespace/newlines
+                # and does not interpret the content as HTML.
+                self._clean_and_set_mime_type(trans, "text/plain", headers)
                 if len(chunk) <= max_peek_size:
-                    mime = "text/plain"
-                    self._clean_and_set_mime_type(trans, mime, headers)
-                    return chunk[:-1], headers
-                headers["x-content-truncated"] = max_peek_size
-                return util.unicodify(chunk[:-1]), headers
+                    return chunk, headers
+                headers["x-content-truncated"] = str(max_peek_size)
+                return util.unicodify(chunk[:max_peek_size]), headers
         else:
             return super().display_data(trans, dataset, preview, filename, to_ext, **kwd)
 

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -355,6 +355,22 @@ class TestDatasetsApi(ApiTestCase):
         assert content_type.startswith("text/plain"), content_type
         assert display_response.text == contents
 
+    def test_display_preview_large_fasta_uses_text_plain(self, history_id):
+        # Regression test for https://github.com/galaxyproject/galaxy/issues/22719
+        # A fasta larger than the 100 KB preview limit must still be served as
+        # text/plain so the browser preserves newlines; otherwise the header line
+        # runs into the sequence and the content is rendered as HTML.
+        header = ">seq0 large fasta regression test\n"
+        contents = header + "".join(f"{'ACGT' * 20}\n" for _ in range(2000))
+        hda1 = self.dataset_populator.new_dataset(history_id, content=contents, file_type="fasta", wait=True)
+        display_response = self._get(f"histories/{history_id}/contents/{hda1['id']}/display", {"preview": "True"})
+        self._assert_status_code_is(display_response, 200)
+        content_type = display_response.headers.get("content-type", "")
+        assert content_type.startswith("text/plain"), content_type
+        assert display_response.headers.get("x-content-truncated") == "100000"
+        assert display_response.text.startswith(header)
+        assert len(display_response.text) <= 100000
+
     def test_display_extra_paths(self, history_id: str):
         test_data_resolver = TestDataResolver()
         with open(test_data_resolver.get_filename("1.fasta")) as fh:


### PR DESCRIPTION
Fixes #22719

### The bug

`Sequence.display_data` (inherited by `Fasta`, `Fastq`, and every sequence datatype) only set the `text/plain` content-type on the **non-truncated** preview branch. Any sequence larger than the 100 KB preview limit fell through to a branch that returned the content with **no content-type**, so the browser fell back to `text/html` — collapsing newlines and running the header line straight into the sequence, in a proportional font. This is the "horrible" fasta preview reported in the issue, and it affected compressed (`fasta.gz`) and uncompressed fasta identically (`get_fileobj` decompresses both), so compression was a red herring.

### The fix

- Hoist `_clean_and_set_mime_type(trans, "text/plain", headers)` above the size check so **both** branches serve `text/plain`.
- Set `x-content-truncated` to `str(max_peek_size)` instead of an `int` — Starlette cannot encode an int header value, so the truncated branch actually raised a 500 at the response layer (the same fix already applied to `data.py` in a prior commit, but never carried over to `sequence.py`).
- Stop dropping the final byte of small previews: the non-truncated branch returned `chunk[:-1]`, but the `+1` read-ahead byte only exists when the content is truncated.

### Verification

New regression test `test_display_preview_large_fasta_uses_text_plain` uploads a fasta larger than the 100 KB limit and asserts the preview is served as `text/plain`, that `x-content-truncated` is set, and that the header line survives on its own line.

Preview of a large `fasta.gz` after the fix — monospace, newlines preserved, header on its own line:

![Fasta preview after fix](https://raw.githubusercontent.com/mvdbeek/galaxy/pr-assets-22719/22719-fasta-preview-fixed.png)
