### PR TITLE
JAICE: environment key (ESK/EPK) management (step 2)

### DIFF
--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -4688,3 +4688,26 @@ mapping:
         required: false
         desc: |
           Enable beta tool formats (yaml, cwl, ...) which is a prerequisite for user defined tools.
+
+      jaice_environment_key_path:
+        type: str
+        required: false
+        desc: |
+          Path to an Ed25519 private key file (PEM-encoded, PKCS#8) used as the
+          JAICE Computing Environment signing key (ESK). The corresponding public
+          key (EPK) must be pre-registered at the Repository. If neither this nor
+          ``jaice_environment_key_vault_path`` is set, JAICE authentication is
+          disabled. For production deployments, storing the key in the configured
+          vault (via ``jaice_environment_key_vault_path``) is preferred over a
+          plaintext file.
+
+      jaice_environment_key_vault_path:
+        type: str
+        required: false
+        default: jaice/environment_key
+        desc: |
+          Vault key path where the JAICE Computing Environment signing key (ESK)
+          is stored as a PEM-encoded Ed25519 private key. Takes precedence over
+          ``jaice_environment_key_path`` if both are set. A key can be generated
+          and stored with the ``generate_environment_keypair`` and
+          ``store_esk_to_vault`` helpers in ``lib/galaxy/security/jaice/env_key.py``.

--- a/lib/galaxy/security/jaice/__init__.py
+++ b/lib/galaxy/security/jaice/__init__.py
@@ -1,0 +1,62 @@
+"""JAICE - Job Authentication in Computation Environment.
+
+Implementation of the cryptographic primitives and JWT token format defined
+by the JAICE protocol (see ``doc/source/dev/jaice_design.md`` for the design
+and the ``jaice.pdf`` reference document for the full specification).
+
+This module implements the lowest-risk slice: key generation, the RFC 7748
+curve mapping that lets a single Ed25519 keypair double as the X25519 key used
+for Crypt4GH, JWK (de)serialization, and the compact-JWT tokens for both
+authentication options (CE-signed "Option B" and user-co-signed "Option A").
+
+Design notes:
+
+* The protocol document specifies ``alg: "Ed25519"``. That is not a standard
+  JWA identifier; the standard algorithm name for Ed25519 signatures in JWTs
+  is ``EdDSA`` (RFC 8037 / RFC 8705). We emit ``EdDSA`` for interoperability
+  with standard JWT libraries and note the divergence here.
+* The protocol reuses one keypair for both Ed25519 signing and X25519
+  Crypt4GH decryption via the RFC 7748 Montgomery <-> Twisted-Edwards mapping.
+  This module implements that mapping and exposes both key halves. See the
+  design doc for the key-separation trade-off discussion.
+"""
+
+from galaxy.security.jaice.env_key import (
+    EnvironmentKeyError,
+    EnvironmentKeypair,
+    generate_environment_keypair,
+    load_esk_from_file,
+    load_esk_from_vault,
+    store_esk_to_vault,
+)
+from galaxy.security.jaice.jwt import (
+    build_ce_jwt,
+    build_user_jwt,
+    header_jwk,
+    verify_jwt,
+)
+from galaxy.security.jaice.keys import (
+    ed25519_seed_to_x25519_private,
+    from_jwk,
+    generate_job_keypair,
+    JobKeypair,
+    to_jwk,
+)
+
+__all__ = (
+    "JobKeypair",
+    "EnvironmentKeypair",
+    "EnvironmentKeyError",
+    "ed25519_seed_to_x25519_private",
+    "from_jwk",
+    "generate_environment_keypair",
+    "generate_job_keypair",
+    "load_esk_from_file",
+    "load_esk_from_vault",
+    "store_esk_to_vault",
+    "to_jwk",
+    "build_ce_jwt",
+    "build_user_jwt",
+    "header_jwk",
+    "verify_jwt",
+)

--- a/lib/galaxy/security/jaice/env_key.py
+++ b/lib/galaxy/security/jaice/env_key.py
@@ -1,0 +1,211 @@
+"""JAICE environment key (ESK/EPK) management.
+
+The Computing Environment (CE) holds an Ed25519 keypair whose public half (EPK)
+is pre-registered at the Repository. The private half (ESK) signs every Option B
+(CE-signed) request JWT and MUST be protected: ESK compromise = full CE
+impersonation.
+
+This module handles:
+
+* Generating a fresh environment keypair (for initial setup by an admin).
+* Loading ESK from a PEM file on disk (``load_esk_from_file``).
+* Loading/storing ESK via Galaxy's vault abstraction
+  (``load_esk_from_vault`` / ``store_esk_to_vault``).
+* Exposing EPK as a JWK for embedding in JWT headers.
+
+The recommended production pattern is:
+
+1. Generate the keypair with ``generate_environment_keypair``.
+2. Store the PEM in the configured vault under a well-known path
+   (default: ``jaice/environment_key``).
+3. Set ``jaice_environment_key_vault_path`` in ``galaxy.yml`` to that path.
+4. The EPK JWK is exposed at ``/api/jaice/epk`` so operators can register it
+   at the Repository out-of-band.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from galaxy.security.jaice.keys import ED25519_CRV, to_jwk
+from galaxy.security.jaice.jwt import build_ce_jwt
+
+if TYPE_CHECKING:
+    from galaxy.security.jaice.keys import JobKeypair
+    from galaxy.security.vault import Vault
+
+# Default vault path where the ESK PEM is stored when using the vault backend.
+DEFAULT_VAULT_KEY_PATH = "jaice/environment_key"
+
+
+class EnvironmentKeyError(Exception):
+    """Raised when the environment key cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class EnvironmentKeypair:
+    """CE environment keypair.
+
+    ``signing_key`` is the Ed25519 private key (ESK). The public half (EPK) is
+    derived from it and exposed as a JWK for embedding in JWT headers.
+    """
+
+    signing_key: Ed25519PrivateKey
+
+    @property
+    def public_key(self) -> Ed25519PublicKey:
+        """The EPK as a ``cryptography`` public key object."""
+        return self.signing_key.public_key()
+
+    @property
+    def public_bytes(self) -> bytes:
+        """Raw 32-byte EPK."""
+        return self.public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+
+    @property
+    def epk_jwk(self) -> dict:
+        """EPK serialized as a JWK (``kty:OKP, crv:Ed25519``)."""
+        return to_jwk(self.public_key)
+
+    def sign_jwt(
+        self,
+        job_keypair: JobKeypair,
+        *,
+        include_epk: bool = True,
+    ) -> str:
+        """Sign an Option B (CE-signed) JWT for *job_keypair*.
+
+        This is a convenience wrapper around :func:`~.jwt.build_ce_jwt`.
+        """
+        return build_ce_jwt(job_keypair, self.signing_key, include_epk=include_epk)
+
+    def private_pem(self) -> bytes:
+        """Export ESK as unencrypted PKCS#8 PEM bytes.
+
+        **Handle with care** — this is the ESK in the clear.
+        """
+        return self.signing_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+
+def generate_environment_keypair() -> tuple[EnvironmentKeypair, bytes]:
+    """Generate a fresh ESK/EPK and return the keypair and its PEM encoding.
+
+    Returns a ``(EnvironmentKeypair, pem_bytes)`` tuple. The caller is
+    responsible for storing the PEM securely (vault or file).
+    """
+    esk = Ed25519PrivateKey.generate()
+    keypair = EnvironmentKeypair(signing_key=esk)
+    return keypair, keypair.private_pem()
+
+
+def load_esk_from_file(path: str | os.PathLike) -> EnvironmentKeypair:
+    """Load ESK from a PEM-encoded PKCS#8 Ed25519 private-key file.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the PEM file.
+
+    Returns
+    -------
+    EnvironmentKeypair
+        The loaded environment keypair.
+
+    Raises
+    ------
+    EnvironmentKeyError
+        If the file cannot be read or does not contain a valid Ed25519 key.
+    """
+    path = os.fspath(path)
+    try:
+        with open(path, "rb") as fh:
+            key = serialization.load_pem_private_key(fh.read(), password=None)
+    except (OSError, ValueError, TypeError) as exc:
+        raise EnvironmentKeyError(
+            f"Failed to load ESK from {path!r}: {exc}"
+        ) from exc
+
+    if not isinstance(key, Ed25519PrivateKey):
+        raise EnvironmentKeyError(
+            f"Key in {path!r} is {type(key).__name__}, expected Ed25519PrivateKey"
+        )
+    return EnvironmentKeypair(signing_key=key)
+
+
+def load_esk_from_vault(
+    vault: Vault,
+    key_path: str = DEFAULT_VAULT_KEY_PATH,
+) -> EnvironmentKeypair:
+    """Load ESK from the Galaxy vault.
+
+    Parameters
+    ----------
+    vault:
+        The Galaxy vault instance (``app.vault``).
+    key_path:
+        Vault key where the PEM-encoded ESK is stored.
+
+    Returns
+    -------
+    EnvironmentKeypair
+        The loaded environment keypair.
+
+    Raises
+    ------
+    EnvironmentKeyError
+        If no key is found at *key_path* or the stored data is not a valid
+        Ed25519 private key.
+    """
+    pem_data = vault.read_secret(key_path)
+    if not pem_data:
+        raise EnvironmentKeyError(
+            f"No ESK found in vault at {key_path!r}"
+        )
+    try:
+        key = serialization.load_pem_private_key(
+            pem_data.encode("utf-8"), password=None
+        )
+    except (ValueError, TypeError) as exc:
+        raise EnvironmentKeyError(
+            f"Failed to parse ESK from vault key {key_path!r}: {exc}"
+        ) from exc
+
+    if not isinstance(key, Ed25519PrivateKey):
+        raise EnvironmentKeyError(
+            f"Vault key {key_path!r} does not contain an Ed25519 key"
+        )
+    return EnvironmentKeypair(signing_key=key)
+
+
+def store_esk_to_vault(
+    vault: Vault,
+    keypair: EnvironmentKeypair,
+    key_path: str = DEFAULT_VAULT_KEY_PATH,
+) -> None:
+    """Store ESK PEM in the Galaxy vault.
+
+    Parameters
+    ----------
+    vault:
+        The Galaxy vault instance.
+    keypair:
+        The environment keypair to store.
+    key_path:
+        Vault key path to write to.
+    """
+    vault.write_secret(key_path, keypair.private_pem().decode("ascii"))

--- a/lib/galaxy/security/jaice/jwt.py
+++ b/lib/galaxy/security/jaice/jwt.py
@@ -1,0 +1,119 @@
+"""JAICE JWT token construction and verification.
+
+Two token flavors, matching the protocol's two authentication options:
+
+* **Option B (CE-signed)** - ``build_ce_jwt``. The Computing Environment signs
+  the token with its ``ESK``. The header carries the ``EPK`` as a ``jwk`` so
+  the Repository can identify the CE before verifying.
+* **Option A (user-signed)** - ``build_user_jwt``. The user signs the *same*
+  payload with their ``USK``; the header carries the ``UPK``. The CE forwards
+  both tokens so the Repository can confirm a real user authorized the job.
+
+Both use the standard ``EdDSA`` JWA algorithm (Ed25519). The protocol document
+writes ``alg: "Ed25519"``; that is not a standard JWA identifier, so we emit
+``EdDSA`` for interoperability with standard JWT libraries. ``Ed25519`` is
+reflected in the JWK ``crv`` field, which is the correct place for it.
+
+Signatures are produced with PyJWT's registered ``EdDSA`` algorithm, which
+consumes ``cryptography`` OKP key objects.
+"""
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+def _as_public_key(public_key: Ed25519PublicKey | bytes) -> Ed25519PublicKey:
+    """Coerce a public key into a ``cryptography`` key object.
+
+    PyJWT's ``EdDSA`` verifier accepts ``cryptography`` key objects but not raw
+    bytes (it attempts PEM decoding on bytes), so raw 32-byte keys must be
+    wrapped first.
+    """
+    if isinstance(public_key, Ed25519PublicKey):
+        return public_key
+    if isinstance(public_key, bytes | bytearray):
+        return Ed25519PublicKey.from_public_bytes(bytes(public_key))
+    raise TypeError("public_key must be an Ed25519PublicKey or 32 raw bytes")
+
+
+from galaxy.security.jaice.keys import (
+    b64url_encode,
+    JobKeypair,
+    to_jwk,
+)
+
+# Standard JWA algorithm name for Ed25519 signatures (RFC 8037 / RFC 8705).
+# The JAICE document uses the non-standard literal "Ed25519" here; the curve
+# name belongs in the JWK `crv`, not the `alg`.
+ALG = "EdDSA"
+
+
+def _build_header(public_key: Ed25519PublicKey, include_jwk: bool) -> dict:
+    header = {"typ": "JWT", "alg": ALG}
+    if include_jwk:
+        header["jwk"] = to_jwk(public_key)
+    return header
+
+
+def _build_payload(job_keypair: JobKeypair) -> dict:
+    return {
+        "sub": job_keypair.job_id,
+        "jpk": b64url_encode(job_keypair.ed25519_public_bytes),
+    }
+
+
+def build_ce_jwt(
+    job_keypair: JobKeypair,
+    esk: Ed25519PrivateKey,
+    *,
+    include_epk: bool = True,
+) -> str:
+    """Option B: build a CE-signed JWT for a data request.
+
+    ``esk`` is the Computing Environment's signing key. By default the EPK is
+    embedded in the header ``jwk`` so the Repository can identify the CE
+    without an out-of-band channel; set ``include_epk=False`` to omit it (the
+    Repository then identifies the CE by other means, e.g. IP).
+    """
+    header = _build_header(esk.public_key(), include_epk)
+    payload = _build_payload(job_keypair)
+    return jwt.encode(payload, esk, algorithm=ALG, headers=header)
+
+
+def build_user_jwt(
+    job_keypair: JobKeypair,
+    usk: Ed25519PrivateKey,
+) -> str:
+    """Option A: build a user-signed JWT authorizing a data request.
+
+    ``usk`` is the user's signing key; the UPK is always embedded in the
+    header ``jwk`` so the Repository can match it against its user registry.
+    """
+    header = _build_header(usk.public_key(), include_jwk=True)
+    payload = _build_payload(job_keypair)
+    return jwt.encode(payload, usk, algorithm=ALG, headers=header)
+
+
+def verify_jwt(token: str, public_key: Ed25519PublicKey | bytes) -> dict:
+    """Verify a JAICE JWT signature and return the decoded payload.
+
+    ``public_key`` is the key the caller has resolved for this token: the CE's
+    pre-registered ``EPK`` for an Option B token, or the user's ``UPK`` for an
+    Option A token (looked up by matching the header ``jwk`` against a user
+    registry). Accepts a ``cryptography`` public key or raw 32 bytes.
+    """
+    decoded = jwt.decode(token, _as_public_key(public_key), algorithms=[ALG])
+    return decoded
+
+
+def header_jwk(token: str) -> dict | None:
+    """Return the ``jwk`` from a token's header, or ``None`` if absent.
+
+    Useful for Option A verification: extract the UPK the user claimed, then
+    match it against the user registry before verifying.
+    """
+    header = jwt.get_unverified_header(token)
+    return header.get("jwk")

--- a/lib/galaxy/security/jaice/keys.py
+++ b/lib/galaxy/security/jaice/keys.py
@@ -1,0 +1,150 @@
+"""JAICE key management: Ed25519 job/CE/user keypairs and the RFC 7748 curve
+mapping to X25519 for Crypt4GH.
+
+Key types used by the protocol:
+
+* ``ESK``/``EPK`` - Computing Environment signing keypair (Ed25519). Signs
+  request JWTs. The EPK is pre-registered at the Repository.
+* ``JSK``/``JPK`` - per-job keypair. ``JSK`` signs job data/requests; ``JPK``
+  (after curve mapping) is the X25519 recipient key for Crypt4GH containers.
+* ``USK``/``UPK`` - user signing keypair (Ed25519). Used only in Option A.
+
+The curve mapping (RFC 7748 section 1) lets the *same* Ed25519 private key
+serve as an X25519 private key: hash the 32-byte Ed25519 seed with SHA-512,
+clamp it, and take the first 32 bytes. The resulting X25519 public key is what
+Crypt4GH encrypts to.
+
+This module uses ``cryptography`` OKP keys (the same objects PyJWT's EdDSA
+algorithm consumes) for signing, and ``nacl.bindings`` for the X25519 scalar
+multiplication used to derive the Crypt4GH recipient public key.
+"""
+
+import hashlib
+from dataclasses import dataclass
+
+import nacl.bindings
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+# JWK curve identifier for Ed25519 keys (RFC 8037).
+ED25519_CRV = "Ed25519"
+# JWK curve identifier for X25519 keys (RFC 8037).
+X25519_CRV = "X25519"
+
+
+def b64url_encode(data: bytes) -> str:
+    """Base64URL-encode without padding (the JWT/JWK convention)."""
+    import base64
+
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def b64url_decode(data: str) -> bytes:
+    """Base64URL-decode, tolerating missing padding."""
+    import base64
+
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + pad)
+
+
+def ed25519_seed_to_x25519_private(ed25519_seed: bytes) -> bytes:
+    """Map an Ed25519 private seed to an X25519 private key (RFC 7748 sec 1).
+
+    The Ed25519 private key is a 32-byte seed. Hashing it with SHA-512 and
+    clamping the first 32 bytes yields a valid X25519 private scalar, so a
+    single keypair can be used for both signing (Ed25519) and Crypt4GH
+    decryption (X25519).
+    """
+    if len(ed25519_seed) != 32:
+        raise ValueError("Ed25519 seed must be 32 bytes")
+    digest = hashlib.sha512(ed25519_seed).digest()
+    scalar = bytearray(digest[:32])
+    scalar[0] &= 248
+    scalar[31] &= 127
+    scalar[31] |= 64
+    return bytes(scalar)
+
+
+def to_jwk(public_key: Ed25519PublicKey | bytes, *, crv: str = ED25519_CRV) -> dict:
+    """Serialize an Ed25519/X25519 public key as a JWK ``dict``.
+
+    Accepts either a ``cryptography`` public key object or raw public bytes
+    (32 bytes for both Ed25519 and X25519).
+    """
+    if isinstance(public_key, Ed25519PublicKey):
+        if crv != ED25519_CRV:
+            raise ValueError(f"Ed25519PublicKey can only be serialized as {ED25519_CRV}")
+        raw = public_key.public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
+    else:
+        raw = bytes(public_key)
+    if len(raw) != 32:
+        raise ValueError("public key must be 32 raw bytes")
+    return {"kty": "OKP", "crv": crv, "x": b64url_encode(raw)}
+
+
+def from_jwk(jwk: dict) -> bytes:
+    """Return the raw 32-byte public key from an OKP Ed25519/X25519 JWK."""
+    if jwk.get("kty") != "OKP":
+        raise ValueError("JWK kty must be OKP")
+    if jwk.get("crv") not in (ED25519_CRV, X25519_CRV):
+        raise ValueError(f"JWK crv must be {ED25519_CRV} or {X25519_CRV}")
+    return b64url_decode(jwk["x"])
+
+
+@dataclass(frozen=True)
+class JobKeypair:
+    """A per-job JAICE keypair.
+
+    ``signing_key`` is the Ed25519 key used for JWT signing (the ``JSK``).
+    The X25519 halves are derived lazily from the same seed and are what
+    Crypt4GH encrypts to / the job decrypts with.
+    """
+
+    job_id: str
+    signing_key: Ed25519PrivateKey
+
+    @property
+    def ed25519_seed(self) -> bytes:
+        return self.signing_key.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    @property
+    def ed25519_public_bytes(self) -> bytes:
+        """The Ed25519 public key (``JPK`` for signing)."""
+        return self.signing_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+        )
+
+    @property
+    def ed25519_public_key(self) -> Ed25519PublicKey:
+        return self.signing_key.public_key()
+
+    @property
+    def x25519_private_bytes(self) -> bytes:
+        """The X25519 private key for Crypt4GH decryption (RFC 7748 map)."""
+        return ed25519_seed_to_x25519_private(self.ed25519_seed)
+
+    @property
+    def x25519_public_bytes(self) -> bytes:
+        """The X25519 public key Crypt4GH containers are encrypted to."""
+        return nacl.bindings.crypto_scalarmult_base(self.x25519_private_bytes)
+
+    @property
+    def x25519_public_jwk(self) -> dict:
+        return to_jwk(self.x25519_public_bytes, crv=X25519_CRV)
+
+
+def generate_job_keypair(job_id: str) -> JobKeypair:
+    """Generate a fresh Ed25519 keypair for a job.
+
+    ``job_id`` becomes the ``sub`` claim of every JWT issued for this job.
+    """
+    if not job_id:
+        raise ValueError("job_id must be non-empty")
+    return JobKeypair(job_id=job_id, signing_key=Ed25519PrivateKey.generate())

--- a/test/unit/security/test_jaice_env_key.py
+++ b/test/unit/security/test_jaice_env_key.py
@@ -1,0 +1,245 @@
+"""Unit tests for JAICE environment key management."""
+
+import os
+import tempfile
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+)
+from galaxy.security.jaice.env_key import (
+    DEFAULT_VAULT_KEY_PATH,
+    EnvironmentKeyError,
+    EnvironmentKeypair,
+    generate_environment_keypair,
+    load_esk_from_file,
+    load_esk_from_vault,
+    store_esk_to_vault,
+)
+from galaxy.security.jaice.jwt import verify_jwt
+from galaxy.security.jaice.keys import from_jwk, generate_job_keypair
+
+
+# ---------------------------------------------------------------------------
+# generate_environment_keypair
+# ---------------------------------------------------------------------------
+
+
+def test_generate_produces_valid_keypair():
+    env_kp, pem = generate_environment_keypair()
+    assert isinstance(env_kp, EnvironmentKeypair)
+    assert isinstance(env_kp.signing_key, Ed25519PrivateKey)
+    assert isinstance(pem, bytes)
+    assert pem.startswith(b"-----BEGIN PRIVATE KEY-----")
+
+
+def test_generate_is_distinct():
+    kp1, _ = generate_environment_keypair()
+    kp2, _ = generate_environment_keypair()
+    assert kp1.public_bytes != kp2.public_bytes
+
+
+# ---------------------------------------------------------------------------
+# EnvironmentKeypair properties
+# ---------------------------------------------------------------------------
+
+
+def test_epk_jwk_shape():
+    env_kp, _ = generate_environment_keypair()
+    jwk = env_kp.epk_jwk
+    assert jwk["kty"] == "OKP"
+    assert jwk["crv"] == "Ed25519"
+    assert "x" in jwk
+
+
+def test_epk_jwk_roundtrip():
+    env_kp, _ = generate_environment_keypair()
+    jwk = env_kp.epk_jwk
+    assert from_jwk(jwk) == env_kp.public_bytes
+
+
+def test_public_bytes_is_32():
+    env_kp, _ = generate_environment_keypair()
+    assert len(env_kp.public_bytes) == 32
+
+
+def test_sign_jwt_roundtrip():
+    env_kp, _ = generate_environment_keypair()
+    job_kp = generate_job_keypair("job-1")
+    token = env_kp.sign_jwt(job_kp)
+    payload = verify_jwt(token, env_kp.public_key)
+    assert payload["sub"] == "job-1"
+    assert payload["jpk"]
+
+
+def test_sign_jwt_can_omit_epk():
+    env_kp, _ = generate_environment_keypair()
+    job_kp = generate_job_keypair("job-1")
+    token = env_kp.sign_jwt(job_kp, include_epk=False)
+    from galaxy.security.jaice.jwt import header_jwk
+
+    assert header_jwk(token) is None
+    # Token still verifies.
+    payload = verify_jwt(token, env_kp.public_key)
+    assert payload["sub"] == "job-1"
+
+
+def test_private_pem_roundtrip():
+    env_kp, _ = generate_environment_keypair()
+    pem = env_kp.private_pem()
+    assert pem.startswith(b"-----BEGIN PRIVATE KEY-----")
+    # Write to temp file and reload.
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pem") as f:
+        f.write(pem)
+        tmp = f.name
+    try:
+        reloaded = load_esk_from_file(tmp)
+        assert reloaded.public_bytes == env_kp.public_bytes
+    finally:
+        os.unlink(tmp)
+
+
+# ---------------------------------------------------------------------------
+# load_esk_from_file
+# ---------------------------------------------------------------------------
+
+
+def test_load_esk_from_file():
+    env_kp, pem = generate_environment_keypair()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pem") as f:
+        f.write(pem)
+        tmp = f.name
+    try:
+        loaded = load_esk_from_file(tmp)
+        assert loaded.public_bytes == env_kp.public_bytes
+    finally:
+        os.unlink(tmp)
+
+
+def test_load_esk_from_file_missing():
+    with pytest.raises(EnvironmentKeyError, match="Failed to load ESK"):
+        load_esk_from_file("/nonexistent/jaice_esk.pem")
+
+
+def test_load_esk_from_file_wrong_key_type():
+    """If the file contains an RSA key, not Ed25519, raise EnvironmentKeyError."""
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    rsa_key = rsa.generate_private_key(65537, 2048)
+    rsa_pem = rsa_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pem") as f:
+        f.write(rsa_pem)
+        tmp = f.name
+    try:
+        with pytest.raises(EnvironmentKeyError, match="expected Ed25519"):
+            load_esk_from_file(tmp)
+    finally:
+        os.unlink(tmp)
+
+
+def test_load_esk_from_file_garbage():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pem") as f:
+        f.write(b"not a key")
+        tmp = f.name
+    try:
+        with pytest.raises(EnvironmentKeyError, match="Failed to load ESK"):
+            load_esk_from_file(tmp)
+    finally:
+        os.unlink(tmp)
+
+
+def test_load_esk_from_file_pathlib():
+    import pathlib
+
+    env_kp, pem = generate_environment_keypair()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pem") as f:
+        f.write(pem)
+        tmp = f.name
+    try:
+        loaded = load_esk_from_file(pathlib.Path(tmp))
+        assert loaded.public_bytes == env_kp.public_bytes
+    finally:
+        os.unlink(tmp)
+
+
+# ---------------------------------------------------------------------------
+# vault load/store
+# ---------------------------------------------------------------------------
+
+
+class _FakeVault:
+    """Minimal in-memory vault for testing vault-based key operations."""
+
+    def __init__(self):
+        self._store: dict[str, str] = {}
+
+    def read_secret(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    def write_secret(self, key: str, value: str) -> None:
+        self._store[key] = value
+
+
+def test_vault_store_and_load_roundtrip():
+    vault = _FakeVault()
+    env_kp, _ = generate_environment_keypair()
+    store_esk_to_vault(vault, env_kp)
+    loaded = load_esk_from_vault(vault)
+    assert loaded.public_bytes == env_kp.public_bytes
+
+
+def test_vault_load_uses_default_path():
+    vault = _FakeVault()
+    env_kp, _ = generate_environment_keypair()
+    vault.write_secret(DEFAULT_VAULT_KEY_PATH, env_kp.private_pem().decode("ascii"))
+    loaded = load_esk_from_vault(vault)
+    assert loaded.public_bytes == env_kp.public_bytes
+
+
+def test_vault_load_custom_path():
+    vault = _FakeVault()
+    env_kp, _ = generate_environment_keypair()
+    store_esk_to_vault(vault, env_kp, key_path="custom/esk")
+    loaded = load_esk_from_vault(vault, key_path="custom/esk")
+    assert loaded.public_bytes == env_kp.public_bytes
+
+
+def test_vault_load_missing_key():
+    vault = _FakeVault()
+    with pytest.raises(EnvironmentKeyError, match="No ESK found"):
+        load_esk_from_vault(vault)
+
+
+def test_vault_load_garbage():
+    vault = _FakeVault()
+    vault.write_secret(DEFAULT_VAULT_KEY_PATH, "not-a-valid-pem")
+    with pytest.raises(EnvironmentKeyError, match="Failed to parse ESK"):
+        load_esk_from_vault(vault)
+
+
+# ---------------------------------------------------------------------------
+# convenience: sign then verify with loaded key
+# ---------------------------------------------------------------------------
+
+
+def test_sign_with_loaded_key_verifies():
+    """End-to-end: generate an env keypair, persist via PEM, reload, sign a
+    job JWT, and verify."""
+    env_kp, pem = generate_environment_keypair()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pem") as f:
+        f.write(pem)
+        tmp = f.name
+    try:
+        reloaded = load_esk_from_file(tmp)
+        job_kp = generate_job_keypair("e2e-job")
+        token = reloaded.sign_jwt(job_kp)
+        payload = verify_jwt(token, reloaded.public_key)
+        assert payload["sub"] == "e2e-job"
+    finally:
+        os.unlink(tmp)

--- a/test/unit/security/test_jaice_jwt.py
+++ b/test/unit/security/test_jaice_jwt.py
@@ -1,0 +1,125 @@
+"""Unit tests for JAICE JWT token construction and verification."""
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+)
+
+from galaxy.security.jaice import (
+    build_ce_jwt,
+    build_user_jwt,
+    from_jwk,
+    generate_job_keypair,
+    header_jwk,
+    verify_jwt,
+)
+from galaxy.security.jaice.jwt import ALG
+
+JOB_ID = "0123456789abcdef"
+
+
+@pytest.fixture
+def job_kp():
+    return generate_job_keypair(JOB_ID)
+
+
+@pytest.fixture
+def esk():
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture
+def usk():
+    return Ed25519PrivateKey.generate()
+
+
+def test_ce_jwt_roundtrip(job_kp, esk):
+    token = build_ce_jwt(job_kp, esk)
+    payload = verify_jwt(token, esk.public_key())
+    assert payload["sub"] == JOB_ID
+    assert payload["jpk"]  # base64url of JPK
+
+
+def test_ce_jwt_alg_is_eddsa(job_kp, esk):
+    token = build_ce_jwt(job_kp, esk)
+    assert jwt.get_unverified_header(token)["alg"] == ALG
+
+
+def test_ce_jwt_header_carries_epk_by_default(job_kp, esk):
+    token = build_ce_jwt(job_kp, esk)
+    jwk = header_jwk(token)
+    assert jwk is not None
+    epk_raw = esk.public_key().public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
+    assert from_jwk(jwk) == epk_raw
+
+
+def test_ce_jwt_epk_can_be_omitted(job_kp, esk):
+    token = build_ce_jwt(job_kp, esk, include_epk=False)
+    assert header_jwk(token) is None
+
+
+def test_user_jwt_carries_upk(job_kp, usk):
+    token = build_user_jwt(job_kp, usk)
+    jwk = header_jwk(token)
+    assert jwk is not None
+    assert from_jwk(jwk) == usk.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    payload = verify_jwt(token, usk.public_key())
+    assert payload["sub"] == JOB_ID
+
+
+def test_user_jwt_verifies_under_user_key_not_ce_key(job_kp, esk, usk):
+    """Option A: the user token is signed by USK, not the CE's ESK."""
+    user_token = build_user_jwt(job_kp, usk)
+    with pytest.raises(jwt.InvalidSignatureError):
+        verify_jwt(user_token, esk.public_key())
+
+
+def test_ce_jwt_verifies_under_ce_key_not_user_key(job_kp, esk, usk):
+    ce_token = build_ce_jwt(job_kp, esk)
+    with pytest.raises(jwt.InvalidSignatureError):
+        verify_jwt(ce_token, usk.public_key())
+
+
+def test_tampered_payload_rejected(job_kp, esk):
+    token = build_ce_jwt(job_kp, esk)
+    header, payload_b64, sig = token.split(".")
+    # Flip a character in the payload segment.
+    tampered_payload = payload_b64[:-1] + ("A" if payload_b64[-1] != "A" else "B")
+    tampered = f"{header}.{tampered_payload}.{sig}"
+    with pytest.raises(jwt.InvalidSignatureError):
+        verify_jwt(tampered, esk.public_key())
+
+
+def test_wrong_public_key_rejected(job_kp, esk):
+    token = build_ce_jwt(job_kp, esk)
+    other = Ed25519PrivateKey.generate().public_key()
+    with pytest.raises(jwt.InvalidSignatureError):
+        verify_jwt(token, other)
+
+
+def test_verify_jwt_accepts_raw_bytes(job_kp, esk):
+    from cryptography.hazmat.primitives import serialization
+
+    token = build_ce_jwt(job_kp, esk)
+    raw = esk.public_key().public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
+    payload = verify_jwt(token, raw)
+    assert payload["sub"] == JOB_ID
+
+
+def test_token_is_deterministic_across_calls(job_kp, esk):
+    """EdDSA signatures are deterministic, so identical inputs yield identical tokens."""
+    t1 = build_ce_jwt(job_kp, esk)
+    t2 = build_ce_jwt(job_kp, esk)
+    assert t1 == t2
+
+
+def test_jpk_in_payload_matches_job_public_key(job_kp, esk):
+    from galaxy.security.jaice.keys import b64url_encode
+
+    token = build_ce_jwt(job_kp, esk)
+    payload = verify_jwt(token, esk.public_key())
+    assert payload["jpk"] == b64url_encode(job_kp.ed25519_public_bytes)

--- a/test/unit/security/test_jaice_keys.py
+++ b/test/unit/security/test_jaice_keys.py
@@ -1,0 +1,91 @@
+"""Unit tests for JAICE key generation and the RFC 7748 curve mapping."""
+
+import nacl.bindings
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from galaxy.security.jaice.keys import (
+    b64url_decode,
+    b64url_encode,
+    ED25519_CRV,
+    ed25519_seed_to_x25519_private,
+    from_jwk,
+    generate_job_keypair,
+    to_jwk,
+    X25519_CRV,
+)
+
+
+def test_b64url_roundtrip():
+    raw = bytes(range(256))
+    assert b64url_decode(b64url_encode(raw)) == raw
+
+
+def test_b64url_decode_tolerates_missing_padding():
+    assert b64url_decode("AA") == b"\x00"
+
+
+def test_generate_job_keypair_distinct():
+    kp1 = generate_job_keypair("job-1")
+    kp2 = generate_job_keypair("job-1")
+    assert kp1.ed25519_public_bytes != kp2.ed25519_public_bytes
+
+
+def test_generate_job_keypair_requires_id():
+    with pytest.raises(ValueError):
+        generate_job_keypair("")
+
+
+def test_jwk_roundtrip():
+    kp = generate_job_keypair("job-1")
+    jwk = to_jwk(kp.ed25519_public_key)
+    assert jwk["kty"] == "OKP"
+    assert jwk["crv"] == ED25519_CRV
+    assert from_jwk(jwk) == kp.ed25519_public_bytes
+
+
+def test_jwk_accepts_raw_bytes():
+    raw = bytes(range(32))
+    jwk = to_jwk(raw)
+    assert from_jwk(jwk) == raw
+
+
+def test_jwk_wrong_crv_for_key_type():
+    kp = generate_job_keypair("job-1")
+    with pytest.raises(ValueError):
+        to_jwk(kp.ed25519_public_key, crv=X25519_CRV)
+
+
+def test_curve_mapping_yields_valid_x25519_keypair():
+    """The RFC 7748 map must produce a scalar whose X25519 public key matches."""
+    kp = generate_job_keypair("job-1")
+    x_sk = kp.x25519_private_bytes
+    x_pk = nacl.bindings.crypto_scalarmult_base(x_sk)
+    assert x_pk == kp.x25519_public_bytes
+
+
+def test_curve_mapping_is_deterministic():
+    kp = generate_job_keypair("job-1")
+    seed = kp.ed25519_seed
+    assert ed25519_seed_to_x25519_private(seed) == kp.x25519_private_bytes
+
+
+def test_curve_mapping_rejects_bad_seed_length():
+    with pytest.raises(ValueError):
+        ed25519_seed_to_x25519_private(b"short")
+
+
+def test_x25519_public_jwk_has_correct_crv():
+    kp = generate_job_keypair("job-1")
+    jwk = kp.x25519_public_jwk
+    assert jwk["crv"] == X25519_CRV
+    assert from_jwk(jwk) == kp.x25519_public_bytes
+
+
+def test_ed25519_public_key_object_matches_bytes():
+    kp = generate_job_keypair("job-1")
+    pub = kp.ed25519_public_key
+    assert isinstance(pub, Ed25519PublicKey)
+    raw = pub.public_bytes(encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
+    assert raw == kp.ed25519_public_bytes


### PR DESCRIPTION
## Summary

Step 2 of the JAICE (Job Authentication in Computation Environment) implementation, building on the cryptographic primitives from step 1 (`keys.py` + `jwt.py`).

### What's new

**`env_key.py`** — CE environment signing key lifecycle:

- `EnvironmentKeypair` — dataclass wrapping an Ed25519 ESK, exposing EPK as JWK, with JWT signing and PEM export.
- `generate_environment_keypair()` — fresh keypair for admin setup.
- `load_esk_from_file()` — load from PEM-encoded PKCS#8 file.
- `load_esk_from_vault()` / `store_esk_to_vault()` — vault-backed key storage (Hashicorp or DatabaseVault).
- `EnvironmentKeyError` — clean error type for key-load failures.

**Config schema** — two new options in `config_schema.yml`:

- `jaice_environment_key_path` — path to a PEM file holding the ESK.
- `jaice_environment_key_vault_path` — vault key path (default: `jaice/environment_key`), takes precedence when both are set.

### Design doc

See `doc/source/dev/jaice_design.md` for the full implementation plan (phasing section 4, items 1–2).

### Testing

19 new unit tests covering: generation, file load (valid, missing, wrong key type, garbage), vault roundtrip, pathlib support, and end-to-end sign-then-verify.

43 total tests pass (24 from step 1 + 19 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)