### PR TITLE
Consume a data-manager bundle whose table entry is a bare dict

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -898,7 +898,13 @@ class DynamicOptions:
         # No processor description at hand here, so path columns fall back to the naming convention.
         path_headers = get_path_headers(None, table_name)
         table_entries = {}
-        for value in hda._metadata["data_tables"][table_name]:
+        entries = hda._metadata["data_tables"][table_name]
+        if isinstance(entries, dict):
+            # Some data managers record a single entry as a bare dict rather than
+            # a one-element list (e.g. motus); iterating that dict would yield its
+            # column names. Normalize so both shapes are consumable.
+            entries = [entries]
+        for value in entries:
             # Key entries by dbkey when the table has one; otherwise fall back to
             # the ``value`` column so tables without a dbkey column (e.g. motus,
             # dada2_species) are still consumable from a data-manager bundle.

--- a/test/unit/app/tools/test_dynamic_options.py
+++ b/test/unit/app/tools/test_dynamic_options.py
@@ -67,19 +67,20 @@ def test_hda_to_table_entries_without_dbkey():
     dada2_species) must still yield a table entry - keyed by its ``value``
     column - so it can be consumed by a downstream tool in a workflow (the
     data-manager bundle chain). Previously such entries were dropped, leaving
-    the downstream select param with "no legal values defined"."""
+    the downstream select param with "no legal values defined".
+
+    The motus DM records the entry as a bare dict (not a one-element list), so
+    exercise that shape here - iterating it directly would yield column names."""
     hda = Bunch(
         extra_files_path="/bundle/extra",
         _metadata={
             "data_tables": {
-                "motus_db_versioned": [
-                    {
-                        "value": "db_from_2026-04-27T094930Z",
-                        "version": "3.1.0",
-                        "name": "mOTUs DB version 3.1.0",
-                        "path": "db_from_2026-04-27T094930Z",
-                    }
-                ]
+                "motus_db_versioned": {
+                    "value": "db_from_2026-04-27T094930Z",
+                    "version": "3.1.0",
+                    "name": "mOTUs DB version 3.1.0",
+                    "path": "db_from_2026-04-27T094930Z",
+                }
             }
         },
     )


### PR DESCRIPTION
Follow-up to #23210.

`hda_to_table_entries` iterates `hda._metadata["data_tables"][name]` expecting a **list** of entry dicts. But some data managers record a single entry as a **bare dict** rather than a one-element list — the mOTUs DM does:

```json
{"data_tables": {"motus_db_versioned": {"value": "...", "version": "3.1.0", "name": "...", "path": "..."}}}
```

Iterating that dict yields its **column names** (strings), so `str.get("dbkey")` raised `AttributeError`, which the caller (`get_fields`) swallowed — leaving the downstream select param with `requires a value, but no legal values defined` when consuming the bundle in a workflow (the data-manager bundle chain). #23210 added the dbkey→value fallback but not this normalization, so mOTUs still failed.

Normalize a single dict to a one-element list. The dbkey-less unit test now uses the bare-dict shape the mOTUs DM actually emits (mutation-verified: fails without the normalization). metaphlan/samestr DMs emit a list and are unaffected.

Found building an mOTUs-derived SameStr reference-data bundle chain on test.galaxyproject.org.