### PR TITLE
Resolve tool lineages against the toolbox that owns the lineage map

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -348,7 +348,7 @@ class AbstractToolBox(ManagesIntegratedToolPanelMixin):
         self._tool_panel = ToolPanelElements()
         self._index = 0
         self.data_manager_tools: dict[str, Tool] = {}
-        self._lineage_map = LineageMap(app)
+        self._lineage_map = LineageMap(self)
         # Sets self._integrated_tool_panel and self._integrated_tool_panel_config_has_contents
         self._init_integrated_tool_panel(app.config)
         # The following refers to the tool_path config setting for backward compatibility.  The shed-related

--- a/lib/galaxy/tool_util/toolbox/lineages/factory.py
+++ b/lib/galaxy/tool_util/toolbox/lineages/factory.py
@@ -11,14 +11,15 @@ from .interface import ToolLineage
 
 if TYPE_CHECKING:
     from galaxy.tools import Tool
+    from ..base import AbstractToolBox
 
 
 class LineageMap:
     """Map each unique tool id to a lineage object."""
 
-    def __init__(self, app):
+    def __init__(self, toolbox: "AbstractToolBox"):
         self.lineage_map: dict[str, ToolLineage] = {}
-        self.app = app
+        self.toolbox = toolbox
 
     def register(self, tool: "Tool") -> ToolLineage:
         tool_id = tool.id
@@ -62,18 +63,12 @@ class LineageMap:
         if lineage:
             return lineage
         if tool_id not in self.lineage_map:
-            toolbox = None
-            try:
-                toolbox = self.app.toolbox
-            except AttributeError:
-                # We're building the lineage map while building the toolbox,
-                # so app.toolbox may not be available.
-                # TODO: is the fallback really needed / can it be fixed by improving _get_versionless ?
-                pass
-            tool = toolbox and toolbox._tools_by_id.get(tool_id)
-            if tool:
-                lineage = ToolLineage.from_tool(tool)
-                self.lineage_map[tool_id] = lineage
+            # Not every tool reaches the toolbox through `__add_tool`, which is
+            # what registers a lineage: built-in converters, hidden tools and
+            # single-tool reloads all go straight to `register_tool`. Derive the
+            # lineage for those on first lookup.
+            if tool := self.toolbox._tools_by_id.get(tool_id):
+                return self.register(tool)
         return self.lineage_map.get(tool_id)
 
     def _get_versionless(self, tool_id: str) -> ToolLineage | None:
@@ -94,8 +89,8 @@ class CachedLineageMap(LineageMap):
     on demand.
     """
 
-    def __init__(self, app, versions_for: Callable[[str], Iterable[str]] | None = None):
-        super().__init__(app)
+    def __init__(self, toolbox: "AbstractToolBox", versions_for: Callable[[str], Iterable[str]] | None = None):
+        super().__init__(toolbox)
         self._versions_for = versions_for
 
     def get(self, tool_id: str) -> ToolLineage | None:

--- a/lib/galaxy/tools/cached_toolbox.py
+++ b/lib/galaxy/tools/cached_toolbox.py
@@ -563,7 +563,7 @@ class CachedToolBox(ToolBox):
     def _init_tools_from_configs(self, config_filenames: list[str]) -> None:
         """Load or populate the index, then let the eager walk register stubs."""
         # Index-backed lineages reflect reloads and all known versions.
-        self._lineage_map = CachedLineageMap(self.app, versions_for=self._index_versions_for)
+        self._lineage_map = CachedLineageMap(self, versions_for=self._index_versions_for)
         self._tool_panel_loaded_from_index = False
         if self._store is not None:
             self._tool_index = self._store.load_index() or ToolIndex()

--- a/test/unit/app/tools/test_cached_tool.py
+++ b/test/unit/app/tools/test_cached_tool.py
@@ -578,7 +578,7 @@ def _registry_box():
     box._tools_by_uuid = {}
     box._tool_panel = ToolPanelElements()
     box._integrated_tool_panel = ToolPanelElements()
-    box._lineage_map = CachedLineageMap(box.app, versions_for=box._index_versions_for)
+    box._lineage_map = CachedLineageMap(box, versions_for=box._index_versions_for)
     box._tool_to_dict_cache = {}
     box._tool_to_dict_cache_admin = {}
     box._curated_tool_tags = None

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -229,6 +229,37 @@ class TestToolBox(BaseToolBoxTestCase):
         assert favorites_section["name"] == "Favorites"
         assert favorites_section["tools"] == []
 
+    def test_panel_view_referencing_tool_by_old_id_loads_while_toolbox_is_built(self):
+        # Panel views are rendered from within ToolBox.__init__, before any
+        # toolbox is registered on the app.
+        self._init_tool()
+        self._setup_two_versions_in_config()
+        self._setup_two_versions()
+        self.app.config.panel_views = [
+            {
+                "id": "old_id_view",
+                "name": "Old Id View",
+                "type": "generic",
+                "items": [{"type": "tool", "id": "test_tool"}],
+            }
+        ]
+
+        assert "old_id_view" in self.toolbox.panel_view_dicts()
+
+    def test_lineage_for_tool_registered_outside_of_panel_load(self):
+        # `register_tool` is how built-in converters and hidden tools enter the
+        # toolbox, and it registers no lineage. Resolving one must not depend on
+        # the toolbox already being the one registered on the app.
+        self._init_tool()
+        self._add_config("""<toolbox></toolbox>""")
+        toolbox = self.toolbox
+        hidden_tool = toolbox.load_hidden_tool(self._tool_path())
+        self.app._toolbox = None
+
+        lineage = toolbox._lineage_map.get("test_tool")
+        assert lineage is not None
+        assert hidden_tool.version in lineage.tool_versions
+
     def test_out_of_panel_filtering(self):
         self._init_tool_in_section()
 


### PR DESCRIPTION
`LineageMap.get()` derives a lineage from a registered `Tool` when a tool id has no
lineage yet. That fallback carries real weight: a lineage is only registered by
`AbstractToolBox.__add_tool`, while built-in converters, hidden lib tools, data
manager tools and single-tool reloads all enter the toolbox through
`register_tool()` alone.

It read `app.toolbox`, though, which is not the toolbox owning the lineage map at
the moment it is consulted:

- While a toolbox is being built `app._toolbox` is `None`, so panel views rendered
  from `ToolBox.__init__` resolved no lineage at all.
- `reload_toolbox()` registers converters, lib tools and data manager tools into
  the new toolbox before assigning `app._toolbox`, so lookups in that window
  resolved against the toolbox being replaced, and memoized that in the new map.

Since 454e85c9f52 the first case no longer fails quietly: the app initializes
`_toolbox` to `None` and the `toolbox` property asserts, so the `AttributeError`
guard from 44903311b59 no longer catches. A panel view listing a tool that
resolves through `_tools_by_old_id` (a shed tool referenced by its unqualified id)
takes startup down instead — with gunicorn `--preload` that happens in the arbiter,
so no workers come up at all:

```
  File "lib/galaxy/tools/__init__.py", line 696, in load_builtin_converters
    self._load_tool_panel_views()
  File "lib/galaxy/tool_util/toolbox/base.py", line 789, in _load_tool_panel_views
    self._tool_panel_view_rendered[key] = view.apply_view(self._integrated_tool_panel, registry)
  File "lib/galaxy/tool_util/toolbox/views/static.py", line 140, in definition_with_items_to_panel
    tool = toolbox_registry.get_tool(tool_id)
  File "lib/galaxy/tool_util/toolbox/base.py", line 949, in get_tool
    tool_lineage = self._lineage_map.get(tool_id)
  File "lib/galaxy/tool_util/toolbox/lineages/factory.py", line 67, in get
    toolbox = self.app.toolbox
  File "lib/galaxy/app/__init__.py", line 530, in toolbox
    assert self._toolbox is not None
AssertionError
```

Bind the lineage map to the toolbox that owns it, so both windows resolve against
the tools actually being loaded and the app is out of the picture — rather than
re-patching a guard whose exception type has now drifted twice. The derived
lineage also goes through `register()`, which shares it under the versionless id;
keyed only by `tool_id` it stays invisible to `_get_versionless` and sibling
versions stop collapsing in `ToolSection.copy(merge_tools=True)`.

Both new tests were confirmed to fail without the change — with the
`AssertionError` above, and with a `None` lineage respectively.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
