### PR TITLE
Add object store multi cache sharding

### DIFF
--- a/lib/galaxy/config/sample/object_store_conf.sample.yml
+++ b/lib/galaxy/config/sample/object_store_conf.sample.yml
@@ -20,7 +20,8 @@
 #
 # Instead of a single `path`, the cache can be sharded across multiple directories
 # with weighted distribution. All cache entries for the same dataset (including
-# extra_files and metadata) resolve to the same shard deterministically:
+# extra_files) resolve to the same shard deterministically. Metadata files have
+# their own id space and may land on a different shard:
 #
 # cache:
 #   dirs:

--- a/lib/galaxy/config/sample/object_store_conf.sample.yml
+++ b/lib/galaxy/config/sample/object_store_conf.sample.yml
@@ -18,6 +18,20 @@
 #   # cache. By default (true) data is also copied to the cache.
 #   cache_updated_data: true
 #
+# Instead of a single `path`, the cache can be sharded across multiple directories
+# with weighted distribution. All cache entries for the same dataset (including
+# extra_files and metadata) resolve to the same shard deterministically:
+#
+# cache:
+#   dirs:
+#     - path: /fast/cache
+#       weight: 3
+#       size: 500
+#     - path: /slow/cache
+#       weight: 1
+#       size: 200
+#   cache_updated_data: true
+#
 # Most object store types have a `store_by` option which can be set to either `uuid` or `id`. Older Galaxy servers
 # stored datasets by their numeric id (000/dataset_1.dat, 00/dataset_2.dat, ...), whereas newer Galaxy servers store
 # them by UUID (b/5/e/dataset_b5e0301c-4c2e-41ac-b2c1-3c243f91b6ec.dat, ...). Storing by UUID is preferred, storing by

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -3,9 +3,7 @@ import os
 import shutil
 from contextlib import contextmanager
 from datetime import datetime
-from typing import (
-    Any,
-)
+from typing import Any
 
 from galaxy.exceptions import (
     ObjectInvalid,
@@ -19,34 +17,36 @@ from galaxy.util import (
 from galaxy.util.path import safe_relpath
 from ._util import fix_permissions
 from .caching import (
+    CacheShard,
+    CacheShardManager,
     CacheTarget,
     InProcessCacheMonitor,
+    ObjectId,
 )
 
 log = logging.getLogger(__name__)
 
 
 class CachingConcreteObjectStore(ConcreteObjectStore):
-    staging_path: str
     extra_dirs: dict[str, str]
     config: Any
     cache_updated_data: bool
     enable_cache_monitor: bool
-    cache_size: int
     cache_monitor: InProcessCacheMonitor | None = None
     cache_monitor_interval: int
+    _cache_shards: CacheShardManager
 
     def _ensure_staging_path_writable(self):
-        staging_path = self.staging_path
-        if not os.path.exists(staging_path):
-            os.makedirs(staging_path, exist_ok=True)
-            if not os.path.exists(staging_path):
-                raise Exception(f"Caching object store created with path '{staging_path}' that does not exist")
+        for path in self._cache_shards.paths:
+            if not os.path.exists(path):
+                os.makedirs(path, exist_ok=True)
+                if not os.path.exists(path):
+                    raise Exception(f"Caching object store created with path '{path}' that does not exist")
 
-        if not os.access(staging_path, os.R_OK):
-            raise Exception(f"Caching object store created with path '{staging_path}' that does not readable")
-        if not os.access(staging_path, os.W_OK):
-            raise Exception(f"Caching object store created with path '{staging_path}' that does not writable")
+            if not os.access(path, os.R_OK):
+                raise Exception(f"Caching object store created with path '{path}' that does not readable")
+            if not os.access(path, os.W_OK):
+                raise Exception(f"Caching object store created with path '{path}' that does not writable")
 
     def _construct_path(
         self,
@@ -99,38 +99,39 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{object_id}.dat")
 
         if in_cache:
-            return self._get_cache_path(rel_path)
+            return self._get_cache_path(rel_path, object_id)
 
         return rel_path
 
-    def _get_cache_path(self, rel_path: str) -> str:
-        return os.path.abspath(os.path.join(self.staging_path, rel_path))
+    def _get_cache_path(self, rel_path: str, object_id: ObjectId) -> str:
+        return self._cache_shards.get_cache_path(object_id, rel_path)
 
-    def _in_cache(self, rel_path: str) -> bool:
+    def _in_cache(self, rel_path: str, object_id: ObjectId) -> bool:
         """Check if the given dataset is in the local cache and return True if so."""
-        cache_path = self._get_cache_path(rel_path)
+        cache_path = self._get_cache_path(rel_path, object_id)
         return os.path.exists(cache_path)
 
-    def _pull_into_cache(self, rel_path, **kwargs) -> bool:
+    def _pull_into_cache(self, rel_path, object_id: ObjectId, **kwargs) -> bool:
         # Ensure the cache directory structure exists (e.g., dataset_#_files/)
         rel_path_dir = os.path.dirname(rel_path)
-        if not os.path.exists(self._get_cache_path(rel_path_dir)):
-            os.makedirs(self._get_cache_path(rel_path_dir), exist_ok=True)
+        if not os.path.exists(self._get_cache_path(rel_path_dir, object_id)):
+            os.makedirs(self._get_cache_path(rel_path_dir, object_id), exist_ok=True)
         # Now pull in the file
-        file_ok = self._download(rel_path)
+        file_ok = self._download(rel_path, object_id=object_id)
         if file_ok:
-            fix_permissions(self.config, self._get_cache_path(rel_path_dir))
+            fix_permissions(self.config, self._get_cache_path(rel_path_dir, object_id))
         else:
-            unlink(self._get_cache_path(rel_path), ignore_errors=True)
+            unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
         return file_ok
 
     def _get_data(self, obj, start=0, count=-1, **kwargs):
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         # Check cache first and get file if not there
-        if not self._in_cache(rel_path):
-            self._pull_into_cache(rel_path, **kwargs)
+        if not self._in_cache(rel_path, object_id):
+            self._pull_into_cache(rel_path, object_id=object_id, **kwargs)
         # Read the file content from cache
-        data_file = open(self._get_cache_path(rel_path))
+        data_file = open(self._get_cache_path(rel_path, object_id))
         data_file.seek(start)
         content = data_file.read(count)
         data_file.close()
@@ -139,6 +140,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
     def _exists(self, obj, **kwargs) -> bool:
         in_cache = exists_remotely = False
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         dir_only = kwargs.get("dir_only", False)
         base_dir = kwargs.get("base_dir", None)
 
@@ -148,7 +150,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 os.makedirs(rel_path, exist_ok=True)
             return True
 
-        in_cache = self._in_cache(rel_path)
+        in_cache = self._in_cache(rel_path, object_id)
         exists_remotely = self._exists_remotely(rel_path)
         dir_only = kwargs.get("dir_only", False)
         base_dir = kwargs.get("base_dir", None)
@@ -160,7 +162,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
         # TODO: Sync should probably not be done here. Add this to an async upload stack?
         if in_cache and not exists_remotely:
-            self._push_to_storage(rel_path, source_file=self._get_cache_path(rel_path))
+            self._push_to_storage(rel_path, source_file=self._get_cache_path(rel_path, object_id), object_id=object_id)
             return True
         elif exists_remotely:
             return True
@@ -175,8 +177,10 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             dir_only = kwargs.get("dir_only", False)
             alt_name = kwargs.get("alt_name", None)
 
+            object_id = self._get_object_id(obj)
+
             # Construct hashed path
-            rel_path = os.path.join(*directory_hash_id(self._get_object_id(obj)))
+            rel_path = os.path.join(*directory_hash_id(object_id))
 
             # Optionally append extra_dir
             if extra_dir is not None:
@@ -186,32 +190,35 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                     rel_path = os.path.join(rel_path, extra_dir)
 
             # Create given directory in cache
-            cache_dir = os.path.join(self.staging_path, rel_path)
+            cache_dir = self._get_cache_path(rel_path, object_id)
             if not os.path.exists(cache_dir):
                 os.makedirs(cache_dir, exist_ok=True)
 
             # If instructed, create the dataset in cache & in S3
             if not dir_only:
-                rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
-                open(os.path.join(self.staging_path, rel_path), "w").close()
-                self._push_to_storage(rel_path, from_string="")
+                rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{object_id}.dat")
+                open(self._get_cache_path(rel_path, object_id), "w").close()
+                self._push_to_storage(rel_path, from_string="", object_id=object_id)
         return self
 
-    def _caching_allowed(self, rel_path: str, remote_size: int | None = None) -> bool:
+    def _caching_allowed(
+        self, rel_path: str, remote_size: int | None = None, object_id: ObjectId | None = None
+    ) -> bool:
         if remote_size is None:
             remote_size = self._get_remote_size(rel_path)
-        if not self.cache_target.fits_in_cache(remote_size):
+        cache_target = self._cache_shards.get_cache_target(object_id) if object_id is not None else self.cache_target
+        if not cache_target.fits_in_cache(remote_size):
             log.critical(
                 "File %s is larger (%s bytes) than the configured cache allows (%s). Cannot download.",
                 rel_path,
                 remote_size,
-                self.cache_target.log_description,
+                cache_target.log_description,
             )
             return False
         return True
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None):
-        source_file = source_file or self._get_cache_path(rel_path)
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
+        source_file = source_file or self._get_cache_path(rel_path, object_id)
         if from_string is None and not os.path.exists(source_file):
             log.error(
                 "Tried updating remote path '%s' from source file '%s', but source file does not exist.",
@@ -253,14 +260,15 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         else:
             raise ObjectNotFound(f"objectstore.empty, object does not exist: {obj}, kwargs: {kwargs}")
 
-    def _get_size_in_cache(self, rel_path):
-        return os.path.getsize(self._get_cache_path(rel_path))
+    def _get_size_in_cache(self, rel_path, object_id: ObjectId):
+        return os.path.getsize(self._get_cache_path(rel_path, object_id))
 
     def _size(self, obj, **kwargs) -> int:
         rel_path = self._construct_path(obj, **kwargs)
-        if self._in_cache(rel_path):
+        object_id = self._get_object_id(obj)
+        if self._in_cache(rel_path, object_id):
             try:
-                return self._get_size_in_cache(rel_path)
+                return self._get_size_in_cache(rel_path, object_id)
             except OSError as ex:
                 log.info("Could not get size of file '%s' in local cache, will try Azure. Error: %s", rel_path, ex)
         elif self._exists_remotely(rel_path):
@@ -274,17 +282,22 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         obj_dir = kwargs.get("obj_dir", False)
 
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
 
         # for JOB_WORK directory
         if base_dir and dir_only and obj_dir:
             return os.path.abspath(rel_path)
 
-        cache_path = self._get_cache_path(rel_path)
+        cache_path = self._get_cache_path(rel_path, object_id)
         if not sync_cache:
             return cache_path
 
         # Check if the file exists in the cache first, always pull if file size in cache is zero
-        if not dir_only and self._in_cache(rel_path) and os.path.getsize(self._get_cache_path(rel_path)) > 0:
+        if (
+            not dir_only
+            and self._in_cache(rel_path, object_id)
+            and os.path.getsize(self._get_cache_path(rel_path, object_id)) > 0
+        ):
             return cache_path
 
         # For directories: trust cache if it has files. Individual file accesses
@@ -300,7 +313,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 self._download_directory_into_cache(rel_path, cache_path)
                 return cache_path
             else:
-                if self._pull_into_cache(rel_path, **kwargs):
+                if self._pull_into_cache(rel_path, object_id=object_id, **kwargs):
                     return cache_path
         raise ObjectNotFound(f"objectstore.get_filename, no cache_path: {obj}, kwargs: {kwargs}")
 
@@ -317,6 +330,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         extra_dir = kwargs.get("extra_dir", None)
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
@@ -332,11 +346,11 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual key in S3 and deleing it.
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path), ignore_errors=True)
+                shutil.rmtree(self._get_cache_path(rel_path, object_id), ignore_errors=True)
                 return self._delete_remote_all(rel_path)
             else:
                 # Delete from cache first
-                unlink(self._get_cache_path(rel_path), ignore_errors=True)
+                unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
                 # Delete from S3 as well
                 if self._exists_remotely(rel_path):
                     return self._delete_existing_remote(rel_path)
@@ -352,11 +366,12 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
         if self._exists(obj, **kwargs):
             rel_path = self._construct_path(obj, **kwargs)
+            object_id = self._get_object_id(obj)
             # Chose whether to use the dataset file itself or an alternate file
             if file_name:
                 source_file = os.path.abspath(file_name)
                 # Copy into cache
-                cache_file = self._get_cache_path(rel_path)
+                cache_file = self._get_cache_path(rel_path, object_id)
                 try:
                     if source_file != cache_file and self.cache_updated_data:
                         # FIXME? Should this be a `move`?
@@ -365,9 +380,9 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 except OSError:
                     log.exception("Trouble copying source file '%s' to cache '%s'", source_file, cache_file)
             else:
-                source_file = self._get_cache_path(rel_path)
+                source_file = self._get_cache_path(rel_path, object_id)
 
-            self._push_to_storage(rel_path, source_file)
+            self._push_to_storage(rel_path, source_file, object_id=object_id)
 
         else:
             raise ObjectNotFound(
@@ -375,19 +390,36 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             )
 
     @property
+    def staging_path(self) -> str:
+        return self._cache_shards.paths[0]
+
+    @staging_path.setter
+    def staging_path(self, value: str) -> None:
+        self._cache_shards = CacheShardManager([CacheShard(path=value, weight=1, size=self.cache_size)])
+
+    @property
+    def cache_size(self) -> float:
+        return self._cache_shards.cache_targets[0].size
+
+    @property
     def cache_target(self) -> CacheTarget:
-        return CacheTarget(
-            self.staging_path,
-            self.cache_size,
-            0.9,
-        )
+        return self._cache_shards.cache_targets[0]
+
+    def cache_targets(self) -> list[CacheTarget]:
+        return self._cache_shards.cache_targets
+
+    def _cache_config_to_dict(self) -> dict:
+        """Serialize cache config for ``to_dict``. Preserves multi-shard config."""
+        result = self._cache_shards.to_config_dict()
+        result["cache_updated_data"] = self.cache_updated_data
+        return result
 
     def _shutdown_cache_monitor(self) -> None:
         self.cache_monitor and self.cache_monitor.shutdown()
 
     def _start_cache_monitor_if_needed(self):
         if self.enable_cache_monitor:
-            self.cache_monitor = InProcessCacheMonitor(self.cache_target, self.cache_monitor_interval)
+            self.cache_monitor = InProcessCacheMonitor(self.cache_targets(), self.cache_monitor_interval)
 
     def _get_remote_size(self, rel_path: str) -> int:
         raise NotImplementedError()
@@ -417,7 +449,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 os.remove(tmp_path)
             raise
 
-    def _download(self, rel_path: str) -> bool:
+    def _download(self, rel_path: str, object_id: ObjectId) -> bool:
         raise NotImplementedError()
 
     # Do not need to override these if instead replacing _delete

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -17,7 +17,6 @@ from galaxy.util import (
 from galaxy.util.path import safe_relpath
 from ._util import fix_permissions
 from .caching import (
-    CacheShard,
     CacheShardManager,
     CacheTarget,
     InProcessCacheMonitor,
@@ -42,7 +41,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 os.makedirs(path, exist_ok=True)
                 if not os.path.exists(path):
                     raise Exception(f"Caching object store created with path '{path}' that does not exist")
-
             if not os.access(path, os.R_OK):
                 raise Exception(f"Caching object store created with path '{path}' that does not readable")
             if not os.access(path, os.W_OK):
@@ -201,12 +199,10 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 self._push_to_storage(rel_path, from_string="", object_id=object_id)
         return self
 
-    def _caching_allowed(
-        self, rel_path: str, remote_size: int | None = None, object_id: ObjectId | None = None
-    ) -> bool:
+    def _caching_allowed(self, rel_path: str, object_id: ObjectId, remote_size: int | None = None) -> bool:
         if remote_size is None:
             remote_size = self._get_remote_size(rel_path)
-        cache_target = self._cache_shards.get_cache_target(object_id) if object_id is not None else self.cache_target
+        cache_target = self._cache_shards.get_cache_target(object_id)
         if not cache_target.fits_in_cache(remote_size):
             log.critical(
                 "File %s is larger (%s bytes) than the configured cache allows (%s). Cannot download.",
@@ -392,10 +388,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
     @property
     def staging_path(self) -> str:
         return self._cache_shards.paths[0]
-
-    @staging_path.setter
-    def staging_path(self, value: str) -> None:
-        self._cache_shards = CacheShardManager([CacheShard(path=value, weight=1, size=self.cache_size)])
 
     @property
     def cache_size(self) -> float:

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -109,15 +109,16 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         cache_path = self._get_cache_path(rel_path, object_id)
         return os.path.exists(cache_path)
 
-    def _pull_into_cache(self, rel_path, object_id: ObjectId, **kwargs) -> bool:
+    def _pull_into_cache(self, rel_path, *, object_id: ObjectId, **kwargs) -> bool:
         # Ensure the cache directory structure exists (e.g., dataset_#_files/)
         rel_path_dir = os.path.dirname(rel_path)
-        if not os.path.exists(self._get_cache_path(rel_path_dir, object_id)):
-            os.makedirs(self._get_cache_path(rel_path_dir, object_id), exist_ok=True)
+        cache_dir = self._get_cache_path(rel_path_dir, object_id)
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir, exist_ok=True)
         # Now pull in the file
         file_ok = self._download(rel_path, object_id=object_id)
         if file_ok:
-            fix_permissions(self.config, self._get_cache_path(rel_path_dir, object_id))
+            fix_permissions(self.config, cache_dir)
         else:
             unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
         return file_ok
@@ -129,7 +130,8 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         if not self._in_cache(rel_path, object_id):
             self._pull_into_cache(rel_path, object_id=object_id, **kwargs)
         # Read the file content from cache
-        data_file = open(self._get_cache_path(rel_path, object_id))
+        cache_path = self._get_cache_path(rel_path, object_id)
+        data_file = open(cache_path)
         data_file.seek(start)
         content = data_file.read(count)
         data_file.close()
@@ -197,7 +199,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 self._push_to_storage(rel_path, from_string="", object_id=object_id)
         return self
 
-    def _caching_allowed(self, rel_path: str, object_id: ObjectId, remote_size: int | None = None) -> bool:
+    def _caching_allowed(self, rel_path: str, *, object_id: ObjectId, remote_size: int | None = None) -> bool:
         if remote_size is None:
             remote_size = self._get_remote_size(rel_path)
         cache_target = self._cache_shards.get_cache_target(object_id)
@@ -254,7 +256,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         else:
             raise ObjectNotFound(f"objectstore.empty, object does not exist: {obj}, kwargs: {kwargs}")
 
-    def _get_size_in_cache(self, rel_path, object_id: ObjectId):
+    def _get_size_in_cache(self, rel_path, *, object_id: ObjectId):
         return os.path.getsize(self._get_cache_path(rel_path, object_id))
 
     def _size(self, obj, **kwargs) -> int:
@@ -262,7 +264,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         object_id = self._get_object_id(obj)
         if self._in_cache(rel_path, object_id):
             try:
-                return self._get_size_in_cache(rel_path, object_id)
+                return self._get_size_in_cache(rel_path, object_id=object_id)
             except OSError as ex:
                 log.info("Could not get size of file '%s' in local cache, will try Azure. Error: %s", rel_path, ex)
         elif self._exists_remotely(rel_path):
@@ -287,11 +289,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             return cache_path
 
         # Check if the file exists in the cache first, always pull if file size in cache is zero
-        if (
-            not dir_only
-            and self._in_cache(rel_path, object_id)
-            and os.path.getsize(self._get_cache_path(rel_path, object_id)) > 0
-        ):
+        if not dir_only and self._in_cache(rel_path, object_id) and os.path.getsize(cache_path) > 0:
             return cache_path
 
         # For directories: trust cache if it has files. Individual file accesses
@@ -385,14 +383,17 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
     @property
     def staging_path(self) -> str:
+        """First shard's cache path. For shard-aware operations, use ``_cache_shards``."""
         return self._cache_shards.paths[0]
 
     @property
     def cache_size(self) -> float:
+        """First shard's cache size. For shard-aware operations, use ``_cache_shards``."""
         return self._cache_shards.cache_targets[0].size
 
     @property
     def cache_target(self) -> CacheTarget:
+        """First shard's cache target. For all targets, use ``cache_targets()``."""
         return self._cache_shards.cache_targets[0]
 
     def cache_targets(self) -> list[CacheTarget]:
@@ -439,7 +440,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 os.remove(tmp_path)
             raise
 
-    def _download(self, rel_path: str, object_id: ObjectId) -> bool:
+    def _download(self, rel_path: str, *, object_id: ObjectId) -> bool:
         raise NotImplementedError()
 
     # Do not need to override these if instead replacing _delete

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -97,16 +97,15 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{object_id}.dat")
 
         if in_cache:
-            return self._get_cache_path(rel_path, object_id)
+            return self._cache_shards.get_cache_path(object_id, rel_path)
 
         return rel_path
 
     def _get_cache_path(self, rel_path: str, object_id: ObjectId) -> str:
         return self._cache_shards.get_cache_path(object_id, rel_path)
 
-    def _in_cache(self, rel_path: str, object_id: ObjectId) -> bool:
+    def _in_cache(self, cache_path: str) -> bool:
         """Check if the given dataset is in the local cache and return True if so."""
-        cache_path = self._get_cache_path(rel_path, object_id)
         return os.path.exists(cache_path)
 
     def _pull_into_cache(self, rel_path, *, object_id: ObjectId, **kwargs) -> bool:
@@ -116,21 +115,23 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         if not os.path.exists(cache_dir):
             os.makedirs(cache_dir, exist_ok=True)
         # Now pull in the file
-        file_ok = self._download(rel_path, object_id=object_id)
+        cache_path = self._get_cache_path(rel_path, object_id)
+        cache_target = self._cache_shards.get_cache_target(object_id)
+        file_ok = self._download(rel_path, cache_path=cache_path, cache_target=cache_target)
         if file_ok:
             fix_permissions(self.config, cache_dir)
         else:
-            unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
+            unlink(cache_path, ignore_errors=True)
         return file_ok
 
     def _get_data(self, obj, start=0, count=-1, **kwargs):
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
         # Check cache first and get file if not there
-        if not self._in_cache(rel_path, object_id):
+        if not self._in_cache(cache_path):
             self._pull_into_cache(rel_path, object_id=object_id, **kwargs)
         # Read the file content from cache
-        cache_path = self._get_cache_path(rel_path, object_id)
         data_file = open(cache_path)
         data_file.seek(start)
         content = data_file.read(count)
@@ -141,6 +142,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         in_cache = exists_remotely = False
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
         dir_only = kwargs.get("dir_only", False)
         base_dir = kwargs.get("base_dir", None)
 
@@ -150,7 +152,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 os.makedirs(rel_path, exist_ok=True)
             return True
 
-        in_cache = self._in_cache(rel_path, object_id)
+        in_cache = self._in_cache(cache_path)
         exists_remotely = self._exists_remotely(rel_path)
         if dir_only:
             if in_cache or exists_remotely:
@@ -160,7 +162,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
         # TODO: Sync should probably not be done here. Add this to an async upload stack?
         if in_cache and not exists_remotely:
-            self._push_to_storage(rel_path, source_file=self._get_cache_path(rel_path, object_id), object_id=object_id)
+            self._push_to_storage(rel_path, cache_path=cache_path)
             return True
         elif exists_remotely:
             return True
@@ -195,14 +197,14 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             # If instructed, create the dataset in cache & in S3
             if not dir_only:
                 rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{object_id}.dat")
-                open(self._get_cache_path(rel_path, object_id), "w").close()
-                self._push_to_storage(rel_path, from_string="", object_id=object_id)
+                cache_path = self._get_cache_path(rel_path, object_id)
+                open(cache_path, "w").close()
+                self._push_to_storage(rel_path, from_string="", cache_path=cache_path)
         return self
 
-    def _caching_allowed(self, rel_path: str, *, object_id: ObjectId, remote_size: int | None = None) -> bool:
+    def _caching_allowed(self, rel_path: str, *, cache_target: CacheTarget, remote_size: int | None = None) -> bool:
         if remote_size is None:
             remote_size = self._get_remote_size(rel_path)
-        cache_target = self._cache_shards.get_cache_target(object_id)
         if not cache_target.fits_in_cache(remote_size):
             log.critical(
                 "File %s is larger (%s bytes) than the configured cache allows (%s). Cannot download.",
@@ -213,8 +215,8 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             return False
         return True
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
-        source_file = source_file or self._get_cache_path(rel_path, object_id)
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
+        source_file = source_file or cache_path
         if from_string is None and not os.path.exists(source_file):
             log.error(
                 "Tried updating remote path '%s' from source file '%s', but source file does not exist.",
@@ -256,15 +258,16 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         else:
             raise ObjectNotFound(f"objectstore.empty, object does not exist: {obj}, kwargs: {kwargs}")
 
-    def _get_size_in_cache(self, rel_path, *, object_id: ObjectId):
-        return os.path.getsize(self._get_cache_path(rel_path, object_id))
+    def _get_size_in_cache(self, cache_path: str):
+        return os.path.getsize(cache_path)
 
     def _size(self, obj, **kwargs) -> int:
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
-        if self._in_cache(rel_path, object_id):
+        cache_path = self._get_cache_path(rel_path, object_id)
+        if self._in_cache(cache_path):
             try:
-                return self._get_size_in_cache(rel_path, object_id=object_id)
+                return self._get_size_in_cache(cache_path)
             except OSError as ex:
                 log.info("Could not get size of file '%s' in local cache, will try Azure. Error: %s", rel_path, ex)
         elif self._exists_remotely(rel_path):
@@ -289,7 +292,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             return cache_path
 
         # Check if the file exists in the cache first, always pull if file size in cache is zero
-        if not dir_only and self._in_cache(rel_path, object_id) and os.path.getsize(cache_path) > 0:
+        if not dir_only and self._in_cache(cache_path) and os.path.getsize(cache_path) > 0:
             return cache_path
 
         # For directories: trust cache if it has files. Individual file accesses
@@ -323,6 +326,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
         extra_dir = kwargs.get("extra_dir", None)
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
@@ -338,11 +342,11 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual key in S3 and deleing it.
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path, object_id), ignore_errors=True)
+                shutil.rmtree(cache_path, ignore_errors=True)
                 return self._delete_remote_all(rel_path)
             else:
                 # Delete from cache first
-                unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
+                unlink(cache_path, ignore_errors=True)
                 # Delete from S3 as well
                 if self._exists_remotely(rel_path):
                     return self._delete_existing_remote(rel_path)
@@ -359,22 +363,22 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
         if self._exists(obj, **kwargs):
             rel_path = self._construct_path(obj, **kwargs)
             object_id = self._get_object_id(obj)
+            cache_path = self._get_cache_path(rel_path, object_id)
             # Chose whether to use the dataset file itself or an alternate file
             if file_name:
                 source_file = os.path.abspath(file_name)
                 # Copy into cache
-                cache_file = self._get_cache_path(rel_path, object_id)
                 try:
-                    if source_file != cache_file and self.cache_updated_data:
+                    if source_file != cache_path and self.cache_updated_data:
                         # FIXME? Should this be a `move`?
-                        shutil.copy(source_file, cache_file)
-                    fix_permissions(self.config, cache_file)
+                        shutil.copy(source_file, cache_path)
+                    fix_permissions(self.config, cache_path)
                 except OSError:
-                    log.exception("Trouble copying source file '%s' to cache '%s'", source_file, cache_file)
+                    log.exception("Trouble copying source file '%s' to cache '%s'", source_file, cache_path)
             else:
-                source_file = self._get_cache_path(rel_path, object_id)
+                source_file = cache_path
 
-            self._push_to_storage(rel_path, source_file, object_id=object_id)
+            self._push_to_storage(rel_path, source_file, cache_path=cache_path)
 
         else:
             raise ObjectNotFound(
@@ -440,7 +444,7 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
                 os.remove(tmp_path)
             raise
 
-    def _download(self, rel_path: str, *, object_id: ObjectId) -> bool:
+    def _download(self, rel_path: str, *, cache_path: str, cache_target: CacheTarget) -> bool:
         raise NotImplementedError()
 
     # Do not need to override these if instead replacing _delete

--- a/lib/galaxy/objectstore/_caching_base.py
+++ b/lib/galaxy/objectstore/_caching_base.py
@@ -150,8 +150,6 @@ class CachingConcreteObjectStore(ConcreteObjectStore):
 
         in_cache = self._in_cache(rel_path, object_id)
         exists_remotely = self._exists_remotely(rel_path)
-        dir_only = kwargs.get("dir_only", False)
-        base_dir = kwargs.get("base_dir", None)
         if dir_only:
             if in_cache or exists_remotely:
                 return True

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -236,7 +236,7 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
     def _blob_client(self, rel_path: str):
         return self.service.get_blob_client(self.container_name, rel_path)
 
-    def _download(self, rel_path, object_id: ObjectId):
+    def _download(self, rel_path, *, object_id: ObjectId):
         local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling '%s' into cache to %s", rel_path, local_destination)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -19,7 +19,9 @@ except ImportError:
 from galaxy.util import now
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
+    CacheShardManager,
     enable_cache_monitor,
+    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 
@@ -139,9 +141,8 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
                 typed_transfer_dict[key] = int(value)
         self.transfer_dict = typed_transfer_dict
 
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
-        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
+        self._cache_shards = CacheShardManager.from_config(cache_dict, self.config)
 
         self._initialize()
 
@@ -168,11 +169,7 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
                     "name": self.container_name,
                 },
                 "transfer": self.transfer_dict,
-                "cache": {
-                    "size": self.cache_size,
-                    "path": self.staging_path,
-                    "cache_updated_data": self.cache_updated_data,
-                },
+                "cache": self._cache_config_to_dict(),
             }
         )
         return as_dict
@@ -239,11 +236,11 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
     def _blob_client(self, rel_path: str):
         return self.service.get_blob_client(self.container_name, rel_path)
 
-    def _download(self, rel_path):
-        local_destination = self._get_cache_path(rel_path)
+    def _download(self, rel_path, object_id: ObjectId):
+        local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling '%s' into cache to %s", rel_path, local_destination)
-            if not self._caching_allowed(rel_path):
+            if not self._caching_allowed(rel_path, object_id=object_id):
                 return False
             else:
                 with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -20,8 +20,8 @@ from galaxy.util import now
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     CacheShardManager,
+    CacheTarget,
     enable_cache_monitor,
-    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 
@@ -236,11 +236,11 @@ class AzureBlobObjectStore(CachingConcreteObjectStore):
     def _blob_client(self, rel_path: str):
         return self.service.get_blob_client(self.container_name, rel_path)
 
-    def _download(self, rel_path, *, object_id: ObjectId):
-        local_destination = self._get_cache_path(rel_path, object_id)
+    def _download(self, rel_path, *, cache_path: str, cache_target: CacheTarget):
+        local_destination = cache_path
         try:
             log.debug("Pulling '%s' into cache to %s", rel_path, local_destination)
-            if not self._caching_allowed(rel_path, object_id=object_id):
+            if not self._caching_allowed(rel_path, cache_target=cache_target):
                 return False
             else:
                 with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -120,7 +120,8 @@ class CacheShardManager:
         """Serialize shard config for backend ``to_dict`` / reconstruction.
 
         Emits ``dirs`` when there are multiple shards, otherwise the legacy
-        single ``path`` / ``size`` keys.
+        single ``path`` / ``size`` keys.  ``weight`` is intentionally omitted
+        for the single-shard case because it is meaningless with only one shard.
         """
         if len(self.shards) == 1:
             s = self.shards[0]
@@ -253,15 +254,6 @@ def parse_caching_config_dict_from_xml(config_xml):
     else:
         cache_dict = {}
     return cache_dict
-
-
-def configured_cache_size(config, config_dict) -> int:
-    cache_config_dict = config_dict.get("cache") or {}
-    cache_size = cache_config_dict.get("size") or config.object_store_cache_size
-    if cache_size != -1:
-        # Convert admin-set GBs to bytes internally for quick comparison
-        cache_size = cache_size * ONE_GIGA_BYTE
-    return cache_size
 
 
 def enable_cache_monitor(config, config_dict) -> tuple[bool, int]:

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -25,8 +25,8 @@ ONE_GIGA_BYTE = 1024 * 1024 * 1024
 FileListT = list[tuple[time.struct_time, str, int]]
 
 #: The type of an object identifier used for cache shard selection.
-#: Can be a numeric id (``store_by="id"``) or a UUID / string
-#: (``store_by="uuid"``).
+#: Can be a numeric id (``store_by="id"``) or a UUID object / its
+#: string representation (``store_by="uuid"``).
 ObjectId = int | UUID | str
 
 
@@ -90,13 +90,19 @@ class CacheShardManager:
             cumulative += shard.weight
             self._weighted_index.append((cumulative, shard))
         self._total_weight = total_weight
+        self._shard_cache: dict[str, CacheShard] = {}
 
     def _select_shard(self, object_id: ObjectId) -> CacheShard:
-        digest = hashlib.sha256(str(object_id).encode()).digest()
+        key = str(object_id)
+        shard = self._shard_cache.get(key)
+        if shard is not None:
+            return shard
+        digest = hashlib.sha256(key.encode()).digest()
         hash_value = int.from_bytes(digest, "big")
         point = hash_value % self._total_weight
         for cumulative, shard in self._weighted_index:
             if point < cumulative:
+                self._shard_cache[key] = shard
                 return shard
         return self.shards[-1]
 

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -1,10 +1,12 @@
 """ """
 
+import hashlib
 import logging
 import os
 import threading
 import time
 from math import inf
+from uuid import UUID
 
 from typing_extensions import NamedTuple
 
@@ -22,10 +24,15 @@ ONE_GIGA_BYTE = 1024 * 1024 * 1024
 
 FileListT = list[tuple[time.struct_time, str, int]]
 
+#: The type of an object identifier used for cache shard selection.
+#: Can be a numeric id (``store_by="id"``) or a UUID / string
+#: (``store_by="uuid"``).
+ObjectId = int | UUID | str
+
 
 class CacheTarget(NamedTuple):
     path: str
-    size: int  # cache size in gigabytes
+    size: float  # cache size in gigabytes
     limit: float  # cache limit as a percent
 
     def fits_in_cache(self, bytes: int) -> bool:
@@ -41,6 +48,110 @@ class CacheTarget(NamedTuple):
     @property
     def log_description(self) -> str:
         return f"{self.limit} percent of {self.size} gigabytes"
+
+
+class CacheShard(NamedTuple):
+    path: str
+    weight: int
+    size: float
+
+
+def parse_cache_dirs_from_xml(cache_element) -> list[dict] | None:
+    """Parse <dirs><dir .../></dirs> from a cache XML element.
+
+    Returns a list of dicts with keys ``path``, ``weight``, ``size``
+    (size may be ``None``), or ``None`` if no ``<dirs>`` element is present.
+    """
+    dirs_els = cache_element.findall("dirs")
+    if not dirs_els:
+        return None
+    dir_els = dirs_els[0].findall("dir")
+    if not dir_els:
+        return None
+    return [
+        {
+            "path": d.get("path"),
+            "weight": int(d.get("weight", 1)),
+            "size": float(d.get("size", -1)) if d.get("size") is not None else None,
+        }
+        for d in dir_els
+    ]
+
+
+class CacheShardManager:
+    def __init__(self, shards: list[CacheShard]):
+        if not shards:
+            raise ValueError("CacheShardManager requires at least one shard")
+        self.shards = shards
+        total_weight = sum(s.weight for s in shards)
+        self._weighted_index: list[tuple[int, CacheShard]] = []
+        cumulative = 0
+        for shard in shards:
+            cumulative += shard.weight
+            self._weighted_index.append((cumulative, shard))
+        self._total_weight = total_weight
+
+    def _select_shard(self, object_id: ObjectId) -> CacheShard:
+        digest = hashlib.sha256(str(object_id).encode()).digest()
+        hash_value = int.from_bytes(digest, "big")
+        point = hash_value % self._total_weight
+        for cumulative, shard in self._weighted_index:
+            if point < cumulative:
+                return shard
+        return self.shards[-1]
+
+    def get_cache_path(self, object_id: ObjectId, rel_path: str) -> str:
+        shard = self._select_shard(object_id)
+        return os.path.abspath(os.path.join(shard.path, rel_path))
+
+    def get_cache_target(self, object_id: ObjectId) -> CacheTarget:
+        shard = self._select_shard(object_id)
+        return CacheTarget(shard.path, shard.size, 0.9)
+
+    @property
+    def paths(self) -> list[str]:
+        return [s.path for s in self.shards]
+
+    @property
+    def cache_targets(self) -> list[CacheTarget]:
+        return [CacheTarget(s.path, s.size, 0.9) for s in self.shards]
+
+    def to_config_dict(self) -> dict:
+        """Serialize shard config for backend ``to_dict`` / reconstruction.
+
+        Emits ``dirs`` when there are multiple shards, otherwise the legacy
+        single ``path`` / ``size`` keys.
+        """
+        if len(self.shards) == 1:
+            s = self.shards[0]
+            return {"path": s.path, "size": s.size}
+        return {
+            "dirs": [{"path": s.path, "weight": s.weight, "size": s.size} for s in self.shards],
+        }
+
+    @classmethod
+    def from_config(cls, cache_dict: dict, config) -> "CacheShardManager":
+        default_size = cache_dict.get("size") or config.object_store_cache_size
+        default_path = cache_dict.get("path") or config.object_store_cache_path
+
+        dirs = cache_dict.get("dirs")
+        if dirs:
+            shards: list[CacheShard] = []
+            for d in dirs:
+                path = d.get("path")
+                if not path:
+                    continue
+                weight = d.get("weight", 1)
+                if weight <= 0:
+                    continue
+                size = d.get("size")
+                if size is None:
+                    size = default_size
+                shards.append(CacheShard(path=path, weight=weight, size=size))
+            if shards:
+                return cls(shards)
+
+        return cls([CacheShard(path=default_path, weight=1, size=default_size)])
 
 
 def check_caches(targets: list[CacheTarget]):
@@ -135,6 +246,10 @@ def parse_caching_config_dict_from_xml(config_xml):
             "monitor": monitor,
             "cache_updated_data": cache_updated_data,
         }
+
+        dirs = parse_cache_dirs_from_xml(c_xml)
+        if dirs:
+            cache_dict["dirs"] = dirs
     else:
         cache_dict = {}
     return cache_dict
@@ -170,7 +285,7 @@ def enable_cache_monitor(config, config_dict) -> tuple[bool, int]:
 
 
 class InProcessCacheMonitor:
-    def __init__(self, cache_target: CacheTarget, interval: int = 30, initial_sleep: int | None = 2):
+    def __init__(self, cache_targets: list[CacheTarget], interval: int = 30, initial_sleep: int | None = 2):
         # This Event object is initialized to False
         # It is set to True in shutdown(), causing
         # the cache monitor thread to return/terminate
@@ -178,7 +293,7 @@ class InProcessCacheMonitor:
         # Helper for interruptable sleep
         self.sleeper = Sleeper()
 
-        self.cache_target = cache_target
+        self.cache_targets = cache_targets
         self.interval = interval
         self.initial_sleep = initial_sleep
 
@@ -194,7 +309,7 @@ class InProcessCacheMonitor:
                 self.initial_sleep
             )  # startup sleep hack - probably originally implemented to prevent contention at app startup
         while not self.stop_cache_monitor_event.is_set():
-            check_cache(self.cache_target)
+            check_caches(self.cache_targets)
             self.sleeper.sleep(self.interval)
 
     def shutdown(self):

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -90,19 +90,17 @@ class CacheShardManager:
             cumulative += shard.weight
             self._weighted_index.append((cumulative, shard))
         self._total_weight = total_weight
-        self._shard_cache: dict[str, CacheShard] = {}
 
     def _select_shard(self, object_id: ObjectId) -> CacheShard:
+        if len(self.shards) == 1:
+            # Non-sharded deployments short-circuit — no hashing needed.
+            return self.shards[0]
         key = str(object_id)
-        shard = self._shard_cache.get(key)
-        if shard is not None:
-            return shard
         digest = hashlib.sha256(key.encode()).digest()
         hash_value = int.from_bytes(digest, "big")
         point = hash_value % self._total_weight
         for cumulative, shard in self._weighted_index:
             if point < cumulative:
-                self._shard_cache[key] = shard
                 return shard
         return self.shards[-1]
 

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -168,6 +168,11 @@ def check_caches(targets: list[CacheTarget]):
 
 def check_cache(cache_target: CacheTarget):
     """Run a step of the cache monitor."""
+    if not (cache_target.size > 0):
+        # Matches CacheTarget.fits_in_cache - a non-positive size is an unbounded
+        # cache, not a zero-byte budget. Without this the limit below goes negative,
+        # every directory looks over budget, and the whole path gets reaped.
+        return
     total_size, file_list = _get_cache_size_files(cache_target.path)
     # Sort the file list (based on access time)
     file_list.sort()

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -8,7 +8,11 @@ import os.path
 
 from ._caching_base import CachingConcreteObjectStore
 from ._util import UsesAxel
-from .caching import enable_cache_monitor
+from .caching import (
+    CacheShardManager,
+    enable_cache_monitor,
+    ObjectId,
+)
 from .s3 import parse_config_xml
 
 try:
@@ -51,9 +55,8 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
         self.use_rr = bucket_dict.get("use_reduced_redundancy", False)
         self.max_chunk_size = bucket_dict.get("max_chunk_size", 250)
 
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
-        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
+        self._cache_shards = CacheShardManager.from_config(cache_dict, self.config)
 
         self._initialize()
 
@@ -195,11 +198,7 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
                 "name": self.bucket_name,
                 "use_reduced_redundancy": self.use_rr,
             },
-            "cache": {
-                "size": self.cache_size,
-                "path": self.staging_path,
-                "cache_updated_data": self.cache_updated_data,
-            },
+            "cache": self._cache_config_to_dict(),
         }
 
     def _get_bucket(self, bucket_name):
@@ -245,13 +244,13 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             return False
         return exists
 
-    def _download(self, rel_path):
-        local_destination = self._get_cache_path(rel_path)
+    def _download(self, rel_path, object_id: ObjectId):
+        local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
             key = self.bucket.objects.get(rel_path)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, remote_size):
+            if not self._caching_allowed(rel_path, remote_size, object_id=object_id):
                 return False
             log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
             with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -250,7 +250,7 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
             key = self.bucket.objects.get(rel_path)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, remote_size, object_id=object_id):
+            if not self._caching_allowed(rel_path, object_id, remote_size=remote_size):
                 return False
             log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
             with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -244,13 +244,13 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             return False
         return exists
 
-    def _download(self, rel_path, object_id: ObjectId):
+    def _download(self, rel_path, *, object_id: ObjectId):
         local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
             key = self.bucket.objects.get(rel_path)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, object_id, remote_size=remote_size):
+            if not self._caching_allowed(rel_path, object_id=object_id, remote_size=remote_size):
                 return False
             log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
             with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -10,8 +10,8 @@ from ._caching_base import CachingConcreteObjectStore
 from ._util import UsesAxel
 from .caching import (
     CacheShardManager,
+    CacheTarget,
     enable_cache_monitor,
-    ObjectId,
 )
 from .s3 import parse_config_xml
 
@@ -244,13 +244,13 @@ class Cloud(CachingConcreteObjectStore, UsesAxel):
             return False
         return exists
 
-    def _download(self, rel_path, *, object_id: ObjectId):
-        local_destination = self._get_cache_path(rel_path, object_id)
+    def _download(self, rel_path, *, cache_path: str, cache_target: CacheTarget):
+        local_destination = cache_path
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
             key = self.bucket.objects.get(rel_path)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, object_id=object_id, remote_size=remote_size):
+            if not self._caching_allowed(rel_path, cache_target=cache_target, remote_size=remote_size):
                 return False
             log.debug("Pulled key '%s' into cache to %s", rel_path, local_destination)
             with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -27,6 +27,11 @@ from galaxy.util import (
     unlink,
 )
 from ._caching_base import CachingConcreteObjectStore
+from .caching import (
+    CacheShardManager,
+    ObjectId,
+    parse_cache_dirs_from_xml,
+)
 
 IRODS_IMPORT_MESSAGE = "The Python irods package is required to use this feature, please install it"
 # 1 MB
@@ -105,6 +110,16 @@ def parse_config_xml(config_xml):
         staging_path = c_xml[0].get("path", None)
         cache_updated_data = string_as_bool(c_xml[0].get("cache_updated_data", "True"))
 
+        cache_dict = {
+            "size": cache_size,
+            "path": staging_path,
+            "cache_updated_data": cache_updated_data,
+        }
+
+        dirs = parse_cache_dirs_from_xml(c_xml[0])
+        if dirs:
+            cache_dict["dirs"] = dirs
+
         attrs = ("type", "path")
         e_xml = config_xml.findall("extra_dir")
         if not e_xml:
@@ -142,11 +157,7 @@ def parse_config_xml(config_xml):
             "logical": {
                 "path": logical_path,
             },
-            "cache": {
-                "size": cache_size,
-                "path": staging_path,
-                "cache_updated_data": cache_updated_data,
-            },
+            "cache": cache_dict,
             "extra_dirs": extra_dirs,
             "private": CachingConcreteObjectStore.parse_private_from_config_xml(config_xml),
         }
@@ -227,9 +238,8 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         self.logical_path = logical_dict.get("path") or f"/{self.zone}/home/{self.username}"
 
         cache_dict = config_dict.get("cache") or {}
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
-        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
+        self._cache_shards = CacheShardManager.from_config(cache_dict, self.config)
         extra_dirs = {e["type"]: e["path"] for e in config_dict.get("extra_dirs", [])}
         self.extra_dirs.update(extra_dirs)
 
@@ -368,11 +378,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
             "logical": {
                 "path": self.logical_path,
             },
-            "cache": {
-                "size": self.cache_size,
-                "path": self.staging_path,
-                "cache_updated_data": self.cache_updated_data,
-            },
+            "cache": self._cache_config_to_dict(),
         }
 
     # rel_path is file or folder?
@@ -415,9 +421,9 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _exists_remotely: %s", ipt_timer)
 
-    def _download(self, rel_path):
+    def _download(self, rel_path, object_id: ObjectId):
         ipt_timer = ExecutionTimer()
-        cache_path = self._get_cache_path(rel_path)
+        cache_path = self._get_cache_path(rel_path, object_id)
         log.debug("Pulling data object '%s' into cache to %s", rel_path, cache_path)
 
         p = Path(rel_path)
@@ -442,7 +448,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _download: %s", ipt_timer)
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None):
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
         """
         Push the file pointed to by ``rel_path`` to the iRODS. Extract folder name
         from rel_path as iRODS collection name, and extract file name from rel_path
@@ -456,7 +462,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         data_object_name = p.stem + p.suffix
         subcollection_name = p.parent
 
-        source_file = source_file if source_file else self._get_cache_path(rel_path)
+        source_file = source_file if source_file else self._get_cache_path(rel_path, object_id)
         options = {kw.FORCE_FLAG_KW: "", kw.DEST_RESC_NAME_KW: self.resource}
 
         if not os.path.exists(source_file):
@@ -524,6 +530,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         ipt_timer = ExecutionTimer()
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         extra_dir = kwargs.get("extra_dir", None)
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
@@ -542,7 +549,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual key in irods and deleing it.
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path), ignore_errors=True)
+                shutil.rmtree(self._get_cache_path(rel_path, object_id), ignore_errors=True)
 
                 col_path = f"{self.logical_path}/{rel_path}"
                 col = None
@@ -566,7 +573,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
 
             else:
                 # Delete from cache first
-                unlink(self._get_cache_path(rel_path), ignore_errors=True)
+                unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
                 # Delete from irods as well
                 p = Path(rel_path)
                 data_object_name = p.stem + p.suffix

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -29,7 +29,7 @@ from galaxy.util import (
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     CacheShardManager,
-    ObjectId,
+    CacheTarget,
     parse_cache_dirs_from_xml,
 )
 
@@ -421,9 +421,8 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _exists_remotely: %s", ipt_timer)
 
-    def _download(self, rel_path, *, object_id: ObjectId):
+    def _download(self, rel_path, *, cache_path: str, cache_target: CacheTarget):
         ipt_timer = ExecutionTimer()
-        cache_path = self._get_cache_path(rel_path, object_id)
         log.debug("Pulling data object '%s' into cache to %s", rel_path, cache_path)
 
         p = Path(rel_path)
@@ -448,7 +447,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _download: %s", ipt_timer)
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """
         Push the file pointed to by ``rel_path`` to the iRODS. Extract folder name
         from rel_path as iRODS collection name, and extract file name from rel_path
@@ -462,7 +461,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         data_object_name = p.stem + p.suffix
         subcollection_name = p.parent
 
-        source_file = source_file if source_file else self._get_cache_path(rel_path, object_id)
+        source_file = source_file if source_file else cache_path
         options = {kw.FORCE_FLAG_KW: "", kw.DEST_RESC_NAME_KW: self.resource}
 
         if not os.path.exists(source_file):
@@ -531,6 +530,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         ipt_timer = ExecutionTimer()
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
         extra_dir = kwargs.get("extra_dir", None)
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
@@ -549,7 +549,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual key in irods and deleing it.
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path, object_id), ignore_errors=True)
+                shutil.rmtree(cache_path, ignore_errors=True)
 
                 col_path = f"{self.logical_path}/{rel_path}"
                 col = None
@@ -573,7 +573,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
 
             else:
                 # Delete from cache first
-                unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
+                unlink(cache_path, ignore_errors=True)
                 # Delete from irods as well
                 p = Path(rel_path)
                 data_object_name = p.stem + p.suffix

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -421,7 +421,7 @@ class IRODSObjectStore(CachingConcreteObjectStore):
         finally:
             log.debug("irods_pt _exists_remotely: %s", ipt_timer)
 
-    def _download(self, rel_path, object_id: ObjectId):
+    def _download(self, rel_path, *, object_id: ObjectId):
         ipt_timer = ExecutionTimer()
         cache_path = self._get_cache_path(rel_path, object_id)
         log.debug("Pulling data object '%s' into cache to %s", rel_path, cache_path)

--- a/lib/galaxy/objectstore/onedata.py
+++ b/lib/galaxy/objectstore/onedata.py
@@ -195,7 +195,7 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             file_size = self._client.get_attributes(self.space_name, attributes=["size"], file_path=remote_path)["size"]
 
             # Test if cache is large enough to hold the new file
-            if not self._caching_allowed(rel_path, file_size, object_id=object_id):
+            if not self._caching_allowed(rel_path, object_id, remote_size=file_size):
                 return False
 
             with self._atomic_download(dst_path) as tmp:

--- a/lib/galaxy/objectstore/onedata.py
+++ b/lib/galaxy/objectstore/onedata.py
@@ -22,8 +22,8 @@ from galaxy.util import (
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     CacheShardManager,
+    CacheTarget,
     enable_cache_monitor,
-    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 
@@ -185,9 +185,9 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             log.exception("Trouble checking '%s' existence in Onedata", rel_path)
             return False
 
-    def _download(self, rel_path, *, object_id: ObjectId):
+    def _download(self, rel_path, *, cache_path: str, cache_target: CacheTarget):
         try:
-            dst_path = self._get_cache_path(rel_path, object_id)
+            dst_path = cache_path
 
             log.debug("Pulling file '%s' into cache to %s", rel_path, dst_path)
 
@@ -195,7 +195,7 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             file_size = self._client.get_attributes(self.space_name, attributes=["size"], file_path=remote_path)["size"]
 
             # Test if cache is large enough to hold the new file
-            if not self._caching_allowed(rel_path, object_id=object_id, remote_size=file_size):
+            if not self._caching_allowed(rel_path, cache_target=cache_target, remote_size=file_size):
                 return False
 
             with self._atomic_download(dst_path) as tmp:
@@ -212,14 +212,14 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             log.exception("Problem downloading file '%s'", rel_path)
             return False
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """
         Push the file pointed to by ``rel_path`` to the object store under ``rel_path``.
         If ``source_file`` is provided, push that file instead while still using
         ``rel_path`` as the path.
         """
         try:
-            source_file = source_file or self._get_cache_path(rel_path, object_id)
+            source_file = source_file or cache_path
             if os.path.exists(source_file):
                 if os.path.getsize(source_file) == 0 and self._exists_remotely(rel_path):
                     log.debug(

--- a/lib/galaxy/objectstore/onedata.py
+++ b/lib/galaxy/objectstore/onedata.py
@@ -185,7 +185,7 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             log.exception("Trouble checking '%s' existence in Onedata", rel_path)
             return False
 
-    def _download(self, rel_path, object_id: ObjectId):
+    def _download(self, rel_path, *, object_id: ObjectId):
         try:
             dst_path = self._get_cache_path(rel_path, object_id)
 
@@ -195,7 +195,7 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             file_size = self._client.get_attributes(self.space_name, attributes=["size"], file_path=remote_path)["size"]
 
             # Test if cache is large enough to hold the new file
-            if not self._caching_allowed(rel_path, object_id, remote_size=file_size):
+            if not self._caching_allowed(rel_path, object_id=object_id, remote_size=file_size):
                 return False
 
             with self._atomic_download(dst_path) as tmp:

--- a/lib/galaxy/objectstore/onedata.py
+++ b/lib/galaxy/objectstore/onedata.py
@@ -21,7 +21,9 @@ from galaxy.util import (
 )
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
+    CacheShardManager,
     enable_cache_monitor,
+    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 
@@ -110,9 +112,8 @@ class OnedataObjectStore(CachingConcreteObjectStore):
 
         cache_dict = config_dict.get("cache") or {}
         self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
-        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
+        self._cache_shards = CacheShardManager.from_config(cache_dict, self.config)
 
         extra_dirs = {e["type"]: e["path"] for e in config_dict.get("extra_dirs", [])}
         self.extra_dirs.update(extra_dirs)
@@ -156,11 +157,7 @@ class OnedataObjectStore(CachingConcreteObjectStore):
                     "disable_tls_certificate_validation": self.disable_tls_certificate_validation,
                 },
                 "space": {"name": self.space_name, "galaxy_root_dir": self.galaxy_root_dir},
-                "cache": {
-                    "size": self.cache_size,
-                    "path": self.staging_path,
-                    "cache_updated_data": self.cache_updated_data,
-                },
+                "cache": self._cache_config_to_dict(),
             }
         )
         return as_dict
@@ -188,9 +185,9 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             log.exception("Trouble checking '%s' existence in Onedata", rel_path)
             return False
 
-    def _download(self, rel_path):
+    def _download(self, rel_path, object_id: ObjectId):
         try:
-            dst_path = self._get_cache_path(rel_path)
+            dst_path = self._get_cache_path(rel_path, object_id)
 
             log.debug("Pulling file '%s' into cache to %s", rel_path, dst_path)
 
@@ -198,7 +195,7 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             file_size = self._client.get_attributes(self.space_name, attributes=["size"], file_path=remote_path)["size"]
 
             # Test if cache is large enough to hold the new file
-            if not self._caching_allowed(rel_path, file_size):
+            if not self._caching_allowed(rel_path, file_size, object_id=object_id):
                 return False
 
             with self._atomic_download(dst_path) as tmp:
@@ -215,14 +212,14 @@ class OnedataObjectStore(CachingConcreteObjectStore):
             log.exception("Problem downloading file '%s'", rel_path)
             return False
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None):
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
         """
         Push the file pointed to by ``rel_path`` to the object store under ``rel_path``.
         If ``source_file`` is provided, push that file instead while still using
         ``rel_path`` as the path.
         """
         try:
-            source_file = source_file or self._get_cache_path(rel_path)
+            source_file = source_file or self._get_cache_path(rel_path, object_id)
             if os.path.exists(source_file):
                 if os.path.getsize(source_file) == 0 and self._exists_remotely(rel_path):
                     log.debug(

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -150,7 +150,7 @@ class PithosObjectStore(CachingConcreteObjectStore):
         if project and c.get("x-container-policy-project") != project:
             self.pithos.reassign_container(project)
 
-    def _download(self, rel_path, object_id: ObjectId):
+    def _download(self, rel_path, *, object_id: ObjectId):
         local_destination = self._get_cache_path(rel_path, object_id)
         with self._atomic_download(local_destination) as tmp:
             self.pithos.download_object(rel_path, tmp)

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -20,7 +20,7 @@ from galaxy.util import directory_hash_id
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     CacheShardManager,
-    ObjectId,
+    CacheTarget,
 )
 
 NO_KAMAKI_ERROR_MESSAGE = (
@@ -145,8 +145,8 @@ class PithosObjectStore(CachingConcreteObjectStore):
         if project and c.get("x-container-policy-project") != project:
             self.pithos.reassign_container(project)
 
-    def _download(self, rel_path, *, object_id: ObjectId):
-        local_destination = self._get_cache_path(rel_path, object_id)
+    def _download(self, rel_path, *, cache_path: str, cache_target: CacheTarget):
+        local_destination = cache_path
         with self._atomic_download(local_destination) as tmp:
             self.pithos.download_object(rel_path, tmp)
 
@@ -158,6 +158,7 @@ class PithosObjectStore(CachingConcreteObjectStore):
         """
         path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(path, object_id)
         try:
             self.pithos.get_object_info(path)
             return True
@@ -165,7 +166,7 @@ class PithosObjectStore(CachingConcreteObjectStore):
             if ce.status not in (404,):
                 raise
 
-        in_cache = self._in_cache(path, object_id)
+        in_cache = self._in_cache(cache_path)
         dir_only = kwargs.get("dir_only", False)
         if dir_only:
             base_dir = kwargs.get("base_dir", None)
@@ -178,7 +179,6 @@ class PithosObjectStore(CachingConcreteObjectStore):
             return False
 
         if in_cache:
-            cache_path = self._get_cache_path(path, object_id)
             # Maybe the upload should have happened in some thread elsewhere?
             with open(cache_path) as f:
                 self.pithos.upload_object(path, f)

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -94,6 +94,9 @@ class PithosObjectStore(CachingConcreteObjectStore):
 
     def __init__(self, config, config_dict):
         super().__init__(config, config_dict)
+        # Pithos ignores cache config and uses config.file_path as its cache.
+        # A single fixed shard satisfies the CacheShardManager interface required
+        # by CachingConcreteObjectStore without enabling multi-shard behavior.
         self._cache_shards = CacheShardManager([CacheShard(path=self.config.file_path, weight=1, size=-1)])
         log.info("Parse config_xml for pithos object store")
         self.config_dict = config_dict

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -18,6 +18,11 @@ except ImportError:
 
 from galaxy.util import directory_hash_id
 from ._caching_base import CachingConcreteObjectStore
+from .caching import (
+    CacheShard,
+    CacheShardManager,
+    ObjectId,
+)
 
 NO_KAMAKI_ERROR_MESSAGE = (
     "ObjectStore configured, but no kamaki.clients dependency available."
@@ -89,7 +94,7 @@ class PithosObjectStore(CachingConcreteObjectStore):
 
     def __init__(self, config, config_dict):
         super().__init__(config, config_dict)
-        self.staging_path = self.config.file_path
+        self._cache_shards = CacheShardManager([CacheShard(path=self.config.file_path, weight=1, size=-1)])
         log.info("Parse config_xml for pithos object store")
         self.config_dict = config_dict
 
@@ -142,8 +147,8 @@ class PithosObjectStore(CachingConcreteObjectStore):
         if project and c.get("x-container-policy-project") != project:
             self.pithos.reassign_container(project)
 
-    def _download(self, rel_path):
-        local_destination = self._get_cache_path(rel_path)
+    def _download(self, rel_path, object_id: ObjectId):
+        local_destination = self._get_cache_path(rel_path, object_id)
         with self._atomic_download(local_destination) as tmp:
             self.pithos.download_object(rel_path, tmp)
 
@@ -154,6 +159,7 @@ class PithosObjectStore(CachingConcreteObjectStore):
         :returns: weather the file exists remotely or in cache
         """
         path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         try:
             self.pithos.get_object_info(path)
             return True
@@ -161,7 +167,7 @@ class PithosObjectStore(CachingConcreteObjectStore):
             if ce.status not in (404,):
                 raise
 
-        in_cache = self._in_cache(path)
+        in_cache = self._in_cache(path, object_id)
         dir_only = kwargs.get("dir_only", False)
         if dir_only:
             base_dir = kwargs.get("base_dir", None)
@@ -174,7 +180,7 @@ class PithosObjectStore(CachingConcreteObjectStore):
             return False
 
         if in_cache:
-            cache_path = self._get_cache_path(path)
+            cache_path = self._get_cache_path(path, object_id)
             # Maybe the upload should have happened in some thread elsewhere?
             with open(cache_path) as f:
                 self.pithos.upload_object(path, f)
@@ -190,8 +196,10 @@ class PithosObjectStore(CachingConcreteObjectStore):
             dir_only = kwargs.get("dir_only", False)
             alt_name = kwargs.get("alt_name", None)
 
+            object_id = self._get_object_id(obj)
+
             # Construct hashed path
-            rel_path = os.path.join(*directory_hash_id(self._get_object_id(obj)))
+            rel_path = os.path.join(*directory_hash_id(object_id))
 
             # Optionally append extra_dir
             if extra_dir is not None:
@@ -201,15 +209,15 @@ class PithosObjectStore(CachingConcreteObjectStore):
                     rel_path = os.path.join(rel_path, extra_dir)
 
             # Create given directory in cache
-            cache_dir = os.path.join(self.staging_path, rel_path)
+            cache_dir = self._get_cache_path(rel_path, object_id)
             if not os.path.exists(cache_dir):
                 os.makedirs(cache_dir, exist_ok=True)
 
             if dir_only:
                 self.pithos.upload_from_string(rel_path, "", content_type="application/directory")
             else:
-                rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
-                new_file = os.path.join(self.staging_path, rel_path)
+                rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{object_id}.dat")
+                new_file = self._get_cache_path(rel_path, object_id)
                 open(new_file, "w").close()
                 self.pithos.upload_from_string(rel_path, "")
         return self

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -19,7 +19,6 @@ except ImportError:
 from galaxy.util import directory_hash_id
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
-    CacheShard,
     CacheShardManager,
     ObjectId,
 )
@@ -87,17 +86,13 @@ def parse_config_xml(config_xml):
 class PithosObjectStore(CachingConcreteObjectStore):
     """
     Object store that stores objects as items in a Pithos+ container.
-    Cache is ignored for the time being.
     """
 
     store_type = "pithos"
 
     def __init__(self, config, config_dict):
         super().__init__(config, config_dict)
-        # Pithos ignores cache config and uses config.file_path as its cache.
-        # A single fixed shard satisfies the CacheShardManager interface required
-        # by CachingConcreteObjectStore without enabling multi-shard behavior.
-        self._cache_shards = CacheShardManager([CacheShard(path=self.config.file_path, weight=1, size=-1)])
+        self._cache_shards = CacheShardManager.from_config(config_dict.get("cache") or {}, config)
         log.info("Parse config_xml for pithos object store")
         self.config_dict = config_dict
 

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -385,13 +385,14 @@ class RucioObjectStore(CachingConcreteObjectStore):
     def _exists(self, obj, **kwargs) -> bool:
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
         log.debug("rucio _exists: %s", rel_path)
 
         dir_only = kwargs.get("dir_only", False)
         base_dir = kwargs.get("base_dir", None)
 
         # Check cache and rucio
-        if self._in_cache(rel_path, object_id) or (not dir_only and self.rucio_broker.data_object_exists(rel_path)):
+        if self._in_cache(cache_path) or (not dir_only and self.rucio_broker.data_object_exists(rel_path)):
             return True
 
         # dir_only does not get synced so shortcut the decision
@@ -441,12 +442,13 @@ class RucioObjectStore(CachingConcreteObjectStore):
     def _size(self, obj, **kwargs) -> int:
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
         log.debug("rucio _size: %s", rel_path)
 
-        if self._in_cache(rel_path, object_id):
+        if self._in_cache(cache_path):
             size: int | None = None
             try:
-                size = os.path.getsize(self._get_cache_path(rel_path, object_id))
+                size = os.path.getsize(cache_path)
             except OSError as ex:
                 log.info("Could not get size of file '%s' in local cache, will try iRODS. Error: %s", rel_path, ex)
             if size is not None:
@@ -462,6 +464,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         rel_path = self._construct_path(obj, **kwargs)
         object_id = self._get_object_id(obj)
+        cache_path = self._get_cache_path(rel_path, object_id)
         extra_dir = kwargs.get("extra_dir", None)
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
@@ -477,9 +480,9 @@ class RucioObjectStore(CachingConcreteObjectStore):
 
             # Delete from cache first
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path, object_id), ignore_errors=True)
+                shutil.rmtree(cache_path, ignore_errors=True)
             else:
-                unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
+                unlink(cache_path, ignore_errors=True)
 
             # Delete from rucio as well
             if self.rucio_broker.data_object_exists(rel_path):
@@ -523,7 +526,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
         if not sync_cache:
             return cache_path
 
-        in_cache = self._in_cache(rel_path, object_id)
+        in_cache = self._in_cache(cache_path)
         size_in_cache = 0
         if in_cache:
             size_in_cache = os.path.getsize(cache_path)
@@ -547,9 +550,9 @@ class RucioObjectStore(CachingConcreteObjectStore):
                     return cache_path
         raise ObjectNotFound(f"objectstore.get_filename, no cache_path: {obj}, kwargs: {kwargs}")
 
-    def _register_file(self, rel_path, file_name, *, object_id: ObjectId):
+    def _register_file(self, rel_path, file_name, *, cache_path: str):
         if file_name is None:
-            file_name = self._get_cache_path(rel_path, object_id)
+            file_name = cache_path
             if not os.path.islink(file_name):
                 raise ObjectInvalid(
                     "rucio objectstore._register_file, rucio_register_only is set, but file in cache is not a link "
@@ -573,7 +576,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
             )
 
         if self.rucio_config["register_only"]:
-            self._register_file(rel_path, file_name, object_id=object_id)
+            self._register_file(rel_path, file_name, cache_path=self._get_cache_path(rel_path, object_id))
             return
 
         # Choose whether to use the dataset file itself or an alternate file

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -35,7 +35,9 @@ from galaxy.util import (
 )
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
+    CacheShardManager,
     enable_cache_monitor,
+    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 
@@ -340,10 +342,9 @@ class RucioObjectStore(CachingConcreteObjectStore):
         cache_dict = config_dict.get("cache") or {}
         self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
 
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
-        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
-        self.cache_config = cache_dict
+        self._cache_shards = CacheShardManager.from_config(cache_dict, self.config)
+        self.cache_config = self._cache_config_to_dict()
         self._initialize()
 
     def _initialize(self):
@@ -351,17 +352,17 @@ class RucioObjectStore(CachingConcreteObjectStore):
             self._ensure_staging_path_writable()
         self._start_cache_monitor_if_needed()
 
-    def _pull_into_cache(self, rel_path, **kwargs) -> bool:
+    def _pull_into_cache(self, rel_path, object_id: ObjectId, **kwargs) -> bool:
         log.debug("rucio _pull_into_cache: %s", rel_path)
         # Ensure the cache directory structure exists (e.g., dataset_#_files/)
         rel_path_dir = os.path.dirname(rel_path)
-        if not os.path.exists(self._get_cache_path(rel_path_dir)):
-            os.makedirs(self._get_cache_path(rel_path_dir), exist_ok=True)
+        if not os.path.exists(self._get_cache_path(rel_path_dir, object_id)):
+            os.makedirs(self._get_cache_path(rel_path_dir, object_id), exist_ok=True)
         # Now pull in the file
-        dest = self._get_cache_path(rel_path)
+        dest = self._get_cache_path(rel_path, object_id)
         auth_token = self._get_token(**kwargs)
         file_ok = self.rucio_broker.download(rel_path, dest, auth_token)
-        self._fix_permissions(self._get_cache_path(rel_path_dir))
+        self._fix_permissions(self._get_cache_path(rel_path_dir, object_id))
         return file_ok
 
     def _fix_file_permissions(self, path):
@@ -382,13 +383,14 @@ class RucioObjectStore(CachingConcreteObjectStore):
 
     def _exists(self, obj, **kwargs) -> bool:
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         log.debug("rucio _exists: %s", rel_path)
 
         dir_only = kwargs.get("dir_only", False)
         base_dir = kwargs.get("base_dir", None)
 
         # Check cache and rucio
-        if self._in_cache(rel_path) or (not dir_only and self.rucio_broker.data_object_exists(rel_path)):
+        if self._in_cache(rel_path, object_id) or (not dir_only and self.rucio_broker.data_object_exists(rel_path)):
             return True
 
         # dir_only does not get synced so shortcut the decision
@@ -411,8 +413,10 @@ class RucioObjectStore(CachingConcreteObjectStore):
             dir_only = kwargs.get("dir_only", False)
             alt_name = kwargs.get("alt_name", None)
 
+            object_id = self._get_object_id(obj)
+
             # Construct hashed path
-            rel_path = os.path.join(*directory_hash_id(self._get_object_id(obj)))
+            rel_path = os.path.join(*directory_hash_id(object_id))
 
             # Optionally append extra_dir
             if extra_dir is not None:
@@ -422,25 +426,26 @@ class RucioObjectStore(CachingConcreteObjectStore):
                     rel_path = os.path.join(rel_path, extra_dir)
 
             # Create given directory in cache
-            cache_dir = os.path.join(self.staging_path, rel_path)
+            cache_dir = self._get_cache_path(rel_path, object_id)
             if not os.path.exists(cache_dir):
                 os.makedirs(cache_dir, exist_ok=True)
 
             if not dir_only:
-                rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
+                rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{object_id}.dat")
                 # need this line to set the dataset filename, not sure how this is done - filesystem is monitored?
-                open(os.path.join(self.staging_path, rel_path), "w").close()
+                open(self._get_cache_path(rel_path, object_id), "w").close()
             log.debug("rucio _create: %s", rel_path)
         return self
 
     def _size(self, obj, **kwargs) -> int:
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         log.debug("rucio _size: %s", rel_path)
 
-        if self._in_cache(rel_path):
+        if self._in_cache(rel_path, object_id):
             size: int | None = None
             try:
-                size = os.path.getsize(self._get_cache_path(rel_path))
+                size = os.path.getsize(self._get_cache_path(rel_path, object_id))
             except OSError as ex:
                 log.info("Could not get size of file '%s' in local cache, will try iRODS. Error: %s", rel_path, ex)
             if size is not None:
@@ -455,6 +460,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
 
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         extra_dir = kwargs.get("extra_dir", None)
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
@@ -470,9 +476,9 @@ class RucioObjectStore(CachingConcreteObjectStore):
 
             # Delete from cache first
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path), ignore_errors=True)
+                shutil.rmtree(self._get_cache_path(rel_path, object_id), ignore_errors=True)
             else:
-                unlink(self._get_cache_path(rel_path), ignore_errors=True)
+                unlink(self._get_cache_path(rel_path, object_id), ignore_errors=True)
 
             # Delete from rucio as well
             if self.rucio_broker.data_object_exists(rel_path):
@@ -504,6 +510,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
         base_dir = kwargs.get("base_dir", None)
         dir_only = kwargs.get("dir_only", False)
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
 
         log.debug("rucio _get_filename: %s", rel_path)
 
@@ -511,14 +518,14 @@ class RucioObjectStore(CachingConcreteObjectStore):
         if base_dir and dir_only:
             return os.path.abspath(rel_path)
 
-        cache_path = self._get_cache_path(rel_path)
+        cache_path = self._get_cache_path(rel_path, object_id)
         if not sync_cache:
             return cache_path
 
-        in_cache = self._in_cache(rel_path)
+        in_cache = self._in_cache(rel_path, object_id)
         size_in_cache = 0
         if in_cache:
-            size_in_cache = os.path.getsize(self._get_cache_path(rel_path))
+            size_in_cache = os.path.getsize(self._get_cache_path(rel_path, object_id))
 
         # return path if we do not need to update cache
         if in_cache and dir_only:
@@ -535,13 +542,13 @@ class RucioObjectStore(CachingConcreteObjectStore):
             if dir_only:  # Directories do not get pulled into cache
                 return cache_path
             else:
-                if self._pull_into_cache(rel_path, auth=kwargs.get("auth")):
+                if self._pull_into_cache(rel_path, object_id=object_id, auth=kwargs.get("auth")):
                     return cache_path
         raise ObjectNotFound(f"objectstore.get_filename, no cache_path: {obj}, kwargs: {kwargs}")
 
-    def _register_file(self, rel_path, file_name):
+    def _register_file(self, rel_path, file_name, object_id: ObjectId):
         if file_name is None:
-            file_name = self._get_cache_path(rel_path)
+            file_name = self._get_cache_path(rel_path, object_id)
             if not os.path.islink(file_name):
                 raise ObjectInvalid(
                     "rucio objectstore._register_file, rucio_register_only is set, but file in cache is not a link "
@@ -556,6 +563,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
         self, obj, file_name=None, create: bool = False, preserve_symlinks: bool = False, **kwargs
     ) -> None:
         rel_path = self._construct_path(obj, **kwargs)
+        object_id = self._get_object_id(obj)
         log.debug("rucio _update_from_file: %s", rel_path)
 
         if not create:
@@ -564,14 +572,14 @@ class RucioObjectStore(CachingConcreteObjectStore):
             )
 
         if self.rucio_config["register_only"]:
-            self._register_file(rel_path, file_name)
+            self._register_file(rel_path, file_name, object_id=object_id)
             return
 
         # Choose whether to use the dataset file itself or an alternate file
         if file_name:
             source_file = os.path.abspath(file_name)
             # Copy into cache
-            cache_file = self._get_cache_path(rel_path)
+            cache_file = self._get_cache_path(rel_path, object_id)
             try:
                 if source_file != cache_file and self.cache_updated_data:
                     try:
@@ -584,7 +592,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
             except OSError:
                 log.exception("Trouble copying source file '%s' to cache '%s'", source_file, cache_file)
         else:
-            source_file = self._get_cache_path(rel_path)
+            source_file = self._get_cache_path(rel_path, object_id)
 
         # Update the file on rucio
         self.rucio_broker.upload(rel_path, source_file)

--- a/lib/galaxy/objectstore/rucio.py
+++ b/lib/galaxy/objectstore/rucio.py
@@ -352,17 +352,18 @@ class RucioObjectStore(CachingConcreteObjectStore):
             self._ensure_staging_path_writable()
         self._start_cache_monitor_if_needed()
 
-    def _pull_into_cache(self, rel_path, object_id: ObjectId, **kwargs) -> bool:
+    def _pull_into_cache(self, rel_path, *, object_id: ObjectId, **kwargs) -> bool:
         log.debug("rucio _pull_into_cache: %s", rel_path)
         # Ensure the cache directory structure exists (e.g., dataset_#_files/)
         rel_path_dir = os.path.dirname(rel_path)
-        if not os.path.exists(self._get_cache_path(rel_path_dir, object_id)):
-            os.makedirs(self._get_cache_path(rel_path_dir, object_id), exist_ok=True)
+        cache_dir = self._get_cache_path(rel_path_dir, object_id)
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir, exist_ok=True)
         # Now pull in the file
         dest = self._get_cache_path(rel_path, object_id)
         auth_token = self._get_token(**kwargs)
         file_ok = self.rucio_broker.download(rel_path, dest, auth_token)
-        self._fix_permissions(self._get_cache_path(rel_path_dir, object_id))
+        self._fix_permissions(cache_dir)
         return file_ok
 
     def _fix_file_permissions(self, path):
@@ -525,7 +526,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
         in_cache = self._in_cache(rel_path, object_id)
         size_in_cache = 0
         if in_cache:
-            size_in_cache = os.path.getsize(self._get_cache_path(rel_path, object_id))
+            size_in_cache = os.path.getsize(cache_path)
 
         # return path if we do not need to update cache
         if in_cache and dir_only:
@@ -546,7 +547,7 @@ class RucioObjectStore(CachingConcreteObjectStore):
                     return cache_path
         raise ObjectNotFound(f"objectstore.get_filename, no cache_path: {obj}, kwargs: {kwargs}")
 
-    def _register_file(self, rel_path, file_name, object_id: ObjectId):
+    def _register_file(self, rel_path, file_name, *, object_id: ObjectId):
         if file_name is None:
             file_name = self._get_cache_path(rel_path, object_id)
             if not os.path.islink(file_name):

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -302,7 +302,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
     def _transfer_cb(self, complete, total):
         self.transfer_progress += 10
 
-    def _download(self, rel_path, object_id: ObjectId):
+    def _download(self, rel_path, *, object_id: ObjectId):
         local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
@@ -312,7 +312,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
                 log.critical(message)
                 raise Exception(message)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, object_id, remote_size=remote_size):
+            if not self._caching_allowed(rel_path, object_id=object_id, remote_size=remote_size):
                 return False
             if self.use_axel:
                 log.debug("Parallel pulled key '%s' into cache to %s", rel_path, local_destination)

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -21,8 +21,8 @@ from ._caching_base import CachingConcreteObjectStore
 from ._util import UsesAxel
 from .caching import (
     CacheShardManager,
+    CacheTarget,
     enable_cache_monitor,
-    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 from .s3_multipart_upload import multipart_upload
@@ -302,8 +302,8 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
     def _transfer_cb(self, complete, total):
         self.transfer_progress += 10
 
-    def _download(self, rel_path, *, object_id: ObjectId):
-        local_destination = self._get_cache_path(rel_path, object_id)
+    def _download(self, rel_path, *, cache_path: str, cache_target: CacheTarget):
+        local_destination = cache_path
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
             key = self._bucket.get_key(rel_path)
@@ -312,7 +312,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
                 log.critical(message)
                 raise Exception(message)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, object_id=object_id, remote_size=remote_size):
+            if not self._caching_allowed(rel_path, cache_target=cache_target, remote_size=remote_size):
                 return False
             if self.use_axel:
                 log.debug("Parallel pulled key '%s' into cache to %s", rel_path, local_destination)
@@ -328,7 +328,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self._bucket.name)
         return False
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, cache_path: str):
         """
         Push the file pointed to by ``rel_path`` to the object store naming the key
         ``rel_path``. If ``source_file`` is provided, push that file instead while
@@ -337,7 +337,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
         the string.
         """
         try:
-            source_file = source_file if source_file else self._get_cache_path(rel_path, object_id)
+            source_file = source_file if source_file else cache_path
             if os.path.exists(source_file):
                 key = Key(self._bucket, rel_path)
                 if os.path.getsize(source_file) == 0 and key.exists():

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -20,7 +20,9 @@ from galaxy.util import string_as_bool
 from ._caching_base import CachingConcreteObjectStore
 from ._util import UsesAxel
 from .caching import (
+    CacheShardManager,
     enable_cache_monitor,
+    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 from .s3_multipart_upload import multipart_upload
@@ -140,11 +142,7 @@ class CloudConfigMixin:
                 "conn_path": self.conn_path,
                 "region": self.region,
             },
-            "cache": {
-                "size": self.cache_size,
-                "path": self.staging_path,
-                "cache_updated_data": self.cache_updated_data,
-            },
+            "cache": self._cache_config_to_dict(),
         }
 
 
@@ -184,9 +182,8 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
         self.conn_path = connection_dict.get("conn_path", "/")
         self.region = connection_dict.get("region", None)
 
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
-        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
+        self._cache_shards = CacheShardManager.from_config(cache_dict, self.config)
 
         extra_dirs = {e["type"]: e["path"] for e in config_dict.get("extra_dirs", [])}
         self.extra_dirs.update(extra_dirs)
@@ -305,8 +302,8 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
     def _transfer_cb(self, complete, total):
         self.transfer_progress += 10
 
-    def _download(self, rel_path):
-        local_destination = self._get_cache_path(rel_path)
+    def _download(self, rel_path, object_id: ObjectId):
+        local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
             key = self._bucket.get_key(rel_path)
@@ -315,7 +312,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
                 log.critical(message)
                 raise Exception(message)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, remote_size):
+            if not self._caching_allowed(rel_path, remote_size, object_id=object_id):
                 return False
             if self.use_axel:
                 log.debug("Parallel pulled key '%s' into cache to %s", rel_path, local_destination)
@@ -331,7 +328,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
             log.exception("Problem downloading key '%s' from S3 bucket '%s'", rel_path, self._bucket.name)
         return False
 
-    def _push_to_storage(self, rel_path, source_file=None, from_string=None):
+    def _push_to_storage(self, rel_path, source_file=None, from_string=None, *, object_id: ObjectId):
         """
         Push the file pointed to by ``rel_path`` to the object store naming the key
         ``rel_path``. If ``source_file`` is provided, push that file instead while
@@ -340,7 +337,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
         the string.
         """
         try:
-            source_file = source_file if source_file else self._get_cache_path(rel_path)
+            source_file = source_file if source_file else self._get_cache_path(rel_path, object_id)
             if os.path.exists(source_file):
                 key = Key(self._bucket, rel_path)
                 if os.path.getsize(source_file) == 0 and key.exists():

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -312,7 +312,7 @@ class S3ObjectStore(CachingConcreteObjectStore, CloudConfigMixin, UsesAxel):
                 log.critical(message)
                 raise Exception(message)
             remote_size = key.size
-            if not self._caching_allowed(rel_path, remote_size, object_id=object_id):
+            if not self._caching_allowed(rel_path, object_id, remote_size=remote_size):
                 return False
             if self.use_axel:
                 log.debug("Parallel pulled key '%s' into cache to %s", rel_path, local_destination)

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -32,7 +32,9 @@ from galaxy.util import asbool
 from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
+    CacheShardManager,
     enable_cache_monitor,
+    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 
@@ -203,9 +205,8 @@ class S3ObjectStore(CachingConcreteObjectStore):
 
         self.region = connection_dict.get("region")
 
-        self.cache_size = cache_dict.get("size") or self.config.object_store_cache_size
-        self.staging_path = cache_dict.get("path") or self.config.object_store_cache_path
         self.cache_updated_data = cache_dict.get("cache_updated_data", True)
+        self._cache_shards = CacheShardManager.from_config(cache_dict, self.config)
 
         extra_dirs = {e["type"]: e["path"] for e in config_dict.get("extra_dirs", [])}
         self.extra_dirs.update(extra_dirs)
@@ -293,11 +294,7 @@ class S3ObjectStore(CachingConcreteObjectStore):
                 "region": self.region,
             },
             "transfer": self.transfer_dict,
-            "cache": {
-                "size": self.cache_size,
-                "path": self.staging_path,
-                "cache_updated_data": self.cache_updated_data,
-            },
+            "cache": self._cache_config_to_dict(),
         }
 
     def to_dict(self):
@@ -325,11 +322,11 @@ class S3ObjectStore(CachingConcreteObjectStore):
                 return False
             raise
 
-    def _download(self, rel_path: str) -> bool:
-        local_destination = self._get_cache_path(rel_path)
+    def _download(self, rel_path: str, object_id: ObjectId) -> bool:
+        local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
-            if not self._caching_allowed(rel_path):
+            if not self._caching_allowed(rel_path, object_id=object_id):
                 return False
             config = self._transfer_config("download")
             with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -33,8 +33,8 @@ from galaxy.util.s3_checksum import s3_checksum_config_kwargs
 from ._caching_base import CachingConcreteObjectStore
 from .caching import (
     CacheShardManager,
+    CacheTarget,
     enable_cache_monitor,
-    ObjectId,
     parse_caching_config_dict_from_xml,
 )
 
@@ -322,11 +322,11 @@ class S3ObjectStore(CachingConcreteObjectStore):
                 return False
             raise
 
-    def _download(self, rel_path: str, *, object_id: ObjectId) -> bool:
-        local_destination = self._get_cache_path(rel_path, object_id)
+    def _download(self, rel_path: str, *, cache_path: str, cache_target: CacheTarget) -> bool:
+        local_destination = cache_path
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)
-            if not self._caching_allowed(rel_path, object_id=object_id):
+            if not self._caching_allowed(rel_path, cache_target=cache_target):
                 return False
             config = self._transfer_config("download")
             with self._atomic_download(local_destination) as tmp:

--- a/lib/galaxy/objectstore/s3_boto3.py
+++ b/lib/galaxy/objectstore/s3_boto3.py
@@ -322,7 +322,7 @@ class S3ObjectStore(CachingConcreteObjectStore):
                 return False
             raise
 
-    def _download(self, rel_path: str, object_id: ObjectId) -> bool:
+    def _download(self, rel_path: str, *, object_id: ObjectId) -> bool:
         local_destination = self._get_cache_path(rel_path, object_id)
         try:
             log.debug("Pulling key '%s' into cache to %s", rel_path, local_destination)

--- a/test/unit/objectstore/test_caching.py
+++ b/test/unit/objectstore/test_caching.py
@@ -238,7 +238,7 @@ class StubCachingBackend(CachingConcreteObjectStore):
     def _exists_remotely(self, rel_path):
         return False
 
-    def _download(self, rel_path, *, object_id):
+    def _download(self, rel_path, *, cache_path, cache_target):
         return False
 
     def _push_string_to_path(self, rel_path, from_string):
@@ -339,8 +339,7 @@ def test_backend_pull_into_cache_writes_to_correct_shard(two_dir_cache):
     expected_shard = cache_a if _is_in_shard(expected_path, cache_a) else cache_b
 
     # Patch _download to write a file instead of returning False
-    def fake_download(rel_path, *, object_id):
-        cache_path = backend._get_cache_path(rel_path, object_id)
+    def fake_download(rel_path, *, cache_path, cache_target):
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         with open(cache_path, "w") as f:
             f.write("downloaded content")

--- a/test/unit/objectstore/test_caching.py
+++ b/test/unit/objectstore/test_caching.py
@@ -199,7 +199,7 @@ class StubCachingBackend(CachingConcreteObjectStore):
     def _exists_remotely(self, rel_path):
         return False
 
-    def _download(self, rel_path, object_id=None):
+    def _download(self, rel_path, object_id):
         return False
 
     def _push_string_to_path(self, rel_path, from_string):

--- a/test/unit/objectstore/test_caching.py
+++ b/test/unit/objectstore/test_caching.py
@@ -42,13 +42,12 @@ def test_same_shard_for_same_object_id():
     extra_path = mgr.get_cache_path(obj_id, "000/dataset_12345_files/extra.txt")
     meta_path = mgr.get_cache_path(obj_id, "000/metadata_12345.dat")
     shard_paths = mgr.paths
-    for path in [main_path, extra_path, meta_path]:
-        assert any(path.startswith(sp) for sp in shard_paths), f"{path} not in any shard"
+
+    def shard_root(path):
+        return next(sp for sp in shard_paths if path == sp or path.startswith(sp + os.sep))
+
     # All three must resolve to the same shard root
-    main_root = next(sp for sp in shard_paths if main_path.startswith(sp))
-    extra_root = next(sp for sp in shard_paths if extra_path.startswith(sp))
-    meta_root = next(sp for sp in shard_paths if meta_path.startswith(sp))
-    assert main_root == extra_root == meta_root
+    assert shard_root(main_path) == shard_root(extra_path) == shard_root(meta_path)
 
 
 def test_weight_distribution():

--- a/test/unit/objectstore/test_caching.py
+++ b/test/unit/objectstore/test_caching.py
@@ -196,6 +196,8 @@ class StubCachingBackend(CachingConcreteObjectStore):
     def __init__(self, cache_shards):
         self._cache_shards = cache_shards
         self.config = MagicMock()
+        self.config.umask = 0o002
+        self.config.gid = -1
         self.cache_updated_data = True
         self.store_by = "id"
         self.extra_dirs = {}
@@ -209,7 +211,7 @@ class StubCachingBackend(CachingConcreteObjectStore):
     def _exists_remotely(self, rel_path):
         return False
 
-    def _download(self, rel_path, object_id):
+    def _download(self, rel_path, *, object_id):
         return False
 
     def _push_string_to_path(self, rel_path, from_string):
@@ -295,4 +297,36 @@ def test_backend_update_and_size(two_dir_cache, tmp_path):
         assert f.read() == "hello world"
     assert backend._size(obj) == len("hello world")
 
+    backend._delete(obj)
+
+
+def test_backend_pull_into_cache_writes_to_correct_shard(two_dir_cache):
+    """_pull_into_cache should download the file to the shard selected for that object_id."""
+    backend, cache_a, cache_b = two_dir_cache
+    obj_id = 42
+    obj = MagicMock()
+    obj.id = obj_id
+
+    # Determine which shard this object_id maps to
+    expected_path = backend._get_cache_path("000/dataset_42.dat", object_id=obj_id)
+    expected_shard = cache_a if _is_in_shard(expected_path, cache_a) else cache_b
+
+    # Patch _download to write a file instead of returning False
+    def fake_download(rel_path, *, object_id):
+        cache_path = backend._get_cache_path(rel_path, object_id)
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        with open(cache_path, "w") as f:
+            f.write("downloaded content")
+        return True
+
+    backend._download = fake_download
+
+    result = backend._pull_into_cache("000/dataset_42.dat", object_id=obj_id)
+    assert result is True
+    assert os.path.exists(expected_path)
+    assert _is_in_shard(expected_path, expected_shard)
+    with open(expected_path) as f:
+        assert f.read() == "downloaded content"
+
+    # Cleanup
     backend._delete(obj)

--- a/test/unit/objectstore/test_caching.py
+++ b/test/unit/objectstore/test_caching.py
@@ -1,0 +1,288 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from galaxy.objectstore._caching_base import CachingConcreteObjectStore
+from galaxy.objectstore.caching import (
+    CacheShard,
+    CacheShardManager,
+)
+
+
+class FakeConfig:
+    def __init__(self, cache_path=None, cache_size=-1):
+        self.object_store_cache_path = cache_path or "/tmp/default_cache"
+        self.object_store_cache_size = cache_size
+
+
+def make_shards(paths, weights=None, sizes=None):
+    weights = weights or [1] * len(paths)
+    sizes = sizes or [-1] * len(paths)
+    return [CacheShard(path=p, weight=w, size=s) for p, w, s in zip(paths, weights, sizes)]
+
+
+def test_multi_shard_manager():
+    shards = make_shards(["/fast", "/slow"], weights=[3, 1], sizes=[500, 200])
+    mgr = CacheShardManager(shards)
+    assert len(mgr.shards) == 2
+    assert mgr.paths == ["/fast", "/slow"]
+    assert len(mgr.cache_targets) == 2
+    assert mgr.cache_targets[0].path == "/fast"
+    assert mgr.cache_targets[0].size == 500
+    assert mgr.cache_targets[1].path == "/slow"
+    assert mgr.cache_targets[1].size == 200
+
+
+def test_same_shard_for_same_object_id():
+    shards = make_shards(["/a", "/b", "/c"], weights=[2, 1, 1])
+    mgr = CacheShardManager(shards)
+    obj_id = 12345
+    main_path = mgr.get_cache_path(obj_id, "000/dataset_12345.dat")
+    extra_path = mgr.get_cache_path(obj_id, "000/dataset_12345_files/extra.txt")
+    meta_path = mgr.get_cache_path(obj_id, "000/metadata_12345.dat")
+    shard_paths = mgr.paths
+    for path in [main_path, extra_path, meta_path]:
+        assert any(path.startswith(sp) for sp in shard_paths), f"{path} not in any shard"
+    # All three must resolve to the same shard root
+    main_root = next(sp for sp in shard_paths if main_path.startswith(sp))
+    extra_root = next(sp for sp in shard_paths if extra_path.startswith(sp))
+    meta_root = next(sp for sp in shard_paths if meta_path.startswith(sp))
+    assert main_root == extra_root == meta_root
+
+
+def test_weight_distribution():
+    shards = make_shards(["/a", "/b"], weights=[3, 1])
+    mgr = CacheShardManager(shards)
+    counts = {"a": 0, "b": 0}
+    n = 10000
+    for i in range(n):
+        path = mgr.get_cache_path(i, "file.dat")
+        if path.startswith("/a"):
+            counts["a"] += 1
+        else:
+            counts["b"] += 1
+    ratio_a = counts["a"] / n
+    assert 0.70 < ratio_a < 0.80, f"Expected ~75% for weight 3, got {ratio_a}"
+
+
+def test_from_config_legacy_single_path():
+    cache_dict = {"path": "/cache", "size": 100}
+    config = FakeConfig()
+    mgr = CacheShardManager.from_config(cache_dict, config)
+    assert len(mgr.shards) == 1
+    assert mgr.shards[0].path == "/cache"
+    assert mgr.shards[0].size == 100
+    assert mgr.shards[0].weight == 1
+
+
+def test_from_config_multi_dir():
+    cache_dict = {
+        "dirs": [
+            {"path": "/fast", "weight": 3, "size": 500},
+            {"path": "/slow", "weight": 1, "size": 200},
+        ],
+        "size": 100,
+    }
+    config = FakeConfig()
+    mgr = CacheShardManager.from_config(cache_dict, config)
+    assert len(mgr.shards) == 2
+    assert mgr.shards[0].path == "/fast"
+    assert mgr.shards[0].weight == 3
+    assert mgr.shards[0].size == 500
+    assert mgr.shards[1].path == "/slow"
+    assert mgr.shards[1].weight == 1
+    assert mgr.shards[1].size == 200
+
+
+@pytest.mark.parametrize(
+    "cache_dict, config_size, expected_paths, expected_sizes",
+    [
+        # Empty dirs → fallback to single path
+        ({"dirs": [], "path": "/cache", "size": 100}, -1, ["/cache"], [100]),
+        # All invalid entries → fallback to single path
+        (
+            {
+                "dirs": [{"path": None}, {"path": "/zero", "weight": 0}],
+                "path": "/fallback",
+                "size": 100,
+            },
+            -1,
+            ["/fallback"],
+            [100],
+        ),
+        # Empty dict → config defaults
+        ({}, 10, ["/default"], [10]),
+        # Invalid entries filtered, valid ones kept
+        (
+            {
+                "dirs": [
+                    {"path": "/valid", "weight": 2, "size": 300},
+                    {"path": None, "weight": 1},
+                    {"path": "/zero_weight", "weight": 0, "size": 100},
+                    {"path": "/negative", "weight": -1, "size": 100},
+                ],
+                "path": "/fallback",
+                "size": 100,
+            },
+            -1,
+            ["/valid"],
+            [300],
+        ),
+        # Size fallback: per-dir missing → top-level size
+        (
+            {
+                "dirs": [
+                    {"path": "/a", "weight": 1},
+                    {"path": "/b", "weight": 1, "size": 200},
+                ],
+                "size": 100,
+            },
+            -1,
+            ["/a", "/b"],
+            [100, 200],
+        ),
+        # Size fallback: per-dir + top-level missing → config default
+        (
+            {"dirs": [{"path": "/a", "weight": 1}]},
+            50,
+            ["/a"],
+            [50],
+        ),
+    ],
+)
+def test_from_config_fallbacks(cache_dict, config_size, expected_paths, expected_sizes):
+    config = FakeConfig(cache_path="/default", cache_size=config_size)
+    mgr = CacheShardManager.from_config(cache_dict, config)
+    assert mgr.paths == expected_paths
+    assert [s.size for s in mgr.shards] == expected_sizes
+
+
+def test_cache_targets_sizes():
+    shards = make_shards(["/a", "/b"], sizes=[100, 200])
+    mgr = CacheShardManager(shards)
+    targets = mgr.cache_targets
+    assert targets[0].size == 100
+    assert targets[1].size == 200
+    assert targets[0].path == "/a"
+    assert targets[1].path == "/b"
+
+
+def test_get_cache_target():
+    shards = make_shards(["/a", "/b"], sizes=[100, 200])
+    mgr = CacheShardManager(shards)
+    target = mgr.get_cache_target(42)
+    assert target.path in ["/a", "/b"]
+    assert target.size in [100, 200]
+    assert target.limit == 0.9
+
+
+def test_empty_shards_raises():
+    with pytest.raises(ValueError, match="at least one shard"):
+        CacheShardManager([])
+
+
+class StubCachingBackend(CachingConcreteObjectStore):
+    def __init__(self, cache_shards):
+        self._cache_shards = cache_shards
+        self.config = MagicMock()
+        self.cache_updated_data = True
+        self.store_by = "id"
+        self.extra_dirs = {}
+
+    def _get_object_id(self, obj):
+        return obj
+
+    def _get_remote_size(self, rel_path):
+        return 0
+
+    def _exists_remotely(self, rel_path):
+        return False
+
+    def _download(self, rel_path, object_id=None):
+        return False
+
+    def _push_string_to_path(self, rel_path, from_string):
+        return True
+
+    def _push_file_to_path(self, rel_path, source_file):
+        return True
+
+    def _delete_existing_remote(self, rel_path):
+        return True
+
+    def _delete_remote_all(self, rel_path):
+        return True
+
+
+@pytest.fixture
+def two_dir_cache(tmp_path):
+    cache_a = tmp_path / "cache_a"
+    cache_b = tmp_path / "cache_b"
+    cache_a.mkdir()
+    cache_b.mkdir()
+    config = FakeConfig(cache_path=str(cache_a), cache_size=-1)
+    cache_dict = {
+        "dirs": [
+            {"path": str(cache_a), "weight": 1, "size": -1},
+            {"path": str(cache_b), "weight": 1, "size": -1},
+        ],
+    }
+    mgr = CacheShardManager.from_config(cache_dict, config)
+    return StubCachingBackend(mgr), str(cache_a), str(cache_b)
+
+
+def test_backend_cache_targets(two_dir_cache):
+    backend, cache_a, cache_b = two_dir_cache
+    targets = backend.cache_targets()
+    assert len(targets) == 2
+    paths = {t.path for t in targets}
+    assert paths == {cache_a, cache_b}
+
+
+def test_backend_first_shard_properties(two_dir_cache):
+    backend, cache_a, cache_b = two_dir_cache
+    assert backend.staging_path == cache_a
+    assert backend.cache_target.path == cache_a
+
+
+def test_backend_get_filename_no_sync(two_dir_cache):
+    backend, cache_a, cache_b = two_dir_cache
+    obj_id = 42
+    cache_path = backend._get_cache_path("000/dataset_42.dat", object_id=obj_id)
+    assert cache_path.startswith(cache_a) or cache_path.startswith(cache_b)
+
+
+def test_backend_create_and_delete(two_dir_cache):
+    backend, cache_a, cache_b = two_dir_cache
+    obj_id = 99
+    obj = MagicMock()
+    obj.id = obj_id
+
+    backend._create(obj)
+
+    filename = backend._get_filename(obj, sync_cache=False)
+    assert os.path.exists(filename)
+
+    backend._delete(obj)
+    assert not os.path.exists(filename)
+
+
+def test_backend_update_and_size(two_dir_cache, tmp_path):
+    backend, cache_a, cache_b = two_dir_cache
+    obj = MagicMock()
+    obj.id = 77
+
+    src = tmp_path / "source.txt"
+    src.write_text("hello world")
+
+    backend._create(obj)
+    backend._update_from_file(obj, file_name=str(src), create=True)
+
+    filename = backend._get_filename(obj, sync_cache=False)
+    assert os.path.exists(filename)
+    with open(filename) as f:
+        assert f.read() == "hello world"
+    assert backend._size(obj) == len("hello world")
+
+    backend._delete(obj)

--- a/test/unit/objectstore/test_caching.py
+++ b/test/unit/objectstore/test_caching.py
@@ -22,6 +22,16 @@ def make_shards(paths, weights=None, sizes=None):
     return [CacheShard(path=p, weight=w, size=s) for p, w, s in zip(paths, weights, sizes)]
 
 
+def _is_in_shard(path: str, shard_path: str) -> bool:
+    """True if *path* is *shard_path* itself or a file/directory inside it."""
+    return path == shard_path or path.startswith(shard_path + os.sep)
+
+
+def _shard_root(path: str, shard_paths: list[str]) -> str:
+    """Return the shard root that *path* belongs to."""
+    return next(sp for sp in shard_paths if _is_in_shard(path, sp))
+
+
 def test_multi_shard_manager():
     shards = make_shards(["/fast", "/slow"], weights=[3, 1], sizes=[500, 200])
     mgr = CacheShardManager(shards)
@@ -43,11 +53,12 @@ def test_same_shard_for_same_object_id():
     meta_path = mgr.get_cache_path(obj_id, "000/metadata_12345.dat")
     shard_paths = mgr.paths
 
-    def shard_root(path):
-        return next(sp for sp in shard_paths if path == sp or path.startswith(sp + os.sep))
-
     # All three must resolve to the same shard root
-    assert shard_root(main_path) == shard_root(extra_path) == shard_root(meta_path)
+    assert (
+        _shard_root(main_path, shard_paths)
+        == _shard_root(extra_path, shard_paths)
+        == _shard_root(meta_path, shard_paths)
+    )
 
 
 def test_weight_distribution():
@@ -57,7 +68,7 @@ def test_weight_distribution():
     n = 10000
     for i in range(n):
         path = mgr.get_cache_path(i, "file.dat")
-        if path.startswith("/a"):
+        if _is_in_shard(path, "/a"):
             counts["a"] += 1
         else:
             counts["b"] += 1
@@ -249,7 +260,7 @@ def test_backend_get_filename_no_sync(two_dir_cache):
     backend, cache_a, cache_b = two_dir_cache
     obj_id = 42
     cache_path = backend._get_cache_path("000/dataset_42.dat", object_id=obj_id)
-    assert cache_path.startswith(cache_a) or cache_path.startswith(cache_b)
+    assert _is_in_shard(cache_path, cache_a) or _is_in_shard(cache_path, cache_b)
 
 
 def test_backend_create_and_delete(two_dir_cache):

--- a/test/unit/objectstore/test_caching.py
+++ b/test/unit/objectstore/test_caching.py
@@ -50,15 +50,42 @@ def test_same_shard_for_same_object_id():
     obj_id = 12345
     main_path = mgr.get_cache_path(obj_id, "000/dataset_12345.dat")
     extra_path = mgr.get_cache_path(obj_id, "000/dataset_12345_files/extra.txt")
-    meta_path = mgr.get_cache_path(obj_id, "000/metadata_12345.dat")
     shard_paths = mgr.paths
 
-    # All three must resolve to the same shard root
-    assert (
-        _shard_root(main_path, shard_paths)
-        == _shard_root(extra_path, shard_paths)
-        == _shard_root(meta_path, shard_paths)
-    )
+    # The main dataset file and its extra_files must resolve to the same shard
+    # because they share the same object_id.
+    assert _shard_root(main_path, shard_paths) == _shard_root(extra_path, shard_paths)
+
+
+def test_metadata_file_may_land_on_different_shard():
+    """MetadataFile has its own id space — _get_object_id returns the
+    MetadataFile's id, not the Dataset's id.  With multiple shards the
+    metadata file may land on a different shard than the dataset.
+
+    This test verifies that the shard selection is purely a function of
+    the object_id passed in — different ids can (and often do) map to
+    different shards.
+    """
+    shards = make_shards(["/a", "/b"], weights=[1, 1])
+    mgr = CacheShardManager(shards)
+    shard_paths = mgr.paths
+
+    # Find a dataset id and a metadata id that land on different shards.
+    # With 2 equal-weight shards this happens ~50% of the time.
+    found_divergence = False
+    for dataset_id in range(1000):
+        dataset_path = mgr.get_cache_path(dataset_id, "000/dataset.dat")
+        dataset_shard = _shard_root(dataset_path, shard_paths)
+        for metadata_id in range(1000):
+            metadata_path = mgr.get_cache_path(metadata_id, "000/metadata.dat")
+            metadata_shard = _shard_root(metadata_path, shard_paths)
+            if dataset_shard != metadata_shard:
+                found_divergence = True
+                break
+        if found_divergence:
+            break
+
+    assert found_divergence, "Expected at least one dataset/metadata pair to land on different shards"
 
 
 def test_weight_distribution():

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -1023,7 +1023,7 @@ def test_cache_monitor_thread(tmp_path):
     path.write_text("this is an example file")
 
     cache_target = CacheTarget(cache_dir, 1, 0.000000001)
-    monitor = InProcessCacheMonitor(cache_target, 30, 0)
+    monitor = InProcessCacheMonitor([cache_target], 30, 0)
 
     path_cleaned = False
     for _ in range(100):

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -579,6 +579,16 @@ PITHOS_TEST_CONFIG_YAML = get_example("pithos_simple.yml")
 
 
 @patch_object_stores_to_skip_initialize
+def test_pithos_caches_outside_the_dataset_directory():
+    # Pithos used to stage into config.file_path - the primary dataset directory -
+    # which puts cache files among datasets and points the cache monitor at them.
+    for config_str in [PITHOS_TEST_CONFIG, PITHOS_TEST_CONFIG_YAML]:
+        with TestConfig(config_str) as (directory, object_store):
+            assert object_store.staging_path == directory.global_config.object_store_cache_path
+            assert object_store.staging_path != directory.global_config.file_path
+
+
+@patch_object_stores_to_skip_initialize
 def test_config_parse_pithos():
     for config_str in [PITHOS_TEST_CONFIG, PITHOS_TEST_CONFIG_YAML]:
         with TestConfig(config_str) as (directory, object_store):

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -1055,6 +1055,21 @@ def test_check_cache_sanity(tmp_path):
     assert not path.exists()
 
 
+def test_check_cache_treats_non_positive_size_as_unbounded(tmp_path):
+    # A non-positive cache size means "unbounded" everywhere else in this module
+    # (see CacheTarget.fits_in_cache), so the monitor must not treat it as a
+    # zero-byte budget and reap the whole directory.
+    cache_dir = tmp_path
+    path = cache_dir / "a_file_0"
+    path.write_text("this is an example file")
+
+    check_cache(CacheTarget(cache_dir, -1, 0.2))
+    assert path.exists()
+
+    check_cache(CacheTarget(cache_dir, 0, 0.2))
+    assert path.exists()
+
+
 def test_fits_in_cache_check(tmp_path):
     cache_dir = tmp_path
     big_cache_target = CacheTarget(cache_dir, 1, 0.2)


### PR DESCRIPTION
Closes #20062

## Summary

Extends caching object stores so a backend cache can use multiple weighted cache directories with deterministic sharding. All cache entries for the same dataset — including extra_files — resolve to the same shard by hashing the dataset's object id.

Note: Metadata files (MetadataFile) have their own mapped class with their own id space, so _get_object_id returns the metadata file's id rather than the dataset's id. This means metadata files are not guaranteed to co-locate with their corresponding dataset in a sharded cache. Extra files (extra_files) do co-locate because they share the dataset's object id.

This is Phase B of discussion #23107.

Existing single-path cache configuration remains fully compatible — no migration required. Cache storage is transient, so a missing file in the expected shard is treated as a normal cache miss and re-downloaded from remote storage.

## Configuration

Cache sharding is configured per-backend in your object store config file (set via `object_store_config_file` in `galaxy.yml`, defaults to `object_store_conf.xml`). Both XML and YAML formats are supported — a YAML sample is available at `lib/galaxy/config/sample/object_store_conf.sample.yml`.

### Legacy single-path (unchanged)

```yaml
# object_store_conf.yml — existing single-path cache still works as-is
type: boto3
auth:
    access_key: ...
    secret_key: ...
bucket:
    name: my-bucket
cache:
    path: database/object_store_cache
    size: 1000
    cache_updated_data: true
```

### New multi-dir sharding

Replace the single `path` with a `dirs` list. Each entry supports `path`, `weight` (default `1`), and `size` (falls back to top-level `cache.size`, then `object_store_cache_size`):

```yaml
# object_store_conf.yml — multi-directory cache sharding
type: boto3
auth:
    access_key: ...
    secret_key: ...
bucket:
    name: my-bucket
cache:
    dirs:
        - path: /fast/cache
          weight: 3
          size: 500
        - path: /slow/cache
          weight: 1
          size: 200
    cache_updated_data: true
```

This also works inside distributed or hierarchical stores — each backend can independently use sharded or single-path cache:

```yaml
# object_store_conf.yml — sharded cache in a distributed store
type: distributed
backends:
    - id: primary
      type: boto3
      store_by: uuid
      weight: 3
      auth:
          access_key: ...
          secret_key: ...
      bucket:
          name: primary-bucket
      cache:
          dirs:
              - path: /nvme/cache
                weight: 3
                size: 500
              - path: /ssd/cache
                weight: 1
                size: 200
    - id: secondary
      type: azure_blob
      store_by: uuid
      weight: 1
      cache:
          path: /default/cache
          size: 100
```

XML config is also supported for backends that use `object_store_conf.xml`:

```xml
<cache monitor="auto" cache_updated_data="true">
  <dirs>
    <dir path="/fast/cache" weight="3" size="500" />
    <dir path="/slow/cache" weight="1" size="200" />
  </dirs>
</cache>
```

Zero or negative weight dirs are silently excluded. Empty or invalid `dirs` falls back to legacy single-path behavior.

## Manual setup & testing

### Prerequisites

A running Galaxy instance with a remote caching object store backend (e.g., S3). For local testing without real cloud services, the unit tests in `test/unit/objectstore/test_caching.py` use a `StubCachingBackend` that requires no network.

### Setup

1. Create two or more cache directories on different mount points:

    ```bash
    mkdir -p /fast/cache /slow/cache
    ```

2. Edit your object store config file (e.g., `config/object_store_conf.yml` — set `object_store_config_file` in `galaxy.yml` if using a different name) and add a `dirs` list under the backend's `cache` section. For example, a boto3 S3 backend:

    ```yaml
    type: boto3
    auth:
        access_key: AKIA...
        secret_key: ...
    bucket:
        name: my-galaxy-bucket
    connection:
        region: us-east-1
    cache:
        dirs:
            - path: /fast/cache
              weight: 3
              size: 500
            - path: /slow/cache
              weight: 1
              size: 200
        cache_updated_data: true
    extra_dirs:
        - type: job_work
          path: database/job_working_directory_s3
    ```

    See `lib/galaxy/config/sample/object_store_conf.sample.yml` for full examples of each backend type.

3. Restart Galaxy.

### Verifying sharding behavior

1. Upload a dataset through the Galaxy UI or API. The dataset will be downloaded to one of the cache shards on first access.

2. Check which shard the dataset landed on:

    ```bash
    find /fast/cache /slow/cache -name "dataset_*.dat" -ls
    ```

3. Verify that the same dataset's data and extra_files are all on the same shard:

    ```bash
    # For a dataset with id 42:
    find /fast/cache /slow/cache -path "*dataset_42*" -ls
    ```

4. Access the dataset multiple times (e.g., re-run a tool on it). Confirm the cache path remains on the same shard — no cross-shard lookups occur.

5. Verify cache monitoring is running for all shards by checking Galaxy logs for cache monitor output referencing both paths.

## Design notes

- **No database migration** — cache contents are transient.
- **No cross-shard search on miss** — a missing file in the expected shard triggers a re-download from remote storage.
- **Deterministic across processes/restarts** — SHA-256 hashing of the object id ensures the same dataset always maps to the same shard.
- **Pithos is out of scope** — it intentionally uses `config.file_path` and is not converted to sharded cache config.
- **Runtime drain or weight changes** are not part of this initial implementation. Old cache entries expire through normal LRU cleanup.
- Metadata files are not co-located with their dataset — MetadataFile has its own id space and is hashed independently.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
