### PR TITLE
Use Galaxy User-Agent for more requests calls

### DIFF
--- a/lib/galaxy/files/sources/github_fsspec.py
+++ b/lib/galaxy/files/sources/github_fsspec.py
@@ -13,9 +13,8 @@ access to the repository.
 import base64
 import logging
 
-import requests
-
 from galaxy.exceptions import MessageException
+from galaxy.util import requests
 
 try:
     from fsspec.implementations.github import GithubFileSystem

--- a/lib/galaxy/files/sources/onedrive.py
+++ b/lib/galaxy/files/sources/onedrive.py
@@ -6,7 +6,6 @@ from typing import (
 )
 from urllib.parse import quote
 
-import requests
 from pydantic import (
     AliasChoices,
     Field,
@@ -27,6 +26,7 @@ from galaxy.files.models import (
     RemoteDirectory,
     RemoteFile,
 )
+from galaxy.util import requests
 from galaxy.util.config_templates import TemplateExpansion
 from . import BaseFilesSource
 
@@ -102,7 +102,7 @@ class OneDriveFilesSource(BaseFilesSource[OneDriveFileSourceTemplateConfiguratio
     ) -> requests.Response:
         try:
             response = requests.request(method, url, headers=self._headers(context.config), timeout=timeout, **kwargs)
-        except requests.RequestException as exc:
+        except requests.exceptions.RequestException as exc:
             raise MessageException(f"Error connecting to OneDrive. Reason: {exc}") from exc
 
         if response.status_code in {401, 403}:

--- a/lib/galaxy/files/sources/remotezip.py
+++ b/lib/galaxy/files/sources/remotezip.py
@@ -11,14 +11,13 @@ from urllib.parse import (
     urlparse,
 )
 
-import requests
-
 from galaxy.files.models import (
     BaseFileSourceConfiguration,
     BaseFileSourceTemplateConfiguration,
     FilesSourceRuntimeContext,
 )
 from galaxy.files.uris import validate_uri_access
+from galaxy.util import requests
 from . import (
     DefaultBaseFilesSource,
     PluginKind,

--- a/lib/galaxy/tool_util/client/landing.py
+++ b/lib/galaxy/tool_util/client/landing.py
@@ -8,9 +8,9 @@ import string
 import sys
 from dataclasses import dataclass
 
-import requests
 import yaml
 
+from galaxy.util import requests
 from galaxy.util.resources import resource_string
 
 DESCRIPTION = """

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -20,7 +20,6 @@ from typing import (
 )
 from urllib.parse import urlencode
 
-import requests
 import yaml
 from boltons.iterutils import remap
 from pydantic import (
@@ -54,7 +53,10 @@ from galaxy.exceptions import (
     RequestParameterMissingException,
 )
 from galaxy.tool_util_models.parameter_validators import AnySafeValidatorModel
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    requests,
+)
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/util/requests.py
+++ b/lib/galaxy/util/requests.py
@@ -51,4 +51,5 @@ patch = _request_decorator(requests.patch)
 post = _request_decorator(requests.post)
 options = _request_decorator(requests.options)
 put = _request_decorator(requests.put)
+request = _request_decorator(requests.request)
 session = Session

--- a/test/unit/util/test_requests.py
+++ b/test/unit/util/test_requests.py
@@ -26,6 +26,15 @@ def test_user_agent_and_caller_headers_are_set(method: str):
     assert req_headers["X-Custom"] == "value"
 
 
+@responses.activate
+def test_request_injects_user_agent_and_preserves_caller_headers():
+    responses.add(responses.GET, "https://example.com/", status=200)
+    galaxy_requests.request("GET", "https://example.com/", headers={"X-Custom": "value"})
+    req_headers = responses.calls[0].request.headers
+    assert req_headers["user-agent"] == EXPECTED_USER_AGENT
+    assert req_headers["X-Custom"] == "value"
+
+
 # --- Session factory ---
 
 


### PR DESCRIPTION
Closes https://github.com/galaxyproject/galaxy/issues/17518

This updates production call sites that still imported `requests` directly to use Galaxy's `galaxy.util.requests` wrapper, so outbound requests include Galaxy's configured User-Agent header.

It also exposes the generic `request()` entry point from the wrapper because the OneDrive file source sends dynamic HTTP methods through that API.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

Tested locally with:

```console
$ uv run --no-project --with ruff==0.16.1 ruff check lib/galaxy/files/sources/github_fsspec.py lib/galaxy/files/sources/onedrive.py lib/galaxy/files/sources/remotezip.py lib/galaxy/tool_util/client/landing.py lib/galaxy/util/config_templates.py lib/galaxy/util/requests.py test/unit/util/test_requests.py
All checks passed!

$ PYTHONPATH=lib uv run --no-project --with pytest --with requests --with responses --with typing-extensions --with boltons python -m pytest test/unit/util/test_requests.py -q
18 passed, 1 warning

$ PYTHONPATH=lib uv run --no-project --with requests --with typing-extensions --with boltons python -m py_compile lib/galaxy/files/sources/github_fsspec.py lib/galaxy/files/sources/onedrive.py lib/galaxy/files/sources/remotezip.py lib/galaxy/tool_util/client/landing.py lib/galaxy/util/config_templates.py lib/galaxy/util/requests.py test/unit/util/test_requests.py
```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
