### PR TITLE
Consume data-manager bundles for tables without a dbkey column

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -899,8 +899,11 @@ class DynamicOptions:
         path_headers = get_path_headers(None, table_name)
         table_entries = {}
         for value in hda._metadata["data_tables"][table_name]:
-            if dbkey := value.get("dbkey"):
-                table_entries[dbkey] = value
+            # Key entries by dbkey when the table has one; otherwise fall back to
+            # the ``value`` column so tables without a dbkey column (e.g. motus,
+            # dada2_species) are still consumable from a data-manager bundle.
+            if entry_key := (value.get("dbkey") or value.get("value")):
+                table_entries[entry_key] = value
             for header in path_headers:
                 if path := value.get(header):
                     # maybe a hack, should probably pass around dataset or src id combinations ?

--- a/test/unit/app/tools/test_dynamic_options.py
+++ b/test/unit/app/tools/test_dynamic_options.py
@@ -62,6 +62,57 @@ def test_dynamic_option_cache():
     assert from_url_option.get_options(trans, {}) == [ParameterOption("chr2L", "23513712", False)]
 
 
+def test_hda_to_table_entries_without_dbkey():
+    """A data-manager bundle whose table has no dbkey column (e.g. motus,
+    dada2_species) must still yield a table entry - keyed by its ``value``
+    column - so it can be consumed by a downstream tool in a workflow (the
+    data-manager bundle chain). Previously such entries were dropped, leaving
+    the downstream select param with "no legal values defined"."""
+    hda = Bunch(
+        extra_files_path="/bundle/extra",
+        _metadata={
+            "data_tables": {
+                "motus_db_versioned": [
+                    {
+                        "value": "db_from_2026-04-27T094930Z",
+                        "version": "3.1.0",
+                        "name": "mOTUs DB version 3.1.0",
+                        "path": "db_from_2026-04-27T094930Z",
+                    }
+                ]
+            }
+        },
+    )
+    entries = DynamicOptions.hda_to_table_entries(hda, "motus_db_versioned")
+    assert list(entries) == ["db_from_2026-04-27T094930Z"]
+    entry = entries["db_from_2026-04-27T094930Z"]
+    # the path column is relocated under the bundle's extra_files_path
+    assert entry["path"] == "/bundle/extra/db_from_2026-04-27T094930Z"
+    assert entry["__hda__"] is hda
+
+
+def test_hda_to_table_entries_prefers_dbkey():
+    """When the table has a dbkey column it is still used as the entry key."""
+    hda = Bunch(
+        extra_files_path="/bundle/extra",
+        _metadata={
+            "data_tables": {
+                "metaphlan_database_versioned": [
+                    {
+                        "value": "mpa_vJan21_CHOCOPhlAnSGB_202103-04042023",
+                        "name": "MetaPhlAn clade-specific marker genes",
+                        "dbkey": "mpa_vJan21_CHOCOPhlAnSGB_202103",
+                        "path": "mpa_vJan21_CHOCOPhlAnSGB_202103",
+                        "db_version": "SGB",
+                    }
+                ]
+            }
+        },
+    )
+    entries = DynamicOptions.hda_to_table_entries(hda, "metaphlan_database_versioned")
+    assert list(entries) == ["mpa_vJan21_CHOCOPhlAnSGB_202103"]
+
+
 def test_get_options_handles_missing_name_column():
     """Must fall back to value column if display name is missing."""
     tool_param = Bunch(tool=Bunch(app=Bunch()))


### PR DESCRIPTION
### What

When a downstream tool consumes a **data-manager bundle** in a workflow (the data-manager bundle *chain* — an upstream DM runs in `bundle` mode and feeds a data-table-backed input of a downstream tool), the option list for that input is built by `DynamicOptions.hda_to_table_entries`. It only registered an entry when the entry had a **`dbkey`**:

```python
for value in hda._metadata["data_tables"][table_name]:
    if dbkey := value.get("dbkey"):
        table_entries[dbkey] = value
```

So a data table **without a `dbkey` column** (e.g. `motus_db_versioned`, `dada2_species`) yielded **no** entries, and the downstream select param failed with:

```
Parameter '<name>': requires a value, but no legal values defined
```

The call site in `get_fields` already documents this as a known gap:

```python
# This is a bug, `hda_to_table_entries` is not generic enough for certain loc file
# structures, such as for the dada2_species, which doesn't have a dbkey column
```

### Fix

Key entries by `dbkey` when present, otherwise fall back to the `value` column (the table's primary identifier). Tables that have a `dbkey` are unchanged; dbkey-less tables are now consumable from a bundle.

### Testing

Two unit tests in `test_dynamic_options.py`:
- `test_hda_to_table_entries_without_dbkey` — a motus-style entry (no dbkey) is registered, keyed by `value`, with its `path` relocated under the bundle's `extra_files_path`. Mutation-verified: fails on `dev`, passes with this change.
- `test_hda_to_table_entries_prefers_dbkey` — a metaphlan-style entry still keys by `dbkey`.

### Context

Found while building an mOTUs-derived SameStr database as a reference-data bundle chain (mOTUs DM bundle → SameStr DM): the `motus_db_versioned` table has no `dbkey`, so the SameStr `motus_db` select had no legal values. Same family as the earlier bundle-chaining path fixes (#23097).
