### PR TITLE
Added cloning option to repeats form field blocks on Tool Form page

### DIFF
--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -38,6 +38,7 @@
                     :prefix="prefix"
                     @insert="() => repeatInsert(input)"
                     @delete="(id) => repeatDelete(input, id)"
+                    @clone="(id) => repeatClone(input, id)"
                     @swap="(a, b) => repeatSwap(input, a, b)" />
             </div>
             <div v-else-if="input.type == 'section'">
@@ -211,6 +212,14 @@ export default {
         },
         repeatDelete(input, cacheId) {
             input.cache.splice(cacheId, 1);
+            this.onChangeForm();
+        },
+        repeatClone(input, cacheId) {
+            const clonedInputs = structuredClone(input.cache[cacheId]);
+
+            set(input, "cache", input.cache ?? []);
+            input.cache.splice(cacheId + 1, 0, clonedInputs);
+
             this.onChangeForm();
         },
         repeatSwap(input, a, b) {

--- a/client/src/components/Form/FormListElementOperations.vue
+++ b/client/src/components/Form/FormListElementOperations.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { faCaretDown, faCaretUp, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { faCaretDown, faCaretUp, faCopy, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 import GButton from "@/components/BaseComponents/GButton.vue";
@@ -10,14 +10,18 @@ interface Props {
     numElements: number;
     upButtonId: string;
     downButtonId: string;
+    cloneButtonId: string;
     canDelete: boolean;
+    canClone: boolean;
     deleteTooltip: string;
+    cloneTooltip: string;
 }
 
 defineProps<Props>();
 
 const emit = defineEmits<{
     (e: "delete"): void;
+    (e: "clone"): void;
     (e: "swap-up"): void;
     (e: "swap-down"): void;
 }>();
@@ -48,6 +52,18 @@ const emit = defineEmits<{
             size="small"
             @click="() => emit('swap-down')">
             <FontAwesomeIcon :icon="faCaretDown" />
+        </GButton>
+        <GButton
+            :id="cloneButtonId"
+            :disabled="!canClone"
+            tooltip
+            tooltip-placement="bottom"
+            :title="cloneTooltip"
+            color="blue"
+            transparent
+            size="small"
+            @click="() => emit('clone')">
+            <FontAwesomeIcon :icon="faCopy" />
         </GButton>
         <GButton
             :disabled="!canDelete"

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -43,6 +43,12 @@ const deleteTooltip = computed(() => {
         : localize(`Click to delete ${props.input.title || "Repeat"} fields`);
 });
 
+const cloneTooltip = computed(() => {
+    return maxRepeats.value
+        ? localize(`Maximum number of ${props.input.title || "Repeat"} fields reached`)
+        : localize(`Click to clone ${props.input.title || "Repeat"} fields`);
+});
+
 const props = defineProps({
     input: {
         type: Object as PropType<Input>,
@@ -65,6 +71,7 @@ const props = defineProps({
 const emit = defineEmits<{
     (e: "insert"): void;
     (e: "delete", index: number): void;
+    (e: "clone", index: number): void;
     (e: "swap", a: number, b: number): void;
 }>();
 
@@ -74,6 +81,10 @@ function onInsert() {
 
 function onDelete(index: number) {
     emit("delete", index);
+}
+
+function onClone(index: number) {
+    emit("clone", index);
 }
 
 function getPrefix(index: number) {
@@ -102,8 +113,8 @@ async function swap(index: number, swapWith: number, direction: "up" | "down") {
     }
 }
 
-/** get a uid for the up/down button */
-function getButtonId(index: number, direction: "up" | "down") {
+/** get a uid for the up/down/clone button */
+function getButtonId(index: number, direction: "up" | "down" | "clone") {
     const prefix = getPrefix(index);
     return `${prefix}_${direction}`;
 }
@@ -133,10 +144,14 @@ const { keyObject } = useKeyedObjects();
                     :num-elements="props.input.cache?.length || 0"
                     :up-button-id="getButtonId(cacheId, 'up')"
                     :down-button-id="getButtonId(cacheId, 'down')"
+                    :clone-button-id="getButtonId(cacheId, 'clone')"
                     :delete-tooltip="deleteTooltip"
+                    :clone-tooltip="cloneTooltip"
                     :can-delete="minRepeats"
+                    :can-clone="!maxRepeats"
                     @swap-up="() => swap(cacheId, cacheId - 1, 'up')"
                     @swap-down="() => swap(cacheId, cacheId + 1, 'down')"
+                    @clone="() => onClone(cacheId)"
                     @delete="() => onDelete(cacheId)" />
             </template>
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -771,6 +771,7 @@ tool_form:
     repeat_insert: '[data-description="repeat insert"]'
     repeat_move_up: '#${parameter}_up'
     repeat_move_down: '#${parameter}_down'
+    repeat_clone: '#${parameter}_clone'
     section_header: '.ui-portlet-section .portlet-header'
     reference: '.formatted-reference'
     about: '.tool-footer'

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -180,7 +180,7 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         self.tool_set_value("the_repeat_2|texttest", "Cloned Text B")
         assert_input_order(["Text A", "Text B", "Cloned Text B", "Text C"])
 
-        # Validate for: "shared reference" independence holds in both directions
+        # Validate for: deep copy independence holds in both directions
         self.tool_set_value("the_repeat_1|texttest", "Edited Text B")
         assert_input_order(["Text A", "Edited Text B", "Cloned Text B", "Text C"])
 

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -156,6 +156,52 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_only("Not yet migrated to support Playwright backend")
     @selenium_test
+    def test_repeat_cloning(self):
+        self.home()
+        self.tool_open("text_repeat")
+
+        def assert_input_order(inputs: list[str]):
+            for index, input_value in enumerate(inputs):
+                parameter_input = self.components.tool_form.parameter_input(parameter=f"the_repeat_{index}|texttest")
+                assert parameter_input.wait_for_value() == input_value
+
+        self.components.tool_form.repeat_insert.wait_for_and_click()
+        self.tool_set_value("the_repeat_0|texttest", "Text A")
+        self.components.tool_form.repeat_insert.wait_for_and_click()
+        self.tool_set_value("the_repeat_1|texttest", "Text B")
+        self.components.tool_form.repeat_insert.wait_for_and_click()
+        self.tool_set_value("the_repeat_2|texttest", "Text C")
+
+        # Validate for: order of insertion
+        self.components.tool_form.repeat_clone(parameter="the_repeat_1").wait_for_and_click()
+        assert_input_order(["Text A", "Text B", "Text B", "Text C"])
+
+        # Validate for: deep copy, not a "shared reference"
+        self.tool_set_value("the_repeat_2|texttest", "Cloned Text B")
+        assert_input_order(["Text A", "Text B", "Cloned Text B", "Text C"])
+
+        # Validate for: "shared reference" independence holds in both directions
+        self.tool_set_value("the_repeat_1|texttest", "Edited Text B")
+        assert_input_order(["Text A", "Edited Text B", "Cloned Text B", "Text C"])
+
+        # Job parameters are recorded server-side, so this assertion is independent of the live form.
+        self.tool_form_execute()
+        self.history_panel_wait_for_hid_ok(1)
+
+        details = [d.text for d in self._get_dataset_tool_parameters(1)]
+        assert details == [
+            "texttest",
+            "Text A",
+            "texttest",
+            "Edited Text B",
+            "texttest",
+            "Cloned Text B",
+            "texttest",
+            "Text C",
+        ]
+
+    @selenium_only("Not yet migrated to support Playwright backend")
+    @selenium_test
     def test_rerun(self):
         self._run_environment_test_tool()
         self.history_panel_wait_for_hid_ok(1)


### PR DESCRIPTION
_Addresses #23082_ 

_screenshot:_
<img width="347" height="95" alt="Greenshot 2026-08-04 10 12 09" src="https://github.com/user-attachments/assets/7cea96a3-e950-47f7-a67b-82ba7a3a413e" />

_animation:_
<img width="600" height="974" alt="2026-07-28 10-07-26 2026-07-28 10_09_41" src="https://github.com/user-attachments/assets/e9905667-9c2a-4cec-ac6e-d1ac56791dd7" />

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
