### PR TITLE
[26.1] Drop unused _setup-dev-venv rule from package Makefiles

### DIFF
--- a/packages/package.Makefile
+++ b/packages/package.Makefile
@@ -73,9 +73,6 @@ _lint:
 
 lint: _setup-lint-venv _lint
 
-_setup-dev-venv:
-	uv pip install -r dev-requirements.txt
-
 lint-dist:
 	uvx --with-requirements dev-requirements.txt --from twine twine check $(DIST)/*
 

--- a/packages/web_client/Makefile
+++ b/packages/web_client/Makefile
@@ -80,9 +80,6 @@ _mypy:
 
 mypy: _setup-mypy-venv _mypy
 
-_setup-dev-venv:
-	uv pip install -r dev-requirements.txt
-
 lint-dist:
 	uvx --with-requirements dev-requirements.txt --from twine twine check $(DIST)/*
 


### PR DESCRIPTION
Follow-up to https://github.com/galaxyproject/galaxy/pull/23231#discussion_r3692172361.

Since #23231 changed `lint-dist` to run twine via `uvx --with-requirements dev-requirements.txt`, the `_setup-dev-venv` rule in `packages/package.Makefile` and `packages/web_client/Makefile` has no remaining consumers. Removing it as @nsoranzo suggested.

`make -C packages/util -n lint-dist` and `make -C packages/web_client -n lint-dist` both still resolve to the `uvx` invocation.