### PR TITLE
[26.1] Fix TUS uploads when galaxy_url_prefix is set

### DIFF
--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -4,7 +4,6 @@ from typing import (
     Any,
     TYPE_CHECKING,
 )
-from urllib.parse import urljoin
 
 from a2wsgi import WSGIMiddleware
 from fastapi import (
@@ -244,14 +243,19 @@ def get_openapi_schema() -> dict[str, Any]:
 
 def include_tus(app: FastAPI, gx_app):
     config = gx_app.config
-    root_path = "" if config.galaxy_url_prefix == "/" else config.galaxy_url_prefix
+    # These prefixes must not include galaxy_url_prefix. When a prefix is configured,
+    # initialize_fast_app mounts this whole app underneath it, so routes registered here
+    # are matched against the prefix-stripped path -- prepending it again never matches,
+    # and the request silently falls through to the legacy WSGI upload hooks endpoint,
+    # which returns 200 with no TUS Location header. tuspyserver reconstructs the external
+    # URL from the request's root_path, so the Location header stays correct either way.
     upload_tus_router = create_tus_router(
-        prefix=urljoin(root_path, "api/upload/resumable_upload"),
+        prefix="api/upload/resumable_upload",
         files_dir=config.tus_upload_store or config.new_file_path,
         max_size=config.maximum_upload_file_size,
     )
     job_files_tus_router = create_tus_router(
-        prefix=urljoin(root_path, "api/job_files/resumable_upload"),
+        prefix="api/job_files/resumable_upload",
         files_dir=config.tus_upload_store_job_files or config.tus_upload_store or config.new_file_path,
         max_size=config.maximum_upload_file_size,
     )

--- a/test/unit/webapps/test_tus_prefix.py
+++ b/test/unit/webapps/test_tus_prefix.py
@@ -1,0 +1,58 @@
+"""Verify the TUS routers stay reachable when galaxy_url_prefix is set.
+
+initialize_fast_app mounts the Galaxy app underneath galaxy_url_prefix, so the TUS
+routers must be registered without it. Registering them with the prefix made the
+creation POST miss the router entirely and fall through to the legacy WSGI upload
+hooks endpoint, which answers 200 without a Location header, leaving TUS clients
+with no upload URL to PATCH to.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from galaxy.util.bunch import Bunch
+from galaxy.webapps.galaxy.fast_app import include_tus
+
+UPLOAD_PATH = "api/upload/resumable_upload"
+JOB_FILES_PATH = "api/job_files/resumable_upload"
+
+
+def _build_app(tmp_path, url_prefix):
+    """Mirror how initialize_fast_app wires the app for a given url prefix."""
+    config = Bunch(
+        galaxy_url_prefix=url_prefix,
+        tus_upload_store=str(tmp_path),
+        tus_upload_store_job_files=None,
+        new_file_path=str(tmp_path),
+        maximum_upload_file_size=1024,
+    )
+    root_path = "" if url_prefix == "/" else url_prefix
+    app = FastAPI(root_path=root_path)
+    include_tus(app, Bunch(config=config))
+    if not root_path:
+        return app
+    parent_app = FastAPI()
+    parent_app.mount(root_path, app=app)
+    return parent_app
+
+
+@pytest.mark.parametrize("url_prefix", ["/", "/galaxypf", "/proxy/google/v1/apps/ns/app/galaxy"])
+@pytest.mark.parametrize("tus_path", [UPLOAD_PATH, JOB_FILES_PATH])
+def test_tus_creation_returns_prefixed_location(tmp_path, url_prefix, tus_path):
+    client = TestClient(_build_app(tmp_path, url_prefix))
+    base = "" if url_prefix == "/" else url_prefix
+
+    response = client.post(
+        f"{base}/{tus_path}/",
+        headers={
+            "Tus-Resumable": "1.0.0",
+            "Upload-Length": "11",
+            "Host": "galaxy.example.org",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+
+    assert response.status_code == 201
+    location = response.headers["location"]
+    assert location.startswith(f"https://galaxy.example.org{base}/{tus_path}/")

--- a/test/unit/webapps/test_tus_prefix.py
+++ b/test/unit/webapps/test_tus_prefix.py
@@ -1,5 +1,4 @@
-"""Verify the TUS routers stay reachable when galaxy_url_prefix is set.
-"""
+"""Verify the TUS routers stay reachable when galaxy_url_prefix is set."""
 
 import pytest
 from fastapi import FastAPI

--- a/test/unit/webapps/test_tus_prefix.py
+++ b/test/unit/webapps/test_tus_prefix.py
@@ -1,10 +1,4 @@
 """Verify the TUS routers stay reachable when galaxy_url_prefix is set.
-
-initialize_fast_app mounts the Galaxy app underneath galaxy_url_prefix, so the TUS
-routers must be registered without it. Registering them with the prefix made the
-creation POST miss the router entirely and fall through to the legacy WSGI upload
-hooks endpoint, which answers 200 without a Location header, leaving TUS clients
-with no upload URL to PATCH to.
 """
 
 import pytest


### PR DESCRIPTION
On any deployment with a non-`/` `galaxy_url_prefix`, uploads fail silently. The TUS creation `POST` returns `200` with a JSON `null` body and **no `Location` header**, so `tus-js-client` never learns where to send its `PATCH` chunks.

  Found on AnVIL/Terra, where Leonardo proxies Galaxy under `/proxy/google/v1/apps/<namespace>/<app>/galaxy`.

  ## Cause

  `initialize_fast_app` already mounts the whole app under the prefix, so routes registered inside it are matched against the **prefix-stripped** path — which is why `include_all_package_routers` registers everything bare. But `include_tus`
  prepended the prefix a second time:

  ```python
  root_path = "" if config.galaxy_url_prefix == "/" else config.galaxy_url_prefix
  prefix=urljoin(root_path, "api/upload/resumable_upload")
  ```

  Double-prefixed, the router matches nothing. The request falls through to `app.mount("/", wsgi_handler)` onto the legacy `UploadsAPIController.hooks`, which is also wired to `/api/upload/resumable_upload` and whose body is `return None` —
  producing exactly the observed `200` + `null`.

  ## Fix

  Register both TUS routers at their bare paths, like every other router. `tuspyserver` rebuilds the external URL from `request.url.path` and `scope["root_path"]`, so `Location` still carries the prefix.

  This also repairs `api/job_files/resumable_upload`, broken identically (Pulsar remote job files).

  **No change when `galaxy_url_prefix` is `/`** — `urljoin("", "api/...")` already equalled `"api/..."`, so unprefixed deployments are byte-identical.

  ## Verification

  Against a real prefixed Kubernetes deployment:

  | | Before | After |
  |---|---|---|
  | `POST` | `200`, `null`, no `Location` | `201`, `Location` with full prefix |
  | `PATCH` | never sent — no URL | `204`, offset advances |
  | `HEAD` | — | `200`, correct offset |

  Uploaded bytes confirmed in `tus_upload_store`. Unprefixed deployments re-tested, unchanged.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
