### PR TITLE
Add auto_compressed_types to pdb datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -973,7 +973,7 @@
     <datatype extension="obfs" type="galaxy.datatypes.molecules:OBFS" mimetype="text/html" display_in_upload="true"/>
     <datatype extension="drf" type="galaxy.datatypes.molecules:DRF" display_in_upload="true"/>
     <datatype extension="phar" type="galaxy.datatypes.molecules:PHAR" display_in_upload="true"/>
-    <datatype extension="pdb" type="galaxy.datatypes.molecules:PDB" display_in_upload="true">
+    <datatype extension="pdb" auto_compressed_types="gz" type="galaxy.datatypes.molecules:PDB" display_in_upload="true">
         <infer_from suffix="pdb" />
         <visualization plugin="molstar" />
         <display file="icn3d/icn3d_simple.xml"/>


### PR DESCRIPTION
@mvdbeek do you know if this gz features has any influence on the display/converter/vis?

@guerler do you know if the vis supports GZ.

In other words, do I need to extend the converters and vis before we add this?