### PR TITLE
Remove last BCollapse usages from markdown navbar elements

### DIFF
--- a/client/src/components/Markdown/Sections/Elements/DatasetCollectionElementPicker.vue
+++ b/client/src/components/Markdown/Sections/Elements/DatasetCollectionElementPicker.vue
@@ -40,7 +40,7 @@ function handleInput(value: string) {
 <template>
     <div>
         <b-navbar class="align-items-center">
-            <b-collapse id="nav-text-collapse" is-nav>
+            <div class="navbar-collapse">
                 <b-navbar-nav>
                     <b-nav-text class="mr-3">Select Element</b-nav-text>
                 </b-navbar-nav>
@@ -51,7 +51,7 @@ function handleInput(value: string) {
                         :options="dceToId"
                         @input="handleInput"></b-form-select>
                 </b-nav-form>
-            </b-collapse>
+            </div>
         </b-navbar>
         <slot name="element" :element="value"></slot>
     </div>

--- a/client/src/components/Markdown/Sections/Elements/JobSelection.vue
+++ b/client/src/components/Markdown/Sections/Elements/JobSelection.vue
@@ -23,7 +23,7 @@ defineProps<JobSelectionProps>();
         <slot v-if="jobId"> </slot>
         <div v-else>
             <b-navbar>
-                <b-collapse id="nav-text-collapse" is-nav>
+                <div class="navbar-collapse">
                     <b-navbar-nav>
                         <b-nav-text>Select Job</b-nav-text>
                     </b-navbar-nav>
@@ -36,7 +36,7 @@ defineProps<JobSelectionProps>();
                                 @input="handleInput"></b-form-select>
                         </b-input-group>
                     </b-nav-form>
-                </b-collapse>
+                </div>
             </b-navbar>
             <slot />
         </div>


### PR DESCRIPTION
Part of #21956, finishing the `BCollapse` removal.

#21958 migrated 11 files from `BCollapse` to `GCollapse` but deliberately left two navbar usages as-is: `JobSelection.vue` and `DatasetCollectionElementPicker.vue` (Galaxy Markdown report/page elements). Both wrapped their content in `<b-collapse is-nav>` inside a non-toggleable `<b-navbar>`. Since there is no `navbar-toggler` and a non-toggleable navbar renders with `navbar-expand`, Bootstrap forces the collapse visible at every viewport width (`.navbar-expand .navbar-collapse { display: flex !important; }`) — the collapse never actually collapses. It is navbar plumbing, not collapsible content, which is why `GCollapse` (a real height-transition collapse, documented "for regular (non-navbar) usage") is not the right replacement here.

This PR replaces the `<b-collapse is-nav>` wrapper with a static `<div class="navbar-collapse">`. Rendering and behavior are unchanged.

It also drops the `id="nav-text-collapse"` attribute: both components used the same id, producing duplicate DOM ids when both render on one page, and nothing referenced it (it only existed as a `v-b-toggle` target, which these navbars never had).

With this change, `client/src` contains no `BCollapse` / `b-collapse` usages at all.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open a workflow invocation report containing a `job_metrics`, `job_parameters`, `tool_stdout` or `tool_stderr` directive for a step that was mapped over a collection (`implicit_collection_jobs_id`). The "Select Job" bar should render as before, and switching jobs should update the metrics/output shown below it.
  2. Open a Galaxy Page (or invocation report) containing `history_dataset_as_image(history_dataset_collection_id=...)` or `visualization(..., history_dataset_collection_id=...)`. The "Select Element" bar should render as before, and switching elements should re-render the image/visualization below it.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).