### PR TITLE
add resubmission as job_metrics

### DIFF
--- a/doc/source/admin/job_metrics.rst
+++ b/doc/source/admin/job_metrics.rst
@@ -51,6 +51,19 @@ zone library and can be listed with the following command:
 
     python3 -c 'import zoneinfo; list(map(print, sorted(zoneinfo.available_timezones())))'
 
+resubmission
+~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+    - type: resubmission
+
+The optional resubmission plugin records ``resubmission_count``, the number of Galaxy-level job resubmission events. It reads the persisted job state history, so the value is retained when a resubmission clears or recreates the job working directory. A job that runs once reports ``0``; the execution attempt number is therefore ``resubmission_count + 1``.
+
+This metric includes both configured resubmission rules and runner-triggered resubmissions, such as Slurm node-failure recovery. It does not include scheduler-internal requeues that Galaxy does not observe.
+
+It has no options.
+
 cpuinfo
 ~~~~~~~
 

--- a/doc/source/lib/galaxy.job_metrics.instrumenters.rst
+++ b/doc/source/lib/galaxy.job_metrics.instrumenters.rst
@@ -25,8 +25,16 @@ galaxy.job\_metrics.instrumenters.core module
    :undoc-members:
    :show-inheritance:
 
+galaxy.job\_metrics.instrumenters.resubmission module
+------------------------------------------------------
+
+.. automodule:: galaxy.job_metrics.instrumenters.resubmission
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 galaxy.job\_metrics.instrumenters.cpuinfo module
-------------------------------------------------
+-------------------------------------------------
 
 .. automodule:: galaxy.job_metrics.instrumenters.cpuinfo
    :members:

--- a/lib/galaxy/job_metrics/instrumenters/resubmission.py
+++ b/lib/galaxy/job_metrics/instrumenters/resubmission.py
@@ -1,0 +1,58 @@
+"""The job metrics plugin that records Galaxy-level resubmissions."""
+
+from typing import (
+    Any,
+    TYPE_CHECKING,
+)
+
+from sqlalchemy import (
+    func,
+    select,
+)
+
+from galaxy import model
+from . import InstrumentPlugin
+from ..formatting import (
+    FormattedMetric,
+    JobMetricFormatter,
+)
+from ..safety import Safety
+
+if TYPE_CHECKING:
+    from galaxy.app import GalaxyManagerApplication
+
+RESUBMISSION_COUNT_KEY = "resubmission_count"
+
+
+class ResubmissionPluginFormatter(JobMetricFormatter):
+    def format(self, key: str, value: Any) -> FormattedMetric:
+        return FormattedMetric("Resubmission Count", str(int(value)))
+
+
+class ResubmissionPlugin(InstrumentPlugin):
+    """Count Galaxy-visible job resubmission events from persisted state history."""
+
+    plugin_type = "resubmission"
+    formatter = ResubmissionPluginFormatter()
+    default_safety = Safety.SAFE
+
+    def __init__(self, app: "GalaxyManagerApplication | None" = None, **kwargs):
+        self.app = app
+
+    def job_properties(self, job_id: int, job_directory: str) -> dict[str, int]:
+        if self.app is None:
+            return {}
+
+        statement = (
+            select(func.count())
+            .select_from(model.JobStateHistory)
+            .where(
+                model.JobStateHistory.job_id == job_id,
+                model.JobStateHistory.state == model.Job.states.RESUBMITTED,
+            )
+        )
+        count = self.app.model.context.scalar(statement)
+        return {RESUBMISSION_COUNT_KEY: int(count or 0)}
+
+
+__all__ = ("ResubmissionPlugin",)

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -61,9 +61,20 @@ class TestJobResubmissionIntegration(_BaseResubmissionIntegrationTestCase):
         config["job_resource_params_file"] = JOB_RESUBMISSION_JOB_RESOURCES_CONFIG_FILE
         config["job_runner_monitor_sleep"] = 1
         config["job_handler_monitor_sleep"] = 1
-        config["job_metrics"] = [{"type": "core"}]
+        config["job_metrics"] = [{"type": "core"}, {"type": "resubmission"}]
         # Can't set job_metrics_config_file to None as default location will be used otherwise
         config["job_metrics_config_file"] = "xxx.xml"
+
+    def _assert_resubmission_count(self, history_id, expected_count):
+        jobs = self.dataset_populator.history_jobs(history_id=history_id)
+        assert len(jobs) == 1
+        job_metrics = self.dataset_populator._get(f"/api/jobs/{jobs[0]['id']}/metrics").json()
+        resubmission_metric = next(metric for metric in job_metrics if metric["plugin"] == "resubmission")
+        assert resubmission_metric["name"] == "resubmission_count"
+        assert resubmission_metric["plugin"] == "resubmission"
+        assert resubmission_metric["title"] == "Resubmission Count"
+        assert resubmission_metric["value"] == str(expected_count)
+        assert int(resubmission_metric["raw_value"]) == expected_count
 
     def test_retry_tools_have_resource_params(self):
         tool_show = self._get("tools/simple_constructs", data=dict(io_details=True)).json()
@@ -95,15 +106,15 @@ class TestJobResubmissionIntegration(_BaseResubmissionIntegrationTestCase):
                 },
                 history_id=history_id,
             )
-            jobs = self.dataset_populator.history_jobs(history_id=history_id)
-            assert len(jobs) == 1
-            job_metrics = self.dataset_populator._get(f"/api/jobs/{jobs[0]['id']}/metrics").json()
-            assert job_metrics
+            self._assert_resubmission_count(history_id, 0)
 
     def test_walltime_resubmission(self):
-        self._assert_job_passes(
-            resource_parameters={"test_name": "test_walltime_resubmission", "failure_state": "walltime_reached"}
-        )
+        with self.dataset_populator.test_history() as history_id:
+            self._assert_job_passes(
+                resource_parameters={"test_name": "test_walltime_resubmission", "failure_state": "walltime_reached"},
+                history_id=history_id,
+            )
+            self._assert_resubmission_count(history_id, 1)
 
     def test_memory_resubmission(self):
         self._assert_job_passes(
@@ -162,6 +173,18 @@ class TestJobResubmissionIntegration(_BaseResubmissionIntegrationTestCase):
                 "failure_state": "walltime_reached",
             }
         )
+
+    def test_multiple_resubmissions_are_counted_after_working_directory_reset(self):
+        with self.dataset_populator.test_history() as history_id:
+            self._assert_job_fails(
+                resource_parameters={
+                    "test_name": "test_condition_attempt",
+                    "initial_target_environment": "fail_two_attempts",
+                    "failure_state": "unknown_error",
+                },
+                history_id=history_id,
+            )
+            self._assert_resubmission_count(history_id, 2)
 
     def test_condition_seconds_running(self):
         self._assert_job_passes(

--- a/test/unit/job_metrics/test_job_metrics.py
+++ b/test/unit/job_metrics/test_job_metrics.py
@@ -33,6 +33,16 @@ def test_job_metrics_format_core():
     )
 
 
+def test_job_metrics_format_resubmission():
+    _assert_format(
+        "resubmission",
+        "resubmission_count",
+        2,
+        assert_title="Resubmission Count",
+        assert_value="2",
+    )
+
+
 def test_job_metrics_format_cgroup():
     _assert_format(
         "cgroup",

--- a/test/unit/job_metrics/test_resubmission.py
+++ b/test/unit/job_metrics/test_resubmission.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+from galaxy.job_metrics.instrumenters.resubmission import (
+    RESUBMISSION_COUNT_KEY,
+    ResubmissionPlugin,
+)
+from galaxy.job_metrics.safety import Safety
+
+
+def test_resubmission_count_comes_from_persisted_state_history():
+    app = Mock()
+    app.model.context.scalar.return_value = 2
+    plugin = ResubmissionPlugin(app=app)
+
+    properties = plugin.job_properties(42, "/cleared-and-recreated-working-directory")
+
+    assert properties == {RESUBMISSION_COUNT_KEY: 2}
+    app.model.context.scalar.assert_called_once()
+
+
+def test_resubmission_plugin_without_application_does_not_collect():
+    assert ResubmissionPlugin().job_properties(42, "/job-directory") == {}
+
+
+def test_resubmission_metric_formatting_and_safety():
+    plugin = ResubmissionPlugin()
+
+    assert plugin.formatter.format(RESUBMISSION_COUNT_KEY, 1) == ("Resubmission Count", "1")
+    assert plugin.safety(RESUBMISSION_COUNT_KEY) == Safety.SAFE


### PR DESCRIPTION
Adding resubmission count as an optional job metric would make it easier to spot TPV rules that are unoptimized — jobs that repeatedly get resubmitted with bumped-up resource requests are a good signal that the initial allocation was off. This is also directly useful for the ESG4Stars effort to flag tools with the biggest potential for resource-usage optimization.

<details>
This pull request introduces a new job metrics plugin for tracking Galaxy-level job resubmissions, updates documentation, and adds comprehensive tests to ensure correct behavior and formatting. The most important changes are grouped below.

**New Resubmission Metrics Plugin:**

* Added `ResubmissionPlugin` in `resubmission.py` to count and report the number of Galaxy-level job resubmission events using persisted job state history. This provides a reliable resubmission count even if the job working directory is cleared or recreated.
* Integrated the new resubmission metric into the job metrics configuration in integration tests to ensure it is collected and reported as expected.

**Documentation Updates:**

* Added documentation for the new `resubmission` job metrics plugin, describing its purpose, behavior, and configuration in `job_metrics.rst` and the API documentation in `instrumenters.rst`. [[1]](diffhunk://#diff-cb70a68102f666503cbbfeb261d7eb583603de553458334b4bef6f7790f5288bR54-R66) [[2]](diffhunk://#diff-9ecfcbe22d11a09582cf423e9f8db947c19dc9d675505d1bd4f763a6f971ee87R28-R37)

**Testing and Validation:**

* Added and updated integration tests to validate that the resubmission count is accurately reported under different conditions, including after working directory resets and multiple resubmissions. [[1]](diffhunk://#diff-4098ff0fca488f315df1024f29d1ca6d38346027fb626434814bf97d61574013L98-R117) [[2]](diffhunk://#diff-4098ff0fca488f315df1024f29d1ca6d38346027fb626434814bf97d61574013R177-R188)
* Added unit tests for the resubmission plugin to verify correct metric extraction, formatting, and safety classification. [[1]](diffhunk://#diff-fa96ef47ee1d78b0169d809aa4bf97f39040bf299fa66c37c2269d0f40a9780bR1-R29) [[2]](diffhunk://#diff-ee9461e13e256f3dab456c7f29a6bc699324ef3e8291c4f43a39055a98a4dc2cR36-R45) 

</details>

xref: https://github.com/usegalaxy-eu/issues/issues/1035

@davelopez can you take a look at this before opening?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
