### PR TITLE
Show wall clock runtime for each collection job in invocation view

### DIFF
--- a/client/src/api/invocations.ts
+++ b/client/src/api/invocations.ts
@@ -22,6 +22,8 @@ export type StepJobSummary =
     | components["schemas"]["InvocationStepJobsResponseJobModel"]
     | components["schemas"]["InvocationStepJobsResponseCollectionJobsModel"];
 
+export type WorkflowJobMetric = components["schemas"]["WorkflowJobMetric"];
+
 export type WorkflowInvocation = components["schemas"]["WorkflowInvocationResponse"];
 
 export function isWorkflowInvocationElementView(

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -7,7 +7,6 @@ import { JobConsoleOutputProvider, JobDetailsProvider } from "@/components/provi
 import { rethrowSimple } from "@/utils/simple-error";
 
 import type { JobMessage } from "../../api/jobs";
-import { getJobDuration } from "./utilities";
 
 import Heading from "../Common/Heading.vue";
 import DecodedId from "../DecodedId.vue";
@@ -50,7 +49,6 @@ function jobStateIsRunning(jobState: string) {
     return jobState == "running";
 }
 
-const jobIsTerminal = computed(() => (job.value?.state ? jobStateIsTerminal(job.value?.state) : false));
 const jobIsRunning = computed(() => (job.value?.state ? jobStateIsRunning(job.value.state) : false));
 const routeToInvocation = computed(() => `/workflows/invocations/${fetchedInvocationId.value}`);
 
@@ -199,12 +197,6 @@ watch(
                     <td>Updated</td>
                     <td v-if="job.update_time" id="updated">
                         <UtcDate :date="job.update_time" mode="pretty" />
-                    </td>
-                </tr>
-                <tr v-if="job && props.includeTimes && jobIsTerminal">
-                    <td>Time To Finish</td>
-                    <td id="runtime">
-                        {{ getJobDuration(job) }}
                     </td>
                 </tr>
                 <CodeRow

--- a/client/src/components/JobInformation/utilities.ts
+++ b/client/src/components/JobInformation/utilities.ts
@@ -1,7 +1,0 @@
-import { formatDuration, intervalToDuration } from "date-fns";
-
-import type { JobBaseModel } from "@/api/jobs";
-
-export function getJobDuration(job: JobBaseModel): string {
-    return formatDuration(intervalToDuration({ start: new Date(job.create_time), end: new Date(job.update_time) }));
-}

--- a/client/src/components/JobMetrics/JobMetrics.vue
+++ b/client/src/components/JobMetrics/JobMetrics.vue
@@ -10,47 +10,30 @@ import Heading from "../Common/Heading.vue";
 import AwsEstimate from "./AwsEstimate.vue";
 import CarbonEmissions from "./CarbonEmissions/CarbonEmissions.vue";
 
-const props = defineProps({
-    datasetFilesize: {
-        type: Number,
-        default: 0,
-    },
-    datasetId: {
-        type: String,
-        default: "",
-    },
-    datasetType: {
-        type: String,
-        default: "hda",
-    },
-    includeTitle: {
-        type: Boolean,
-        default: true,
-    },
-    jobId: {
-        type: String,
-        default: null,
-    },
-    powerUsageEffectiveness: {
-        type: Number,
-        default: worldwidePowerUsageEffectiveness,
-    },
-    geographicalServerLocationName: {
-        type: String,
-        default: "GLOBAL",
-    },
-    carbonIntensity: {
-        type: Number,
-        default: worldwideCarbonIntensity,
-    },
-    shouldShowAwsEstimate: {
-        type: Boolean,
-        default: false,
-    },
-    shouldShowCarbonEmissionEstimates: {
-        type: Boolean,
-        default: true,
-    },
+interface Props {
+    datasetFilesize?: number;
+    datasetId?: string;
+    datasetType?: "hda" | "ldda";
+    includeTitle?: boolean;
+    jobId?: string | null;
+    powerUsageEffectiveness?: number;
+    geographicalServerLocationName?: string;
+    carbonIntensity?: number;
+    shouldShowAwsEstimate?: boolean;
+    shouldShowCarbonEmissionEstimates?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    datasetFilesize: 0,
+    datasetId: "",
+    datasetType: "hda",
+    includeTitle: true,
+    jobId: null,
+    powerUsageEffectiveness: worldwidePowerUsageEffectiveness,
+    geographicalServerLocationName: "GLOBAL",
+    carbonIntensity: worldwideCarbonIntensity,
+    shouldShowAwsEstimate: false,
+    shouldShowCarbonEmissionEstimates: true,
 });
 
 const jobMetricsStore = useJobMetricsStore();
@@ -97,7 +80,7 @@ const jobMetrics = computed(() => {
 });
 
 const jobMetricsGroupedByPluginType = computed(() => {
-    const pluginGroups: Record<string, any> = {};
+    const pluginGroups: Record<string, Record<string, string>> = {};
 
     for (const metric of jobMetrics.value) {
         // new group found
@@ -107,7 +90,9 @@ const jobMetricsGroupedByPluginType = computed(() => {
 
         // Add metric to group
         const group = pluginGroups[metric.plugin];
-        group[metric.title] = metric.value;
+        if (group) {
+            group[metric.title] = metric.value;
+        }
     }
 
     return pluginGroups;

--- a/client/src/components/JobMetrics/JobMetrics.vue
+++ b/client/src/components/JobMetrics/JobMetrics.vue
@@ -59,7 +59,7 @@ async function getJobMetrics() {
     if (props.jobId) {
         await jobMetricsStore.fetchJobMetricsForJobId(props.jobId);
     } else {
-        await jobMetricsStore.fetchJobMetricsForDatasetId(props.datasetId, props.datasetType);
+        await jobMetricsStore.fetchJobMetricsForDatasetId(props.datasetId, props.datasetType as "hda" | "ldda");
     }
 }
 

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.vue
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.vue
@@ -33,12 +33,8 @@ const emit = defineEmits<{
 
 const invocationStore = useInvocationStore();
 
-watch(
-    () => props.invocationId,
-    (invocationId) => invocationStore.fetchInvocationMetricsForId({ id: invocationId }),
-    { immediate: true },
-);
-
+// `getInvocationJobRuntimeById` (via `getInvocationMetricsById`) fetches on first read and
+// self-refreshes as steps finish -- see invocationStore.ts for details.
 const runtimeByJobId = computed(() => invocationStore.getInvocationJobRuntimeById(props.invocationId));
 
 const showModal = ref(false);

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.vue
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.vue
@@ -5,7 +5,7 @@ import { computed, ref, watch } from "vue";
 
 import type { JobBaseModel } from "@/api/jobs";
 import type { TableField } from "@/components/Common/GTable.types";
-import { getJobDuration } from "@/components/JobInformation/utilities";
+import { useInvocationStore } from "@/stores/invocationStore";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
 import GButtonGroup from "@/components/BaseComponents/GButtonGroup.vue";
@@ -31,12 +31,22 @@ const emit = defineEmits<{
     (e: "update:sort-desc", value: boolean): void;
 }>();
 
+const invocationStore = useInvocationStore();
+
+watch(
+    () => props.invocationId,
+    (invocationId) => invocationStore.fetchInvocationMetricsForId({ id: invocationId }),
+    { immediate: true },
+);
+
+const runtimeByJobId = computed(() => invocationStore.getInvocationJobRuntimeById(props.invocationId));
+
 const showModal = ref(false);
 
 const fields: TableField[] = [
     { key: "id", label: "Job ID" },
     { key: "update_time", label: "Updated", sortable: true },
-    { key: "duration", label: "Time To Finish" },
+    { key: "duration", label: "Runtime (Wall Clock)" },
     { key: "state", label: "State" },
 ];
 
@@ -154,7 +164,7 @@ watch(
             </template>
 
             <template v-slot:cell(duration)="data">
-                {{ getJobDuration(data.item) }}
+                {{ runtimeByJobId[data.item.id] ?? "N/A" }}
             </template>
         </GTable>
 

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.vue
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.vue
@@ -35,7 +35,6 @@ const showModal = ref(false);
 
 const fields: TableField[] = [
     { key: "id", label: "Job ID" },
-    { key: "tool_id", label: "Tool" },
     { key: "update_time", label: "Updated", sortable: true },
     { key: "duration", label: "Time To Finish" },
     { key: "state", label: "State" },

--- a/client/src/components/WorkflowInvocationState/JobStepJobs.vue
+++ b/client/src/components/WorkflowInvocationState/JobStepJobs.vue
@@ -146,7 +146,7 @@ watch(
             </template>
 
             <template v-slot:cell(update_time)="data">
-                <UtcDate :date="data.item.update_time" mode="timeonly" />
+                <UtcDate :date="data.item.update_time" mode="elapsed" />
             </template>
 
             <template v-slot:cell(state)="data">

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -37,6 +37,16 @@ watch(
     { immediate: true },
 );
 
+// Trigger a fetch of invocation metrics when the workflow transitions to a terminal state.
+watch(
+    () => props.notTerminal,
+    (notTerminal, wasNotTerminal) => {
+        if (wasNotTerminal && !notTerminal) {
+            invocationStore.fetchInvocationMetricsForId({ id: props.invocationId });
+        }
+    },
+);
+
 function itemToX(item: WorkflowJobMetric) {
     if (groupBy.value === "tool_id") {
         return item.tool_id;

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -4,9 +4,9 @@ import type { VisualizationSpec } from "vega-embed";
 import type { ComputedRef } from "vue";
 import { computed, ref, watch } from "vue";
 
-import { type components, GalaxyApi } from "@/api";
+import type { WorkflowJobMetric } from "@/api/invocations";
 import { getAppRoot } from "@/onload/loadConfig";
-import { errorMessageAsString } from "@/utils/simple-error";
+import { useInvocationStore } from "@/stores/invocationStore";
 import { capitalizeFirstLetter } from "@/utils/strings";
 
 import LoadingSpan from "../LoadingSpan.vue";
@@ -20,38 +20,24 @@ interface Props {
 }
 const props = defineProps<Props>();
 
+const invocationStore = useInvocationStore();
+
 const groupBy = ref<"tool_id" | "step_id">("tool_id");
 const timing = ref<"seconds" | "minutes" | "hours">("seconds");
-const jobMetrics = ref<components["schemas"]["WorkflowJobMetric"][]>();
-const fetchError = ref<string>();
+const jobMetrics = computed(() => invocationStore.getInvocationMetricsById(props.invocationId) ?? undefined);
 
 const attributeToLabel = {
     tool_id: "Tool ID",
     step_id: "Step",
 };
 
-async function fetchMetrics() {
-    const { data, error } = await GalaxyApi().GET("/api/invocations/{invocation_id}/metrics", {
-        params: {
-            path: {
-                invocation_id: props.invocationId,
-            },
-        },
-    });
-    if (error) {
-        fetchError.value = errorMessageAsString(error);
-    } else {
-        jobMetrics.value = data;
-    }
-}
-
 watch(
     () => props.invocationId,
-    () => fetchMetrics(),
+    (invocationId) => invocationStore.fetchInvocationMetricsForId({ id: invocationId }),
     { immediate: true },
 );
 
-function itemToX(item: components["schemas"]["WorkflowJobMetric"]) {
+function itemToX(item: WorkflowJobMetric) {
     if (groupBy.value === "tool_id") {
         return item.tool_id;
     } else if (groupBy.value === "step_id") {
@@ -99,11 +85,9 @@ interface DerivedMetric {
     step_label: string | null;
 }
 
-type AnyMetric = components["schemas"]["WorkflowJobMetric"] & DerivedMetric;
+type AnyMetric = WorkflowJobMetric & DerivedMetric;
 
-function computeAllocatedCoreTime(
-    jobMetrics: components["schemas"]["WorkflowJobMetric"][] | undefined,
-): DerivedMetric[] {
+function computeAllocatedCoreTime(jobMetrics: WorkflowJobMetric[] | undefined): DerivedMetric[] {
     const walltimePerJob: Record<string, number> = {};
     const coresPerJob: Record<string, number> = {};
     const jobInfo: Record<string, JobInfo> = {};

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -2,7 +2,7 @@
 import { BAlert, BButtonGroup, BCol, BContainer, BDropdown, BDropdownItem, BRow } from "bootstrap-vue";
 import type { VisualizationSpec } from "vega-embed";
 import type { ComputedRef } from "vue";
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 
 import type { WorkflowJobMetric } from "@/api/invocations";
 import { getAppRoot } from "@/onload/loadConfig";
@@ -24,28 +24,17 @@ const invocationStore = useInvocationStore();
 
 const groupBy = ref<"tool_id" | "step_id">("tool_id");
 const timing = ref<"seconds" | "minutes" | "hours">("seconds");
+
+// `getInvocationMetricsById` fetches on first read, and self-refreshes whenever a step that was
+// previously non-terminal has since finished (tracked in the store, driven by the step job summary
+// that's already kept fresh by the parent's own polling in WorkflowInvocationState.vue) -- so no
+// manual fetch/watch is needed here.
 const jobMetrics = computed(() => invocationStore.getInvocationMetricsById(props.invocationId) ?? undefined);
 
 const attributeToLabel = {
     tool_id: "Tool ID",
     step_id: "Step",
 };
-
-watch(
-    () => props.invocationId,
-    (invocationId) => invocationStore.fetchInvocationMetricsForId({ id: invocationId }),
-    { immediate: true },
-);
-
-// Trigger a fetch of invocation metrics when the workflow transitions to a terminal state.
-watch(
-    () => props.notTerminal,
-    (notTerminal, wasNotTerminal) => {
-        if (wasNotTerminal && !notTerminal) {
-            invocationStore.fetchInvocationMetricsForId({ id: props.invocationId });
-        }
-    },
-);
 
 function itemToX(item: WorkflowJobMetric) {
     if (groupBy.value === "tool_id") {

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationMetrics.vue
@@ -2,7 +2,7 @@
 import { BAlert, BButtonGroup, BCol, BContainer, BDropdown, BDropdownItem, BRow } from "bootstrap-vue";
 import type { VisualizationSpec } from "vega-embed";
 import type { ComputedRef } from "vue";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 
 import type { WorkflowJobMetric } from "@/api/invocations";
 import { getAppRoot } from "@/onload/loadConfig";
@@ -25,11 +25,27 @@ const invocationStore = useInvocationStore();
 const groupBy = ref<"tool_id" | "step_id">("tool_id");
 const timing = ref<"seconds" | "minutes" | "hours">("seconds");
 
-// `getInvocationMetricsById` fetches on first read, and self-refreshes whenever a step that was
-// previously non-terminal has since finished (tracked in the store, driven by the step job summary
-// that's already kept fresh by the parent's own polling in WorkflowInvocationState.vue) -- so no
-// manual fetch/watch is needed here.
-const jobMetrics = computed(() => invocationStore.getInvocationMetricsById(props.invocationId) ?? undefined);
+// Fetch explicitly, once per `invocationId`, instead of relying on `jobMetrics`'s read to trigger it
+// via the store's fetch-if-absent accessor; that accessor only records "already fetching" state
+// after the fetch resolves, so a re-render before then (e.g. vue-router resolving async components)
+// could read it mid-flight and fire a real duplicate request.
+const hasLoadedMetricsForInvocationId = ref<string>();
+watch(
+    () => props.invocationId,
+    async (invocationId) => {
+        await invocationStore.fetchInvocationMetricsForId({ id: invocationId });
+        hasLoadedMetricsForInvocationId.value = invocationId;
+    },
+    { immediate: true },
+);
+
+// Only read the store's accessor (and let it self-refresh) once our own fetch above has resolved.
+const jobMetrics = computed(() => {
+    if (hasLoadedMetricsForInvocationId.value !== props.invocationId) {
+        return undefined;
+    }
+    return invocationStore.getInvocationMetricsById(props.invocationId) ?? undefined;
+});
 
 const attributeToLabel = {
     tool_id: "Tool ID",

--- a/client/src/components/WorkflowInvocationState/util.test.ts
+++ b/client/src/components/WorkflowInvocationState/util.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { getStepTitle } from "./util";
+import type { StepJobSummary } from "@/api/invocations";
+
+import { getStepTitle, isTerminal, numTerminal } from "./util";
 
 describe("getStepTitle", () => {
     it("uses label when provided, regardless of type", () => {
@@ -37,5 +39,35 @@ describe("getStepTitle", () => {
 
     it("handles unknown step types", () => {
         expect(getStepTitle(0, "some_future_type")).toBe("Step 1: Unknown step type 'some_future_type'");
+    });
+});
+
+describe("numTerminal / isTerminal", () => {
+    // A collection-mapped step: one `StepJobSummary` entry can represent many jobs at once, so
+    // partial completion (some terminal, some still running) must be visible as a count, not just
+    // a step-wide terminal/non-terminal flag.
+    const partiallyDoneCollectionStep = {
+        id: "collection1",
+        model: "ImplicitCollectionJobs",
+        states: { ok: 2, running: 1 },
+    } as unknown as StepJobSummary;
+
+    it("counts only terminal jobs within a partially-completed collection step", () => {
+        expect(numTerminal(partiallyDoneCollectionStep)).toBe(2);
+    });
+
+    it("does not consider a step terminal while any job in it is still running", () => {
+        expect(isTerminal(partiallyDoneCollectionStep)).toBe(false);
+    });
+
+    it("considers a step terminal once every job in it has a terminal state", () => {
+        const fullyDoneCollectionStep = {
+            id: "collection1",
+            model: "ImplicitCollectionJobs",
+            states: { ok: 2, error: 1 },
+        } as unknown as StepJobSummary;
+
+        expect(numTerminal(fullyDoneCollectionStep)).toBe(3);
+        expect(isTerminal(fullyDoneCollectionStep)).toBe(true);
     });
 });

--- a/client/src/components/WorkflowInvocationState/util.ts
+++ b/client/src/components/WorkflowInvocationState/util.ts
@@ -54,7 +54,7 @@ export function runningCount(jobSummary: InvocationJobsSummary): number {
     return countStates(jobSummary, ["running"]);
 }
 
-export function numTerminal(jobSummary: InvocationJobsSummary): number {
+export function numTerminal(jobSummary: InvocationJobsSummary | StepJobSummary): number {
     return countStates(jobSummary, TERMINAL_STATES);
 }
 
@@ -62,11 +62,11 @@ export function errorCount(jobSummary: InvocationJobsSummary | StepJobSummary): 
     return countStates(jobSummary, ERROR_STATES);
 }
 
-function isNew(jobSummary: InvocationJobsSummary) {
+function isNew(jobSummary: InvocationJobsSummary | StepJobSummary) {
     return jobSummary.populated_state && jobSummary.populated_state == "new";
 }
 
-function anyWithStates(jobSummary: InvocationJobsSummary, queryStates: string[]) {
+function anyWithStates(jobSummary: InvocationJobsSummary | StepJobSummary, queryStates: string[]) {
     const states = jobSummary.states;
     for (const index in queryStates) {
         const state: string = queryStates[index] as string;
@@ -77,7 +77,7 @@ function anyWithStates(jobSummary: InvocationJobsSummary, queryStates: string[])
     return false;
 }
 
-export function isTerminal(jobSummary: InvocationJobsSummary) {
+export function isTerminal(jobSummary: InvocationJobsSummary | StepJobSummary) {
     if (isNew(jobSummary)) {
         return false;
     } else {

--- a/client/src/stores/invocationStore.test.ts
+++ b/client/src/stores/invocationStore.test.ts
@@ -1,0 +1,117 @@
+import flushPromises from "flush-promises";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useServerMock } from "@/api/client/__mocks__";
+import type { StepJobSummary, WorkflowJobMetric } from "@/api/invocations";
+
+import { useInvocationStore } from "./invocationStore";
+
+const { server, http } = useServerMock();
+
+function stepJobsSummaryResponse(states: Record<string, number>): StepJobSummary[] {
+    return [{ id: "step1", model: "ImplicitCollectionJobs", states } as unknown as StepJobSummary];
+}
+
+function metricsResponse(jobIds: string[]): WorkflowJobMetric[] {
+    return jobIds.map(
+        (job_id) =>
+            ({
+                plugin: "core",
+                name: "runtime_seconds",
+                title: "Job Runtime",
+                value: `${job_id}-runtime`,
+                raw_value: "1",
+                job_id,
+            }) as unknown as WorkflowJobMetric,
+    );
+}
+
+describe("stores/invocationStore", () => {
+    let stepJobsSummary: StepJobSummary[];
+    let metricsCallCount: number;
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+
+        stepJobsSummary = stepJobsSummaryResponse({ running: 1 });
+        metricsCallCount = 0;
+
+        server.use(
+            http.get("/api/invocations/{invocation_id}/step_jobs_summary", ({ response }) => {
+                return response(200).json(stepJobsSummary);
+            }),
+            http.get("/api/invocations/{invocation_id}/metrics", ({ response }) => {
+                metricsCallCount++;
+                return response(200).json(metricsResponse(["job1"]));
+            }),
+        );
+    });
+
+    describe("getInvocationMetricsById", () => {
+        it("fetches once for a given invocation id and reuses the cached result", async () => {
+            const store = useInvocationStore();
+
+            store.getInvocationMetricsById("inv1");
+            store.getInvocationMetricsById("inv1");
+            await flushPromises();
+
+            expect(metricsCallCount).toBe(1);
+        });
+
+        it("refetches once a step's terminal job count increases since the last fetch", async () => {
+            const store = useInvocationStore();
+
+            // Initial fetch, with one job still running (nothing terminal yet).
+            store.getInvocationMetricsById("inv1");
+            await flushPromises();
+            expect(metricsCallCount).toBe(1);
+
+            // A job in the collection finishes -- terminal count for the step goes from 0 to 1.
+            // (Refreshed explicitly, mirroring the polling loop in WorkflowInvocationState.vue that
+            // keeps the step jobs summary cache up to date independently of the metrics fetch.)
+            stepJobsSummary = stepJobsSummaryResponse({ running: 1, ok: 1 });
+            await store.fetchInvocationStepJobsSummaryForId({ id: "inv1" });
+
+            store.getInvocationMetricsById("inv1");
+            await flushPromises();
+
+            expect(metricsCallCount).toBe(2);
+        });
+
+        it("does not refetch when the terminal job count is unchanged", async () => {
+            stepJobsSummary = stepJobsSummaryResponse({ ok: 1, running: 1 });
+
+            const store = useInvocationStore();
+
+            store.getInvocationMetricsById("inv1");
+            await flushPromises();
+            expect(metricsCallCount).toBe(1);
+
+            // Step jobs summary is refreshed but reports the same states -- no newly-terminal jobs.
+            await store.fetchInvocationStepJobsSummaryForId({ id: "inv1" });
+
+            store.getInvocationMetricsById("inv1");
+            await flushPromises();
+
+            expect(metricsCallCount).toBe(1);
+        });
+    });
+
+    describe("getInvocationJobRuntimeById", () => {
+        it("maps job ids to their runtime_seconds metric value", async () => {
+            const store = useInvocationStore();
+
+            store.getInvocationMetricsById("inv1");
+            await flushPromises();
+
+            expect(store.getInvocationJobRuntimeById("inv1")).toEqual({ job1: "job1-runtime" });
+        });
+
+        it("returns an empty lookup before metrics have loaded", () => {
+            const store = useInvocationStore();
+
+            expect(store.getInvocationJobRuntimeById("inv1")).toEqual({});
+        });
+    });
+});

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -151,10 +151,19 @@ export const useInvocationStore = defineStore("invocationStore", () => {
      */
     const terminalCountsByStepIdAtLastMetricsFetch: Record<string, Record<string, number>> = {};
 
-    function currentTerminalCountsByStepId(invocationId: string): Record<string, number> {
+    /**
+     * Returns `null` if the step jobs summary hasn't loaded yet (it's fetched/kept fresh
+     * independently, e.g. by `WorkflowInvocationState.vue`'s polling) -- callers must treat that as
+     * "unknown" rather than "zero terminal jobs", otherwise the summary arriving a moment later would
+     * look like a burst of newly-terminal jobs and trigger a spurious extra fetch.
+     */
+    function currentTerminalCountsByStepId(invocationId: string): Record<string, number> | null {
         const stepsJobsSummary = getInvocationStepJobsSummaryById.value(invocationId);
+        if (!stepsJobsSummary) {
+            return null;
+        }
         const counts: Record<string, number> = {};
-        for (const step of stepsJobsSummary ?? []) {
+        for (const step of stepsJobsSummary) {
             counts[step.id] = numTerminal(step);
         }
         return counts;
@@ -166,7 +175,13 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         // the next staleness check, rather than being (incorrectly) folded into "already accounted for".
         const snapshotAtFetchStart = currentTerminalCountsByStepId(params.id);
         const result = await fetchInvocationMetricsRawForId(params);
-        terminalCountsByStepIdAtLastMetricsFetch[params.id] = snapshotAtFetchStart;
+        // The step jobs summary may not have loaded yet when this fetch started (snapshot `null`) --
+        // fall back to whatever it looks like now, so we don't leave the snapshot permanently
+        // unrecorded (which would make every future read think metrics were "never fetched").
+        const snapshot = snapshotAtFetchStart ?? currentTerminalCountsByStepId(params.id);
+        if (snapshot !== null) {
+            terminalCountsByStepIdAtLastMetricsFetch[params.id] = snapshot;
+        }
         return result;
     }
 
@@ -192,9 +207,13 @@ export const useInvocationStore = defineStore("invocationStore", () => {
             }
 
             const newTerminalCountsByStepId = currentTerminalCountsByStepId(invocationId);
-            const hasNewlyTerminalJob = Object.entries(newTerminalCountsByStepId).some(
-                ([stepId, count]) => count > (oldTerminalCountsByStepId[stepId] ?? 0),
-            );
+            // Step jobs summary not loaded (yet, or anymore) -- nothing to compare against, so don't
+            // fetch based on incomplete information.
+            const hasNewlyTerminalJob =
+                newTerminalCountsByStepId !== null &&
+                Object.entries(newTerminalCountsByStepId).some(
+                    ([stepId, count]) => count > (oldTerminalCountsByStepId[stepId] ?? 0),
+                );
             if (hasNewlyTerminalJob) {
                 fetchInvocationMetricsForId({ id: invocationId });
             }

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -154,6 +154,24 @@ export const useInvocationStore = defineStore("invocationStore", () => {
             .filter((invocation) => invocation !== undefined);
     });
 
+    /**
+     * A computed function that returns a `job_id -> runtime (wall clock)` lookup for a given
+     * invocation, using the `core` plugin's pre-formatted `runtime_seconds` metric value
+     * (see `getInvocationMetricsById`).
+     */
+    const getInvocationJobRuntimeById = computed(() => {
+        return (invocationId: string): Record<string, string> => {
+            const metrics = getInvocationMetricsById.value(invocationId);
+            const runtimeByJobId: Record<string, string> = {};
+            for (const metric of metrics ?? []) {
+                if (metric.name === "runtime_seconds") {
+                    runtimeByJobId[metric.job_id] = metric.value;
+                }
+            }
+            return runtimeByJobId;
+        };
+    });
+
     const totalInvocationCount = ref<number | undefined>(undefined);
 
     return {
@@ -167,6 +185,7 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         getInvocationJobsSummaryById,
         getInvocationStepJobsSummaryById,
         getInvocationMetricsById,
+        getInvocationJobRuntimeById,
         getInvocationLoadError,
         getInvocationStepById,
         getInvocationRequestById,

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -10,6 +10,7 @@ import type {
     WorkflowInvocationRequest,
     WorkflowJobMetric,
 } from "@/api/invocations";
+import { numTerminal } from "@/components/WorkflowInvocationState/util";
 import { type FetchParams, useKeyedCache } from "@/composables/keyedCache";
 import { rethrowSimple, rethrowSimpleWithStatus } from "@/utils/simple-error";
 
@@ -135,8 +136,71 @@ export const useInvocationStore = defineStore("invocationStore", () => {
     const { getItemById: getInvocationStepJobsSummaryById, fetchItemById: fetchInvocationStepJobsSummaryForId } =
         useKeyedCache<StepJobSummary[]>(fetchInvocationStepJobsSummary);
 
-    const { getItemById: getInvocationMetricsById, fetchItemById: fetchInvocationMetricsForId } =
+    const { storedItems: storedInvocationMetrics, fetchItemById: fetchInvocationMetricsRawForId } =
         useKeyedCache<WorkflowJobMetric[]>(fetchInvocationMetrics);
+
+    /**
+     * For each invocation id, a `step/job id -> number of terminal jobs` mapping as of the last
+     * metrics fetch.
+     *
+     * A *count* (rather than a plain terminal/non-terminal flag) is needed because a single step
+     * can have multiple jobs and their metrics (e.g. `runtime_seconds`) wouldn't show up until
+     * the entire collection completed.
+     *
+     * `undefined` means metrics haven't been fetched for this invocation yet.
+     */
+    const terminalCountsByStepIdAtLastMetricsFetch: Record<string, Record<string, number>> = {};
+
+    function currentTerminalCountsByStepId(invocationId: string): Record<string, number> {
+        const stepsJobsSummary = getInvocationStepJobsSummaryById.value(invocationId);
+        const counts: Record<string, number> = {};
+        for (const step of stepsJobsSummary ?? []) {
+            counts[step.id] = numTerminal(step);
+        }
+        return counts;
+    }
+
+    /** Fetches invocation metrics and records the terminal-count mapping for the fetch. */
+    async function fetchInvocationMetricsForId(params: FetchParams) {
+        // Snapshot *before* fetching, so a job that goes terminal mid-fetch is still seen as new by
+        // the next staleness check, rather than being (incorrectly) folded into "already accounted for".
+        const snapshotAtFetchStart = currentTerminalCountsByStepId(params.id);
+        const result = await fetchInvocationMetricsRawForId(params);
+        terminalCountsByStepIdAtLastMetricsFetch[params.id] = snapshotAtFetchStart;
+        return result;
+    }
+
+    /**
+     * Returns the cached metrics for an invocation, fetching once if absent (like `useKeyedCache`'s
+     * own accessors) -- but additionally triggers a background refetch (returning the current,
+     * possibly-stale cached value immediately, same stale-while-revalidate behavior) whenever any
+     * step's terminal-job count has increased since the last fetch (see above for why a count, not a
+     * boolean, is needed). This keeps consumers (e.g. the Metrics tab, per-job runtime lookups) fresh
+     * as an invocation's jobs finish over time, without every consumer needing its own
+     * polling/diffing logic.
+     */
+    const getInvocationMetricsById = computed(() => {
+        return (invocationId: string) => {
+            const metrics = storedInvocationMetrics.value[invocationId];
+            const oldTerminalCountsByStepId = terminalCountsByStepIdAtLastMetricsFetch[invocationId];
+
+            if (oldTerminalCountsByStepId === undefined) {
+                // Never fetched for this invocation -- kick off the initial fetch (via the wrapper,
+                // so the terminal-count snapshot gets recorded once it lands).
+                fetchInvocationMetricsForId({ id: invocationId });
+                return metrics ?? null;
+            }
+
+            const newTerminalCountsByStepId = currentTerminalCountsByStepId(invocationId);
+            const hasNewlyTerminalJob = Object.entries(newTerminalCountsByStepId).some(
+                ([stepId, count]) => count > (oldTerminalCountsByStepId[stepId] ?? 0),
+            );
+            if (hasNewlyTerminalJob) {
+                fetchInvocationMetricsForId({ id: invocationId });
+            }
+            return metrics ?? null;
+        };
+    });
 
     const {
         getItemById: getInvocationStepById,

--- a/client/src/stores/invocationStore.ts
+++ b/client/src/stores/invocationStore.ts
@@ -8,6 +8,7 @@ import type {
     StepJobSummary,
     WorkflowInvocation,
     WorkflowInvocationRequest,
+    WorkflowJobMetric,
 } from "@/api/invocations";
 import { type FetchParams, useKeyedCache } from "@/composables/keyedCache";
 import { rethrowSimple, rethrowSimpleWithStatus } from "@/utils/simple-error";
@@ -37,6 +38,16 @@ export const useInvocationStore = defineStore("invocationStore", () => {
 
     async function fetchInvocationStepJobsSummary(params: FetchParams): Promise<StepJobSummary[]> {
         const { data, error, response } = await GalaxyApi().GET("/api/invocations/{invocation_id}/step_jobs_summary", {
+            params: { path: { invocation_id: params.id } },
+        });
+        if (error) {
+            rethrowSimpleWithStatus(error, response);
+        }
+        return data;
+    }
+
+    async function fetchInvocationMetrics(params: FetchParams): Promise<WorkflowJobMetric[]> {
+        const { data, error, response } = await GalaxyApi().GET("/api/invocations/{invocation_id}/metrics", {
             params: { path: { invocation_id: params.id } },
         });
         if (error) {
@@ -124,6 +135,9 @@ export const useInvocationStore = defineStore("invocationStore", () => {
     const { getItemById: getInvocationStepJobsSummaryById, fetchItemById: fetchInvocationStepJobsSummaryForId } =
         useKeyedCache<StepJobSummary[]>(fetchInvocationStepJobsSummary);
 
+    const { getItemById: getInvocationMetricsById, fetchItemById: fetchInvocationMetricsForId } =
+        useKeyedCache<WorkflowJobMetric[]>(fetchInvocationMetrics);
+
     const {
         getItemById: getInvocationStepById,
         fetchItemById: fetchInvocationStepById,
@@ -147,10 +161,12 @@ export const useInvocationStore = defineStore("invocationStore", () => {
         fetchInvocationById,
         fetchInvocationJobsSummaryForId,
         fetchInvocationStepJobsSummaryForId,
+        fetchInvocationMetricsForId,
         fetchInvocationStepById,
         getInvocationById,
         getInvocationJobsSummaryById,
         getInvocationStepJobsSummaryById,
+        getInvocationMetricsById,
         getInvocationLoadError,
         getInvocationStepById,
         getInvocationRequestById,

--- a/client/src/stores/jobMetricsStore.ts
+++ b/client/src/stores/jobMetricsStore.ts
@@ -1,9 +1,9 @@
-import axios from "axios";
 import { defineStore } from "pinia";
-import Vue, { computed, ref } from "vue";
+import { computed, ref, set } from "vue";
 
+import { GalaxyApi } from "@/api/client";
 import type { JobMetric } from "@/api/jobs";
-import { prependPath } from "@/utils/redirect";
+import { rethrowSimpleWithStatus } from "@/utils/simple-error";
 
 export const useJobMetricsStore = defineStore("jobMetricsStore", () => {
     const jobMetricsByHdaId = ref<Record<string, JobMetric[]>>({});
@@ -23,16 +23,20 @@ export const useJobMetricsStore = defineStore("jobMetricsStore", () => {
         };
     });
 
-    async function fetchJobMetricsForDatasetId(datasetId: string, datasetType = "hda") {
+    async function fetchJobMetricsForDatasetId(datasetId: string, datasetType: "hda" | "ldda" = "hda") {
         if (jobMetricsByHdaId.value[datasetId] || jobMetricsByLddaId.value[datasetId]) {
             return;
         }
 
-        const path = prependPath(`api/datasets/${datasetId}/metrics?hda_ldda=${datasetType}`);
-        const jobMetrics = (await axios.get<JobMetric[]>(path)).data;
-        const jobMetricsObject = datasetType == "hda" ? jobMetricsByHdaId : jobMetricsByLddaId;
+        const { data, error, response } = await GalaxyApi().GET("/api/datasets/{dataset_id}/metrics", {
+            params: { path: { dataset_id: datasetId }, query: { hda_ldda: datasetType } },
+        });
+        if (error) {
+            rethrowSimpleWithStatus(error, response);
+        }
+        const jobMetricsObject = datasetType === "hda" ? jobMetricsByHdaId : jobMetricsByLddaId;
 
-        Vue.set(jobMetricsObject.value, datasetId, jobMetrics);
+        set(jobMetricsObject.value, datasetId, data);
     }
 
     async function fetchJobMetricsForJobId(jobId: string) {
@@ -40,10 +44,14 @@ export const useJobMetricsStore = defineStore("jobMetricsStore", () => {
             return;
         }
 
-        const path = prependPath(`api/jobs/${jobId}/metrics`);
-        const jobMetrics = (await axios.get<JobMetric[]>(path)).data;
+        const { data, error, response } = await GalaxyApi().GET("/api/jobs/{job_id}/metrics", {
+            params: { path: { job_id: jobId } },
+        });
+        if (error) {
+            rethrowSimpleWithStatus(error, response);
+        }
 
-        Vue.set(jobMetricsByJobId.value, jobId, jobMetrics);
+        set(jobMetricsByJobId.value, jobId, data);
     }
 
     return {


### PR DESCRIPTION
This removes the tool ID column, and replaces the `update_time - create_time` Time To Finish and replaces it with the job metrics wall clock runtime.

The `/api/invocations/{invocation_id}/metrics` endpoint is used and reactively fetched every time the step jobs summary indicates ANY singular job in the invocation has become terminal.

| Before | After |
| ---- | ---- |
| <img width="1159" height="609" alt="firefox_db7XQCMsZR" src="https://github.com/user-attachments/assets/760c1199-3af8-4b2b-9d44-b5a7591efb8f" /> | <img width="1159" height="609" alt="d35REl8shA" src="https://github.com/user-attachments/assets/c9353e7e-df76-4f7d-ba57-8554fabc2fda" /> |

Fixes https://github.com/galaxyproject/galaxy/issues/22826

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
