### PR TITLE
Build the documentation in parallel by default

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -57,6 +57,11 @@ jobs:
       - name: Append doc/source/conf.versioning.py
         run: cat doc/source/conf.versioning.py >> doc/source/conf.py
       - name: Build docs
+        env:
+          # sphinx.ext.viewcode is not parallelized and dominates the build.
+          # Pull request builds only need to prove the documentation still
+          # builds, so skip it there and keep it for the deployed builds.
+          GALAXY_DOCS_SKIP_VIEW_CODE: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         run: make docs
       - name: Deploy docs
         if: github.event_name == 'push' && github.repository_owner == 'galaxyproject'

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ docs: ## Generate HTML documentation.
 	$(IN_VENV) $(MAKE) -C doc html
 
 docs-develop: ## Fast doc generation and more warnings (for development)
-	$(IN_VENV) GALAXY_DOCS_SKIP_VIEW_CODE=1 SPHINXOPTS='-j 4' $(MAKE) -C doc html
+	$(IN_VENV) GALAXY_DOCS_SKIP_VIEW_CODE=1 $(MAKE) -C doc html
 
 setup-venv:
 	if [ ! -f $(VENV)/bin/activate ]; then bash scripts/common_startup.sh --dev-wheels; fi

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,8 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?=
+# Build in parallel by default; override with `SPHINXOPTS=` for a serial build.
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build


### PR DESCRIPTION
Split out of #23198 (https://github.com/galaxyproject/galaxy/pull/23198#issuecomment-5105842289).

The docs job takes ~83m on a pull request, ~82m of which is a single serial sphinx-build.

`-j auto` is now the default in `doc/Makefile` rather than a CI-only flag, so `make docs` and local builds get it too; `SPHINXOPTS=` still gives a serial build, and `docs-develop` no longer needs its own `-j 4`.

sphinx.ext.viewcode is not parallelized — 45ed3178327c651ce9267838a2078c48ed775883 added `GALAXY_DOCS_SKIP_VIEW_CODE` for that exact reason — so the workflow skips it for pull requests, which only need to prove the documentation still builds. Pushes, which are what gets deployed to docs.galaxyproject.org, keep the embedded highlighted source.

Measured on the run in #23198: 83m → 15m.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
