### PR TITLE
Repository-level data-table linting for data-manager / reference-data bundles

### DIFF
--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
 
 
-class MissingLocFixture(Linter):
+class MissingLocFixture(Linter[RepositoryDataTables]):
     """A configured table references a loc file that resolves to no file on disk.
 
     ``LocAsset.found`` already accounts for the ``.sample`` fallback, so a
@@ -53,7 +53,7 @@ class MissingLocFixture(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
         missing = [asset for asset in model.loc_assets if not asset.found]
         for asset in missing:
             lint_ctx.error(
@@ -64,7 +64,7 @@ class MissingLocFixture(Linter):
             lint_ctx.valid("All referenced loc files resolve", linter=cls.name())
 
 
-class LocRowShape(Linter):
+class LocRowShape(Linter[RepositoryDataTables]):
     """A non-comment loc row cannot supply every declared column index.
 
     Reuses the row-shape errors captured by ``TabularToolDataTable`` at load
@@ -73,7 +73,7 @@ class LocRowShape(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
         found_error = False
         for asset in model.loc_assets:
             for message in asset.errors:
@@ -97,7 +97,7 @@ def _is_literal(name: str) -> bool:
     return bool(name) and not any(marker in name for marker in _DYNAMIC_MARKERS)
 
 
-class ManagerTableConfigured(Linter):
+class ManagerTableConfigured(Linter[RepositoryDataTables]):
     """A data manager populates a table that nothing in the bundle configures.
 
     The manager's ``<data_table name="...">`` entries must correspond to a
@@ -106,7 +106,7 @@ class ManagerTableConfigured(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
         known = model.configured_table_names | model.external_table_names
         clean = True
         for manager in model.managers:
@@ -124,7 +124,7 @@ class ManagerTableConfigured(Linter):
             lint_ctx.valid("All data-manager tables are locally configured", linter=cls.name())
 
 
-class ConsumerTableDefined(Linter):
+class ConsumerTableDefined(Linter[RepositoryDataTables]):
     """A tool references a data table that no local (or known-external) table defines.
 
     Only literal, fully-expanded ``from_data_table`` names are checked. Because a
@@ -133,7 +133,7 @@ class ConsumerTableDefined(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
         known = model.configured_table_names | model.external_table_names
         checked = False
         clean = True
@@ -153,7 +153,7 @@ class ConsumerTableDefined(Linter):
             lint_ctx.valid("All literal from_data_table references resolve locally", linter=cls.name())
 
 
-class OutputRefValid(Linter):
+class OutputRefValid(Linter[RepositoryDataTables]):
     """A data-manager ``output_ref`` names an output the expanded wrapper does not declare.
 
     Only checked when the manager wrapper was actually resolved; an unresolved
@@ -167,7 +167,7 @@ class OutputRefValid(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
         checked = False
         clean = True
         for manager in model.managers:
@@ -190,7 +190,7 @@ class OutputRefValid(Linter):
             lint_ctx.valid("All data-manager output_ref values name real wrapper outputs", linter=cls.name())
 
 
-class DuplicateColumnNames(Linter):
+class DuplicateColumnNames(Linter[RepositoryDataTables]):
     """A ``<table>`` declares the same column name more than once.
 
     The parsed ``columns`` dict silently collapses duplicates, so this is checked
@@ -198,7 +198,7 @@ class DuplicateColumnNames(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
         clean = True
         for decl in model.raw_table_decls:
             seen = set()
@@ -218,7 +218,7 @@ class DuplicateColumnNames(Linter):
             lint_ctx.valid("No data table declares duplicate column names", linter=cls.name())
 
 
-class ConflictingTableSchema(Linter):
+class ConflictingTableSchema(Linter[RepositoryDataTables]):
     """The same table name is declared with different columns/separator/comment across the bundle.
 
     A column conflict would make the loader raise, so this reads the pre-merge raw
@@ -227,7 +227,7 @@ class ConflictingTableSchema(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
         by_name: Dict[str, List] = {}
         for decl in model.raw_table_decls:
             by_name.setdefault(decl.name, []).append(decl)

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -257,6 +257,13 @@ REPOSITORY_DATA_TABLE_LINTERS = (
     ConflictingTableSchema,
 )
 
+# Tables that Galaxy core ships (config/tool_data_table_conf.xml.sample) or that a
+# stock data manager provides on essentially every deployment. A repository may consume
+# these via from_data_table without defining them locally, so they are treated as
+# externally supplied by default; callers extend this set through the
+# external_table_names argument (e.g. from a Tool Shed supplier index).
+DEFAULT_EXTERNAL_TABLE_NAMES: FrozenSet[str] = frozenset({"all_fasta", "fasta_indexes", "__dbkeys__"})
+
 
 def lint_repository_data_tables(model: RepositoryDataTables, lint_ctx: "LintContext") -> None:
     """Run the repository data-table linters over ``model``.
@@ -364,7 +371,12 @@ def find_and_lint_repository_data_tables(
     ``tool_data_table_conf`` files and the consumer tool sources, then hands them to
     :func:`lint_repository_data_tables_bundle`. Consumer tools are only walked when the
     repository actually declares a data-table bundle.
+
+    The common Galaxy-core tables (:data:`DEFAULT_EXTERNAL_TABLE_NAMES`) are always
+    treated as externally supplied so a bare invocation does not warn on every stock
+    ``from_data_table`` reference; ``external_table_names`` adds to that set.
     """
+    external_table_names = DEFAULT_EXTERNAL_TABLE_NAMES | external_table_names
     data_manager_conf = _find_data_manager_conf(repo_root)
     tool_data_table_conf = _find_tool_data_table_conf(repo_root)
     consumer_tool_sources = None

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -68,9 +68,78 @@ class LocRowShape(Linter):
             lint_ctx.valid("All loc rows supply every declared column", linter=cls.name())
 
 
+# Markers that mean a table name did not fully resolve to a literal after macro /
+# token expansion (Cheetah ``$``/``${}``, an undefined ``@TOKEN@``). Such names are
+# reported as not-checked rather than demonstrably missing -- see galaxyproject/
+# tools-iuc#5003, where raw ``@IDX_DATA_TABLE@`` looks unconfigured but resolves.
+_DYNAMIC_MARKERS = ("$", "@", "{", "}")
+
+
+def _is_literal(name: str) -> bool:
+    return bool(name) and not any(marker in name for marker in _DYNAMIC_MARKERS)
+
+
+class ManagerTableConfigured(Linter):
+    """A data manager populates a table that nothing in the bundle configures.
+
+    The manager's ``<data_table name="...">`` entries must correspond to a
+    configured ``tool_data_table_conf`` table (or a known externally-supplied
+    one); an unconfigured target is a broken producer contract (Planemo #706).
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        known = model.configured_table_names | model.external_table_names
+        clean = True
+        for manager in model.managers:
+            for table_name in manager.processor.data_table_names:
+                if not _is_literal(table_name):
+                    continue
+                if table_name not in known:
+                    lint_ctx.error(
+                        f"Data manager '{manager.id}' populates table '{table_name}' but no local "
+                        "tool_data_table configuration defines it",
+                        linter=cls.name(),
+                    )
+                    clean = False
+        if model.managers and clean:
+            lint_ctx.valid("All data-manager tables are locally configured", linter=cls.name())
+
+
+class ConsumerTableDefined(Linter):
+    """A tool references a data table that no local (or known-external) table defines.
+
+    Only literal, fully-expanded ``from_data_table`` names are checked. Because a
+    table may validly be supplied by Galaxy core or another installed repository,
+    an unknown reference is a warning, not an error.
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        known = model.configured_table_names | model.external_table_names
+        checked = False
+        clean = True
+        for consumer in model.consumers:
+            name = consumer.table_name
+            if not _is_literal(name):
+                continue
+            checked = True
+            if name not in known:
+                lint_ctx.warn(
+                    f"Tool '{consumer.tool_id}' references data table '{name}' via {consumer.kind}, but no "
+                    "local configuration defines it (it may be supplied by Galaxy core or another repository)",
+                    linter=cls.name(),
+                )
+                clean = False
+        if checked and clean:
+            lint_ctx.valid("All literal from_data_table references resolve locally", linter=cls.name())
+
+
 REPOSITORY_DATA_TABLE_LINTERS = (
     MissingLocFixture,
     LocRowShape,
+    ManagerTableConfigured,
+    ConsumerTableDefined,
 )
 
 

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -18,13 +18,8 @@ they are never reported here as demonstrably missing.
 """
 
 import os
+from collections.abc import Iterable
 from typing import (
-    Dict,
-    FrozenSet,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
     TYPE_CHECKING,
 )
 
@@ -230,7 +225,7 @@ class ConflictingTableSchema(Linter[RepositoryDataTables]):
 
     @classmethod
     def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
-        by_name: Dict[str, List] = {}
+        by_name: dict[str, list] = {}
         for decl in model.raw_table_decls:
             by_name.setdefault(decl.name, []).append(decl)
         conflicted = False
@@ -287,7 +282,7 @@ REPOSITORY_DATA_TABLE_LINTERS = (
 # these via from_data_table without defining them locally, so they are treated as
 # externally supplied by default; callers extend this set through the
 # external_table_names argument (e.g. from a Tool Shed supplier index).
-DEFAULT_EXTERNAL_TABLE_NAMES: FrozenSet[str] = frozenset({"all_fasta", "fasta_indexes", "__dbkeys__"})
+DEFAULT_EXTERNAL_TABLE_NAMES: frozenset[str] = frozenset({"all_fasta", "fasta_indexes", "__dbkeys__"})
 
 
 def lint_repository_data_tables(model: RepositoryDataTables, lint_ctx: "LintContext") -> None:
@@ -303,10 +298,10 @@ def lint_repository_data_tables(model: RepositoryDataTables, lint_ctx: "LintCont
 def lint_repository_data_tables_bundle(
     lint_ctx: "LintContext",
     repo_root: str,
-    data_manager_conf: Optional[str] = None,
-    tool_data_table_confs: Optional[List[str]] = None,
-    consumer_tool_sources: Optional[Iterable[Tuple[str, "ToolSource"]]] = None,
-    external_table_names: FrozenSet[str] = frozenset(),
+    data_manager_conf: str | None = None,
+    tool_data_table_confs: list[str] | None = None,
+    consumer_tool_sources: Iterable[tuple[str, "ToolSource"]] | None = None,
+    external_table_names: frozenset[str] = frozenset(),
 ) -> None:
     """Assemble a repository data-table model from already-discovered paths and lint it.
 
@@ -322,7 +317,7 @@ def lint_repository_data_tables_bundle(
     are then dispatched by :func:`lint_repository_data_tables`, so they must not nest
     inside that same call (which would print them twice).
     """
-    model: Optional[RepositoryDataTables] = None
+    model: RepositoryDataTables | None = None
 
     def assemble(_unused_target, lint_ctx: "LintContext") -> None:
         nonlocal model
@@ -355,12 +350,12 @@ TOOL_DATA_TABLE_CONF_NAMES = (
 )
 
 
-def _find_data_manager_conf(repo_root: str) -> Optional[str]:
+def _find_data_manager_conf(repo_root: str) -> str | None:
     candidate = os.path.join(repo_root, DATA_MANAGER_CONF)
     return candidate if os.path.exists(candidate) else None
 
 
-def _find_tool_data_table_conf(repo_root: str) -> Optional[str]:
+def _find_tool_data_table_conf(repo_root: str) -> str | None:
     for name in TOOL_DATA_TABLE_CONF_NAMES:
         candidate = os.path.join(repo_root, name)
         if os.path.exists(candidate):
@@ -368,13 +363,13 @@ def _find_tool_data_table_conf(repo_root: str) -> Optional[str]:
     return None
 
 
-def _discover_consumer_tool_sources(repo_root: str) -> List[Tuple[str, "ToolSource"]]:
+def _discover_consumer_tool_sources(repo_root: str) -> list[tuple[str, "ToolSource"]]:
     """Walk ``repo_root`` for loadable tool wrappers that might consume a data table.
 
     Uses the same directory loader Planemo's ``yield_tool_sources`` is built on;
     tool files that fail to load or are not ordinary tool wrappers are skipped.
     """
-    sources: List[Tuple[str, ToolSource]] = []
+    sources: list[tuple[str, ToolSource]] = []
     for tool_path, tool_source in load_tool_sources_from_path(repo_root, recursive=True, register_load_errors=True):
         if is_tool_load_error(tool_source):
             continue
@@ -387,7 +382,7 @@ def _discover_consumer_tool_sources(repo_root: str) -> List[Tuple[str, "ToolSour
 def find_and_lint_repository_data_tables(
     lint_ctx: "LintContext",
     repo_root: str,
-    external_table_names: FrozenSet[str] = frozenset(),
+    external_table_names: frozenset[str] = frozenset(),
 ) -> None:
     """Discover a repository's data-table bundle from ``repo_root`` and lint it.
 

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -135,11 +135,49 @@ class ConsumerTableDefined(Linter):
             lint_ctx.valid("All literal from_data_table references resolve locally", linter=cls.name())
 
 
+class OutputRefValid(Linter):
+    """A data-manager ``output_ref`` names an output the expanded wrapper does not declare.
+
+    Only checked when the manager wrapper was actually resolved; an unresolved
+    wrapper leaves its outputs unknown, so the reference is not-checked rather
+    than reported as demonstrably missing.
+
+    Coverage note: ``output_ref_by_data_table`` keys columns by name, so two
+    columns in one ``<data_table>`` sharing a name collapse (last wins) -- the
+    same duplicate-column limitation deferred alongside conflicting-schema
+    detection also caps output_ref coverage.
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        checked = False
+        clean = True
+        for manager in model.managers:
+            if not manager.wrapper_resolved:
+                continue
+            outputs = manager.tool_output_names
+            for table_name, refs in manager.processor.output_ref_by_data_table.items():
+                for column_name, output_ref in refs.items():
+                    checked = True
+                    if output_ref not in outputs:
+                        declared = ", ".join(sorted(outputs)) or "none"
+                        lint_ctx.error(
+                            f"Data manager '{manager.id}' table '{table_name}' column '{column_name}' has "
+                            f"output_ref '{output_ref}', which is not an output of the manager tool "
+                            f"(declared outputs: {declared})",
+                            linter=cls.name(),
+                        )
+                        clean = False
+        if checked and clean:
+            lint_ctx.valid("All data-manager output_ref values name real wrapper outputs", linter=cls.name())
+
+
 REPOSITORY_DATA_TABLE_LINTERS = (
     MissingLocFixture,
     LocRowShape,
     ManagerTableConfigured,
     ConsumerTableDefined,
+    OutputRefValid,
 )
 
 

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -247,6 +247,30 @@ class ConflictingTableSchema(Linter[RepositoryDataTables]):
             lint_ctx.valid("Each data table is declared with a single consistent schema", linter=cls.name())
 
 
+class EmptyLocFile(Linter[RepositoryDataTables]):
+    """A ``.loc`` / ``.loc.sample`` file is empty and carries no format comment.
+
+    An empty loc file with a leading ``#`` comment documenting the column format is
+    the accepted convention (a data manager fills the real rows on install), so a
+    documented-but-dataless file is fine; only an empty *and* undocumented file is
+    flagged. A warning, not an error: the file is present, just undocumented
+    (Planemo #869).
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        undocumented = [loc for loc in model.loc_files if not loc.has_data and not loc.has_comment]
+        for loc in undocumented:
+            rel = os.path.relpath(loc.path, model.repo_root)
+            lint_ctx.warn(
+                f"Location file [{rel}] is empty and has no comment describing the expected "
+                "column format; add a comment documenting the format",
+                linter=cls.name(),
+            )
+        if model.loc_files and not undocumented:
+            lint_ctx.valid("All loc files carry data or a documenting comment", linter=cls.name())
+
+
 REPOSITORY_DATA_TABLE_LINTERS = (
     MissingLocFixture,
     LocRowShape,
@@ -255,6 +279,7 @@ REPOSITORY_DATA_TABLE_LINTERS = (
     OutputRefValid,
     DuplicateColumnNames,
     ConflictingTableSchema,
+    EmptyLocFile,
 )
 
 # Tables that Galaxy core ships (config/tool_data_table_conf.xml.sample) or that a

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -47,14 +47,16 @@ if TYPE_CHECKING:
 class MissingLocFixture(Linter[RepositoryDataTables]):
     """A configured table references a loc file that resolves to no file on disk.
 
-    ``LocAsset.found`` already accounts for the ``.sample`` fallback, so a
-    sample-backed production loc does not trip this error (only that the
-    reference resolves to *something*).
+    A reference backed by a shipped ``.sample`` (``LocAsset.sample_backed``) is not
+    reported: on install Galaxy materializes the real ``.loc`` from the sample, so
+    only a reference the loader could not resolve *and* that no sample backs is a
+    demonstrably missing loc. (The loader's own ``found`` misses ``tool-data`` samples,
+    hence ``sample_backed`` is resolved separately -- see ``LocAsset.found``.)
     """
 
     @classmethod
     def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
-        missing = [asset for asset in model.loc_assets if not asset.found]
+        missing = [asset for asset in model.loc_assets if not asset.found and not asset.sample_backed]
         for asset in missing:
             lint_ctx.error(
                 f"Data table '{asset.table_name}' references loc file [{asset.path}] which does not exist",

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -48,7 +48,7 @@ class MissingLocFixture(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
         missing = [asset for asset in model.loc_assets if not asset.found]
         for asset in missing:
             lint_ctx.error(
@@ -68,7 +68,7 @@ class LocRowShape(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
         found_error = False
         for asset in model.loc_assets:
             for message in asset.errors:
@@ -101,7 +101,7 @@ class ManagerTableConfigured(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
         known = model.configured_table_names | model.external_table_names
         clean = True
         for manager in model.managers:
@@ -128,7 +128,7 @@ class ConsumerTableDefined(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
         known = model.configured_table_names | model.external_table_names
         checked = False
         clean = True
@@ -162,7 +162,7 @@ class OutputRefValid(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
         checked = False
         clean = True
         for manager in model.managers:
@@ -193,7 +193,7 @@ class DuplicateColumnNames(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
         clean = True
         for decl in model.raw_table_decls:
             seen = set()
@@ -222,7 +222,7 @@ class ConflictingTableSchema(Linter):
     """
 
     @classmethod
-    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):  # type: ignore[override]
         by_name: Dict[str, List] = {}
         for decl in model.raw_table_decls:
             by_name.setdefault(decl.name, []).append(decl)

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -17,6 +17,7 @@ Advisory / unresolved / externally-supplied conditions are handled elsewhere so
 they are never reported here as demonstrably missing.
 """
 
+import os
 from typing import (
     Dict,
     FrozenSet,
@@ -32,11 +33,15 @@ from galaxy.tool_util.data.bundles.repository import (
     RepositoryDataTables,
 )
 from galaxy.tool_util.lint import Linter
+from galaxy.tool_util.loader_directory import (
+    is_tool_load_error,
+    load_tool_sources_from_path,
+)
+from galaxy.tool_util.parser.interface import ToolSource
 from galaxy.util import unicodify
 
 if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
-    from galaxy.tool_util.parser.interface import ToolSource
 
 
 class MissingLocFixture(Linter):
@@ -304,3 +309,70 @@ def lint_repository_data_tables_bundle(
     lint_ctx.lint("lint_data_tables_bundle", assemble, None)
     if model is not None:
         lint_repository_data_tables(model, lint_ctx)
+
+
+DATA_MANAGER_CONF = "data_manager_conf.xml"
+# tool_data_table_conf variants, most-preferred first: the test conf points loc files
+# at real test-data, then the shipped sample, then a plain checked-in conf.
+TOOL_DATA_TABLE_CONF_NAMES = (
+    "tool_data_table_conf.xml.test",
+    "tool_data_table_conf.xml.sample",
+    "tool_data_table_conf.xml",
+)
+
+
+def _find_data_manager_conf(repo_root: str) -> Optional[str]:
+    candidate = os.path.join(repo_root, DATA_MANAGER_CONF)
+    return candidate if os.path.exists(candidate) else None
+
+
+def _find_tool_data_table_conf(repo_root: str) -> Optional[str]:
+    for name in TOOL_DATA_TABLE_CONF_NAMES:
+        candidate = os.path.join(repo_root, name)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def _discover_consumer_tool_sources(repo_root: str) -> List[Tuple[str, "ToolSource"]]:
+    """Walk ``repo_root`` for loadable tool wrappers that might consume a data table.
+
+    Uses the same directory loader Planemo's ``yield_tool_sources`` is built on;
+    tool files that fail to load or are not ordinary tool wrappers are skipped.
+    """
+    sources: List[Tuple[str, ToolSource]] = []
+    for tool_path, tool_source in load_tool_sources_from_path(repo_root, recursive=True, register_load_errors=True):
+        if is_tool_load_error(tool_source):
+            continue
+        if not isinstance(tool_source, ToolSource):
+            continue
+        sources.append((tool_path, tool_source))
+    return sources
+
+
+def find_and_lint_repository_data_tables(
+    lint_ctx: "LintContext",
+    repo_root: str,
+    external_table_names: FrozenSet[str] = frozenset(),
+) -> None:
+    """Discover a repository's data-table bundle from ``repo_root`` and lint it.
+
+    The one-call entry point for a repository linter (Planemo's ``shed_lint``, the
+    ``galaxy-tool-data-lint`` CLI): it locates the ``data_manager_conf`` /
+    ``tool_data_table_conf`` files and the consumer tool sources, then hands them to
+    :func:`lint_repository_data_tables_bundle`. Consumer tools are only walked when the
+    repository actually declares a data-table bundle.
+    """
+    data_manager_conf = _find_data_manager_conf(repo_root)
+    tool_data_table_conf = _find_tool_data_table_conf(repo_root)
+    consumer_tool_sources = None
+    if data_manager_conf or tool_data_table_conf:
+        consumer_tool_sources = _discover_consumer_tool_sources(repo_root)
+    lint_repository_data_tables_bundle(
+        lint_ctx,
+        repo_root,
+        data_manager_conf=data_manager_conf,
+        tool_data_table_confs=[tool_data_table_conf] if tool_data_table_conf else None,
+        consumer_tool_sources=consumer_tool_sources,
+        external_table_names=external_table_names,
+    )

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -19,15 +19,24 @@ they are never reported here as demonstrably missing.
 
 from typing import (
     Dict,
+    FrozenSet,
+    Iterable,
     List,
+    Optional,
+    Tuple,
     TYPE_CHECKING,
 )
 
-from galaxy.tool_util.data.bundles.repository import RepositoryDataTables
+from galaxy.tool_util.data.bundles.repository import (
+    build_repository_data_tables,
+    RepositoryDataTables,
+)
 from galaxy.tool_util.lint import Linter
+from galaxy.util import unicodify
 
 if TYPE_CHECKING:
     from galaxy.tool_util.lint import LintContext
+    from galaxy.tool_util.parser.interface import ToolSource
 
 
 class MissingLocFixture(Linter):
@@ -250,3 +259,48 @@ def lint_repository_data_tables(model: RepositoryDataTables, lint_ctx: "LintCont
     """
     for linter in REPOSITORY_DATA_TABLE_LINTERS:
         lint_ctx.lint(linter.name(), linter.lint, model)
+
+
+def lint_repository_data_tables_bundle(
+    lint_ctx: "LintContext",
+    repo_root: str,
+    data_manager_conf: Optional[str] = None,
+    tool_data_table_confs: Optional[List[str]] = None,
+    consumer_tool_sources: Optional[Iterable[Tuple[str, "ToolSource"]]] = None,
+    external_table_names: FrozenSet[str] = frozenset(),
+) -> None:
+    """Assemble a repository data-table model from already-discovered paths and lint it.
+
+    The convenience entry point for repository linters (e.g. Planemo's ``shed_lint``):
+    the caller does discovery -- which ``data_manager_conf`` / ``tool_data_table_conf``
+    files, which consumer tool sources -- and this builds the
+    :class:`~galaxy.tool_util.data.bundles.repository.RepositoryDataTables` and runs the
+    linters over it.
+
+    Assembly (the discovery-result build) runs inside its own ``lint_ctx.lint`` so its
+    skip / assembly-failure diagnostics are actually emitted -- ``LintContext`` only
+    flushes messages appended during a dispatched ``lint`` call. The per-table linters
+    are then dispatched by :func:`lint_repository_data_tables`, so they must not nest
+    inside that same call (which would print them twice).
+    """
+    model: Optional[RepositoryDataTables] = None
+
+    def assemble(_unused_target, lint_ctx: "LintContext") -> None:
+        nonlocal model
+        if not data_manager_conf and not tool_data_table_confs:
+            lint_ctx.info("No data manager or tool data table configuration found, skipping data table linting.")
+            return
+        try:
+            model = build_repository_data_tables(
+                repo_root,
+                data_manager_conf=data_manager_conf,
+                tool_data_table_confs=tool_data_table_confs,
+                consumer_tool_sources=consumer_tool_sources,
+                external_table_names=external_table_names,
+            )
+        except Exception as e:
+            lint_ctx.error(f"Problem assembling repository data table model [{unicodify(e)}]")
+
+    lint_ctx.lint("lint_data_tables_bundle", assemble, None)
+    if model is not None:
+        lint_repository_data_tables(model, lint_ctx)

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -1,0 +1,84 @@
+"""Repository-level linters over a :class:`RepositoryDataTables` model.
+
+These are the deterministic bundle-contract checks a repository linter (e.g.
+Planemo's ``shed_lint``) runs across a data-manager / reference-data repository.
+Assembly and path/``.sample`` resolution live in :mod:`repository`; the linters
+here only classify the already-resolved model and report through a
+:class:`~galaxy.tool_util.lint.LintContext`.
+
+The set is intentionally limited to conditions Planemo can *prove* from
+statically resolved evidence:
+
+- a referenced loc fixture is absent (:class:`MissingLocFixture`); and
+- a non-comment loc row cannot supply every declared column index
+  (:class:`LocRowShape`).
+
+Advisory / unresolved / externally-supplied conditions are handled elsewhere so
+they are never reported here as demonstrably missing.
+"""
+
+from typing import TYPE_CHECKING
+
+from galaxy.tool_util.data.bundles.repository import RepositoryDataTables
+from galaxy.tool_util.lint import Linter
+
+if TYPE_CHECKING:
+    from galaxy.tool_util.lint import LintContext
+
+
+class MissingLocFixture(Linter):
+    """A configured table references a loc file that resolves to no file on disk.
+
+    ``LocAsset.found`` already accounts for the ``.sample`` fallback, so a
+    sample-backed production loc does not trip this error (only that the
+    reference resolves to *something*).
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        missing = [asset for asset in model.loc_assets if not asset.found]
+        for asset in missing:
+            lint_ctx.error(
+                f"Data table '{asset.table_name}' references loc file [{asset.path}] which does not exist",
+                linter=cls.name(),
+            )
+        if model.loc_assets and not missing:
+            lint_ctx.valid("All referenced loc files resolve", linter=cls.name())
+
+
+class LocRowShape(Linter):
+    """A non-comment loc row cannot supply every declared column index.
+
+    Reuses the row-shape errors captured by ``TabularToolDataTable`` at load
+    time (too-few-fields / wrong-separator rows), which already name the offending
+    file line and table.
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        found_error = False
+        for asset in model.loc_assets:
+            for message in asset.errors:
+                lint_ctx.error(message, linter=cls.name())
+                found_error = True
+        # Only assets whose file resolved were actually parsed -- an unfound loc has
+        # no rows to check, so it must not license a "rows are fine" confirmation.
+        checked = [asset for asset in model.loc_assets if asset.found]
+        if checked and not found_error:
+            lint_ctx.valid("All loc rows supply every declared column", linter=cls.name())
+
+
+REPOSITORY_DATA_TABLE_LINTERS = (
+    MissingLocFixture,
+    LocRowShape,
+)
+
+
+def lint_repository_data_tables(model: RepositoryDataTables, lint_ctx: "LintContext") -> None:
+    """Run the repository data-table linters over ``model``.
+
+    Each linter is dispatched through ``lint_ctx.lint`` so it is individually
+    skippable by name (matching how Planemo drives the tool linters).
+    """
+    for linter in REPOSITORY_DATA_TABLE_LINTERS:
+        lint_ctx.lint(linter.name(), linter.lint, model)

--- a/lib/galaxy/tool_util/data/bundles/lint.py
+++ b/lib/galaxy/tool_util/data/bundles/lint.py
@@ -17,7 +17,11 @@ Advisory / unresolved / externally-supplied conditions are handled elsewhere so
 they are never reported here as demonstrably missing.
 """
 
-from typing import TYPE_CHECKING
+from typing import (
+    Dict,
+    List,
+    TYPE_CHECKING,
+)
 
 from galaxy.tool_util.data.bundles.repository import RepositoryDataTables
 from galaxy.tool_util.lint import Linter
@@ -172,12 +176,69 @@ class OutputRefValid(Linter):
             lint_ctx.valid("All data-manager output_ref values name real wrapper outputs", linter=cls.name())
 
 
+class DuplicateColumnNames(Linter):
+    """A ``<table>`` declares the same column name more than once.
+
+    The parsed ``columns`` dict silently collapses duplicates, so this is checked
+    against the raw declared column list.
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        clean = True
+        for decl in model.raw_table_decls:
+            seen = set()
+            duplicates = []
+            for name in decl.column_names:
+                if name in seen and name not in duplicates:
+                    duplicates.append(name)
+                seen.add(name)
+            if duplicates:
+                dupes = ", ".join(duplicates)
+                lint_ctx.error(
+                    f"Data table '{decl.name}' declares duplicate column name(s): {dupes}",
+                    linter=cls.name(),
+                )
+                clean = False
+        if model.raw_table_decls and clean:
+            lint_ctx.valid("No data table declares duplicate column names", linter=cls.name())
+
+
+class ConflictingTableSchema(Linter):
+    """The same table name is declared with different columns/separator/comment across the bundle.
+
+    A column conflict would make the loader raise, so this reads the pre-merge raw
+    declarations; a separator/comment-only conflict loads fine but is still
+    structurally ambiguous.
+    """
+
+    @classmethod
+    def lint(cls, model: RepositoryDataTables, lint_ctx: "LintContext"):
+        by_name: Dict[str, List] = {}
+        for decl in model.raw_table_decls:
+            by_name.setdefault(decl.name, []).append(decl)
+        conflicted = False
+        for name, decls in by_name.items():
+            schemas = {(tuple(sorted(decl.columns.items())), decl.separator, decl.comment_char) for decl in decls}
+            if len(schemas) > 1:
+                lint_ctx.error(
+                    f"Data table '{name}' is declared with conflicting schemas across the bundle "
+                    f"({len(decls)} definitions do not agree on columns/separator/comment_char)",
+                    linter=cls.name(),
+                )
+                conflicted = True
+        if model.raw_table_decls and not conflicted:
+            lint_ctx.valid("Each data table is declared with a single consistent schema", linter=cls.name())
+
+
 REPOSITORY_DATA_TABLE_LINTERS = (
     MissingLocFixture,
     LocRowShape,
     ManagerTableConfigured,
     ConsumerTableDefined,
     OutputRefValid,
+    DuplicateColumnNames,
+    ConflictingTableSchema,
 )
 
 

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -86,6 +86,25 @@ class LocAsset:
 
 
 @dataclass
+class LocFile:
+    """A ``.loc`` / ``.loc.sample`` file present in the repository tree.
+
+    Distinct from :class:`LocAsset`, which is a *configured-table reference* the
+    loader resolved: many ``.loc.sample`` files ship without ever appearing as a
+    resolved asset (the loader's ``.sample`` fallback misses the shed ``tool-data``
+    layout -- see ``LocAsset.found``), so the empty-file check must look at the files
+    on disk, not the resolved references. Records only facts; the policy (an empty,
+    undocumented file wants a format comment) lives in the linter.
+    """
+
+    path: str
+    # A non-blank, non-comment line -- i.e. an actual data row.
+    has_data: bool
+    # A ``#`` comment line documenting the expected column format.
+    has_comment: bool
+
+
+@dataclass
 class RawTableDecl:
     """A single ``<table>`` element as declared, before the loader merges same-named tables.
 
@@ -162,6 +181,9 @@ class RepositoryDataTables:
     # for one name. Populated even when the loader is skipped over a conflict.
     raw_table_decls: List[RawTableDecl] = field(default_factory=list)
     loc_assets: List[LocAsset] = field(default_factory=list)
+    # Every ``.loc`` / ``.loc.sample`` file found in the repo tree (independent of
+    # whether a configured table resolves to it), for the empty-file check.
+    loc_files: List[LocFile] = field(default_factory=list)
     consumers: List[ConsumerRef] = field(default_factory=list)
     # Tables validly supplied by Galaxy core or another installed repository; a
     # consumer of one of these is not a demonstrably-missing definition (req #2).
@@ -340,6 +362,34 @@ def _sample_backed(repo_root: str, filename: str) -> bool:
     return os.path.exists(tool_data_sample)
 
 
+def _classify_loc_file(path: str) -> LocFile:
+    """Record whether a loc file carries any data row and any format comment."""
+    has_data = False
+    has_comment = False
+    # utf-8-sig so a leading BOM is stripped rather than surviving str.strip() and
+    # masking an otherwise-empty file as a data row.
+    with open(path, encoding="utf-8-sig", errors="replace") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.startswith("#"):
+                has_comment = True
+            else:
+                has_data = True
+    return LocFile(path=path, has_data=has_data, has_comment=has_comment)
+
+
+def _discover_loc_files(repo_root: str) -> List[LocFile]:
+    """Every ``.loc`` / ``.loc.sample`` file under ``repo_root`` (data rows / comments recorded)."""
+    loc_files = []
+    for dirpath, _, filenames in os.walk(repo_root):
+        for filename in filenames:
+            if filename.endswith(".loc") or filename.endswith(".loc.sample"):
+                loc_files.append(_classify_loc_file(os.path.join(dirpath, filename)))
+    return loc_files
+
+
 def _build_tables(
     repo_root: str, tool_data_table_confs: List[str], raw_decls: List[RawTableDecl]
 ) -> Tuple[List[TableDecl], List[LocAsset]]:
@@ -407,6 +457,7 @@ def build_repository_data_tables(
     (non data-manager) tools that may reference the repository's tables.
     """
     model = RepositoryDataTables(repo_root=repo_root, external_table_names=external_table_names)
+    model.loc_files = _discover_loc_files(repo_root)
     if data_manager_conf:
         model.managers = _build_managers(data_manager_conf)
     if tool_data_table_confs:

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -100,7 +100,11 @@ class RawTableDecl:
 
 @dataclass
 class TableDecl:
-    """A ``tool_data_table_conf.xml*`` ``<table>`` definition, plus its live instance."""
+    """A ``tool_data_table_conf.xml*`` ``<table>`` definition (name + parsed schema).
+
+    Only ``name`` is read today (via ``configured_table_names``); the parsed schema
+    fields are retained for the planned bundle-completeness check.
+    """
 
     name: str
     columns: Dict[str, int]
@@ -109,8 +113,6 @@ class TableDecl:
     comment_char: str
     allow_duplicate_entries: bool
     loc_paths: Tuple[str, ...]
-    # The configured runtime table -- reused by downstream row-shape / schema checks.
-    instance: TabularToolDataTable
     source: Optional[SourceLoc] = None
 
 
@@ -164,12 +166,6 @@ class RepositoryDataTables:
         names |= {d.name for d in self.raw_table_decls}
         return frozenset(names)
 
-    def table(self, name: str) -> Optional[TableDecl]:
-        for table in self.configured_tables:
-            if table.name == name:
-                return table
-        return None
-
 
 def _xml_output_names(root: Optional[Element]) -> FrozenSet[str]:
     """Names of ``<data>`` / ``<collection>`` outputs declared by a (macro-expanded) wrapper."""
@@ -187,9 +183,19 @@ def _xml_output_names(root: Optional[Element]) -> FrozenSet[str]:
     return frozenset(names)
 
 
+def _tool_source_root(tool_source: ToolSource) -> Optional[Element]:
+    """Root element of a (macro-expanded) XML wrapper, or None for a non-XML source.
+
+    Reads the ``xml_tree`` attribute the tool linters standardize on rather than the
+    equivalent ``root`` attribute.
+    """
+    xml_tree = getattr(tool_source, "xml_tree", None)
+    return xml_tree.getroot() if xml_tree is not None else None
+
+
 def _consumer_refs(tool_source: ToolSource, path: str) -> List[ConsumerRef]:
     """Scan a (macro-expanded) wrapper for ``from_data_table`` table references."""
-    root = getattr(tool_source, "root", None)
+    root = _tool_source_root(tool_source)
     if root is None:
         return []
     tool_id = tool_source.parse_id()
@@ -227,7 +233,7 @@ def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
             tool_path = os.path.join(conf_dir, tool_file)
             if os.path.exists(tool_path):
                 tool_source = get_tool_source(config_file=tool_path)
-                output_names = _xml_output_names(getattr(tool_source, "root", None))
+                output_names = _xml_output_names(_tool_source_root(tool_source))
                 wrapper_resolved = True
         managers.append(
             ManagerDecl(
@@ -245,26 +251,23 @@ def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
 def _raw_column_spec(table_elem: Element) -> Tuple[Tuple[str, ...], Dict[str, int]]:
     """Declared column names (with duplicates) and the parsed name->index map.
 
-    Mirrors ``TabularToolDataTable.parse_column_spec_element`` so the map matches
-    what the loader compares when merging same-named tables, while the ordered name
-    list preserves duplicates the map collapses.
+    The name->index map is produced by the canonical
+    ``TabularToolDataTable.parse_column_spec_element`` so it matches exactly what the
+    loader compares when merging same-named tables. Only the ordered name list (which
+    keeps the duplicates ``DuplicateColumnNames`` needs, but the canonical map
+    collapses) is derived here.
     """
-    columns: Dict[str, int] = {}
+    columns, _, _ = TabularToolDataTable.parse_column_spec_element(table_elem)
     columns_elem = table_elem.find("columns")
     if columns_elem is not None:
-        names = tuple(name.strip() for name in xml_text(columns_elem).split(","))
-        for index, name in enumerate(names):
-            columns[name] = index
-        return names, columns
-    names_list = []
-    for column_elem in table_elem.findall("column"):
-        name = column_elem.get("name")
-        index_attr = column_elem.get("index")
-        if name is None or index_attr is None:
-            continue
-        columns[name] = int(index_attr)
-        names_list.append(name)
-    return tuple(names_list), columns
+        column_names = tuple(name.strip() for name in xml_text(columns_elem).split(","))
+    else:
+        column_names = tuple(
+            column_elem.get("name")
+            for column_elem in table_elem.findall("column")
+            if column_elem.get("name") is not None and column_elem.get("index") is not None
+        )
+    return column_names, columns
 
 
 def _raw_table_decls(tool_data_table_confs: List[str]) -> List[RawTableDecl]:
@@ -290,9 +293,12 @@ def _raw_table_decls(tool_data_table_confs: List[str]) -> List[RawTableDecl]:
 def _has_column_conflict(raw_decls: List[RawTableDecl]) -> bool:
     """Whether any table name is declared with differing columns (what the loader's merge rejects).
 
-    Keys on the parsed name->index map, not the raw name list, because that is
-    exactly what ``merge_tool_data_table`` asserts on -- two ``<column>`` forms
-    can share names yet differ by index.
+    Keys on the parsed name->index map, not the raw name list, because that map is
+    exactly what the loader compares -- ``merge_tool_data_table`` /
+    ``ToolDataTableManager.assert_data_table_consistency`` reject same-named tables
+    whose ``columns`` maps differ (two ``<column>`` forms can share names yet differ
+    by index). This is the pre-load counterpart of that check: same columns-equality
+    rule, applied to the raw declarations before the loader is invoked.
     """
     by_name: Dict[str, List[Dict[str, int]]] = {}
     for decl in raw_decls:
@@ -342,7 +348,6 @@ def _build_tables(
                 comment_char=table.comment_char,
                 allow_duplicate_entries=table.allow_duplicate_entries,
                 loc_paths=tuple(loc_paths),
-                instance=table,
                 source=conf_source,
             )
         )

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -45,6 +45,7 @@ from galaxy.tool_util.parser.interface import ToolSource
 from galaxy.util import (
     Element,
     parse_xml,
+    xml_text,
 )
 
 
@@ -73,6 +74,28 @@ class LocAsset:
     # resolved file), so "no errors" is not "clean" for an unfound reference.
     errors: Tuple[str, ...] = ()
     source: Optional[SourceLoc] = None
+
+
+@dataclass
+class RawTableDecl:
+    """A single ``<table>`` element as declared, before the loader merges same-named tables.
+
+    Kept separate from :class:`TableDecl` because the loader collapses duplicate
+    column names into a dict and *raises* when two same-named tables declare
+    different columns -- so conflicting/duplicate schemas are only observable in
+    this pre-merge view.
+    """
+
+    name: str
+    # Declared column names in order, keeping duplicates (the parsed ``columns``
+    # map collapses them) -- used to detect a table declaring one name twice.
+    column_names: Tuple[str, ...]
+    # The name->index map the loader would parse; this is what it compares when
+    # merging same-named tables, so schema-conflict detection keys on this.
+    columns: Dict[str, int]
+    separator: str
+    comment_char: str
+    source: SourceLoc
 
 
 @dataclass
@@ -124,6 +147,9 @@ class RepositoryDataTables:
     repo_root: str
     managers: List[ManagerDecl] = field(default_factory=list)
     configured_tables: List[TableDecl] = field(default_factory=list)
+    # Every ``<table>`` element as declared (pre-merge); may hold several entries
+    # for one name. Populated even when the loader is skipped over a conflict.
+    raw_table_decls: List[RawTableDecl] = field(default_factory=list)
     loc_assets: List[LocAsset] = field(default_factory=list)
     consumers: List[ConsumerRef] = field(default_factory=list)
     # Tables validly supplied by Galaxy core or another installed repository; a
@@ -132,7 +158,11 @@ class RepositoryDataTables:
 
     @property
     def configured_table_names(self) -> FrozenSet[str]:
-        return frozenset(t.name for t in self.configured_tables)
+        # Union of loader-enriched and raw declarations: names stay available for
+        # cross-component checks even when a schema conflict made the loader skip.
+        names = {t.name for t in self.configured_tables}
+        names |= {d.name for d in self.raw_table_decls}
+        return frozenset(names)
 
     def table(self, name: str) -> Optional[TableDecl]:
         for table in self.configured_tables:
@@ -212,7 +242,75 @@ def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
     return managers
 
 
-def _build_tables(repo_root: str, tool_data_table_confs: List[str]) -> Tuple[List[TableDecl], List[LocAsset]]:
+def _raw_column_spec(table_elem: Element) -> Tuple[Tuple[str, ...], Dict[str, int]]:
+    """Declared column names (with duplicates) and the parsed name->index map.
+
+    Mirrors ``TabularToolDataTable.parse_column_spec_element`` so the map matches
+    what the loader compares when merging same-named tables, while the ordered name
+    list preserves duplicates the map collapses.
+    """
+    columns: Dict[str, int] = {}
+    columns_elem = table_elem.find("columns")
+    if columns_elem is not None:
+        names = tuple(name.strip() for name in xml_text(columns_elem).split(","))
+        for index, name in enumerate(names):
+            columns[name] = index
+        return names, columns
+    names_list = []
+    for column_elem in table_elem.findall("column"):
+        name = column_elem.get("name")
+        index_attr = column_elem.get("index")
+        if name is None or index_attr is None:
+            continue
+        columns[name] = int(index_attr)
+        names_list.append(name)
+    return tuple(names_list), columns
+
+
+def _raw_table_decls(tool_data_table_confs: List[str]) -> List[RawTableDecl]:
+    """Parse every ``<table>`` element as declared, before the loader merges same names."""
+    decls = []
+    for conf in tool_data_table_confs:
+        root = parse_xml(conf).getroot()
+        for table_elem in root.findall("table"):
+            column_names, columns = _raw_column_spec(table_elem)
+            decls.append(
+                RawTableDecl(
+                    name=table_elem.get("name") or "",
+                    column_names=column_names,
+                    columns=columns,
+                    separator=table_elem.get("separator", "\t"),
+                    comment_char=table_elem.get("comment_char", "#"),
+                    source=SourceLoc(path=conf, line=getattr(table_elem, "sourceline", None)),
+                )
+            )
+    return decls
+
+
+def _has_column_conflict(raw_decls: List[RawTableDecl]) -> bool:
+    """Whether any table name is declared with differing columns (what the loader's merge rejects).
+
+    Keys on the parsed name->index map, not the raw name list, because that is
+    exactly what ``merge_tool_data_table`` asserts on -- two ``<column>`` forms
+    can share names yet differ by index.
+    """
+    by_name: Dict[str, List[Dict[str, int]]] = {}
+    for decl in raw_decls:
+        specs = by_name.setdefault(decl.name, [])
+        if decl.columns not in specs:
+            specs.append(decl.columns)
+    return any(len(specs) > 1 for specs in by_name.values())
+
+
+def _build_tables(
+    repo_root: str, tool_data_table_confs: List[str], raw_decls: List[RawTableDecl]
+) -> Tuple[List[TableDecl], List[LocAsset]]:
+    # A same-named table declared with conflicting columns makes the loader's merge
+    # raise; skip enrichment in that case and let the linter report the conflict from
+    # the raw declarations (table names still come from those). Loc diagnostics for
+    # sibling tables are suppressed until the conflict is fixed and the loader re-runs.
+    if _has_column_conflict(raw_decls):
+        return [], []
     # ToolDataTableManager loads the confs, resolving ${__HERE__} / .sample fallback and
     # recording per-file parse errors -- we read that resolved state back out.
     tdt_manager = ToolDataTableManager(repo_root, config_filename=tool_data_table_confs)
@@ -270,7 +368,10 @@ def build_repository_data_tables(
     if data_manager_conf:
         model.managers = _build_managers(data_manager_conf)
     if tool_data_table_confs:
-        model.configured_tables, model.loc_assets = _build_tables(repo_root, tool_data_table_confs)
+        model.raw_table_decls = _raw_table_decls(tool_data_table_confs)
+        model.configured_tables, model.loc_assets = _build_tables(
+            repo_root, tool_data_table_confs, model.raw_table_decls
+        )
     for path, tool_source in consumer_tool_sources or []:
         model.consumers.extend(_consumer_refs(tool_source, path))
     return model

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -1,0 +1,269 @@
+"""Cross-file *lint view* of a repository's data-table bundle.
+
+This module assembles the producer/configuration/consumer artifacts of a
+data-manager / reference-data repository into a single :class:`RepositoryDataTables`
+model so repository-level linters can reason across files. It is deliberately
+*pure data assembly* -- it parses and resolves, it does not emit diagnostics.
+
+It composes existing galaxy-tool-util abstractions rather than duplicating them:
+
+- the data-manager ``<data_tables>`` block is parsed with
+  :func:`galaxy.tool_util.data.bundles.models.convert_data_tables_xml` into a
+  :class:`~galaxy.tool_util.data.bundles.models.DataTableBundleProcessorDescription`
+  (giving ``output_ref`` values, table names, and column mappings);
+- ``tool_data_table_conf.xml*`` files are loaded with
+  :class:`~galaxy.tool_util.data.ToolDataTableManager`, which already resolves
+  ``${__HERE__}`` / ``.sample`` fallback and records per-row parse errors; and
+- tool wrappers are read through :func:`galaxy.tool_util.parser.factory.get_tool_source`,
+  which expands macros before names are resolved.
+"""
+
+import os
+from dataclasses import (
+    dataclass,
+    field,
+)
+from typing import (
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+)
+
+from galaxy.tool_util.data import (
+    TabularToolDataTable,
+    ToolDataTableManager,
+)
+from galaxy.tool_util.data.bundles.models import (
+    convert_data_tables_xml,
+    DataTableBundleProcessorDescription,
+)
+from galaxy.tool_util.parser.factory import get_tool_source
+from galaxy.tool_util.parser.interface import ToolSource
+from galaxy.util import (
+    Element,
+    parse_xml,
+)
+
+
+@dataclass
+class SourceLoc:
+    """Where a modeled element came from, for narrow skips and PR annotations."""
+
+    path: str
+    line: Optional[int] = None
+
+
+@dataclass
+class LocAsset:
+    """A resolved ``.loc`` / ``.loc.sample`` file referenced by a configured table."""
+
+    table_name: str
+    path: str
+    # ``found`` means the loader resolved *some* file for this reference. Note a table's
+    # ``<file path="tool-data/x.loc">`` whose real ``.loc`` is absent resolves to the
+    # ``x.loc.sample`` fallback with ``found=True`` -- so a check that a production loc
+    # exists must consider ``found and not is_sample``, not ``found`` alone.
+    found: bool
+    is_sample: bool
+    # Row-shape errors captured by ``parse_file_fields`` at load time (too-few-fields /
+    # wrong-separator lines). Only populated when ``found`` (parsing only runs on a
+    # resolved file), so "no errors" is not "clean" for an unfound reference.
+    errors: Tuple[str, ...] = ()
+    source: Optional[SourceLoc] = None
+
+
+@dataclass
+class TableDecl:
+    """A ``tool_data_table_conf.xml*`` ``<table>`` definition, plus its live instance."""
+
+    name: str
+    columns: Dict[str, int]
+    largest_index: int
+    separator: str
+    comment_char: str
+    allow_duplicate_entries: bool
+    loc_paths: Tuple[str, ...]
+    # The configured runtime table -- reused by downstream row-shape / schema checks.
+    instance: TabularToolDataTable
+    source: Optional[SourceLoc] = None
+
+
+@dataclass
+class ConsumerRef:
+    """A tool reference to a data table (``from_data_table``)."""
+
+    table_name: str
+    kind: str
+    tool_id: Optional[str]
+    source: SourceLoc
+
+
+@dataclass
+class ManagerDecl:
+    """A ``<data_manager>`` and the wrapper it points at."""
+
+    id: str
+    tool_file: str
+    tool_output_names: FrozenSet[str]
+    # Reused manager-side model: output_ref values, table names, column mappings.
+    processor: DataTableBundleProcessorDescription
+    source: SourceLoc
+
+
+@dataclass
+class RepositoryDataTables:
+    """Cross-file lint view of one repository's data-table bundle."""
+
+    repo_root: str
+    managers: List[ManagerDecl] = field(default_factory=list)
+    configured_tables: List[TableDecl] = field(default_factory=list)
+    loc_assets: List[LocAsset] = field(default_factory=list)
+    consumers: List[ConsumerRef] = field(default_factory=list)
+    # Tables validly supplied by Galaxy core or another installed repository; a
+    # consumer of one of these is not a demonstrably-missing definition (req #2).
+    external_table_names: FrozenSet[str] = frozenset()
+
+    @property
+    def configured_table_names(self) -> FrozenSet[str]:
+        return frozenset(t.name for t in self.configured_tables)
+
+    def table(self, name: str) -> Optional[TableDecl]:
+        for table in self.configured_tables:
+            if table.name == name:
+                return table
+        return None
+
+
+def _xml_output_names(root: Optional[Element]) -> FrozenSet[str]:
+    """Names of ``<data>`` / ``<collection>`` outputs declared by a (macro-expanded) wrapper."""
+    if root is None:
+        return frozenset()
+    outputs_elem = root.find("outputs")
+    if outputs_elem is None:
+        return frozenset()
+    names = set()
+    for output_elem in outputs_elem:
+        if output_elem.tag in ("data", "collection"):
+            name = output_elem.get("name")
+            if name:
+                names.add(name)
+    return frozenset(names)
+
+
+def _consumer_refs(tool_source: ToolSource, path: str) -> List[ConsumerRef]:
+    """Scan a (macro-expanded) wrapper for ``from_data_table`` table references."""
+    root = getattr(tool_source, "root", None)
+    if root is None:
+        return []
+    tool_id = tool_source.parse_id()
+    refs = []
+    for elem in root.iter():
+        table_name = elem.get("from_data_table")
+        if table_name:
+            refs.append(
+                ConsumerRef(
+                    table_name=table_name,
+                    kind="from_data_table",
+                    tool_id=tool_id,
+                    source=SourceLoc(path=path, line=getattr(elem, "sourceline", None)),
+                )
+            )
+    return refs
+
+
+def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
+    conf_dir = os.path.dirname(os.path.abspath(data_manager_conf))
+    root = parse_xml(data_manager_conf).getroot()
+    managers = []
+    for dm_elem in root.findall("data_manager"):
+        manager_id = dm_elem.get("guid") or dm_elem.get("id") or ""
+        # tool_file is either the attribute form or the nested <tool file="..."/> (shed/guid)
+        # form -- mirror DataManager._load_from_element in tools/data_manager/manager.py.
+        tool_file = dm_elem.get("tool_file")
+        if tool_file is None:
+            tool_elem = dm_elem.find("tool")
+            tool_file = tool_elem.get("file") if tool_elem is not None else None
+        tool_file = tool_file or ""
+        output_names: FrozenSet[str] = frozenset()
+        if tool_file:
+            tool_path = os.path.join(conf_dir, tool_file)
+            if os.path.exists(tool_path):
+                tool_source = get_tool_source(config_file=tool_path)
+                output_names = _xml_output_names(getattr(tool_source, "root", None))
+        managers.append(
+            ManagerDecl(
+                id=manager_id,
+                tool_file=tool_file,
+                tool_output_names=output_names,
+                processor=convert_data_tables_xml(dm_elem),
+                source=SourceLoc(path=data_manager_conf, line=getattr(dm_elem, "sourceline", None)),
+            )
+        )
+    return managers
+
+
+def _build_tables(repo_root: str, tool_data_table_confs: List[str]) -> Tuple[List[TableDecl], List[LocAsset]]:
+    # ToolDataTableManager loads the confs, resolving ${__HERE__} / .sample fallback and
+    # recording per-file parse errors -- we read that resolved state back out.
+    tdt_manager = ToolDataTableManager(repo_root, config_filename=tool_data_table_confs)
+    conf_source = SourceLoc(path=tool_data_table_confs[0]) if len(tool_data_table_confs) == 1 else None
+    tables = []
+    loc_assets = []
+    for table in tdt_manager.data_tables.values():
+        if not isinstance(table, TabularToolDataTable):
+            continue
+        loc_paths = []
+        for filename, info in table.filenames.items():
+            loc_paths.append(filename)
+            loc_assets.append(
+                LocAsset(
+                    table_name=table.name,
+                    path=str(filename),
+                    found=bool(info.get("found")),
+                    is_sample=str(filename).endswith(".sample"),
+                    errors=tuple(info.get("errors") or ()),
+                    source=SourceLoc(path=str(filename)),
+                )
+            )
+        tables.append(
+            TableDecl(
+                name=table.name,
+                columns=dict(table.columns),
+                largest_index=table.largest_index,
+                separator=table.separator,
+                comment_char=table.comment_char,
+                allow_duplicate_entries=table.allow_duplicate_entries,
+                loc_paths=tuple(loc_paths),
+                instance=table,
+                source=conf_source,
+            )
+        )
+    return tables, loc_assets
+
+
+def build_repository_data_tables(
+    repo_root: str,
+    data_manager_conf: Optional[str] = None,
+    tool_data_table_confs: Optional[List[str]] = None,
+    consumer_tool_sources: Optional[Iterable[Tuple[str, ToolSource]]] = None,
+    external_table_names: FrozenSet[str] = frozenset(),
+) -> RepositoryDataTables:
+    """Assemble a :class:`RepositoryDataTables` from already-discovered repository assets.
+
+    ``repo_root`` anchors ``${__HERE__}`` resolution and shed path handling.
+    Discovery (which files to pass) is the caller's responsibility -- e.g. Planemo's
+    ``shed_lint`` preferring ``tool_data_table_conf.xml.test`` over ``.sample``.
+    ``consumer_tool_sources`` are ``(path, tool_source)`` pairs for ordinary
+    (non data-manager) tools that may reference the repository's tables.
+    """
+    model = RepositoryDataTables(repo_root=repo_root, external_table_names=external_table_names)
+    if data_manager_conf:
+        model.managers = _build_managers(data_manager_conf)
+    if tool_data_table_confs:
+        model.configured_tables, model.loc_assets = _build_tables(repo_root, tool_data_table_confs)
+    for path, tool_source in consumer_tool_sources or []:
+        model.consumers.extend(_consumer_refs(tool_source, path))
+    return model

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -19,19 +19,13 @@ It composes existing galaxy-tool-util abstractions rather than duplicating them:
 """
 
 import os
+from collections.abc import Iterable
 from dataclasses import (
     dataclass,
     field,
 )
 from typing import (
     cast,
-    Dict,
-    FrozenSet,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Union,
 )
 
 from galaxy.tool_util.data import (
@@ -56,7 +50,7 @@ class SourceLoc:
     """Where a modeled element came from, for narrow skips and PR annotations."""
 
     path: str
-    line: Optional[int] = None
+    line: int | None = None
 
 
 @dataclass
@@ -81,8 +75,8 @@ class LocAsset:
     # Row-shape errors captured by ``parse_file_fields`` at load time (too-few-fields /
     # wrong-separator lines). Only populated when ``found`` (parsing only runs on a
     # loader-resolved file), so "no errors" is not "clean" for an unfound reference.
-    errors: Tuple[str, ...] = ()
-    source: Optional[SourceLoc] = None
+    errors: tuple[str, ...] = ()
+    source: SourceLoc | None = None
 
 
 @dataclass
@@ -117,10 +111,10 @@ class RawTableDecl:
     name: str
     # Declared column names in order, keeping duplicates (the parsed ``columns``
     # map collapses them) -- used to detect a table declaring one name twice.
-    column_names: Tuple[str, ...]
+    column_names: tuple[str, ...]
     # The name->index map the loader would parse; this is what it compares when
     # merging same-named tables, so schema-conflict detection keys on this.
-    columns: Dict[str, int]
+    columns: dict[str, int]
     separator: str
     comment_char: str
     source: SourceLoc
@@ -135,13 +129,13 @@ class TableDecl:
     """
 
     name: str
-    columns: Dict[str, int]
+    columns: dict[str, int]
     largest_index: int
     separator: str
     comment_char: str
     allow_duplicate_entries: bool
-    loc_paths: Tuple[str, ...]
-    source: Optional[SourceLoc] = None
+    loc_paths: tuple[str, ...]
+    source: SourceLoc | None = None
 
 
 @dataclass
@@ -150,7 +144,7 @@ class ConsumerRef:
 
     table_name: str
     kind: str
-    tool_id: Optional[str]
+    tool_id: str | None
     source: SourceLoc
 
 
@@ -160,7 +154,7 @@ class ManagerDecl:
 
     id: str
     tool_file: str
-    tool_output_names: FrozenSet[str]
+    tool_output_names: frozenset[str]
     # Reused manager-side model: output_ref values, table names, column mappings.
     processor: DataTableBundleProcessorDescription
     source: SourceLoc
@@ -175,36 +169,36 @@ class RepositoryDataTables:
     """Cross-file lint view of one repository's data-table bundle."""
 
     repo_root: str
-    managers: List[ManagerDecl] = field(default_factory=list)
-    configured_tables: List[TableDecl] = field(default_factory=list)
+    managers: list[ManagerDecl] = field(default_factory=list)
+    configured_tables: list[TableDecl] = field(default_factory=list)
     # Every ``<table>`` element as declared (pre-merge); may hold several entries
     # for one name. Populated even when the loader is skipped over a conflict.
-    raw_table_decls: List[RawTableDecl] = field(default_factory=list)
-    loc_assets: List[LocAsset] = field(default_factory=list)
+    raw_table_decls: list[RawTableDecl] = field(default_factory=list)
+    loc_assets: list[LocAsset] = field(default_factory=list)
     # Every ``.loc`` / ``.loc.sample`` file found in the repo tree (independent of
     # whether a configured table resolves to it), for the empty-file check.
-    loc_files: List[LocFile] = field(default_factory=list)
-    consumers: List[ConsumerRef] = field(default_factory=list)
+    loc_files: list[LocFile] = field(default_factory=list)
+    consumers: list[ConsumerRef] = field(default_factory=list)
     # Tables validly supplied by Galaxy core or another installed repository; a
     # consumer of one of these is not a demonstrably-missing definition (req #2).
-    external_table_names: FrozenSet[str] = frozenset()
+    external_table_names: frozenset[str] = frozenset()
 
     @property
-    def configured_table_names(self) -> FrozenSet[str]:
+    def configured_table_names(self) -> frozenset[str]:
         # Union of loader-enriched and raw declarations: names stay available for
         # cross-component checks even when a schema conflict made the loader skip.
         names = {t.name for t in self.configured_tables}
         names |= {d.name for d in self.raw_table_decls}
         return frozenset(names)
 
-    def table(self, name: str) -> Optional[TableDecl]:
+    def table(self, name: str) -> TableDecl | None:
         for table in self.configured_tables:
             if table.name == name:
                 return table
         return None
 
 
-def _xml_output_names(root: Optional[Element]) -> FrozenSet[str]:
+def _xml_output_names(root: Element | None) -> frozenset[str]:
     """Names of ``<data>`` / ``<collection>`` outputs declared by a (macro-expanded) wrapper."""
     if root is None:
         return frozenset()
@@ -220,7 +214,7 @@ def _xml_output_names(root: Optional[Element]) -> FrozenSet[str]:
     return frozenset(names)
 
 
-def _tool_source_root(tool_source: ToolSource) -> Optional[Element]:
+def _tool_source_root(tool_source: ToolSource) -> Element | None:
     """Root element of a (macro-expanded) XML wrapper, or None for a non-XML source.
 
     Reads the ``xml_tree`` attribute the tool linters standardize on rather than the
@@ -230,7 +224,7 @@ def _tool_source_root(tool_source: ToolSource) -> Optional[Element]:
     return xml_tree.getroot() if xml_tree is not None else None
 
 
-def _consumer_refs(tool_source: ToolSource, path: str) -> List[ConsumerRef]:
+def _consumer_refs(tool_source: ToolSource, path: str) -> list[ConsumerRef]:
     """Scan a (macro-expanded) wrapper for ``from_data_table`` table references."""
     root = _tool_source_root(tool_source)
     if root is None:
@@ -251,7 +245,7 @@ def _consumer_refs(tool_source: ToolSource, path: str) -> List[ConsumerRef]:
     return refs
 
 
-def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
+def _build_managers(data_manager_conf: str) -> list[ManagerDecl]:
     conf_dir = os.path.dirname(os.path.abspath(data_manager_conf))
     root = parse_xml(data_manager_conf).getroot()
     managers = []
@@ -264,7 +258,7 @@ def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
             tool_elem = dm_elem.find("tool")
             tool_file = tool_elem.get("file") if tool_elem is not None else None
         tool_file = tool_file or ""
-        output_names: FrozenSet[str] = frozenset()
+        output_names: frozenset[str] = frozenset()
         wrapper_resolved = False
         if tool_file:
             tool_path = os.path.join(conf_dir, tool_file)
@@ -285,7 +279,7 @@ def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
     return managers
 
 
-def _raw_column_spec(table_elem: Element) -> Tuple[Tuple[str, ...], Dict[str, int]]:
+def _raw_column_spec(table_elem: Element) -> tuple[tuple[str, ...], dict[str, int]]:
     """Declared column names (with duplicates) and the parsed name->index map.
 
     The name->index map is produced by the canonical
@@ -307,7 +301,7 @@ def _raw_column_spec(table_elem: Element) -> Tuple[Tuple[str, ...], Dict[str, in
     return column_names, columns
 
 
-def _raw_table_decls(tool_data_table_confs: List[str]) -> List[RawTableDecl]:
+def _raw_table_decls(tool_data_table_confs: list[str]) -> list[RawTableDecl]:
     """Parse every ``<table>`` element as declared, before the loader merges same names."""
     decls = []
     for conf in tool_data_table_confs:
@@ -327,7 +321,7 @@ def _raw_table_decls(tool_data_table_confs: List[str]) -> List[RawTableDecl]:
     return decls
 
 
-def _has_column_conflict(raw_decls: List[RawTableDecl]) -> bool:
+def _has_column_conflict(raw_decls: list[RawTableDecl]) -> bool:
     """Whether any table name is declared with differing columns (what the loader's merge rejects).
 
     Keys on the parsed name->index map, not the raw name list, because that map is
@@ -337,7 +331,7 @@ def _has_column_conflict(raw_decls: List[RawTableDecl]) -> bool:
     by index). This is the pre-load counterpart of that check: same columns-equality
     rule, applied to the raw declarations before the loader is invoked.
     """
-    by_name: Dict[str, List[Dict[str, int]]] = {}
+    by_name: dict[str, list[dict[str, int]]] = {}
     for decl in raw_decls:
         specs = by_name.setdefault(decl.name, [])
         if decl.columns not in specs:
@@ -380,7 +374,7 @@ def _classify_loc_file(path: str) -> LocFile:
     return LocFile(path=path, has_data=has_data, has_comment=has_comment)
 
 
-def _discover_loc_files(repo_root: str) -> List[LocFile]:
+def _discover_loc_files(repo_root: str) -> list[LocFile]:
     """Every ``.loc`` / ``.loc.sample`` file under ``repo_root`` (data rows / comments recorded)."""
     loc_files = []
     for dirpath, _, filenames in os.walk(repo_root):
@@ -391,8 +385,8 @@ def _discover_loc_files(repo_root: str) -> List[LocFile]:
 
 
 def _build_tables(
-    repo_root: str, tool_data_table_confs: List[str], raw_decls: List[RawTableDecl]
-) -> Tuple[List[TableDecl], List[LocAsset]]:
+    repo_root: str, tool_data_table_confs: list[str], raw_decls: list[RawTableDecl]
+) -> tuple[list[TableDecl], list[LocAsset]]:
     # A same-named table declared with conflicting columns makes the loader's merge
     # raise; skip enrichment in that case and let the linter report the conflict from
     # the raw declarations (table names still come from those). Loc diagnostics for
@@ -404,7 +398,7 @@ def _build_tables(
     # cast around list invariance: ToolDataTableManager takes list[str | PathLike]; our
     # str paths are compatible element-wise, but List[str] is not List[str | PathLike].
     tdt_manager = ToolDataTableManager(
-        repo_root, config_filename=cast("List[Union[str, os.PathLike[str]]]", tool_data_table_confs)
+        repo_root, config_filename=cast("list[str | os.PathLike[str]]", tool_data_table_confs)
     )
     conf_source = SourceLoc(path=tool_data_table_confs[0]) if len(tool_data_table_confs) == 1 else None
     tables = []
@@ -443,10 +437,10 @@ def _build_tables(
 
 def build_repository_data_tables(
     repo_root: str,
-    data_manager_conf: Optional[str] = None,
-    tool_data_table_confs: Optional[List[str]] = None,
-    consumer_tool_sources: Optional[Iterable[Tuple[str, ToolSource]]] = None,
-    external_table_names: FrozenSet[str] = frozenset(),
+    data_manager_conf: str | None = None,
+    tool_data_table_confs: list[str] | None = None,
+    consumer_tool_sources: Iterable[tuple[str, ToolSource]] | None = None,
+    external_table_names: frozenset[str] = frozenset(),
 ) -> RepositoryDataTables:
     """Assemble a :class:`RepositoryDataTables` from already-discovered repository assets.
 

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -24,12 +24,14 @@ from dataclasses import (
     field,
 )
 from typing import (
+    cast,
     Dict,
     FrozenSet,
     Iterable,
     List,
     Optional,
     Tuple,
+    Union,
 )
 
 from galaxy.tool_util.data import (
@@ -165,6 +167,12 @@ class RepositoryDataTables:
         names = {t.name for t in self.configured_tables}
         names |= {d.name for d in self.raw_table_decls}
         return frozenset(names)
+
+    def table(self, name: str) -> Optional[TableDecl]:
+        for table in self.configured_tables:
+            if table.name == name:
+                return table
+        return None
 
 
 def _xml_output_names(root: Optional[Element]) -> FrozenSet[str]:
@@ -319,7 +327,11 @@ def _build_tables(
         return [], []
     # ToolDataTableManager loads the confs, resolving ${__HERE__} / .sample fallback and
     # recording per-file parse errors -- we read that resolved state back out.
-    tdt_manager = ToolDataTableManager(repo_root, config_filename=tool_data_table_confs)
+    # cast around list invariance: ToolDataTableManager takes list[str | PathLike]; our
+    # str paths are compatible element-wise, but List[str] is not List[str | PathLike].
+    tdt_manager = ToolDataTableManager(
+        repo_root, config_filename=cast("List[Union[str, os.PathLike[str]]]", tool_data_table_confs)
+    )
     conf_source = SourceLoc(path=tool_data_table_confs[0]) if len(tool_data_table_confs) == 1 else None
     tables = []
     loc_assets = []

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -111,6 +111,10 @@ class ManagerDecl:
     # Reused manager-side model: output_ref values, table names, column mappings.
     processor: DataTableBundleProcessorDescription
     source: SourceLoc
+    # Whether the wrapper was located and parsed. When False ``tool_output_names``
+    # is unknown (not "empty"), so output_ref checks must treat it as not-checked
+    # rather than reporting a demonstrably-missing output.
+    wrapper_resolved: bool = False
 
 
 @dataclass
@@ -188,11 +192,13 @@ def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
             tool_file = tool_elem.get("file") if tool_elem is not None else None
         tool_file = tool_file or ""
         output_names: FrozenSet[str] = frozenset()
+        wrapper_resolved = False
         if tool_file:
             tool_path = os.path.join(conf_dir, tool_file)
             if os.path.exists(tool_path):
                 tool_source = get_tool_source(config_file=tool_path)
                 output_names = _xml_output_names(getattr(tool_source, "root", None))
+                wrapper_resolved = True
         managers.append(
             ManagerDecl(
                 id=manager_id,
@@ -200,6 +206,7 @@ def _build_managers(data_manager_conf: str) -> List[ManagerDecl]:
                 tool_output_names=output_names,
                 processor=convert_data_tables_xml(dm_elem),
                 source=SourceLoc(path=data_manager_conf, line=getattr(dm_elem, "sourceline", None)),
+                wrapper_resolved=wrapper_resolved,
             )
         )
     return managers

--- a/lib/galaxy/tool_util/data/bundles/repository.py
+++ b/lib/galaxy/tool_util/data/bundles/repository.py
@@ -65,15 +65,22 @@ class LocAsset:
 
     table_name: str
     path: str
-    # ``found`` means the loader resolved *some* file for this reference. Note a table's
-    # ``<file path="tool-data/x.loc">`` whose real ``.loc`` is absent resolves to the
-    # ``x.loc.sample`` fallback with ``found=True`` -- so a check that a production loc
-    # exists must consider ``found and not is_sample``, not ``found`` alone.
+    # ``found`` means the *loader* resolved and parsed a real file for this reference.
+    # The loader's ``.sample`` fallback (data/__init__.py) strips the ``tool-data/``
+    # subdir and only looks in ``tool_data_path`` root, so it does *not* match a shed
+    # repo's ``tool-data/x.loc.sample`` -- those come back ``found=False``. Use
+    # ``sample_backed`` for "the repo ships a sample for this reference"; a reference is
+    # unresolved only when ``not found and not sample_backed``.
     found: bool
     is_sample: bool
+    # Whether the repo ships a ``.sample`` backing this reference (a sibling
+    # ``<ref>.sample`` or the conventional ``tool-data/<basename>.sample``). On install
+    # Galaxy materializes the real ``.loc`` from it, so a sample-backed reference is not
+    # a missing loc even though the loader reports ``found=False``.
+    sample_backed: bool = False
     # Row-shape errors captured by ``parse_file_fields`` at load time (too-few-fields /
     # wrong-separator lines). Only populated when ``found`` (parsing only runs on a
-    # resolved file), so "no errors" is not "clean" for an unfound reference.
+    # loader-resolved file), so "no errors" is not "clean" for an unfound reference.
     errors: Tuple[str, ...] = ()
     source: Optional[SourceLoc] = None
 
@@ -316,6 +323,23 @@ def _has_column_conflict(raw_decls: List[RawTableDecl]) -> bool:
     return any(len(specs) > 1 for specs in by_name.values())
 
 
+def _sample_backed(repo_root: str, filename: str) -> bool:
+    """Whether the repo ships a ``.sample`` that backs a loc ``filename``.
+
+    The loader's own ``.sample`` fallback does not match the shed layout (see
+    ``LocAsset.found``), so resolve it the way the shed does: a reference is
+    sample-backed if a sibling ``<filename>.sample`` exists, or the conventional
+    ``tool-data/<basename>.sample`` does (samples ship there and the real ``.loc`` is
+    materialized on install). Basename matching mirrors that a table is keyed by name,
+    so ``test-data/x.loc`` in a ``.test`` conf is still backed by ``tool-data/x.loc.sample``.
+    """
+    sibling = filename if os.path.isabs(filename) else os.path.join(repo_root, filename)
+    if os.path.exists(f"{sibling}.sample"):
+        return True
+    tool_data_sample = os.path.join(repo_root, "tool-data", f"{os.path.basename(filename)}.sample")
+    return os.path.exists(tool_data_sample)
+
+
 def _build_tables(
     repo_root: str, tool_data_table_confs: List[str], raw_decls: List[RawTableDecl]
 ) -> Tuple[List[TableDecl], List[LocAsset]]:
@@ -347,6 +371,7 @@ def _build_tables(
                     path=str(filename),
                     found=bool(info.get("found")),
                     is_sample=str(filename).endswith(".sample"),
+                    sample_backed=_sample_backed(repo_root, str(filename)),
                     errors=tuple(info.get("errors") or ()),
                     source=SourceLoc(path=str(filename)),
                 )

--- a/lib/galaxy/tool_util/data/bundles/script.py
+++ b/lib/galaxy/tool_util/data/bundles/script.py
@@ -10,10 +10,6 @@ table schemas), runnable standalone without a Planemo install.
 import argparse
 import sys
 from json import dumps
-from typing import (
-    List,
-    Optional,
-)
 
 from galaxy.tool_util.data.bundles.lint import find_and_lint_repository_data_tables
 from galaxy.tool_util.lint import LintContext
@@ -72,7 +68,7 @@ def lint(repository: str, skip: str, report_level: str, fail_level: str, json: b
     return 1 if lint_ctx.failed(fail_level) else 0
 
 
-def main(argv: Optional[List[str]] = None) -> None:
+def main(argv: list[str] | None = None) -> None:
     if argv is None:
         argv = sys.argv[1:]
     args = arg_parser().parse_args(argv)

--- a/lib/galaxy/tool_util/data/bundles/script.py
+++ b/lib/galaxy/tool_util/data/bundles/script.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""``galaxy-tool-data-lint`` -- lint a data-manager / reference-data repository.
+
+Runs the repository-level data-table linters over a repository directory: the same
+checks Planemo's ``shed_lint`` applies (missing loc fixtures, malformed loc rows,
+data-manager tables nothing configures, output_ref mismatches, duplicate / conflicting
+table schemas), runnable standalone without a Planemo install.
+"""
+
+import argparse
+import sys
+from json import dumps
+from typing import (
+    List,
+    Optional,
+)
+
+from galaxy.tool_util.data.bundles.lint import find_and_lint_repository_data_tables
+from galaxy.tool_util.lint import LintContext
+
+DESCRIPTION = """
+Lint the data tables of a data-manager / reference-data repository. Reports conditions
+that can be proven from the repository's own files (a referenced loc file is absent, a
+loc row cannot supply every declared column, a data manager populates an unconfigured
+table, and similar). Exits non-zero when the configured fail level is reached.
+"""
+
+REPORT_LEVELS = ("all", "valid", "info", "warn", "error")
+
+
+def arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("repository", help="Path to the repository root directory to lint.")
+    parser.add_argument(
+        "-s",
+        "--skip",
+        default="",
+        help="Comma-separated list of linter names to skip (e.g. ConsumerTableDefined).",
+    )
+    parser.add_argument(
+        "--report-level",
+        choices=REPORT_LEVELS,
+        default="all",
+        help="Lowest message level to print (ignored with --json).",
+    )
+    parser.add_argument(
+        "--fail-level",
+        choices=("warn", "error"),
+        default="error",
+        help="Exit non-zero when a message at this level or above is emitted (default: error).",
+    )
+    parser.add_argument(
+        "-j",
+        "--json",
+        default=False,
+        action="store_true",
+        help="Emit the collected messages as JSON instead of printing them.",
+    )
+    return parser
+
+
+def lint(repository: str, skip: str, report_level: str, fail_level: str, json: bool) -> int:
+    skip_types = [name.strip() for name in skip.split(",") if name.strip()]
+    # In JSON mode dispatch at SILENT so the linters do not also print as they run;
+    # messages still accumulate in message_list for serialization.
+    level = "silent" if json else report_level
+    lint_ctx = LintContext(level, skip_types=skip_types)
+    find_and_lint_repository_data_tables(lint_ctx, repository)
+    if json:
+        messages = [{"level": m.level, "message": m.message, "linter": m.linter} for m in lint_ctx.message_list]
+        print(dumps({"messages": messages}, indent=2))
+    return 1 if lint_ctx.failed(fail_level) else 0
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    args = arg_parser().parse_args(argv)
+    sys.exit(lint(args.repository, args.skip, args.report_level, args.fail_level, args.json))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -118,6 +118,11 @@ class Linter(ABC, Generic[LintTargetType]):
         list the names of all linter derived from Linter
         """
         submodules.import_submodules(galaxy.tool_util.linters)
+        # Repository data-table linters subclass Linter but live outside the
+        # tool_util.linters package; import here so they are always registered
+        # (function-level to avoid a circular import with this module).
+        from galaxy.tool_util.data.bundles import lint as _repo_lint  # noqa: F401
+
         return [s.__name__ for s in cls.__subclasses__()]
 
     list_listers: Callable[[], list[str]]  # deprecated alias

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -52,6 +52,7 @@ from abc import (
 from collections.abc import Callable
 from enum import IntEnum
 from typing import (
+    Generic,
     TYPE_CHECKING,
     TypeVar,
 )
@@ -67,8 +68,12 @@ from galaxy.util import (
 )
 
 if TYPE_CHECKING:
-    from galaxy.tool_util.parser.interface import ToolSource
     from galaxy.tool_util_models import UserToolSource
+
+# The object a linter classifies -- a ToolSource for the tool linters, a
+# RepositoryDataTables for the repository data-table linters, etc. LintContext.lint
+# dispatches over this generically, and Linter is generic over it.
+LintTargetType = TypeVar("LintTargetType")
 
 
 class LintLevel(IntEnum):
@@ -80,15 +85,21 @@ class LintLevel(IntEnum):
     ALL = 0
 
 
-class Linter(ABC):
+class Linter(ABC, Generic[LintTargetType]):
     """
     a linter. needs to define a lint method and the code property.
     optionally a fix method can be given
+
+    Generic over the lint target so non-tool linters (e.g. the repository
+    data-table linters, which lint a ``RepositoryDataTables``) can subclass
+    ``Linter[SomeTarget]`` without violating the override contract. A bare
+    ``class Foo(Linter)`` is ``Linter[Any]`` -- the ordinary tool linters,
+    which annotate their own ``tool_source: ToolSource``.
     """
 
     @classmethod
     @abstractmethod
-    def lint(cls, tool_source: "ToolSource", lint_ctx: "LintContext"):
+    def lint(cls, tool_source: LintTargetType, lint_ctx: "LintContext"):
         """
         should add at most one message to the lint context
         """
@@ -182,9 +193,6 @@ class XMLLintMessageXPath(LintMessage):
         if self.xpath is not None:
             rval += f" [{self.xpath}]"
         return rval
-
-
-LintTargetType = TypeVar("LintTargetType")
 
 
 # TODO: Nothing inherently tool-y about LintContext and in fact

--- a/packages/tool_util/pyproject.toml
+++ b/packages/tool_util/pyproject.toml
@@ -73,6 +73,7 @@ test = [
 galaxy-tool-format = "galaxy.tool_util.format:main"
 galaxy-tool-test = "galaxy.tool_util.verify.script:main"
 galaxy-tool-test-case-validation = "galaxy.tool_util.parameters.scripts.validate_test_cases:main"
+galaxy-tool-data-lint = "galaxy.tool_util.data.bundles.script:main"
 galaxy-tool-upgrade-advisor = "galaxy.tool_util.upgrade.script:main"
 validate-test-format = "galaxy.tool_util.validate_test_format:main"
 mulled-build = "galaxy.tool_util.deps.mulled.mulled_build:main"

--- a/test/unit/tool_util/data/repositories/.gitignore
+++ b/test/unit/tool_util/data/repositories/.gitignore
@@ -1,0 +1,4 @@
+# These are test fixtures, not runtime Galaxy config. Re-include the config
+# filenames the top-level .gitignore drops so fixture repositories are complete.
+!data_manager_conf.xml
+!shed_data_manager_conf.xml

--- a/test/unit/tool_util/data/repositories/README.md
+++ b/test/unit/tool_util/data/repositories/README.md
@@ -49,6 +49,13 @@ repo can drive the error cases without a repo-per-case:
 - `broken_rows/` — `broken.loc` with a too-short row and a wrong-separator row → two errors
 - `missing_and_broken/` — one missing loc **and** one broken loc; both linters fire and no false "rows are fine" green is emitted off the unparsed missing file
 
+### Empty-loc fixture — `EmptyLocFile`
+
+- `empty_loc/` — ships an empty, comment-less `tool-data/undocumented.loc.sample`
+  (the Planemo #869 case → one warning) alongside a header-only
+  `tool-data/documented.loc.sample` that must **not** be flagged (a dataless file
+  with a format comment is the accepted convention).
+
 ### Schema-conflict / duplicate fixtures — `DuplicateColumnNames`, `ConflictingTableSchema`
 
 Each declares the same table twice (or with a repeated column) in a way that would

--- a/test/unit/tool_util/data/repositories/README.md
+++ b/test/unit/tool_util/data/repositories/README.md
@@ -65,3 +65,12 @@ make the loader's merge raise; assembly must skip the loader and still report cl
 - `conflicting_columns/` — same table, different column sets → `ConflictingTableSchema`
 - `conflicting_indexes/` — same column names, different index attributes → `ConflictingTableSchema`
 - `conflicting_separator/` — same table, different separators → `ConflictingTableSchema`
+
+### Core-table exclusion fixture — `find_and_lint_repository_data_tables`
+
+- `core_table_consumer/` — an index-builder data manager (modeled on IUC
+  `data_manager_bwa_mem2_index_builder`) that defines its own `bwa_mem2_indexes`
+  table but consumes the core `all_fasta` table via `from_data_table`. The one-call
+  `find_and_lint` entry seeds `DEFAULT_EXTERNAL_TABLE_NAMES` (`all_fasta`,
+  `fasta_indexes`, `__dbkeys__`), so the core reference must **not** warn; linted
+  without that seeding it does, proving the exclusion is what suppresses it.

--- a/test/unit/tool_util/data/repositories/README.md
+++ b/test/unit/tool_util/data/repositories/README.md
@@ -1,0 +1,60 @@
+# Repository data-table lint fixtures
+
+Miniature Tool Shed repositories used as **fixtures** (not runtime config) by the
+repository data-table linting tests. Each subdirectory is a self-contained repo
+laid out the way a real data-manager / reference-data repo is — `data_manager_conf.xml`,
+`tool_data_table_conf.xml.*`, `tool-data/*.loc.sample`, `test-data/*.loc`, consumer
+tool wrappers — so the tests build real `RepositoryDataTables` models over them with
+no mocks (`build_repository_data_tables(...)`).
+
+Consumed by:
+
+- `../test_repository_data_tables.py` — the parser/model builder
+- `../test_repository_data_table_lint.py` — the linters
+- `../test_data_lint_cli.py` — the `galaxy-tool-data-lint` CLI entry point
+
+## `.gitignore`
+
+Galaxy's top-level `.gitignore` drops `data_manager_conf.xml` and
+`shed_data_manager_conf.xml` as runtime config. Here those filenames are fixture
+content, so the local `.gitignore` re-includes (`!`) them — otherwise the fixture
+repos would be committed incomplete.
+
+## Fixtures
+
+### `fetch_genome_dbkeys_all_fasta/` — the clean, full repo
+
+The one well-formed repo (modeled on IUC's fetch-genome / `all_fasta` data manager);
+the happy-path baseline where every linter is expected to pass. Ships extra
+`data_manager_conf_*.xml` variants and two consumer wrappers so a single realistic
+repo can drive the error cases without a repo-per-case:
+
+- `data_manager_conf.xml` — clean manager (`all_fasta`, `__dbkeys__`)
+- `data_manager_conf_bad_output_ref.xml` — `output_ref` to a nonexistent output → `OutputRefValid`
+- `data_manager_conf_mixed_output_ref.xml` — one good + one bad ref (per-table iteration)
+- `data_manager_conf_missing_wrapper.xml` — `tool_file` points at a missing wrapper (outputs unresolved → not flagged)
+- `data_manager_conf_nested_tool.xml` — nested `<tool>` element form (output resolution)
+- `tools/consume_all_fasta.xml` — consumer with a **literal** `from_data_table`
+- `tools/consume_dynamic_table.xml` — consumer whose `from_data_table` stays **non-literal** after macro expansion (false-positive guard, tools-iuc#5003)
+
+### Missing loc fixtures — `MissingLocFixture`
+
+- `missing_loc/` — conf references a `.loc` that does not exist → one error
+- `missing_two/` — two missing locs → two errors
+- `sample_fallback/` — production loc resolved via the loader's own `.sample` fallback (`foo.loc.sample`); must **not** be reported missing
+- `tool_data_sample/` — Tool Shed layout: conf → `tool-data/bar.loc`, sample ships as `tool-data/bar.loc.sample`. The loader's `.sample` fallback misses this; `sample_backed` must recognize it so reference-data repos aren't falsely flagged.
+
+### Row-shape fixtures — `LocRowShape`
+
+- `broken_rows/` — `broken.loc` with a too-short row and a wrong-separator row → two errors
+- `missing_and_broken/` — one missing loc **and** one broken loc; both linters fire and no false "rows are fine" green is emitted off the unparsed missing file
+
+### Schema-conflict / duplicate fixtures — `DuplicateColumnNames`, `ConflictingTableSchema`
+
+Each declares the same table twice (or with a repeated column) in a way that would
+make the loader's merge raise; assembly must skip the loader and still report cleanly.
+
+- `dup_columns/` — duplicate column name within one table → `DuplicateColumnNames`
+- `conflicting_columns/` — same table, different column sets → `ConflictingTableSchema`
+- `conflicting_indexes/` — same column names, different index attributes → `ConflictingTableSchema`
+- `conflicting_separator/` — same table, different separators → `ConflictingTableSchema`

--- a/test/unit/tool_util/data/repositories/broken_rows/test-data/broken.loc
+++ b/test/unit/tool_util/data/repositories/broken_rows/test-data/broken.loc
@@ -1,0 +1,4 @@
+# value	name	path
+val1	name1	/data/path1
+val2	name2
+val3,name3,/data/path3

--- a/test/unit/tool_util/data/repositories/broken_rows/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/broken_rows/tool_data_table_conf.xml.test
@@ -1,0 +1,6 @@
+<tables>
+    <table name="broken" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/broken.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/conflicting_columns/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/conflicting_columns/tool_data_table_conf.xml.test
@@ -1,0 +1,11 @@
+<tables>
+    <!-- Same table name declared twice with different columns. The loader's merge
+         would raise on this; the linter reports it from the raw declarations and
+         bundle assembly must not crash. -->
+    <table name="conflict_tbl" comment_char="#">
+        <columns>value, name</columns>
+    </table>
+    <table name="conflict_tbl" comment_char="#">
+        <columns>value, name, path</columns>
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/conflicting_indexes/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/conflicting_indexes/tool_data_table_conf.xml.test
@@ -1,0 +1,14 @@
+<tables>
+    <!-- Same table name, same column NAMES, but different index attributes via the
+         explicit <column> form. The raw name tuples are identical, so a name-based
+         conflict check would miss this and the loader's merge would then crash; the
+         columns map (name->index) differs, so the map-based check catches it. -->
+    <table name="idx_tbl" comment_char="#">
+        <column name="value" index="0" />
+        <column name="path" index="1" />
+    </table>
+    <table name="idx_tbl" comment_char="#">
+        <column name="value" index="0" />
+        <column name="path" index="5" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/conflicting_separator/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/conflicting_separator/tool_data_table_conf.xml.test
@@ -1,0 +1,10 @@
+<tables>
+    <!-- Same table name and columns, but a different separator. The loader accepts
+         this (it only checks columns on merge), yet the schema is ambiguous. -->
+    <table name="sep_tbl" comment_char="#">
+        <columns>value, path</columns>
+    </table>
+    <table name="sep_tbl" comment_char="#" separator=",">
+        <columns>value, path</columns>
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/core_table_consumer/data_manager/bwa_mem2_index_builder.xml
+++ b/test/unit/tool_util/data/repositories/core_table_consumer/data_manager/bwa_mem2_index_builder.xml
@@ -1,0 +1,56 @@
+<tool id="bwa_mem2_index_builder_data_manager" name="BWA-MEM2 index builder" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" tool_type="manage_data" profile="23.0">
+    <description></description>
+    <macros>
+        <token name="@TOOL_VERSION@">2.2.1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
+    </macros>
+    <requirements>
+        <requirement type="package" version="@TOOL_VERSION@">bwa-mem2</requirement>
+    </requirements>
+    <command detect_errors="exit_code"><![CDATA[
+        #set $fasta_file_name = str($all_fasta_source.fields.path).split('/')[-1]
+        mkdir -p '${out_file.extra_files_path}' &&
+        ln -s '${all_fasta_source.fields.path}' '${out_file.extra_files_path}/${fasta_file_name}' &&
+        bwa-mem2 index '${out_file.extra_files_path}/${fasta_file_name}' &&
+        rm '${out_file.extra_files_path}/${fasta_file_name}' &&
+        cp '$dmjson' '$out_file'
+        ]]>
+    </command>
+    <configfiles>
+        <configfile name="dmjson"><![CDATA[#slurp
+#set $fasta_file_name = str($all_fasta_source.fields.path).split('/')[-1]
+#set $value = $sequence_id or $all_fasta_source.fields.dbkey
+#set $name = $sequence_name or $all_fasta_source.fields.name
+{
+  "data_tables":{
+    "bwa_mem2_indexes":[
+      {
+        "value": "${value}",
+        "dbkey": "${all_fasta_source.fields.dbkey}",
+        "name": "${name}",
+        "path": "${fasta_file_name}"
+      }
+    ]
+  }
+}
+]]></configfile>
+    </configfiles>
+    <inputs>
+        <param name="all_fasta_source" type="select" label="Source FASTA Sequence">
+            <options from_data_table="all_fasta"/>
+        </param>
+        <param name="sequence_name" type="text" value="" label="Name of sequence" />
+        <param name="sequence_id" type="text" value="" label="ID for sequence" />
+    </inputs>
+    <outputs>
+        <data name="out_file" format="data_manager_json" />
+    </outputs>
+    <help>
+<![CDATA[
+Builds a BWA-MEM2 index from a FASTA sequence chosen from the core all_fasta table.
+]]>
+    </help>
+    <citations>
+        <citation type="doi">10.1038/nmeth.3317</citation>
+    </citations>
+</tool>

--- a/test/unit/tool_util/data/repositories/core_table_consumer/data_manager_conf.xml
+++ b/test/unit/tool_util/data/repositories/core_table_consumer/data_manager_conf.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<data_managers>
+    <data_manager tool_file="data_manager/bwa_mem2_index_builder.xml" id="bwa_mem2_index_builder">
+        <data_table name="bwa_mem2_indexes">
+            <output>
+                <column name="value" />
+                <column name="dbkey" />
+                <column name="name" />
+                <column name="path" output_ref="out_file" >
+                    <move type="directory" relativize_symlinks="True">
+                        <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">genomes/${dbkey}/bwa_mem_index/v2/${value}</target>
+                    </move>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/genomes/${dbkey}/bwa_mem_index/v2/${value}/${path}</value_translation>
+                    <value_translation type="function">abspath</value_translation>
+                </column>
+            </output>
+        </data_table>
+    </data_manager>
+</data_managers>

--- a/test/unit/tool_util/data/repositories/core_table_consumer/tool-data/bwa_mem2_index.loc.sample
+++ b/test/unit/tool_util/data/repositories/core_table_consumer/tool-data/bwa_mem2_index.loc.sample
@@ -1,0 +1,10 @@
+#This is a sample file distributed with Galaxy that enables tools
+#to use a directory of BWA-MEM2 indexed sequences data files. The loc
+#file has this format (white space characters are TAB characters):
+#
+#<unique_build_id>	<dbkey>	<display_name>	<file_path>
+#
+#So, for example, if you had phiX indexed and stored in
+#/depot/data2/galaxy/phiX/base/, the entry would look like this:
+#
+#phiX174	phiX	phiX Pretty	/depot/data2/galaxy/phiX/base/phiX.fa

--- a/test/unit/tool_util/data/repositories/core_table_consumer/tool_data_table_conf.xml.sample
+++ b/test/unit/tool_util/data/repositories/core_table_consumer/tool_data_table_conf.xml.sample
@@ -1,0 +1,7 @@
+<tables>
+    <!-- Locations of indexes in the BWA-MEM2 mapper format-->
+    <table name="bwa_mem2_indexes" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/bwa_mem2_index.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/dup_columns/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/dup_columns/tool_data_table_conf.xml.test
@@ -1,0 +1,7 @@
+<tables>
+    <!-- 'value' is declared twice. The parsed columns dict collapses it, so the
+         duplicate is only visible in the raw declared column list. -->
+    <table name="dup_cols" comment_char="#">
+        <columns>value, value, path</columns>
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/empty_loc/tool-data/documented.loc.sample
+++ b/test/unit/tool_util/data/repositories/empty_loc/tool-data/documented.loc.sample
@@ -1,0 +1,1 @@
+#<value>	<path>

--- a/test/unit/tool_util/data/repositories/empty_loc/tool_data_table_conf.xml.sample
+++ b/test/unit/tool_util/data/repositories/empty_loc/tool_data_table_conf.xml.sample
@@ -1,0 +1,10 @@
+<tables>
+    <table name="undocumented" comment_char="#">
+        <columns>value, path</columns>
+        <file path="${__HERE__}/tool-data/undocumented.loc" />
+    </table>
+    <table name="documented" comment_char="#">
+        <columns>value, path</columns>
+        <file path="${__HERE__}/tool-data/documented.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml
@@ -1,0 +1,102 @@
+<tool id="data_manager_fetch_genome_all_fasta_dbkey" name="Create DBKey and Reference Genome" version="0.0.2" tool_type="manage_data">
+    <description>fetching</description>
+    <command detect_errors="exit_code"><![CDATA[
+       python '$__tool_directory__/data_manager_fetch_genome_all_fasta_dbkeys.py'
+       '${out_file}'
+       #if str( $dbkey_source.dbkey_source_selector ) == 'existing':
+           --dbkey_description '${dbkey_source.dbkey}'
+       #else
+           --dbkey_description '${ dbkey_source.dbkey_name or $dbkey_source.dbkey }'
+       #end if
+    ]]></command>
+    <inputs>
+        <conditional name="dbkey_source">
+            <param name="dbkey_source_selector" type="select" label="Use existing dbkey or create a new one.">
+                <option value="existing" selected="True">Existing</option>
+                <option value="new">New</option>
+            </param>
+            <when value="existing">
+                <param name="dbkey" type="genomebuild" label="DBKEY to assign to data" />
+            </when>
+            <when value="new">
+                <param name="dbkey" type="text" value="" optional="false" label="dbkey" />
+                <param name="dbkey_name" type="text" value="" label="Display name for dbkey" />
+            </when>
+        </conditional>
+        <param name="sequence_name" type="text" value="" label="Name of sequence" />
+        <param name="sequence_id" type="text" value="" label="ID for sequence" />
+        <conditional name="reference_source">
+            <param name="reference_source_selector" type="select" label="Choose the source for the reference genome">
+                <option value="ucsc" selected="True">UCSC</option>
+                <option value="ncbi">NCBI</option>
+                <option value="url">URL</option>
+                <option value="history">History</option>
+                <option value="directory">Directory on Server</option>
+            </param>
+            <when value="ucsc">
+                <param name="requested_dbkey" type="text" value="" optional="false" label="UCSC's DBKEY for source FASTA" />
+            </when>
+            <when value="ncbi">
+                <param name="requested_identifier" type="text" value="" optional="false" label="NCBI identifier/accession" help="Identifiers (e.g 667699573) or accessions (e.g AC020606.7) may be used" />
+            </when>
+            <when value="url">
+                <param name="user_url" type="text" area="True" value="http://" optional="false" label="URLs" />
+            </when>
+            <when value="history">
+                <param name="input_fasta" type="data" format="fasta" label="FASTA file" />
+            </when>
+            <when value="directory">
+                <param name="fasta_filename" type="text" value="" optional="false" label="Full path to FASTA file on disk" />
+                <param name="create_symlink" type="boolean" truevalue="create_symlink" falsevalue="copy_file" label="Create symlink to original data instead of copying" />
+            </when>
+        </conditional>
+        <conditional name="sorting">
+            <param name="sort_selector" type="select" label="Sort by chromosome name">
+                <option value="as_is" selected="True">As is</option>
+                <option value="lexicographical">Lexicographical</option>
+                <option value="gatk">GATK</option>
+                <option value="custom">Custom</option>
+            </param>
+            <when value="as_is" />
+            <when value="lexicographical" />
+            <when value="gatk" />
+            <when value="custom">
+                <repeat name="sequence_identifiers" title="Sequence Identifiers" min="1" default="1">
+                    <param name="identifier" type="text" value="" optional="false" label="Sequence Identifier" />
+                </repeat>
+                <param name="handle_not_listed_selector" type="select" label="How to handle non-specified Identifiers">
+                    <option value="discard" selected="True">Discard</option>
+                    <option value="keep_append">Keep and Append</option>
+                    <option value="keep_prepend">Keep and Prepend</option>
+                </param>
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out_file" format="data_manager_json"/>
+    </outputs>
+    <tests>
+        <!-- TODO: need some way to test that new entry was added to data table -->
+        <test>
+            <param name="dbkey" value="phiX174"/>
+            <param name="dbkey_source|dbkey_source_selector" value="new"/>
+            <param name="sequence_name" value="phiX174 sequence name"/>
+            <param name="sequence_id" value="phix174"/>
+            <param name="reference_source_selector" value="history"/>
+            <param name="input_fasta" value="phiX174.fasta"/>
+            <param name="sort_selector" value="as_is"/>
+            <output name="out_file" file="phiX174.data_manager_json"/>
+        </test>
+    </tests>
+    <help>
+**What it does**
+
+Fetches a reference genome from various sources (UCSC, NCBI, URL, Galaxy History, or a server directory) and populates the "all_fasta" data table.
+
+------
+
+.. class:: infomark
+
+**Notice:** If you leave name, description, or id blank, it will be generated automatically.
+    </help>
+</tool>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<data_managers>
+
+    <data_manager tool_file="data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml" id="fetch_genome_all_fasta_dbkeys">
+        <data_table name="all_fasta">
+            <output>
+                <column name="value" />
+                <column name="dbkey" />
+                <column name="name" />
+                <column name="path" output_ref="out_file" >
+                    <move type="file">
+                        <source>${path}</source>
+                        <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">${dbkey}/seq/${path}</target>
+                    </move>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/${dbkey}/seq/${path}</value_translation>
+                    <value_translation type="function">abspath</value_translation>
+                </column>
+            </output>
+        </data_table>
+        <data_table name="__dbkeys__">
+            <output>
+                <column name="value" />
+                <column name="name" />
+                <column name="len_path" output_ref="out_file" >
+                    <move type="file">
+                        <source>${len_path}</source>
+                        <target base="${GALAXY_DATA_MANAGER_DATA_PATH}">${value}/len/${len_path}</target>
+                    </move>
+                    <value_translation>${GALAXY_DATA_MANAGER_DATA_PATH}/${value}/len/${len_path}</value_translation>
+                    <value_translation type="function">abspath</value_translation>
+                </column>
+            </output>
+        </data_table>
+    </data_manager>
+
+</data_managers>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_bad_output_ref.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_bad_output_ref.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!-- Same wrapper (whose only output is out_file), but the all_fasta path column
+     names output_ref="no_such_output". Fixture for OutputRefValid. -->
+<data_managers>
+    <data_manager tool_file="data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml" id="fetch_genome_all_fasta_dbkeys">
+        <data_table name="all_fasta">
+            <output>
+                <column name="value" />
+                <column name="dbkey" />
+                <column name="name" />
+                <column name="path" output_ref="no_such_output" />
+            </output>
+        </data_table>
+    </data_manager>
+</data_managers>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_missing_wrapper.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_missing_wrapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!-- tool_file points at a wrapper that does not exist, so the manager's outputs
+     cannot be resolved. OutputRefValid must treat the output_ref as not-checked
+     (unknown outputs), never as a demonstrably-missing output. -->
+<data_managers>
+    <data_manager tool_file="data_manager/does_not_exist.xml" id="fetch_genome_all_fasta_dbkeys">
+        <data_table name="all_fasta">
+            <output>
+                <column name="value" />
+                <column name="path" output_ref="no_such_output" />
+            </output>
+        </data_table>
+    </data_manager>
+</data_managers>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_mixed_output_ref.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_mixed_output_ref.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!-- Same wrapper (only output is out_file). all_fasta's output_ref is valid;
+     __dbkeys__'s is not. OutputRefValid must flag exactly the bad one. -->
+<data_managers>
+    <data_manager tool_file="data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml" id="fetch_genome_all_fasta_dbkeys">
+        <data_table name="all_fasta">
+            <output>
+                <column name="value" />
+                <column name="path" output_ref="out_file" />
+            </output>
+        </data_table>
+        <data_table name="__dbkeys__">
+            <output>
+                <column name="value" />
+                <column name="len_path" output_ref="no_such_output" />
+            </output>
+        </data_table>
+    </data_manager>
+</data_managers>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_nested_tool.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/data_manager_conf_nested_tool.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!-- Same manager as data_manager_conf.xml but using the nested <tool file="..."/>
+     (shed/guid) form instead of the tool_file attribute. Fixture for parser coverage. -->
+<data_managers>
+    <data_manager id="fetch_genome_all_fasta_dbkeys">
+        <tool file="data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml" guid="toolshed.example/repos/iuc/fetch/abcdef" />
+        <data_table name="all_fasta">
+            <output>
+                <column name="value" />
+                <column name="dbkey" />
+                <column name="name" />
+                <column name="path" output_ref="out_file" />
+            </output>
+        </data_table>
+    </data_manager>
+</data_managers>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/test-data/all_fasta.loc
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/test-data/all_fasta.loc
@@ -1,0 +1,1 @@
+#<unique_build_id>	<dbkey>	<display_name>	<file_path>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/test-data/dbkeys.loc
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/test-data/dbkeys.loc
@@ -1,0 +1,2 @@
+#<dbkey>	<display_name>	<len_file_path>
+anoGam1	A. gambiae Feb. 2003 (IAGEC MOZ2/anoGam1) (anoGam1)	some.len

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/test-data/phiX174.data_manager_json
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/test-data/phiX174.data_manager_json
@@ -1,0 +1,1 @@
+{"data_tables": {"__dbkeys__": [{"len_path": "phiX174.len", "name": "phiX174", "value": "phiX174"}], "all_fasta": [{"dbkey": "phiX174", "name": "phiX174 sequence name", "path": "phix174.fa", "value": "phix174"}]}}

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool-data/all_fasta.loc.sample
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool-data/all_fasta.loc.sample
@@ -1,0 +1,18 @@
+#This file lists the locations and dbkeys of all the fasta files
+#under the "genome" directory (a directory that contains a directory
+#for each build). The script extract_fasta.py will generate the file
+#all_fasta.loc. This file has the format (white space characters are
+#TAB characters):
+#
+#<unique_build_id>	<dbkey>		<display_name>	<file_path>
+#
+#So, all_fasta.loc could look something like this:
+#
+#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3		/path/to/genome/apiMel3/apiMel3.fa
+#hg19canon	hg19		Human (Homo sapiens): hg19 Canonical		/path/to/genome/hg19/hg19canon.fa
+#hg19full	hg19		Human (Homo sapiens): hg19 Full			/path/to/genome/hg19/hg19full.fa
+#
+#Your all_fasta.loc file should contain an entry for each individual
+#fasta file. So there will be multiple fasta files for each build,
+#such as with hg19 above.
+#

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool-data/dbkeys.loc.sample
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool-data/dbkeys.loc.sample
@@ -1,0 +1,1 @@
+#<dbkey>		<display_name>	<len_file_path>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool_data_table_conf.xml.sample
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool_data_table_conf.xml.sample
@@ -1,0 +1,12 @@
+<tables>
+    <!-- Locations of all fasta files under genome directory -->
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/all_fasta.loc" />
+    </table>
+    <!-- Locations of dbkeys and len files under genome directory -->
+    <table name="__dbkeys__" comment_char="#">
+        <columns>value, name, len_path</columns>
+        <file path="tool-data/dbkeys.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tool_data_table_conf.xml.test
@@ -1,0 +1,12 @@
+<tables>
+    <!-- Locations of all fasta files under genome directory -->
+    <table name="all_fasta" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="${__HERE__}/test-data/all_fasta.loc" />
+    </table>
+    <!-- Locations of dbkeys and len files under genome directory -->
+    <table name="__dbkeys__" comment_char="#">
+        <columns>value, name, len_path</columns>
+        <file path="${__HERE__}/test-data/dbkeys.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tools/consume_all_fasta.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tools/consume_all_fasta.xml
@@ -1,0 +1,18 @@
+<tool id="consume_all_fasta" name="Consume all_fasta" version="0.1.0">
+    <description>ordinary consumer of the all_fasta data table</description>
+    <command detect_errors="exit_code"><![CDATA[
+        echo '${reference_genome}' > '${output}'
+    ]]></command>
+    <inputs>
+        <param name="reference_genome" type="select" label="Reference genome">
+            <options from_data_table="all_fasta">
+                <filter type="sort_by" column="2" />
+                <validator type="no_options" message="No reference genomes are available." />
+            </options>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <help>Consumer used as a fixture for repository data-table linting.</help>
+</tool>

--- a/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tools/consume_dynamic_table.xml
+++ b/test/unit/tool_util/data/repositories/fetch_genome_dbkeys_all_fasta/tools/consume_dynamic_table.xml
@@ -1,0 +1,20 @@
+<tool id="consume_dynamic_table" name="Consume dynamic table" version="0.1.0">
+    <description>consumer whose from_data_table stays non-literal after macro expansion</description>
+    <command detect_errors="exit_code"><![CDATA[
+        echo '${reference_genome}' > '${output}'
+    ]]></command>
+    <inputs>
+        <param name="reference_genome" type="select" label="Reference genome">
+            <!-- @UNRESOLVED_TABLE@ is not a defined token, so it survives macro
+                 expansion as a non-literal name. It must be treated as not-checked,
+                 never flagged as a demonstrably-missing table definition. -->
+            <options from_data_table="@UNRESOLVED_TABLE@">
+                <validator type="no_options" message="No options." />
+            </options>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <help>Consumer fixture exercising the non-literal from_data_table guard.</help>
+</tool>

--- a/test/unit/tool_util/data/repositories/missing_and_broken/test-data/broken.loc
+++ b/test/unit/tool_util/data/repositories/missing_and_broken/test-data/broken.loc
@@ -1,0 +1,4 @@
+# value	name	path
+val1	name1	/data/path1
+val2	name2
+val3,name3,/data/path3

--- a/test/unit/tool_util/data/repositories/missing_and_broken/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/missing_and_broken/tool_data_table_conf.xml.test
@@ -1,0 +1,13 @@
+<tables>
+    <!-- One table whose loc is absent and one whose loc has short / wrong-separator
+         rows. Both linters must fire, and LocRowShape must not emit a green "rows
+         are fine" check off the back of the unparsed missing file. -->
+    <table name="absent" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/absent.loc" />
+    </table>
+    <table name="broken" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/broken.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/missing_loc/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/missing_loc/tool_data_table_conf.xml.test
@@ -1,0 +1,6 @@
+<tables>
+    <table name="absent" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/absent.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/missing_two/tool_data_table_conf.xml.test
+++ b/test/unit/tool_util/data/repositories/missing_two/tool_data_table_conf.xml.test
@@ -1,0 +1,12 @@
+<tables>
+    <!-- Two tables whose loc fixtures are both absent; exercises MissingLocFixture
+         emitting one error per unfound reference (not just the single-missing case). -->
+    <table name="absent_one" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/absent_one.loc" />
+    </table>
+    <table name="absent_two" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="${__HERE__}/test-data/absent_two.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/sample_fallback/foo.loc.sample
+++ b/test/unit/tool_util/data/repositories/sample_fallback/foo.loc.sample
@@ -1,0 +1,1 @@
+#value	name	path

--- a/test/unit/tool_util/data/repositories/sample_fallback/tool_data_table_conf.xml.sample
+++ b/test/unit/tool_util/data/repositories/sample_fallback/tool_data_table_conf.xml.sample
@@ -1,0 +1,9 @@
+<tables>
+    <!-- The referenced production loc (foo.loc) does not exist; the loader falls back
+         to foo.loc.sample. This fixture exercises that .sample fallback branch so a
+         resolved-but-sample-backed loc reports found=True with is_sample=True. -->
+    <table name="foo" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="tool-data/foo.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/repositories/tool_data_sample/tool-data/bar.loc.sample
+++ b/test/unit/tool_util/data/repositories/tool_data_sample/tool-data/bar.loc.sample
@@ -1,0 +1,1 @@
+#value	name	path

--- a/test/unit/tool_util/data/repositories/tool_data_sample/tool_data_table_conf.xml.sample
+++ b/test/unit/tool_util/data/repositories/tool_data_sample/tool_data_table_conf.xml.sample
@@ -1,0 +1,10 @@
+<tables>
+    <!-- The real Tool Shed layout: the production loc (tool-data/bar.loc) is absent and
+         the sample ships beside it at tool-data/bar.loc.sample. The loader's own .sample
+         fallback strips the tool-data/ subdir and only looks in tool_data_path root, so it
+         does NOT resolve this (found=False); sample_backed picks it up instead. -->
+    <table name="bar" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="tool-data/bar.loc" />
+    </table>
+</tables>

--- a/test/unit/tool_util/data/test_data_lint_cli.py
+++ b/test/unit/tool_util/data/test_data_lint_cli.py
@@ -1,0 +1,69 @@
+"""Tests for the ``galaxy-tool-data-lint`` CLI.
+
+These drive the command-line entry point over the real fixture repositories under
+``repositories/`` and assert on its exit code and output -- the standalone counterpart
+to the in-process linter tests in ``test_repository_data_table_lint.py``.
+"""
+
+import json
+import os
+
+import pytest
+
+from galaxy.tool_util.data.bundles.script import (
+    lint,
+    main,
+)
+
+REPOS = os.path.join(os.path.dirname(__file__), "repositories")
+CLEAN_REPO = os.path.join(REPOS, "fetch_genome_dbkeys_all_fasta")
+MISSING_LOC_REPO = os.path.join(REPOS, "missing_loc")
+
+
+def _lint(repository, skip="", report_level="all", fail_level="error", json=False):
+    return lint(repository, skip=skip, report_level=report_level, fail_level=fail_level, json=json)
+
+
+def test_clean_repository_exits_zero(capsys):
+    code = _lint(CLEAN_REPO)
+    assert code == 0
+    out = capsys.readouterr().out
+    # Discovery found the bundle and every linter ran (all green checks printed).
+    assert "MissingLocFixture" in out
+    assert "ERROR" not in out
+
+
+def test_missing_loc_repository_exits_one(capsys):
+    code = _lint(MISSING_LOC_REPO)
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "ERROR (MissingLocFixture)" in out
+    assert "does not exist" in out
+
+
+def test_skip_suppresses_linter_and_exit_code(capsys):
+    # Skipping the only failing linter drops both its message and the failure.
+    code = _lint(MISSING_LOC_REPO, skip="MissingLocFixture")
+    assert code == 0
+    assert "MissingLocFixture" not in capsys.readouterr().out
+
+
+def test_no_configuration_is_skipped(tmp_path, capsys):
+    code = _lint(str(tmp_path))
+    assert code == 0
+    assert "skipping data table linting" in capsys.readouterr().out
+
+
+def test_json_output_lists_messages(capsys):
+    code = _lint(MISSING_LOC_REPO, json=True)
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    errors = [m for m in payload["messages"] if m["level"] == "error"]
+    assert len(errors) == 1
+    assert errors[0]["linter"] == "MissingLocFixture"
+
+
+def test_main_exits_via_system_exit():
+    with pytest.raises(SystemExit) as exc_info:
+        main([MISSING_LOC_REPO])
+    assert exc_info.value.code == 1

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -11,6 +11,7 @@ from galaxy.tool_util.data.bundles.lint import (
     ConflictingTableSchema,
     ConsumerTableDefined,
     DuplicateColumnNames,
+    EmptyLocFile,
     lint_repository_data_tables,
     lint_repository_data_tables_bundle,
     LocRowShape,
@@ -18,7 +19,10 @@ from galaxy.tool_util.data.bundles.lint import (
     MissingLocFixture,
     OutputRefValid,
 )
-from galaxy.tool_util.data.bundles.repository import build_repository_data_tables
+from galaxy.tool_util.data.bundles.repository import (
+    _classify_loc_file,
+    build_repository_data_tables,
+)
 from galaxy.tool_util.lint import (
     LintContext,
     LintLevel,
@@ -37,6 +41,7 @@ DUP_COLUMNS_REPO = os.path.join(REPOS, "dup_columns")
 CONFLICT_COLUMNS_REPO = os.path.join(REPOS, "conflicting_columns")
 CONFLICT_SEPARATOR_REPO = os.path.join(REPOS, "conflicting_separator")
 CONFLICT_INDEXES_REPO = os.path.join(REPOS, "conflicting_indexes")
+EMPTY_LOC_REPO = os.path.join(REPOS, "empty_loc")
 
 FETCH_TABLE_TEST_CONF = os.path.join(FETCH_REPO, "tool_data_table_conf.xml.test")
 FETCH_DM_CONF = os.path.join(FETCH_REPO, "data_manager_conf.xml")
@@ -283,6 +288,47 @@ def test_clean_repo_has_no_schema_or_duplicate_errors():
     assert [e for e in lint_ctx.error_messages if e.linter in schema_linters] == []
     linters_with_valid = {v.linter for v in lint_ctx.valid_messages}
     assert schema_linters <= linters_with_valid
+
+
+def test_empty_undocumented_loc_files_warn():
+    # Empty, comment-less loc files are flagged (Planemo #869), whether a shipped
+    # .loc.sample or a plain test-data *.loc; a sibling empty-but-documented
+    # (header-only) sample must NOT be flagged.
+    conf = os.path.join(EMPTY_LOC_REPO, "tool_data_table_conf.xml.sample")
+    model = build_repository_data_tables(EMPTY_LOC_REPO, tool_data_table_confs=[conf])
+    # Guard against a vacuous pass: bare loc files are present, and a documented
+    # (header-only) one is too.
+    assert any(not f.has_data and not f.has_comment for f in model.loc_files)
+    assert any(not f.has_data and f.has_comment for f in model.loc_files)
+    warns = [w for w in _lint(model).warn_messages if w.linter == EmptyLocFile.name()]
+    flagged = {os.path.basename(w.message.split("[", 1)[1].split("]", 1)[0]) for w in warns}
+    assert flagged == {"undocumented.loc.sample", "empty.loc"}
+
+
+def test_loc_file_classification(tmp_path):
+    # The empty/documented distinction the linter keys on: whitespace-only and a
+    # lone UTF-8 BOM both count as empty-and-undocumented; a comment (even behind a
+    # BOM) documents the file; a data row is data.
+    def classify(name, data, *, binary=False):
+        p = tmp_path / name
+        p.write_bytes(data) if binary else p.write_text(data)
+        loc = _classify_loc_file(str(p))
+        return loc.has_data, loc.has_comment
+
+    assert classify("blank.loc", "  \n\n\t\n") == (False, False)
+    assert classify("bom_only.loc", b"\xef\xbb\xbf", binary=True) == (False, False)
+    assert classify("bom_comment.loc", b"\xef\xbb\xbf# value\tpath\n", binary=True) == (False, True)
+    assert classify("comment.loc", "# value\tpath\n\n") == (False, True)
+    assert classify("data.loc", "# value\tpath\nv1\t/data/x\n") == (True, True)
+
+
+def test_documented_loc_files_do_not_warn():
+    # The clean fixture ships data rows and header-only samples only; the empty-loc
+    # linter must stay green and confirm valid (no false positive on documented files).
+    model = build_repository_data_tables(FETCH_REPO, tool_data_table_confs=[FETCH_TABLE_TEST_CONF])
+    lint_ctx = _lint(model)
+    assert [w for w in lint_ctx.warn_messages if w.linter == EmptyLocFile.name()] == []
+    assert any(v.linter == EmptyLocFile.name() for v in lint_ctx.valid_messages)
 
 
 def test_linters_are_skippable_by_name():

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -8,7 +8,9 @@ assert on the emitted :class:`~galaxy.tool_util.lint.LintContext` messages.
 import os
 
 from galaxy.tool_util.data.bundles.lint import (
+    ConflictingTableSchema,
     ConsumerTableDefined,
+    DuplicateColumnNames,
     lint_repository_data_tables,
     LocRowShape,
     ManagerTableConfigured,
@@ -29,6 +31,10 @@ MISSING_LOC_REPO = os.path.join(REPOS, "missing_loc")
 MISSING_TWO_REPO = os.path.join(REPOS, "missing_two")
 MISSING_AND_BROKEN_REPO = os.path.join(REPOS, "missing_and_broken")
 SAMPLE_FALLBACK_REPO = os.path.join(REPOS, "sample_fallback")
+DUP_COLUMNS_REPO = os.path.join(REPOS, "dup_columns")
+CONFLICT_COLUMNS_REPO = os.path.join(REPOS, "conflicting_columns")
+CONFLICT_SEPARATOR_REPO = os.path.join(REPOS, "conflicting_separator")
+CONFLICT_INDEXES_REPO = os.path.join(REPOS, "conflicting_indexes")
 
 FETCH_TABLE_TEST_CONF = os.path.join(FETCH_REPO, "tool_data_table_conf.xml.test")
 FETCH_DM_CONF = os.path.join(FETCH_REPO, "data_manager_conf.xml")
@@ -108,7 +114,9 @@ def test_missing_and_broken_together_no_contradictory_valid():
     row = [e for e in lint_ctx.error_messages if e.linter == LocRowShape.name()]
     assert len(missing) == 1
     assert len(row) == 2
-    assert lint_ctx.valid_messages == []
+    # The point of this case: LocRowShape must not emit a green "rows are fine"
+    # check off the back of the unparsed missing file.
+    assert [v for v in lint_ctx.valid_messages if v.linter == LocRowShape.name()] == []
 
 
 def test_full_bundle_names_all_resolve():
@@ -212,6 +220,54 @@ def test_output_ref_not_checked_when_wrapper_unresolved():
     lint_ctx = _lint(model)
     assert [e for e in lint_ctx.error_messages if e.linter == OutputRefValid.name()] == []
     assert [v for v in lint_ctx.valid_messages if v.linter == OutputRefValid.name()] == []
+
+
+def test_duplicate_column_names_is_an_error():
+    conf = os.path.join(DUP_COLUMNS_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(DUP_COLUMNS_REPO, tool_data_table_confs=[conf])
+    errors = [e for e in _lint(model).error_messages if e.linter == DuplicateColumnNames.name()]
+    assert len(errors) == 1
+    assert "value" in errors[0].message
+
+
+def test_conflicting_columns_reported_without_crashing_assembly():
+    conf = os.path.join(CONFLICT_COLUMNS_REPO, "tool_data_table_conf.xml.test")
+    # Assembly must not raise even though the loader's merge would on this conflict.
+    model = build_repository_data_tables(CONFLICT_COLUMNS_REPO, tool_data_table_confs=[conf])
+    # Loader was skipped, but the name is still known from the raw declarations.
+    assert "conflict_tbl" in model.configured_table_names
+    errors = [e for e in _lint(model).error_messages if e.linter == ConflictingTableSchema.name()]
+    assert len(errors) == 1
+    assert "conflict_tbl" in errors[0].message
+
+
+def test_conflicting_indexes_reported_without_crashing_assembly():
+    # Same column names but different index attributes: the raw name tuples match,
+    # so only the parsed columns-map catches the conflict -- and the loader would
+    # crash on it, so assembly must skip the loader and still not raise.
+    conf = os.path.join(CONFLICT_INDEXES_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(CONFLICT_INDEXES_REPO, tool_data_table_confs=[conf])
+    assert "idx_tbl" in model.configured_table_names
+    errors = [e for e in _lint(model).error_messages if e.linter == ConflictingTableSchema.name()]
+    assert len(errors) == 1
+    assert "idx_tbl" in errors[0].message
+
+
+def test_conflicting_separator_is_reported():
+    conf = os.path.join(CONFLICT_SEPARATOR_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(CONFLICT_SEPARATOR_REPO, tool_data_table_confs=[conf])
+    errors = [e for e in _lint(model).error_messages if e.linter == ConflictingTableSchema.name()]
+    assert len(errors) == 1
+    assert "sep_tbl" in errors[0].message
+
+
+def test_clean_repo_has_no_schema_or_duplicate_errors():
+    model = build_repository_data_tables(FETCH_REPO, tool_data_table_confs=[FETCH_TABLE_TEST_CONF])
+    lint_ctx = _lint(model)
+    schema_linters = {DuplicateColumnNames.name(), ConflictingTableSchema.name()}
+    assert [e for e in lint_ctx.error_messages if e.linter in schema_linters] == []
+    linters_with_valid = {v.linter for v in lint_ctx.valid_messages}
+    assert schema_linters <= linters_with_valid
 
 
 def test_linters_are_skippable_by_name():

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -13,6 +13,7 @@ from galaxy.tool_util.data.bundles.lint import (
     LocRowShape,
     ManagerTableConfigured,
     MissingLocFixture,
+    OutputRefValid,
 )
 from galaxy.tool_util.data.bundles.repository import build_repository_data_tables
 from galaxy.tool_util.lint import (
@@ -31,6 +32,9 @@ SAMPLE_FALLBACK_REPO = os.path.join(REPOS, "sample_fallback")
 
 FETCH_TABLE_TEST_CONF = os.path.join(FETCH_REPO, "tool_data_table_conf.xml.test")
 FETCH_DM_CONF = os.path.join(FETCH_REPO, "data_manager_conf.xml")
+FETCH_DM_CONF_BAD_OUTPUT_REF = os.path.join(FETCH_REPO, "data_manager_conf_bad_output_ref.xml")
+FETCH_DM_CONF_MIXED_OUTPUT_REF = os.path.join(FETCH_REPO, "data_manager_conf_mixed_output_ref.xml")
+FETCH_DM_CONF_MISSING_WRAPPER = os.path.join(FETCH_REPO, "data_manager_conf_missing_wrapper.xml")
 FETCH_CONSUMER = os.path.join(FETCH_REPO, "tools", "consume_all_fasta.xml")
 FETCH_DYNAMIC_CONSUMER = os.path.join(FETCH_REPO, "tools", "consume_dynamic_table.xml")
 
@@ -170,6 +174,44 @@ def test_non_literal_consumer_table_is_not_checked():
     assert lint_ctx.warn_messages == []
     # Nothing literal was checked, so no green confirmation either.
     assert [v for v in lint_ctx.valid_messages if v.linter == ConsumerTableDefined.name()] == []
+
+
+def test_output_ref_names_real_output_is_clean():
+    model = build_repository_data_tables(FETCH_REPO, data_manager_conf=FETCH_DM_CONF)
+    lint_ctx = _lint(model)
+    assert [e for e in lint_ctx.error_messages if e.linter == OutputRefValid.name()] == []
+    assert any(v.linter == OutputRefValid.name() for v in lint_ctx.valid_messages)
+
+
+def test_output_ref_to_missing_output_is_an_error():
+    model = build_repository_data_tables(FETCH_REPO, data_manager_conf=FETCH_DM_CONF_BAD_OUTPUT_REF)
+    lint_ctx = _lint(model)
+    errors = [e for e in lint_ctx.error_messages if e.linter == OutputRefValid.name()]
+    assert len(errors) == 1
+    assert "no_such_output" in errors[0].message
+    assert "out_file" in errors[0].message  # names the real declared output for the fix
+
+
+def test_output_ref_flags_only_the_bad_ref_in_a_mixed_manager():
+    # One <data_table> has a valid output_ref, another a bad one; only the bad
+    # one is flagged (exercises per-table iteration within a single manager).
+    model = build_repository_data_tables(FETCH_REPO, data_manager_conf=FETCH_DM_CONF_MIXED_OUTPUT_REF)
+    errors = [e for e in _lint(model).error_messages if e.linter == OutputRefValid.name()]
+    assert len(errors) == 1
+    assert "no_such_output" in errors[0].message
+    assert "__dbkeys__" in errors[0].message
+
+
+def test_output_ref_not_checked_when_wrapper_unresolved():
+    # tool_file points at a wrapper that does not exist, so build resolves
+    # wrapper_resolved=False and the outputs are unknown; a bad-looking output_ref
+    # must not be reported as demonstrably missing.
+    model = build_repository_data_tables(FETCH_REPO, data_manager_conf=FETCH_DM_CONF_MISSING_WRAPPER)
+    # Precondition: the wrapper genuinely failed to resolve (guard is exercised).
+    assert model.managers and all(not m.wrapper_resolved for m in model.managers)
+    lint_ctx = _lint(model)
+    assert [e for e in lint_ctx.error_messages if e.linter == OutputRefValid.name()] == []
+    assert [v for v in lint_ctx.valid_messages if v.linter == OutputRefValid.name()] == []
 
 
 def test_linters_are_skippable_by_name():

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -32,6 +32,7 @@ MISSING_LOC_REPO = os.path.join(REPOS, "missing_loc")
 MISSING_TWO_REPO = os.path.join(REPOS, "missing_two")
 MISSING_AND_BROKEN_REPO = os.path.join(REPOS, "missing_and_broken")
 SAMPLE_FALLBACK_REPO = os.path.join(REPOS, "sample_fallback")
+TOOL_DATA_SAMPLE_REPO = os.path.join(REPOS, "tool_data_sample")
 DUP_COLUMNS_REPO = os.path.join(REPOS, "dup_columns")
 CONFLICT_COLUMNS_REPO = os.path.join(REPOS, "conflicting_columns")
 CONFLICT_SEPARATOR_REPO = os.path.join(REPOS, "conflicting_separator")
@@ -91,6 +92,19 @@ def test_sample_fallback_is_not_a_missing_fixture():
     model = build_repository_data_tables(SAMPLE_FALLBACK_REPO, tool_data_table_confs=[conf])
     # Guard against the test passing vacuously: the asset must actually resolve via .sample.
     assert any(asset.found and asset.is_sample for asset in model.loc_assets)
+    lint_ctx = _lint(model)
+    assert [e for e in lint_ctx.error_messages if e.linter == MissingLocFixture.name()] == []
+
+
+def test_tool_data_sample_backed_loc_is_not_a_missing_fixture():
+    # The real Tool Shed layout: conf references tool-data/bar.loc, the sample ships at
+    # tool-data/bar.loc.sample. The loader's own .sample fallback does NOT resolve this
+    # (found=False), so without sample_backed every reference-data repo would wrongly
+    # report a missing loc. sample_backed must recognize the shipped sample.
+    conf = os.path.join(TOOL_DATA_SAMPLE_REPO, "tool_data_table_conf.xml.sample")
+    model = build_repository_data_tables(TOOL_DATA_SAMPLE_REPO, tool_data_table_confs=[conf])
+    # Guard against a vacuous pass: the loader must genuinely miss it, and sample_backed catch it.
+    assert any(not asset.found and asset.sample_backed for asset in model.loc_assets)
     lint_ctx = _lint(model)
     assert [e for e in lint_ctx.error_messages if e.linter == MissingLocFixture.name()] == []
 

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -1,0 +1,105 @@
+"""Linter tests for the repository data-table bundle.
+
+These run the repository-level linters over :class:`RepositoryDataTables` models
+built from the real fixture repositories under ``repositories/`` (no mocks) and
+assert on the emitted :class:`~galaxy.tool_util.lint.LintContext` messages.
+"""
+
+import os
+
+from galaxy.tool_util.data.bundles.lint import (
+    lint_repository_data_tables,
+    LocRowShape,
+    MissingLocFixture,
+)
+from galaxy.tool_util.data.bundles.repository import build_repository_data_tables
+from galaxy.tool_util.lint import (
+    LintContext,
+    LintLevel,
+)
+
+REPOS = os.path.join(os.path.dirname(__file__), "repositories")
+FETCH_REPO = os.path.join(REPOS, "fetch_genome_dbkeys_all_fasta")
+BROKEN_REPO = os.path.join(REPOS, "broken_rows")
+MISSING_LOC_REPO = os.path.join(REPOS, "missing_loc")
+MISSING_TWO_REPO = os.path.join(REPOS, "missing_two")
+MISSING_AND_BROKEN_REPO = os.path.join(REPOS, "missing_and_broken")
+SAMPLE_FALLBACK_REPO = os.path.join(REPOS, "sample_fallback")
+
+FETCH_TABLE_TEST_CONF = os.path.join(FETCH_REPO, "tool_data_table_conf.xml.test")
+
+
+def _lint(model):
+    lint_ctx = LintContext(level=LintLevel.SILENT)
+    lint_repository_data_tables(model, lint_ctx)
+    return lint_ctx
+
+
+def test_clean_repository_has_no_errors():
+    model = build_repository_data_tables(FETCH_REPO, tool_data_table_confs=[FETCH_TABLE_TEST_CONF])
+    lint_ctx = _lint(model)
+    assert lint_ctx.error_messages == []
+
+
+def test_missing_loc_fixture_is_an_error():
+    conf = os.path.join(MISSING_LOC_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(MISSING_LOC_REPO, tool_data_table_confs=[conf])
+    lint_ctx = _lint(model)
+    errors = lint_ctx.error_messages
+    assert len(errors) == 1
+    assert errors[0].linter == MissingLocFixture.name()
+    # Assert on stable linter wording, not the fixture's ("absent") file name.
+    assert "does not exist" in errors[0].message
+
+
+def test_short_and_wrong_separator_rows_are_errors():
+    conf = os.path.join(BROKEN_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(BROKEN_REPO, tool_data_table_confs=[conf])
+    lint_ctx = _lint(model)
+    errors = lint_ctx.error_messages
+    assert len(errors) == 2
+    assert all(e.linter == LocRowShape.name() for e in errors)
+    assert all("invalid" in e.message for e in errors)
+
+
+def test_sample_fallback_is_not_a_missing_fixture():
+    # A production loc resolved via .sample fallback is found; the missing-fixture
+    # error must not fire on it (a P1 warning about the missing production loc is
+    # a separate, later check).
+    conf = os.path.join(SAMPLE_FALLBACK_REPO, "tool_data_table_conf.xml.sample")
+    model = build_repository_data_tables(SAMPLE_FALLBACK_REPO, tool_data_table_confs=[conf])
+    # Guard against the test passing vacuously: the asset must actually resolve via .sample.
+    assert any(asset.found and asset.is_sample for asset in model.loc_assets)
+    lint_ctx = _lint(model)
+    assert [e for e in lint_ctx.error_messages if e.linter == MissingLocFixture.name()] == []
+
+
+def test_multiple_missing_fixtures_each_error():
+    conf = os.path.join(MISSING_TWO_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(MISSING_TWO_REPO, tool_data_table_confs=[conf])
+    lint_ctx = _lint(model)
+    errors = lint_ctx.error_messages
+    assert len(errors) == 2
+    assert all(e.linter == MissingLocFixture.name() for e in errors)
+
+
+def test_missing_and_broken_together_no_contradictory_valid():
+    # A repo with one unfound loc AND one loc with short rows: the missing-fixture
+    # error and the row-shape errors must both fire, and LocRowShape must NOT also
+    # emit a green "all rows fine" check off the back of the unparsed missing file.
+    conf = os.path.join(MISSING_AND_BROKEN_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(MISSING_AND_BROKEN_REPO, tool_data_table_confs=[conf])
+    lint_ctx = _lint(model)
+    missing = [e for e in lint_ctx.error_messages if e.linter == MissingLocFixture.name()]
+    row = [e for e in lint_ctx.error_messages if e.linter == LocRowShape.name()]
+    assert len(missing) == 1
+    assert len(row) == 2
+    assert lint_ctx.valid_messages == []
+
+
+def test_linters_are_skippable_by_name():
+    conf = os.path.join(MISSING_LOC_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(MISSING_LOC_REPO, tool_data_table_confs=[conf])
+    lint_ctx = LintContext(level=LintLevel.SILENT, skip_types=[MissingLocFixture.name()])
+    lint_repository_data_tables(model, lint_ctx)
+    assert lint_ctx.error_messages == []

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -12,6 +12,7 @@ from galaxy.tool_util.data.bundles.lint import (
     ConsumerTableDefined,
     DuplicateColumnNames,
     lint_repository_data_tables,
+    lint_repository_data_tables_bundle,
     LocRowShape,
     ManagerTableConfigured,
     MissingLocFixture,
@@ -276,3 +277,41 @@ def test_linters_are_skippable_by_name():
     lint_ctx = LintContext(level=LintLevel.SILENT, skip_types=[MissingLocFixture.name()])
     lint_repository_data_tables(model, lint_ctx)
     assert lint_ctx.error_messages == []
+
+
+def _lint_bundle(repo_root, **kwargs):
+    lint_ctx = LintContext(level=LintLevel.SILENT)
+    lint_repository_data_tables_bundle(lint_ctx, repo_root, **kwargs)
+    return lint_ctx
+
+
+def test_bundle_clean_repository_has_no_errors():
+    lint_ctx = _lint_bundle(FETCH_REPO, data_manager_conf=FETCH_DM_CONF, tool_data_table_confs=[FETCH_TABLE_TEST_CONF])
+    assert lint_ctx.error_messages == []
+    # the per-table linters actually ran (not skipped)
+    assert lint_ctx.valid_messages
+
+
+def test_bundle_surfaces_linter_errors():
+    conf = os.path.join(MISSING_LOC_REPO, "tool_data_table_conf.xml.test")
+    lint_ctx = _lint_bundle(MISSING_LOC_REPO, tool_data_table_confs=[conf])
+    errors = lint_ctx.error_messages
+    assert len(errors) == 1
+    assert errors[0].linter == MissingLocFixture.name()
+
+
+def test_bundle_skips_when_no_configuration():
+    lint_ctx = _lint_bundle(FETCH_REPO)
+    assert lint_ctx.error_messages == []
+    assert any("skipping data table linting" in m.message for m in lint_ctx.info_messages)
+    # nothing was assembled, so no per-table linter ran
+    assert lint_ctx.valid_messages == []
+
+
+def test_bundle_reports_assembly_failure(tmp_path):
+    conf = tmp_path / "data_manager_conf.xml"
+    conf.write_text("<data_managers><data_manager id='x'\n")  # unclosed tag -> parse error
+    lint_ctx = _lint_bundle(str(tmp_path), data_manager_conf=str(conf))
+    errors = lint_ctx.error_messages
+    assert len(errors) == 1
+    assert "Problem assembling repository data table model" in errors[0].message

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -12,6 +12,7 @@ from galaxy.tool_util.data.bundles.lint import (
     ConsumerTableDefined,
     DuplicateColumnNames,
     EmptyLocFile,
+    find_and_lint_repository_data_tables,
     lint_repository_data_tables,
     lint_repository_data_tables_bundle,
     LocRowShape,
@@ -42,6 +43,7 @@ CONFLICT_COLUMNS_REPO = os.path.join(REPOS, "conflicting_columns")
 CONFLICT_SEPARATOR_REPO = os.path.join(REPOS, "conflicting_separator")
 CONFLICT_INDEXES_REPO = os.path.join(REPOS, "conflicting_indexes")
 EMPTY_LOC_REPO = os.path.join(REPOS, "empty_loc")
+CORE_CONSUMER_REPO = os.path.join(REPOS, "core_table_consumer")
 
 FETCH_TABLE_TEST_CONF = os.path.join(FETCH_REPO, "tool_data_table_conf.xml.test")
 FETCH_DM_CONF = os.path.join(FETCH_REPO, "data_manager_conf.xml")
@@ -375,3 +377,35 @@ def test_bundle_reports_assembly_failure(tmp_path):
     errors = lint_ctx.error_messages
     assert len(errors) == 1
     assert "Problem assembling repository data table model" in errors[0].message
+
+
+CORE_CONSUMER_SAMPLE_CONF = os.path.join(CORE_CONSUMER_REPO, "tool_data_table_conf.xml.sample")
+CORE_CONSUMER_WRAPPER = os.path.join(CORE_CONSUMER_REPO, "data_manager", "bwa_mem2_index_builder.xml")
+
+
+def test_find_and_lint_excludes_core_tables():
+    # An index-builder data manager that defines its own bwa_mem2_indexes table but
+    # consumes the core all_fasta table (supplied by Galaxy core) via from_data_table.
+    # The one-call find_and_lint entry seeds DEFAULT_EXTERNAL_TABLE_NAMES, so the core
+    # reference must not be flagged as an undefined consumer table -- and, because a
+    # literal reference was still checked, ConsumerTableDefined confirms valid.
+    lint_ctx = LintContext(level=LintLevel.SILENT)
+    find_and_lint_repository_data_tables(lint_ctx, CORE_CONSUMER_REPO)
+    assert [w for w in lint_ctx.warn_messages if w.linter == ConsumerTableDefined.name()] == []
+    assert any(v.linter == ConsumerTableDefined.name() for v in lint_ctx.valid_messages)
+
+
+def test_core_table_exclusion_is_what_suppresses_the_warning():
+    # Guard against a vacuous pass above: the same repo, linted WITHOUT the default
+    # core-table seeding, does warn on all_fasta -- so it really is consumed, not
+    # locally defined, and the DEFAULT_EXTERNAL_TABLE_NAMES seeding is doing the work.
+    model = build_repository_data_tables(
+        CORE_CONSUMER_REPO,
+        tool_data_table_confs=[CORE_CONSUMER_SAMPLE_CONF],
+        consumer_tool_sources=_consumer_sources(CORE_CONSUMER_WRAPPER),
+    )
+    assert "all_fasta" not in model.configured_table_names
+    assert any(c.table_name == "all_fasta" for c in model.consumers)
+    warns = [w for w in _lint(model).warn_messages if w.linter == ConsumerTableDefined.name()]
+    assert len(warns) == 1
+    assert "all_fasta" in warns[0].message

--- a/test/unit/tool_util/data/test_repository_data_table_lint.py
+++ b/test/unit/tool_util/data/test_repository_data_table_lint.py
@@ -8,8 +8,10 @@ assert on the emitted :class:`~galaxy.tool_util.lint.LintContext` messages.
 import os
 
 from galaxy.tool_util.data.bundles.lint import (
+    ConsumerTableDefined,
     lint_repository_data_tables,
     LocRowShape,
+    ManagerTableConfigured,
     MissingLocFixture,
 )
 from galaxy.tool_util.data.bundles.repository import build_repository_data_tables
@@ -17,6 +19,7 @@ from galaxy.tool_util.lint import (
     LintContext,
     LintLevel,
 )
+from galaxy.tool_util.parser.factory import get_tool_source
 
 REPOS = os.path.join(os.path.dirname(__file__), "repositories")
 FETCH_REPO = os.path.join(REPOS, "fetch_genome_dbkeys_all_fasta")
@@ -27,6 +30,13 @@ MISSING_AND_BROKEN_REPO = os.path.join(REPOS, "missing_and_broken")
 SAMPLE_FALLBACK_REPO = os.path.join(REPOS, "sample_fallback")
 
 FETCH_TABLE_TEST_CONF = os.path.join(FETCH_REPO, "tool_data_table_conf.xml.test")
+FETCH_DM_CONF = os.path.join(FETCH_REPO, "data_manager_conf.xml")
+FETCH_CONSUMER = os.path.join(FETCH_REPO, "tools", "consume_all_fasta.xml")
+FETCH_DYNAMIC_CONSUMER = os.path.join(FETCH_REPO, "tools", "consume_dynamic_table.xml")
+
+
+def _consumer_sources(*paths):
+    return [(path, get_tool_source(config_file=path)) for path in paths]
 
 
 def _lint(model):
@@ -95,6 +105,71 @@ def test_missing_and_broken_together_no_contradictory_valid():
     assert len(missing) == 1
     assert len(row) == 2
     assert lint_ctx.valid_messages == []
+
+
+def test_full_bundle_names_all_resolve():
+    # Manager tables + consumer reference are all locally configured -> no errors,
+    # no warnings; both name-relationship linters confirm valid.
+    model = build_repository_data_tables(
+        FETCH_REPO,
+        data_manager_conf=FETCH_DM_CONF,
+        tool_data_table_confs=[FETCH_TABLE_TEST_CONF],
+        consumer_tool_sources=_consumer_sources(FETCH_CONSUMER),
+    )
+    lint_ctx = _lint(model)
+    assert lint_ctx.error_messages == []
+    assert lint_ctx.warn_messages == []
+
+
+def test_manager_table_not_configured_is_an_error():
+    # Manager declares all_fasta + __dbkeys__ but no tool_data_table config is present.
+    model = build_repository_data_tables(FETCH_REPO, data_manager_conf=FETCH_DM_CONF)
+    lint_ctx = _lint(model)
+    errors = [e for e in lint_ctx.error_messages if e.linter == ManagerTableConfigured.name()]
+    assert len(errors) == 2
+    flagged = {name for name in ("all_fasta", "__dbkeys__") for e in errors if name in e.message}
+    assert flagged == {"all_fasta", "__dbkeys__"}
+
+
+def test_manager_table_supplied_externally_is_ok():
+    model = build_repository_data_tables(
+        FETCH_REPO,
+        data_manager_conf=FETCH_DM_CONF,
+        external_table_names=frozenset({"all_fasta", "__dbkeys__"}),
+    )
+    lint_ctx = _lint(model)
+    assert [e for e in lint_ctx.error_messages if e.linter == ManagerTableConfigured.name()] == []
+
+
+def test_consumer_of_unknown_table_warns():
+    model = build_repository_data_tables(FETCH_REPO, consumer_tool_sources=_consumer_sources(FETCH_CONSUMER))
+    lint_ctx = _lint(model)
+    warns = [w for w in lint_ctx.warn_messages if w.linter == ConsumerTableDefined.name()]
+    assert len(warns) == 1
+    assert "all_fasta" in warns[0].message
+
+
+def test_consumer_of_externally_supplied_table_does_not_warn():
+    model = build_repository_data_tables(
+        FETCH_REPO,
+        consumer_tool_sources=_consumer_sources(FETCH_CONSUMER),
+        external_table_names=frozenset({"all_fasta"}),
+    )
+    lint_ctx = _lint(model)
+    assert [w for w in lint_ctx.warn_messages if w.linter == ConsumerTableDefined.name()] == []
+
+
+def test_non_literal_consumer_table_is_not_checked():
+    # A from_data_table that stays non-literal after macro expansion must not be
+    # flagged as missing (galaxyproject/tools-iuc#5003 false-positive guard).
+    model = build_repository_data_tables(FETCH_REPO, consumer_tool_sources=_consumer_sources(FETCH_DYNAMIC_CONSUMER))
+    # Precondition: the consumer's table name really is non-literal (guard is exercised).
+    assert any("@" in c.table_name for c in model.consumers)
+    lint_ctx = _lint(model)
+    assert lint_ctx.error_messages == []
+    assert lint_ctx.warn_messages == []
+    # Nothing literal was checked, so no green confirmation either.
+    assert [v for v in lint_ctx.valid_messages if v.linter == ConsumerTableDefined.name()] == []
 
 
 def test_linters_are_skippable_by_name():

--- a/test/unit/tool_util/data/test_repository_data_tables.py
+++ b/test/unit/tool_util/data/test_repository_data_tables.py
@@ -1,0 +1,137 @@
+"""Parser tests for the repository data-table bundle model.
+
+These build :class:`RepositoryDataTables` from real fixture repositories (no mocks)
+under ``repositories/`` and assert the assembled cross-file model.
+"""
+
+import os
+
+from galaxy.tool_util.data.bundles.repository import (
+    build_repository_data_tables,
+    ConsumerRef,
+    RepositoryDataTables,
+)
+from galaxy.tool_util.parser.factory import get_tool_source
+
+REPOS = os.path.join(os.path.dirname(__file__), "repositories")
+FETCH_REPO = os.path.join(REPOS, "fetch_genome_dbkeys_all_fasta")
+BROKEN_REPO = os.path.join(REPOS, "broken_rows")
+
+FETCH_DM_CONF = os.path.join(FETCH_REPO, "data_manager_conf.xml")
+FETCH_DM_CONF_NESTED = os.path.join(FETCH_REPO, "data_manager_conf_nested_tool.xml")
+FETCH_TABLE_TEST_CONF = os.path.join(FETCH_REPO, "tool_data_table_conf.xml.test")
+FETCH_CONSUMER = os.path.join(FETCH_REPO, "tools", "consume_all_fasta.xml")
+
+SAMPLE_FALLBACK_REPO = os.path.join(REPOS, "sample_fallback")
+MISSING_LOC_REPO = os.path.join(REPOS, "missing_loc")
+
+
+def _consumer_sources(*paths):
+    return [(path, get_tool_source(config_file=path)) for path in paths]
+
+
+def test_manager_side_reuses_processor_description():
+    model = build_repository_data_tables(FETCH_REPO, data_manager_conf=FETCH_DM_CONF)
+    assert len(model.managers) == 1
+    manager = model.managers[0]
+    assert manager.id == "fetch_genome_all_fasta_dbkeys"
+    # Output names come from the (macro-expanded) wrapper's <outputs>.
+    assert "out_file" in manager.tool_output_names
+    # Reused manager-side model exposes declared tables + output_ref mapping.
+    assert manager.processor.data_table_names == ["all_fasta", "__dbkeys__"]
+    output_refs = manager.processor.output_ref_by_data_table
+    assert output_refs["all_fasta"]["path"] == "out_file"
+    assert output_refs["__dbkeys__"]["len_path"] == "out_file"
+    assert manager.source.path == FETCH_DM_CONF
+    assert manager.source.line is not None
+
+
+def test_configured_tables_from_test_conf():
+    model = build_repository_data_tables(FETCH_REPO, tool_data_table_confs=[FETCH_TABLE_TEST_CONF])
+    assert model.configured_table_names == frozenset({"all_fasta", "__dbkeys__"})
+
+    all_fasta = model.table("all_fasta")
+    assert all_fasta is not None
+    assert all_fasta.columns == {"value": 0, "dbkey": 1, "name": 2, "path": 3}
+    assert all_fasta.largest_index == 3
+    assert all_fasta.separator == "\t"
+    assert all_fasta.comment_char == "#"
+
+
+def test_loc_assets_resolved_and_clean():
+    model = build_repository_data_tables(FETCH_REPO, tool_data_table_confs=[FETCH_TABLE_TEST_CONF])
+    by_table = {loc.table_name: loc for loc in model.loc_assets}
+    # dbkeys.loc has one valid 3-field row; all_fasta.loc is empty. Both resolve, neither errors.
+    assert by_table["__dbkeys__"].found is True
+    assert by_table["__dbkeys__"].is_sample is False
+    assert by_table["__dbkeys__"].errors == ()
+    assert by_table["all_fasta"].found is True
+    assert by_table["all_fasta"].errors == ()
+
+
+def test_consumer_references_scanned():
+    model = build_repository_data_tables(FETCH_REPO, consumer_tool_sources=_consumer_sources(FETCH_CONSUMER))
+    assert len(model.consumers) == 1
+    consumer = model.consumers[0]
+    assert isinstance(consumer, ConsumerRef)
+    assert consumer.table_name == "all_fasta"
+    assert consumer.kind == "from_data_table"
+    assert consumer.tool_id == "consume_all_fasta"
+    assert consumer.source.path == FETCH_CONSUMER
+
+
+def test_full_bundle_is_internally_consistent():
+    model = build_repository_data_tables(
+        FETCH_REPO,
+        data_manager_conf=FETCH_DM_CONF,
+        tool_data_table_confs=[FETCH_TABLE_TEST_CONF],
+        consumer_tool_sources=_consumer_sources(FETCH_CONSUMER),
+    )
+    assert isinstance(model, RepositoryDataTables)
+    configured = model.configured_table_names
+    # Every manager-produced and consumer-referenced table is locally configured in this repo.
+    for manager in model.managers:
+        for table_name in manager.processor.data_table_names:
+            assert table_name in configured
+    for consumer in model.consumers:
+        assert consumer.table_name in configured
+
+
+def test_nested_tool_element_form_resolves_outputs():
+    # The shed/guid <data_manager><tool file="..."/></data_manager> form must resolve
+    # the wrapper's outputs just like the tool_file attribute form.
+    model = build_repository_data_tables(FETCH_REPO, data_manager_conf=FETCH_DM_CONF_NESTED)
+    assert len(model.managers) == 1
+    manager = model.managers[0]
+    assert manager.tool_file == "data_manager/data_manager_fetch_genome_all_fasta_dbkeys.xml"
+    assert "out_file" in manager.tool_output_names
+
+
+def test_sample_conf_loc_reports_found_and_is_sample():
+    # A missing production loc that resolves via .sample fallback is found but sample-backed;
+    # step-2 checks must use `found and not is_sample`, not `found` alone.
+    conf = os.path.join(SAMPLE_FALLBACK_REPO, "tool_data_table_conf.xml.sample")
+    model = build_repository_data_tables(SAMPLE_FALLBACK_REPO, tool_data_table_confs=[conf])
+    foo = {loc.table_name: loc for loc in model.loc_assets}["foo"]
+    assert foo.found is True
+    assert foo.is_sample is True
+    assert foo.path.endswith("foo.loc.sample")
+
+
+def test_missing_loc_reports_not_found():
+    conf = os.path.join(MISSING_LOC_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(MISSING_LOC_REPO, tool_data_table_confs=[conf])
+    absent = {loc.table_name: loc for loc in model.loc_assets}["absent"]
+    assert absent.found is False
+    # No parse runs on an unfound file, so empty errors here is not "clean".
+    assert absent.errors == ()
+
+
+def test_broken_loc_rows_are_captured():
+    conf = os.path.join(BROKEN_REPO, "tool_data_table_conf.xml.test")
+    model = build_repository_data_tables(BROKEN_REPO, tool_data_table_confs=[conf])
+    broken = {loc.table_name: loc for loc in model.loc_assets}["broken"]
+    assert broken.found is True
+    # Short row (2 fields) and wrong-separator row (comma-joined) are both too short for index 2.
+    assert len(broken.errors) == 2
+    assert all("invalid" in message for message in broken.errors)

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -4,6 +4,7 @@ import tempfile
 
 import pytest
 
+import galaxy.tool_util.data.bundles.lint  # noqa: F401  (registers repository data-table linters)
 import galaxy.tool_util.linters
 from galaxy.tool_util.lint import (
     lint_tool_source_with,
@@ -2676,7 +2677,8 @@ def test_skip_by_module(lint_ctx):
 def test_list_linters():
     linter_names = Linter.list_listers()
     # make sure to add/remove a test for new/removed linters if this number changes
-    assert len(linter_names) == 148
+    # (155 = 148 tool linters + 7 repository data-table linters)
+    assert len(linter_names) == 155
     assert "Linter" not in linter_names
     # make sure that linters from all modules are available
     for prefix in [

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -2676,8 +2676,8 @@ def test_skip_by_module(lint_ctx):
 def test_list_linters():
     linter_names = Linter.list_listers()
     # make sure to add/remove a test for new/removed linters if this number changes
-    # (155 = 148 tool linters + 7 repository data-table linters registered via list_linters)
-    assert len(linter_names) == 155
+    # (156 = 148 tool linters + 8 repository data-table linters registered via list_linters)
+    assert len(linter_names) == 156
     assert "Linter" not in linter_names
     # make sure that linters from all modules are available
     for prefix in [

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -4,7 +4,6 @@ import tempfile
 
 import pytest
 
-import galaxy.tool_util.data.bundles.lint  # noqa: F401  (registers repository data-table linters)
 import galaxy.tool_util.linters
 from galaxy.tool_util.lint import (
     lint_tool_source_with,
@@ -2677,7 +2676,7 @@ def test_skip_by_module(lint_ctx):
 def test_list_linters():
     linter_names = Linter.list_listers()
     # make sure to add/remove a test for new/removed linters if this number changes
-    # (155 = 148 tool linters + 7 repository data-table linters)
+    # (155 = 148 tool linters + 7 repository data-table linters registered via list_linters)
     assert len(linter_names) == 155
     assert "Linter" not in linter_names
     # make sure that linters from all modules are available


### PR DESCRIPTION
Implements the repository-level lint block proposed in galaxyproject/planemo#1672:
validates a data-manager / reference-data repository as a *connected bundle*
(`data_manager_conf.xml` + `tool_data_table_conf.xml*` + `.loc`/`.loc.sample`
fixtures + consumer `from_data_table` references), rather than only the individual
tool wrappers.

Adds eight linters, a standalone `galaxy-tool-data-lint <repo>` CLI, and wiring
into Planemo `shed_lint`. The linters run cleanly across the entire tools-iuc tree
(780 repositories) and surfaced real bugs, each fixed in its own PR. This
consolidates several long-standing lint requests: galaxyproject/planemo#96,
galaxyproject/planemo#531, galaxyproject/planemo#706, galaxyproject/planemo#869.

## Architecture

Discovery and analysis are split from linting. `build_repository_data_tables(repo_root, ...)`
assembles a single `RepositoryDataTables` model — the realized bundle — from the
manager configs, table configs, loc assets, and expanded consumer tool sources; the
linters are then pure functions over that model and never touch the filesystem. This
keeps each check small and independently testable, and lets one traversal feed every
linter.

Key model facts the linters key on:

- **Loc resolution** is tri-state per referenced asset, not a boolean. `found` is what
  Galaxy's own loader resolves; `is_sample` marks a production loc satisfied only via
  the loader's `.sample` fallback; `sample_backed` recognizes the real Tool Shed layout
  (`tool-data/<name>.loc.sample`, materialized on install) that the loader's fallback
  misses. Only the combination distinguishes a genuinely missing fixture from a
  reference-data repo that is correctly shipped — without it every such repo would be
  falsely flagged.
- **Assembly is defensive.** A table declared with conflicting schemas would make the
  loader's merge raise, so assembly falls back to raw declarations and records the
  conflict as data rather than crashing; `ConflictingTableSchema` then reports it.
- **Evidence is graded.** Only literal, fully macro-expanded names are checked;
  unresolved dynamic/`@TOKEN@` references are treated as "not checked," never as
  demonstrably missing (the galaxyproject/tools-iuc#5003 false-positive guard).

Each linter is dispatched through `LintContext.lint(name, ...)`, so every check is
individually **skippable by name** the same way Planemo drives the tool linters.
Severity is deliberate: a broken producer/consumer *contract* provable from static
evidence is an **error**; a condition that a legitimately external supplier could
explain is a **warning** (see `ConsumerTableDefined`). The same model drives all three
entry points — `lint_repository_data_tables` (model in hand),
`lint_repository_data_tables_bundle` (caller did discovery), and
`find_and_lint_repository_data_tables` (one-call discover-and-lint, used by the CLI and
`shed_lint`).

## Linters

| Linter | Severity | Checks |
|--------|----------|--------|
| LocRowShape | error | loc rows use the configured separator and can fill every declared column |
| MissingLocFixture | error | a configured table's referenced loc resolves to a file or a shipped sample |
| ManagerTableConfigured | error | every data-manager table has a matching `tool_data_table_conf` entry |
| OutputRefValid | error | each `output_ref` names a real output of the expanded manager wrapper |
| DuplicateColumnNames | error | no table declares the same column name twice |
| ConflictingTableSchema | error | a table is declared with one consistent schema across the repo |
| ConsumerTableDefined | warning | a consumed `from_data_table` table is defined locally or supplied externally |
| EmptyLocFile | warning | a `.loc` / `.loc.sample` that is empty carries a format comment |

All eight pass across every tools-iuc repository that declares a data-table bundle;
the row, fixture, consumer, and empty-loc linters found real defects.

### LocRowShape and MissingLocFixture — proven against real repositories
`LocRowShape` flags space- instead of TAB-delimited rows and truncated rows that
cannot fill the declared columns: galaxyproject/tools-iuc#8234 (checkm2 data manager),
galaxyproject/tools-iuc#8235 (dram), galaxyproject/tools-iuc#8237 (tools/checkm2),
galaxyproject/tools-iuc#8239 (coverm), galaxyproject/tools-iuc#8240 (vsnp_genbank).
`MissingLocFixture` flags a configured table whose loc resolves to nothing and no
shipped `.sample` backs: galaxyproject/tools-iuc#8236 (hisat2 index builder — a stray
`bwa_mem_indexes` table). Loc resolution honours the shed layout
(`tool-data/<name>.loc.sample`, materialized on install) so real reference-data
repositories are not falsely flagged. Addresses galaxyproject/planemo#96.

### ManagerTableConfigured / OutputRefValid / DuplicateColumnNames / ConflictingTableSchema — structural
Guard rarer structural misconfigurations. All 285 bundle repositories in tools-iuc
pass them (verified by running the linters over the current tree); each is covered by
unit fixtures. `ManagerTableConfigured` addresses galaxyproject/planemo#706 and
galaxyproject/planemo#531; the remaining three are defensive checks with no live
tools-iuc incident, exercised only by fixtures.
Representative repositories they validate cleanly: `data_manager_fetch_genome_dbkeys_all_fasta`
(a multi-table producer of `all_fasta` + `__dbkeys__`), `data_manager_bwa_mem2_index_builder`,
and `data_manager_star_index_builder` (index builders whose `output_ref` columns and
configured tables all resolve).

### ConsumerTableDefined — undefined table references
A warning, never an error: a consumed table may legitimately be supplied by Galaxy
core or another installed repository, so an undefined reference is advisory. The
common core tables (`all_fasta`, `fasta_indexes`, `__dbkeys__`) are treated as
externally supplied by default (`DEFAULT_EXTERNAL_TABLE_NAMES`); callers extend the
set via `external_table_names`. Across tools-iuc it flagged one genuine
inconsistency, fixed in galaxyproject/tools-iuc#8255: `tools/artic` consumed `from_data_table="clair3_models"`
but declared that table locally as `model`, shipped `tool-data/models.loc.sample`
while the config pointed at `model.loc`, and wired `model` to
`test-data/clair3_models.loc`, so its cached-model selector had no local data.

### EmptyLocFile — undocumented empty fixtures (galaxyproject/planemo#869)
A warning: a `.loc` / `.loc.sample` that is empty *and* carries no `#` comment gives
no hint of its expected columns — the remedy is a one-line header, not data, so a
documented-but-dataless fixture passes. Unlike the configured-table linters this
reads a fresh repository-tree walk (`model.loc_files`) rather than the loader's
resolved `loc_assets`: an empty `.loc.sample` never resolves into an asset (the
loader's `.sample` fallback misses the shed `tool-data/` layout), so a walk is the
only way to reach them. Across tools-iuc this flagged 32 header-less files
(14 `.loc.sample`, 18 `test-data/*.loc`) out of 660; the corpus cleanup landed in
galaxyproject/tools-iuc#8256, and the 384 comment-only files already passed.

## Design decisions

- `ConsumerTableDefined` only walks `from_data_table` references in repositories
  that ship a bundle (a data-manager or tool-data-table config); pure-consumer tool
  repositories are deliberately left uninspected. A pure consumer's table is by
  definition supplied elsewhere, so flagging it as "not defined locally" would warn
  on nearly every tool repo in the shed — noise, not a defect — and loading every
  wrapper only earns its cost when there is a local bundle to validate against. This
  is a sensible boundary for the initial pass; it can be revisited once real usage
  shows whether cross-repo consumer validation (against a supplier index) is wanted.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

Unit coverage: `test/unit/tool_util/data/test_repository_data_table_lint.py`,
`test_repository_data_tables.py`, and `test_data_lint_cli.py`, driven by real fixture
repositories under `test/unit/tool_util/data/repositories/`. The linters were also run
over the full current tools-iuc tree (285 bundle repositories) with no crashes.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
