### PR TITLE
Cover interactive tools on the native Kubernetes runner, and type-check it

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -602,7 +602,6 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             if self.__has_guest_ports(ajs.job_wrapper):
                 configured_eps = [ep for ep in ajs.job_wrapper.get_job().interactivetool_entry_points if ep.configured]
                 for entry_point in configured_eps:
-                    # sending in self.app as `trans` since it's only used for `.security` so seems to work
                     entry_point_path = self.app.interactivetool_manager.get_entry_point_path(entry_point)
                     if "?" in entry_point_path:
                         # Removing all the parameters from the ingress path, but they will still be in the database

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -109,7 +109,7 @@ class KubernetesJobRunner(AsynchronousJobRunner[AsynchronousJobState]):
             k8s_extra_job_envs=dict(map=str, default=None),
             k8s_tolerations=dict(map=str, default=None),
             k8s_galaxy_instance_id=dict(map=str),
-            k8s_timeout_seconds_job_deletion=dict(map=int, valid=lambda x: int > 0, default=30),
+            k8s_timeout_seconds_job_deletion=dict(map=int, valid=lambda x: int(x) > 0, default=30),
             k8s_job_api_version=dict(map=str, default=DEFAULT_JOB_API_VERSION),
             k8s_job_ttl_secs_after_finished=dict(map=int, valid=lambda x: x is None or int(x) >= 0, default=None),
             k8s_job_metadata=dict(map=str, default=None),

--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -170,7 +170,11 @@ class InteractiveToolManager:
         self.dispatcher = dispatcher if dispatcher is not None else app.resolve_or_none(SSEEventDispatcher)
 
     def create_entry_points(
-        self, job: Job, tool: "Tool", entry_points=Iterable[dict[str, Any]] | None, flush: bool = True
+        self,
+        job: Job,
+        tool: "Tool",
+        entry_points: Iterable[dict[str, Any]] | None = None,
+        flush: bool = True,
     ) -> None:
         entry_points = entry_points or tool.ports
         for entry in entry_points:

--- a/mypy.ini
+++ b/mypy.ini
@@ -608,8 +608,6 @@ check_untyped_defs = False
 check_untyped_defs = False
 [mypy-galaxy.jobs.runners.local]
 check_untyped_defs = False
-[mypy-galaxy.jobs.runners.kubernetes]
-check_untyped_defs = False
 [mypy-galaxy.jobs.runners.godocker]
 check_untyped_defs = False
 [mypy-galaxy.jobs.runners.drmaa]

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -1,6 +1,8 @@
 """Integration tests for realtime tools."""
 
+import json
 import os
+import subprocess
 from typing import (
     Any,
 )
@@ -24,13 +26,30 @@ from .test_containerized_jobs import (
     disable_dependency_resolution,
     DOCKERIZED_JOB_CONFIG_FILE,
 )
+from .test_kubernetes_runner import (
+    job_config as kubernetes_job_config,
+    KubeSetupConfigTuple,
+    persistent_volume,
+    persistent_volume_claim,
+    TOOL_DIR,
+)
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 EMBEDDED_PULSAR_JOB_CONFIG_FILE_DOCKER = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_docker_job_conf.yml")
+# The Kubernetes runner builds ingress hosts as "<subdomain>.<interactivetools_proxy_host>".
+# Nothing connects to this host - the entry point is only inspected through the API and
+# through the ingress object the runner created - but it has to be a valid DNS name.
+KUBERNETES_PROXY_HOST = "interactivetool.test.invalid"
 
 
 class AbstractTestCases:
-    class BaseInteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
+    class BaseInteractiveToolsTestCase(ContainerizedIntegrationTestCase):
+        """Configuration and helpers shared by interactive tool test cases.
+
+        Holds no tests itself so that deployments which cannot reach an
+        interactive tool through a proxy can still reuse the helpers.
+        """
+
         dataset_populator: DatasetPopulator
         framework_tool_and_types = True
         container_type = "docker"
@@ -89,6 +108,7 @@ class AbstractTestCases:
             api_asserts.assert_status_code_is(entry_points_response, 200)
             return entry_points_response.json()
 
+    class BaseInteractiveToolsIntegrationTestCase(BaseInteractiveToolsTestCase):
         def test_simple_execution(self, history_id: str) -> None:
             response_dict = self.dataset_populator.run_tool("interactivetool_simple", {}, history_id)
             assert "jobs" in response_dict, response_dict
@@ -219,3 +239,87 @@ class TestKubeInteractiveToolsRemoteProxyIntegration(AbstractTestCases.BaseInter
 
         set_infrastucture_url(config)
         disable_dependency_resolution(config)
+
+
+@integration_util.skip_unless_kubernetes()
+class TestKubernetesNativeInteractiveToolsIntegration(AbstractTestCases.BaseInteractiveToolsTestCase):
+    """Interactive tools submitted through ``KubernetesJobRunner`` itself.
+
+    ``TestKubeInteractiveToolsRemoteProxyIntegration`` covers interactive tools on
+    Kubernetes via Pulsar, so it never touches this runner. It also needs an
+    externally started gx-it-proxy to reach the tool over HTTP, which is why it is
+    skipped in CI. This case asserts only what the runner is responsible for -
+    configuring the entry points and creating a matching ingress - so it needs no
+    proxy and can run wherever a cluster is available.
+    """
+
+    jobs_directory: str
+    persistent_volume_claims: list[KubeSetupConfigTuple]
+    persistent_volumes: list[KubeSetupConfigTuple]
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config) -> None:
+        cls.jobs_directory = os.path.realpath(cls._test_driver.mkdtemp())
+        volumes = [
+            (cls.jobs_directory, "it-jobs-directory-volume", "it-jobs-directory-claim"),
+            (TOOL_DIR, "it-tool-directory-volume", "it-tool-directory-claim"),
+        ]
+        cls.persistent_volumes = []
+        cls.persistent_volume_claims = []
+        for path, volume, claim in volumes:
+            volume_obj = persistent_volume(path, volume)
+            volume_obj.setup()
+            cls.persistent_volumes.append(volume_obj)
+            claim_obj = persistent_volume_claim(volume, claim)
+            claim_obj.setup()
+            cls.persistent_volume_claims.append(claim_obj)
+        super().handle_galaxy_config_kwds(config)
+        config["jobs_directory"] = cls.jobs_directory
+        config["file_path"] = cls.jobs_directory
+        config["job_config_file"] = kubernetes_job_config(
+            cls.jobs_directory,
+            jobs_directory_claim="it-jobs-directory-claim",
+            tool_directory_claim="it-tool-directory-claim",
+        ).path
+        config["default_job_shell"] = "/bin/sh"
+        config["interactivetools_proxy_host"] = KUBERNETES_PROXY_HOST
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for claim in cls.persistent_volume_claims:
+            claim.teardown()
+        for volume in cls.persistent_volumes:
+            volume.teardown()
+        super().tearDownClass()
+
+    @staticmethod
+    def ingress_for_tool(tool_id: str) -> dict[str, Any]:
+        ingresses = json.loads(subprocess.check_output(["kubectl", "get", "ingress", "-o", "json"]))["items"]
+        matching = [
+            i
+            for i in ingresses
+            if (i["metadata"].get("annotations") or {}).get("app.galaxyproject.org/tool_id") == tool_id
+        ]
+        assert len(matching) == 1, f"Expected exactly one ingress for {tool_id}, got {matching}"
+        return matching[0]
+
+    def test_entry_point_and_ingress(self, history_id: str) -> None:
+        response_dict = self.dataset_populator.run_tool("interactivetool_simple", {}, history_id)
+        job_id = response_dict["jobs"][0]["id"]
+        entry_points = self.wait_on_entry_points_active(job_id)
+        assert len(entry_points) == 1
+
+        # interactivetool_simple declares requires_domain, so the runner routes it by
+        # host and the ingress path stays at the root.
+        ingress = self.ingress_for_tool("interactivetool_simple")
+        rules = ingress["spec"]["rules"]
+        assert len(rules) == 1, rules
+        assert rules[0]["host"].endswith(f".{KUBERNETES_PROXY_HOST}"), rules[0]["host"]
+        paths = rules[0]["http"]["paths"]
+        assert len(paths) == 1, paths
+        assert paths[0]["path"] == "/", paths[0]
+
+        # Stop the entry point so the tool container does not outlive the test.
+        stop_response = self.dataset_populator._delete(f'entry_points/{entry_points[0]["id"]}')
+        stop_response.raise_for_status()
+        self.dataset_populator.wait_for_job(job_id, assert_ok=True)

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -95,18 +95,22 @@ spec:
     return KubeSetupConfigTuple(path=volume_claim.name)
 
 
-def job_config(jobs_directory: str) -> Config:
+def job_config(
+    jobs_directory: str,
+    jobs_directory_claim: str = "jobs-directory-claim",
+    tool_directory_claim: str = "tool-directory-claim",
+) -> Config:
     job_conf_template = string.Template("""<job_conf>
     <plugins>
         <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
         <plugin id="k8s" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
-            <param id="k8s_persistent_volume_claims">jobs-directory-claim:$jobs_directory,tool-directory-claim:$tool_directory</param>
+            <param id="k8s_persistent_volume_claims">$jobs_directory_claim:$jobs_directory,$tool_directory_claim:$tool_directory</param>
             <param id="k8s_config_path">$k8s_config_path</param>
             <param id="k8s_galaxy_instance_id">gx-short-id</param>
             <param id="k8s_run_as_user_id">$$uid</param>
         </plugin>
         <plugin id="k8s_walltime_short" type="runner" load="galaxy.jobs.runners.kubernetes:KubernetesJobRunner">
-            <param id="k8s_persistent_volume_claims">jobs-directory-claim:$jobs_directory,tool-directory-claim:$tool_directory</param>
+            <param id="k8s_persistent_volume_claims">$jobs_directory_claim:$jobs_directory,$tool_directory_claim:$tool_directory</param>
             <param id="k8s_config_path">$k8s_config_path</param>
             <param id="k8s_galaxy_instance_id">gx-short-id</param>
             <param id="k8s_walltime_limit">10</param>
@@ -139,7 +143,9 @@ def job_config(jobs_directory: str) -> Config:
 """)
     job_conf_str = job_conf_template.substitute(
         jobs_directory=jobs_directory,
+        jobs_directory_claim=jobs_directory_claim,
         tool_directory=TOOL_DIR,
+        tool_directory_claim=tool_directory_claim,
         k8s_config_path=integration_util.k8s_config_path(),
     )
     with tempfile.NamedTemporaryFile(suffix="_kubernetes_integration_job_conf.xml", mode="w", delete=False) as job_conf:


### PR DESCRIPTION
Follow-up to the #23203 fix, which is already on `dev` via `release_25.1`. This adds the regression test that fix never had, plus the remaining defects and the type checking that would have caught it in the first place.

### Why nothing caught #23203

`TestKubeInteractiveToolsRemoteProxyIntegration` looks like it covers this, but its job config loads `PulsarKubernetesJobRunner` — it exercises `runners/pulsar.py`, never `runners/kubernetes.py`. It is also skipped in CI by `@skip_if_github_workflow()` and needs an externally started gx-it-proxy. `TestKubernetesIntegration` does run in CI on every push, but had no interactive tool coverage at all. So the native runner's interactive tool support was untested from both directions.

Separately, the runner sat on the `check_untyped_defs = False` list in `mypy.ini`, so mypy skipped the bodies of its unannotated methods entirely — even though `StructuredApp.interactivetool_manager` is properly annotated and the call sites were plainly wrong.

### What is here

- **`TestKubernetesNativeInteractiveToolsIntegration::test_entry_point_and_ingress`** — runs `interactivetool_simple` through `KubernetesJobRunner` and asserts the entry point activates and the ingress the runner created carries the expected host and path. The runner configures entry points and creates the service and ingress while submitting the job, before any proxy is involved, so this needs no gx-it-proxy and is gated only by `@skip_unless_kubernetes()`. It runs in the existing Minikube CI job.
- **`check_untyped_defs` removed** for the runner.
- **`k8s_timeout_seconds_job_deletion` validator** compared the `int` type rather than the value (`lambda x: int > 0`), so setting that destination parameter raised `TypeError: '>' not supported between instances of 'type' and 'int'`. Surfaced by the flag removal; it is the only other error it reports.
- **`create_entry_points()`** had its type expression as the parameter's default value instead of its annotation, leaving `entry_points` bound to a `UnionType` when omitted. Latent — the sole caller always passes it.
- A stale comment claiming `self.app` is passed as a `trans`, left behind by the #23203 fix.

### Verification

Both guards were checked against a scratch branch with the #23203 fix reverted:

- the new test was the **only** failing test in the Integration run, with `TypeError: InteractiveToolManager.get_entry_point_path() takes 2 positional arguments but 3 were given` in the log;
- Python linting failed with 8 mypy errors across all four call sites, on 3.10 and 3.14.

With the fix in place the test passes (executed, not skipped) and `tox -e mypy` reports `Success: no issues found in 2343 source files`.

Two fixes from the original branch were dropped in rebase — `dev` had already made both, better: the `entry_points` hoist now carries a `list[EntryPoint]` TypedDict, and the ingress annotations lookup is already bound once.