### PR TITLE
Sets realistic chunk size in tests

### DIFF
--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -212,7 +212,7 @@ def setup_galaxy_config(
         allow_user_deletion=True,
         api_allow_run_as="test@bx.psu.edu",
         auto_configure_logging=logging_config_file is None,
-        chunk_upload_size=100,
+        chunk_upload_size=1048576,
         conda_prefix=conda_prefix,
         conda_auto_init=conda_auto_init,
         conda_auto_install=conda_auto_install,


### PR DESCRIPTION
While working on #22787, I realized some tests were timing out in the upload phase, and noticed the uploads were generating thousands of small requests even for a few KB files. This should use a more realistic value for the TUS chunk size in the testing environment.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
