### PR TITLE
Perf/metadata registration

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1213,6 +1213,31 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``max_optional_metadata_filesize``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Maximum size, in bytes, of a dataset for which optional metadata
+    is computed. Setting optional metadata means reading the dataset
+    from end to end: for FASTQ and FASTA this is what produces the
+    sequence and line counts shown in the history. On installations
+    where datasets are large or live on shared storage, that read is
+    often the slowest part of finishing a job, and it happens once per
+    output dataset.
+    Datasets larger than this are given the non-optional metadata
+    only, and their history entry shows the file size instead of a
+    sequence count. Nothing else about the dataset changes and tools
+    are unaffected.
+    Set to 0 to never read datasets for optional metadata. The default
+    of -1 means no limit, which is the historical behaviour.
+    This can be configured/overridden on a per-datatype basis in the
+    datatypes_conf.xml file, where a max_optional_metadata_filesize
+    attribute on a datatype takes precedence over this value.
+:Default: ``-1``
+:Type: int
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``datatypes_disable_auto``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -195,6 +195,26 @@
 :Type: float
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``slow_job_finish_log_threshold``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Slow job finalization logging. Finalizing a job (moving outputs
+    into place, discovering them, setting metadata and sizing them)
+    happens after the tool itself has finished, so a quick tool can
+    still take a long time to appear as ready. Jobs whose finalization
+    takes longer than this threshold, in seconds, have a breakdown of
+    the time spent in each phase logged as a warning. A value of '0'
+    is disabled. The breakdown is always available at debug level;
+    this threshold exists so it can be collected on a production
+    instance without turning on debug logging. For example, set this
+    to 10 to report every job that takes more than ten seconds to
+    finalize.
+:Default: ``0.0``
+:Type: float
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``enable_per_request_sql_debugging``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -94,6 +94,7 @@ class GalaxyAppConfigurationAttributes:
     len_file_path: str
     datatypes_config_file: str
     sniff_compressed_dynamic_datatypes_default: bool
+    max_optional_metadata_filesize: int
     datatypes_disable_auto: bool
     visualization_plugins_directory: str
     tour_config_dir: str

--- a/lib/galaxy/config/_galaxy_config_schema_attributes.py
+++ b/lib/galaxy/config/_galaxy_config_schema_attributes.py
@@ -21,6 +21,7 @@ class GalaxyAppConfigurationAttributes:
     database_template: str | None
     database_log_query_counts: bool
     slow_query_log_threshold: float
+    slow_job_finish_log_threshold: float
     enable_per_request_sql_debugging: bool
     install_database_connection: str | None
     database_auto_migrate: bool

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -977,6 +977,24 @@ galaxy:
   # compressed datatypes will be unpacked before sniffing.
   #sniff_compressed_dynamic_datatypes_default: true
 
+  # Maximum size, in bytes, of a dataset for which optional metadata is
+  # computed. Setting optional metadata means reading the dataset from
+  # end to end: for FASTQ and FASTA this is what produces the sequence
+  # and line counts shown in the history. On installations where
+  # datasets are large or live on shared storage, that read is often the
+  # slowest part of finishing a job, and it happens once per output
+  # dataset.
+  # Datasets larger than this are given the non-optional metadata only,
+  # and their history entry shows the file size instead of a sequence
+  # count. Nothing else about the dataset changes and tools are
+  # unaffected.
+  # Set to 0 to never read datasets for optional metadata. The default
+  # of -1 means no limit, which is the historical behaviour.
+  # This can be configured/overridden on a per-datatype basis in the
+  # datatypes_conf.xml file, where a max_optional_metadata_filesize
+  # attribute on a datatype takes precedence over this value.
+  #max_optional_metadata_filesize: -1
+
   # Disable the 'Auto-detect' option for file uploads
   #datatypes_disable_auto: false
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -477,6 +477,18 @@ galaxy:
   # than 5 milliseconds.
   #slow_query_log_threshold: 0.0
 
+  # Slow job finalization logging. Finalizing a job (moving outputs into
+  # place, discovering them, setting metadata and sizing them) happens
+  # after the tool itself has finished, so a quick tool can still take a
+  # long time to appear as ready. Jobs whose finalization takes longer
+  # than this threshold, in seconds, have a breakdown of the time spent
+  # in each phase logged as a warning. A value of '0' is disabled. The
+  # breakdown is always available at debug level; this threshold exists
+  # so it can be collected on a production instance without turning on
+  # debug logging. For example, set this to 10 to report every job that
+  # takes more than ten seconds to finalize.
+  #slow_job_finish_log_threshold: 0.0
+
   # Enables a per request sql debugging option. If this is set to true,
   # append ?sql_debug=1 to web request URLs to enable detailed logging
   # on the backend of SQL queries generated during that request. This is

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -887,6 +887,29 @@ mapping:
           With this option set to false the compressed datatypes will be unpacked
           before sniffing.
 
+      max_optional_metadata_filesize:
+        type: int
+        default: -1
+        required: false
+        desc: |
+          Maximum size, in bytes, of a dataset for which optional metadata is
+          computed. Setting optional metadata means reading the dataset from end
+          to end: for FASTQ and FASTA this is what produces the sequence and line
+          counts shown in the history. On installations where datasets are large
+          or live on shared storage, that read is often the slowest part of
+          finishing a job, and it happens once per output dataset.
+
+          Datasets larger than this are given the non-optional metadata only, and
+          their history entry shows the file size instead of a sequence count.
+          Nothing else about the dataset changes and tools are unaffected.
+
+          Set to 0 to never read datasets for optional metadata. The default of
+          -1 means no limit, which is the historical behaviour.
+
+          This can be configured/overridden on a per-datatype basis in the
+          datatypes_conf.xml file, where a max_optional_metadata_filesize
+          attribute on a datatype takes precedence over this value.
+
       datatypes_disable_auto:
         type: bool
         default: false

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -161,6 +161,21 @@ mapping:
           be logged to debug.  A value of '0' is disabled.  For example, you would set
           this to .005 to log all queries taking longer than 5 milliseconds.
 
+      slow_job_finish_log_threshold:
+        type: float
+        default: 0.0
+        required: false
+        desc: |
+          Slow job finalization logging. Finalizing a job (moving outputs into place,
+          discovering them, setting metadata and sizing them) happens after the tool
+          itself has finished, so a quick tool can still take a long time to appear
+          as ready. Jobs whose finalization takes longer than this threshold, in
+          seconds, have a breakdown of the time spent in each phase logged as a
+          warning. A value of '0' is disabled. The breakdown is always available at
+          debug level; this threshold exists so it can be collected on a production
+          instance without turning on debug logging. For example, set this to 10 to
+          report every job that takes more than ten seconds to finalize.
+
       enable_per_request_sql_debugging:
         type: bool
         default: false

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -32,18 +32,10 @@ from bx.seq.twobit import (
     TWOBIT_MAGIC_NUMBER,
     TWOBIT_MAGIC_NUMBER_SWAP,
 )
-from h5grove.content import (
-    DatasetContent,
-    get_content_from_file,
-    GroupContent,
-    ResolvedEntityContent,
-)
-from h5grove.encoders import encode
-from h5grove.utils import (
-    convert,
-    parse_slice,
-    QueryArgumentError,
-)
+# h5grove is imported inside the four functions that use it. It is only needed
+# to serve the h5web visualization protocol, but this module is loaded by
+# galaxy.datatypes.registry, which every upload job and every set_metadata
+# process imports. Deferring it avoids ~270 modules per job.
 
 from galaxy import util
 from galaxy.datatypes import metadata
@@ -1298,6 +1290,8 @@ def _h5_normalize_selection(shape: tuple[int, ...], selection: str | None) -> tu
     if selection is None:
         return [slice(*slice(None).indices(dim)) for dim in shape], tuple(shape)
 
+    from h5grove.utils import parse_slice
+
     try:
         members = parse_slice(selection)
     except (ValueError, TypeError) as e:
@@ -1429,6 +1423,8 @@ def _h5_stream_data(
     npy_shape: tuple[int, ...],
     flatten: bool,
 ) -> Iterator[bytes]:
+    from h5grove.utils import convert
+
     # This generator owns its own file handle: the caller's get_content_from_file
     # context closes before the streaming response body is iterated.
     with h5py.File(file_name, "r", locking=False) as f:
@@ -1455,6 +1451,11 @@ def _h5_prepare_streaming_data(
     flatten: bool,
     selection: str | None,
 ) -> tuple[Iterator[bytes], dict[str, str]]:
+    from h5grove.utils import (
+        convert,
+        QueryArgumentError,
+    )
+
     read_slices, result_shape = _h5_normalize_selection(ds.shape, selection)
     try:
         out_dtype = convert(np.empty((0,), ds.dtype), dtype).dtype
@@ -1614,6 +1615,14 @@ class H5(Binary):
         This allows the h5web visualization tool (https://github.com/silx-kit/h5web)
         to be used directly with Galaxy datasets.
         """
+        from h5grove.content import (
+            DatasetContent,
+            get_content_from_file,
+            GroupContent,
+            ResolvedEntityContent,
+        )
+        from h5grove.encoders import encode
+
         flatten = str(flatten).lower() != "false"
         file_name = dataset.get_file_name()
         with get_content_from_file(file_name, path, self._create_error, h5py_options={"locking": False}) as content:

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -12,13 +12,10 @@ from collections.abc import Iterator
 from typing import (
     Any,
     Literal,
+    TYPE_CHECKING,
 )
 
-import mrcfile
 import numpy as np
-import png
-import pydicom
-import tifffile
 
 try:
     import PIL
@@ -44,6 +41,16 @@ from galaxy.util import nice_size
 from galaxy.util.image_util import check_image_type
 from . import data
 from .xml import GenericXml
+
+if TYPE_CHECKING:
+    import tifffile
+
+# mrcfile, png, pydicom and tifffile are imported inside the methods that use
+# them. They are only needed to handle those specific image formats, but this
+# module is reached from galaxy.datatypes.registry, which every upload job and
+# every set_metadata process loads. pydicom alone costs about 0.8s and 500
+# modules, paid twice per job on installations where Galaxy lives on shared
+# storage.
 
 log = logging.getLogger(__name__)
 
@@ -215,6 +222,8 @@ class Png(Image):
 
         # Read the image data row by row, to avoid allocating memory for the entire image
         if dataset.metadata.dtype == "uint8" and dataset.metadata.frames in (0, 1):
+            import png
+
             reader = png.Reader(filename=dataset.get_file_name())
             width, height, pixels, metadata = reader.asDirect()
 
@@ -268,6 +277,8 @@ class Tiff(Image):
         """
         Populate the metadata of the TIFF image using the tifffile library.
         """
+        import tifffile
+
         spec_key = "offsets"
         if hasattr(dataset.metadata, spec_key):
             offsets_file = dataset.metadata.offsets
@@ -348,7 +359,7 @@ class Tiff(Image):
         return shape[idx] if idx >= 0 else 0
 
     @staticmethod
-    def _get_num_unique_values(series: tifffile.TiffPageSeries) -> int | None:
+    def _get_num_unique_values(series: "tifffile.TiffPageSeries") -> int | None:
         """
         Determines the number of unique values in a TIFF series of pages.
         """
@@ -367,7 +378,7 @@ class Tiff(Image):
 
     @staticmethod
     def _read_chunks(
-        page: tifffile.TiffPage | tifffile.TiffFrame, mmap_chunk_size: int = 2**14
+        page: "tifffile.TiffPage | tifffile.TiffFrame", mmap_chunk_size: int = 2**14
     ) -> Iterator["np.typing.NDArray"]:
         """
         Generator that reads all chunks of values from a TIFF page.
@@ -388,7 +399,7 @@ class Tiff(Image):
                 yield from np.array_split(arr_flat, chunks_count)
 
     @staticmethod
-    def _read_segments(page: tifffile.TiffPage | tifffile.TiffFrame) -> Iterator["np.typing.NDArray"]:
+    def _read_segments(page: "tifffile.TiffPage | tifffile.TiffFrame") -> Iterator["np.typing.NDArray"]:
         """
         Generator that reads all segments of a TIFF page.
         """
@@ -408,6 +419,8 @@ class OMETiff(Tiff):
     file_ext = "ome.tiff"
 
     def sniff_prefix(self, file_prefix: FilePrefix) -> bool:
+        import tifffile
+
         buf = io.BytesIO(file_prefix.contents_header_bytes)
         with tifffile.TiffFile(buf) as tif:
             return tif.is_ome
@@ -587,6 +600,8 @@ class Dicom(Image):
         tiles of a mosaic or pyramid (WSI DICOM). Distinguishing these cases is not straight-forward (and, as a
         consequence, neither is determining the `axes` of the image). This can be implemented in the future.
         """
+        import pydicom
+
         try:
             dcm = pydicom.dcmread(dataset.get_file_name(), stop_before_pixels=True)
         except pydicom.errors.InvalidDicomError:
@@ -755,6 +770,8 @@ class Mrc2014(Binary):
     file_ext = "mrc"
 
     def sniff(self, filename: str) -> bool:
+        import mrcfile
+
         try:
             # An exception is thrown
             # if the file is not an

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -40,12 +40,12 @@ from . import (
     tracks,
     xml,
 )
-from .display_applications.application import DisplayApplication
 
 if TYPE_CHECKING:
     from galaxy.datatypes.data import Data
     from galaxy.tool_util.toolbox.base import AbstractToolBox
     from galaxy.tools import SetMetadataTool
+    from .display_applications.application import DisplayApplication
 
 
 class ConfigurationError(Exception):
@@ -97,7 +97,7 @@ class Registry:
         # Datatype elements defined in local datatypes_conf.xml that contain display applications.
         self.display_app_containers = []
         # Map a display application id to a display application
-        self.display_applications: dict[str, DisplayApplication] = {}
+        self.display_applications: dict[str, "DisplayApplication"] = {}
         # The following 2 attributes are used in the to_xml_file()
         # method to persist the current state into an xml file.
         self.display_path_attr = None
@@ -728,6 +728,12 @@ class Registry:
         """
         Add display applications from self.display_app_containers or to appropriate datatypes.
         """
+        # Imported here rather than at module level: the display application
+        # subsystem pulls in Cheetah via galaxy.util.template, and this module is
+        # loaded by every upload job and every set_metadata process. Those call
+        # load_datatypes(use_display_applications=False) and never reach this method.
+        from .display_applications.application import DisplayApplication
+
         # Load display applications defined by local datatypes_conf.xml.
         datatype_elems = self.display_app_containers
         for elem in datatype_elems:

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -290,9 +290,20 @@ class Registry:
                             self.available_tracks.append(extension)
                         if display_in_upload and extension not in self.upload_file_formats:
                             self.upload_file_formats.append(extension)
-                        # Max file size cut off for setting optional metadata.
-                        self.datatypes_by_extension[extension].max_optional_metadata_filesize = elem.get(
-                            "max_optional_metadata_filesize", None
+                        # Max file size cut off for setting optional metadata. A value on the
+                        # datatype wins; otherwise fall back to the global config option.
+                        max_optional_metadata_filesize = elem.get("max_optional_metadata_filesize", None)
+                        if max_optional_metadata_filesize is None:
+                            max_optional_metadata_filesize = getattr(
+                                self.config, "max_optional_metadata_filesize", None
+                            )
+                            if max_optional_metadata_filesize is not None:
+                                # Make sure this is set in the elems we write out so the config option
+                                # reaches the metadata and upload processes, which build a registry
+                                # from that XML and have no config object.
+                                elem.set("max_optional_metadata_filesize", str(max_optional_metadata_filesize))
+                        self.datatypes_by_extension[extension].max_optional_metadata_filesize = (
+                            max_optional_metadata_filesize
                         )
                         infer_from_suffixes = []
                         # read from element instead of attribute so we can customize references to

--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -24,9 +24,8 @@ from galaxy.util.config_parsers import (
     parse_allowlist_ips,
 )
 from galaxy.util.config_templates import EnvironmentDict
-from galaxy.util.pydantic_partial import partial_model
 from galaxy.util.hash_util import HashFunctionNames
-from galaxy.util.template import fill_template
+from galaxy.util.pydantic_partial import partial_model
 
 if TYPE_CHECKING:
     from galaxy.files import OptionalUserContext
@@ -418,6 +417,12 @@ def resolve_file_source_template(
     Returns:
         Resolved configuration with all templates evaluated
     """
+    # Imported here rather than at module level: galaxy.util.template pulls in
+    # Cheetah and the lib2to3/fissix py2-to-py3 translation machinery, and this
+    # module is reached from galaxy.files, which galaxy.datatypes.sniff imports.
+    # Every upload job and every set_metadata process pays that otherwise.
+    from galaxy.util.template import fill_template
+
     template_variables = context.to_dict()
 
     def expand_template_value(value: Any) -> Any:

--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -23,10 +23,8 @@ from galaxy.util.config_parsers import (
     IpAllowedListEntryT,
     parse_allowlist_ips,
 )
-from galaxy.util.config_templates import (
-    EnvironmentDict,
-    partial_model,
-)
+from galaxy.util.config_templates import EnvironmentDict
+from galaxy.util.pydantic_partial import partial_model
 from galaxy.util.hash_util import HashFunctionNames
 from galaxy.util.template import fill_template
 

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -19,6 +19,7 @@ from collections.abc import (
     Callable,
     Iterable,
 )
+from contextlib import contextmanager
 from dataclasses import (
     dataclass,
     field,
@@ -161,6 +162,22 @@ class JobToolConfiguration(Bunch):
 
     def get_resource_group(self):
         return self.get("resources", None)
+
+
+@contextmanager
+def _timed_phase(timings: dict[str, float], name: str):
+    """Accumulate the wall time spent in one phase of finalizing a job.
+
+    The phases are logged together at the end of ``finish``. Which one
+    dominates is not obvious from the outside: it depends on the tool, the
+    metadata strategy and, on a network filesystem, on how many round trips
+    each phase makes.
+    """
+    begin = time.time()
+    try:
+        yield
+    finally:
+        timings[name] = timings.get(name, 0.0) + (time.time() - begin)
 
 
 def config_exception(e, file):
@@ -2056,6 +2073,7 @@ class MinimalJobWrapper(HasResourceParameters):
         finish_timer = self.app.execution_timer_factory.get_timer(
             "internals.galaxy.jobs.job_wrapper_finish", "job_wrapper.finish for job ${job_id} executed"
         )
+        finish_timings: dict[str, float] = {}
 
         # default post job setup
         job = self.get_job()
@@ -2149,7 +2167,8 @@ class MinimalJobWrapper(HasResourceParameters):
                     user=job.user,
                     tag_handler=self.app.tag_handler.create_tag_handler_session(job.galaxy_session),
                 )
-                import_model_store.perform_import(history=job.history, job=job)
+                with _timed_phase(finish_timings, "import_metadata"):
+                    import_model_store.perform_import(history=job.history, job=job)
                 if job.state == job.states.ERROR:
                     final_job_state = job.state
             except store.FileTracebackException as e:
@@ -2161,8 +2180,9 @@ class MinimalJobWrapper(HasResourceParameters):
                 return fail(str(e), exception=e)
         else:
             if self.tool.version_string_cmd:
-                version_filename = self.get_version_string_path()
-                self.version_string = collect_shrinked_content_from_path(version_filename)
+                with _timed_phase(finish_timings, "version_string"):
+                    version_filename = self.get_version_string_path()
+                    self.version_string = collect_shrinked_content_from_path(version_filename)
 
         output_dataset_associations = job.output_datasets + job.output_library_datasets
         inp_data, out_data, out_collections = job.io_dicts()
@@ -2170,7 +2190,8 @@ class MinimalJobWrapper(HasResourceParameters):
         if not extended_metadata:
             # importing metadata will discover outputs if extended metadata
             try:
-                self.discover_outputs(job, inp_data, out_data, out_collections, final_job_state=final_job_state)
+                with _timed_phase(finish_timings, "discover_outputs"):
+                    self.discover_outputs(job, inp_data, out_data, out_collections, final_job_state=final_job_state)
             except (MaxDiscoveredFilesExceededError, JobOutputNameTooLongError) as e:
                 log.warning("Job %s failed during output discovery: %s", job.id, e)
                 final_job_state = job.states.ERROR
@@ -2201,7 +2222,10 @@ class MinimalJobWrapper(HasResourceParameters):
                     output_name = dataset_assoc.name
 
                     # Handles retry internally on error for instance...
-                    self._finish_dataset(output_name, dataset, job, context, final_job_state, remote_metadata_directory)
+                    with _timed_phase(finish_timings, "finish_datasets"):
+                        self._finish_dataset(
+                            output_name, dataset, job, context, final_job_state, remote_metadata_directory
+                        )
                 if (
                     not final_job_state == job.states.ERROR
                     and not dataset_assoc.dataset.dataset.state == job.states.ERROR
@@ -2240,7 +2264,8 @@ class MinimalJobWrapper(HasResourceParameters):
             dataset = dataset_assoc.dataset.dataset
             # assume all datasets in a job get written to the same objectstore
             quota_source_info = dataset.quota_source_info
-            collected_bytes += dataset.set_total_size()
+            with _timed_phase(finish_timings, "set_total_size"):
+                collected_bytes += dataset.set_total_size()
             if dataset.purged:
                 # Purge, in case job wrote directly to object store
                 dataset.full_delete()
@@ -2277,9 +2302,10 @@ class MinimalJobWrapper(HasResourceParameters):
         param_dict = self.get_param_dict(job)
         task_wrapper = None
         try:
-            task_wrapper = self.tool.exec_after_process(
-                self.app, inp_data, out_data, param_dict, job=job, final_job_state=final_job_state
-            )
+            with _timed_phase(finish_timings, "exec_after_process"):
+                task_wrapper = self.tool.exec_after_process(
+                    self.app, inp_data, out_data, param_dict, job=job, final_job_state=final_job_state
+                )
         except Exception as e:
             log.exception(f"exec_after_process hook failed for job {self.job_id}")
             return fail("exec_after_process hook failed", exception=e)
@@ -2325,6 +2351,12 @@ class MinimalJobWrapper(HasResourceParameters):
         delete_files = cleanup_job == "always" or (job.state == job.states.OK and cleanup_job == "onsuccess")
         self.cleanup(delete_files=delete_files)
         log.debug(finish_timer.to_str(job_id=self.job_id, tool_id=job.tool_id))
+        if finish_timings:
+            log.debug(
+                "(%s) finish() spent (ms): %s",
+                job.id,
+                ", ".join(f"{phase}={seconds * 1000:0.1f}" for phase, seconds in finish_timings.items()),
+            )
 
     def discover_outputs(self, job, inp_data, out_data, out_collections, final_job_state):
         # Try to just recover input_ext and dbkey from job parameters (used and set in

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2352,11 +2352,21 @@ class MinimalJobWrapper(HasResourceParameters):
         self.cleanup(delete_files=delete_files)
         log.debug(finish_timer.to_str(job_id=self.job_id, tool_id=job.tool_id))
         if finish_timings:
-            log.debug(
-                "(%s) finish() spent (ms): %s",
-                job.id,
-                ", ".join(f"{phase}={seconds * 1000:0.1f}" for phase, seconds in finish_timings.items()),
-            )
+            breakdown = ", ".join(f"{phase}={seconds * 1000:0.1f}" for phase, seconds in finish_timings.items())
+            elapsed = finish_timer.elapsed
+            threshold = self.app.config.slow_job_finish_log_threshold
+            # Reporting slow finalization has to be possible without turning on
+            # debug logging, which is not something to enable on a busy instance.
+            if threshold and elapsed > threshold:
+                log.warning(
+                    "(%s) tool %s took %0.1fs to finalize, spent (ms): %s",
+                    job.id,
+                    job.tool_id,
+                    elapsed,
+                    breakdown,
+                )
+            else:
+                log.debug("(%s) finish() spent (ms): %s", job.id, breakdown)
 
     def discover_outputs(self, job, inp_data, out_data, out_collections, final_job_state):
         # Try to just recover input_ext and dbkey from job parameters (used and set in

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -27,6 +27,16 @@ log = getLogger(__name__)
 SET_METADATA_SCRIPT = """
 import os
 import traceback
+
+# Pydantic discovers and activates plugins declared via entry points the first
+# time it is imported. Galaxy pins logfire, which registers such a plugin, so
+# every process that imports pydantic also imports logfire, opentelemetry and
+# protobuf: about 330 modules for instrumentation no Galaxy code consumes. This
+# process exists only to set metadata for one job and then exits, so the plugin
+# has nothing to report. setdefault leaves it overridable from the job
+# environment for anyone who does want the instrumentation.
+os.environ.setdefault("PYDANTIC_DISABLE_PLUGINS", "1")
+
 try:
     from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()
 except Exception:

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -20,11 +20,15 @@ import traceback
 from functools import partial
 from pathlib import Path
 
-try:
-    from pulsar.client.staging import COMMAND_VERSION_FILENAME
-except ImportError:
-    # Package unit tests
-    COMMAND_VERSION_FILENAME = "COMMAND_VERSION"
+# Importing this constant from pulsar.client.staging costs roughly a thousand
+# extra modules, because it first executes pulsar.client, which reaches back
+# into galaxy.jobs.runners and from there pulls in the whole tool framework
+# (galaxy.tools, the CWL parser, tool_shed.util.repository_util). None of that
+# is used while setting metadata, but this module runs as a fresh process for
+# every job, so on a shared filesystem the import alone dominates the script.
+# The value is part of the Galaxy/Pulsar wire contract and is asserted against
+# pulsar in test_set_metadata_constants.py.
+COMMAND_VERSION_FILENAME = "COMMAND_VERSION"
 
 import galaxy.datatypes.registry
 import galaxy.model.mapping

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -145,11 +145,6 @@ import galaxy.exceptions
 import galaxy.model.metadata
 import galaxy.security.passwords
 import galaxy.util
-from galaxy.files.templates import (
-    FileSourceConfiguration,
-    FileSourceTemplate,
-    template_to_configuration as file_source_template_to_configuration,
-)
 from galaxy.model.base import ensure_object_added_to_session
 from galaxy.model.custom_types import (
     DoubleEncodedJsonType,
@@ -169,11 +164,6 @@ from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.objectstore import (
     ObjectStoreAuth,
     USER_OBJECTS_SCHEME,
-)
-from galaxy.objectstore.templates import (
-    ObjectStoreConfiguration,
-    ObjectStoreTemplate,
-    template_to_configuration as object_store_template_to_configuration,
 )
 from galaxy.schema.invocation import (
     InvocationCancellationUserRequest,
@@ -249,6 +239,14 @@ if TYPE_CHECKING:
         BaseObjectStore,
         ObjectStorePopulator,
         QuotaSourceMap,
+    )
+    from galaxy.files.templates import (
+        FileSourceConfiguration,
+        FileSourceTemplate,
+    )
+    from galaxy.objectstore.templates import (
+        ObjectStoreConfiguration,
+        ObjectStoreTemplate,
     )
     from galaxy.schema.invocation import InvocationMessageUnion
     from galaxy.webapps.base.webapp import GalaxyWebTransaction
@@ -12639,12 +12637,19 @@ class UserObjectStore(Base, HasConfigTemplate):
     user: Mapped["User"] = relationship("User", back_populates="object_stores")
 
     @property
-    def template(self) -> ObjectStoreTemplate:
+    def template(self) -> "ObjectStoreTemplate":
+        # Deferred for the same reason as FileSourceTemplate below.
+        from galaxy.objectstore.templates import ObjectStoreTemplate
+
         return ObjectStoreTemplate(**self.template_definition or {})
 
     def object_store_configuration(
-        self, secrets: SecretsDict, environment: EnvironmentDict, templates: list[ObjectStoreTemplate] | None = None
-    ) -> ObjectStoreConfiguration:
+        self, secrets: SecretsDict, environment: EnvironmentDict, templates: list["ObjectStoreTemplate"] | None = None
+    ) -> "ObjectStoreConfiguration":
+        from galaxy.objectstore.templates import (
+            template_to_configuration as object_store_template_to_configuration,
+        )
+
         if templates is None:
             templates = [self.template]
         user_details = self.user.config_template_details()
@@ -12707,7 +12712,13 @@ class UserFileSource(Base, HasConfigTemplate):
     user: Mapped["User"] = relationship("User", back_populates="file_sources")
 
     @property
-    def template(self) -> FileSourceTemplate:
+    def template(self) -> "FileSourceTemplate":
+        # Imported lazily: galaxy.files.templates reaches galaxy.files.sources and
+        # galaxy.util.config_templates, which nothing else in this module needs.
+        # galaxy.model is imported by set_metadata, and that runs as a fresh
+        # process for every finished job, so the cost is paid per job.
+        from galaxy.files.templates import FileSourceTemplate
+
         return FileSourceTemplate(**self.template_definition or {})
 
     def file_source_configuration(
@@ -12715,8 +12726,10 @@ class UserFileSource(Base, HasConfigTemplate):
         secrets: SecretsDict,
         environment: EnvironmentDict,
         implicit: ImplicitConfigurationParameters,
-        templates: list[FileSourceTemplate] | None = None,
-    ) -> FileSourceConfiguration:
+        templates: list["FileSourceTemplate"] | None = None,
+    ) -> "FileSourceConfiguration":
+        from galaxy.files.templates import template_to_configuration as file_source_template_to_configuration
+
         if templates is None:
             templates = [self.template]
         user_details = self.user.config_template_details()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -729,6 +729,37 @@ WHERE dataset.id IN (SELECT dataset_id FROM per_hist_hdas)
 """
 
 
+def _sum_file_sizes(path: str) -> int:
+    """Return the total size of every file under ``path``, 0 if it is unreadable.
+
+    Uses the stat that ``scandir`` already performs for the walk rather than a
+    separate ``exists`` plus ``getsize`` per file, which halves the syscalls.
+    On a network filesystem those are round trips, and this runs for every
+    output of every job.
+    """
+    total = 0
+    try:
+        entries = list(os.scandir(path))
+    except OSError:
+        return 0
+    for entry in entries:
+        try:
+            if entry.is_dir(follow_symlinks=False):
+                total += _sum_file_sizes(entry.path)
+            elif entry.is_dir():
+                # A symlink to a directory: os.walk lists it but does not
+                # descend into it, so it contributes nothing.
+                continue
+            else:
+                # Follows symlinks, as os.path.getsize did. A broken one
+                # raises here and is skipped, as the os.path.exists guard did.
+                total += entry.stat().st_size
+        except OSError:
+            # Vanished between listing and stat, or otherwise unreadable.
+            continue
+    return total
+
+
 def calculate_user_disk_usage_statements(user_id: int, quota_source_map: "QuotaSourceMap", for_sqlite: bool = False):
     """Standalone function so can be reused for postgres directly in pgcleanup.py."""
     statements: list[tuple[str, dict[str, Any]]] = []
@@ -5009,12 +5040,7 @@ class Dataset(Base, StorableObject, Serializable):
         self.total_size = self.file_size or 0
         if (rel_path := self._extra_files_rel_path) is not None:
             if self.object_store.exists(self, extra_dir=rel_path, dir_only=True):
-                for root, _, files in os.walk(self.extra_files_path):
-                    self.total_size += sum(
-                        os.path.getsize(os.path.join(root, file))
-                        for file in files
-                        if os.path.exists(os.path.join(root, file))
-                    )
+                self.total_size += _sum_file_sizes(self.extra_files_path)
         return self.total_size
 
     def has_data(self):

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -37,11 +37,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
 )
-from rocrate.model.computationalworkflow import (
-    ComputationalWorkflow,
-    WorkflowDescription,
-)
-from rocrate.rocrate import ROCrate
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.scoping import scoped_session
@@ -117,7 +112,6 @@ from ._bco_convert_utils import (
     bco_workflow_version,
     SoftwarePrerequisiteTracker,
 )
-from .ro_crate_utils import WorkflowRunCrateProfileBuilder
 from ..custom_types import json_encoder
 from ..item_attrs import (
     add_item_annotation,
@@ -125,6 +119,8 @@ from ..item_attrs import (
 )
 
 if TYPE_CHECKING:
+    from rocrate.rocrate import ROCrate
+
     from galaxy.managers.workflows import WorkflowContentsManager
     from galaxy.model import (
         HistoryItem,
@@ -2627,7 +2623,14 @@ class WriteCrates:
         # But for now we only populate included_invocations when exporting a workflow invocation, so this is fine.
         return bool(self.included_invocations)
 
-    def _init_crate(self) -> ROCrate:
+    def _init_crate(self) -> "ROCrate":
+        # Imported here rather than at module level: RO-Crate export is one of
+        # several export formats, but galaxy.model.store is imported by
+        # set_metadata, which runs once per finished job and never exports.
+        from rocrate.rocrate import ROCrate
+
+        from .ro_crate_utils import WorkflowRunCrateProfileBuilder
+
         is_invocation_export = self._is_invocation_export()
         if is_invocation_export:
             invocation_crate_builder = WorkflowRunCrateProfileBuilder(self)
@@ -2686,6 +2689,11 @@ class WriteCrates:
         if os.path.exists(workflows_directory):
             for filename in os.listdir(workflows_directory):
                 is_computational_wf = not filename.endswith(".cwl")
+                from rocrate.model.computationalworkflow import (
+                    ComputationalWorkflow,
+                    WorkflowDescription,
+                )
+
                 workflow_cls = ComputationalWorkflow if is_computational_wf else WorkflowDescription
                 lang = "galaxy" if not filename.endswith(".cwl") else "cwl"
                 dest_path = os.path.join("workflows", filename)

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1110,25 +1110,44 @@ class DiskObjectStore(ConcreteObjectStore):
         """Override `ObjectStore`'s stub by checking file size on disk."""
         return self._size(obj, **kwargs) == 0
 
+    def _stat_size(self, obj, **kwargs) -> int | None:
+        """Return the size of the first candidate path that exists, else None.
+
+        A single ``getsize`` answers both "does this exist" and "how big is
+        it", so the caller does not have to stat the same path again.
+        """
+        paths = []
+        if self.check_old_style:
+            # For backward compatibility: check root path first; otherwise
+            # construct and check hashed path.
+            paths.append(self._construct_path(obj, old_style=True, **kwargs))
+        paths.append(self._construct_path(obj, **kwargs))
+        for path in paths:
+            try:
+                return os.path.getsize(path)
+            except OSError:
+                continue
+        return None
+
     def _size(self, obj, **kwargs) -> int:
         """Override `ObjectStore`'s stub by return file size on disk.
 
         Returns 0 if the object doesn't exist yet or other error.
         """
-        if self._exists(obj, **kwargs):
-            try:
-                filepath = self._get_filename(obj, **kwargs)
-                for _ in range(0, 2):
-                    size = os.path.getsize(filepath)
-                    if size != 0:
-                        break
-                    # May be legitimately 0, or there may be an issue with the FS / kernel, so we try again
-                    time.sleep(0.01)
-                return size
-            except OSError:
+        # Resolving through _exists() and then _get_filename() would stat the
+        # same path twice more before getsize() stats it a third time. On a
+        # network filesystem each of those is a round trip, and this is paid
+        # for every output of every job, so do it with one stat instead.
+        for _ in range(0, 2):
+            size = self._stat_size(obj, **kwargs)
+            if size is None:
+                # Doesn't exist; no point waiting for it to grow.
                 return 0
-        else:
-            return 0
+            if size != 0:
+                return size
+            # May be legitimately 0, or there may be an issue with the FS / kernel, so we try again
+            time.sleep(0.01)
+        return 0
 
     def _delete(self, obj, entire_dir: bool = False, **kwargs) -> bool:
         """Override `ObjectStore`'s stub; delete the file or folder on disk."""

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -57,7 +57,6 @@ from .badges import (
     StoredBadgeDict,
 )
 from .caching import CacheTarget
-from .templates import ObjectStoreConfiguration
 
 if TYPE_CHECKING:
     from galaxy.model import (
@@ -65,6 +64,13 @@ if TYPE_CHECKING:
         DatasetInstance,
         User,
     )
+
+    # Only ever used in annotations, which this module defers via
+    # "from __future__ import annotations". Importing it eagerly would pull in
+    # galaxy.util.config_templates and galaxy.tool_util_models, which are needed
+    # exclusively for user-defined object stores. galaxy.objectstore is imported
+    # by set_metadata, and that runs as a fresh process for every finished job.
+    from .templates import ObjectStoreConfiguration
 
 NO_SESSION_ERROR_MESSAGE = (
     "Attempted to 'create' object store entity in configuration with no database session present."

--- a/lib/galaxy/schema/groups.py
+++ b/lib/galaxy/schema/groups.py
@@ -16,7 +16,7 @@ from galaxy.schema.schema import (
     Model,
     WithModelClass,
 )
-from galaxy.util.config_templates import partial_model
+from galaxy.util.pydantic_partial import partial_model
 
 GROUP_MODEL_CLASS = Literal["Group"]
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -58,7 +58,7 @@ from galaxy.tool_util_models.sample_sheet import (
     SampleSheetRows,
 )
 from galaxy.tool_util_models.tool_source import FieldDict
-from galaxy.util.config_templates import partial_model
+from galaxy.util.pydantic_partial import partial_model
 from galaxy.util.hash_util import HashFunctionNameEnum
 from galaxy.util.sanitize_html import sanitize_html
 

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -13,8 +13,6 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import dns.resolver
-from dns.exception import DNSException
 from sqlalchemy import (
     func,
     select,
@@ -140,6 +138,13 @@ def validate_email(
 
 
 def validate_email_domain_name(domain: str) -> LiteralString:
+    # Imported here rather than at module level: dnspython is only needed to
+    # resolve email domains during user registration, but galaxy.model imports
+    # validate_password_str from this module, so every process loading the model
+    # was also loading dnspython.
+    import dns.resolver
+    from dns.exception import DNSException
+
     message = ""
     try:
         dns.resolver.resolve(domain, "MX")

--- a/lib/galaxy/tool_util/parser/factory.py
+++ b/lib/galaxy/tool_util/parser/factory.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from yaml import safe_load
 
@@ -12,10 +13,6 @@ from galaxy.util import (
 )
 from galaxy.util.path import StrPath
 from galaxy.util.yaml_util import ordered_load
-from .cwl import (
-    CwlToolSource,
-    tool_proxy,
-)
 from .interface import (
     InputSource,
     ToolSource,
@@ -30,6 +27,9 @@ from .yaml import (
 )
 from ..fetcher import ToolLocationFetcher
 
+if TYPE_CHECKING:
+    from .cwl import CwlToolSource
+
 log = logging.getLogger(__name__)
 
 
@@ -42,7 +42,15 @@ def build_xml_tool_source(xml_string: str) -> XmlToolSource:
     return XmlToolSource(parse_xml_string_to_etree(xml_string, strip_whitespace=False))
 
 
-def build_cwl_tool_source(yaml_string: str) -> CwlToolSource:
+def build_cwl_tool_source(yaml_string: str) -> "CwlToolSource":
+    # Imported lazily: the CWL parser pulls in a large dependency tree that only
+    # CWL tools need, and this module is imported (via parser.stdio) by
+    # set_metadata, which runs as a fresh process for every finished job.
+    from .cwl import (
+        CwlToolSource,
+        tool_proxy,
+    )
+
     proxy = tool_proxy(tool_object=safe_load(yaml_string))
     # regular CwlToolSource sets basename as tool id, but that's not going to cut it in production
     return CwlToolSource(tool_proxy=proxy)
@@ -101,6 +109,8 @@ def get_tool_source(
         log.info(
             "Loading CWL tool - this is experimental - tool likely will not function in future at least in same way."
         )
+        from .cwl import CwlToolSource
+
         return CwlToolSource(config_file)
     else:
         tree, macro_paths = load_tool_with_refereces(config_file)

--- a/lib/galaxy/tool_util/parser/output_actions.py
+++ b/lib/galaxy/tool_util/parser/output_actions.py
@@ -13,12 +13,24 @@ from typing_extensions import Protocol
 
 from galaxy import util
 
-try:
-    from galaxy.util.template import fill_template
-except ImportError:
-    fill_template = None  # type: ignore[assignment, unused-ignore]
-
 log = logging.getLogger(__name__)
+
+
+def _get_fill_template():
+    """Return Cheetah's fill_template, or None when Cheetah is unavailable.
+
+    Imported on demand rather than at module level: galaxy.util.template pulls in
+    Cheetah plus the lib2to3/fissix py2-to-py3 translation machinery, and this
+    module is reached from galaxy.tool_util.parser, which set_metadata imports.
+    set_metadata runs as a fresh process for every finished job, so the cost is
+    paid per job even though only Cheetah-templated output actions need it.
+    """
+    try:
+        from galaxy.util.template import fill_template
+
+        return fill_template
+    except ImportError:
+        return None
 
 
 class ToolOutputActionAppConfig(Protocol):
@@ -337,6 +349,7 @@ class MetadataToolOutputAction(ToolOutputAction):
         if self.default:
             # For historical reasons the default value takes preference over value,
             # and we only treat the default value as potentially containing cheetah.
+            fill_template = _get_fill_template()
             if fill_template is not None:
                 value = fill_template(
                     self.default,

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -5,6 +5,16 @@ import os
 import shutil
 import sys
 import tempfile
+
+if __name__ == "__main__":
+    # Set before the imports below pull in pydantic. Pydantic activates plugins
+    # declared via entry points on first import, and Galaxy pins logfire, which
+    # registers one; that costs roughly 330 modules (logfire, opentelemetry,
+    # protobuf) for instrumentation no Galaxy code consumes. The fetch tool runs
+    # as a short-lived subprocess per job, so there is nothing to instrument.
+    # Guarded on __main__ so importing this module inside the Galaxy server or a
+    # celery worker, where plugins may legitimately be wanted, is unaffected.
+    os.environ.setdefault("PYDANTIC_DISABLE_PLUGINS", "1")
 from io import StringIO
 from typing import (
     Any,

--- a/lib/galaxy/util/config_templates.py
+++ b/lib/galaxy/util/config_templates.py
@@ -6,12 +6,9 @@ This is capturing code shared by file source templates and object store template
 import logging
 import os
 from collections.abc import (
-    Callable,
-    Iterable,
     Sequence,
 )
 from typing import (
-    Annotated,
     Any,
     cast,
     Literal,
@@ -26,11 +23,9 @@ from boltons.iterutils import remap
 from pydantic import (
     BaseModel,
     ConfigDict,
-    create_model,
     RootModel,
     ValidationError,
 )
-from pydantic.fields import FieldInfo
 from typing_extensions import (
     NotRequired,
     Protocol,
@@ -704,50 +699,3 @@ class ImplicitConfigurationParameters(TypedDict):
     oauth2_access_token: NotRequired[str]
 
 
-M = TypeVar("M", bound="BaseModel")
-
-
-# Implementation copied from https://github.com/pydantic/pydantic/issues/12329#issuecomment-3382159312
-def _make_field_optional(field_info: FieldInfo):
-    """Returns the field's definition to be used in a `create_model()` call to make the field optional."""
-    annotation = field_info.annotation
-    assert annotation is not None
-    if field_info.is_required():
-        return Annotated[annotation | None, field_info], None
-    else:
-        return Annotated[annotation, field_info]
-
-
-def make_model_with_all_fields_optional(model: type[M], fields=None) -> type[M]:
-    """Returns a new Pydantic model based on `model`, but with all fields optional."""
-    if fields is None:
-        fields = model.model_fields.items()
-    return create_model(
-        model.__name__,
-        __doc__=model.__doc__,
-        __base__=model,
-        **{field_name: _make_field_optional(field_info) for field_name, field_info in fields},
-    )
-
-
-# TODO: This is a workaround to make all fields optional.
-#       It should be removed when Python/pydantic supports this feature natively.
-# https://github.com/pydantic/pydantic/issues/1673
-def partial_model(include: list[str] | None = None, exclude: list[str] | None = None) -> Callable[[type[M]], type[M]]:
-    """Decorator to make all model fields optional"""
-
-    if exclude is None:
-        exclude = []
-
-    def decorator(model: type[M]) -> type[M]:
-        if include is None:
-            fields: Iterable[tuple[str, FieldInfo]] = model.model_fields.items()
-        else:
-            fields = ((k, v) for k, v in model.model_fields.items() if k in include)
-
-        if exclude is not None:
-            fields = ((k, v) for k, v in fields if k not in exclude)
-
-        return make_model_with_all_fields_optional(model, fields)
-
-    return decorator

--- a/lib/galaxy/util/pydantic_partial.py
+++ b/lib/galaxy/util/pydantic_partial.py
@@ -1,0 +1,71 @@
+"""Helpers for deriving Pydantic models whose fields are all optional.
+
+These live in their own module rather than in galaxy.util.config_templates
+because they are generic Pydantic utilities with no relation to configuration
+templates, and are used from galaxy.schema.schema, which is imported by
+galaxy.model. Keeping them here means that import does not drag in
+config_templates' own dependencies (requests, yaml, boltons, tool_util_models).
+"""
+
+from collections.abc import (
+    Callable,
+    Iterable,
+)
+from typing import (
+    Annotated,
+    TypeVar,
+)
+
+from pydantic import (
+    BaseModel,
+    create_model,
+)
+from pydantic.fields import FieldInfo
+
+M = TypeVar("M", bound=BaseModel)
+
+
+# Implementation copied from https://github.com/pydantic/pydantic/issues/12329#issuecomment-3382159312
+def _make_field_optional(field_info: FieldInfo):
+    """Returns the field's definition to be used in a `create_model()` call to make the field optional."""
+    annotation = field_info.annotation
+    assert annotation is not None
+    if field_info.is_required():
+        return Annotated[annotation | None, field_info], None
+    else:
+        return Annotated[annotation, field_info]
+
+
+def make_model_with_all_fields_optional(model: type[M], fields=None) -> type[M]:
+    """Returns a new Pydantic model based on `model`, but with all fields optional."""
+    if fields is None:
+        fields = model.model_fields.items()
+    return create_model(
+        model.__name__,
+        __doc__=model.__doc__,
+        __base__=model,
+        **{field_name: _make_field_optional(field_info) for field_name, field_info in fields},
+    )
+
+
+# TODO: This is a workaround to make all fields optional.
+#       It should be removed when Python/pydantic supports this feature natively.
+# https://github.com/pydantic/pydantic/issues/1673
+def partial_model(include: list[str] | None = None, exclude: list[str] | None = None) -> Callable[[type[M]], type[M]]:
+    """Decorator to make all model fields optional"""
+
+    if exclude is None:
+        exclude = []
+
+    def decorator(model: type[M]) -> type[M]:
+        if include is None:
+            fields: Iterable[tuple[str, FieldInfo]] = model.model_fields.items()
+        else:
+            fields = ((k, v) for k, v in model.model_fields.items() if k in include)
+
+        if exclude is not None:
+            fields = ((k, v) for k, v in fields if k not in exclude)
+
+        return make_model_with_all_fields_optional(model, fields)
+
+    return decorator

--- a/lib/galaxy/util/rst_to_html.py
+++ b/lib/galaxy/util/rst_to_html.py
@@ -2,15 +2,27 @@ import functools
 import os
 import threading
 
-try:
-    import docutils.core
-    import docutils.io
-    import docutils.utils
-    import docutils.writers.html4css1
-except ImportError:
-    docutils = None  # type: ignore[assignment]
-
 from .custom_logging import get_logger
+
+
+@functools.cache
+def _get_docutils():
+    """Return the docutils package, or None when it is not installed.
+
+    Imported on demand rather than at module level because galaxy.util re-exports
+    rst_to_html, so every importer of galaxy.util was loading docutils. Only tool
+    help rendering needs it, and the per-job metadata and fetch processes never
+    render help.
+    """
+    try:
+        import docutils.core
+        import docutils.io
+        import docutils.utils
+        import docutils.writers.html4css1
+
+        return docutils
+    except ImportError:
+        return None
 
 
 class FakeStream:
@@ -28,6 +40,8 @@ class FakeStream:
 
 @functools.cache
 def get_publisher(error=False):
+    docutils = _get_docutils()
+    assert docutils is not None, "docutils unavailable"
     docutils_writer = docutils.writers.html4css1.Writer()
     docutils_template_path = os.path.join(os.path.dirname(__file__), "docutils_template.txt")
     no_report_level = docutils.utils.Reporter.SEVERE_LEVEL + 1
@@ -64,7 +78,7 @@ _publish_lock = threading.Lock()
 
 @functools.cache
 def rst_to_html(s, error=False):
-    if docutils is None:
+    if _get_docutils() is None:
         raise Exception("Attempted to use rst_to_html but docutils unavailable.")
 
     with _publish_lock:

--- a/lib/galaxy/util/sanitize_html.py
+++ b/lib/galaxy/util/sanitize_html.py
@@ -2,7 +2,6 @@
 HTML Sanitizer (lists of acceptable_* ripped from feedparser)
 """
 
-import bleach
 
 from galaxy.util import unicodify
 
@@ -251,6 +250,11 @@ _acceptable_attributes = [
 
 
 def sanitize_html(htmlSource, allow_data_urls=False):
+    # Imported here rather than at module level: this module is reached from
+    # galaxy.schema.schema, so every process importing the model was loading
+    # bleach even though only page and markdown rendering sanitizes HTML.
+    import bleach
+
     kwd = dict(tags=_acceptable_elements, attributes=_acceptable_attributes, strip=True)
     if allow_data_urls:
         kwd["protocols"] = list(bleach.ALLOWED_PROTOCOLS) + ["data"]

--- a/test/unit/app/tools/test_set_metadata_constants.py
+++ b/test/unit/app/tools/test_set_metadata_constants.py
@@ -1,0 +1,51 @@
+"""Guards for the import surface of galaxy.metadata.set_metadata.
+
+set_metadata runs as a separate process for every finished job. On installations
+where the Galaxy tree lives on a shared filesystem, the cost of importing this
+module is paid once per job and is dominated by how many modules it drags in, so
+the import surface is a correctness-adjacent property worth pinning down.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+def test_command_version_filename_matches_pulsar():
+    """The inlined constant must stay in sync with pulsar's definition.
+
+    set_metadata defines COMMAND_VERSION_FILENAME itself rather than importing it
+    from pulsar.client.staging, to avoid pulling in the job runner and tool
+    framework. That is only safe while both agree on the value.
+    """
+    pulsar_staging = pytest.importorskip("pulsar.client.staging")
+
+    from galaxy.metadata.set_metadata import COMMAND_VERSION_FILENAME
+
+    assert COMMAND_VERSION_FILENAME == pulsar_staging.COMMAND_VERSION_FILENAME
+
+
+def test_set_metadata_does_not_import_tool_framework():
+    """Importing set_metadata must not drag in the tool or job runner framework.
+
+    Runs in a subprocess because the modules may already be imported in the
+    pytest process by unrelated tests.
+    """
+    unwanted = [
+        "galaxy.tools",
+        "galaxy.jobs.runners",
+        "galaxy.tool_util.cwl.parser",
+        "galaxy.tool_shed.util.repository_util",
+    ]
+    program = (
+        "import sys\n"
+        "import galaxy.metadata.set_metadata\n"
+        f"unwanted = {unwanted!r}\n"
+        "print(','.join(m for m in unwanted if m in sys.modules))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program], capture_output=True, text=True, check=True
+    )
+    leaked = [m for m in result.stdout.strip().split(",") if m]
+    assert not leaked, f"set_metadata should not import: {', '.join(leaked)}"

--- a/test/unit/data/datatypes/test_max_optional_metadata_filesize.py
+++ b/test/unit/data/datatypes/test_max_optional_metadata_filesize.py
@@ -1,0 +1,158 @@
+"""Tests for the global max_optional_metadata_filesize config option.
+
+Setting optional metadata means reading a dataset from end to end. The size cut
+off that suppresses it existed only as a per-datatype attribute in
+datatypes_conf.xml; these tests cover the global default, its precedence rules,
+and the fact that it reaches the separate processes that set metadata.
+"""
+
+import os
+
+import pytest
+
+from galaxy.datatypes.data import (
+    Data,
+    Text,
+)
+from galaxy.datatypes.registry import Registry
+from galaxy.datatypes.sequence import FastqSanger
+from galaxy.util import galaxy_directory
+from galaxy.util.bunch import Bunch
+
+DATATYPES_CONF = os.path.join(galaxy_directory(), "lib", "galaxy", "config", "sample", "datatypes_conf.xml.sample")
+
+
+@pytest.fixture(autouse=True)
+def restore_class_level_cut_off():
+    """Undo the class-level mutation these tests cause.
+
+    The cut off is stored on the datatype class, not the instance, so both
+    load_datatypes() and a direct assignment leak into every later test in the
+    same process. Without this, these tests silently broke test_sequence.py.
+    """
+    touched = [FastqSanger, Text, Data]
+    sentinel = object()
+    saved = [(cls, cls.__dict__.get("_max_optional_metadata_filesize", sentinel)) for cls in touched]
+    yield
+    for cls, previous in saved:
+        if previous is sentinel:
+            if "_max_optional_metadata_filesize" in cls.__dict__:
+                delattr(cls, "_max_optional_metadata_filesize")
+        else:
+            cls._max_optional_metadata_filesize = previous
+
+
+def _registry(config=None):
+    registry = Registry(config=config)
+    registry.load_datatypes(
+        root_dir=galaxy_directory(),
+        config=DATATYPES_CONF,
+        use_build_sites=False,
+        use_converters=False,
+        use_display_applications=False,
+    )
+    return registry
+
+
+def _cut_off_for(registry, extension):
+    return registry.datatypes_by_extension[extension].max_optional_metadata_filesize
+
+
+def test_without_the_option_behaviour_is_unchanged():
+    """No config value means the cut off comes from datatypes_conf.xml as before.
+
+    Note what that actually yields: the sample config sets the attribute only on
+    the ``data`` datatype, but the cut off is stored on the datatype *class*, so
+    every datatype deriving from Data inherits it through the MRO. fastqsanger
+    never mentions the attribute yet ends up with Data's 1MB. That implicit
+    inheritance is why a global option is worth having, and this test pins the
+    pre-existing behaviour so the option does not change it.
+    """
+    registry = _registry()
+    assert _cut_off_for(registry, "fastqsanger") == 1048576
+
+
+def test_global_option_applies_to_datatypes():
+    registry = _registry(config=Bunch(max_optional_metadata_filesize=1024))
+    assert _cut_off_for(registry, "fastqsanger") == 1024
+
+
+def test_zero_means_never_read():
+    """0 is the 'do not read datasets for optional metadata' setting."""
+    registry = _registry(config=Bunch(max_optional_metadata_filesize=0))
+    assert _cut_off_for(registry, "fastqsanger") == 0
+
+
+def test_reaches_processes_that_have_no_config(tmp_path):
+    """The value must survive the round trip through the job's registry XML.
+
+    set_metadata and the fetch tool build a Registry from that XML in a separate
+    process and never see a config object, so the option is only effective if it
+    is written into the datatype elements.
+    """
+    registry = _registry(config=Bunch(max_optional_metadata_filesize=4096))
+    registry_xml = tmp_path / "registry.xml"
+    registry.to_xml_file(str(registry_xml))
+
+    reloaded = Registry()  # no config, exactly as the metadata process builds it
+    reloaded.load_datatypes(
+        root_dir=galaxy_directory(),
+        config=str(registry_xml),
+        use_build_sites=False,
+        use_converters=False,
+        use_display_applications=False,
+    )
+    assert _cut_off_for(reloaded, "fastqsanger") == 4096
+
+
+def test_datatype_attribute_wins_over_global_option():
+    """An explicit attribute in datatypes_conf.xml takes precedence."""
+    import xml.etree.ElementTree as ET
+
+    tree = ET.parse(DATATYPES_CONF)
+    root = tree.getroot()
+    for elem in root.find("registration").findall("datatype"):
+        if elem.get("extension") == "fastqsanger":
+            elem.set("max_optional_metadata_filesize", "777")
+
+    registry = Registry(config=Bunch(max_optional_metadata_filesize=4096))
+    registry.load_datatypes(
+        root_dir=galaxy_directory(),
+        config=root,
+        use_build_sites=False,
+        use_converters=False,
+        use_display_applications=False,
+    )
+    assert _cut_off_for(registry, "fastqsanger") == 777
+
+
+def test_large_fastq_is_not_read(tmp_path):
+    """The point of the option: no bytes are read for an oversized dataset."""
+    fastq = tmp_path / "reads.fastqsanger"
+    fastq.write_text("@r1\nACGT\n+\nIIII\n" * 500)
+    size = fastq.stat().st_size
+
+    class FakeDataset:
+        metadata = Bunch(data_lines=0, sequences=0)
+
+        def get_file_name(self, sync_cache=True):
+            return str(fastq)
+
+        def get_size(self, nice_size=False, calculate_size=True):
+            return size
+
+        def has_data(self):
+            return True
+
+    datatype = FastqSanger()
+
+    datatype.max_optional_metadata_filesize = -1
+    dataset = FakeDataset()
+    datatype.set_meta(dataset)
+    assert dataset.metadata.sequences == 500
+
+    datatype.max_optional_metadata_filesize = 0
+    dataset = FakeDataset()
+    datatype.set_meta(dataset)
+    assert dataset.metadata.sequences is None
+    assert dataset.metadata.data_lines is None


### PR DESCRIPTION
# Cut the per-job cost of setting metadata on shared storage

Branch: `perf/metadata-registration` → `dev`

> **Proposal, open for discussion.** This comes out of profiling a production
> instance whose Galaxy tree, dependencies and job directories all live on a
> 1 GbE NFS mount.

## The problem

On an instance whose Galaxy tree is on shared storage, a tool that runs for ten
seconds can take another one to three minutes before its output turns green. The
striking part is that this is **independent of dataset size**: a 200 line
tabular file costs the same as a large BAM.

That points away from data movement and towards fixed per-job cost. Every
finished job runs `lib/galaxy/metadata/set_metadata.py` as a fresh Python
process, and an upload additionally runs `data_fetch.py` as a second one. What
those processes import is paid once per job, per output, on every job.

Measured on the NFS install, this is what `set.py` spent before touching the
dataset at all:

| | import | datatypes registry | total | read syscalls |
|---|---|---|---|---|
| before | 8.57 s | 0.63 s | **9.19 s** | **9,014** |
| after | 2.85 s | 0.95 s | **3.80 s** | **3,539** |

Most of those syscalls are NFS round trips on a cold client cache. On a compute
node whose cache holds job data rather than Galaxy's code, nearly every lookup
is a first access, which is why raising `actimeo` does not help: there is no
cached entry whose lifetime could be extended.

## What was being imported, and why none of it is needed

Each change follows the same pattern: a module needed for one feature is
imported at the top of a module that every job loads.

- **`COMMAND_VERSION_FILENAME` from `pulsar.client.staging`.** Reaching it
  executes `pulsar.client`, which imports `galaxy.jobs.runners` and from there
  the whole tool framework, the CWL parser, `tool_shed.util.repository_util` and
  `google.cloud.batch_v1`. The value is the string `"COMMAND_VERSION"`, which
  the file already defined as its own `ImportError` fallback. It is now defined
  directly, with a test asserting it still matches pulsar.
- **`galaxy.tool_util.parser.factory` imported the CWL parser at module level.**
  `set_metadata` reaches that package only for `parser.stdio`.
- **Datatype dependencies.** `galaxy.datatypes.registry` imports every datatype
  module, so `images.py` was pulling in mrcfile, png, pydicom and tifffile, and
  `binary.py` was pulling in h5grove. pydicom alone is 0.81 s and 504 modules;
  every upload of a text file was loading a DICOM library. `pysam` keeps its
  module level import because it calls `set_verbosity(0)` at import time, and
  `h5py` stays because it appears in module level annotations that SQLAlchemy
  evaluates at runtime.
- **Cheetah and the display application subsystem.** `galaxy.util.template`
  pulls in Cheetah plus the lib2to3/fissix py2-to-py3 translation machinery, and
  was reachable by three independent paths. The notable one:
  `datatypes/registry.py` imported the display application subsystem at module
  level, yet `set_metadata` calls `load_datatypes(use_display_applications=False)`
  and never reaches the method that needs it. All three paths had to go; cutting
  any one left the others loading it.
- **Pydantic plugin discovery.** This one is not Galaxy code. Pydantic activates
  plugins declared via entry points on first import, and Galaxy pins `logfire`,
  which registers one. So every process importing pydantic also imported
  logfire, opentelemetry and protobuf: about 330 modules of instrumentation that
  no Galaxy code consumes and that a process living for one job cannot usefully
  report. Both per-job entry points now set `PYDANTIC_DISABLE_PLUGINS` before
  pydantic loads, via `os.environ.setdefault` so it stays overridable from the
  job environment. In `data_fetch` this is guarded on `__main__`, because celery
  workers and the web application import the same module.
- **docutils, dnspython, rocrate, bleach.** Reached respectively through
  `galaxy.util`'s re-export of `rst_to_html`, `validate_password_str`, one export
  format, and `galaxy.schema.schema`.

Net effect on a `set_metadata` process: **3,245 modules down to 1,219**.

## A global `max_optional_metadata_filesize`

Setting optional metadata means reading a dataset end to end; for FASTQ and
FASTA that is what produces the sequence counts shown in the history. A size cut
off existed, but only as a per-datatype attribute in `datatypes_conf.xml`, with
no way to set it once for an instance.

What an administrator gets today is also somewhat accidental. The cut off is
stored on the datatype **class**, and the sample config sets the attribute only
on the `data` datatype, so every datatype deriving from `Data` inherits it
through the MRO. `fastqsanger` never mentions the attribute yet ends up with
Data's 1 MB. Removing that one line from `datatypes_conf.xml` would silently
switch an instance to unlimited reads.

```yaml
# 0 means never read datasets for optional metadata.
# -1, the default, means no limit and preserves current behaviour.
max_optional_metadata_filesize: 104857600
```

The resolved value is written into the datatype elements, following the existing
`sniff_compressed_dynamic_datatypes_default` pattern, because `set_metadata` and
the fetch tool rebuild a registry from that XML in a separate process and never
see a config object. Without that step the option would appear to work in the
web application and do nothing where it matters.

Measured on a 264 MB fastqsanger, bytes counted via `/proc/self/io`:

| | bytes read | sequences |
|---|---|---|
| no cut off | 264.7 MB of 264 MB | 1500000 |
| cut off 100 MB | 0.0 MB | None |

## Results

All measured on an installation with the Galaxy tree, virtualenv, conda prefix
and job directories on a 1 GbE NFS mount, against an unpatched instance on the
same filer with its own database. Rounds alternate order so cache warming and
load drift hit both sides equally.

**100 `Cut1` jobs on a 150 line table**, the small-file case that motivated this:

| | dev | branch |
|---|---|---|
| wall | 49.7 / 47.5 s | 35.4 / 34.0 s |
| NFS RPCs per job | 4,995 | 1,849 |

**40 jobs landing at once**, three rounds:

| | dev | branch |
|---|---|---|
| all green | 33.1 / 32.6 / 32.5 s | 27.3 / 26.4 / 26.5 s |
| first green | 22.8 to 29.8 s | 15.3 to 20.8 s |
| NFS RPCs | ~337k | ~197k |

**A single job**, with no concurrency to share the client attribute cache:
12,606 round trips down to 5,501.

Non-NFS installations see a smaller but real gain, since the module count drops
either way.

### What did not help, reported for completeness

The first three commits on this branch (removing redundant `stat` calls in
`DiskObjectStore._size`, using `scandir`'s own stat in `set_total_size`, and the
phase timing) make **no measurable difference to end to end job time**. A clean
A/B put dev at 21.6 / 21.1 / 22.1 s against 21.0 / 21.1 / 22.8 s for the branch.
They save microseconds against a job measured in seconds. They are retained for
the instrumentation value, not as a speedup, and I would understand a reviewer
wanting them dropped.

I also measured and discarded several plausible causes: conda environment
activation on NFS costs at most about 300 RPCs per job, `outputs_to_working_directory`
makes no difference for small outputs, and dataset content reads are irrelevant
when the file has 200 lines.

## How to test the changes?

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

New tests:

- `test/unit/app/tools/test_set_metadata_constants.py`: asserts the inlined
  `COMMAND_VERSION_FILENAME` still matches pulsar's, and fails if `set_metadata`
  ever re-imports the tool framework, the job runners, the CWL parser or
  `tool_shed.util.repository_util`. The second test is what caught the CWL path
  after the pulsar import was removed.
- `test/unit/data/datatypes/test_max_optional_metadata_filesize.py`: the
  default, the global value, `0`, precedence of the per-datatype attribute, that
  a large FASTQ is genuinely not read, and that the value survives the round trip
  through the job registry XML into a `Registry` built without a config. These
  restore the class level attribute afterwards, since not doing so leaks into
  `test_sequence.py`.

Full unit suite, branch against `dev` in the same environment:

| | dev | branch |
|---|---|---|
| passed | 4,462 | 4,470 |
| failed | 161 | 161 |
| errors | 34 | 34 |
| skipped | 178 | 178 |

The 8 additional passes are exactly the new tests. All 44 distinct failing tests
on the branch reproduce on `dev`; they are environmental (CWL conformance data
comes from an uninitialised submodule, conda resolution needs network,
`rocrate_validator` requires Python 3.11).

Manual verification of the performance numbers:

1. Put the Galaxy tree, virtualenv and job directories on a network mount.
2. Time the fixed cost directly:
   `time .venv/bin/python -c "import galaxy.metadata.set_metadata"`
3. Run a batch of small jobs, for example `Cut1` on a short tabular dataset, and
   compare `/proc/net/rpc/nfs` before and after, or per operation latency from
   `/proc/self/mountstats`.

## Note on authorship

These changes were written by Claude Code using Opus 5, working against a copy of
a production instance. Every number quoted above was measured rather than
estimated, and the cases where a change turned out not to help are reported
alongside the ones that did.

## License

- [x] I agree to license these and all my past contributions to the core galaxy
  codebase under the [MIT license](https://opensource.org/licenses/MIT).