### PR TITLE
Fix collection wizard SCSS not compiling, clear own-source client build warnings

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,18 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "vue-demi"
+    ],
+    "ignoredBuiltDependencies": [
+      "@fortawesome/fontawesome-common-types",
+      "@fortawesome/fontawesome-free",
+      "@fortawesome/fontawesome-svg-core",
+      "@fortawesome/free-brands-svg-icons",
+      "@fortawesome/free-regular-svg-icons",
+      "@fortawesome/free-solid-svg-icons",
+      "@parcel/watcher",
+      "bootstrap-vue",
+      "core-js-pure",
+      "msw"
     ]
   },
   "dependencies": {

--- a/client/src/components/Collections/SampleSheetWizard.vue
+++ b/client/src/components/Collections/SampleSheetWizard.vue
@@ -490,7 +490,7 @@ async function download() {
     </GenericWizard>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 @import "@/components/Collections/wizard/workbook-dropzones.scss";
 
 .dropzone {

--- a/client/src/components/Collections/wizard/CardUploadWorkbook.vue
+++ b/client/src/components/Collections/wizard/CardUploadWorkbook.vue
@@ -47,7 +47,7 @@ const emit = defineEmits(["workbookContents"]);
     </BCard>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 @import "@/style/scss/theme/blue.scss";
 @import "@/components/Collections/wizard/workbook-dropzones.scss";
 

--- a/client/src/components/Collections/wizard/PasteData.vue
+++ b/client/src/components/Collections/wizard/PasteData.vue
@@ -49,7 +49,7 @@ const handleDrop = (event: DragEvent) => {
     </div>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 @import "@/style/scss/theme/blue.scss";
 
 .paste-data {

--- a/client/src/style/scss/select2.scss
+++ b/client/src/style/scss/select2.scss
@@ -5,9 +5,6 @@ Version: 3.5.1 Timestamp: Tue Jul 22 18:58:56 EDT 2014
     margin: 0;
     position: relative;
     display: inline-block;
-    /* inline-block for ie7 */
-    zoom: 1;
-    *display: inline;
     vertical-align: middle;
 }
 

--- a/client/src/style/scss/unsorted.scss
+++ b/client/src/style/scss/unsorted.scss
@@ -724,25 +724,6 @@ div.toolSectionTitle {
 
 // @import "base_sprites";
 
-.text-and-autocomplete-select {
-    // -sprite-group: fugue;
-    // -sprite-image: fugue/control-270@extend png;
-    // -sprite-horiz-position: right;
-    background: none;
-    position: relative;
-    padding-right: 18px;
-    &:after {
-        margin-top: 6px;
-        position: absolute;
-        top: 2px;
-        right: 6px;
-        width: 10px;
-        height: 10px;
-        @include caret();
-        @include opacity(80);
-    }
-}
-
 .icon-button.general-question {
     background: url(../../assets/images/question-octagon-frame.png) no-repeat;
     float: right;


### PR DESCRIPTION
Three `<style scoped>` blocks in the collection wizards import SCSS partials and use SCSS variables, but they were missing `lang="scss"`. Vite therefore handled them as plain CSS: the variables were never resolved and got emitted verbatim into `dist/base.css`, where browsers discard them as invalid declarations.

```css
/* dev branch, dist/base.css */
.paste-data textarea[data-v-ca04421f]{resize:none;width:100%;height:300px;font-size:$font-size-base;border-radius:$border-radius-large;border-color:$border-color;border-width:2px}
```

So the paste-data textarea has been shipping without its intended font size, border radius and border colour. Same for the `.dropzone.highlight` rules pulled in from `workbook-dropzones.scss`, which is imported by two of the affected components.

Adding `lang="scss"` fixes the output and also removes the `[vite:css][postcss] .../style/scss/theme/blue.scss is empty` build warning — that warning came from postcss-import inlining a variables-only file, which naturally produces no CSS.

While in there, this PR also clears the remaining build warnings that originate in our own stylesheets:

- `.text-and-autocomplete-select` in `unsorted.scss` nested `@include caret()` inside `&:after`, so it emitted `:after::after` and `:after:empty::after`. Those are invalid selectors and lightningcss warned about them in every chunk. The class has no usages left anywhere in the repo, so the rule is removed rather than repaired.
- The vendored select2 stylesheet still carried the IE7 `*display` / `zoom: 1` hack, which is a parse error for lightningcss.
- pnpm 10 warns about every dependency whose install scripts it blocks. None of the listed packages need theirs, so they are recorded in `ignoredBuiltDependencies` to keep install output readable.

Measured on a full `NODE_ENV=production vite build`:

| | before | after |
| --- | --- | --- |
| `lightningcss minify` warnings | 24 | 8 |
| `blue.scss is empty` warnings | 2 | 0 |
| unresolved `$scss-variables` in `dist/base.css` | 4 | 0 |
| pnpm `Ignored build scripts` warning | yes | no |

The 8 remaining lightningcss warnings come from dependencies and cannot be fixed here: `handsontable@4.0.0` bundles pikaday 1.5.1 with more IE7 star hacks, and `vue-multiselect@2.1.7` ships a `::webkit-scrollbar` typo.

Resulting CSS for the textarea:

```css
.paste-data textarea[data-v-bb13e0e1]{resize:none;border-width:2px;border-color:#bdc6d0;border-radius:.3125rem;width:100%;height:300px;font-size:.85rem}
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `make client-production`, and confirm the build no longer prints `blue.scss is empty`, `:after::after` or `:after:empty::after` warnings.
  2. `grep -c 'border-color:\$border-color' client/dist/base.css` returns 0 (returns 1 on `dev`).
  3. In the UI, open Upload → Collection wizard → Paste data. The textarea now picks up the theme border colour, border radius and base font size; dragging a file over a dropzone shows the dashed highlight border.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
