### PR TITLE
[26.1] Allow prebuilt clients for .dev versions

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -248,15 +248,20 @@ if [ "$SKIP_CLIENT_BUILD" -eq 0 ]; then
         # webapp.py picks it up via `import galaxy.web_client` and serves its
         # bundled dist/ directly -- no pnpm or staging required.
         GALAXY_WEB_CLIENT_VERSION=$(PYTHONPATH=lib python -c "from galaxy.version import VERSION; print(VERSION)")
+        GALAXY_WEB_CLIENT_REQUIREMENT="galaxy-web-client==${GALAXY_WEB_CLIENT_VERSION}"
         case "$GALAXY_WEB_CLIENT_VERSION" in
             *dev*)
-                echo "ERROR: Galaxy is at development version ${GALAXY_WEB_CLIENT_VERSION}, for which no galaxy-web-client wheel is published to PyPI."
-                echo "The prebuilt client install path (GALAXY_INSTALL_PREBUILT_CLIENT=1) is only supported against tagged releases.  Unset GALAXY_INSTALL_PREBUILT_CLIENT to build the client from source instead."
-                exit 1
+                echo "WARNING: Galaxy is at development version ${GALAXY_WEB_CLIENT_VERSION}. The prebuilt client install path (GALAXY_INSTALL_PREBUILT_CLIENT=1) is only supported against tagged releases."
+                GALAXY_WEB_CLIENT_RELEASE_VERSION=${GALAXY_WEB_CLIENT_VERSION%%.dev*}
+                GALAXY_WEB_CLIENT_PATCH_VERSION=${GALAXY_WEB_CLIENT_RELEASE_VERSION##*.}
+                GALAXY_WEB_CLIENT_VERSION_PREFIX=${GALAXY_WEB_CLIENT_RELEASE_VERSION%.*}
+                GALAXY_WEB_CLIENT_VERSION="${GALAXY_WEB_CLIENT_VERSION_PREFIX}.$((GALAXY_WEB_CLIENT_PATCH_VERSION - 1))"
+                echo "Installing galaxy-web-client ${GALAXY_WEB_CLIENT_VERSION}, which may differ slightly from this development version."
+                GALAXY_WEB_CLIENT_REQUIREMENT="galaxy-web-client==${GALAXY_WEB_CLIENT_VERSION}"
                 ;;
         esac
         # shellcheck disable=SC2086
-        if ! ${PIP_CMD} install "galaxy-web-client==${GALAXY_WEB_CLIENT_VERSION}"; then
+        if ! ${PIP_CMD} install "$GALAXY_WEB_CLIENT_REQUIREMENT"; then
             echo "ERROR: Galaxy prebuilt client install failed.  See ./client/README.md for more information, including how to get help."
             exit 1
         fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -250,14 +250,18 @@ if [ "$SKIP_CLIENT_BUILD" -eq 0 ]; then
         GALAXY_WEB_CLIENT_VERSION=$(PYTHONPATH=lib python -c "from galaxy.version import VERSION; print(VERSION)")
         GALAXY_WEB_CLIENT_REQUIREMENT="galaxy-web-client==${GALAXY_WEB_CLIENT_VERSION}"
         case "$GALAXY_WEB_CLIENT_VERSION" in
-            *dev*)
-                echo "WARNING: Galaxy is at development version ${GALAXY_WEB_CLIENT_VERSION}. The prebuilt client install path (GALAXY_INSTALL_PREBUILT_CLIENT=1) is only supported against tagged releases."
+            *dev*|*rc*)
+                # Only tagged releases are published, so ask the resolver for the
+                # most recent one below this version instead of pinning exactly.
+                # Bound on the version with the .dev/rc suffix stripped: a bound
+                # that is itself a prerelease would let pip match the stray
+                # prerelease wheels on PyPI.
                 GALAXY_WEB_CLIENT_RELEASE_VERSION=${GALAXY_WEB_CLIENT_VERSION%%.dev*}
-                GALAXY_WEB_CLIENT_PATCH_VERSION=${GALAXY_WEB_CLIENT_RELEASE_VERSION##*.}
-                GALAXY_WEB_CLIENT_VERSION_PREFIX=${GALAXY_WEB_CLIENT_RELEASE_VERSION%.*}
-                GALAXY_WEB_CLIENT_VERSION="${GALAXY_WEB_CLIENT_VERSION_PREFIX}.$((GALAXY_WEB_CLIENT_PATCH_VERSION - 1))"
-                echo "Installing galaxy-web-client ${GALAXY_WEB_CLIENT_VERSION}, which may differ slightly from this development version."
-                GALAXY_WEB_CLIENT_REQUIREMENT="galaxy-web-client==${GALAXY_WEB_CLIENT_VERSION}"
+                GALAXY_WEB_CLIENT_RELEASE_VERSION=${GALAXY_WEB_CLIENT_RELEASE_VERSION%%rc*}
+                GALAXY_WEB_CLIENT_RELEASE_VERSION=${GALAXY_WEB_CLIENT_RELEASE_VERSION%.}
+                echo "WARNING: Galaxy is at untagged version ${GALAXY_WEB_CLIENT_VERSION}, for which no galaxy-web-client wheel is published to PyPI."
+                echo "Installing the most recent galaxy-web-client release below ${GALAXY_WEB_CLIENT_RELEASE_VERSION}, which may differ slightly from this version of Galaxy."
+                GALAXY_WEB_CLIENT_REQUIREMENT="galaxy-web-client<${GALAXY_WEB_CLIENT_RELEASE_VERSION}"
                 ;;
         esac
         # shellcheck disable=SC2086


### PR DESCRIPTION
Planemo enables `GALAXY_INSTALL_PREBUILT_CLIENT` by default when serving Galaxy. The current hard failure for .dev versions therefore breaks `planemo serve` against Galaxy release branches.

Only tagged `galaxy-web-client` releases are published, and the client generally differs only slightly from the subsequent patch development branch. For development versions, warn and install the preceding patch release (for example, Galaxy `26.1.2.dev0` uses `galaxy-web-client==26.1.1`). Tagged Galaxy versions remain exactly pinned.

## How to test the changes?

- [ ] I have included appropriate automated tests.
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run startup from a development version with `GALAXY_INSTALL_PREBUILT_CLIENT=1`.
  2. Confirm startup warns about the development version and installs the preceding tagged `galaxy-web-client` release.

Validated locally with `sh -n scripts/common_startup.sh`, `git diff --check`, and an `uv pip install --dry-run` confirming Galaxy `26.1.2.dev0` selects the published `galaxy-web-client==26.1.1` wheel.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).