### PR TITLE
[26.1] Fix webhooks broken by the Backbone/underscore removal

### DIFF
--- a/client/src/components/Common/Webhook.test.ts
+++ b/client/src/components/Common/Webhook.test.ts
@@ -1,0 +1,46 @@
+import { getLocalVue } from "@tests/vitest/helpers";
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Webhook from "./Webhook.vue";
+
+const { WEBHOOK, targetExistsAtInjection } = vi.hoisted(() => ({
+    WEBHOOK: { id: "phdcomics", type: ["tool"], weight: 1, script: "/* noop */", styles: "" },
+    // Records whether the target mount point existed in the document at the
+    // moment the webhook script would have been injected.
+    targetExistsAtInjection: vi.fn(),
+}));
+
+vi.mock("@/utils/webhooks", () => ({
+    loadWebhooks: vi.fn().mockResolvedValue([WEBHOOK]),
+    pickWebhook: vi.fn().mockReturnValue(WEBHOOK),
+}));
+
+vi.mock("@/utils/utils", () => ({
+    appendScriptStyle: (data: { id?: string }) => {
+        targetExistsAtInjection(Boolean(data.id && document.getElementById(data.id)));
+    },
+}));
+
+const localVue = getLocalVue();
+
+describe("Webhook.vue", () => {
+    beforeEach(() => {
+        targetExistsAtInjection.mockClear();
+    });
+
+    it("renders the webhook mount point before injecting its script", async () => {
+        mount(Webhook as object, {
+            localVue,
+            propsData: { type: "tool", toolId: "cat1", toolVersion: "1.0" },
+            attachTo: document.body,
+        });
+
+        await flushPromises();
+
+        expect(targetExistsAtInjection).toHaveBeenCalledTimes(1);
+        // Injected script queries `#<webhookId>`; that div must exist when it runs.
+        expect(targetExistsAtInjection).toHaveBeenCalledWith(true);
+    });
+});

--- a/client/src/components/Common/Webhook.vue
+++ b/client/src/components/Common/Webhook.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { nextTick, onMounted, ref } from "vue";
 
 import { appendScriptStyle } from "@/utils/utils";
 import { loadWebhooks, pickWebhook } from "@/utils/webhooks";
@@ -28,6 +28,9 @@ onMounted(async () => {
     if (webhooks.length > 0) {
         const model = pickWebhook(webhooks);
         webhookId.value = model.id;
+        // Wait for the `#<webhookId>` mount point to render before injecting the
+        // webhook script, which targets that element as soon as it executes.
+        await nextTick();
         appendScriptStyle(model);
     }
 });

--- a/doc/source/admin/special_topics/webhooks.rst
+++ b/doc/source/admin/special_topics/webhooks.rst
@@ -121,6 +121,13 @@ static files
 - script.js - all JavaScript code (with all third-party dependencies) must be here
 - styles.css - all CSS styles, used by the plugin
 
+script.js must be self-contained, modern vanilla JavaScript. The client no longer
+exposes Backbone, underscore or jQuery as globals, so webhook scripts cannot rely
+on them; use standard DOM APIs (``document.getElementById``, ``fetch``, etc.). Each
+script is wrapped in an IIFE and injected only after its ``#<webhook-id>`` mount
+point has rendered, so it may query that element immediately. The *phdcomics* and
+*xkcd* example plugins in ``test/functional/webhooks/`` show the expected style.
+
 
 Plugin dependencies
 -------------------

--- a/lib/galaxy_test/api/test_webhooks.py
+++ b/lib/galaxy_test/api/test_webhooks.py
@@ -1,4 +1,16 @@
+import re
+
 from ._framework import ApiTestCase
+
+# Backbone, underscore and jQuery are no longer bundled as global objects for
+# injected webhook scripts. These patterns catch webhook scripts that still rely
+# on them (matching usage, not passing mentions in comments).
+REMOVED_GLOBAL_PATTERNS = [
+    re.compile(r"Backbone\."),
+    re.compile(r"_\.(template|each|map|extend|isEmpty)\("),
+    re.compile(r"\bjQuery\("),
+    re.compile(r"\$\(document\)"),
+]
 
 
 class TestWebhooksApi(ApiTestCase):
@@ -26,6 +38,16 @@ class TestWebhooksApi(ApiTestCase):
         response = self._get("webhooks/trans_object/data")
         self._assert_status_code_is(response, 200)
         self._assert_has_keys(response.json(), "username")
+
+    def test_scripts_avoid_removed_globals(self):
+        response = self._get("webhooks")
+        self._assert_status_code_is(response, 200)
+        for webhook in response.json():
+            script = webhook.get("script") or ""
+            for pattern in REMOVED_GLOBAL_PATTERNS:
+                assert not pattern.search(
+                    script
+                ), f"Webhook '{webhook.get('id')}' script uses removed global matching {pattern.pattern!r}"
 
     def _assert_are_webhooks(self, response):
         response_list = response.json()

--- a/test/functional/webhooks/phdcomics/script.js
+++ b/test/functional/webhooks/phdcomics/script.js
@@ -1,56 +1,37 @@
-$(document).ready(function() {
+// Injected by the webhook framework (see appendScriptStyle in client/src/utils/utils.ts).
+// Runs in the global page scope wrapped in an IIFE, so it must be self-contained
+// vanilla JS -- Backbone, underscore and jQuery are no longer available globals.
+const root = typeof Galaxy !== "undefined" && Galaxy.root ? Galaxy.root : "/";
+const container = document.getElementById("phdcomics");
 
-    var galaxyRoot = typeof Galaxy != 'undefined' ? Galaxy.root : '/';
+if (container) {
+    container.innerHTML =
+        '<div id="phdcomics-header">' +
+        '<div id="phdcomics-name">PHD Comics</div>' +
+        '<button id="phdcomics-random" type="button">Random</button>' +
+        "</div>" +
+        '<div id="phdcomics-img"></div>';
 
-    var PHDComicsAppView = Backbone.View.extend({
-        el: '#phdcomics',
+    const imgContainer = document.getElementById("phdcomics-img");
 
-        appTemplate: _.template(
-            '<div id="phdcomics-header">' +
-                '<div id="phdcomics-name">PHD Comics</div>' +
-                '<button id="phdcomics-random">Random</button>' +
-            '</div>' +
-            '<div id="phdcomics-img"></div>'
-        ),
-
-        imgTemplate: _.template('<img src="<%= src %>"">'),
-
-        events: {
-            'click #phdcomics-random': 'getRandomComic'
-        },
-
-        initialize: function() {
-            this.render();
-        },
-
-        render: function() {
-            this.$el.html(this.appTemplate());
-            this.$comicImg = this.$('#phdcomics-img');
-            this.getRandomComic();
-            return this;
-        },
-
-        getRandomComic: function() {
-            var me = this,
-                url = galaxyRoot + 'api/webhooks/phdcomics/data';
-
-            this.$comicImg.html($('<div/>', {
-                id: 'phdcomics-loader'
-            }));
-
-            $.getJSON(url, function(data) {
-                if (data.success) {
-                    me.renderImg(data.src);
-                } else {
-                    console.error('[ERROR] "' + url + '":\n' + data.error);
-                }
-            });
-        },
-
-        renderImg: function(src) {
-            this.$comicImg.html(this.imgTemplate({src: src}));
+    async function loadRandomComic() {
+        imgContainer.innerHTML = '<div id="phdcomics-loader"></div>';
+        const url = `${root}api/webhooks/phdcomics/data`;
+        try {
+            const response = await fetch(url);
+            const data = await response.json();
+            if (data.success) {
+                const img = document.createElement("img");
+                img.src = data.src;
+                imgContainer.replaceChildren(img);
+            } else {
+                console.error(`[phdcomics webhook] "${url}":\n${data.error}`);
+            }
+        } catch (e) {
+            console.error(`[phdcomics webhook] request to "${url}" failed`, e);
         }
-    });
+    }
 
-    new PHDComicsAppView();
-});
+    document.getElementById("phdcomics-random").addEventListener("click", loadRandomComic);
+    loadRandomComic();
+}

--- a/test/functional/webhooks/xkcd/__init__.py
+++ b/test/functional/webhooks/xkcd/__init__.py
@@ -1,0 +1,24 @@
+import json
+import logging
+import random
+from urllib.request import urlopen
+
+log = logging.getLogger(__name__)
+
+
+def main(trans, webhook, params):
+    error = ""
+    comic = {}
+
+    try:
+        # The xkcd JSON API has no CORS headers and info.0.json is only served
+        # over HTTPS, so fetch it server-side rather than from the browser.
+        latest = json.loads(urlopen("https://xkcd.com/info.0.json").read())
+        random_id = random.randint(1, latest["num"])
+        data = json.loads(urlopen(f"https://xkcd.com/{random_id}/info.0.json").read())
+        comic = {"img": data["img"], "alt": data["alt"], "title": data["title"]}
+    except Exception as e:
+        log.exception(e)
+        error = str(e)
+
+    return {"success": not error, "error": error, "comic": comic}

--- a/test/functional/webhooks/xkcd/__init__.py
+++ b/test/functional/webhooks/xkcd/__init__.py
@@ -5,6 +5,11 @@ from urllib.request import urlopen
 
 log = logging.getLogger(__name__)
 
+TIMEOUT = 10
+# xkcd #404 is a deliberate joke: the comic does not exist and its API endpoint
+# returns HTTP 404, so it must never be picked.
+MISSING_COMIC_ID = 404
+
 
 def main(trans, webhook, params):
     error = ""
@@ -13,9 +18,11 @@ def main(trans, webhook, params):
     try:
         # The xkcd JSON API has no CORS headers and info.0.json is only served
         # over HTTPS, so fetch it server-side rather than from the browser.
-        latest = json.loads(urlopen("https://xkcd.com/info.0.json").read())
-        random_id = random.randint(1, latest["num"])
-        data = json.loads(urlopen(f"https://xkcd.com/{random_id}/info.0.json").read())
+        latest = json.loads(urlopen("https://xkcd.com/info.0.json", timeout=TIMEOUT).read())
+        random_id = MISSING_COMIC_ID
+        while random_id == MISSING_COMIC_ID:
+            random_id = random.randint(1, latest["num"])
+        data = json.loads(urlopen(f"https://xkcd.com/{random_id}/info.0.json", timeout=TIMEOUT).read())
         comic = {"img": data["img"], "alt": data["alt"], "title": data["title"]}
     except Exception as e:
         log.exception(e)

--- a/test/functional/webhooks/xkcd/script.js
+++ b/test/functional/webhooks/xkcd/script.js
@@ -1,56 +1,41 @@
-$(document).ready(function() {
+// Injected by the webhook framework (see appendScriptStyle in client/src/utils/utils.ts).
+// Runs in the global page scope wrapped in an IIFE, so it must be self-contained
+// vanilla JS -- Backbone, underscore and jQuery are no longer available globals.
+// The comic is fetched through the server-side helper (__init__.py) because the
+// xkcd JSON API sends no CORS headers and is only served over HTTPS.
+const root = typeof Galaxy !== "undefined" && Galaxy.root ? Galaxy.root : "/";
+const container = document.getElementById("xkcd");
 
-    var XkcdAppView = Backbone.View.extend({
-        el: '#xkcd',
+if (container) {
+    container.innerHTML =
+        '<div id="xkcd-header">' +
+        '<div id="xkcd-name">xkcd</div>' +
+        '<button id="xkcd-random" type="button">Random</button>' +
+        "</div>" +
+        '<div id="xkcd-img"></div>';
 
-        appTemplate: _.template(
-            '<div id="xkcd-header">' +
-                '<div id="xkcd-name">xkcd</div>' +
-                '<button id="xkcd-random">Random</button>' +
-            '</div>' +
-            '<div id="xkcd-img"></div>'
-        ),
+    const imgContainer = document.getElementById("xkcd-img");
 
-        imgTemplate: _.template('<img src="<%= img %>" alt="<%= alt %>" title="<%= title %>">'),
-
-        events: {
-            'click #xkcd-random': 'getRandomXkcd'
-        },
-
-        initialize: function() {
-            var me = this;
-
-            this.render();
-
-            // Get id of the last xkcd
-            $.getJSON('http://dynamic.xkcd.com/api-0/jsonp/comic?callback=?', function(data) {
-                me.latestXkcdId = data.num;
-                me.getRandomXkcd();
-            });
-        },
-
-        render: function() {
-            this.$el.html(this.appTemplate());
-            this.xkcdImg = this.$('#xkcd-img');
-            return this;
-        },
-
-        getRandomXkcd: function() {
-            var me = this,
-                randomId = Math.floor(Math.random() * this.latestXkcdId) + 1;
-
-            this.xkcdImg.html($('<div/>', {id: 'xkcd-loader'}));
-            $.getJSON('http://dynamic.xkcd.com/api-0/jsonp/comic/' + randomId + '?callback=?', function(data) {
-                me.xkcd = {img: data.img, alt: data.alt, title: data.title};
-                me.renderImg();
-            });
-        },
-
-        renderImg: function() {
-            this.xkcdImg.html(this.imgTemplate({img: this.xkcd.img, alt: this.xkcd.alt, title: this.xkcd.title}));
+    async function loadRandomComic() {
+        imgContainer.innerHTML = '<div id="xkcd-loader"></div>';
+        const url = `${root}api/webhooks/xkcd/data`;
+        try {
+            const response = await fetch(url);
+            const data = await response.json();
+            if (data.success) {
+                const img = document.createElement("img");
+                img.src = data.comic.img;
+                img.alt = data.comic.alt;
+                img.title = data.comic.title;
+                imgContainer.replaceChildren(img);
+            } else {
+                console.error(`[xkcd webhook] "${url}":\n${data.error}`);
+            }
+        } catch (e) {
+            console.error(`[xkcd webhook] request to "${url}" failed`, e);
         }
-    });
+    }
 
-    var XkcdApp = new XkcdAppView;
-
-});
+    document.getElementById("xkcd-random").addEventListener("click", loadRandomComic);
+    loadRandomComic();
+}


### PR DESCRIPTION
Tool and workflow webhooks stopped rendering anything after Backbone and underscore were removed from the client in galaxyproject/galaxy#22357 and galaxyproject/galaxy#22355. The former explicitly removed "the global `window.Backbone` exposure from libs.js".

Webhook `script.js` files are injected into the page as-is and run in the global scope, so they can only use globals the client still exposes. Both example plugins were written against `Backbone.View.extend` and `_.template`, so they now throw immediately and their container renders empty:

```
ReferenceError: Backbone is not defined
```

jQuery is still assigned to `window.$`/`window.jQuery` (`client/src/entry/libs.js`), which is why `$`-only webhooks such as `gtn` kept working and the breakage looks selective rather than total.

### What this PR does

- Ports the `phdcomics` and `xkcd` example webhooks to self-contained vanilla JS (plain DOM APIs + `fetch`). Element ids are unchanged, so the existing `styles.css` still applies.
- Adds an `xkcd` server-side helper (`__init__.py`). The old script called `http://dynamic.xkcd.com/api-0/jsonp/comic` directly from the browser; that endpoint now redirects to HTTPS and the xkcd JSON API sends no CORS headers, so the call is blocked as mixed content on any HTTPS Galaxy. Fetching server-side matches what `phdcomics` already does. The helper also skips comic _404_, which intentionally does not exist and returns HTTP 404, and bounds both requests with a timeout.
- Fixes a mount race in `Webhook.vue`: `appendScriptStyle()` ran synchronously right after setting `webhookId`, so the injected script executed before Vue had flushed the `v-if` div and could not find its own `#<webhookId>` mount point. The old scripts happened to mask this by deferring their body through `$(document).ready`; vanilla scripts run immediately, so the script is now injected after `nextTick()`.
- Adds a regression test asserting that no served webhook script references the removed globals.
- Documents in `webhooks.rst` that webhook scripts must be self-contained vanilla JS.

### Not included

`config/plugins/webhooks/demo/search/script.js` (the `searchover` overlay) is also Backbone-based and still broken. It is ~49 KB of bundled view code and is `activate: false` by default, so porting it is left to a follow-up rather than bundling it here.

Webhooks maintained outside this repository (for example usegalaxy.eu's `citation_needed` and `iframe`) are affected by the same root cause and need the equivalent change in their own repositories.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy with `webhooks_dir: test/functional/webhooks` in `galaxy.yml`.
  2. Run any tool and land on the tool success page.
  3. The phdcomics or xkcd panel should render a comic with a working "Random" button, and the browser console should be free of `ReferenceError` messages.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).