### PR TITLE
Fix invocation view header styling broken by the addition of `NavigationTitle` in dev

### DIFF
--- a/client/src/components/Common/NavigationTitle.vue
+++ b/client/src/components/Common/NavigationTitle.vue
@@ -27,7 +27,7 @@ const emit = defineEmits<{
 <template>
     <div>
         <div class="bg-secondary px-2 py-1 rounded d-flex flex-gapx-1 justify-content-between">
-            <div class="py-1 d-flex flex-wrap align-items-center flex-gapx-1" :data-description="headingDescription">
+            <div class="py-1 align-items-center flex-gapx-1" :data-description="headingDescription">
                 <GButton
                     v-if="collapsible"
                     transparent
@@ -39,7 +39,7 @@ const emit = defineEmits<{
                     <FontAwesomeIcon :icon="collapsed ? faAngleDoubleDown : faAngleDoubleUp" fixed-width />
                 </GButton>
                 <slot name="before-icon" />
-                <FontAwesomeIcon :icon="icon" fixed-width />
+                <FontAwesomeIcon class="mr-1" :icon="icon" fixed-width />
                 <slot name="title">
                     <b>{{ title }}</b>
                 </slot>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -577,7 +577,6 @@ async function onCancel() {
     // progress bar shrinks to fit divs on either side
     flex-grow: 1;
     flex-shrink: 1;
-    max-width: 50%;
 
     .steps-progress,
     .jobs-progress {


### PR DESCRIPTION
The `client/src/components/Common/NavigationTitle.vue` component was added which reverted the styling fix for the `client/src/components/Workflow/WorkflowNavigationTitle.vue` done in https://github.com/galaxyproject/galaxy/pull/22639.

| Before | After |
| ---- | ---- |
| <img width="664" height="152" alt="image" src="https://github.com/user-attachments/assets/bc81c61b-48b0-4064-8c46-e75321eb6bcb" /> | <img width="664" height="112" alt="image" src="https://github.com/user-attachments/assets/3a063fc8-d0f8-4238-bd3e-a4b0bc055653" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
