### PR TITLE
Support running Dockerized tools as users resolved from OIDC token claims

### DIFF
--- a/lib/galaxy/config/sample/job_conf.sample.yml
+++ b/lib/galaxy/config/sample/job_conf.sample.yml
@@ -533,6 +533,22 @@ execution:
       # Docker.
       #docker_set_user: $UID
 
+      # Alternatively, resolve a username from an OIDC token claim. This can be used to
+      # launch the Docker container as that user and/or expose the username
+      # inside the container as an environment variable.
+      #
+      # When set_user is true, docker_set_user must be unset, null, or empty.
+      # Galaxy resolves the username to UID/GID on the execution host with
+      # id -u/id -g and adds the user's supplementary groups with --group-add.
+      #
+      #docker_username_from_oidc_token_claim:
+      #  set_user: true
+      #  expose_as_env: GALAXY_TOOL_USER
+      #  providers:
+      #    azure:
+      #      claim: unique_name
+      #      template: "^.{0,3}"
+
       # Pass extra arguments to the docker run command not covered by the
       # above options.
       #docker_run_extra_arguments:

--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -578,6 +578,10 @@
                remote job user. Leave empty to not use the -u argument with
                Docker. -->
           <!-- <param id="docker_set_user">$UID</param> -->
+          <!-- Docker containers can also use a username resolved from an OIDC
+               token claim via the docker_username_from_oidc_token_claim destination
+               parameter. This is a nested setting and must be configured in
+               job_conf.yml. See config/job_conf.sample.yml for an example. -->
           <!-- Pass extra arguments to the docker run command not covered by the
                above options. -->
           <!-- <param id="docker_run_extra_arguments"></param> -->

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -4,6 +4,7 @@ Base classes for job runner plugins.
 
 import datetime
 import os
+import re
 import string
 import subprocess
 import sys
@@ -23,10 +24,12 @@ from typing import (
     Union,
 )
 
+import jwt
 from sqlalchemy import select
 from sqlalchemy.orm import object_session
 
 from galaxy import model
+from galaxy.authnz.util import provider_name_to_backend
 from galaxy.exceptions import ConfigurationError
 from galaxy.job_execution.output_collect import (
     default_exit_code_file,
@@ -539,6 +542,50 @@ class BaseJobRunner:
     def write_executable_script(self, path: str, contents: str, job_io: DescribesScriptIntegrityChecks) -> None:
         write_script(path, contents, job_io)
 
+    def _configure_docker_username_from_oidc_token_claim(self, job_wrapper: "MinimalJobWrapper") -> None:
+        destination_info = job_wrapper.job_destination.params
+        user_oidc_config = destination_info.get("docker_username_from_oidc_token_claim")
+        if not user_oidc_config:
+            return
+
+        set_user = user_oidc_config.get("set_user", False)
+        expose_as_env = user_oidc_config.get("expose_as_env")
+        if not set_user and not expose_as_env:
+            return
+
+        if set_user and destination_info.get("docker_set_user"):
+            raise ConfigurationError(
+                "docker_set_user cannot be used together with docker_username_from_oidc_token_claim set_user"
+            )
+
+        providers = user_oidc_config.get("providers")
+        if not providers:
+            return
+
+        username = None
+        user = job_wrapper.get_job().user
+        if user is None:
+            raise Exception("Failed to get a username for container from OIDC token, job has no user.")
+        for token_provider, settings in providers.items():
+            try:
+                provider_backend = provider_name_to_backend(token_provider)
+                tokens = user.get_oidc_tokens(provider_backend)
+                oidc_token = tokens.get("access") or tokens.get("id")
+                if not oidc_token:
+                    continue
+                token_user = jwt.decode(oidc_token, options={"verify_signature": False})[settings["claim"]]
+                match = re.match(settings.get("template", ".*"), token_user)
+                if match:
+                    username = match.group(0)
+                    break
+            except Exception:
+                log.debug("Failed to extract Docker user from OIDC provider [%s]", token_provider, exc_info=True)
+
+        if not username:
+            raise Exception("Failed to get a username for container from OIDC token, contact Galaxy admin.")
+
+        destination_info["docker_username_from_token"] = username
+
     def _find_container(
         self,
         job_wrapper: "MinimalJobWrapper",
@@ -582,6 +629,7 @@ class BaseJobRunner:
             job_directory_type=job_directory_type,
         )
 
+        self._configure_docker_username_from_oidc_token_claim(job_wrapper)
         destination_info = job_wrapper.job_destination.params
         container = self.app.container_finder.find_container(tool_info, destination_info, job_info)
         if container:

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import string
 from abc import (
     ABCMeta,
@@ -39,6 +40,15 @@ log = getLogger(__name__)
 DOCKER_CONTAINER_TYPE = "docker"
 SINGULARITY_CONTAINER_TYPE = "singularity"
 TRAP_KILL_CONTAINER = "trap _on_exit EXIT"
+
+SET_USER_GROUPS_TEMPLATE = r"""
+USERGROUPS=`id -G ${username}`
+GROUPADD=""
+for i in $(echo $USERGROUPS | tr "," "\n")
+do
+    GROUPADD="$GROUPADD --group-add $i"
+done
+"""
 
 LOAD_CACHED_IMAGE_COMMAND_TEMPLATE = r"""
 python << EOF
@@ -455,6 +465,26 @@ class DockerContainer(Container, HasDockerLikeVolumes):
             cache_command = docker_util.build_docker_cache_command(self.container_id, **docker_host_props)
         else:
             cache_command = self.__cache_from_file_command(cached_image_file, docker_host_props)
+
+        run_extra_arguments = self.prop("run_extra_arguments", docker_util.DEFAULT_RUN_EXTRA_ARGUMENTS)
+        group_command = ""
+        oidc_username = self.prop("username_from_token", None)
+        oidc_username_config = self.prop("username_from_oidc_token_claim", None) or {}
+        should_set_user_from_token = bool(oidc_username and oidc_username_config.get("set_user", False))
+        if should_set_user_from_token:
+            group_command = string.Template(SET_USER_GROUPS_TEMPLATE).safe_substitute(
+                username=shlex.quote(oidc_username)
+            )
+        if group_command:
+            run_extra_arguments = f"{run_extra_arguments} $GROUPADD" if run_extra_arguments else "$GROUPADD"
+        expose_as_env = oidc_username_config.get("expose_as_env")
+        if oidc_username and expose_as_env:
+            env_directives.append(f"{expose_as_env}={oidc_username}")
+
+        set_user = self.prop("set_user", docker_util.DEFAULT_SET_USER)
+        if should_set_user_from_token:
+            set_user = oidc_username
+
         run_command = docker_util.build_docker_run_command(
             command,
             self.container_id,
@@ -464,8 +494,9 @@ class DockerContainer(Container, HasDockerLikeVolumes):
             working_directory=working_directory,
             net=self.prop("net", None),  # By default, docker instance has networking disabled
             auto_rm=asbool(self.prop("auto_rm", docker_util.DEFAULT_AUTO_REMOVE)),
-            set_user=self.prop("set_user", docker_util.DEFAULT_SET_USER),
-            run_extra_arguments=self.prop("run_extra_arguments", docker_util.DEFAULT_RUN_EXTRA_ARGUMENTS),
+            set_user=set_user,
+            set_user_from_host=should_set_user_from_token,
+            run_extra_arguments=run_extra_arguments,
             guest_ports=self.tool_info.guest_ports,
             host_port_cmd=self.prop("host_port_cmd", None),
             container_name=self.container_name,
@@ -486,6 +517,7 @@ _on_exit() {{
 }}
 {TRAP_KILL_CONTAINER}
 {cache_command}
+{group_command}
 {run_command}"""
 
     def __cache_from_file_command(self, cached_image_file: str, docker_host_props: dict[str, Any]) -> str:

--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -110,6 +110,7 @@ def build_docker_run_command(
     sudo_cmd: str = DEFAULT_SUDO_COMMAND,
     auto_rm: bool = DEFAULT_AUTO_REMOVE,
     set_user: str | None = DEFAULT_SET_USER,
+    set_user_from_host: bool = False,
     host: str | None = DEFAULT_HOST,
     guest_ports: bool | str | list[str] = False,
     host_port_cmd: str | None = None,
@@ -159,14 +160,18 @@ def build_docker_run_command(
     if run_extra_arguments:
         command_parts.append(run_extra_arguments)
     if set_user:
-        user = set_user
-        if set_user == DEFAULT_SET_USER:
+        if set_user_from_host:
+            user_name = shlex.quote(set_user)
+            user = f"`id -u {user_name}`:`id -g {user_name}`"
+        elif set_user == DEFAULT_SET_USER:
             # If future-us is ever in here and fixing this for docker-machine just
             # use cwltool.docker_id - it takes care of this default nicely.
             euid = os.geteuid()
             egid = os.getgid()
 
             user = f"{euid}:{egid}"
+        else:
+            user = set_user
         command_parts.extend(["--user", user])
     full_image = image
     if tag:

--- a/test/unit/tool_util/test_docker_user.py
+++ b/test/unit/tool_util/test_docker_user.py
@@ -1,0 +1,105 @@
+from galaxy.tool_util.deps import docker_util
+from galaxy.tool_util.deps.container_classes import DockerContainer
+from galaxy.tool_util.deps.dependencies import (
+    AppInfo,
+    JobInfo,
+    ToolInfo,
+)
+
+
+def test_docker_run_command_can_set_user_from_host():
+    command = docker_util.build_docker_run_command(
+        "echo hello",
+        "busybox",
+        set_user="alice",
+        set_user_from_host=True,
+    )
+
+    assert "--user `id -u alice`:`id -g alice`" in command
+
+
+def test_docker_run_command_prefers_explicit_set_user():
+    command = docker_util.build_docker_run_command(
+        "echo hello",
+        "busybox",
+        set_user="1000:1000",
+        set_user_from_host=False,
+    )
+
+    assert "--user 1000:1000" in command
+    assert "id -u alice" not in command
+
+
+def test_docker_container_passes_docker_username_from_token_env_and_groups():
+    container = _docker_container(
+        {
+            "docker_volumes": "$working_directory:rw",
+            "docker_set_user": None,
+            "docker_username_from_token": "alice",
+            "docker_username_from_oidc_token_claim": {"set_user": True, "expose_as_env": "GALAXY_TOOL_USER"},
+        }
+    )
+
+    command = container.containerize_command("echo hello")
+
+    assert "-e GALAXY_TOOL_USER=alice" in command
+    assert "USERGROUPS=`id -G alice`" in command
+    assert "$GROUPADD" in command
+    assert "--user `id -u alice`:`id -g alice`" in command
+
+
+def test_docker_container_oidc_user_overrides_implicit_default_user():
+    container = _docker_container(
+        {
+            "docker_volumes": "$working_directory:rw",
+            "docker_username_from_token": "alice",
+            "docker_username_from_oidc_token_claim": {"set_user": True},
+        }
+    )
+
+    command = container.containerize_command("echo hello")
+
+    assert "--user `id -u alice`:`id -g alice`" in command
+    assert "USERGROUPS=`id -G alice`" in command
+    assert "$GROUPADD" in command
+
+
+def test_docker_container_can_expose_token_username_without_setting_user():
+    container = _docker_container(
+        {
+            "docker_volumes": "$working_directory:rw",
+            "docker_username_from_token": "alice",
+            "docker_username_from_oidc_token_claim": {"expose_as_env": "GALAXY_TOOL_USER"},
+            "docker_set_user": None,
+        }
+    )
+
+    command = container.containerize_command("echo hello")
+
+    assert "-e GALAXY_TOOL_USER=alice" in command
+    assert "USERGROUPS=`id -G alice`" not in command
+    assert "$GROUPADD" not in command
+    assert "--user `id -u alice`:`id -g alice`" not in command
+
+
+def _docker_container(destination_info):
+    return DockerContainer(
+        "busybox",
+        AppInfo(
+            galaxy_root_dir="/galaxy",
+            default_file_path="/data",
+            container_image_cache_path="/tmp/galaxy-test-container-cache",
+        ),
+        ToolInfo(env_pass_through=[], profile=24.0),
+        destination_info,
+        JobInfo(
+            working_directory="/job/working",
+            tool_directory=None,
+            job_directory="/job",
+            tmp_directory=None,
+            home_directory=None,
+            job_directory_type="galaxy",
+        ),
+        None,
+        container_name="test-container",
+    )


### PR DESCRIPTION
This adds a Docker destination option that can extract a username from a configured OIDC provider token claim, optionally use that username as the Docker runtime user, and optionally expose it inside the container as an environment variable. When used as the Docker user, the username is resolved on the execution host to UID/GID and supplementary groups are added so host filesystem permissions match the resolved account.

This is needed for deployments where tool containers must run as the authenticated facility or site user rather than the Galaxy service account, deriving that identity from the user’s OIDC token.

## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
