### PR TITLE
Populate AnnData spec version metadata

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1910,10 +1910,24 @@ class Anndata(H5):
     def set_meta(self, dataset: DatasetProtocol, overwrite: bool = True, **kwd) -> None:
         super().set_meta(dataset, overwrite=overwrite, **kwd)
         with h5py.File(dataset.get_file_name(), "r", locking=False) as anndata_file:
+            root_encoding_type = anndata_file.attrs.get("encoding-type")
+            if isinstance(root_encoding_type, np.ndarray):
+                root_encoding_type = root_encoding_type[0] if root_encoding_type.size else None
+            if isinstance(root_encoding_type, bytes):
+                root_encoding_type = root_encoding_type.decode()
+            root_encoding_version = anndata_file.attrs.get("encoding-version")
+            if isinstance(root_encoding_version, np.ndarray):
+                root_encoding_version = root_encoding_version[0] if root_encoding_version.size else None
+            if isinstance(root_encoding_version, bytes):
+                root_encoding_version = root_encoding_version.decode()
+
             dataset.metadata.title = anndata_file.attrs.get("title")
             dataset.metadata.description = anndata_file.attrs.get("description")
             dataset.metadata.url = anndata_file.attrs.get("url")
             dataset.metadata.doi = anndata_file.attrs.get("doi")
+            dataset.metadata.anndata_spec_version = (
+                root_encoding_version if root_encoding_type == "anndata" and root_encoding_version else ""
+            )
             dataset.metadata.creation_date = anndata_file.attrs.get("creation_date")
             dataset.metadata.shape = anndata_file.attrs.get("shape", dataset.metadata.shape)
             # none of the above appear to work in any dataset tested, but could be useful for

--- a/test/unit/data/datatypes/test_anndata.py
+++ b/test/unit/data/datatypes/test_anndata.py
@@ -1,0 +1,23 @@
+import pytest
+
+from galaxy.datatypes.binary import Anndata
+from .util import get_dataset
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_version"),
+    [
+        ("adata_0_6_small.h5ad", ""),
+        ("adata_0_7_4_small.h5ad", ""),
+        ("adata_noX.h5ad", "0.1.0"),
+        ("adata_unk.h5ad", ""),
+        ("adata_unk2.h5ad", ""),
+        ("pbmc3k_tiny.h5ad", ""),
+    ],
+)
+def test_set_meta_sets_anndata_spec_version(filename, expected_version):
+    with get_dataset(filename) as dataset:
+        dataset.metadata.shape = (-1, -1)
+        dataset.metadata.obs_names = []
+        Anndata().set_meta(dataset=dataset)
+        assert dataset.metadata.anndata_spec_version == expected_version


### PR DESCRIPTION
Refs https://github.com/galaxyproject/galaxy/issues/17934

This populates the existing `anndata_spec_version` metadata field from root-level AnnData HDF5 encoding attributes when the file explicitly identifies itself as AnnData.

The implementation intentionally does not infer this value from child element `encoding-version` attributes such as `X`, `obs`, or `var`, because those describe the serialization encoding of individual elements rather than the AnnData file-level spec version. Existing fixtures cover both cases: only `adata_noX.h5ad` has the root `encoding-type="anndata"` / `encoding-version` pair, while older and ambiguous fixtures expose only child element versions or no root AnnData marker.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

Tested locally with:

```console
$ uv run --no-project --with ruff==0.16.1 ruff check lib/galaxy/datatypes/binary.py test/unit/data/datatypes/test_anndata.py
All checks passed!

$ PYTHONPATH=lib uv run --no-project --with h5py --with numpy --with typing-extensions --with boltons python -m py_compile lib/galaxy/datatypes/binary.py test/unit/data/datatypes/test_anndata.py

$ git diff --check

$ uv run --no-project --with h5py --with numpy python - <fixture metadata check>
adata_0_6_small.h5ad: ''
adata_0_7_4_small.h5ad: ''
adata_noX.h5ad: '0.1.0'
adata_unk.h5ad: ''
adata_unk2.h5ad: ''
pbmc3k_tiny.h5ad: ''
fixture metadata checks passed
```

I also attempted to run the new pytest directly on Windows, but local dependency installation is blocked while building `pysam==0.24.0`:

```console
$ PYTHONPATH=lib uv run --no-project --with h5py --with numpy --with pytest --with typing-extensions --with boltons --with defusedxml --with six --with packaging --with pyyaml --with requests --with python-dateutil --with pillow --with lxml --with pysam python -m pytest test/unit/data/datatypes/test_anndata.py -q
Building pysam==0.24.0
Failed to build `pysam==0.24.0`
'.' is not recognized as an internal or external command
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

## Datatype notes
- `set_meta` opens the HDF5 file metadata only; it does not read dataset contents into memory.
- No `sniff` behavior changes are included.
- The metadata is intended for downstream single-cell tools that need to branch on known AnnData encoding compatibility.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
