### PR TITLE
[26.1] Pin release npm upgrade to 11.x and fix PyPI repository-url precedence

### DIFF
--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ (github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease') || (github.event_name == 'release' && github.event.release.prerelease) && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
+          repository-url: ${{ ((github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease') || (github.event_name == 'release' && github.event.release.prerelease)) && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
 
   build-and-publish-npm:
     if: |

--- a/.github/workflows/publish_artifacts.yaml
+++ b/.github/workflows/publish_artifacts.yaml
@@ -118,8 +118,10 @@ jobs:
       - name: build client
         run: pnpm install && pnpm build-production
         working-directory: 'client'
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - run: npm install -g npm@latest
+      # Ensure npm 11.5.1 or later for trusted publishing.  Stay on the 11.x
+      # line: npm 12 requires node ^22.22.2, and client/.node_version pins
+      # 22.20.0.
+      - run: npm install -g npm@11
         working-directory: 'client'
       - name: publish client
         if: (github.event_name == 'workflow_dispatch' && inputs.release_type == 'release') || (github.event_name == 'release' && !github.event.release.prerelease)


### PR DESCRIPTION
The pnpm fix in #23249 got the npm job past `Setup pnpm` and through `build client`, but it hit two more things before reaching a publish.

**npm@latest outran the node pin.** `npm@latest` is 12.0.2 now, which requires node `^22.22.2 || ^24.15.0 || >=26.0.0`, and `client/.node_version` pins 22.20.0 -- so the step that upgrades npm for trusted publishing dies with EBADENGINE:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.3","node":"v22.20.0"}
```

The actual requirement is only >= 11.5.1, and npm 11.19.0 accepts `^20.17.0 || >=22.9.0`, so `npm@11` clears the floor without dragging the node pin along. Bumping `.node_version` would also work, but that touches every workflow and every dev checkout, which isn't a change I want to make on a release branch.

Worth noting the npm upgrade is still load-bearing even though we publish with pnpm. `pnpm publish` packs the tarball -- that's where `workspace:*` gets rewritten, which is why we moved off plain `npm publish` -- and then spawns `npm publish --ignore-scripts <tarball>` against whatever `npm` is on PATH. npm is the process doing the OIDC exchange and provenance, so its version matters.

**`repository-url` evaluates to `true`.** `&&` binds tighter than `||` in GitHub expressions, so

```
A || B && 'test-url' || 'upload-url'
```

parses as `A || (B && 'test-url') || 'upload-url'`. On a workflow_dispatch prerelease run `A` is true, `||` returns the first truthy operand -- the boolean -- and the action builds an audience URL with no host:

```
requests.exceptions.InvalidURL: Invalid URL 'https:///_/oidc/audience': No host supplied
```

Wrapping both prerelease conditions before the `&&` gets the intended conditional. Only the workflow_dispatch path was affected; a prerelease triggered by an actual release event parses correctly by luck, which is why this hadn't surfaced.

One caveat for whoever runs the next dispatch: `pnpm publish` has never actually executed in this workflow. The switch landed in 77ad750 and 5a08214, and `git tag --contains` on both returns only v26.1.0 -- v26.0.1 shipped off release_26.0 using `npm publish` directly. Both v26.1.0 attempts died before reaching the publish steps, so the next run is the first end-to-end test of that path.
