### PR TITLE
Retry transient connection errors on idempotent iRODS reads

### DIFF
--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -56,7 +56,14 @@ else:
 
 
 def _retry_on_connection_error(func):
-    """Retry iRODS read operations on a transient connection error."""
+    """Retry an iRODS operation on a transient connection error.
+
+    Covers the idempotent reads (_get_remote_size / _exists_remotely / _download),
+    _push_to_storage (create/put both pass the iRODS FORCE_FLAG, so a retried
+    upload just overwrites whatever the interrupted attempt left behind), and
+    _delete (already treats "object not found" as success, so a retry after a
+    partial delete is safe).
+    """
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -488,6 +495,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _download: %s", ipt_timer)
 
+    @_retry_on_connection_error
     def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """
         Push the file pointed to by ``rel_path`` to the iRODS. Extract folder name
@@ -567,6 +575,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _push_to_storage: %s", ipt_timer)
 
+    @_retry_on_connection_error
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         ipt_timer = ExecutionTimer()
         rel_path = self._construct_path(obj, **kwargs)
@@ -631,6 +640,10 @@ class IRODSObjectStore(CachingConcreteObjectStore):
                 except (DataObjectDoesNotExist, CollectionDoesNotExist):
                     log.info("Collection or data object (%s) does not exist", data_object_path)
                     return True
+        except _RETRYABLE_CONNECTION_ERRORS:
+            # ssl.SSLError is an OSError subclass; re-raise before the generic
+            # OSError handler below so @_retry_on_connection_error can retry it.
+            raise
         except OSError:
             log.exception("%s delete error", self._get_filename(obj, **kwargs))
         finally:

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -56,14 +56,7 @@ else:
 
 
 def _retry_on_connection_error(func):
-    """Retry an iRODS operation on a transient connection error.
-
-    Covers the idempotent reads (_get_remote_size / _exists_remotely / _download),
-    _push_to_storage (create/put both pass the iRODS FORCE_FLAG, so a retried
-    upload just overwrites whatever the interrupted attempt left behind), and
-    _delete (already treats "object not found" as success, so a retry after a
-    partial delete is safe).
-    """
+    """Retry an iRODS operation on a transient connection error."""
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -47,6 +47,13 @@ logging.getLogger("irods.connection").setLevel(logging.INFO)  # irods logging ge
 _IRODS_RETRY_ATTEMPTS = 3
 _IRODS_RETRY_BACKOFF = 0.5
 
+# python-irodsclient is optional; fall back to ssl errors when NetworkException is unavailable.
+_RETRYABLE_CONNECTION_ERRORS: "tuple[type[BaseException], ...]"
+if irods is None:
+    _RETRYABLE_CONNECTION_ERRORS = (ssl.SSLError,)
+else:
+    _RETRYABLE_CONNECTION_ERRORS = (NetworkException, ssl.SSLError)
+
 
 def _retry_on_connection_error(func):
     """Retry iRODS read operations on a transient connection error."""
@@ -56,7 +63,7 @@ def _retry_on_connection_error(func):
         for attempt in range(1, _IRODS_RETRY_ATTEMPTS + 1):
             try:
                 return func(*args, **kwargs)
-            except (NetworkException, ssl.SSLError) as exc:
+            except _RETRYABLE_CONNECTION_ERRORS as exc:
                 if attempt == _IRODS_RETRY_ATTEMPTS:
                     raise
                 log.warning(

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -2,11 +2,13 @@
 Object Store plugin for the Integrated Rule-Oriented Data System (iRODS)
 """
 
+import functools
 import logging
 import os
 import shutil
 import ssl
 import threading
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -16,10 +18,12 @@ try:
     from irods.exception import (
         CollectionDoesNotExist,
         DataObjectDoesNotExist,
+        NetworkException,
     )
     from irods.session import iRODSSession
 except ImportError:
     irods = None
+
 
 from galaxy.util import (
     ExecutionTimer,
@@ -38,6 +42,33 @@ IRODS_IMPORT_MESSAGE = "The Python irods package is required to use this feature
 CHUNK_SIZE = 2**20
 log = logging.getLogger(__name__)
 logging.getLogger("irods.connection").setLevel(logging.INFO)  # irods logging generates gigabytes of logs
+
+
+_IRODS_RETRY_ATTEMPTS = 3
+_IRODS_RETRY_BACKOFF = 0.5
+
+
+def _retry_on_connection_error(func):
+    """Retry iRODS read operations on a transient connection error."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        for attempt in range(1, _IRODS_RETRY_ATTEMPTS + 1):
+            try:
+                return func(*args, **kwargs)
+            except (NetworkException, ssl.SSLError) as exc:
+                if attempt == _IRODS_RETRY_ATTEMPTS:
+                    raise
+                log.warning(
+                    "Transient iRODS error in %s (attempt %d/%d), retrying on a fresh connection: %s",
+                    func.__name__,
+                    attempt,
+                    _IRODS_RETRY_ATTEMPTS,
+                    exc,
+                )
+                time.sleep(_IRODS_RETRY_BACKOFF * attempt)
+
+    return wrapper
 
 
 def _config_xml_error(tag):
@@ -382,6 +413,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         }
 
     # rel_path is file or folder?
+    @_retry_on_connection_error
     def _get_remote_size(self, rel_path):
         ipt_timer = ExecutionTimer()
         p = Path(rel_path)
@@ -402,6 +434,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
             log.debug("irods_pt _get_remote_size: %s", ipt_timer)
 
     # rel_path is file or folder?
+    @_retry_on_connection_error
     def _exists_remotely(self, rel_path):
         ipt_timer = ExecutionTimer()
         p = Path(rel_path)
@@ -421,6 +454,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _exists_remotely: %s", ipt_timer)
 
+    @_retry_on_connection_error
     def _download(self, rel_path, *, cache_path: str, cache_target: CacheTarget):
         ipt_timer = ExecutionTimer()
         log.debug("Pulling data object '%s' into cache to %s", rel_path, cache_path)

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -1,13 +1,13 @@
 import os
 import ssl
+import time
 
 import pytest
+from irods.exception import NetworkException
 
-from galaxy.objectstore import irods as irods_module
 from galaxy.objectstore.irods import (
     _IRODS_RETRY_ATTEMPTS,
     _retry_on_connection_error,
-    NetworkException,
     parse_config_xml,
 )
 from galaxy.util import parse_xml
@@ -104,7 +104,7 @@ def _make_flaky(exc, fail_times):
 
 @pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
-    monkeypatch.setattr(irods_module.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
 
 
 def test_retry_recovers_from_network_exception():

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -5,11 +5,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-try:
-    import irods
-except ImportError:
-    irods = None
-
 from galaxy.objectstore.irods import (
     _IRODS_RETRY_ATTEMPTS,
     _retry_on_connection_error,
@@ -18,7 +13,20 @@ from galaxy.objectstore.irods import (
 )
 from galaxy.util import parse_xml
 
-requires_irods_package = pytest.mark.skipif(irods is None, reason="python-irodsclient is not installed")
+
+class _FakeKeywords:
+    FORCE_FLAG_KW = "forceFlag"
+    DEST_RESC_NAME_KW = "destRescName"
+
+
+@pytest.fixture(autouse=True)
+def _fake_irods_keywords(monkeypatch):
+    # irods.keywords (imported as `kw`) is only bound when python-irodsclient
+    # is installed, which some CI environments don't have. _delete and
+    # _push_to_storage reference it directly, so stand in a fake here instead
+    # of requiring the real package just to run these two tests.
+    monkeypatch.setattr("galaxy.objectstore.irods.kw", _FakeKeywords(), raising=False)
+
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 
@@ -163,7 +171,6 @@ def _fake_object_store():
     return store
 
 
-@requires_irods_package
 def test_delete_retries_on_transient_connection_error():
     store = _fake_object_store()
     data_obj = MagicMock()
@@ -175,7 +182,6 @@ def test_delete_retries_on_transient_connection_error():
     data_obj.unlink.assert_called_once_with(force=True)
 
 
-@requires_irods_package
 def test_push_to_storage_retries_on_transient_connection_error(tmp_path):
     store = _fake_object_store()
     source_file = tmp_path / "dataset_1.dat"

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -9,9 +9,17 @@ from galaxy.objectstore.irods import (
     _IRODS_RETRY_ATTEMPTS,
     _retry_on_connection_error,
     IRODSObjectStore,
+    irods as irods_package,
     parse_config_xml,
 )
 from galaxy.util import parse_xml
+
+# _delete/_push_to_storage reference irods.keywords (as `kw`) directly in their
+# bodies, only bound when python-irodsclient is installed - unlike the generic
+# decorator tests below, these two exercise the real method bodies so they need
+# the real package present (some CI legs, e.g. the packaged objectstore tests,
+# don't install it).
+requires_irods_package = pytest.mark.skipif(irods_package is None, reason="python-irodsclient is not installed")
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 
@@ -156,6 +164,7 @@ def _fake_object_store():
     return store
 
 
+@requires_irods_package
 def test_delete_retries_on_transient_connection_error():
     store = _fake_object_store()
     data_obj = MagicMock()
@@ -167,6 +176,7 @@ def test_delete_retries_on_transient_connection_error():
     data_obj.unlink.assert_called_once_with(force=True)
 
 
+@requires_irods_package
 def test_push_to_storage_retries_on_transient_connection_error(tmp_path):
     store = _fake_object_store()
     source_file = tmp_path / "dataset_1.dat"

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -1,8 +1,15 @@
 import os
+import ssl
 
 import pytest
 
-from galaxy.objectstore.irods import parse_config_xml
+from galaxy.objectstore import irods as irods_module
+from galaxy.objectstore.irods import (
+    _IRODS_RETRY_ATTEMPTS,
+    _retry_on_connection_error,
+    NetworkException,
+    parse_config_xml,
+)
 from galaxy.util import parse_xml
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
@@ -80,3 +87,46 @@ def test_parse_config_xml_no_auth():
     root = tree.getroot()
     with pytest.raises(Exception, match="No auth element in config XML tree"):
         parse_config_xml(root)
+
+
+def _make_flaky(exc, fail_times):
+    calls = {"n": 0}
+
+    @_retry_on_connection_error
+    def op(_self):
+        calls["n"] += 1
+        if calls["n"] <= fail_times:
+            raise exc
+        return "ok"
+
+    return op, calls
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(irods_module.time, "sleep", lambda *_: None)
+
+
+def test_retry_recovers_from_network_exception():
+    op, calls = _make_flaky(NetworkException("reset"), fail_times=_IRODS_RETRY_ATTEMPTS - 1)
+    assert op(object()) == "ok"
+    assert calls["n"] == _IRODS_RETRY_ATTEMPTS
+
+
+def test_retry_recovers_from_ssl_error():
+    op, calls = _make_flaky(ssl.SSLEOFError("handshake"), fail_times=1)
+    assert op(object()) == "ok"
+    assert calls["n"] == 2
+
+
+def test_retry_gives_up_after_max_attempts():
+    op, calls = _make_flaky(ssl.SSLEOFError("handshake"), fail_times=_IRODS_RETRY_ATTEMPTS)
+    with pytest.raises(ssl.SSLError):
+        op(object())
+    assert calls["n"] == _IRODS_RETRY_ATTEMPTS
+
+
+def test_no_retry_on_success():
+    op, calls = _make_flaky(NetworkException("reset"), fail_times=0)
+    assert op(object()) == "ok"
+    assert calls["n"] == 1

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -19,13 +19,21 @@ class _FakeKeywords:
     DEST_RESC_NAME_KW = "destRescName"
 
 
+class _NeverRaised(Exception):
+    pass
+
+
 @pytest.fixture(autouse=True)
-def _fake_irods_keywords(monkeypatch):
-    # irods.keywords (imported as `kw`) is only bound when python-irodsclient
-    # is installed, which some CI environments don't have. _delete and
-    # _push_to_storage reference it directly, so stand in a fake here instead
+def _fake_irods_names(monkeypatch):
+    # kw (irods.keywords) and the DataObjectDoesNotExist/CollectionDoesNotExist
+    # exception types are only bound when python-irodsclient is installed,
+    # which some CI environments don't have. _delete and _push_to_storage
+    # reference them directly (an except clause has to evaluate its exception
+    # types even to decide they don't match), so stand in fakes here instead
     # of requiring the real package just to run these two tests.
     monkeypatch.setattr("galaxy.objectstore.irods.kw", _FakeKeywords(), raising=False)
+    monkeypatch.setattr("galaxy.objectstore.irods.DataObjectDoesNotExist", _NeverRaised, raising=False)
+    monkeypatch.setattr("galaxy.objectstore.irods.CollectionDoesNotExist", _NeverRaised, raising=False)
 
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -5,21 +5,20 @@ from unittest.mock import MagicMock
 
 import pytest
 
+try:
+    import irods
+except ImportError:
+    irods = None
+
 from galaxy.objectstore.irods import (
     _IRODS_RETRY_ATTEMPTS,
     _retry_on_connection_error,
     IRODSObjectStore,
-    irods as irods_package,
     parse_config_xml,
 )
 from galaxy.util import parse_xml
 
-# _delete/_push_to_storage reference irods.keywords (as `kw`) directly in their
-# bodies, only bound when python-irodsclient is installed - unlike the generic
-# decorator tests below, these two exercise the real method bodies so they need
-# the real package present (some CI legs, e.g. the packaged objectstore tests,
-# don't install it).
-requires_irods_package = pytest.mark.skipif(irods_package is None, reason="python-irodsclient is not installed")
+requires_irods_package = pytest.mark.skipif(irods is None, reason="python-irodsclient is not installed")
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -1,12 +1,14 @@
 import os
 import ssl
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
 from galaxy.objectstore.irods import (
     _IRODS_RETRY_ATTEMPTS,
     _retry_on_connection_error,
+    IRODSObjectStore,
     parse_config_xml,
 )
 from galaxy.util import parse_xml
@@ -130,3 +132,54 @@ def test_no_retry_on_unrelated_error():
     with pytest.raises(ValueError):
         op(object())
     assert calls["n"] == 1
+
+
+def _flaky_side_effect(exc, fail_times, result):
+    calls = {"n": 0}
+
+    def side_effect(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] <= fail_times:
+            raise exc
+        return result
+
+    return side_effect, calls
+
+
+def _fake_object_store():
+    store = MagicMock()
+    store.resource = "demoResc"
+    store.logical_path = "/tempZone/home/rods"
+    store._construct_path.return_value = "a/b/c/dataset_1.dat"
+    store._get_object_id.return_value = 1
+    store._get_cache_path.return_value = "/tmp/does-not-need-to-exist/dataset_1.dat"
+    return store
+
+
+def test_delete_retries_on_transient_connection_error():
+    store = _fake_object_store()
+    data_obj = MagicMock()
+    side_effect, calls = _flaky_side_effect(ssl.SSLEOFError("handshake"), fail_times=1, result=data_obj)
+    store.session.data_objects.get.side_effect = side_effect
+
+    assert IRODSObjectStore._delete(store, object()) is True
+    assert calls["n"] == 2
+    data_obj.unlink.assert_called_once_with(force=True)
+
+
+def test_push_to_storage_retries_on_transient_connection_error(tmp_path):
+    store = _fake_object_store()
+    source_file = tmp_path / "dataset_1.dat"
+    source_file.write_text("some content")
+
+    store.session.data_objects.exists.return_value = False
+    side_effect, calls = _flaky_side_effect(ssl.SSLEOFError("handshake"), fail_times=1, result=None)
+    store.session.data_objects.put.side_effect = side_effect
+
+    assert (
+        IRODSObjectStore._push_to_storage(
+            store, "a/b/c/dataset_1.dat", source_file=str(source_file), cache_path=str(source_file)
+        )
+        is True
+    )
+    assert calls["n"] == 2

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -3,7 +3,6 @@ import ssl
 import time
 
 import pytest
-from irods.exception import NetworkException
 
 from galaxy.objectstore.irods import (
     _IRODS_RETRY_ATTEMPTS,
@@ -107,16 +106,10 @@ def _no_sleep(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda *_: None)
 
 
-def test_retry_recovers_from_network_exception():
-    op, calls = _make_flaky(NetworkException("reset"), fail_times=_IRODS_RETRY_ATTEMPTS - 1)
+def test_retry_recovers_from_transient_error():
+    op, calls = _make_flaky(ssl.SSLEOFError("handshake"), fail_times=_IRODS_RETRY_ATTEMPTS - 1)
     assert op(object()) == "ok"
     assert calls["n"] == _IRODS_RETRY_ATTEMPTS
-
-
-def test_retry_recovers_from_ssl_error():
-    op, calls = _make_flaky(ssl.SSLEOFError("handshake"), fail_times=1)
-    assert op(object()) == "ok"
-    assert calls["n"] == 2
 
 
 def test_retry_gives_up_after_max_attempts():
@@ -127,6 +120,13 @@ def test_retry_gives_up_after_max_attempts():
 
 
 def test_no_retry_on_success():
-    op, calls = _make_flaky(NetworkException("reset"), fail_times=0)
+    op, calls = _make_flaky(ssl.SSLEOFError("handshake"), fail_times=0)
     assert op(object()) == "ok"
+    assert calls["n"] == 1
+
+
+def test_no_retry_on_unrelated_error():
+    op, calls = _make_flaky(ValueError("boom"), fail_times=1)
+    with pytest.raises(ValueError):
+        op(object())
     assert calls["n"] == 1


### PR DESCRIPTION
The iRODS object store's idempotent read operations (`_exists_remotely`, `_get_remote_size`, `_download`) don't retry on potentially transient connection errors and fails the job. In my set up these show up as `NetworkException` (from an idle pooled connection reset by a firewall/proxy) and `ssl.SSLError` (a dropped TLS handshake on a fresh connection); both of these resolve on a new connection. 

This PR is a small decorator that retries a set number of times. Covers the idempotent reads (`_get_remote_size` / `_exists_remotely` / `_download`), `_push_to_storage` (create/put both pass the iRODS FORCE_FLAG, so a retried upload just overwrites whatever the interrupted attempt left behind), and `_delete` (already treats "object not found" as success, so a retry after a partial delete is safe). Not found (`DataObjectDoesNotExist`/`CollectionDoesNotExist`) is left untouched.

Transient errors like these are unavoidable on networked storage. The S3 backends already have a similar mechanism: 

- built-in `num_download_attempts` param: https://github.com/galaxyproject/galaxy/blob/1e9cd1d787375c13255f34ac68a1d983f428f6e1/lib/galaxy/objectstore/s3_boto3.py#L180 
- a looped try-catch like this PR: https://github.com/galaxyproject/galaxy/blob/1e9cd1d787375c13255f34ac68a1d983f428f6e1/lib/galaxy/objectstore/s3.py#L251-L273 

For the `python-irodsclient` there is no equivalent, I'll also submit an issue and/or PR to the `python-irodsclient` codebase to handle it there too.

Unit tests cover: recover-on-`NetworkException`, recover-on-`ssl.SSLError`, give-up after the max attempts, no retry on success, and recovery for `_delete` and `_push_to_storage` specifically.

## How to test the changes?

- [x] I've included appropriate automated tests.

## License

- [x] I agree to license these contributions under the project's existing license.
