### PR TITLE
[26.1] Prevent loss of unsaved changes on navigation

### DIFF
--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -980,21 +980,40 @@ export function getRouter(Galaxy) {
         return false;
     }
 
+    /** Checks for unsaved changes (e.g., in the workflow editor) before navigating.
+     * Prompts the user to confirm if there are unsaved changes.
+     * @returns true if navigation should proceed, false to abort.
+     */
+    function checkUnsavedChanges(router) {
+        if (!router.confirmation) {
+            return true;
+        }
+        if (confirm("There are unsaved changes which will be lost.")) {
+            router.confirmation = undefined;
+            return true;
+        }
+        return false;
+    }
+
     router.beforeEach(async (to, from, next) => {
         // TODO: merge anon redirect functionality here for more standard handling
+
+        if (!checkUnsavedChanges(router)) {
+            return next(false);
+        }
 
         const isAdminAccessRequired = checkAdminAccessRequired(to);
         if (isAdminAccessRequired) {
             const error = new Error(`Admin access required for '${to.path}'.`);
             error.name = "AdminRequired";
-            next(error);
+            return next(error);
         }
 
         const isRegisteredUserAccessRequired = checkRegisteredUserAccessRequired(to);
         if (isRegisteredUserAccessRequired) {
             const error = new Error(`Registered user access required for '${to.path}'.`);
             error.name = "RegisteredUserRequired";
-            next(error);
+            return next(error);
         }
         next();
     });


### PR DESCRIPTION
Fixes #23144

Adds a router guard that prompts users to confirm navigation when unsaved changes exist. This stops accidental data loss in editors. Also standardizes early returns in access control logic for consistency.

The issue in #23144 was not specific to Firefox, but you could actually reproduce it in any browser just by using the back button.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Open the Workflow Editor and make some changes
  - Click the navigate back button in the browser
  - You should now get a confirmation before navigating back

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
