### PR TITLE
[26.1] Tolerate libmagic non-utf-8 descriptions in FilePrefix sniffing

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -585,6 +585,14 @@ def guess_ext_from_file_name(fname, registry, requested_ext="auto"):
     return registry.get_datatype_from_filename(fname).file_ext
 
 
+def _detect_mime_and_encoding(detect, arg):
+    try:
+        file_magic = detect(arg)
+        return file_magic.mime_type, file_magic.encoding
+    except UnicodeDecodeError:
+        return "application/octet-stream", "binary"
+
+
 class FilePrefix:
     def __init__(self, filename, auto_decompress=True):
         non_utf8_error = None
@@ -612,15 +620,13 @@ class FilePrefix:
         self.truncated = truncated
         self.filename = filename
         self.non_utf8_error = non_utf8_error
-        file_magic = magic.detect_from_content(contents_header_bytes)
-        self.encoding = file_magic.encoding
-        self.mime_type = file_magic.mime_type
+        self.mime_type, self.encoding = _detect_mime_and_encoding(magic.detect_from_content, contents_header_bytes)
         self.compressed_mime_type = None
         self.compressed_encoding = None
         if compressed_format:
-            compressed_magic = magic.detect_from_filename(filename)
-            self.compressed_mime_type = compressed_magic.mime_type
-            self.compressed_encoding = compressed_magic.encoding
+            self.compressed_mime_type, self.compressed_encoding = _detect_mime_and_encoding(
+                magic.detect_from_filename, filename
+            )
         self.compressed_format = compressed_format
         self.contents_header = contents_header
         self.contents_header_bytes = contents_header_bytes

--- a/test/unit/data/datatypes/test_sniff.py
+++ b/test/unit/data/datatypes/test_sniff.py
@@ -7,6 +7,7 @@ from galaxy.datatypes.sniff import (
     convert_newlines,
     convert_newlines_sep2tabs,
     convert_sep2tabs,
+    FilePrefix,
     get_test_fname,
 )
 
@@ -109,3 +110,18 @@ def test_infer_from_filename():
     assert datatypes_registry.get_datatype_from_filename("mycool.fq").file_ext == "fastqsanger"
     assert datatypes_registry.get_datatype_from_filename("mycool.fq.gz").file_ext == "fastqsanger.gz"
     assert datatypes_registry.get_datatype_from_filename("mycool.fastq").file_ext == "fastqsanger"
+
+
+def test_file_prefix_tolerates_magic_unicode_error(monkeypatch):
+    import magic
+
+    def raise_unicode_error(_content):
+        raise UnicodeDecodeError("utf-8", b"\x80", 0, 1, "invalid start byte")
+
+    monkeypatch.setattr(magic, "detect_from_content", raise_unicode_error)
+    with tempfile.NamedTemporaryFile(delete=False, mode="wb") as tf:
+        tf.write(b"\x80\x81\x82\x83")
+    file_prefix = FilePrefix(tf.name)
+    assert file_prefix.binary
+    assert file_prefix.mime_type == "application/octet-stream"
+    assert file_prefix.encoding == "binary"


### PR DESCRIPTION
Fixes #23146.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
