### PR TITLE
[26.0] Fix AssertionError remapping malformed galaxy markdown blocks

### DIFF
--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -1400,16 +1400,16 @@ def _parse_directive_argument_value(arg_name: str, line: str) -> Optional[str]:
 
 def _remap_galaxy_markdown_calls(func, markdown):
     def _remap_container(container):
-        matching_line = None
+        match = None
         for line in container.splitlines():
-            if GALAXY_MARKDOWN_FUNCTION_CALL_LINE.match(line):
-                assert matching_line is None
-                matching_line = line
+            line_match = GALAXY_MARKDOWN_FUNCTION_CALL_LINE.match(line)
+            if line_match:
+                if match is not None:
+                    raise MalformedContents("Only one Galaxy directive is allowed per fenced Galaxy block (```galaxy)")
+                match = line_match
 
-        if matching_line:
-            match = GALAXY_MARKDOWN_FUNCTION_CALL_LINE.match(line)
-            assert match  # already matched
-            return func(match.group(1), f"{matching_line}\n")
+        if match:
+            return func(match.group(1), f"{match.group(0)}\n")
         else:
             return (container, True)
 

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -3,9 +3,14 @@ import tempfile
 from contextlib import contextmanager
 from unittest import mock
 
+import pytest
+
 from galaxy import model
+from galaxy.exceptions import MalformedContents
 from galaxy.managers.jobs import JobManager
 from galaxy.managers.markdown_util import (
+    _remap_galaxy_markdown_calls,
+    populate_invocation_markdown,
     ready_galaxy_markdown_for_export,
     to_basic_markdown,
 )
@@ -490,3 +495,32 @@ I ran a cool analysis at [http://mycoolgalaxy.org](http://mycoolgalaxy.org).
 
     def _ready_export(self, example: str):
         return ready_galaxy_markdown_for_export(self.trans, example)
+
+
+class TestPopulateInvocationMarkdown(BaseExportTestCase):
+    def test_directive_followed_by_stray_prose_remaps_directive(self):
+        invocation = self._new_invocation()
+        example = """# Report
+```galaxy
+history_dataset_as_image(output="spatial scatter plots filtered")
+
+
+---
+<br>
+### Filtering by cell area
+<br>
+### Quality metrics after filtering by cell area
+<br>
+```
+"""
+        result = populate_invocation_markdown(self.trans, invocation, example)
+        assert 'history_dataset_as_image(invocation_id=1, output="spatial scatter plots filtered")' in result
+
+    def test_two_directives_in_one_block_raises(self):
+        example = """```galaxy
+history_dataset_display(history_dataset_id=1)
+history_dataset_display(history_dataset_id=2)
+```
+"""
+        with pytest.raises(MalformedContents):
+            _remap_galaxy_markdown_calls(lambda container, line: (line, False), example)


### PR DESCRIPTION
`_remap_container` (in `_remap_galaxy_markdown_calls`) saved the directive line while looping over a ```` ```galaxy ```` container's lines, but then re-matched `GALAXY_MARKDOWN_FUNCTION_CALL_LINE` against the loop variable holding the container's *last* line. For stored report markdown that was never validated — e.g. an unclosed ```` ```galaxy ```` fence, which makes `GALAXY_FENCED_BLOCK` swallow the following prose into the container — the re-match returned `None` and the subsequent `assert` produced an unhandled 500 on `GET /api/invocations/{invocation_id}/report`.

Sentry captured the failing locals directly (9 occurrences on usegalaxy.eu 26.1.rc1): `matching_line` held the directive `history_dataset_as_image(output="spatial scatter plots filtered")` while `line` was `<br>`, so `match` was `None`.

This keeps the match object found during the loop instead of re-matching, and turns the other assert (a second directive within one block) into `MalformedContents` so malformed user content yields a 4xx rather than an `AssertionError`.

Fixes #23175
Fixes USEGALAXY-EU-MAIN-61HFG00001W43

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).