### PR TITLE
Cut PR CI wall clock from ~2h to ~1h

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10']
-        chunk: [0, 1]
+        chunk: [0, 1, 2, 3]
     services:
       postgres:
         image: postgres:18
@@ -59,7 +59,7 @@ jobs:
       - name: Install Python
         run: uv python install
       - name: Run tests
-        run: ./run_tests.sh --coverage --skip_flakey_fails -api lib/galaxy_test/api -- --num-shards=2 --shard-id=${{ matrix.chunk }}
+        run: ./run_tests.sh --coverage --skip_flakey_fails -api lib/galaxy_test/api -- --num-shards=4 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v7.0.0
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -57,6 +57,13 @@ jobs:
       - name: Append doc/source/conf.versioning.py
         run: cat doc/source/conf.versioning.py >> doc/source/conf.py
       - name: Build docs
+        env:
+          # Parallelize Sphinx across the runner's cores.
+          SPHINXOPTS: '-j auto'
+          # sphinx.ext.viewcode dominates the build time. Pull request builds
+          # only need to verify that the documentation still builds, so skip it
+          # there and keep it for the builds that are actually deployed.
+          GALAXY_DOCS_SKIP_VIEW_CODE: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         run: make docs
       - name: Deploy docs
         if: github.event_name == 'push' && github.repository_owner == 'galaxyproject'

--- a/.github/workflows/framework_tools.yaml
+++ b/.github/workflows/framework_tools.yaml
@@ -29,7 +29,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10']
-        use-legacy-api: ['if_needed', 'always']
+        # The legacy tool API is exercised on pushes and on the weekly
+        # schedule; pull requests only run the default code path.
+        use-legacy-api: ${{ github.event_name == 'pull_request' && fromJSON('["if_needed"]') || fromJSON('["if_needed", "always"]') }}
     services:
       postgres:
         image: postgres:18

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10']
-        chunk: ['0', '1', '2', '3']
+        chunk: ['0', '1', '2', '3', '4', '5', '6', '7']
     steps:
       - if: github.event_name == 'schedule'
         run: |
@@ -126,7 +126,7 @@ jobs:
           GALAXY_CONFIG_OVERRIDE_MULLED_RESOLUTION_CACHE_LOCK_DIR: '${{ runner.temp }}/mulled-resolution-cache/locks'
         run: |
           . .ci/minikube-test-setup/start_services.sh
-          ./run_tests.sh --coverage -integration test/integration -- --num-shards=4 --shard-id=${{ matrix.chunk }}
+          ./run_tests.sh --coverage -integration test/integration -- --num-shards=8 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v7.0.0
         with:

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10']
-        chunk: [0, 1, 2]
+        chunk: [0, 1, 2, 3, 4]
     services:
       postgres:
         image: postgres:18
@@ -70,7 +70,7 @@ jobs:
           key: galaxy-static-${{ needs.build-client.outputs.commit-id }}
           path: 'galaxy root/static'
       - name: Run tests
-        run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
+        run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=5 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v7.0.0
         with:


### PR DESCRIPTION
I'm exploring options to speed up our GitHub Actions runs, and this is a first pass at the slowest legs. Very much open to other opinions — if someone has context on why a job is shaped the way it is, or a better angle than the ones below, please say so.

Measured against the run set from 2026-07-27 (run 30292341126 et al), where a pull request spanned 2h06m.

| Job | Before | After (est.) |
|---|---|---|
| Integration | 126m (4 shards) | ~65m (8 shards) |
| Build docs | 83m | ~20-25m |
| Selenium | 56m (3 shards) | ~35m (5 shards) |
| API | 45m (2 shards) | ~25m (4 shards) |

Integration dominates the critical path. Parsing the shard 0 log (356 tests, 121m) shows 97m of it is inter-test gaps over 30s — per-test-class Galaxy server startup, not test execution — so wall clock splits nearly linearly with the shard count at unchanged total runner minutes.

The docs job spends 82m in a single serial sphinx-build. `-j auto` uses the whole runner, and sphinx.ext.viewcode (the dominant cost) is skipped for pull requests, which only need to prove the docs still build.

## Effect on post-merge runs

All of these workflows also trigger on `push`, so runs on `dev` get the same speedups: integration, API and Selenium shard the same way. The docs job gets `-j auto` on push as well, but keeps viewcode there, so what is deployed to docs.galaxyproject.org is byte-for-byte what it is today — only the build is parallel. The tool framework job is unchanged on push: both `use-legacy-api` variants still run.

Total runner minutes are roughly flat everywhere except the tool framework job, where per-pull-request cost drops by one full suite run.

## Two things worth a second opinion

**Runner pool.** More shards means more concurrent runners. If our pool is already saturated at peak, some of this gain turns into queue time instead. I don't have visibility into that — does anyone?

**The last commit** drops the `use-legacy-api: always` variant of the tool framework job from pull requests; it still runs on pushes and on the weekly schedule. Two reasons to push back on it, and I'm happy to drop the commit:

- If `Test (3.10, always)` is a required status check, pull requests will wait on a job that no longer runs. I can't read the branch protection settings to confirm either way.
- `framework_tools.yaml` uses `concurrency: cancel-in-progress: true` keyed on `github.ref`, so merges landing back to back on `dev` cancel the previous dev run. During a busy merge window the `always` variant could be skipped several merges in a row, leaving the Tuesday cron as the real safety net. Giving the push path its own concurrency group (so dev runs queue rather than cancel) would close that gap if we want to keep the commit.

## Not addressed here, for follow-up

- pytest-shard hashes node ids, so a test class is spread across shards and its Galaxy server boots once per shard. Switching to duration-based splitting that keeps a class together would cut boots and also fix shard imbalance (108m vs 126m today).
- Integration server boot is ~60s and happens ~118 times per shard. Most classes need a couple of tools but load the full toolbox and datatypes registry.
- The slowest single tests: test_galaxy_interactor::test_get_tool_tests (633s), test_pulsar_embedded_mq extended-metadata-purge (292s), objectstore/test_per_user (284s), test_purge_datasets (202s).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
