### PR TITLE
[26.1] Prevent and tolerate duplicate private roles

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1301,6 +1301,20 @@ ON CONFLICT
 
     def attempt_create_private_role(self):
         session = required_object_session(self)
+        if self.id is not None:
+            # Two requests logging in the same user concurrently would each find no
+            # private role and each insert one; a user with more than one private role
+            # is in an inconsistent state that no code path can resolve. Take a row lock
+            # on the user so the loser of the race re-checks after the winner commits.
+            session.execute(select(User.id).where(User.id == self.id).with_for_update())
+            stmt = (
+                select(Role.id)
+                .join(UserRoleAssociation, Role.id == UserRoleAssociation.role_id)
+                .where(and_(UserRoleAssociation.user_id == self.id, Role.type == Role.types.PRIVATE))
+            )
+            if session.scalars(stmt).first() is not None:
+                session.commit()  # release the lock
+                return
         role = Role(type=Role.types.PRIVATE)
         assoc = UserRoleAssociation(self, role)
         session.add(assoc)

--- a/lib/galaxy/model/db/role.py
+++ b/lib/galaxy/model/db/role.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import (
     Callable,
     Iterable,
@@ -18,6 +19,8 @@ from galaxy.model import (
 )
 from galaxy.model.scoped_session import galaxy_scoped_session
 
+log = logging.getLogger(__name__)
+
 
 def get_npns_roles(session):
     """
@@ -32,6 +35,15 @@ def get_npns_roles(session):
 
 
 def get_private_user_role(user, session):
+    """Return the user's private role, or None.
+
+    A user is supposed to have exactly one private role. Databases in the wild
+    contain users with more than one, which used to make every code path that
+    resolves a private role (including login) raise MultipleResultsFound. We
+    always pick the oldest role instead, so that all callers agree on which
+    role is *the* private role, and so that the role picked is the one existing
+    dataset permissions are most likely to reference.
+    """
     stmt = (
         select(Role)
         .where(
@@ -42,8 +54,18 @@ def get_private_user_role(user, session):
             )
         )
         .distinct()
+        .order_by(Role.id)
     )
-    return session.execute(stmt).scalar_one_or_none()
+    roles = session.scalars(stmt).all()
+    if len(roles) > 1:
+        log.error(
+            "User %s has %d private roles (%s); using role %s. Duplicate private roles should be removed by an administrator.",
+            user.id,
+            len(roles),
+            [role.id for role in roles],
+            roles[0].id,
+        )
+    return roles[0] if roles else None
 
 
 def get_roles_by_ids(session: galaxy_scoped_session, role_ids):

--- a/test/unit/data/model/db/test_role.py
+++ b/test/unit/data/model/db/test_role.py
@@ -1,4 +1,9 @@
-from galaxy.model import Role
+from sqlalchemy import select
+
+from galaxy.model import (
+    Role,
+    UserRoleAssociation,
+)
 from galaxy.model.db.role import (
     get_displayable_roles,
     get_npns_roles,
@@ -35,6 +40,34 @@ def test_get_private_user_role(session, make_user, make_role, make_user_role_ass
 
     role = get_private_user_role(u1, session)
     assert role is r1
+
+
+def test_get_private_user_role_with_duplicate_private_roles(session, make_user, make_role, make_user_role_association):
+    user = make_user()
+    r1 = make_role(type=Role.types.PRIVATE)
+    r2 = make_role(type=Role.types.PRIVATE)
+    make_user_role_association(user, r1)
+    make_user_role_association(user, r2)
+
+    assert len(session.scalars(_private_roles_stmt(user)).all()) == 2
+    assert get_private_user_role(user, session) is r1
+
+
+def test_attempt_create_private_role_does_not_create_a_second_private_role(session, make_user):
+    user = make_user()
+
+    user.attempt_create_private_role()
+    user.attempt_create_private_role()
+
+    assert len(session.scalars(_private_roles_stmt(user)).all()) == 1
+
+
+def _private_roles_stmt(user):
+    return (
+        select(Role)
+        .join(UserRoleAssociation, Role.id == UserRoleAssociation.role_id)
+        .where(UserRoleAssociation.user_id == user.id, Role.type == Role.types.PRIVATE)
+    )
 
 
 def test_get_roles_by_ids(session, make_role):


### PR DESCRIPTION
Fixes #23205

Two concurrent logins for the same user each find no private role and each insert one, leaving the user with two distinct private roles. `get_private_user_role()` then raises `MultipleResultsFound` and the user can no longer log in.

This is a different failure from the duplicate `UserRoleAssociation` rows fixed in 24.2 (#18777): there the associations pointed at the *same* role, and the unique constraint on `user_role_association(user_id, role_id)` plus the data fix-up handled it. Here the associations point at *different* roles, so nothing is violated and neither the constraint nor the `.distinct()` added in #17854 helps. Galaxy Australia sees this on roughly 1 in 1000 registrations since switching to external auth.

- `attempt_create_private_role()` takes a row lock on `galaxy_user` and re-checks for an existing private role before inserting, so the loser of the race stops instead of creating a second one. SQLAlchemy's SQLite dialect omits `FOR UPDATE`, which is fine since SQLite serializes writes.
- `get_private_user_role()` returns the oldest private role instead of raising when a user already has more than one, and logs an error naming the user and the role ids. Affected users can log in without a database fix-up first, and every caller agrees on which role is *the* private role. The oldest is also the role that existing dataset permissions are most likely to reference.

This deliberately does not merge the leftover duplicate roles. Doing so means re-pointing `dataset_permissions` / `default_user_permissions` / `default_history_permissions` rows from the discarded role to the kept one, and getting that wrong silently strips a user's access to their own datasets — the 24.2 data fixes only ever deleted redundant rows, never merged references. Admins can find and clean up affected users with the queries in #23205. If it turns out many instances are affected we can add a data-fix migration separately.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

Both new tests in `test/unit/data/model/db/test_role.py` fail without the change (`MultipleResultsFound`, and two private roles instead of one).

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
