### PR TITLE
Drop the tool materialization from JobManager.enqueue

### DIFF
--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -73,7 +73,6 @@ class JobManager:
         tool_id = None
         configured_handler = None
         if tool:
-            tool = self.app.toolbox.materialize_tool(tool, reason="job_setup")
             tool_id = tool.id
             configured_handler = tool.get_configured_job_handler()
             if configured_handler is not None:


### PR DESCRIPTION
enqueue() reads only tool.id and tool.get_configured_job_handler(), and every caller already hands it a fully parsed Tool, exactly as the Tool | None annotation says. So the materialize_tool() call added in c1c09bcc84e is a no-op: CachedToolBox.materialize_tool returns a plain cast for anything that is not a CachedTool.

It is not free, though. It reaches app.toolbox, and that property asserts _toolbox is not None. Only UniverseApplication calls _configure_toolbox(); the GalaxyManagerApplication that galaxy.celery.build_app() constructs for a worker never does. The async tool request path runs entirely inside that app:

  queue_jobs (celery/tasks.py)
    -> JobSubmitter.queue_jobs
    -> Tool.handle_input_async
    -> execute_async -> _execute
    -> tool.app.job_manager.enqueue(job2, tool=tool, flush=False)

so in a real worker process enqueue() raises AssertionError before the job is ever handed to a handler.

Tests never see this because they run celery in-process: get_galaxy_app() finds galaxy.app.app, the embedded UniverseApplication that buildapp sets, and that one does have a toolbox. Only a worker subprocess falls through to build_app().

Nothing is lost by removing the call. CachedTool is __slots__-based with no __getattr__ and no get_configured_job_handler, so a stub that did reach enqueue() would still fail loudly rather than silently misroute the job.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
