### PR TITLE
[26.1] Move jsonschema to tool-util test requirements

### DIFF
--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -17,7 +17,6 @@ install_requires =
     galaxy-tool-util-models>=26.0
     galaxy-util[template,image-util]>=22.1
     conda-package-streaming
-    jsonschema
     lxml!=4.2.2
     MarkupSafe
     packaging
@@ -47,6 +46,7 @@ extended-assertions =
     tifffile
 test =
     Beaker
+    jsonschema
     pytest
     pytest-mock
 [options.packages.find]


### PR DESCRIPTION
It's used only in `test/unit/tool_util/`, not in `lib/galaxy/tool_util/` .

Introduced in commit f1449237eb3e8e3f3f71968679fa3d73453de23a .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
