### PR TITLE
[26.1] Fix workflow graph css issues

### DIFF
--- a/client/src/components/ProgressBar.vue
+++ b/client/src/components/ProgressBar.vue
@@ -46,6 +46,8 @@ const props = withDefaults(defineProps<Props>(), {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
 }
 .progress-container {
     position: relative;

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -300,8 +300,7 @@ watch(
 .delete-terminal-button {
     position: absolute;
     left: calc(-0.65rem - 5px);
-    top: 50%;
-    transform: translateY(-50%);
+    top: 0.25rem;
     display: grid;
     place-items: center;
     width: 0;

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -363,7 +363,7 @@ const removeTagsAction = computed(() => {
                     v-if="showCalloutActiveOutput"
                     v-g-tooltip
                     class="callout-terminal inline-icon-button mark-terminal"
-                    :class="{ 'mark-terminal-active': workflowOutput }"
+                    :class="{ 'mark-terminal-active': workflowOutput, 'readonly-button': readonly }"
                     :title="activeOutputHint"
                     @click="onToggleActive">
                     <FontAwesomeIcon v-if="workflowOutput" fixed-width :icon="faCheckSquare" />
@@ -373,7 +373,11 @@ const removeTagsAction = computed(() => {
                     v-if="showCalloutVisible"
                     v-g-tooltip
                     class="callout-terminal inline-icon-button mark-terminal"
-                    :class="{ 'mark-terminal-visible': isVisible, 'mark-terminal-hidden': !isVisible }"
+                    :class="{
+                        'mark-terminal-visible': isVisible,
+                        'mark-terminal-hidden': !isVisible,
+                        'readonly-button': readonly,
+                    }"
                     :title="visibleHint"
                     @click="onToggleVisible">
                     <FontAwesomeIcon v-if="isVisible" fixed-width :icon="faEye" />
@@ -461,6 +465,18 @@ const removeTagsAction = computed(() => {
     display: flex;
     flex-direction: row;
     margin-left: -0.2rem;
+
+    .readonly-button {
+        cursor: default !important;
+
+        &:hover,
+        &:focus,
+        &:active,
+        &:focus-visible {
+            background-color: unset !important;
+            color: $brand-primary !important;
+        }
+    }
 }
 
 .output-terminal {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -108,9 +108,17 @@ const isVisible = computed(() => {
 
 const visibleHint = computed(() => {
     if (isVisible.value) {
-        return `Output will be visible in history. Click to hide output.`;
+        return `Output will be visible in history.${!props.readonly ? " Click to hide output." : ""}`;
     } else {
-        return `Output will be hidden in history. Click to make output visible.`;
+        return `Output will be hidden in history.${!props.readonly ? " Click to make output visible." : ""}`;
+    }
+});
+
+const activeOutputHint = computed(() => {
+    if (!props.readonly) {
+        return "Checked outputs will become primary workflow outputs and are available as subworkflow outputs.";
+    } else {
+        return "Checked outputs are primary workflow outputs and are available as subworkflow outputs.";
     }
 });
 
@@ -356,7 +364,7 @@ const removeTagsAction = computed(() => {
                     v-g-tooltip
                     class="callout-terminal inline-icon-button mark-terminal"
                     :class="{ 'mark-terminal-active': workflowOutput }"
-                    title="Checked outputs will become primary workflow outputs and are available as subworkflow outputs."
+                    :title="activeOutputHint"
                     @click="onToggleActive">
                     <FontAwesomeIcon v-if="workflowOutput" fixed-width :icon="faCheckSquare" />
                     <FontAwesomeIcon v-else fixed-width :icon="faSquare" />

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -358,7 +358,7 @@ const removeTagsAction = computed(() => {
 <template>
     <div class="node-output" :class="rowClass" :data-output-name="output.name">
         <div v-if="!props.blank" class="d-flex flex-column w-100">
-            <div class="node-output-buttons">
+            <div class="node-output-buttons align-items-start">
                 <button
                     v-if="showCalloutActiveOutput"
                     v-g-tooltip


### PR DESCRIPTION
Fix the remaining issues as pointed out here: Fixes https://github.com/galaxyproject/galaxy/issues/22768

> - [x] We should add a small padding/margin to the beginning of the progress bar, so the text does not sit right on the border of bar.
> - [x] The connector is aligned at the start which is correct but the delete should be aligned at the exact same position, however it is aligned to the vertical center of the input row.
> - [x] The output option icons should also be aligned to start of the row, that way they have a constant height, right now the height depends on the word-wrapping of the output name and covers 100% of the row height. Additionally these icons are not fully disabled in the invocation graph view, hence they highlight on hover and appear clickable.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
