### PR TITLE
[26.1] Build packages without syncing the workspace virtualenv

### DIFF
--- a/packages/package.Makefile
+++ b/packages/package.Makefile
@@ -55,7 +55,7 @@ _dist:
 	uv build -o $(DIST)
 	ls -l $(DIST)
 
-dist: setup-venv clean _dist
+dist: clean _dist
 
 _setup-mypy-venv: setup-venv
 	uv pip install -r ../../lib/galaxy/dependencies/pinned-typecheck-requirements.txt
@@ -76,8 +76,8 @@ lint: _setup-lint-venv _lint
 _setup-dev-venv:
 	uv pip install -r dev-requirements.txt
 
-lint-dist: _setup-dev-venv
-	uv run twine check $(DIST)/*
+lint-dist:
+	uvx twine check $(DIST)/*
 
 # black doesn't actually work on symlinked files because they are outside
 # the current directory

--- a/packages/package.Makefile
+++ b/packages/package.Makefile
@@ -77,7 +77,7 @@ _setup-dev-venv:
 	uv pip install -r dev-requirements.txt
 
 lint-dist:
-	uvx twine check $(DIST)/*
+	uvx --with-requirements dev-requirements.txt --from twine twine check $(DIST)/*
 
 # black doesn't actually work on symlinked files because they are outside
 # the current directory

--- a/packages/web_client/Makefile
+++ b/packages/web_client/Makefile
@@ -84,7 +84,7 @@ _setup-dev-venv:
 	uv pip install -r dev-requirements.txt
 
 lint-dist:
-	uvx twine check $(DIST)/*
+	uvx --with-requirements dev-requirements.txt --from twine twine check $(DIST)/*
 
 commit-version:
 	$(IN_VENV) DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/commit_version.py $(VERSION)

--- a/packages/web_client/Makefile
+++ b/packages/web_client/Makefile
@@ -83,8 +83,8 @@ mypy: _setup-mypy-venv _mypy
 _setup-dev-venv:
 	uv pip install -r dev-requirements.txt
 
-lint-dist: _setup-dev-venv
-	uv run twine check $(DIST)/*
+lint-dist:
+	uvx twine check $(DIST)/*
 
 commit-version:
 	$(IN_VENV) DEV_RELEASE=$(DEV_RELEASE) python $(BUILD_SCRIPTS_DIR)/commit_version.py $(VERSION)


### PR DESCRIPTION
`make dist` ran `setup-venv` first, installing the entire packages workspace with all extras before calling `uv build`. That install is not needed: `uv build` runs in its own isolated PEP 517 environments.

It is also actively harmful. `uv sync` resolves universally across the whole `requires-python = ">=3.10"` range, so it has to pick a single numpy valid for both 3.10 and 3.14. numpy 2.3 dropped 3.10, which pins the choice to 2.2.x, and 2.2.x publishes no cp314 wheels on any platform. On a 3.14 interpreter the sync therefore falls back to building numpy from source, where the `editable_mode` config setting this workspace sets for mypy reaches meson-python, which rejects it.

packages/test.sh does not hit this because `uv pip install` resolves for the current interpreter alone and picks a numpy that has wheels for it.

Drop `setup-venv` from `dist`, matching what web_client already does, and run twine from a throwaway environment the way packages/test.sh does, so `lint-dist` stays independent of the workspace virtualenv too. That one matters on its own: numpy is a required dependency of galaxy-data, not just an extra, so `uv run` would hit the same wall.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
