### PR TITLE
[26.1] fix(client): compile SCSS in collection wizard style blocks

### DIFF
--- a/client/src/components/Collections/SampleSheetWizard.vue
+++ b/client/src/components/Collections/SampleSheetWizard.vue
@@ -490,7 +490,7 @@ async function download() {
     </GenericWizard>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 @import "@/components/Collections/wizard/workbook-dropzones.scss";
 
 .dropzone {

--- a/client/src/components/Collections/wizard/CardUploadWorkbook.vue
+++ b/client/src/components/Collections/wizard/CardUploadWorkbook.vue
@@ -47,7 +47,7 @@ const emit = defineEmits(["workbookContents"]);
     </BCard>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 @import "@/style/scss/theme/blue.scss";
 @import "@/components/Collections/wizard/workbook-dropzones.scss";
 

--- a/client/src/components/Collections/wizard/PasteData.vue
+++ b/client/src/components/Collections/wizard/PasteData.vue
@@ -49,7 +49,7 @@ const handleDrop = (event: DragEvent) => {
     </div>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 @import "@/style/scss/theme/blue.scss";
 
 .paste-data {


### PR DESCRIPTION
These `<style scoped>` blocks import SCSS partials and use SCSS variables but lacked `lang="scss"`, so Vite processed them as plain CSS. The variables were emitted verbatim into the bundle (`font-size:$font-size-base`, `border-color:$border-color`, `border-radius:$border-radius-large`), which browsers discard, and importing the variables-only theme file through postcss-import produced a `blue.scss is empty` build warning.

(cherry picked from commit 8165a4b28ab8315ac54c0eb0505f1527b110c926 in #23208)

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. See https://github.com/galaxyproject/galaxy/pull/23208

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
