### PR TITLE
Fix "Step NaN" step titles in the workflow invocation Report tab

### DIFF
--- a/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.test.js
+++ b/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.test.js
@@ -1,7 +1,8 @@
+import { createTestingPinia } from "@pinia/testing";
 import { getLocalVue } from "@tests/vitest/helpers";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HttpResponse, useServerMock } from "@/api/client/__mocks__";
 
@@ -16,10 +17,7 @@ beforeEach(() => {
     getRequests = [];
 });
 
-function mountDefault() {
-    const data = {
-        name: "workflow_name",
-    };
+function mountDefault(data = { name: "workflow_name" }) {
     server.use(
         http.untyped.get("/api/workflows/workflow_id/download", ({ request }) => {
             getRequests.push({ url: request.url });
@@ -33,6 +31,12 @@ function mountDefault() {
             expanded: false,
         },
         localVue,
+        pinia: createTestingPinia({ createSpy: vi.fn }),
+        stubs: {
+            FontAwesomeIcon: true,
+            "b-popover": true,
+            "router-link": true,
+        },
     });
 }
 
@@ -68,6 +72,30 @@ describe("WorkflowDisplay", () => {
         expect(getRequests.length).toBe(1);
         expect(getRequests[0].url).toContain("/api/workflows/workflow_id/download");
         expect(getRequests[0].url).toContain("style=preview");
+    });
+
+    it("renders numbered step titles from preview steps", async () => {
+        const wrapper = mountDefault({
+            name: "workflow_name",
+            steps: [
+                { order_index: 0, type: "data_input", label: "Input dataset", inputs: [] },
+                {
+                    order_index: 1,
+                    type: "tool",
+                    label: "My cool tool",
+                    tool_id: "cat1",
+                    tool_version: "1.0",
+                    inputs: [],
+                },
+                { order_index: 2, type: "subworkflow", label: "My subworkflow", inputs: [] },
+            ],
+        });
+        await flushPromises();
+        const text = wrapper.text();
+        expect(text).toContain("Step 1: Input dataset");
+        expect(text).toContain("Step 2: My cool tool");
+        expect(text).toContain("Step 3: My subworkflow");
+        expect(text).not.toContain("NaN");
     });
 
     it("error message as object", async () => {

--- a/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.test.js
+++ b/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.test.js
@@ -77,8 +77,8 @@ describe("WorkflowDisplay", () => {
     it("renders numbered step titles from preview steps", async () => {
         const wrapper = mountDefault({
             name: "workflow_name",
+            // deliberately out of array order to prove numbering comes from order_index
             steps: [
-                { order_index: 0, type: "data_input", label: "Input dataset", inputs: [] },
                 {
                     order_index: 1,
                     type: "tool",
@@ -88,6 +88,7 @@ describe("WorkflowDisplay", () => {
                     inputs: [],
                 },
                 { order_index: 2, type: "subworkflow", label: "My subworkflow", inputs: [] },
+                { order_index: 0, type: "data_input", label: "Input dataset", inputs: [] },
             ],
         });
         await flushPromises();

--- a/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.vue
@@ -2,6 +2,7 @@
 import axios from "axios";
 import { computed, ref, watch } from "vue";
 
+import { getStepTitle } from "@/components/WorkflowInvocationState/util";
 import { withPrefix } from "@/utils/redirect";
 import { isEmpty } from "@/utils/utils";
 
@@ -9,7 +10,6 @@ import WorkflowTree from "./WorkflowTree.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import ToolLinkPopover from "@/components/Tool/ToolLinkPopover.vue";
 import WorkflowStepIcon from "@/components/WorkflowInvocationState/WorkflowStepIcon.vue";
-import WorkflowStepTitle from "@/components/WorkflowInvocationState/WorkflowStepTitle.vue";
 
 interface WorkflowDisplayProps {
     workflowId: string;
@@ -28,6 +28,12 @@ type ItemContent = {
     name: string;
     steps: Array<any>; // This isn't actually a proper workflow step type, right?  TODO, unify w/ workflowStepStore?
 };
+
+// preview-style steps carry order_index and a server-resolved label rather
+// than the id/tool fields WorkflowStepTitle expects
+function stepTitle(step: any): string {
+    return getStepTitle(step.order_index, step.type, step.label || undefined);
+}
 
 const errorContent = ref();
 const itemContent = ref<ItemContent | null>(null);
@@ -123,7 +129,7 @@ watch(
                             :target="`step-icon-${step.order_index}`"
                             :tool-id="step.tool_id"
                             :tool-version="step.tool_version" />
-                        <WorkflowStepTitle :workflow-step="step" />
+                        <span>{{ stepTitle(step) }}</span>
                         <WorkflowTree :input="step" :skip-head="true" />
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #23056.

The workflow preview embedded in invocation reports (and anywhere else `workflow_display` renders) shows every step as "Step NaN: ...". #22476 refactored `WorkflowStepTitle` to take a whole workflow step object and read `workflowStep.id`, but `WorkflowDisplay` feeds it steps from the preview-style download API (`/api/workflows/{id}/download?style=preview`), which carry `order_index` and no `id` -- so the one-based index math came out as NaN.

The preview payload already resolves every step label server-side (tool name, subworkflow name, module name, or the step's custom label), so routing it through `WorkflowStepTitle`'s store lookups wasn't just broken on the numbering -- it also dropped information; subworkflow steps, for example, fell back to a generic "Subworkflow" instead of their actual name. `WorkflowDisplay` now builds titles directly from `order_index` and the preview label via the shared `getStepTitle` helper, which restores the behavior from before the refactor.

The first commit adds a component test that mounts `WorkflowDisplay` with preview-shaped steps and asserts on the numbered titles -- it fails with "Step NaN" before the fix. The steps in the fixture are deliberately out of array order so the assertions only pass when numbering comes from `order_index`.

## How to test

- Run any workflow, open the invocation, and switch to the Report tab: step titles should read "Step 1: ...", "Step 2: ..." instead of "Step NaN: ...".
- `pnpm test src/components/Markdown/Sections/Elements/Workflow/WorkflowDisplay.test.js` from `client/`.
