### PR TITLE
Add: history search fuzzy

### DIFF
--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -2,6 +2,7 @@ import { STATES } from "@/components/History/Content/model/states";
 import Filtering, {
     compare,
     contains,
+    containsTerms,
     equals,
     expandNameTag,
     quotaSourceFilter,
@@ -15,7 +16,7 @@ const excludeStates = ["empty", "failed", "upload", "placeholder", "failed_popul
 const states = Object.keys(STATES).filter((state) => !excludeStates.includes(state));
 
 const validFilters = {
-    name: { placeholder: "name", type: String, handler: contains("name"), menuItem: true },
+    name: { placeholder: "name", type: String, handler: containsTerms("name"), menuItem: true },
     name_eq: { handler: equals("name"), menuItem: false },
     extension: { placeholder: "extension", type: String, handler: equals("extension"), menuItem: true },
     history_content_type: {

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -235,6 +235,30 @@ describe("filtering", () => {
             expect(Object.fromEntries(HistoryFilters.getFiltersForText(filterText))).toEqual(parsedFilters);
         });
     });
+    test("name filter matches words in any separator", () => {
+        const item = { name: "UMI tools dedup", deleted: false, visible: true };
+        // Whichever separator the user types, the item still matches.
+        ["umi-tools", "umi tools", "umi_tools", "UMI-Tools", "umi.tools"].forEach((filterText) => {
+            const filters = HistoryFilters.getFiltersForText(filterText);
+            expect(HistoryFilters.testFilters(filters, { ...item })).toBe(true);
+        });
+        // Each word only has to appear somewhere, so a truncated word still hits.
+        expect(HistoryFilters.testFilters(HistoryFilters.getFiltersForText("um-tool"), { ...item })).toBe(true);
+        // Every word has to appear though, so the search still narrows.
+        expect(HistoryFilters.testFilters(HistoryFilters.getFiltersForText("umi bowtie"), { ...item })).toBe(false);
+        expect(HistoryFilters.testFilters(HistoryFilters.getFiltersForText("umi dedup"), { ...item })).toBe(true);
+        // A trailing separator is a normal state while typing, and behaves as if
+        // it were not there rather than falling back to a literal match.
+        expect(HistoryFilters.testFilters(HistoryFilters.getFiltersForText("umi-"), { ...item })).toBe(true);
+        // A query of nothing but separators matches literally, so it matches
+        // nothing here, rather than an empty term list matching every item.
+        expect(HistoryFilters.testFilters(HistoryFilters.getFiltersForText("___"), { ...item })).toBe(false);
+    });
+    test("name filter still sends the raw value to the backend", () => {
+        // The terms are split server-side too, so the query key is unchanged.
+        const queryDict = HistoryFilters.getQueryDict("umi-tools");
+        expect(queryDict["name-contains"]).toBe("umi-tools");
+    });
     test("named tag (hash) conversion", () => {
         const filters = HistoryFilters.getFiltersForText("tag:#test");
         expect(filters[0][0]).toBe("tag");

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -254,6 +254,25 @@ describe("filtering", () => {
         // nothing here, rather than an empty term list matching every item.
         expect(HistoryFilters.testFilters(HistoryFilters.getFiltersForText("___"), { ...item })).toBe(false);
     });
+    test("name filter tolerates separators typed either way", () => {
+        const item = { name: "UMI-tools deduplicate", deleted: false, visible: true };
+        // The name spells out a separator the query leaves out, and vice versa.
+        ["umitools", "umi-tools", "umi tools", "UMI_Tools"].forEach((filterText) => {
+            const filters = HistoryFilters.getFiltersForText(filterText);
+            expect(HistoryFilters.testFilters(filters, { ...item })).toBe(true);
+        });
+    });
+    test("name filter tolerates a misspelling", () => {
+        const item = { name: "UMI-tools deduplicate", deleted: false, visible: true };
+        // The server matches these with trigram similarity; the local re-filter
+        // has to accept them too or it would discard the rows it was sent.
+        ["umitoos", "umitols", "umi tols"].forEach((filterText) => {
+            const filters = HistoryFilters.getFiltersForText(filterText);
+            expect(HistoryFilters.testFilters(filters, { ...item })).toBe(true);
+        });
+        // Still narrows: an unrelated word of similar length does not match.
+        expect(HistoryFilters.testFilters(HistoryFilters.getFiltersForText("bowtie2"), { ...item })).toBe(false);
+    });
     test("name filter still sends the raw value to the backend", () => {
         // The terms are split server-side too, so the query key is unchanged.
         const queryDict = HistoryFilters.getQueryDict("umi-tools");

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -12,6 +12,8 @@
 import { isEqual, omit } from "lodash";
 import type { DefineComponent } from "vue";
 
+import levenshteinDistance from "@/utils/levenshtein";
+
 export type Converter<T> = (value: T) => T;
 type Handler<T> = (v: T, q: T) => boolean;
 
@@ -221,6 +223,10 @@ export function contains<T>(attribute: string, query?: string, converter?: Conve
  * `lib/galaxy/util/search.py`, which the backend applies to the same filter.
  */
 const NAME_TERM_SEPARATORS = /[\s\-_.,:;/\\|()[\]{}'"]+/;
+/** Same separators, for stripping every occurrence out of a value. */
+const NAME_TERM_SEPARATORS_GLOBAL = /[\s\-_.,:;/\\|()[\]{}'"]+/g;
+/** Below this length a typo is indistinguishable from a different word. */
+const MINIMUM_FUZZY_LENGTH = 5;
 /** Each term becomes its own comparison, so cap them as the backend does. */
 const MAX_NAME_TERMS = 8;
 
@@ -242,6 +248,33 @@ export function splitNameSearchTerms(value: string): string[] {
     return terms;
 }
 
+/** Shortest edit distance from `query` to any same-length run inside `value`.
+ *
+ * Compares against windows of the value rather than the whole thing, so a short
+ * query is not penalised for appearing in a long name.
+ */
+function isCloseMatch(query: string, value: string): boolean {
+    // Too short to tell a typo from a different word.
+    if (query.length < MINIMUM_FUZZY_LENGTH || value.length < query.length) {
+        return false;
+    }
+    const maxDistance = Math.floor(query.length / 4);
+    if (maxDistance < 1) {
+        return false;
+    }
+    for (let start = 0; start + query.length - maxDistance <= value.length; start++) {
+        for (const width of [query.length, query.length - maxDistance, query.length + maxDistance]) {
+            if (width <= 0 || start + width > value.length) {
+                continue;
+            }
+            if (levenshteinDistance(query, value.substr(start, width), true) <= maxDistance) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 /**
  * Checks if every word of the query appears in the item value, independently of
  * the separators used. Searching `umi-tools` finds `umi tools`, and a truncated
@@ -261,7 +294,21 @@ export function containsTerms<T>(attribute: string, query?: string): HandlerRetu
                 // rather than letting an empty term list match every item.
                 return value.includes(toLower(q));
             }
-            return terms.every((term) => value.includes(term));
+            if (terms.every((term) => value.includes(term))) {
+                return true;
+            }
+            // The name may spell out separators the query left out, so compare
+            // both sides with them stripped: "umitools" finds "UMI-tools".
+            const squashedValue = value.replace(NAME_TERM_SEPARATORS_GLOBAL, "");
+            const squashedQuery = terms.join("");
+            if (squashedValue.includes(squashedQuery)) {
+                return true;
+            }
+            // Finally tolerate misspellings, so "umitoos" still finds
+            // "UMI-tools". The server does this with trigram similarity where
+            // the database supports it; this keeps the local re-filter from
+            // discarding the rows it returned.
+            return isCloseMatch(squashedQuery, squashedValue);
         },
     };
 }

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -216,6 +216,56 @@ export function contains<T>(attribute: string, query?: string, converter?: Conve
     };
 }
 
+/** Characters that separate words in a name but that a user should not have to
+ * reproduce exactly to get a hit. Keep in sync with `NAME_TERM_SEPARATORS` in
+ * `lib/galaxy/util/search.py`, which the backend applies to the same filter.
+ */
+const NAME_TERM_SEPARATORS = /[\s\-_.,:;/\\|()[\]{}'"]+/;
+/** Each term becomes its own comparison, so cap them as the backend does. */
+const MAX_NAME_TERMS = 8;
+
+/** Splits a search value into lowercased, separator-insensitive terms.
+ * @param value the raw search value
+ * @returns the distinct terms to match independently
+ */
+export function splitNameSearchTerms(value: string): string[] {
+    const terms: string[] = [];
+    for (const part of toLower(value).split(NAME_TERM_SEPARATORS)) {
+        if (!part || terms.includes(part)) {
+            continue;
+        }
+        terms.push(part);
+        if (terms.length >= MAX_NAME_TERMS) {
+            break;
+        }
+    }
+    return terms;
+}
+
+/**
+ * Checks if every word of the query appears in the item value, independently of
+ * the separators used. Searching `umi-tools` finds `umi tools`, and a truncated
+ * word still matches because each term is itself a substring check.
+ * @param attribute of the content item
+ * @param query parameter if the attribute does not match the server query key
+ */
+export function containsTerms<T>(attribute: string, query?: string): HandlerReturn<T> {
+    return {
+        attribute,
+        query: query || `${attribute}-contains`,
+        handler: (v: T, q: T) => {
+            const value = toLower(v);
+            const terms = splitNameSearchTerms(String(q));
+            if (!terms.length) {
+                // Nothing but separators: match it literally, as the backend does,
+                // rather than letting an empty term list match every item.
+                return value.includes(toLower(q));
+            }
+            return terms.every((term) => value.includes(term));
+        },
+    };
+}
+
 /**
  * Checks if a value is greater or smaller than the item value
  * @param attribute of the content item

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -10,6 +10,7 @@ from typing import (
 )
 
 from sqlalchemy import (
+    and_,
     asc,
     cast,
     desc,
@@ -55,6 +56,7 @@ from galaxy.schema.tasks import (
 )
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.util import listify
+from galaxy.util.search import split_name_search_terms
 from .base import (
     parse_bool,
     raise_filter_err,
@@ -711,6 +713,25 @@ class HistoryContentsFilters(
                     return sql.column("object_store_id").in_(object_store_ids)
 
                 raise_filter_err(attr, op, val, "bad op in filter")
+
+        if attr == "name" and op == "contains":
+            # Match each word of the query independently instead of the value as
+            # a whole, so the separators a user types don't have to match the
+            # ones in the name (``umi-tools`` finds ``umi tools``). A truncated
+            # word still matches because each term is itself a substring match.
+            terms = split_name_search_terms(val)
+            # A value that splits into itself (no separators) is left to the base
+            # parser: the expression would be identical, and that keeps the common
+            # case on the well-trodden path. A value that splits into nothing
+            # (only separators) is left there too, so it keeps matching literally.
+            if terms and terms != [val.lower()]:
+                # Built as an ``orm_function`` rather than an ``orm`` filter
+                # because ``_apply_orm_filter`` only rewrites a lone
+                # BinaryExpression and would silently drop a conjunction.
+                def name_filter(component_class):
+                    return and_(*(func.lower(component_class.name).contains(term, autoescape=True) for term in terms))
+
+                return self.parsed_filter(filter_type="orm_function", filter=name_filter)
 
         if attr == "extension" and op in ("eq", "in"):
             # Apply different filter expressions to the HDA and HDCA branches

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -21,9 +21,11 @@ from sqlalchemy import (
     null,
     nullsfirst,
     nullslast,
+    or_,
     select,
     Select,
     sql,
+    text,
     true,
     UnaryExpression,
 )
@@ -64,6 +66,46 @@ from .base import (
 )
 
 log = logging.getLogger(__name__)
+
+# Separators a user may or may not type when searching for a name. Stripping
+# them from both sides is what lets "umitools" find a dataset called
+# "UMI-tools"; splitting the query on them covers the opposite direction.
+NAME_SEPARATORS_TO_SQUASH = (" ", "-", "_", ".")
+
+
+# Minimum trigram word-similarity for a name to count as a typo-tolerant match.
+# 0.3 is pg_trgm's own default threshold; misspellings of a real word land
+# comfortably above it while unrelated names do not.
+NAME_SIMILARITY_THRESHOLD = 0.3
+_trigram_support: dict[str, bool] = {}
+
+
+def _supports_trigram(session) -> bool:
+    """Whether this database can do trigram similarity matching.
+
+    Requires PostgreSQL with pg_trgm installed. Checked once per engine and
+    cached, since it cannot change while Galaxy is running. Everywhere else
+    (notably SQLite) the caller falls back to exact matching.
+    """
+    bind = session.get_bind()
+    key = str(bind.url)
+    if key not in _trigram_support:
+        supported = False
+        if bind.dialect.name == "postgresql":
+            try:
+                supported = bool(session.execute(text("SELECT 1 FROM pg_extension WHERE extname='pg_trgm'")).scalar())
+            except Exception:
+                log.warning("Could not determine pg_trgm availability; falling back to exact name matching")
+        _trigram_support[key] = supported
+    return _trigram_support[key]
+
+
+def _squash_separators(column):
+    """Lowercase a name column with the common word separators removed."""
+    expression = func.lower(column)
+    for separator in NAME_SEPARATORS_TO_SQUASH:
+        expression = func.replace(expression, separator, "")
+    return expression
 
 
 # into its own class to have it's own filters, etc.
@@ -715,22 +757,39 @@ class HistoryContentsFilters(
                 raise_filter_err(attr, op, val, "bad op in filter")
 
         if attr == "name" and op == "contains":
-            # Match each word of the query independently instead of the value as
-            # a whole, so the separators a user types don't have to match the
-            # ones in the name (``umi-tools`` finds ``umi tools``). A truncated
-            # word still matches because each term is itself a substring match.
+            # Separators should not have to line up between what the user types
+            # and what the dataset is called, in either direction:
+            #   "umi-tools" and "umi tools" have to find "UMI-tools", and
+            #   "umitools" has to find it too.
+            # The first is handled by matching each word of the query on its
+            # own, the second by comparing both sides with the separators
+            # stripped out. A truncated word such as "um-tool" still matches,
+            # because every term is itself a substring match.
             terms = split_name_search_terms(val)
-            # A value that splits into itself (no separators) is left to the base
-            # parser: the expression would be identical, and that keeps the common
-            # case on the well-trodden path. A value that splits into nothing
-            # (only separators) is left there too, so it keeps matching literally.
-            if terms and terms != [val.lower()]:
+            if terms:
+                squashed = "".join(terms)
+
+                use_trigram = _supports_trigram(self.app.model.session)
+
+                def name_filter(component_class):
+                    column = func.lower(component_class.name)
+                    all_words_present = and_(*(column.contains(term, autoescape=True) for term in terms))
+                    clauses = [
+                        all_words_present,
+                        _squash_separators(component_class.name).contains(squashed, autoescape=True),
+                    ]
+                    if use_trigram:
+                        # Tolerate misspellings: "umitoos" should still find
+                        # "UMI-tools". word_similarity compares the query
+                        # against the best matching run of words in the name,
+                        # rather than the name as a whole, so a short query
+                        # against a long name is not penalised.
+                        clauses.append(func.word_similarity(val.lower(), column) >= NAME_SIMILARITY_THRESHOLD)
+                    return or_(*clauses)
+
                 # Built as an ``orm_function`` rather than an ``orm`` filter
                 # because ``_apply_orm_filter`` only rewrites a lone
-                # BinaryExpression and would silently drop a conjunction.
-                def name_filter(component_class):
-                    return and_(*(func.lower(component_class.name).contains(term, autoescape=True) for term in terms))
-
+                # BinaryExpression and would silently drop anything else.
                 return self.parsed_filter(filter_type="orm_function", filter=name_filter)
 
         if attr == "extension" and op in ("eq", "in"):

--- a/lib/galaxy/util/search.py
+++ b/lib/galaxy/util/search.py
@@ -13,6 +13,32 @@ QUOTE_PATTERN = re.compile(r"\'(.*?)\'")
 DEFAULT_MIN_RAW_TERM_LENGTH = 4
 DEFAULT_MAX_RAW_TERMS = 7
 
+# Characters that separate words in a name but that a user should not have to
+# reproduce exactly to get a hit: searching for ``umi-tools`` is expected to
+# find a dataset named ``umi tools`` or ``umi_tools``, and vice versa.
+NAME_TERM_SEPARATORS = re.compile(r"[\s\-_.,:;/\\|()\[\]{}'\"]+")
+# Each term becomes its own LIKE clause, so cap them the way `filter_terms` does.
+DEFAULT_MAX_NAME_TERMS = 8
+
+
+def split_name_search_terms(value: str, max_terms: int = DEFAULT_MAX_NAME_TERMS) -> list[str]:
+    """Split a name search value into lowercased, separator-insensitive terms.
+
+    Matching every term independently rather than the value as a whole is what
+    makes the separators interchangeable, so ``umi-tools``, ``umi tools`` and
+    ``umi_tools`` all find each other. Duplicate terms are dropped since they
+    would only add a redundant clause, and the count is capped to bound the
+    cost of a pathological query.
+    """
+    terms: list[str] = []
+    for part in NAME_TERM_SEPARATORS.split(value.lower()):
+        if not part or part in terms:
+            continue
+        terms.append(part)
+        if len(terms) >= max_terms:
+            break
+    return terms
+
 
 def parse_filters(search_term: str, filters: dict[str, str] | None = None) -> ParseFilterResultT:
     """Support github-like filters for narrowing the results.
@@ -141,9 +167,11 @@ def filter_terms(
 
 
 __all__ = (
+    "DEFAULT_MAX_NAME_TERMS",
     "DEFAULT_MAX_RAW_TERMS",
     "DEFAULT_MIN_RAW_TERM_LENGTH",
     "filter_terms",
     "parse_filters",
     "parse_filters_structured",
+    "split_name_search_terms",
 )

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -974,6 +974,47 @@ class TestHistoryContentsApi(ApiTestCase):
         ).json()
         assert len(contents_response) == 0
 
+    def test_index_filter_by_name_matches_words_in_any_separator(self, history_id):
+        self.dataset_populator.new_dataset(history_id, name="umi tools dedup")
+        self.dataset_populator.new_dataset(history_id, name="UMI-tools count")
+        self.dataset_populator.new_dataset(history_id, name="bowtie2 mapping")
+
+        # Whichever separator the user types, both umi-tools datasets are found.
+        for contains_text in ("umi-tools", "umi tools", "umi_tools", "UMI-Tools"):
+            contents_response = self._get(
+                f"histories/{history_id}/contents?v=dev&q=name-contains&qv={urllib.parse.quote(contains_text)}"
+            ).json()
+            assert len(contents_response) == 2, contains_text
+
+        # Each word only has to appear somewhere, so a truncated word still hits.
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={urllib.parse.quote('um-tool')}"
+        ).json()
+        assert len(contents_response) == 2
+
+        # Every word has to appear though, so the search still narrows.
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={urllib.parse.quote('umi dedup')}"
+        ).json()
+        assert len(contents_response) == 1
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={urllib.parse.quote('umi bowtie2')}"
+        ).json()
+        assert len(contents_response) == 0
+
+        # A trailing separator is a normal state while typing, and behaves as if
+        # it were not there rather than falling back to a literal match.
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={urllib.parse.quote('umi-')}"
+        ).json()
+        assert len(contents_response) == 2
+
+        # A query of nothing but separators keeps matching literally.
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={urllib.parse.quote('___')}"
+        ).json()
+        assert len(contents_response) == 0
+
     @skip_without_tool("cat_data_and_sleep")
     def test_index_filter_by_related_items(self, history_id):
         # initialise history with 2 datasets

--- a/test/unit/util/test_search.py
+++ b/test/unit/util/test_search.py
@@ -4,6 +4,7 @@ from galaxy.util.search import (
     parse_filters,
     parse_filters_structured,
     RawTextTerm,
+    split_name_search_terms,
 )
 
 
@@ -149,3 +150,41 @@ def test_filter_terms_defaults():
     kept = [t.text for t in filtered.terms]
     # of, and, -, RDH, by dropped for length; everything else survives.
     assert kept == ["Copy", "Genomic", "Assembly", "analysis", "shared", "user", "nedflanders"]
+
+
+def test_split_name_search_terms_separators_are_interchangeable():
+    # However the user spells the separator, the terms come out the same, which
+    # is what lets 'umi-tools' find a dataset named 'umi tools'.
+    expected = ["umi", "tools"]
+    assert split_name_search_terms("umi-tools") == expected
+    assert split_name_search_terms("umi tools") == expected
+    assert split_name_search_terms("umi_tools") == expected
+    assert split_name_search_terms("umi.tools") == expected
+    assert split_name_search_terms("umi/tools") == expected
+    assert split_name_search_terms("(umi) [tools]") == expected
+
+
+def test_split_name_search_terms_lowercases():
+    assert split_name_search_terms("UMI-Tools") == ["umi", "tools"]
+
+
+def test_split_name_search_terms_single_term():
+    # A query without separators stays a single term, so the caller can keep
+    # using the plain substring filter.
+    assert split_name_search_terms("umitools") == ["umitools"]
+
+
+def test_split_name_search_terms_drops_empty_and_duplicate_terms():
+    assert split_name_search_terms("  umi --  tools  ") == ["umi", "tools"]
+    # A repeated word would only add a redundant clause.
+    assert split_name_search_terms("umi tools umi") == ["umi", "tools"]
+
+
+def test_split_name_search_terms_caps_term_count():
+    assert split_name_search_terms("a b c d e f g h i j") == ["a", "b", "c", "d", "e", "f", "g", "h"]
+    assert split_name_search_terms("a b c d", max_terms=2) == ["a", "b"]
+
+
+def test_split_name_search_terms_empty():
+    assert split_name_search_terms("") == []
+    assert split_name_search_terms("---") == []


### PR DESCRIPTION
# Tolerate separators and misspellings when searching history contents

> **Proposal, open for discussion.** 

Searching a history for a dataset only matches when the query is spelled exactly as the dataset is. `umi-tool`, `umitools` and any typo all return nothing against a dataset named `UMI-tools deduplicate`, which is a common way to lose track of an item in a large history.

Matching now happens in three layers, each a fallback for the one before:

1. every word of the query must appear, so the separators typed need not match those in the name (`umi tools` finds `UMI-tools`; a truncated `um-tool` still matches)
2. both sides compared with separators stripped, covering the reverse case where the query omits a separator the name spells out (`umitools`)
3. trigram word similarity, so an actual misspelling still finds it (`umitoos`)

`word_similarity` compares the query against the best-matching run of words rather than the whole name, so a short query is not penalised by a long dataset name.

Only layer 3 is database-specific: it requires PostgreSQL with `pg_trgm`, is detected once per engine and cached, and everywhere else — notably SQLite, the default for a fresh install — the first two layers still apply. It wants a trigram index on the name column before being used anywhere the candidate set is not already narrowed to a single history.

The client-side matcher needed the same tolerance: the history panel re-filters loaded rows in the browser, so a strict local matcher discarded exactly the rows the server had just matched fuzzily. It falls back to Damerau-Levenshtein via the existing `levenshtein` util, the technique the tool panel already uses.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. In a history containing a dataset named `UMI-tools deduplicate`, search the history panel for `umi-tools`, `umitools`, `UMI_Tools` and `um-tool` — all should find it.
  2. On PostgreSQL with `pg_trgm` installed, search `umitoos` — it should still find it. On SQLite it should not, which is expected.

---

> **AI-generated contribution.** These changes were written by [Claude Code](https://claude.com/claude-code) using Opus 5, reviewed and tested by the submitter against a copy of a production Galaxy database. Please review accordingly.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
