### PR TITLE
Fix mulled resolution cache seeding in integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -43,6 +43,11 @@ jobs:
         with:
           path: 'galaxy cache source'
           persist-credentials: false
+      - name: Install uv
+        if: steps.restore-mulled-cache.outputs.cache-hit != 'true'
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          python-version: '3.10'
       - name: Fetch Biocontainers repository index
         id: fetch-mulled-cache
         if: steps.restore-mulled-cache.outputs.cache-hit != 'true'
@@ -50,7 +55,7 @@ jobs:
         env:
           SEED_DIRECTORY: '${{ runner.temp }}/mulled-resolution-seed'
         run: |
-          python3 'galaxy cache source/lib/galaxy/tool_util/deps/mulled/mulled_cache.py' \
+          uv tool run --from './galaxy cache source/packages/tool_util' mulled-cache \
               --namespace biocontainers \
               --output "$SEED_DIRECTORY/biocontainers.json"
       - name: Save Biocontainers repository index
@@ -64,6 +69,7 @@ jobs:
         env:
           SEED_DIRECTORY: '${{ runner.temp }}/mulled-resolution-seed'
         run: |
+          echo '::warning::Could not index the biocontainers namespace, integration tests run without a seeded mulled resolution cache'
           mkdir -p "$SEED_DIRECTORY"
           echo '{"namespace":"biocontainers","repositories":[]}' > "$SEED_DIRECTORY/biocontainers.json"
       - name: Upload mulled resolution cache seed


### PR DESCRIPTION
The `Prepare mulled resolution cache` job added in #23202 ran the seed builder as a plain file against a bare checkout:

```
python3 'galaxy cache source/lib/galaxy/tool_util/deps/mulled/mulled_cache.py'
Traceback (most recent call last):
  ...
ModuleNotFoundError: No module named 'galaxy'
```

The step is `continue-on-error: true`, so the fallback step wrote `{"namespace":"biocontainers","repositories":[]}`, the job went green, and every integration run has been starting with an empty mulled resolution cache — each test chunk queried quay.io itself, which is what the shared cache was supposed to avoid. Example run: https://github.com/mvdbeek/galaxy/actions/runs/30537232984/job/90853317526

This installs `packages/tool_util` from the checkout with uv and calls the `mulled-cache` console script that package already declares, so the import chain is satisfied. The fallback step now also emits a `::warning::` annotation, so a genuine failure to index the namespace is visible rather than silently degrading to an empty seed.

Verified locally against a fresh tracked-files-only checkout in a path with a space, using the exact CI command: builds the package and writes a seed with 14369 biocontainers repositories.