### PR TITLE
[26.1] Use a thread-safe libmagic handle when sniffing datasets

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -60,6 +60,18 @@ BINARY_MIMETYPES = {
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 }
 
+# A libmagic cookie builds its description in a buffer it owns and returns a pointer
+# to it, so it cannot be used from more than one thread at a time or the description
+# comes back torn. Datasets are sniffed concurrently (celery runs a thread pool), so
+# go through `magic.Magic`, which locks around every libmagic call.
+_MAGIC = magic.Magic(mime=True, mime_encoding=True)
+
+
+def _split_magic_description(description: str) -> tuple[str, str]:
+    """Split a libmagic ``<mime type>; charset=<encoding>`` description in two."""
+    mime_type, _, encoding = description.partition("; ")
+    return mime_type, encoding.removeprefix("charset=")
+
 
 def get_test_fname(fname):
     """Returns test data filename"""
@@ -612,15 +624,11 @@ class FilePrefix:
         self.truncated = truncated
         self.filename = filename
         self.non_utf8_error = non_utf8_error
-        file_magic = magic.detect_from_content(contents_header_bytes)
-        self.encoding = file_magic.encoding
-        self.mime_type = file_magic.mime_type
+        self.mime_type, self.encoding = _split_magic_description(_MAGIC.from_buffer(contents_header_bytes))
         self.compressed_mime_type = None
         self.compressed_encoding = None
         if compressed_format:
-            compressed_magic = magic.detect_from_filename(filename)
-            self.compressed_mime_type = compressed_magic.mime_type
-            self.compressed_encoding = compressed_magic.encoding
+            self.compressed_mime_type, self.compressed_encoding = _split_magic_description(_MAGIC.from_file(filename))
         self.compressed_format = compressed_format
         self.contents_header = contents_header
         self.contents_header_bytes = contents_header_bytes

--- a/test/unit/data/datatypes/test_sniff.py
+++ b/test/unit/data/datatypes/test_sniff.py
@@ -1,3 +1,4 @@
+import gzip
 import tempfile
 
 import pytest
@@ -7,6 +8,7 @@ from galaxy.datatypes.sniff import (
     convert_newlines,
     convert_newlines_sep2tabs,
     convert_sep2tabs,
+    FilePrefix,
     get_test_fname,
 )
 
@@ -109,3 +111,17 @@ def test_infer_from_filename():
     assert datatypes_registry.get_datatype_from_filename("mycool.fq").file_ext == "fastqsanger"
     assert datatypes_registry.get_datatype_from_filename("mycool.fq.gz").file_ext == "fastqsanger.gz"
     assert datatypes_registry.get_datatype_from_filename("mycool.fastq").file_ext == "fastqsanger"
+
+
+def test_file_prefix_detects_mime_type_of_compressed_file(tmp_path):
+    path = tmp_path / "sample.txt.gz"
+    with gzip.open(path, "wt") as fh:
+        fh.write("1\t2\n3\t4\n")
+
+    file_prefix = FilePrefix(str(path))
+
+    assert file_prefix.compressed_format == "gzip"
+    assert file_prefix.compressed_mime_type == "application/gzip"
+    assert file_prefix.compressed_encoding == "binary"
+    assert file_prefix.mime_type == "text/plain"
+    assert file_prefix.encoding == "us-ascii"


### PR DESCRIPTION
Fixes #23146. Alternative to #23197.

The `UnicodeDecodeError` in that Sentry issue is not raised on the dataset — it is raised on libmagic's own description string:

```
magic/compat.py:161  in buffer     return Magic.__tostr(_buffer(...))
magic/compat.py:124  in __tostr    return str(s, 'utf-8')
```

The frame is the `MAGIC_MIME` cookie, and the dataset in the event is plain ASCII FastQC output, so the description could only ever have been `text/plain; charset=us-ascii`. It came back as `0x80...` because it was corrupted, not because it was exotic.

A libmagic cookie builds its description in a buffer it owns and returns a pointer into that buffer, so a single cookie cannot serve two threads at once. `magic.detect_from_content()` and `magic.detect_from_filename()` are python-magic's compatibility shims over `magic/compat.py`, which holds two process-wide cookies and takes no lock. `magic.Magic`, the supported API, takes `self.lock` around every libmagic call for exactly this reason.

Celery on main runs `--pool threads --concurrency 8`, and `FilePrefix.__init__` sniffs straight through the unguarded shims.

Standalone reproduction: https://gist.github.com/mvdbeek/9a4f649c8eb3cb10099eaa3ea6c565af — same buffers, 8 threads, 300 iterations each:

| | result |
|---|---|
| `magic.Magic.from_buffer` (locked) | clean, 0 errors, correct mime types |
| `magic.detect_from_content` (today) | SIGSEGV / SIGABRT, exit 133–139 |

The `UnicodeDecodeError` is the benign outcome here. The other two are a segfaulted worker, and — worse — a torn description that still decodes and yields the wrong mime type. `Docx`, `Xlsx` and `Pptx` sniff purely on `compressed_mime_type` and `ExcelXls` on `mime_type`, so a silently wrong value there means a silently wrong datatype.

This routes both lookups through a single locked `magic.Magic` instance. The description format is `<mime type>; charset=<encoding>`, which is what `compat.py` was parsing anyway, so the values are unchanged — verified identical in the reproduction above and by the existing datatype tests.

Moving off the compat shims also stops the `PendingDeprecationWarning` emitted on every sniff.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

The added unit test covers the compressed path (`from_file`) and the buffer path (`from_buffer`) against a gzipped file. The thread-safety property itself is left to the linked gist rather than a unit test — a regression reproduces as a segfault, which is not something worth running in CI.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
