### PR TITLE
Raise a clear fetch error when async URL input materialization fails

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -2267,7 +2267,11 @@ class JobSubmitter:
                 # API dataset materialization is immutable and produces new datasets
                 # here we just created the datasets - lets just materialize them in place
                 # and avoid extra and confusing input copies
-                self.hda_manager.materialize(materialize_request, sa_session(), in_place=True)
+                materialized = self.hda_manager.materialize(materialize_request, sa_session(), in_place=True)
+                if not materialized:
+                    raise RequestParameterInvalidException(
+                        f"Failed to fetch dataset from '{to_materialize.request.url}'"
+                    )
             if request.data_manager_mode:
                 tool_request.request["__data_manager_mode"] = request.data_manager_mode
             credentials_context = (


### PR DESCRIPTION
When a tool is submitted through the async path (POST /api/jobs) with a src: url input, queue_jobs materializes the URL before validation, but ignored the boolean returned by hda_manager.materialize(). A failed fetch therefore left the dataset in ERROR/DISCARDED and only surfaced later as the misleading RequestParameterInvalidException: the previously selected dataset has entered an unusable state. This change checks the existing return value and raises a clear error at the point of failure (Failed to fetch dataset from '<url>'). No await or retry logic is added, since materialization is already synchronous.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
