### PR TITLE
[25.1] Fix broken calls to ``InteractiveToolManager`` methods

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -9,7 +9,11 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Union
+from typing import (
+    Any,
+    TypedDict,
+    Union,
+)
 
 import yaml
 
@@ -66,6 +70,12 @@ class RetryableDeleteJobState(JobState):
     def init_retryable_job(self, max_retries, attempts):
         self.max_retries: int = max_retries
         self.attempts: int = attempts
+
+
+class EntryPoint(TypedDict):
+    tool_port: int | None
+    domain: str
+    entry_path: str
 
 
 class KubernetesJobRunner(AsynchronousJobRunner):
@@ -450,16 +460,15 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             ]
         return rules_spec
 
-    def __get_k8s_ingress_spec(self, ajs):
+    def __get_k8s_ingress_spec(self, ajs: AsynchronousJobState) -> dict[str, Any]:
         """The k8s spec template is nothing but a Ingress spec, except that it is nested and does not have an apiversion
         nor kind."""
         guest_ports = ajs.job_wrapper.guest_ports
+        entry_points: list[EntryPoint] = []
         if len(guest_ports) > 0:
-            entry_points = []
             configured_eps = [ep for ep in ajs.job_wrapper.get_job().interactivetool_entry_points if ep.configured]
             for entry_point in configured_eps:
-                # sending in self.app as `trans` since it's only used for `.security` so seems to work
-                entry_point_path = self.app.interactivetool_manager.get_entry_point_path(self.app, entry_point)
+                entry_point_path = self.app.interactivetool_manager.get_entry_point_path(entry_point)
                 if "?" in entry_point_path:
                     # Removing all the parameters from the ingress path, but they will still be in the database
                     # so the link that the user clicks on will still have them
@@ -469,14 +478,13 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                     entry_point_path = entry_point_path.split("?")[0]
                 entry_point_domain = f"{self.app.config.interactivetools_proxy_host}"
                 if entry_point.requires_domain:
-                    entry_point_subdomain = self.app.interactivetool_manager.get_entry_point_subdomain(
-                        self.app, entry_point
-                    )
+                    entry_point_subdomain = self.app.interactivetool_manager.get_entry_point_subdomain(entry_point)
                     entry_point_domain = f"{entry_point_subdomain}.{entry_point_domain}"
                     entry_point_path = "/"
                 entry_points.append(
                     {"tool_port": entry_point.tool_port, "domain": entry_point_domain, "entry_path": entry_point_path}
                 )
+        assert ajs.job_wrapper.tool is not None
         k8s_spec_template = {
             "metadata": {
                 "labels": {
@@ -503,8 +511,10 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 k8s_spec_template["spec"]["tls"] = [
                     {"hosts": [domain], "secretName": re.sub("[^a-z0-9-]", "-", domain)} for domain in domains
                 ]
-        if self.runner_params.get("k8s_interactivetools_ingress_annotations"):
-            new_ann = yaml.safe_load(self.runner_params.get("k8s_interactivetools_ingress_annotations"))
+        if k8s_interactivetools_ingress_annotations := self.runner_params.get(
+            "k8s_interactivetools_ingress_annotations"
+        ):
+            new_ann = yaml.safe_load(k8s_interactivetools_ingress_annotations)
             k8s_spec_template["metadata"]["annotations"].update(new_ann)
         return k8s_spec_template
 
@@ -589,7 +599,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 configured_eps = [ep for ep in ajs.job_wrapper.get_job().interactivetool_entry_points if ep.configured]
                 for entry_point in configured_eps:
                     # sending in self.app as `trans` since it's only used for `.security` so seems to work
-                    entry_point_path = self.app.interactivetool_manager.get_entry_point_path(self.app, entry_point)
+                    entry_point_path = self.app.interactivetool_manager.get_entry_point_path(entry_point)
                     if "?" in entry_point_path:
                         # Removing all the parameters from the ingress path, but they will still be in the database
                         # so the link that the user clicks on will still have them
@@ -599,9 +609,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                         entry_point_path = entry_point_path.split("?")[0]
                     entry_point_domain = f"{self.app.config.interactivetools_proxy_host}"
                     if entry_point.requires_domain:
-                        entry_point_subdomain = self.app.interactivetool_manager.get_entry_point_subdomain(
-                            self.app, entry_point
-                        )
+                        entry_point_subdomain = self.app.interactivetool_manager.get_entry_point_subdomain(entry_point)
                         entry_point_domain = f"{entry_point_subdomain}.{entry_point_domain}"
                     envs.append({"name": "INTERACTIVETOOL_PORT", "value": str(entry_point.tool_port)})
                     envs.append({"name": "INTERACTIVETOOL_DOMAIN", "value": str(entry_point_domain)})


### PR DESCRIPTION
Fix https://github.com/galaxyproject/galaxy/issues/23203 . Introduced in commit aa13a63352a8b18070c285421902274182df3da7 .

Also:
- Add type annotation to affected ``KubernetesJobRunner.__get_k8s_ingress_spec()`` method.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
