### PR TITLE
[26.1] Fix NPM publish job by pointing pnpm setup at client/package.json

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -107,6 +107,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
+        with:
+          package_json_file: client/package.json
       # TODO(post-26.1): the @galaxyproject/galaxy-client npm publish is now
       # redundant with the galaxy-web-client PyPI wheel used by
       # scripts/common_startup.sh and the install-client make target.  Keep


### PR DESCRIPTION
The npm half of the 26.1.0 release never ran -- `@galaxyproject/galaxy-client` and `@galaxyproject/galaxy-api-client` are still at 26.0.1 on the registry. The job died in `Setup pnpm` with "No pnpm version is specified" before it built anything.

`pnpm/action-setup` with no `version:` input reads `packageManager` out of whatever `package_json_file` points at, which defaults to `package.json` at the repo root. Galaxy had one of those until #22514, where I dropped it -- its only job was letting `pnpm install && pnpm run stage` pull the prebuilt client tarball from npm, a flow the `galaxy-web-client` wheel replaced. It happened to carry `"packageManager": "pnpm@10.26.1"`, so deleting it pulled the pnpm version out from under this workflow.

#22514 handled that everywhere else: `build_client`, `client-api-test`, `client-unit`, `js_lint`, and `lint_openapi_schema` all got an explicit `package_json_file` in the same change. `publish_artifacts.yaml` was edited in that PR too, but only to add the `TODO(post-26.1)` comment -- the `with:` clause never landed. Those five run on every PR so they were green immediately; this one only triggers on `release`/`workflow_dispatch`, so there was no signal for 106 days. `v26.0.0` and `v26.0.1` both shipped off `release_26.0`, which branched before the removal and still had the root file, so v26.1.0 was the first release to hit it.

Merging this forward to `dev` will conflict trivially with the Dependabot `@v5` -> `@v6` bump on the adjacent line; keep `@v6` and the new `with:` block.

Once this lands, 26.1.0 can go out via `workflow_dispatch` with `release_tag=v26.1.0` and `release_type=release` -- dispatch runs the workflow definition from the branch while `checkout` pulls the tag's code. The PyPI job will re-run and fail on already-published files (`skip-existing` isn't set), but the npm job only depends on `check-permissions`, so it still completes. Adding `skip-existing: true` there is probably worth a separate PR.
