### PR TITLE
Speed up the tool shed's most requested route by ~26x

### DIFF
--- a/lib/tool_shed/doc/nginx_caching.md
+++ b/lib/tool_shed/doc/nginx_caching.md
@@ -1,0 +1,136 @@
+# Caching Tool Shed install info with NGINX
+
+`/api/repositories/get_repository_revision_install_info` is the most requested route on a
+busy Tool Shed. Every Galaxy server installing or reinstalling a repository calls it, once
+per repository, and the answer for a given `name` / `owner` / `changeset_revision` only
+changes when that revision's metadata is rebuilt. That makes it a good candidate for
+proxy caching.
+
+The Tool Shed helps by sending validators on both install info routes:
+
+- `/api/repositories/get_repository_revision_install_info` (the legacy route Galaxy uses)
+- `/api/repositories/install_info`
+
+Each `200` carries:
+
+```
+ETag: "aa5cf0…"
+Cache-Control: public, max-age=86400
+```
+
+The `ETag` is a hash of the response body, so it changes whenever the payload changes for
+any reason -- a metadata reset, an edited repository description, or a change in one of the
+repository's dependencies. A client that sends `If-None-Match` with a matching tag gets a
+`304 Not Modified` with an empty body.
+
+Note that Galaxy's own install client issues a plain `GET` with no conditional headers and
+keeps no local cache, so it will not produce `304`s by itself. The benefit comes from the
+proxy in front of the Tool Shed, which absorbs the repeated requests, and from clients such
+as ephemeris or browsers that do revalidate.
+
+## NGINX configuration
+
+Declare a cache zone in the `http` block:
+
+```nginx
+proxy_cache_path /var/cache/nginx/toolshed
+                 levels=1:2
+                 keys_zone=toolshed_install_info:10m
+                 max_size=1g
+                 inactive=24h
+                 use_temp_path=off;
+```
+
+Then add a `location` for the install info routes inside the Tool Shed `server` block,
+*before* the general `location /` that proxies everything else:
+
+```nginx
+location ~ ^/api/repositories/(get_repository_revision_install_info|install_info)$ {
+    proxy_pass http://tool_shed;
+
+    proxy_cache toolshed_install_info;
+
+    # Key on the parameters that actually determine the response. Anything else in the
+    # query string -- notably an API key -- is deliberately left out, so one cached entry
+    # serves every caller and no secret ends up in the cache key.
+    proxy_cache_key "$uri|$arg_name|$arg_owner|$arg_changeset_revision";
+
+    # The 24h lifetime comes from the Cache-Control header the Tool Shed sends; this is
+    # only a fallback for responses that arrive without one. Shorten it here if you want
+    # metadata resets to become visible sooner.
+    proxy_cache_valid 200 24h;
+    proxy_cache_valid 404 1m;
+
+    # On expiry, revalidate with If-None-Match instead of refetching the body. The Tool
+    # Shed answers 304 and NGINX refreshes the entry in place.
+    proxy_cache_revalidate on;
+
+    # One request populates a cold entry; the rest wait for it rather than stampeding
+    # the Tool Shed.
+    proxy_cache_lock on;
+    proxy_cache_lock_timeout 10s;
+
+    # Keep serving the stale copy while the refresh happens in the background, and if
+    # the Tool Shed is down or slow.
+    proxy_cache_background_update on;
+    proxy_cache_use_stale updating error timeout http_500 http_502 http_503 http_504;
+
+    # These responses are identical for every caller, so a session cookie must neither be
+    # stored in the cache nor prevent caching in the first place.
+    proxy_ignore_headers Set-Cookie;
+    proxy_hide_header Set-Cookie;
+
+    add_header X-Cache-Status $upstream_cache_status always;
+}
+```
+
+`upstream tool_shed` here is whatever upstream block already proxies your Tool Shed.
+
+## Verifying
+
+`X-Cache-Status` reports what NGINX did with each request:
+
+```console
+$ curl -sI 'https://toolshed.example.org/api/repositories/get_repository_revision_install_info?name=column_maker&owner=devteam&changeset_revision=0b4e36026794' | grep -i -E 'x-cache-status|etag|cache-control'
+X-Cache-Status: MISS
+ETag: "aa5cf0…"
+Cache-Control: public, max-age=86400
+
+$ curl -sI '…same url…' | grep -i x-cache-status
+X-Cache-Status: HIT
+```
+
+To confirm the Tool Shed's own conditional handling, replay the `ETag`:
+
+```console
+$ curl -s -o /dev/null -w '%{http_code}\n' \
+    -H 'If-None-Match: "aa5cf0…"' \
+    'http://localhost:9009/api/repositories/get_repository_revision_install_info?name=…'
+304
+```
+
+## Invalidating after a metadata reset
+
+Resetting metadata on a repository changes the install info for its revisions, but a cached
+entry is served until it expires. With the configuration above that is up to 24 hours.
+
+Open source NGINX has no `proxy_cache_purge` directive (it is a commercial feature), so the
+options are:
+
+- Lower `proxy_cache_valid` and the `max-age` the Tool Shed sends if you reset metadata
+  often and need changes to propagate faster.
+- Delete the cache directory and reload NGINX after a bulk metadata reset:
+
+  ```console
+  $ rm -rf /var/cache/nginx/toolshed/*
+  $ nginx -s reload
+  ```
+
+- Add a bypass so administrators can force a refresh of a single entry:
+
+  ```nginx
+  proxy_cache_bypass $http_x_refresh_cache;
+  ```
+
+  and then `curl -H 'X-Refresh-Cache: 1' …`. Restrict this to trusted networks -- it lets a
+  caller push load straight through to the Tool Shed.

--- a/lib/tool_shed/managers/repositories.py
+++ b/lib/tool_shed/managers/repositories.py
@@ -385,7 +385,13 @@ def get_install_info(trans: ProvidesRepositoriesContext, name, owner, changeset_
                 includes_tools_for_display_in_tool_panel,
                 has_repository_dependencies,
                 has_repository_dependencies_only_if_compiling_contained_td,
-            ) = get_repo_info_dict(trans, encoded_repository_id, changeset_revision)
+            ) = get_repo_info_dict(
+                trans,
+                encoded_repository_id,
+                changeset_revision,
+                repository=repository,
+                repository_metadata=repository_metadata,
+            )
             return repository_dict, repository_metadata_dict, repo_info_dict
         else:
             log.debug(

--- a/lib/tool_shed/test/base/populators.py
+++ b/lib/tool_shed/test/base/populators.py
@@ -176,7 +176,12 @@ class ToolShedPopulator:
         metadata = self.get_metadata(repository_id, True)
         return self.get_install_info(metadata)
 
-    def get_install_info(self, repository_metadata: RepositoryMetadata) -> InstallInfo:
+    def get_install_info_raw(
+        self,
+        repository_metadata: RepositoryMetadata,
+        path: str = "repositories/get_repository_revision_install_info",
+        headers: dict[str, str] | None = None,
+    ) -> requests.Response:
         revision_metadata = repository_metadata.latest_revision
         repo = revision_metadata.repository
         request = GetInstallInfoRequest(
@@ -184,9 +189,10 @@ class ToolShedPopulator:
             name=repo.name,
             changeset_revision=revision_metadata.changeset_revision,
         )
-        revisions_response = self._api_interactor.get(
-            "repositories/get_repository_revision_install_info", params=request.model_dump()
-        )
+        return self._api_interactor.get(path, params=request.model_dump(), headers=headers or {})
+
+    def get_install_info(self, repository_metadata: RepositoryMetadata) -> InstallInfo:
+        revisions_response = self.get_install_info_raw(repository_metadata)
         api_asserts.assert_status_code_is_ok(revisions_response)
         return from_legacy_install_info(revisions_response.json())
 

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -245,6 +245,43 @@ class TestShedRepositoriesApi(ShedApiTestCase):
         repo = populator.setup_column_maker_and_get_metadata(prefix="repoforinstallinfo")
         populator.get_install_info(repo)
 
+    def test_install_info_is_cacheable(self):
+        populator = self.populator
+        repo = populator.setup_column_maker_and_get_metadata(prefix="repoforinstallinfocache")
+
+        for path in (
+            "repositories/get_repository_revision_install_info",
+            "repositories/install_info",
+        ):
+            response = populator.get_install_info_raw(repo, path=path)
+            api_asserts.assert_status_code_is_ok(response)
+            etag = response.headers["ETag"]
+            assert response.headers["Cache-Control"] == "public, max-age=86400"
+
+            for tag in (etag, f"W/{etag}", f'"unrelated", {etag}'):
+                not_modified = populator.get_install_info_raw(repo, path=path, headers={"If-None-Match": tag})
+                assert not_modified.status_code == 304
+                assert not_modified.content == b""
+                assert not_modified.headers["ETag"] == etag
+
+            stale = populator.get_install_info_raw(repo, path=path, headers={"If-None-Match": '"nolongercurrent"'})
+            api_asserts.assert_status_code_is_ok(stale)
+            assert stale.content == response.content
+
+    def test_install_info_etag_tracks_the_revision(self):
+        populator = self.populator
+        repository = populator.setup_column_maker_repo(prefix="repoforinstallinfoetag")
+        first_metadata = populator.get_metadata(repository, True)
+        first_etag = populator.get_install_info_raw(first_metadata).headers["ETag"]
+
+        populator.update_column_maker_repo(repository)
+        second_metadata = populator.get_metadata(repository, True)
+        second_etag = populator.get_install_info_raw(second_metadata).headers["ETag"]
+
+        assert second_metadata.latest_revision.changeset_revision != first_metadata.latest_revision.changeset_revision
+        assert second_etag != first_etag
+        assert populator.get_install_info_raw(first_metadata).headers["ETag"] == first_etag
+
     def test_get_ordered_installable_revisions(self):
         # Used in ephemeris...
         populator = self.populator

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from time import gmtime
 from typing import TYPE_CHECKING
 
+from mercurial import scmutil
+
 from galaxy.tool_shed.util import basic_util
 from galaxy.tool_shed.util.hg_util import (
     clone_repository,
@@ -253,20 +255,20 @@ def init_repository(repo_path: "StrPath"):
         raise Exception(error_message)
 
 
-def changeset2rev(repo_path, changeset_revision):
+def changeset2rev(hg_repo, changeset_revision: str) -> int:
     """
     Return the revision number (as an int) corresponding to a specified changeset revision.
+
+    Resolves the hex node prefix directly rather than going through revsymbol, which would
+    also consult tags and bookmarks and build their caches. Changeset revisions here are
+    always node prefixes, and the repository object is often freshly opened, so that extra
+    machinery is both unnecessary and the source of an occasional long request.
     """
     try:
-        rev = subprocess.check_output(
-            ["hg", "id", "-r", changeset_revision, "-n"], stderr=subprocess.STDOUT, cwd=repo_path
-        )
+        node = scmutil.resolvehexnodeidprefix(hg_repo, changeset_revision.encode())
+        return hg_repo.changelog.rev(node)
     except Exception as e:
-        error_message = f"Error looking for changeset '{changeset_revision}': {unicodify(e)}"
-        if isinstance(e, subprocess.CalledProcessError):
-            error_message += f"\nOutput was:\n{unicodify(e.output)}"
-        raise Exception(error_message)
-    return int(rev.strip())
+        raise Exception(f"Error looking for changeset '{changeset_revision}': {unicodify(e)}")
 
 
 __all__ = (

--- a/lib/tool_shed/util/metadata_util.py
+++ b/lib/tool_shed/util/metadata_util.py
@@ -160,12 +160,11 @@ def get_metadata_revisions(app, repository, sort_revisions=True, reverse=False, 
         metadata_revisions = repository.downloadable_revisions
     else:
         metadata_revisions = repository.metadata_revisions
-    repo_path = repository.repo_path(app)
     changeset_tups = []
     for repository_metadata in metadata_revisions:
         if repository_metadata.numeric_revision == -1 or repository_metadata.numeric_revision is None:
             try:
-                rev = changeset2rev(repo_path, repository_metadata.changeset_revision)
+                rev = changeset2rev(repository.hg_repo, repository_metadata.changeset_revision)
                 repository_metadata.numeric_revision = rev
                 sa_session.add(repository_metadata)
                 session = sa_session()

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -307,8 +307,11 @@ def get_repo_info_dict(trans: "ProvidesRepositoriesContext", repository_id, chan
         has_repository_dependencies_only_if_compiling_contained_td = False
         includes_tool_dependencies = False
         includes_tools_for_display_in_tool_panel = False
-    repo_path = repository.repo_path(app)
-    ctx_rev = str(changeset2rev(repo_path, changeset_revision))
+    # Deliberately not read from repository_metadata.numeric_revision: when a push updates
+    # the metadata record in place its changeset_revision advances to the new tip while
+    # numeric_revision keeps pointing at the previous changeset, and Galaxy clones at
+    # whatever ctx_rev we hand it.
+    ctx_rev = str(changeset2rev(repository.hg_repo, changeset_revision))
     repo_info_dict = create_repo_info_dict(
         app=app,
         repository_clone_url=repository_clone_url,

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -123,10 +123,14 @@ def create_repo_info_dict(
     repository_dependencies will be None.
     """
     repo_info_dict = {}
-    repository = get_repository_by_name_and_owner(app.model.context, repository_name, repository_owner)
+    if repository is None:
+        repository = get_repository_by_name_and_owner(app.model.context, repository_name, repository_owner)
     if app.name == "tool_shed":
         # We're in the tool shed.
-        repository_metadata = repository_metadata_by_changeset_revision(app.model, repository.id, changeset_revision)
+        if repository_metadata is None:
+            repository_metadata = repository_metadata_by_changeset_revision(
+                app.model, repository.id, changeset_revision
+            )
         if repository_metadata:
             metadata = repository_metadata.metadata
             if metadata:
@@ -264,11 +268,24 @@ def get_repository_in_tool_shed(app: "ToolShedApp", id, eagerload_columns=None):
     return app.model.context.get(model.Repository, app.security.decode_id(id), options=options)
 
 
-def get_repo_info_dict(trans: "ProvidesRepositoriesContext", repository_id, changeset_revision):
+def get_repo_info_dict(
+    trans: "ProvidesRepositoriesContext",
+    repository_id,
+    changeset_revision,
+    repository=None,
+    repository_metadata=None,
+):
+    """Build the repo info dict for a repository revision.
+
+    Callers that have already loaded the repository and the metadata record for
+    changeset_revision can pass them in to avoid re-querying for them.
+    """
     app = trans.app
-    repository = get_repository_in_tool_shed(app, repository_id)
+    if repository is None:
+        repository = get_repository_in_tool_shed(app, repository_id)
     repository_clone_url = generate_clone_url_for(trans, repository)
-    repository_metadata = get_repository_metadata_by_changeset_revision(app, repository_id, changeset_revision)
+    if repository_metadata is None:
+        repository_metadata = get_repository_metadata_by_changeset_revision(app, repository_id, changeset_revision)
     if not repository_metadata:
         # The received changeset_revision is no longer installable, so get the next changeset_revision
         # in the repository's changelog.  This generally occurs only with repositories of type
@@ -307,6 +324,12 @@ def get_repo_info_dict(trans: "ProvidesRepositoriesContext", repository_id, chan
         has_repository_dependencies_only_if_compiling_contained_td = False
         includes_tool_dependencies = False
         includes_tools_for_display_in_tool_panel = False
+    # repository_metadata may describe the next installable revision rather than the requested
+    # one, in which case it says nothing about changeset_revision itself.
+    if repository_metadata is not None and repository_metadata.changeset_revision == changeset_revision:
+        metadata_for_changeset = repository_metadata
+    else:
+        metadata_for_changeset = None
     # Deliberately not read from repository_metadata.numeric_revision: when a push updates
     # the metadata record in place its changeset_revision advances to the new tip while
     # numeric_revision keeps pointing at the previous changeset, and Galaxy clones at
@@ -320,7 +343,7 @@ def get_repo_info_dict(trans: "ProvidesRepositoriesContext", repository_id, chan
         repository_owner=repository.user.username,
         repository_name=repository.name,
         repository=repository,
-        repository_metadata=repository_metadata,
+        repository_metadata=metadata_for_changeset,
         tool_dependencies=None,
         repository_dependencies=None,
         trans=trans,

--- a/lib/tool_shed/webapp/api2/repositories.py
+++ b/lib/tool_shed/webapp/api2/repositories.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import logging
 import os
 import shutil
@@ -15,6 +17,7 @@ from fastapi import (
     status,
     UploadFile,
 )
+from fastapi.encoders import jsonable_encoder
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from galaxy.exceptions import (
@@ -115,6 +118,36 @@ router = Router(tags=["repositories"])
 
 IndexResponse = RepositorySearchResults | list[Repository] | PaginatedRepositoryIndexResults
 
+# Install info for a given name/owner/changeset_revision only changes when the repository's
+# metadata is rebuilt, so it is worth caching. Clients that revalidate get a 304 from the
+# ETag; caches that do not revalidate serve their copy for a day.
+INSTALL_INFO_MAX_AGE = 86400
+INSTALL_INFO_CACHE_CONTROL = f"public, max-age={INSTALL_INFO_MAX_AGE}"
+
+
+def _etag_for(payload) -> str:
+    """Build an ETag from the payload the route is about to serialize."""
+    encoded = json.dumps(jsonable_encoder(payload), sort_keys=True, separators=(",", ":"))
+    return f'"{hashlib.sha256(encoded.encode("utf-8")).hexdigest()}"'
+
+
+def _if_none_match(request: Request) -> list[str]:
+    header = request.headers.get("if-none-match")
+    if not header:
+        return []
+    # A conditional request may list several tags; weak validators are compared by value.
+    return [tag.strip().removeprefix("W/") for tag in header.split(",")]
+
+
+def _cacheable(payload, request: Request, response: Response):
+    """Attach cache headers to payload, or hand back a 304 if the client already has it."""
+    etag = _etag_for(payload)
+    headers = {"ETag": etag, "Cache-Control": INSTALL_INFO_CACHE_CONTROL}
+    if etag in _if_none_match(request):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    response.headers.update(headers)
+    return payload
+
 
 @as_form
 class RepositoryUpdateRequestFormData(RepositoryUpdateRequest):
@@ -197,6 +230,8 @@ class FastAPIRepositories:
     )
     def legacy_install_info(
         self,
+        request: Request,
+        response: Response,
         trans: SessionRequestContext = DependsOnTrans,
         name: str = RequiredRepoNameParam,
         owner: str = RequiredRepoOwnerParam,
@@ -208,7 +243,7 @@ class FastAPIRepositories:
             owner,
             changeset_revision,
         )
-        return list(legacy_install_info)
+        return _cacheable(list(legacy_install_info), request, response)
 
     @router.get(
         "/api/repositories/install_info",
@@ -217,6 +252,8 @@ class FastAPIRepositories:
     )
     def install_info(
         self,
+        request: Request,
+        response: Response,
         trans: SessionRequestContext = DependsOnTrans,
         name: str = RequiredRepoNameParam,
         owner: str = RequiredRepoOwnerParam,
@@ -231,7 +268,7 @@ class FastAPIRepositories:
             owner,
             changeset_revision,
         )
-        return from_legacy_install_info(legacy_install_info)
+        return _cacheable(from_legacy_install_info(legacy_install_info), request, response)
 
     @router.get(
         "/api/repositories/{encoded_repository_id}/metadata",


### PR DESCRIPTION
`/api/repositories/get_repository_revision_install_info` is the most requested route on the
tool shed -- every Galaxy server installing or reinstalling a repository calls it once per
repository. Benchmarking it against an embedded shed showed it spending almost all of its
time in one subprocess:

| | p50 | p95 | SQL queries | `hg` subprocesses |
|---|---|---|---|---|
| before | 140.87 ms | 157.30 ms | 9 | 1 |
| after | **4.87 ms** | 6.72 ms | 6 | 0 |

For reference, `/api/version` on the same instance is 1.2 ms, so most of what remains is
framework overhead.

### What was slow

`changeset2rev()` shelled out to `hg id -r <changeset> -n` on every call, paying Python
interpreter startup plus a Mercurial import each time. That single subprocess was **133 ms
of the 141 ms** request (93%). Measured in isolation, `hg id` is 128 ms against 0.7 ms
for the in-process lookup on a freshly opened repository (0.03 ms once the repository
object is warm). The subprocess cost is data-independent, so it is the same on production
hardware.

Two smaller things showed up in the same profile: `create_repo_info_dict()` ignored the
`repository` and `repository_metadata` arguments it was handed and looked them up again, so
one request issued the identical `repository_metadata` SELECT three times.

### The commits

1. **Resolve changeset revision numbers in-process instead of via `hg id`** -- `changeset2rev`
   now takes an already opened repository. Both callers have a `Repository`, whose
   `hg_repo` property already keeps a cached,
   self-invalidating local repo, and the hex node prefix is resolved through the
   changelog rather than via `revsymbol`, which would also build tag and bookmark caches.
   `ctx_rev` is deliberately still computed rather than read from
   `repository_metadata.numeric_revision`: when a push updates a metadata record in place
   its `changeset_revision` advances to the new tip while `numeric_revision` keeps pointing
   at the previous changeset, and handing Galaxy that stale number makes it clone at the
   wrong revision.
2. **Reuse loaded repository objects when building repo info dicts** -- thread the already
   loaded objects through instead of re-querying. 9 -> 6 SQL queries. The metadata record is
   only passed down when it actually describes the requested `changeset_revision`, since
   `get_repo_info_dict` may have resolved a different, next-installable revision.
3. **Send ETag and Cache-Control on the install info routes** -- install info for a given
   name/owner/changeset_revision only changes when that revision's metadata is rebuilt, so
   both install info routes now return an `ETag` plus `Cache-Control: public, max-age=86400`
   and answer a matching `If-None-Match` with `304`. The ETag hashes the serialized payload
   rather than a timestamp, so it also changes when the response shifts for a reason this
   repository's own `update_time` would not capture, such as an edit to one of its
   repository dependencies.

`/api/repositories/install_info` shares the code path and improves identically.

Note that Galaxy's own install client (`util.url_get`) sends no conditional headers and
keeps no local cache, so it will not produce `304`s by itself -- the caching win is at the
proxy. `lib/tool_shed/doc/nginx_caching.md` covers the NGINX side, including keying the
cache on name/owner/changeset_revision so an API key in the query string neither fragments
the cache nor lands in a cache key.

The generated OpenAPI schema is unchanged, so no client regeneration is needed.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `pytest lib/tool_shed/test/functional/test_shed_repositories.py` -- 39 pass, covering
     install info, ordered installable revisions and metadata.
  2. Equivalence of `ctx_rev` was verified out of band: for every revision of a
     multi-revision repository the value returned by the API is identical to
     `hg id -r <changeset> -n`, and the unknown-changeset and unknown-repository responses
     are unchanged.
  3. Caching behaviour is covered by two new API tests in the same file:
     `test_install_info_is_cacheable` asserts the headers on both install info routes, that
     strong, weak and multi-tag `If-None-Match` values all yield an empty `304` repeating
     the tag, and that a non-matching tag still returns the full body;
     `test_install_info_etag_tracks_the_revision` asserts the tag follows the revision
     rather than the repository. Both fail without the change.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
